### PR TITLE
chore: test ENCRYPTION_SALT_KEYS multi-key and two-step rotation

### DIFF
--- a/nodejs/src/cdp/utils/encryption-utils.test.ts
+++ b/nodejs/src/cdp/utils/encryption-utils.test.ts
@@ -40,6 +40,56 @@ describe('Encrypted fields', () => {
             expect(encryptedFields.decrypt('NOT VALID', { ignoreDecryptionErrors: true })).toEqual('NOT VALID')
         })
 
+        describe('two-step key rotation', () => {
+            // Apps are not guaranteed to redeploy simultaneously, so rotation is done in two steps:
+            //   step 1: [OLD] -> [OLD, NEW]      NEW added for decryption; OLD still encrypts
+            //   step 2: [OLD, NEW] -> [NEW, OLD] NEW now encrypts; OLD kept for decryption
+            // Safety invariant: within each step's mixed-version window, every running app can
+            // decrypt whatever any other running app writes.
+            const OLD = 'o'.repeat(32)
+            const NEW = 'n'.repeat(32)
+            const PLAINTEXT = 'super-secret-value'
+
+            const app = (keys: string[]): EncryptedFields => new EncryptedFields(keys.join(','))
+
+            it.each([
+                ['step 1', [[OLD], [OLD, NEW]]],
+                [
+                    'step 2',
+                    [
+                        [OLD, NEW],
+                        [NEW, OLD],
+                    ],
+                ],
+            ])('%s: coexisting apps decrypt each others writes', (_name, coexisting) => {
+                for (const writerKeys of coexisting) {
+                    const token = app(writerKeys).encrypt(PLAINTEXT)
+                    for (const readerKeys of coexisting) {
+                        expect(app(readerKeys).decrypt(token)).toEqual(PLAINTEXT)
+                    }
+                }
+            })
+
+            it.each([
+                ['old only', [OLD]],
+                ['old then new', [OLD, NEW]],
+            ])('step 1 (%s) always encrypts with the old key', (_name, keys) => {
+                const token = app(keys).encrypt(PLAINTEXT)
+                expect(app([OLD]).decrypt(token)).toEqual(PLAINTEXT)
+                expect(() => app([NEW]).decrypt(token)).toThrow()
+            })
+
+            it('step 2 apps encrypt with the new key', () => {
+                const token = app([NEW, OLD]).encrypt(PLAINTEXT)
+                expect(app([NEW]).decrypt(token)).toEqual(PLAINTEXT)
+            })
+
+            it('skipping step 1 would break un-upgraded apps', () => {
+                const token = app([NEW, OLD]).encrypt(PLAINTEXT)
+                expect(() => app([OLD]).decrypt(token)).toThrow()
+            })
+        })
+
         describe('decrypting objects', () => {
             it('should decrypt an object', () => {
                 const exampleObject = {

--- a/posthog/helpers/tests/test_encrypted_fields.py
+++ b/posthog/helpers/tests/test_encrypted_fields.py
@@ -1,8 +1,40 @@
+import base64
+
 from freezegun import freeze_time
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.test import SimpleTestCase, override_settings
+
+from cryptography.fernet import Fernet, InvalidToken
+from parameterized import parameterized
+
 from posthog.helpers.encrypted_fields import EncryptedFieldMixin
+
+KEY_A = "a" * 32
+KEY_B = "b" * 32
+KEY_C = "c" * 32
+
+OLD = "o" * 32
+NEW = "n" * 32
+PLAINTEXT = "super-secret-value"
+
+
+def _fernet(raw_key: str) -> Fernet:
+    # Build a Fernet from a single raw salt key, matching EncryptedFieldMixin.keys derivation
+    return Fernet(base64.urlsafe_b64encode(raw_key.encode("utf-8")))
+
+
+def _encrypt_with(keys: list[str], plaintext: str = PLAINTEXT) -> str:
+    # Simulates an app running with the given ENCRYPTION_SALT_KEYS encrypting a value
+    with override_settings(ENCRYPTION_SALT_KEYS=keys, SALT_KEY=[]):
+        return EncryptedFieldMixin().encrypt(plaintext)
+
+
+def _decrypt_with(keys: list[str], token: str) -> str:
+    # Simulates an app running with the given ENCRYPTION_SALT_KEYS decrypting a value
+    with override_settings(ENCRYPTION_SALT_KEYS=keys, SALT_KEY=[]):
+        return EncryptedFieldMixin().decrypt(token)
 
 
 class TestEncryptedFields(BaseTest):
@@ -22,3 +54,105 @@ class TestEncryptedFields(BaseTest):
         decrypted = ef.f.decrypt(bytes(encrypted, "utf-8")).decode("utf-8")
 
         assert decrypted == "test-case"
+
+
+class TestEncryptedFieldsMultiKey(SimpleTestCase):
+    # SALT_KEY=[] disables the legacy PBKDF2-derived keys so each test only exercises ENCRYPTION_SALT_KEYS
+
+    @override_settings(ENCRYPTION_SALT_KEYS=[KEY_A, KEY_B], SALT_KEY=[])
+    def test_encryption_uses_first_key(self):
+        token = EncryptedFieldMixin().encrypt("secret")
+
+        assert _fernet(KEY_A).decrypt(token.encode("utf-8")).decode("utf-8") == "secret"
+        with self.assertRaises(InvalidToken):
+            _fernet(KEY_B).decrypt(token.encode("utf-8"))
+
+    def test_decryption_tries_every_key_in_the_list(self):
+        with override_settings(ENCRYPTION_SALT_KEYS=[KEY_B], SALT_KEY=[]):
+            token = EncryptedFieldMixin().encrypt("secret")
+
+        with override_settings(ENCRYPTION_SALT_KEYS=[KEY_A, KEY_B], SALT_KEY=[]):
+            assert EncryptedFieldMixin().decrypt(token) == "secret"
+
+    def test_prepending_new_key_keeps_old_data_readable_and_writes_with_new(self):
+        with override_settings(ENCRYPTION_SALT_KEYS=[KEY_B], SALT_KEY=[]):
+            old_token = EncryptedFieldMixin().encrypt("secret")
+
+        with override_settings(ENCRYPTION_SALT_KEYS=[KEY_A, KEY_B], SALT_KEY=[]):
+            ef = EncryptedFieldMixin()
+            assert ef.decrypt(old_token) == "secret"
+            new_token = ef.encrypt("secret")
+
+        assert _fernet(KEY_A).decrypt(new_token.encode("utf-8")).decode("utf-8") == "secret"
+
+    def test_removing_old_key_makes_old_data_undecryptable(self):
+        with override_settings(ENCRYPTION_SALT_KEYS=[KEY_B], SALT_KEY=[]):
+            old_token = EncryptedFieldMixin().encrypt("secret")
+
+        with override_settings(ENCRYPTION_SALT_KEYS=[KEY_A], SALT_KEY=[]):
+            with self.assertRaises(InvalidToken):
+                EncryptedFieldMixin().decrypt(old_token)
+
+    @override_settings(ENCRYPTION_SALT_KEYS=[KEY_B, KEY_A], SALT_KEY=[])
+    def test_key_order_determines_which_key_encrypts(self):
+        token = EncryptedFieldMixin().encrypt("secret")
+
+        assert _fernet(KEY_B).decrypt(token.encode("utf-8")).decode("utf-8") == "secret"
+        with self.assertRaises(InvalidToken):
+            _fernet(KEY_A).decrypt(token.encode("utf-8"))
+
+    def test_three_keys_decrypt_data_from_any_of_them(self):
+        tokens = {}
+        for key in (KEY_A, KEY_B, KEY_C):
+            with override_settings(ENCRYPTION_SALT_KEYS=[key], SALT_KEY=[]):
+                tokens[key] = EncryptedFieldMixin().encrypt(f"secret-{key[0]}")
+
+        with override_settings(ENCRYPTION_SALT_KEYS=[KEY_C, KEY_B, KEY_A], SALT_KEY=[]):
+            ef = EncryptedFieldMixin()
+            for key in (KEY_A, KEY_B, KEY_C):
+                assert ef.decrypt(tokens[key]) == f"secret-{key[0]}"
+
+
+class TestEncryptionKeyRotationTwoStep(SimpleTestCase):
+    # Two-step rollout, used because apps are not guaranteed to redeploy simultaneously:
+    #   step 1: [OLD] -> [OLD, NEW]      NEW added for decryption; OLD still encrypts
+    #   step 2: [OLD, NEW] -> [NEW, OLD] NEW now encrypts; OLD kept for decryption
+    # Safety invariant: within each step's mixed-version window, every running app can
+    # decrypt whatever any other running app writes.
+
+    @parameterized.expand(
+        [
+            ("step_1", [[OLD], [OLD, NEW]]),
+            ("step_2", [[OLD, NEW], [NEW, OLD]]),
+        ]
+    )
+    def test_coexisting_apps_decrypt_each_others_writes(self, _name, coexisting):
+        for writer_keys in coexisting:
+            token = _encrypt_with(writer_keys)
+            for reader_keys in coexisting:
+                assert _decrypt_with(reader_keys, token) == PLAINTEXT
+
+    @parameterized.expand(
+        [
+            ("old_only", [OLD]),
+            ("old_then_new", [OLD, NEW]),
+        ]
+    )
+    def test_step_1_apps_always_encrypt_with_old_key(self, _name, keys):
+        # While [OLD] and [OLD, NEW] apps coexist, OLD is always first, so no app emits
+        # NEW-encrypted data that an un-upgraded [OLD]-only app could not read.
+        token = _encrypt_with(keys)
+        assert _fernet(OLD).decrypt(token.encode("utf-8")).decode("utf-8") == PLAINTEXT
+        with self.assertRaises(InvalidToken):
+            _fernet(NEW).decrypt(token.encode("utf-8"))
+
+    def test_step_2_apps_encrypt_with_new_key(self):
+        token = _encrypt_with([NEW, OLD])
+        assert _fernet(NEW).decrypt(token.encode("utf-8")).decode("utf-8") == PLAINTEXT
+
+    def test_skipping_step_1_would_break_un_upgraded_apps(self):
+        # Justifies the two-step: a direct [OLD] -> [NEW, OLD] jump lets an upgraded app
+        # encrypt with NEW while an un-upgraded [OLD]-only app still cannot decrypt it.
+        token = _encrypt_with([NEW, OLD])
+        with self.assertRaises(InvalidToken):
+            _decrypt_with([OLD], token)


### PR DESCRIPTION
## Problem

We're rotating `ENCRYPTION_SALT_KEYS`. The key list is consumed by two independent implementations — Django (`MultiFernet`) and the Node.js services (`fernet-nodejs`) — and the rotation rolls out across apps that cannot be guaranteed to redeploy at the same moment. Before rotating, we want automated proof that the multi-key contract and the staged rollout behave safely in **both** implementations.

## Changes

Tests only — no production code changes.

- **Python** (`posthog/helpers/tests/test_encrypted_fields.py`): cover the multi-key `ENCRYPTION_SALT_KEYS` contract and the two-step rotation.
- **Node.js** (`nodejs/src/cdp/utils/encryption-utils.test.ts`): matching coverage for the same contract.

Both suites assert the shared contract and the rollout safety property:

- the **first** key encrypts; **every** key is tried for decryption;
- modelling the rollout as `[old] → [old,new] → [new,old]`, within each step's mixed-version window every coexisting app can decrypt whatever any other app writes;
- a direct one-step jump (`[old] → [new,old]`) would break an un-upgraded `[old]`-only app — the negative case that justifies doing it in two steps.

## How did you test this code?

I'm an agent (Claude Code). No manual testing — only the automated tests below, run locally and passing:

- `hogli test posthog/helpers/tests/test_encrypted_fields.py::TestEncryptedFieldsMultiKey` and `::TestEncryptionKeyRotationTwoStep`
- `hogli test nodejs/src/cdp/utils/encryption-utils.test.ts` (14 passed)

Both new suites are database-free (`SimpleTestCase` / jest unit tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Tests only; no docs impact.

## 🤖 Agent context

Authored with Claude Code (Opus). The work verifies the encryption-key-rotation behavior in both implementations independently, since they're separate codebases that must honor the same first-key-encrypts / try-all-keys-to-decrypt contract. The rollout is expressed as coexisting app states (parameterized in Python, `it.each` in Node) so the safety invariant is asserted directly rather than described.

Scope decision: a companion re-encryption management command (and its database-backed tests) was developed alongside these tests but is intentionally **excluded** from this PR by request — this PR is the self-contained behavior tests only. Agent-authored; requires human review.
