### PR TITLE
feat(replay-vision): add version column to scanner observations table

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconRefresh, IconRewindPlay } from '@posthog/icons'
-import { LemonButton, LemonTable, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonTable, LemonTag, LemonTagType, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
@@ -59,6 +59,37 @@ function compareByVerdict(a: ReplayObservationApi, b: ReplayObservationApi): num
     return va ? -1 : 1
 }
 
+// Rows with no snapshot (rendered as "—") sort last regardless of direction, matching compareByScore/Verdict.
+function compareByVersion(a: ReplayObservationApi, b: ReplayObservationApi): number {
+    const va = a.scanner_snapshot?.scanner_version ?? null
+    const vb = b.scanner_snapshot?.scanner_version ?? null
+    if (va === null || vb === null) {
+        return va === vb ? 0 : va === null ? 1 : -1
+    }
+    return va - vb
+}
+
+// Chip color by how many versions behind the live scanner an observation ran: latest → oldest.
+const VERSION_TAG_TYPES: LemonTagType[] = ['success', 'warning', 'caution', 'danger', 'completion']
+
+function versionTag(
+    obsVersion: number | null | undefined,
+    currentVersion: number | null | undefined
+): { type: LemonTagType; label: string; tooltip: string } | null {
+    if (obsVersion == null) {
+        return null
+    }
+    const label = `v${obsVersion}`
+    if (currentVersion == null) {
+        return { type: 'muted', label, tooltip: `Ran with scanner version ${obsVersion}` }
+    }
+    const age = Math.max(0, currentVersion - obsVersion)
+    const type = VERSION_TAG_TYPES[Math.min(age, VERSION_TAG_TYPES.length - 1)]
+    const tooltip =
+        age === 0 ? `Current version (v${currentVersion})` : `${age} version(s) behind current (v${currentVersion})`
+    return { type, label, tooltip }
+}
+
 export function ScannerObservationsTable({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element {
     const logic = replayScannerLogic({ id: scannerId, tabId })
     const {
@@ -114,6 +145,24 @@ export function ScannerObservationsTable({ scannerId, tabId }: { scannerId: stri
             ),
             sorter:
                 scannerType === 'scorer' ? compareByScore : scannerType === 'monitor' ? compareByVerdict : undefined,
+        },
+        {
+            title: 'Version',
+            key: 'version',
+            render: (_, obs) => {
+                const tag = versionTag(obs.scanner_snapshot?.scanner_version, scanner?.scanner_version)
+                if (!tag) {
+                    return <span className="text-muted">—</span>
+                }
+                return (
+                    <Tooltip title={tag.tooltip}>
+                        <LemonTag type={tag.type} className="font-mono">
+                            {tag.label}
+                        </LemonTag>
+                    </Tooltip>
+                )
+            },
+            sorter: compareByVersion,
         },
         {
             title: 'Triggered by',


### PR DESCRIPTION
## Problem

Editing a scanner's prompt or config bumps its `scanner_version`, and each observation keeps a frozen snapshot of the version that produced it. The observations table didn't surface this, so a scanner whose prompt changed over time shows very different results across rows — e.g. a scorer returning 0/10 under an old prompt and 8/10 under the current one — with no indication they came from different versions.

## Changes

Adds a sortable **Version** column to the scanner observations table. Each row shows the `scanner_version` that produced it (read from `scanner_snapshot`), color-coded by how far behind the live scanner it ran:

## How did you test this code?

visual:  
![Screenshot 2026-06-01 at 2.52.06 PM.png](https://app.graphite.com/user-attachments/assets/f8be256e-8c63-4254-9817-3a1275398d19.png)



I'm an agent (PostHog Code), so automated checks only:

- `pnpm --filter=@posthog/frontend format` — clean
- `pnpm --filter=@posthog/frontend typescript:check` — no errors in `replay_vision`

Not yet rendered in a browser; the column should be verified visually before merge.

## 🤖 Agent context

Authored with PostHog Code (Claude) during a Replay Vision dogfooding session, where comparing a scorer's results across prompt edits was confusing because old and current versions weren't distinguishable in the table. The age→color logic maps to existing `LemonTag` types via a small clamped array lookup (`VERSION_TAG_TYPES`); an earlier draft used a nested ternary chain and was simplified for readability. No API or model changes were needed. Requires human review.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)