### PR TITLE
fix(clickhouse): writable_events doesn't exist on DATA

### DIFF
--- a/posthog/clickhouse/migrations/0267_wire_up_existing_dmat_string_columns.py
+++ b/posthog/clickhouse/migrations/0267_wire_up_existing_dmat_string_columns.py
@@ -116,7 +116,7 @@ operations += [
             start=_STRING_RANGE_START,
             end_exclusive=_STRING_RANGE_END,
         ),
-        node_roles=[NodeRole.DATA] + ([NodeRole.INGESTION_EVENTS] if _is_cloud else []),
+        node_roles=([NodeRole.INGESTION_EVENTS] if _is_cloud else [NodeRole.DATA]),
         sharded=False,
         is_alter_on_replicated_table=False,
     ),


### PR DESCRIPTION
## Problem

migration cannot be applied

## Changes

remove DATA node as a target for alter table on writable_events

