### PR TITLE
fix(replay-vision): link observation breadcrumb to its scanner

### DIFF
--- a/products/replay_vision/frontend/observations/replayObservationLogic.ts
+++ b/products/replay_vision/frontend/observations/replayObservationLogic.ts
@@ -6,6 +6,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { visionObservationsRetrieve } from '../generated/api'
 import type { ReplayObservationApi } from '../generated/api.schemas'
 import type { replayObservationLogicType } from './replayObservationLogicType'
+import { replayObservationSceneLogic } from './replayObservationSceneLogic'
 
 export interface ReplayObservationLogicProps {
     id: string
@@ -49,6 +50,11 @@ export const replayObservationLogic = kea<replayObservationLogicType>([
             try {
                 const response = await visionObservationsRetrieve(String(teamId), props.id)
                 actions.loadObservationSuccess(response)
+                // Link the breadcrumb to the parent scanner so "back" returns to the scanner, not the vision home.
+                replayObservationSceneLogic({ tabId: props.tabId }).actions.setScannerContext(
+                    response.scanner_id,
+                    response.scanner_snapshot?.name ?? null
+                )
             } catch (error) {
                 lemonToast.error(`Failed to load observation: ${String(error)}`)
                 actions.loadObservationFailure()

--- a/products/replay_vision/frontend/observations/replayObservationSceneLogic.ts
+++ b/products/replay_vision/frontend/observations/replayObservationSceneLogic.ts
@@ -19,6 +19,8 @@ export const replayObservationSceneLogic = kea<replayObservationSceneLogicType>(
 
     actions({
         setObservationId: (observationId: string) => ({ observationId }),
+        // Pushed by replayObservationLogic once the observation loads, so the breadcrumb can link to its scanner.
+        setScannerContext: (scannerId: string | null, scannerName: string | null) => ({ scannerId, scannerName }),
     }),
 
     reducers({
@@ -28,24 +30,45 @@ export const replayObservationSceneLogic = kea<replayObservationSceneLogicType>(
                 setObservationId: (_, { observationId }) => observationId,
             },
         ],
+        scannerContext: [
+            { scannerId: null, scannerName: null } as { scannerId: string | null; scannerName: string | null },
+            {
+                setScannerContext: (_, { scannerId, scannerName }) => ({ scannerId, scannerName }),
+                // Clear when navigating to a different observation so we don't briefly show the previous scanner.
+                setObservationId: () => ({ scannerId: null, scannerName: null }),
+            },
+        ],
     }),
 
     selectors({
         breadcrumbs: [
-            (s) => [s.observationId],
-            (observationId: string): Breadcrumb[] => [
-                {
-                    key: 'replay-vision',
-                    name: 'Replay vision',
-                    path: urls.replayVision(),
-                    iconType: 'replay_vision',
-                },
-                {
+            (s) => [s.observationId, s.scannerContext],
+            (
+                observationId: string,
+                scannerContext: { scannerId: string | null; scannerName: string | null }
+            ): Breadcrumb[] => {
+                const breadcrumbs: Breadcrumb[] = [
+                    {
+                        key: 'replay-vision',
+                        name: 'Replay vision',
+                        path: urls.replayVision(),
+                        iconType: 'replay_vision',
+                    },
+                ]
+                if (scannerContext.scannerId) {
+                    breadcrumbs.push({
+                        key: `scanner-${scannerContext.scannerId}`,
+                        name: scannerContext.scannerName || 'Scanner',
+                        path: urls.replayVision(scannerContext.scannerId),
+                    })
+                }
+                breadcrumbs.push({
                     key: observationId ? `observation-${observationId}` : 'observation',
                     name: 'Observation',
                     path: urls.replayVisionObservation(observationId),
-                },
-            ],
+                })
+                return breadcrumbs
+            },
         ],
     }),
 


### PR DESCRIPTION
## Problem

Clicking **back** from an observation detail page (`/replay-vision/observations/:id`) went to the Replay vision home rather than the scanner the observation belongs to. There was no quick way to get from one observation back to its scanner to drill into that scanner's other observations.

## Changes

The observation scene's breadcrumb trail was hardcoded to `Replay vision → Observation`. It now inserts the parent scanner in between:

**Replay vision → {scanner name} → Observation**

The scanner crumb links to the scanner page (`urls.replayVision(scannerId)`). Implementation:

- `replayObservationLogic` pushes the observation's `scanner_id` and snapshot name to the scene logic once the observation loads. `scanner_id` is a top-level field on every observation, so the link also works for pending/failed observations; the name falls back to "Scanner" when there's no snapshot yet.
- `replayObservationSceneLogic` holds that context in a reducer and builds the three-level breadcrumb. The context clears when navigating between observations, so a stale scanner never briefly shows.

## How did you test this code?

I'm an agent (PostHog Code), so automated checks only:

- `pnpm --filter=@posthog/frontend format` — clean
- `pnpm --filter=@posthog/frontend typescript:check` — no errors in `replay_vision` (kea types regenerated via `typegen:write`)

Not yet clicked through in a browser; the breadcrumb/back behavior should be verified manually before merge.

## 🤖 Agent context

Authored with PostHog Code (Claude) during a Replay Vision dogfooding session, after noticing "back" from an observation skipped the scanner. Breadcrumbs are sourced only from the active scene logic, and the observation data lives in a separately keyed data logic, so the data logic pushes scanner context to the scene logic on load (both share `tabId`) — chosen over re-fetching in the scene logic or keying the scene by observation id. No API or model changes. Requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
