### PR TITLE
fix(flags): order scheduled flag changes by scheduled date

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -51,6 +51,7 @@ import {
 } from '~/types'
 
 import {
+    byScheduledAt,
     describeCron,
     featureFlagLogic,
     PAIRED_PRESETS,
@@ -1227,6 +1228,7 @@ function FeatureFlagScheduleLegacy(): JSX.Element {
         {
             title: 'Scheduled at',
             dataIndex: 'scheduled_at',
+            sorter: byScheduledAt,
             render: function Render(_, scheduledChange: ScheduledChangeType) {
                 const scheduledAt = dayjs(scheduledChange.scheduled_at).tz(tz)
                 const tzShort = shortTimeZone(tz, scheduledAt.toDate()) ?? tz

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -8,7 +8,7 @@ import { urls } from 'scenes/urls'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
-import { FeatureFlagType, PropertyFilterType, PropertyOperator } from '~/types'
+import { FeatureFlagType, PropertyFilterType, PropertyOperator, ScheduledChangeType } from '~/types'
 import { FeatureFlagFilters } from '~/types'
 
 import { TemplateKey } from 'products/feature_flags/frontend/featureFlagTemplateConstants'
@@ -812,6 +812,105 @@ describe('featureFlagLogic', () => {
                 .toMatchValues({ dependentFlags: [], dependentFlagsLoading: false })
 
             testLogic.unmount()
+        })
+    })
+
+    describe('schedule ordering', () => {
+        const makeScheduledChange = (overrides: Partial<ScheduledChangeType>): ScheduledChangeType =>
+            ({
+                id: 1,
+                team_id: MOCK_DEFAULT_PROJECT.id,
+                record_id: MOCK_FEATURE_FLAG.id,
+                model_name: 'FeatureFlag',
+                payload: {},
+                scheduled_at: '2026-01-01T00:00:00Z',
+                executed_at: null,
+                is_recurring: false,
+                recurrence_interval: null,
+                cron_expression: null,
+                ...overrides,
+            }) as unknown as ScheduledChangeType
+
+        const schedulesUrl = `/api/projects/${MOCK_DEFAULT_PROJECT.id}/scheduled_changes`
+
+        it.each([
+            {
+                // Mirrors the issue: a recurring change created first must not float above sooner one-time changes.
+                desc: 'interleaves recurring and one-time changes by next firing time, soonest first',
+                results: [
+                    makeScheduledChange({ id: 1, scheduled_at: '2026-05-02T15:00:00Z', is_recurring: true }),
+                    makeScheduledChange({ id: 2, scheduled_at: '2026-05-01T14:00:00Z' }),
+                    makeScheduledChange({ id: 3, scheduled_at: '2026-07-04T14:58:00Z' }),
+                    makeScheduledChange({ id: 4, scheduled_at: '2026-06-13T18:59:00Z' }),
+                ],
+                expectedIds: [2, 1, 4, 3],
+            },
+            {
+                desc: 'breaks ties by id when scheduled_at is equal',
+                results: [
+                    makeScheduledChange({ id: 7, scheduled_at: '2026-05-01T00:00:00Z' }),
+                    makeScheduledChange({ id: 3, scheduled_at: '2026-05-01T00:00:00Z' }),
+                    makeScheduledChange({ id: 5, scheduled_at: '2026-05-01T00:00:00Z' }),
+                ],
+                expectedIds: [3, 5, 7],
+            },
+            {
+                desc: 'excludes executed changes',
+                results: [
+                    makeScheduledChange({ id: 1, scheduled_at: '2026-05-01T00:00:00Z' }),
+                    makeScheduledChange({
+                        id: 2,
+                        scheduled_at: '2026-04-01T00:00:00Z',
+                        executed_at: '2026-04-01T00:00:00Z',
+                    }),
+                ],
+                expectedIds: [1],
+            },
+        ])('$desc', async ({ results, expectedIds }) => {
+            useMocks({ get: { [schedulesUrl]: () => [200, { results }] } })
+            await expectLogic(logic, () => {
+                logic.actions.loadScheduledChanges()
+            }).toDispatchActions(['loadScheduledChangesSuccess'])
+
+            await expectLogic(logic).toMatchValues({
+                activeSchedules: expectedIds.map((id) => partial({ id })),
+            })
+        })
+
+        it('orders completed changes most-recent first', async () => {
+            useMocks({
+                get: {
+                    [schedulesUrl]: () => [
+                        200,
+                        {
+                            results: [
+                                makeScheduledChange({
+                                    id: 1,
+                                    scheduled_at: '2026-05-01T00:00:00Z',
+                                    executed_at: '2026-05-01T00:00:00Z',
+                                }),
+                                makeScheduledChange({
+                                    id: 2,
+                                    scheduled_at: '2026-07-01T00:00:00Z',
+                                    executed_at: '2026-07-01T00:00:00Z',
+                                }),
+                                makeScheduledChange({
+                                    id: 3,
+                                    scheduled_at: '2026-06-01T00:00:00Z',
+                                    executed_at: '2026-06-01T00:00:00Z',
+                                }),
+                            ],
+                        },
+                    ],
+                },
+            })
+            await expectLogic(logic, () => {
+                logic.actions.loadScheduledChanges()
+            }).toDispatchActions(['loadScheduledChangesSuccess'])
+
+            await expectLogic(logic).toMatchValues({
+                completedSchedules: [partial({ id: 2 }), partial({ id: 3 }), partial({ id: 1 })],
+            })
         })
     })
 })

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -1,4 +1,4 @@
-import { MOCK_DEFAULT_PROJECT } from 'lib/api.mock'
+import { MOCK_DEFAULT_BASIC_USER, MOCK_DEFAULT_PROJECT } from 'lib/api.mock'
 
 import { router } from 'kea-router'
 import { expectLogic, partial } from 'kea-test-utils'
@@ -8,7 +8,14 @@ import { urls } from 'scenes/urls'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
-import { FeatureFlagType, PropertyFilterType, PropertyOperator, ScheduledChangeType } from '~/types'
+import {
+    FeatureFlagType,
+    PropertyFilterType,
+    PropertyOperator,
+    ScheduledChangeModels,
+    ScheduledChangeOperationType,
+    ScheduledChangeType,
+} from '~/types'
 import { FeatureFlagFilters } from '~/types'
 
 import { TemplateKey } from 'products/feature_flags/frontend/featureFlagTemplateConstants'
@@ -816,20 +823,24 @@ describe('featureFlagLogic', () => {
     })
 
     describe('schedule ordering', () => {
-        const makeScheduledChange = (overrides: Partial<ScheduledChangeType>): ScheduledChangeType =>
-            ({
-                id: 1,
-                team_id: MOCK_DEFAULT_PROJECT.id,
-                record_id: MOCK_FEATURE_FLAG.id,
-                model_name: 'FeatureFlag',
-                payload: {},
-                scheduled_at: '2026-01-01T00:00:00Z',
-                executed_at: null,
-                is_recurring: false,
-                recurrence_interval: null,
-                cron_expression: null,
-                ...overrides,
-            }) as unknown as ScheduledChangeType
+        const makeScheduledChange = (overrides: Partial<ScheduledChangeType>): ScheduledChangeType => ({
+            id: 1,
+            team_id: MOCK_DEFAULT_PROJECT.id,
+            record_id: MOCK_FEATURE_FLAG.id,
+            model_name: ScheduledChangeModels.FeatureFlag,
+            payload: { operation: ScheduledChangeOperationType.UpdateStatus, value: true },
+            scheduled_at: '2026-01-01T00:00:00Z',
+            executed_at: null,
+            failure_reason: null,
+            created_at: '2026-01-01T00:00:00Z',
+            created_by: MOCK_DEFAULT_BASIC_USER,
+            is_recurring: false,
+            recurrence_interval: null,
+            cron_expression: null,
+            last_executed_at: null,
+            end_date: null,
+            ...overrides,
+        })
 
         const schedulesUrl = `/api/projects/${MOCK_DEFAULT_PROJECT.id}/scheduled_changes`
 
@@ -910,6 +921,38 @@ describe('featureFlagLogic', () => {
 
             await expectLogic(logic).toMatchValues({
                 completedSchedules: [partial({ id: 2 }), partial({ id: 3 }), partial({ id: 1 })],
+            })
+        })
+
+        it('orders completed changes by execution time, not scheduled time', async () => {
+            useMocks({
+                get: {
+                    [schedulesUrl]: () => [
+                        200,
+                        {
+                            results: [
+                                // Scheduled first but, after a delay, executed last.
+                                makeScheduledChange({
+                                    id: 1,
+                                    scheduled_at: '2026-05-01T00:00:00Z',
+                                    executed_at: '2026-05-03T00:00:00Z',
+                                }),
+                                makeScheduledChange({
+                                    id: 2,
+                                    scheduled_at: '2026-05-02T00:00:00Z',
+                                    executed_at: '2026-05-02T00:00:00Z',
+                                }),
+                            ],
+                        },
+                    ],
+                },
+            })
+            await expectLogic(logic, () => {
+                logic.actions.loadScheduledChanges()
+            }).toDispatchActions(['loadScheduledChangesSuccess'])
+
+            await expectLogic(logic).toMatchValues({
+                completedSchedules: [partial({ id: 1 }), partial({ id: 2 })],
             })
         })
     })

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -176,6 +176,17 @@ export function scheduleDateFromStoredISO(isoString: string, timezone: string): 
     return dayjs(dayjs.utc(isoString).tz(timezone).format('YYYY-MM-DDTHH:mm:ss.SSS'))
 }
 
+// Order scheduled changes by their `scheduled_at` time, soonest first. `scheduled_at` holds the
+// next occurrence for recurring changes too, so it is a uniform sort key across all change types.
+// Unparseable/missing dates sort last; ties break by `id` (creation order) for a stable order.
+export function byScheduledAt(a: ScheduledChangeType, b: ScheduledChangeType): number {
+    const epoch = (sc: ScheduledChangeType): number => {
+        const ms = dayjs(sc.scheduled_at).valueOf()
+        return Number.isNaN(ms) ? Number.POSITIVE_INFINITY : ms
+    }
+    return epoch(a) - epoch(b) || a.id - b.id
+}
+
 export const PAIRED_PRESETS: Record<Exclude<PairedPresetKey, 'custom_pair'>, PairedPresetDefinition> = {
     business_hours: {
         label: 'Business hours',
@@ -2495,15 +2506,18 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
         ],
         completedSchedules: [
             (s) => [s.scheduledChanges],
-            (scheduledChanges: ScheduledChangeType[]) => scheduledChanges.filter((sc) => !!sc.executed_at),
+            // History reads most-recent first, so reverse the soonest-first order.
+            (scheduledChanges: ScheduledChangeType[]) =>
+                scheduledChanges
+                    .filter((sc) => !!sc.executed_at)
+                    .sort(byScheduledAt)
+                    .reverse(),
         ],
         activeSchedules: [
             (s) => [s.activeRecurringSchedules, s.pausedRecurringSchedules, s.upcomingOneTimeSchedules],
-            (activeRecurring, pausedRecurring, upcomingOneTime) => [
-                ...activeRecurring,
-                ...pausedRecurring,
-                ...upcomingOneTime,
-            ],
+            // Interleave all schedule types so the upcoming list reads soonest first.
+            (activeRecurring, pausedRecurring, upcomingOneTime) =>
+                [...activeRecurring, ...pausedRecurring, ...upcomingOneTime].sort(byScheduledAt),
         ],
         emailDomain: [(s) => [s.user], (user) => user?.email?.split('@')[1] || 'example.com'],
         templates: [

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -187,6 +187,17 @@ export function byScheduledAt(a: ScheduledChangeType, b: ScheduledChangeType): n
     return epoch(a) - epoch(b) || a.id - b.id
 }
 
+// Order executed changes by `executed_at`, most recently executed first, so the history reads as a
+// real execution timeline even when execution is delayed. Unparseable/missing dates sort last; ties
+// break by `id` (creation order) for a stable order.
+export function byExecutedAt(a: ScheduledChangeType, b: ScheduledChangeType): number {
+    const epoch = (sc: ScheduledChangeType): number => {
+        const ms = dayjs(sc.executed_at ?? undefined).valueOf()
+        return Number.isNaN(ms) ? Number.NEGATIVE_INFINITY : ms
+    }
+    return epoch(b) - epoch(a) || b.id - a.id
+}
+
 export const PAIRED_PRESETS: Record<Exclude<PairedPresetKey, 'custom_pair'>, PairedPresetDefinition> = {
     business_hours: {
         label: 'Business hours',
@@ -2506,12 +2517,8 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
         ],
         completedSchedules: [
             (s) => [s.scheduledChanges],
-            // History reads most-recent first, so reverse the soonest-first order.
             (scheduledChanges: ScheduledChangeType[]) =>
-                scheduledChanges
-                    .filter((sc) => !!sc.executed_at)
-                    .sort(byScheduledAt)
-                    .reverse(),
+                scheduledChanges.filter((sc) => !!sc.executed_at).sort(byExecutedAt),
         ],
         activeSchedules: [
             (s) => [s.activeRecurringSchedules, s.pausedRecurringSchedules, s.upcomingOneTimeSchedules],

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -192,7 +192,10 @@ export function byScheduledAt(a: ScheduledChangeType, b: ScheduledChangeType): n
 // break by `id` (creation order) for a stable order.
 export function byExecutedAt(a: ScheduledChangeType, b: ScheduledChangeType): number {
     const epoch = (sc: ScheduledChangeType): number => {
-        const ms = dayjs(sc.executed_at ?? undefined).valueOf()
+        if (!sc.executed_at) {
+            return Number.NEGATIVE_INFINITY
+        }
+        const ms = dayjs(sc.executed_at).valueOf()
         return Number.isNaN(ms) ? Number.NEGATIVE_INFINITY : ms
     }
     return epoch(b) - epoch(a) || b.id - a.id

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -181,6 +181,9 @@ export function scheduleDateFromStoredISO(isoString: string, timezone: string): 
 // Unparseable/missing dates sort last; ties break by `id` (creation order) for a stable order.
 export function byScheduledAt(a: ScheduledChangeType, b: ScheduledChangeType): number {
     const epoch = (sc: ScheduledChangeType): number => {
+        if (!sc.scheduled_at) {
+            return Number.POSITIVE_INFINITY
+        }
         const ms = dayjs(sc.scheduled_at).valueOf()
         return Number.isNaN(ms) ? Number.POSITIVE_INFINITY : ms
     }


### PR DESCRIPTION
## Problem

Scheduled feature flag changes were listed in the order they were created, not by when they fire. Recurring changes were also pinned to the top regardless of their next occurrence. With several changes queued, it was hard to tell at a glance when a flag would next change.

Closes #57043

## Changes

Order scheduled changes chronologically by `scheduled_at`, soonest first. That field holds the next occurrence for recurring changes too, so it works as a single sort key across one-time and recurring changes.

A shared `byScheduledAt` comparator drives both Schedule UIs:

- V2 cards: "Active & upcoming" sorts soonest-first, and "History" sorts most-recent-first.
- Legacy table: the "Scheduled at" column had no `sorter`, so its ascending `defaultSorting` never applied and rows fell back to creation order. Added the sorter so the column sorts on load and is click-sortable like the other columns.

## How did you test this code?

Added unit tests for the ordering selectors: chronological interleaving of recurring and one-time changes, id tie-breaking when `scheduled_at` is equal, exclusion of executed changes, and most-recent-first ordering for History. Verified the legacy table ordering manually in the local app.

<img width="529" height="457" alt="Screenshot 2026-06-01 at 2 43 05 PM" src="https://github.com/user-attachments/assets/f9aa806c-1c61-4fcf-a521-ebd58a0b9ec2" />

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?