### PR TITLE
feat(replay-vision): chart scorer scores as a distribution bar histogram

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { LemonTag } from '@posthog/lemon-ui'
 
 import { buildTheme } from 'lib/charts/utils/theme'
-import { BoxPlot } from 'lib/hog-charts'
+import { BarChart } from 'lib/hog-charts'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 
 import { replayScannerLogic } from '../replayScannerLogic'
@@ -102,17 +102,17 @@ function ClassifierOverview({ scannerId, tabId }: { scannerId: string; tabId: st
 }
 
 function ScorerOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element | null {
-    const { scorerScores, scorerSummary } = useValues(replayScannerLogic({ id: scannerId, tabId }))
+    const { scorerScores, scorerSummary, scorerHistogram } = useValues(replayScannerLogic({ id: scannerId, tabId }))
     const theme = useMemo(() => buildTheme(), [])
-    if (!scorerSummary) {
+    if (!scorerSummary || !scorerHistogram) {
         return null
     }
     return (
         <OverviewPanel title="Score distribution" subtitle={`${scorerScores.length} scored`}>
             <div className="h-40 flex flex-col">
-                <BoxPlot
-                    labels={['Scores']}
-                    series={[{ key: 'scores', label: 'Scores', color: theme.colors[0], data: [scorerSummary] }]}
+                <BarChart
+                    labels={scorerHistogram.labels}
+                    series={[{ key: 'count', label: 'Sessions', color: theme.colors[0], data: scorerHistogram.counts }]}
                     config={{ showGrid: false }}
                     theme={theme}
                 />

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -449,6 +449,36 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 }
             },
         ],
+        // Score histogram: count of observations per score bucket across the configured scale.
+        scorerHistogram: [
+            (s) => [s.scorerScores, s.scanner],
+            (scores: number[], scanner: ReplayScanner | null): { labels: string[]; counts: number[] } | null => {
+                if (scores.length === 0) {
+                    return null
+                }
+                // Span the configured scale (falling back to the observed range) so the axis shows the full
+                // possible range even when scores cluster. Widen the bucket for large scales to cap the bar count.
+                const scale = scanner?.scanner_type === 'scorer' ? scanner.scanner_config.scale : undefined
+                const lo = Math.floor(scale?.min ?? scores[0])
+                const hi = Math.ceil(scale?.max ?? scores[scores.length - 1])
+                const span = Math.max(0, hi - lo)
+                const bucketWidth = Math.max(1, Math.ceil((span + 1) / 21))
+                const bucketCount = Math.floor(span / bucketWidth) + 1
+                const counts = new Array(bucketCount).fill(0)
+                for (const score of scores) {
+                    const idx = Math.min(
+                        bucketCount - 1,
+                        Math.max(0, Math.floor((Math.round(score) - lo) / bucketWidth))
+                    )
+                    counts[idx] += 1
+                }
+                const labels = counts.map((_, i) => {
+                    const start = lo + i * bucketWidth
+                    return bucketWidth === 1 ? String(start) : `${start}–${Math.min(start + bucketWidth - 1, hi)}`
+                })
+                return { labels, counts }
+            },
+        ],
         // Distinct sessions scanned: last 14 days and total. Surfaces sweep-job coverage.
         coverageStats: [
             (s) => [s.observations],


### PR DESCRIPTION
## Problem

The scorer **Score distribution** panel rendered a single horizontal **box-and-whisker plot**. For the small, low-volume samples these scanners produce (often a handful of observations), a box plot is hard to read: the IQR box spans nearly the whole scale, and it implies a smooth continuous distribution from a few points — so you can't tell how many sessions actually landed on each score. (Reported as confusing during dogfooding.)

## Changes

Replace the box plot with a **bar histogram** — count of observations per score bucket — which is the intuitive "scorer" view ("3 sessions scored 0, 1 scored 10").

- Buckets span the scanner's **configured scale** (falling back to the observed range) so the axis shows the full possible range even when scores cluster.
- Per-integer buckets, widening automatically for large scales so the bar count stays bounded (caps at ~21 bars; wide buckets get `start–end` labels).
- The `min / median / avg / max` footer is kept.
- Bucketing logic lives in a new `scorerHistogram` selector on `replayScannerLogic`, keeping `ScorerOverview` presentational (per the kea-logic convention).

Note: the separate "Score percentiles over time" line graph (`ScannerInsightsChart`) is unchanged — this PR only swaps the distribution panel.

## How did you test this code?

Visual Test:   
![Screenshot 2026-06-01 at 4.38.23 PM.png](https://app.graphite.com/user-attachments/assets/56acc4ac-43f6-48fb-99c3-a5309b63b1c4.png)



I'm an agent (PostHog Code), so automated checks only:

- `pnpm --filter=@posthog/frontend format` — clean
- `pnpm --filter=@posthog/frontend typescript:check` — no errors in `replay_vision` (kea types regenerated)

## 🤖 Agent context

Authored with PostHog Code (Claude) during a Replay Vision dogfooding session, after the box plot was flagged as confusing on a 4-observation scorer. Considered `BoxPlot` (kept, but it was the problem), `BoldNumber`, and a distribution bar; the bar histogram was chosen as the clearest for low-volume score data. Uses the existing `BarChart` from `lib/hog-charts`. Requires human review.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)