### PR TITLE
fix(replay-vision): make scanner and observation order_by a string param

### DIFF
--- a/products/replay_vision/backend/api/observations.py
+++ b/products/replay_vision/backend/api/observations.py
@@ -151,6 +151,15 @@ class ReplayObservationSerializer(serializers.ModelSerializer):
         ]
 
 
+# Single source of truth for orderable fields; the list endpoint's OpenAPI override mirrors these as a string enum.
+OBSERVATION_ORDER_FIELDS = ("created_at", "started_at", "completed_at", "status")
+
+
+def _ordering_enum(fields: tuple[str, ...]) -> list[str]:
+    """Ascending + descending (`-`-prefixed) variants of each field, matching OrderingFilter's accepted values."""
+    return [value for field in fields for value in (field, f"-{field}")]
+
+
 class ReplayObservationFilter(django_filters.FilterSet):
     status = django_filters.ChoiceFilter(
         field_name="status",
@@ -167,12 +176,7 @@ class ReplayObservationFilter(django_filters.FilterSet):
         help_text="Filter to observations of a specific session recording.",
     )
     order_by = django_filters.OrderingFilter(
-        fields=(
-            ("created_at", "created_at"),
-            ("started_at", "started_at"),
-            ("completed_at", "completed_at"),
-            ("status", "status"),
-        ),
+        fields=tuple((field, field) for field in OBSERVATION_ORDER_FIELDS),
         help_text="Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.",
     )
 
@@ -181,6 +185,22 @@ class ReplayObservationFilter(django_filters.FilterSet):
         fields = ["status", "triggered_by", "session_id"]
 
 
+@extend_schema_view(
+    list=extend_schema(
+        parameters=[
+            # OrderingFilter renders as an array by default, which the MCP client serializes as a JSON-bracketed
+            # string the filter rejects. Declare it as a single-value string enum so it serializes as ?order_by=field.
+            OpenApiParameter(
+                "order_by",
+                str,
+                OpenApiParameter.QUERY,
+                required=False,
+                enum=_ordering_enum(OBSERVATION_ORDER_FIELDS),
+                description="Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.",
+            )
+        ]
+    )
+)
 class ReplayObservationViewSet(
     TeamAndOrgViewSetMixin,
     mixins.ListModelMixin,

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -9,7 +9,7 @@ import structlog
 import django_filters
 from asgiref.sync import async_to_sync
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_spectacular.utils import extend_schema, extend_schema_field
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field, extend_schema_view
 from pydantic import ValidationError as PydanticValidationError
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
@@ -216,6 +216,10 @@ class ReplayScannerSerializer(serializers.ModelSerializer):
         raise error
 
 
+# Single source of truth for orderable fields; the list endpoint's OpenAPI override mirrors these as a string enum.
+SCANNER_ORDER_FIELDS = ("name", "created_at", "updated_at", "scanner_type")
+
+
 class ReplayScannerFilter(django_filters.FilterSet):
     enabled = django_filters.BooleanFilter(
         field_name="enabled",
@@ -231,12 +235,7 @@ class ReplayScannerFilter(django_filters.FilterSet):
         help_text="Filter to scanners that emit Signals.",
     )
     order_by = django_filters.OrderingFilter(
-        fields=(
-            ("name", "name"),
-            ("created_at", "created_at"),
-            ("updated_at", "updated_at"),
-            ("scanner_type", "scanner_type"),
-        ),
+        fields=tuple((field, field) for field in SCANNER_ORDER_FIELDS),
         help_text="Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.",
     )
 
@@ -313,6 +312,22 @@ class EstimateResponseSerializer(serializers.Serializer):
     )
 
 
+@extend_schema_view(
+    list=extend_schema(
+        parameters=[
+            # OrderingFilter renders as an array by default, which the MCP client serializes as a JSON-bracketed
+            # string the filter rejects. Declare it as a single-value string enum so it serializes as ?order_by=field.
+            OpenApiParameter(
+                "order_by",
+                str,
+                OpenApiParameter.QUERY,
+                required=False,
+                enum=[value for field in SCANNER_ORDER_FIELDS for value in (field, f"-{field}")],
+                description="Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.",
+            )
+        ]
+    )
+)
 class ReplayScannerViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     """CRUD for Replay Vision scanners."""
 

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -392,6 +392,10 @@ export type VisionObservationsListParams = {
      */
     offset?: number
     /**
+     * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
+     */
+    order_by?: string
+    /**
      * Session recording id to return observations for.
      */
     session_id: string
@@ -415,18 +419,9 @@ export type VisionScannersListParams = {
      */
     offset?: number
     /**
- * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
-
-* `name` - Name
-* `-name` - Name (descending)
-* `created_at` - Created at
-* `-created_at` - Created at (descending)
-* `updated_at` - Updated at
-* `-updated_at` - Updated at (descending)
-* `scanner_type` - Scanner type
-* `-scanner_type` - Scanner type (descending)
- */
-    order_by?: string[]
+     * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
+     */
+    order_by?: string
     /**
  * Filter by scanner type (monitor, classifier, scorer, summarizer).
 
@@ -458,18 +453,9 @@ export type VisionScannersObservationsListParams = {
      */
     offset?: number
     /**
- * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
-
-* `created_at` - Created at
-* `-created_at` - Created at (descending)
-* `started_at` - Started at
-* `-started_at` - Started at (descending)
-* `completed_at` - Completed at
-* `-completed_at` - Completed at (descending)
-* `status` - Status
-* `-status` - Status (descending)
- */
-    order_by?: string[]
+     * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
+     */
+    order_by?: string
     /**
      * Filter to observations of a specific session recording.
      */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -43784,6 +43784,10 @@ export namespace Schemas {
      */
     offset?: number;
     /**
+     * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
+     */
+    order_by?: string;
+    /**
      * Session recording id to return observations for.
      */
     session_id: string;
@@ -43808,17 +43812,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
-
-    * `name` - Name
-    * `-name` - Name (descending)
-    * `created_at` - Created at
-    * `-created_at` - Created at (descending)
-    * `updated_at` - Updated at
-    * `-updated_at` - Updated at (descending)
-    * `scanner_type` - Scanner type
-    * `-scanner_type` - Scanner type (descending)
      */
-    order_by?: string[];
+    order_by?: string;
     /**
      * Filter by scanner type (monitor, classifier, scorer, summarizer).
 
@@ -43851,17 +43846,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
-
-    * `created_at` - Created at
-    * `-created_at` - Created at (descending)
-    * `started_at` - Started at
-    * `-started_at` - Started at (descending)
-    * `completed_at` - Completed at
-    * `-completed_at` - Completed at (descending)
-    * `status` - Status
-    * `-status` - Status (descending)
      */
-    order_by?: string[];
+    order_by?: string;
     /**
      * Filter to observations of a specific session recording.
      */
@@ -49858,6 +49844,10 @@ export namespace Schemas {
      */
     offset?: number;
     /**
+     * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
+     */
+    order_by?: string;
+    /**
      * Session recording id to return observations for.
      */
     session_id: string;
@@ -49882,17 +49872,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
-
-    * `name` - Name
-    * `-name` - Name (descending)
-    * `created_at` - Created at
-    * `-created_at` - Created at (descending)
-    * `updated_at` - Updated at
-    * `-updated_at` - Updated at (descending)
-    * `scanner_type` - Scanner type
-    * `-scanner_type` - Scanner type (descending)
      */
-    order_by?: string[];
+    order_by?: string;
     /**
      * Filter by scanner type (monitor, classifier, scorer, summarizer).
 
@@ -49925,17 +49906,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
-
-    * `created_at` - Created at
-    * `-created_at` - Created at (descending)
-    * `started_at` - Started at
-    * `-started_at` - Started at (descending)
-    * `completed_at` - Completed at
-    * `-completed_at` - Completed at (descending)
-    * `status` - Status
-    * `-status` - Status (descending)
      */
-    order_by?: string[];
+    order_by?: string;
     /**
      * Filter to observations of a specific session recording.
      */

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -25,11 +25,9 @@ export const VisionScannersListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     order_by: zod
-        .array(zod.string())
+        .string()
         .optional()
-        .describe(
-            'Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.\n\n* `name` - Name\n* `-name` - Name (descending)\n* `created_at` - Created at\n* `-created_at` - Created at (descending)\n* `updated_at` - Updated at\n* `-updated_at` - Updated at (descending)\n* `scanner_type` - Scanner type\n* `-scanner_type` - Scanner type (descending)'
-        ),
+        .describe('Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.'),
     scanner_type: zod
         .enum(['classifier', 'monitor', 'scorer', 'summarizer'])
         .optional()
@@ -250,10 +248,10 @@ export const VisionScannersObservationsListQueryParams = /* @__PURE__ */ zod.obj
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     order_by: zod
-        .array(zod.string())
+        .string()
         .optional()
         .describe(
-            'Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.\n\n* `created_at` - Created at\n* `-created_at` - Created at (descending)\n* `started_at` - Started at\n* `-started_at` - Started at (descending)\n* `completed_at` - Completed at\n* `-completed_at` - Completed at (descending)\n* `status` - Status\n* `-status` - Status (descending)'
+            'Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.'
         ),
     session_id: zod.string().optional().describe('Filter to observations of a specific session recording.'),
     status: zod


### PR DESCRIPTION
## Problem

`order_by` on the Replay Vision scanner-list and observation-list endpoints was unusable from the MCP tools — any value returned a 400:

```
vision-scanners-observations-list { order_by: ["created_at"] }
→ Select a valid choice. ["created_at"] is not one of the available choices.
```

These filters are django-filters `OrderingFilter`s, which drf-spectacular renders as **array** parameters. The MCP client serializes array query params as a JSON-bracketed string (`order_by=["created_at"]`), and the CSV-style `OrderingFilter` rejects the bracketed token. (The same MCP-client serialization bug affects other products' `OrderingFilter` tools, e.g. ai_observability — tracked separately; this PR fixes Replay Vision only.)

## Changes

Override the OpenAPI `order_by` parameter on both list endpoints to a single-value **string enum** (ascending + `-`-prefixed descending variants) so it serializes as `?order_by=created_at`:

- `ReplayObservationViewSet` and `ReplayScannerViewSet` get an `@extend_schema_view(list=...)` override.
- The orderable fields are now a per-filter constant shared by the `OrderingFilter` definition and the schema enum, so the two can't drift.
- Runtime `OrderingFilter` behavior is unchanged — it already accepts a single value. The frontend doesn't pass `order_by` on these endpoints (the table sorts client-side), so the contract change is safe. Multi-field sort via the API is dropped — it was never reachable through the MCP, and the UI sorts one column at a time.

Generated frontend types and MCP tool schemas were regenerated via `hogli build:openapi` (`order_by` is now `string` instead of `string[]`).

## How did you test this code?

I'm an agent (PostHog Code), so automated checks only:

- `ruff check` on the two backend files — clean
- lint-staged on commit ran `ruff`, Python format, and `ty check` — all passed
- `hogli build:openapi` regenerated cleanly; verified `order_by` flipped to `string` in both the frontend `api.schemas.ts` and the MCP zod schema

End-to-end MCP verification isn't possible from here — the connected MCP is the deployed production server, which won't carry these changes until released. The fix is the serialization contract; the runtime filter already accepted single-string `order_by`.

## 🤖 Agent context

Authored with PostHog Code (Claude) during a Replay Vision dogfooding session. Root cause is a shared MCP-client behavior (`services/mcp/src/api/client.ts` JSON-stringifies array query params, added for the logs MCP's `json.loads` filters). A systemic client fix was considered but rejected for this PR's scope: `OrderingFilter` (CSV) vs DRF list filters (repeated keys) need different serializations, so a blanket change is risky and cross-team. The surgical contract change here has zero blast radius to other MCP tools. Requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
