### PR TITLE
feat(data-stack): add shared duckling backfill concurrency tag

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -188,12 +188,24 @@ EVENTS_COLUMNS = """
 BACKFILL_EVENTS_S3_PREFIX = "backfill/events"
 BACKFILL_PERSONS_S3_PREFIX = "backfill/persons"
 
+# Shared concurrency key across events + persons backfills. Each duckling
+# connection spins up a duckgres worker, and the per-org worker pool is capped
+# (maxWorkers in the duckgres chart) and shared with product queries — so the
+# two backfills must draw from ONE combined limit, not two independent ones.
+# The limit itself is a Dagster Cloud deployment setting (charts repo); this tag
+# is just the key it targets. Per-product keys are kept for optional finer limits.
+DUCKLING_BACKFILL_CONCURRENCY_TAG = {
+    "duckling_backfill_concurrency": "duckling_v1",
+}
+
 EVENTS_CONCURRENCY_TAG = {
     "duckling_events_backfill_concurrency": "duckling_events_v1",
+    **DUCKLING_BACKFILL_CONCURRENCY_TAG,
 }
 
 PERSONS_CONCURRENCY_TAG = {
     "duckling_persons_backfill_concurrency": "duckling_persons_v1",
+    **DUCKLING_BACKFILL_CONCURRENCY_TAG,
 }
 
 # Persons columns for export - joined with person_distinct_id2 to include distinct_ids

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -9,8 +9,10 @@ import psycopg
 from parameterized import parameterized
 
 from posthog.dags.events_backfill_to_duckling import (
+    DUCKLING_BACKFILL_CONCURRENCY_TAG,
     EARLIEST_BACKFILL_DATE,
     EVENTS_COLUMNS,
+    EVENTS_CONCURRENCY_TAG,
     EVENTS_TABLE_DDL,
     EXPECTED_DUCKLAKE_COLUMNS,
     EXPECTED_DUCKLAKE_PERSONS_COLUMNS,
@@ -19,6 +21,7 @@ from posthog.dags.events_backfill_to_duckling import (
     ICEBERG_PERSONS_PARTITION_EXPR,
     ICEBERG_PERSONS_TABLE_DDL,
     PERSONS_COLUMNS,
+    PERSONS_CONCURRENCY_TAG,
     PERSONS_TABLE_DDL,
     _get_cluster,
     _set_iceberg_table_partitioning,
@@ -905,3 +908,13 @@ class TestIcebergInsertByNameHivePartitioning:
         insert_sql = next(s for s in executed if "read_parquet" in s)
         assert "BY NAME" in insert_sql
         assert "hive_partitioning=false" in insert_sql
+
+
+class TestDucklingConcurrencyTags:
+    # The combined events+persons cap is enforced on the shared key in the charts
+    # Dagster deployment settings. If either backfill drops the shared tag, the
+    # cap silently stops applying to it — guard against that here.
+    def test_events_and_persons_share_the_combined_concurrency_key(self):
+        ((shared_key, shared_value),) = DUCKLING_BACKFILL_CONCURRENCY_TAG.items()
+        assert EVENTS_CONCURRENCY_TAG[shared_key] == shared_value
+        assert PERSONS_CONCURRENCY_TAG[shared_key] == shared_value

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -914,7 +914,12 @@ class TestDucklingConcurrencyTags:
     # The combined events+persons cap is enforced on the shared key in the charts
     # Dagster deployment settings. If either backfill drops the shared tag, the
     # cap silently stops applying to it — guard against that here.
-    def test_events_and_persons_share_the_combined_concurrency_key(self):
+    @parameterized.expand(
+        [
+            ("events", EVENTS_CONCURRENCY_TAG),
+            ("persons", PERSONS_CONCURRENCY_TAG),
+        ]
+    )
+    def test_backfill_carries_shared_concurrency_key(self, _name, tag_dict):
         ((shared_key, shared_value),) = DUCKLING_BACKFILL_CONCURRENCY_TAG.items()
-        assert EVENTS_CONCURRENCY_TAG[shared_key] == shared_value
-        assert PERSONS_CONCURRENCY_TAG[shared_key] == shared_value
+        assert tag_dict[shared_key] == shared_value


### PR DESCRIPTION
## Problem

Each duckling backfill op opens a duckgres connection, and duckgres spins up **one worker per connection**. The per-org worker pool is capped (`maxWorkers` in the duckgres chart — 50 in prod-us) and **shared with product HogQL queries and other jobs**. With no combined limit, the events and persons backfills can fan out across many partitions at once and exhaust the pool, producing `psycopg.ConnectionTimeout` on connect.

The two backfills each carried only their **own** concurrency tag (`duckling_events_v1`, `duckling_persons_v1`), so they could only ever be limited *independently* — there was no single key to enforce a **combined** cap across both.

## Changes

Add a shared tag `duckling_backfill_concurrency=duckling_v1` to both the events and persons assets **and** jobs (via the existing `EVENTS_CONCURRENCY_TAG` / `PERSONS_CONCURRENCY_TAG` dicts). The per-product keys are kept for optional finer-grained limits later.

The **limit value** is not set here — it's a Dagster Cloud deployment setting applied from the charts repo (companion PR). This change only establishes the shared key the limit targets.

> Companion charts PR (gitops for the deployment settings): _link to be added_

## How did you test this code?

I'm an agent; automated tests only.

Added `TestDucklingConcurrencyTags::test_events_and_persons_share_the_combined_concurrency_key` — asserts both backfills carry the shared key/value, so a future edit can't silently drop it and detach a backfill from the combined cap. Full file: `101 passed`. `ruff` clean.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8). Part of clamping duckling backfill concurrency below the shared duckgres worker pool. A shared tag is required because Dagster `tag_concurrency_limits` key on run tags — two independent per-product keys can only yield two independent limits, not one combined cap. The deployment-settings gitops that sets the limit (combined cap of 5) lives in the charts repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)