### PR TITLE
feat(file-system): add surface field to support multiple trees in web vs desktop

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -2175,59 +2175,6 @@ export interface SharingConfigurationApi {
     readonly share_passwords: readonly SharePasswordApi[]
 }
 
-/**
- * * `image/png` - image/png
- * `application/pdf` - application/pdf
- * `text/csv` - text/csv
- * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
- * `video/webm` - video/webm
- * `video/mp4` - video/mp4
- * `image/gif` - image/gif
- * `application/json` - application/json
- */
-export type ExportFormatEnumApi = (typeof ExportFormatEnumApi)[keyof typeof ExportFormatEnumApi]
-
-export const ExportFormatEnumApi = {
-    ImagePng: 'image/png',
-    ApplicationPdf: 'application/pdf',
-    TextCsv: 'text/csv',
-    ApplicationVndopenxmlformatsOfficedocumentspreadsheetmlsheet:
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    VideoWebm: 'video/webm',
-    VideoMp4: 'video/mp4',
-    ImageGif: 'image/gif',
-    ApplicationJson: 'application/json',
-} as const
-
-/**
- * Standard ExportedAsset serializer that doesn't return content.
- */
-export interface ExportedAssetApi {
-    readonly id: number
-    /** @nullable */
-    dashboard?: number | null
-    /** @nullable */
-    insight?: number | null
-    export_format: ExportFormatEnumApi
-    readonly created_at: string
-    readonly has_content: boolean
-    export_context?: unknown
-    readonly filename: string
-    /** @nullable */
-    readonly expires_after: string | null
-    /** @nullable */
-    readonly exception: string | null
-}
-
-export interface PaginatedExportedAssetListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ExportedAssetApi[]
-}
-
 export interface FileSystemApi {
     readonly id: string
     path: string
@@ -2279,6 +2226,191 @@ export interface PatchedFileSystemApi {
     readonly created_at?: string
     /** @nullable */
     readonly last_viewed_at?: string | null
+}
+
+export interface FileSystemShortcutApi {
+    readonly id: string
+    /** Display path of the shortcut in the sidebar. */
+    path: string
+    /**
+     * Type of the linked item (e.g. 'folder', 'insight'), or blank.
+     * @maxLength 100
+     */
+    type?: string
+    /**
+     * Reference to the linked item, scoped to its type. Null for href-only shortcuts.
+     * @maxLength 100
+     * @nullable
+     */
+    ref?: string | null
+    /**
+     * Destination URL the shortcut opens. Null when the shortcut points at an item by ref.
+     * @nullable
+     */
+    href?: string | null
+    /**
+     * Display order within the user's shortcut list, ascending.
+     * @minimum -2147483648
+     * @maximum 2147483647
+     */
+    order?: number
+    readonly created_at: string
+}
+
+export interface PaginatedFileSystemShortcutListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: FileSystemShortcutApi[]
+}
+
+export interface PatchedFileSystemShortcutApi {
+    readonly id?: string
+    /** Display path of the shortcut in the sidebar. */
+    path?: string
+    /**
+     * Type of the linked item (e.g. 'folder', 'insight'), or blank.
+     * @maxLength 100
+     */
+    type?: string
+    /**
+     * Reference to the linked item, scoped to its type. Null for href-only shortcuts.
+     * @maxLength 100
+     * @nullable
+     */
+    ref?: string | null
+    /**
+     * Destination URL the shortcut opens. Null when the shortcut points at an item by ref.
+     * @nullable
+     */
+    href?: string | null
+    /**
+     * Display order within the user's shortcut list, ascending.
+     * @minimum -2147483648
+     * @maximum 2147483647
+     */
+    order?: number
+    readonly created_at?: string
+}
+
+export interface FileSystemShortcutReorderApi {
+    /** IDs of the current user's shortcuts in the desired display order. */
+    ordered_ids: string[]
+}
+
+/**
+ * * `home` - Home
+ * `pinned` - Pinned
+ * `custom_products` - Custom Products
+ */
+export type PersistedFolderTypeEnumApi = (typeof PersistedFolderTypeEnumApi)[keyof typeof PersistedFolderTypeEnumApi]
+
+export const PersistedFolderTypeEnumApi = {
+    Home: 'home',
+    Pinned: 'pinned',
+    CustomProducts: 'custom_products',
+} as const
+
+export interface PersistedFolderApi {
+    readonly id: string
+    /** Which persisted folder this is for the user (home, pinned, custom_products).
+
+  * `home` - Home
+  * `pinned` - Pinned
+  * `custom_products` - Custom Products */
+    type: PersistedFolderTypeEnumApi
+    /**
+     * Protocol prefix of the folder location, e.g. 'products://'.
+     * @maxLength 64
+     */
+    protocol?: string
+    /** Path within the protocol that the folder resolves to. */
+    path?: string
+    readonly created_at: string
+    readonly updated_at: string
+}
+
+export interface PaginatedPersistedFolderListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: PersistedFolderApi[]
+}
+
+export interface PatchedPersistedFolderApi {
+    readonly id?: string
+    /** Which persisted folder this is for the user (home, pinned, custom_products).
+
+  * `home` - Home
+  * `pinned` - Pinned
+  * `custom_products` - Custom Products */
+    type?: PersistedFolderTypeEnumApi
+    /**
+     * Protocol prefix of the folder location, e.g. 'products://'.
+     * @maxLength 64
+     */
+    protocol?: string
+    /** Path within the protocol that the folder resolves to. */
+    path?: string
+    readonly created_at?: string
+    readonly updated_at?: string
+}
+
+/**
+ * * `image/png` - image/png
+ * `application/pdf` - application/pdf
+ * `text/csv` - text/csv
+ * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+ * `video/webm` - video/webm
+ * `video/mp4` - video/mp4
+ * `image/gif` - image/gif
+ * `application/json` - application/json
+ */
+export type ExportFormatEnumApi = (typeof ExportFormatEnumApi)[keyof typeof ExportFormatEnumApi]
+
+export const ExportFormatEnumApi = {
+    ImagePng: 'image/png',
+    ApplicationPdf: 'application/pdf',
+    TextCsv: 'text/csv',
+    ApplicationVndopenxmlformatsOfficedocumentspreadsheetmlsheet:
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    VideoWebm: 'video/webm',
+    VideoMp4: 'video/mp4',
+    ImageGif: 'image/gif',
+    ApplicationJson: 'application/json',
+} as const
+
+/**
+ * Standard ExportedAsset serializer that doesn't return content.
+ */
+export interface ExportedAssetApi {
+    readonly id: number
+    /** @nullable */
+    dashboard?: number | null
+    /** @nullable */
+    insight?: number | null
+    export_format: ExportFormatEnumApi
+    readonly created_at: string
+    readonly has_content: boolean
+    export_context?: unknown
+    readonly filename: string
+    /** @nullable */
+    readonly expires_after: string | null
+    /** @nullable */
+    readonly exception: string | null
+}
+
+export interface PaginatedExportedAssetListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ExportedAssetApi[]
 }
 
 export interface ProjectSecretAPIKeyApi {
@@ -3405,6 +3537,43 @@ export type OrganizationsProjectsListParams = {
     search?: string
 }
 
+export type DesktopFileSystemListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+    /**
+     * A search term.
+     */
+    search?: string
+}
+
+export type DesktopFileSystemShortcutListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type DesktopPersistedFolderListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
 export type ExportsListParams = {
     /**
      * Number of results to return per page.
@@ -3429,6 +3598,28 @@ export type FileSystemListParams = {
      * A search term.
      */
     search?: string
+}
+
+export type FileSystemShortcutListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type PersistedFolderListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
 }
 
 export type ProjectSecretApiKeysListParams = {

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -14,12 +14,18 @@ import type {
     CIMDVerificationTokenApi,
     CIMDVerificationTokenWithValueApi,
     CimdVerificationTokensListParams,
+    DesktopFileSystemListParams,
+    DesktopFileSystemShortcutListParams,
+    DesktopPersistedFolderListParams,
     DomainsListParams,
     EnterprisePropertyDefinitionApi,
     ExportedAssetApi,
     ExportsListParams,
     FileSystemApi,
     FileSystemListParams,
+    FileSystemShortcutApi,
+    FileSystemShortcutListParams,
+    FileSystemShortcutReorderApi,
     GitHubBranchesResponseApi,
     GitHubReposRefreshResponseApi,
     GitHubReposResponseApi,
@@ -34,9 +40,11 @@ import type {
     PaginatedEnterprisePropertyDefinitionListApi,
     PaginatedExportedAssetListApi,
     PaginatedFileSystemListApi,
+    PaginatedFileSystemShortcutListApi,
     PaginatedOrganizationDomainListApi,
     PaginatedOrganizationInviteListApi,
     PaginatedOrganizationOAuthApplicationListApi,
+    PaginatedPersistedFolderListApi,
     PaginatedProjectBackwardCompatBasicListApi,
     PaginatedProjectSecretAPIKeyListApi,
     PaginatedSubscriptionDeliveryListApi,
@@ -45,11 +53,15 @@ import type {
     PaginatedUserListApi,
     PatchedEnterprisePropertyDefinitionApi,
     PatchedFileSystemApi,
+    PatchedFileSystemShortcutApi,
     PatchedOrganizationDomainApi,
+    PatchedPersistedFolderApi,
     PatchedProjectBackwardCompatApi,
     PatchedProjectSecretAPIKeyApi,
     PatchedSubscriptionApi,
     PatchedUserApi,
+    PersistedFolderApi,
+    PersistedFolderListParams,
     ProjectBackwardCompatApi,
     ProjectSecretAPIKeyApi,
     ProjectSecretApiKeysListParams,
@@ -1033,6 +1045,596 @@ export const dashboardsSharingRefreshCreate = async (
     })
 }
 
+export const getDesktopFileSystemListUrl = (projectId: string, params?: DesktopFileSystemListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/desktop_file_system/?${stringifiedParams}`
+        : `/api/projects/${projectId}/desktop_file_system/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemList = async (
+    projectId: string,
+    params?: DesktopFileSystemListParams,
+    options?: RequestInit
+): Promise<PaginatedFileSystemListApi> => {
+    return apiMutator<PaginatedFileSystemListApi>(getDesktopFileSystemListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDesktopFileSystemCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemCreate = async (
+    projectId: string,
+    fileSystemApi: NonReadonly<FileSystemApi>,
+    options?: RequestInit
+): Promise<FileSystemApi> => {
+    return apiMutator<FileSystemApi>(getDesktopFileSystemCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemApi),
+    })
+}
+
+export const getDesktopFileSystemRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/${id}/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<FileSystemApi> => {
+    return apiMutator<FileSystemApi>(getDesktopFileSystemRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDesktopFileSystemUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/${id}/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemUpdate = async (
+    projectId: string,
+    id: string,
+    fileSystemApi: NonReadonly<FileSystemApi>,
+    options?: RequestInit
+): Promise<FileSystemApi> => {
+    return apiMutator<FileSystemApi>(getDesktopFileSystemUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemApi),
+    })
+}
+
+export const getDesktopFileSystemPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/${id}/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedFileSystemApi?: NonReadonly<PatchedFileSystemApi>,
+    options?: RequestInit
+): Promise<FileSystemApi> => {
+    return apiMutator<FileSystemApi>(getDesktopFileSystemPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedFileSystemApi),
+    })
+}
+
+export const getDesktopFileSystemDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/${id}/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getDesktopFileSystemDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getDesktopFileSystemCountCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/${id}/count/`
+}
+
+/**
+ * Get count of all files in a folder.
+ */
+export const desktopFileSystemCountCreate = async (
+    projectId: string,
+    id: string,
+    fileSystemApi: NonReadonly<FileSystemApi>,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getDesktopFileSystemCountCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemApi),
+    })
+}
+
+export const getDesktopFileSystemLinkCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/${id}/link/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemLinkCreate = async (
+    projectId: string,
+    id: string,
+    fileSystemApi: NonReadonly<FileSystemApi>,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getDesktopFileSystemLinkCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemApi),
+    })
+}
+
+export const getDesktopFileSystemMoveCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/${id}/move/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemMoveCreate = async (
+    projectId: string,
+    id: string,
+    fileSystemApi: NonReadonly<FileSystemApi>,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getDesktopFileSystemMoveCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemApi),
+    })
+}
+
+export const getDesktopFileSystemCountByPathCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/count_by_path/`
+}
+
+/**
+ * Get count of all files in a folder.
+ */
+export const desktopFileSystemCountByPathCreate = async (
+    projectId: string,
+    fileSystemApi: NonReadonly<FileSystemApi>,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getDesktopFileSystemCountByPathCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemApi),
+    })
+}
+
+export const getDesktopFileSystemLogViewRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/log_view/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemLogViewRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getDesktopFileSystemLogViewRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDesktopFileSystemLogViewCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/log_view/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemLogViewCreate = async (
+    projectId: string,
+    fileSystemApi: NonReadonly<FileSystemApi>,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getDesktopFileSystemLogViewCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemApi),
+    })
+}
+
+export const getDesktopFileSystemUndoDeleteCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/undo_delete/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemUndoDeleteCreate = async (
+    projectId: string,
+    fileSystemApi: NonReadonly<FileSystemApi>,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getDesktopFileSystemUndoDeleteCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemApi),
+    })
+}
+
+export const getDesktopFileSystemUnfiledRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/unfiled/`
+}
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemUnfiledRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getDesktopFileSystemUnfiledRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDesktopFileSystemShortcutListUrl = (
+    projectId: string,
+    params?: DesktopFileSystemShortcutListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/desktop_file_system_shortcut/?${stringifiedParams}`
+        : `/api/projects/${projectId}/desktop_file_system_shortcut/`
+}
+
+/**
+ * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
+behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+the default "web" surface.
+ */
+export const desktopFileSystemShortcutList = async (
+    projectId: string,
+    params?: DesktopFileSystemShortcutListParams,
+    options?: RequestInit
+): Promise<PaginatedFileSystemShortcutListApi> => {
+    return apiMutator<PaginatedFileSystemShortcutListApi>(getDesktopFileSystemShortcutListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDesktopFileSystemShortcutCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop_file_system_shortcut/`
+}
+
+/**
+ * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
+behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+the default "web" surface.
+ */
+export const desktopFileSystemShortcutCreate = async (
+    projectId: string,
+    fileSystemShortcutApi: NonReadonly<FileSystemShortcutApi>,
+    options?: RequestInit
+): Promise<FileSystemShortcutApi> => {
+    return apiMutator<FileSystemShortcutApi>(getDesktopFileSystemShortcutCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemShortcutApi),
+    })
+}
+
+export const getDesktopFileSystemShortcutRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system_shortcut/${id}/`
+}
+
+/**
+ * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
+behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+the default "web" surface.
+ */
+export const desktopFileSystemShortcutRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<FileSystemShortcutApi> => {
+    return apiMutator<FileSystemShortcutApi>(getDesktopFileSystemShortcutRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDesktopFileSystemShortcutUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system_shortcut/${id}/`
+}
+
+/**
+ * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
+behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+the default "web" surface.
+ */
+export const desktopFileSystemShortcutUpdate = async (
+    projectId: string,
+    id: string,
+    fileSystemShortcutApi: NonReadonly<FileSystemShortcutApi>,
+    options?: RequestInit
+): Promise<FileSystemShortcutApi> => {
+    return apiMutator<FileSystemShortcutApi>(getDesktopFileSystemShortcutUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemShortcutApi),
+    })
+}
+
+export const getDesktopFileSystemShortcutPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system_shortcut/${id}/`
+}
+
+/**
+ * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
+behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+the default "web" surface.
+ */
+export const desktopFileSystemShortcutPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedFileSystemShortcutApi?: NonReadonly<PatchedFileSystemShortcutApi>,
+    options?: RequestInit
+): Promise<FileSystemShortcutApi> => {
+    return apiMutator<FileSystemShortcutApi>(getDesktopFileSystemShortcutPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedFileSystemShortcutApi),
+    })
+}
+
+export const getDesktopFileSystemShortcutDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system_shortcut/${id}/`
+}
+
+/**
+ * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
+behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+the default "web" surface.
+ */
+export const desktopFileSystemShortcutDestroy = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getDesktopFileSystemShortcutDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getDesktopFileSystemShortcutReorderCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop_file_system_shortcut/reorder/`
+}
+
+/**
+ * Set the display order of the current user's shortcuts. `ordered_ids` becomes the new top-to-bottom order; any unknown IDs are rejected.
+ */
+export const desktopFileSystemShortcutReorderCreate = async (
+    projectId: string,
+    fileSystemShortcutReorderApi: FileSystemShortcutReorderApi,
+    options?: RequestInit
+): Promise<PaginatedFileSystemShortcutListApi> => {
+    return apiMutator<PaginatedFileSystemShortcutListApi>(getDesktopFileSystemShortcutReorderCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemShortcutReorderApi),
+    })
+}
+
+export const getDesktopPersistedFolderListUrl = (projectId: string, params?: DesktopPersistedFolderListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/desktop_persisted_folder/?${stringifiedParams}`
+        : `/api/projects/${projectId}/desktop_persisted_folder/`
+}
+
+/**
+ * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
+but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+"web" surface.
+ */
+export const desktopPersistedFolderList = async (
+    projectId: string,
+    params?: DesktopPersistedFolderListParams,
+    options?: RequestInit
+): Promise<PaginatedPersistedFolderListApi> => {
+    return apiMutator<PaginatedPersistedFolderListApi>(getDesktopPersistedFolderListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDesktopPersistedFolderCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop_persisted_folder/`
+}
+
+/**
+ * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
+but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+"web" surface.
+ */
+export const desktopPersistedFolderCreate = async (
+    projectId: string,
+    persistedFolderApi: NonReadonly<PersistedFolderApi>,
+    options?: RequestInit
+): Promise<PersistedFolderApi> => {
+    return apiMutator<PersistedFolderApi>(getDesktopPersistedFolderCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(persistedFolderApi),
+    })
+}
+
+export const getDesktopPersistedFolderRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_persisted_folder/${id}/`
+}
+
+/**
+ * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
+but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+"web" surface.
+ */
+export const desktopPersistedFolderRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<PersistedFolderApi> => {
+    return apiMutator<PersistedFolderApi>(getDesktopPersistedFolderRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDesktopPersistedFolderUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_persisted_folder/${id}/`
+}
+
+/**
+ * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
+but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+"web" surface.
+ */
+export const desktopPersistedFolderUpdate = async (
+    projectId: string,
+    id: string,
+    persistedFolderApi: NonReadonly<PersistedFolderApi>,
+    options?: RequestInit
+): Promise<PersistedFolderApi> => {
+    return apiMutator<PersistedFolderApi>(getDesktopPersistedFolderUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(persistedFolderApi),
+    })
+}
+
+export const getDesktopPersistedFolderPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_persisted_folder/${id}/`
+}
+
+/**
+ * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
+but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+"web" surface.
+ */
+export const desktopPersistedFolderPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedPersistedFolderApi?: NonReadonly<PatchedPersistedFolderApi>,
+    options?: RequestInit
+): Promise<PersistedFolderApi> => {
+    return apiMutator<PersistedFolderApi>(getDesktopPersistedFolderPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedPersistedFolderApi),
+    })
+}
+
+export const getDesktopPersistedFolderDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_persisted_folder/${id}/`
+}
+
+/**
+ * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
+but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+"web" surface.
+ */
+export const desktopPersistedFolderDestroy = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getDesktopPersistedFolderDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
 export const getExportsListUrl = (projectId: string, params?: ExportsListParams) => {
     const normalizedParams = new URLSearchParams()
 
@@ -1342,6 +1944,136 @@ export const fileSystemUnfiledRetrieve = async (projectId: string, options?: Req
     })
 }
 
+export const getFileSystemShortcutListUrl = (projectId: string, params?: FileSystemShortcutListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/file_system_shortcut/?${stringifiedParams}`
+        : `/api/projects/${projectId}/file_system_shortcut/`
+}
+
+export const fileSystemShortcutList = async (
+    projectId: string,
+    params?: FileSystemShortcutListParams,
+    options?: RequestInit
+): Promise<PaginatedFileSystemShortcutListApi> => {
+    return apiMutator<PaginatedFileSystemShortcutListApi>(getFileSystemShortcutListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getFileSystemShortcutCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/file_system_shortcut/`
+}
+
+export const fileSystemShortcutCreate = async (
+    projectId: string,
+    fileSystemShortcutApi: NonReadonly<FileSystemShortcutApi>,
+    options?: RequestInit
+): Promise<FileSystemShortcutApi> => {
+    return apiMutator<FileSystemShortcutApi>(getFileSystemShortcutCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemShortcutApi),
+    })
+}
+
+export const getFileSystemShortcutRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/file_system_shortcut/${id}/`
+}
+
+export const fileSystemShortcutRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<FileSystemShortcutApi> => {
+    return apiMutator<FileSystemShortcutApi>(getFileSystemShortcutRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getFileSystemShortcutUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/file_system_shortcut/${id}/`
+}
+
+export const fileSystemShortcutUpdate = async (
+    projectId: string,
+    id: string,
+    fileSystemShortcutApi: NonReadonly<FileSystemShortcutApi>,
+    options?: RequestInit
+): Promise<FileSystemShortcutApi> => {
+    return apiMutator<FileSystemShortcutApi>(getFileSystemShortcutUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemShortcutApi),
+    })
+}
+
+export const getFileSystemShortcutPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/file_system_shortcut/${id}/`
+}
+
+export const fileSystemShortcutPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedFileSystemShortcutApi?: NonReadonly<PatchedFileSystemShortcutApi>,
+    options?: RequestInit
+): Promise<FileSystemShortcutApi> => {
+    return apiMutator<FileSystemShortcutApi>(getFileSystemShortcutPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedFileSystemShortcutApi),
+    })
+}
+
+export const getFileSystemShortcutDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/file_system_shortcut/${id}/`
+}
+
+export const fileSystemShortcutDestroy = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getFileSystemShortcutDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getFileSystemShortcutReorderCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/file_system_shortcut/reorder/`
+}
+
+/**
+ * Set the display order of the current user's shortcuts. `ordered_ids` becomes the new top-to-bottom order; any unknown IDs are rejected.
+ */
+export const fileSystemShortcutReorderCreate = async (
+    projectId: string,
+    fileSystemShortcutReorderApi: FileSystemShortcutReorderApi,
+    options?: RequestInit
+): Promise<PaginatedFileSystemShortcutListApi> => {
+    return apiMutator<PaginatedFileSystemShortcutListApi>(getFileSystemShortcutReorderCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(fileSystemShortcutReorderApi),
+    })
+}
+
 export const getInsightsSharingListUrl = (projectId: string, insightId: number) => {
     return `/api/projects/${projectId}/insights/${insightId}/sharing/`
 }
@@ -1485,6 +2217,112 @@ export const notebooksSharingRefreshCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(sharingConfigurationApi),
+    })
+}
+
+export const getPersistedFolderListUrl = (projectId: string, params?: PersistedFolderListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/persisted_folder/?${stringifiedParams}`
+        : `/api/projects/${projectId}/persisted_folder/`
+}
+
+export const persistedFolderList = async (
+    projectId: string,
+    params?: PersistedFolderListParams,
+    options?: RequestInit
+): Promise<PaginatedPersistedFolderListApi> => {
+    return apiMutator<PaginatedPersistedFolderListApi>(getPersistedFolderListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getPersistedFolderCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/persisted_folder/`
+}
+
+export const persistedFolderCreate = async (
+    projectId: string,
+    persistedFolderApi: NonReadonly<PersistedFolderApi>,
+    options?: RequestInit
+): Promise<PersistedFolderApi> => {
+    return apiMutator<PersistedFolderApi>(getPersistedFolderCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(persistedFolderApi),
+    })
+}
+
+export const getPersistedFolderRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/persisted_folder/${id}/`
+}
+
+export const persistedFolderRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<PersistedFolderApi> => {
+    return apiMutator<PersistedFolderApi>(getPersistedFolderRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getPersistedFolderUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/persisted_folder/${id}/`
+}
+
+export const persistedFolderUpdate = async (
+    projectId: string,
+    id: string,
+    persistedFolderApi: NonReadonly<PersistedFolderApi>,
+    options?: RequestInit
+): Promise<PersistedFolderApi> => {
+    return apiMutator<PersistedFolderApi>(getPersistedFolderUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(persistedFolderApi),
+    })
+}
+
+export const getPersistedFolderPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/persisted_folder/${id}/`
+}
+
+export const persistedFolderPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedPersistedFolderApi?: NonReadonly<PatchedPersistedFolderApi>,
+    options?: RequestInit
+): Promise<PersistedFolderApi> => {
+    return apiMutator<PersistedFolderApi>(getPersistedFolderPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedPersistedFolderApi),
+    })
+}
+
+export const getPersistedFolderDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/persisted_folder/${id}/`
+}
+
+export const persistedFolderDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getPersistedFolderDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
     })
 }
 

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -2411,6 +2411,339 @@ export const DashboardsSharingRefreshCreateBody = /* @__PURE__ */ zod.object({
     password_required: zod.boolean().optional(),
 })
 
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemCreateBodyTypeMax = 100
+
+export const desktopFileSystemCreateBodyRefMax = 100
+
+export const DesktopFileSystemCreateBody = /* @__PURE__ */ zod.object({
+    path: zod.string(),
+    type: zod.string().max(desktopFileSystemCreateBodyTypeMax).optional(),
+    ref: zod.string().max(desktopFileSystemCreateBodyRefMax).nullish(),
+    href: zod.string().nullish(),
+    meta: zod.unknown().optional(),
+    shortcut: zod.boolean().nullish(),
+})
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemUpdateBodyTypeMax = 100
+
+export const desktopFileSystemUpdateBodyRefMax = 100
+
+export const DesktopFileSystemUpdateBody = /* @__PURE__ */ zod.object({
+    path: zod.string(),
+    type: zod.string().max(desktopFileSystemUpdateBodyTypeMax).optional(),
+    ref: zod.string().max(desktopFileSystemUpdateBodyRefMax).nullish(),
+    href: zod.string().nullish(),
+    meta: zod.unknown().optional(),
+    shortcut: zod.boolean().nullish(),
+})
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemPartialUpdateBodyTypeMax = 100
+
+export const desktopFileSystemPartialUpdateBodyRefMax = 100
+
+export const DesktopFileSystemPartialUpdateBody = /* @__PURE__ */ zod.object({
+    path: zod.string().optional(),
+    type: zod.string().max(desktopFileSystemPartialUpdateBodyTypeMax).optional(),
+    ref: zod.string().max(desktopFileSystemPartialUpdateBodyRefMax).nullish(),
+    href: zod.string().nullish(),
+    meta: zod.unknown().optional(),
+    shortcut: zod.boolean().nullish(),
+})
+
+/**
+ * Get count of all files in a folder.
+ */
+export const desktopFileSystemCountCreateBodyTypeMax = 100
+
+export const desktopFileSystemCountCreateBodyRefMax = 100
+
+export const DesktopFileSystemCountCreateBody = /* @__PURE__ */ zod.object({
+    path: zod.string(),
+    type: zod.string().max(desktopFileSystemCountCreateBodyTypeMax).optional(),
+    ref: zod.string().max(desktopFileSystemCountCreateBodyRefMax).nullish(),
+    href: zod.string().nullish(),
+    meta: zod.unknown().optional(),
+    shortcut: zod.boolean().nullish(),
+})
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemLinkCreateBodyTypeMax = 100
+
+export const desktopFileSystemLinkCreateBodyRefMax = 100
+
+export const DesktopFileSystemLinkCreateBody = /* @__PURE__ */ zod.object({
+    path: zod.string(),
+    type: zod.string().max(desktopFileSystemLinkCreateBodyTypeMax).optional(),
+    ref: zod.string().max(desktopFileSystemLinkCreateBodyRefMax).nullish(),
+    href: zod.string().nullish(),
+    meta: zod.unknown().optional(),
+    shortcut: zod.boolean().nullish(),
+})
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemMoveCreateBodyTypeMax = 100
+
+export const desktopFileSystemMoveCreateBodyRefMax = 100
+
+export const DesktopFileSystemMoveCreateBody = /* @__PURE__ */ zod.object({
+    path: zod.string(),
+    type: zod.string().max(desktopFileSystemMoveCreateBodyTypeMax).optional(),
+    ref: zod.string().max(desktopFileSystemMoveCreateBodyRefMax).nullish(),
+    href: zod.string().nullish(),
+    meta: zod.unknown().optional(),
+    shortcut: zod.boolean().nullish(),
+})
+
+/**
+ * Get count of all files in a folder.
+ */
+export const desktopFileSystemCountByPathCreateBodyTypeMax = 100
+
+export const desktopFileSystemCountByPathCreateBodyRefMax = 100
+
+export const DesktopFileSystemCountByPathCreateBody = /* @__PURE__ */ zod.object({
+    path: zod.string(),
+    type: zod.string().max(desktopFileSystemCountByPathCreateBodyTypeMax).optional(),
+    ref: zod.string().max(desktopFileSystemCountByPathCreateBodyRefMax).nullish(),
+    href: zod.string().nullish(),
+    meta: zod.unknown().optional(),
+    shortcut: zod.boolean().nullish(),
+})
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemLogViewCreateBodyTypeMax = 100
+
+export const desktopFileSystemLogViewCreateBodyRefMax = 100
+
+export const DesktopFileSystemLogViewCreateBody = /* @__PURE__ */ zod.object({
+    path: zod.string(),
+    type: zod.string().max(desktopFileSystemLogViewCreateBodyTypeMax).optional(),
+    ref: zod.string().max(desktopFileSystemLogViewCreateBodyRefMax).nullish(),
+    href: zod.string().nullish(),
+    meta: zod.unknown().optional(),
+    shortcut: zod.boolean().nullish(),
+})
+
+/**
+ * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ */
+export const desktopFileSystemUndoDeleteCreateBodyTypeMax = 100
+
+export const desktopFileSystemUndoDeleteCreateBodyRefMax = 100
+
+export const DesktopFileSystemUndoDeleteCreateBody = /* @__PURE__ */ zod.object({
+    path: zod.string(),
+    type: zod.string().max(desktopFileSystemUndoDeleteCreateBodyTypeMax).optional(),
+    ref: zod.string().max(desktopFileSystemUndoDeleteCreateBodyRefMax).nullish(),
+    href: zod.string().nullish(),
+    meta: zod.unknown().optional(),
+    shortcut: zod.boolean().nullish(),
+})
+
+/**
+ * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
+behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+the default "web" surface.
+ */
+export const desktopFileSystemShortcutCreateBodyTypeMax = 100
+
+export const desktopFileSystemShortcutCreateBodyRefMax = 100
+
+export const desktopFileSystemShortcutCreateBodyOrderMin = -2147483648
+export const desktopFileSystemShortcutCreateBodyOrderMax = 2147483647
+
+export const DesktopFileSystemShortcutCreateBody = /* @__PURE__ */ zod.object({
+    path: zod.string().describe('Display path of the shortcut in the sidebar.'),
+    type: zod
+        .string()
+        .max(desktopFileSystemShortcutCreateBodyTypeMax)
+        .optional()
+        .describe("Type of the linked item (e.g. 'folder', 'insight'), or blank."),
+    ref: zod
+        .string()
+        .max(desktopFileSystemShortcutCreateBodyRefMax)
+        .nullish()
+        .describe('Reference to the linked item, scoped to its type. Null for href-only shortcuts.'),
+    href: zod
+        .string()
+        .nullish()
+        .describe('Destination URL the shortcut opens. Null when the shortcut points at an item by ref.'),
+    order: zod
+        .number()
+        .min(desktopFileSystemShortcutCreateBodyOrderMin)
+        .max(desktopFileSystemShortcutCreateBodyOrderMax)
+        .optional()
+        .describe("Display order within the user's shortcut list, ascending."),
+})
+
+/**
+ * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
+behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+the default "web" surface.
+ */
+export const desktopFileSystemShortcutUpdateBodyTypeMax = 100
+
+export const desktopFileSystemShortcutUpdateBodyRefMax = 100
+
+export const desktopFileSystemShortcutUpdateBodyOrderMin = -2147483648
+export const desktopFileSystemShortcutUpdateBodyOrderMax = 2147483647
+
+export const DesktopFileSystemShortcutUpdateBody = /* @__PURE__ */ zod.object({
+    path: zod.string().describe('Display path of the shortcut in the sidebar.'),
+    type: zod
+        .string()
+        .max(desktopFileSystemShortcutUpdateBodyTypeMax)
+        .optional()
+        .describe("Type of the linked item (e.g. 'folder', 'insight'), or blank."),
+    ref: zod
+        .string()
+        .max(desktopFileSystemShortcutUpdateBodyRefMax)
+        .nullish()
+        .describe('Reference to the linked item, scoped to its type. Null for href-only shortcuts.'),
+    href: zod
+        .string()
+        .nullish()
+        .describe('Destination URL the shortcut opens. Null when the shortcut points at an item by ref.'),
+    order: zod
+        .number()
+        .min(desktopFileSystemShortcutUpdateBodyOrderMin)
+        .max(desktopFileSystemShortcutUpdateBodyOrderMax)
+        .optional()
+        .describe("Display order within the user's shortcut list, ascending."),
+})
+
+/**
+ * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
+behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+the default "web" surface.
+ */
+export const desktopFileSystemShortcutPartialUpdateBodyTypeMax = 100
+
+export const desktopFileSystemShortcutPartialUpdateBodyRefMax = 100
+
+export const desktopFileSystemShortcutPartialUpdateBodyOrderMin = -2147483648
+export const desktopFileSystemShortcutPartialUpdateBodyOrderMax = 2147483647
+
+export const DesktopFileSystemShortcutPartialUpdateBody = /* @__PURE__ */ zod.object({
+    path: zod.string().optional().describe('Display path of the shortcut in the sidebar.'),
+    type: zod
+        .string()
+        .max(desktopFileSystemShortcutPartialUpdateBodyTypeMax)
+        .optional()
+        .describe("Type of the linked item (e.g. 'folder', 'insight'), or blank."),
+    ref: zod
+        .string()
+        .max(desktopFileSystemShortcutPartialUpdateBodyRefMax)
+        .nullish()
+        .describe('Reference to the linked item, scoped to its type. Null for href-only shortcuts.'),
+    href: zod
+        .string()
+        .nullish()
+        .describe('Destination URL the shortcut opens. Null when the shortcut points at an item by ref.'),
+    order: zod
+        .number()
+        .min(desktopFileSystemShortcutPartialUpdateBodyOrderMin)
+        .max(desktopFileSystemShortcutPartialUpdateBodyOrderMax)
+        .optional()
+        .describe("Display order within the user's shortcut list, ascending."),
+})
+
+/**
+ * Set the display order of the current user's shortcuts. `ordered_ids` becomes the new top-to-bottom order; any unknown IDs are rejected.
+ */
+export const DesktopFileSystemShortcutReorderCreateBody = /* @__PURE__ */ zod.object({
+    ordered_ids: zod.array(zod.uuid()).describe("IDs of the current user's shortcuts in the desired display order."),
+})
+
+/**
+ * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
+but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+"web" surface.
+ */
+export const desktopPersistedFolderCreateBodyProtocolMax = 64
+
+export const DesktopPersistedFolderCreateBody = /* @__PURE__ */ zod.object({
+    type: zod
+        .enum(['home', 'pinned', 'custom_products'])
+        .describe('\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products')
+        .describe(
+            'Which persisted folder this is for the user (home, pinned, custom_products).\n\n\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products'
+        ),
+    protocol: zod
+        .string()
+        .max(desktopPersistedFolderCreateBodyProtocolMax)
+        .optional()
+        .describe("Protocol prefix of the folder location, e.g. 'products:\/\/'."),
+    path: zod.string().optional().describe('Path within the protocol that the folder resolves to.'),
+})
+
+/**
+ * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
+but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+"web" surface.
+ */
+export const desktopPersistedFolderUpdateBodyProtocolMax = 64
+
+export const DesktopPersistedFolderUpdateBody = /* @__PURE__ */ zod.object({
+    type: zod
+        .enum(['home', 'pinned', 'custom_products'])
+        .describe('\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products')
+        .describe(
+            'Which persisted folder this is for the user (home, pinned, custom_products).\n\n\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products'
+        ),
+    protocol: zod
+        .string()
+        .max(desktopPersistedFolderUpdateBodyProtocolMax)
+        .optional()
+        .describe("Protocol prefix of the folder location, e.g. 'products:\/\/'."),
+    path: zod.string().optional().describe('Path within the protocol that the folder resolves to.'),
+})
+
+/**
+ * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
+but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+"web" surface.
+ */
+export const desktopPersistedFolderPartialUpdateBodyProtocolMax = 64
+
+export const DesktopPersistedFolderPartialUpdateBody = /* @__PURE__ */ zod.object({
+    type: zod
+        .enum(['home', 'pinned', 'custom_products'])
+        .describe('\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products')
+        .optional()
+        .describe(
+            'Which persisted folder this is for the user (home, pinned, custom_products).\n\n\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products'
+        ),
+    protocol: zod
+        .string()
+        .max(desktopPersistedFolderPartialUpdateBodyProtocolMax)
+        .optional()
+        .describe("Protocol prefix of the folder location, e.g. 'products:\/\/'."),
+    path: zod.string().optional().describe('Path within the protocol that the folder resolves to.'),
+})
+
 export const ExportsCreateBody = /* @__PURE__ */ zod
     .object({
         dashboard: zod.number().nullish(),
@@ -2556,6 +2889,106 @@ export const FileSystemUndoDeleteCreateBody = /* @__PURE__ */ zod.object({
     shortcut: zod.boolean().nullish(),
 })
 
+export const fileSystemShortcutCreateBodyTypeMax = 100
+
+export const fileSystemShortcutCreateBodyRefMax = 100
+
+export const fileSystemShortcutCreateBodyOrderMin = -2147483648
+export const fileSystemShortcutCreateBodyOrderMax = 2147483647
+
+export const FileSystemShortcutCreateBody = /* @__PURE__ */ zod.object({
+    path: zod.string().describe('Display path of the shortcut in the sidebar.'),
+    type: zod
+        .string()
+        .max(fileSystemShortcutCreateBodyTypeMax)
+        .optional()
+        .describe("Type of the linked item (e.g. 'folder', 'insight'), or blank."),
+    ref: zod
+        .string()
+        .max(fileSystemShortcutCreateBodyRefMax)
+        .nullish()
+        .describe('Reference to the linked item, scoped to its type. Null for href-only shortcuts.'),
+    href: zod
+        .string()
+        .nullish()
+        .describe('Destination URL the shortcut opens. Null when the shortcut points at an item by ref.'),
+    order: zod
+        .number()
+        .min(fileSystemShortcutCreateBodyOrderMin)
+        .max(fileSystemShortcutCreateBodyOrderMax)
+        .optional()
+        .describe("Display order within the user's shortcut list, ascending."),
+})
+
+export const fileSystemShortcutUpdateBodyTypeMax = 100
+
+export const fileSystemShortcutUpdateBodyRefMax = 100
+
+export const fileSystemShortcutUpdateBodyOrderMin = -2147483648
+export const fileSystemShortcutUpdateBodyOrderMax = 2147483647
+
+export const FileSystemShortcutUpdateBody = /* @__PURE__ */ zod.object({
+    path: zod.string().describe('Display path of the shortcut in the sidebar.'),
+    type: zod
+        .string()
+        .max(fileSystemShortcutUpdateBodyTypeMax)
+        .optional()
+        .describe("Type of the linked item (e.g. 'folder', 'insight'), or blank."),
+    ref: zod
+        .string()
+        .max(fileSystemShortcutUpdateBodyRefMax)
+        .nullish()
+        .describe('Reference to the linked item, scoped to its type. Null for href-only shortcuts.'),
+    href: zod
+        .string()
+        .nullish()
+        .describe('Destination URL the shortcut opens. Null when the shortcut points at an item by ref.'),
+    order: zod
+        .number()
+        .min(fileSystemShortcutUpdateBodyOrderMin)
+        .max(fileSystemShortcutUpdateBodyOrderMax)
+        .optional()
+        .describe("Display order within the user's shortcut list, ascending."),
+})
+
+export const fileSystemShortcutPartialUpdateBodyTypeMax = 100
+
+export const fileSystemShortcutPartialUpdateBodyRefMax = 100
+
+export const fileSystemShortcutPartialUpdateBodyOrderMin = -2147483648
+export const fileSystemShortcutPartialUpdateBodyOrderMax = 2147483647
+
+export const FileSystemShortcutPartialUpdateBody = /* @__PURE__ */ zod.object({
+    path: zod.string().optional().describe('Display path of the shortcut in the sidebar.'),
+    type: zod
+        .string()
+        .max(fileSystemShortcutPartialUpdateBodyTypeMax)
+        .optional()
+        .describe("Type of the linked item (e.g. 'folder', 'insight'), or blank."),
+    ref: zod
+        .string()
+        .max(fileSystemShortcutPartialUpdateBodyRefMax)
+        .nullish()
+        .describe('Reference to the linked item, scoped to its type. Null for href-only shortcuts.'),
+    href: zod
+        .string()
+        .nullish()
+        .describe('Destination URL the shortcut opens. Null when the shortcut points at an item by ref.'),
+    order: zod
+        .number()
+        .min(fileSystemShortcutPartialUpdateBodyOrderMin)
+        .max(fileSystemShortcutPartialUpdateBodyOrderMax)
+        .optional()
+        .describe("Display order within the user's shortcut list, ascending."),
+})
+
+/**
+ * Set the display order of the current user's shortcuts. `ordered_ids` becomes the new top-to-bottom order; any unknown IDs are rejected.
+ */
+export const FileSystemShortcutReorderCreateBody = /* @__PURE__ */ zod.object({
+    ordered_ids: zod.array(zod.uuid()).describe("IDs of the current user's shortcuts in the desired display order."),
+})
+
 /**
  * Create a new password for the sharing configuration.
  */
@@ -2584,6 +3017,58 @@ export const NotebooksSharingRefreshCreateBody = /* @__PURE__ */ zod.object({
     enabled: zod.boolean().optional(),
     settings: zod.unknown().optional(),
     password_required: zod.boolean().optional(),
+})
+
+export const persistedFolderCreateBodyProtocolMax = 64
+
+export const PersistedFolderCreateBody = /* @__PURE__ */ zod.object({
+    type: zod
+        .enum(['home', 'pinned', 'custom_products'])
+        .describe('\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products')
+        .describe(
+            'Which persisted folder this is for the user (home, pinned, custom_products).\n\n\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products'
+        ),
+    protocol: zod
+        .string()
+        .max(persistedFolderCreateBodyProtocolMax)
+        .optional()
+        .describe("Protocol prefix of the folder location, e.g. 'products:\/\/'."),
+    path: zod.string().optional().describe('Path within the protocol that the folder resolves to.'),
+})
+
+export const persistedFolderUpdateBodyProtocolMax = 64
+
+export const PersistedFolderUpdateBody = /* @__PURE__ */ zod.object({
+    type: zod
+        .enum(['home', 'pinned', 'custom_products'])
+        .describe('\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products')
+        .describe(
+            'Which persisted folder this is for the user (home, pinned, custom_products).\n\n\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products'
+        ),
+    protocol: zod
+        .string()
+        .max(persistedFolderUpdateBodyProtocolMax)
+        .optional()
+        .describe("Protocol prefix of the folder location, e.g. 'products:\/\/'."),
+    path: zod.string().optional().describe('Path within the protocol that the folder resolves to.'),
+})
+
+export const persistedFolderPartialUpdateBodyProtocolMax = 64
+
+export const PersistedFolderPartialUpdateBody = /* @__PURE__ */ zod.object({
+    type: zod
+        .enum(['home', 'pinned', 'custom_products'])
+        .describe('\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products')
+        .optional()
+        .describe(
+            'Which persisted folder this is for the user (home, pinned, custom_products).\n\n\* `home` - Home\n\* `pinned` - Pinned\n\* `custom_products` - Custom Products'
+        ),
+    protocol: zod
+        .string()
+        .max(persistedFolderPartialUpdateBodyProtocolMax)
+        .optional()
+        .describe("Protocol prefix of the folder location, e.g. 'products:\/\/'."),
+    path: zod.string().optional().describe('Path within the protocol that the folder resolves to.'),
 })
 
 export const projectSecretApiKeysCreateBodyLabelMax = 40

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -540,6 +540,11 @@ export class ApiRequest {
     }
 
     // # File System
+    // These endpoints operate on the "web" surface — the tree shown in this app's sidebar.
+    // Surface is server-controlled per route (clients can't send it): the `file_system*`
+    // routes are pinned to "web" server-side, while the separate `desktop_file_system*` routes
+    // (used by a different app, not this frontend) serve the "desktop" surface. So every call
+    // from this frontend is implicitly and exclusively scoped to "web".
     public fileSystem(teamId?: TeamType['id']): ApiRequest {
         return this.environmentsDetail(teamId).addPathComponent('file_system')
     }

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -502,6 +502,13 @@ register_legacy_dual_route_team_nested_viewset(
     r"file_system", file_system.FileSystemViewSet, "environment_file_system", ["team_id"]
 )
 
+projects_router.register(
+    r"desktop_file_system",
+    file_system.DesktopFileSystemViewSet,
+    "project_desktop_file_system",
+    ["team_id"],
+)
+
 register_legacy_dual_route_team_nested_viewset(
     r"file_system_shortcut",
     file_system_shortcut.FileSystemShortcutViewSet,
@@ -509,10 +516,24 @@ register_legacy_dual_route_team_nested_viewset(
     ["team_id"],
 )
 
+projects_router.register(
+    r"desktop_file_system_shortcut",
+    file_system_shortcut.DesktopFileSystemShortcutViewSet,
+    "project_desktop_file_system_shortcut",
+    ["team_id"],
+)
+
 register_legacy_dual_route_team_nested_viewset(
     r"persisted_folder",
     persisted_folder.PersistedFolderViewSet,
     "environment_persisted_folder",
+    ["team_id"],
+)
+
+projects_router.register(
+    r"desktop_persisted_folder",
+    persisted_folder.DesktopPersistedFolderViewSet,
+    "project_desktop_persisted_folder",
     ["team_id"],
 )
 

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -23,7 +23,14 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action
 from posthog.decorators import disallow_if_impersonated
-from posthog.models.file_system.file_system import FileSystem, create_or_update_file, join_path, split_path
+from posthog.models.file_system.file_system import (
+    DEFAULT_SURFACE,
+    FileSystem,
+    create_or_update_file,
+    join_path,
+    split_path,
+    surface_q,
+)
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.file_system.file_system_view_log import FileSystemViewLog, annotate_file_system_with_view_logs
 from posthog.models.file_system.unfiled_file_saver import save_unfiled_files
@@ -67,13 +74,14 @@ class FileSystemSerializer(serializers.ModelSerializer):
     def create(self, validated_data: dict[str, Any], *args: Any, **kwargs: Any) -> FileSystem:
         request = self.context["request"]
         team = self.context["get_team"]()
+        surface = self.context.get("file_system_surface", DEFAULT_SURFACE)
 
         full_path = validated_data["path"]
         segments = split_path(full_path)
 
         for depth_index in range(1, len(segments)):
             parent_path = "/".join(segments[:depth_index])
-            folder_exists = FileSystem.objects.filter(team=team, path=parent_path).exists()
+            folder_exists = FileSystem.objects.filter(surface_q(surface), team=team, path=parent_path).exists()
             if not folder_exists:
                 FileSystem.objects.create(
                     team=team,
@@ -82,6 +90,7 @@ class FileSystemSerializer(serializers.ModelSerializer):
                     type="folder",
                     created_by=request.user,
                     shortcut=False,
+                    surface=surface,
                 )
 
         if validated_data.get("shortcut") is None:
@@ -92,6 +101,7 @@ class FileSystemSerializer(serializers.ModelSerializer):
             team=team,
             created_by=request.user,
             depth=depth,
+            surface=surface,
             **validated_data,
         )
 
@@ -156,6 +166,9 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     serializer_class = FileSystemSerializer
     filter_backends = [filters.SearchFilter]
     pagination_class = FileSystemsLimitOffsetPagination
+    # Product surface this tree serves. Subclass and override to expose a different surface
+    # (e.g. "desktop") on its own route. The default surface also matches legacy NULL rows.
+    file_system_surface: str = DEFAULT_SURFACE
 
     def _basename_regex(self, value: str) -> str:
         return rf"(^|(?<!\\)/)([^/]|\\.)*{re.escape(value)}([^/]|\\.)*$"
@@ -278,11 +291,16 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         return queryset.filter(combined_q)
 
+    def get_serializer_context(self) -> dict[str, Any]:
+        context = super().get_serializer_context()
+        context["file_system_surface"] = self.file_system_surface
+        return context
+
     def _scope_by_project(self, queryset: QuerySet) -> QuerySet:
         """
-        Show all objects belonging to the project.
+        Show all objects belonging to the project, restricted to this viewset's surface.
         """
-        return queryset.filter(team__project_id=self.team.project_id)
+        return queryset.filter(surface_q(self.file_system_surface), team__project_id=self.team.project_id)
 
     def _scope_by_project_and_environment(self, queryset: QuerySet) -> QuerySet:
         """
@@ -554,7 +572,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         query_serializer = UnfiledFilesQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)
         file_type = query_serializer.validated_data.get("type")
-        files = save_unfiled_files(self.team, cast(User, request.user), file_type)
+        files = save_unfiled_files(self.team, cast(User, request.user), file_type, surface=self.file_system_surface)
 
         self._retroactively_fix_folders_and_depth(cast(User, request.user))
 
@@ -717,6 +735,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             name="",
             href="",
             meta={},
+            surface=self.file_system_surface,
         )
 
         log_api_file_system_view(
@@ -737,7 +756,9 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         validated = serializer.validated_data
 
-        queryset = FileSystemViewLog.objects.filter(team=self.team, user=request.user)
+        queryset = FileSystemViewLog.objects.filter(
+            surface_q(self.file_system_surface), team=self.team, user=request.user
+        )
         log_type = validated.get("type")
         if log_type:
             queryset = queryset.filter(type=log_type)
@@ -793,6 +814,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     depth=depth_index,
                     type="folder",
                     created_by=created_by,
+                    surface=self.file_system_surface,
                 )
 
     def _restore_file_system_path(self, instance: Any, payload: dict[str, Any]) -> None:
@@ -811,7 +833,9 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         self._assure_parent_folders(restore_path, created_by_user, team)
 
-        update_count = FileSystem.objects.filter(team=team, type=payload["type"], ref=payload["ref"]).update(
+        update_count = FileSystem.objects.filter(
+            surface_q(self.file_system_surface), team=team, type=payload["type"], ref=payload["ref"]
+        ).update(
             path=restore_path,
             depth=len(split_path(restore_path)),
         )
@@ -831,6 +855,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 meta=fs_data.meta,
                 created_at=fs_data.meta.get("created_at"),
                 created_by_id=fs_data.meta.get("created_by"),
+                surface=self.file_system_surface,
             )
 
     def _retroactively_fix_folders_and_depth(self, user: User) -> None:
@@ -871,6 +896,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                             depth=depth_index,
                             type="folder",
                             created_by=user,
+                            surface=self.file_system_surface,
                         )
                     )
 
@@ -880,3 +906,13 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if items_to_update:
             for item in items_to_update:
                 item.save()
+
+
+@extend_schema(extensions={"x-product": "core"})
+class DesktopFileSystemViewSet(FileSystemViewSet):
+    """
+    The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
+    scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+    """
+
+    file_system_surface = "desktop"

--- a/posthog/api/file_system/file_system_shortcut.py
+++ b/posthog/api/file_system/file_system_shortcut.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models import User
+from posthog.models.file_system.constants import DEFAULT_SURFACE, surface_q
 from posthog.models.file_system.file_system_shortcut import FileSystemShortcut
 
 
@@ -31,6 +32,15 @@ class FileSystemShortcutSerializer(serializers.ModelSerializer):
             "id",
             "created_at",
         ]
+        extra_kwargs = {
+            "path": {"help_text": "Display path of the shortcut in the sidebar."},
+            "type": {"help_text": "Type of the linked item (e.g. 'folder', 'insight'), or blank."},
+            "ref": {"help_text": "Reference to the linked item, scoped to its type. Null for href-only shortcuts."},
+            "href": {
+                "help_text": "Destination URL the shortcut opens. Null when the shortcut points at an item by ref."
+            },
+            "order": {"help_text": "Display order within the user's shortcut list, ascending."},
+        }
 
     def update(self, instance: FileSystemShortcut, validated_data: dict[str, Any]) -> FileSystemShortcut:
         instance.team_id = self.context["team_id"]
@@ -52,6 +62,7 @@ class FileSystemShortcutSerializer(serializers.ModelSerializer):
         file_system_shortcut = FileSystemShortcut.objects.create(
             team=team,
             user=request.user,
+            surface=self.context.get("file_system_surface", DEFAULT_SURFACE),
             **validated_data,
         )
         return file_system_shortcut
@@ -65,13 +76,22 @@ class FileSystemShortcutReorderSerializer(serializers.Serializer):
     )
 
 
+@extend_schema(extensions={"x-product": "core"})
 class FileSystemShortcutViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     queryset = FileSystemShortcut.objects.all()
     scope_object = "file_system_shortcut"
     serializer_class = FileSystemShortcutSerializer
+    # Product surface these shortcuts serve. Subclass and override to expose a different surface
+    # (e.g. "desktop") on its own route. The default surface also matches legacy NULL rows.
+    file_system_surface: str = DEFAULT_SURFACE
+
+    def get_serializer_context(self) -> dict[str, Any]:
+        context = super().get_serializer_context()
+        context["file_system_surface"] = self.file_system_surface
+        return context
 
     def _scope_by_project(self, queryset):
-        return queryset.filter(team__project_id=self.team.project_id)
+        return queryset.filter(surface_q(self.file_system_surface), team__project_id=self.team.project_id)
 
     def _scope_by_project_and_environment(self, queryset: QuerySet) -> QuerySet:
         queryset = self._scope_by_project(queryset)
@@ -102,7 +122,9 @@ class FileSystemShortcutViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         ordered_ids = [str(uuid) for uuid in serializer.validated_data["ordered_ids"]]
 
-        user_shortcuts_qs = FileSystemShortcut.objects.filter(team=self.team, user=cast(User, request.user))
+        user_shortcuts_qs = FileSystemShortcut.objects.filter(
+            surface_q(self.file_system_surface), team=self.team, user=cast(User, request.user)
+        )
         existing_ids = {str(pk) for pk in user_shortcuts_qs.values_list("id", flat=True)}
         unknown = [pk for pk in ordered_ids if pk not in existing_ids]
         if unknown:
@@ -122,3 +144,14 @@ class FileSystemShortcutViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         refreshed = self.filter_queryset(self.get_queryset())
         return Response(self.get_serializer(refreshed, many=True).data)
+
+
+@extend_schema(extensions={"x-product": "core"})
+class DesktopFileSystemShortcutViewSet(FileSystemShortcutViewSet):
+    """
+    Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
+    behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+    the default "web" surface.
+    """
+
+    file_system_surface = "desktop"

--- a/posthog/api/file_system/persisted_folder.py
+++ b/posthog/api/file_system/persisted_folder.py
@@ -1,11 +1,14 @@
 from typing import Any
 
+from django.db import IntegrityError
 from django.db.models import QuerySet
 from django.db.models.functions import Lower
 
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, viewsets
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.models.file_system.constants import DEFAULT_SURFACE, surface_q
 from posthog.models.file_system.persisted_folder import PersistedFolder
 
 
@@ -21,33 +24,78 @@ class PersistedFolderSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = ["id", "created_at", "updated_at"]
+        extra_kwargs = {
+            "type": {"help_text": "Which persisted folder this is for the user (home, pinned, custom_products)."},
+            "protocol": {"help_text": "Protocol prefix of the folder location, e.g. 'products://'."},
+            "path": {"help_text": "Path within the protocol that the folder resolves to."},
+        }
 
-    def update(self, instance: PersistedFolder, validated_data: dict[str, Any]) -> PersistedFolder:  # noqa: D401
+    def update(self, instance: PersistedFolder, validated_data: dict[str, Any]) -> PersistedFolder:
         validated_data["team_id"] = self.context["team_id"]
         validated_data["user"] = self.context["request"].user
         return super().update(instance, validated_data)
 
-    def create(self, validated_data: dict[str, Any]) -> PersistedFolder:  # noqa: D401
+    def create(self, validated_data: dict[str, Any]) -> PersistedFolder:
         team = self.context["get_team"]()
         user = self.context["request"].user
+        surface = self.context.get("file_system_surface", DEFAULT_SURFACE)
+        folder_type = validated_data["type"]
+        defaults = {
+            "protocol": validated_data.get("protocol", "products://"),
+            "path": validated_data.get("path", ""),
+        }
 
-        obj, _ = PersistedFolder.objects.update_or_create(
-            team=team,
-            user=user,
-            type=validated_data["type"],
-            defaults={
-                "protocol": validated_data.get("protocol", "products://"),
-                "path": validated_data.get("path", ""),
-            },
-        )
+        # surface_q (not a plain surface=) so an existing legacy NULL row is matched and updated
+        # rather than colliding with a new explicit-surface row under the coalescing unique index.
+        existing = PersistedFolder.objects.filter(surface_q(surface), team=team, user=user, type=folder_type).first()
+        if existing is not None:
+            return self._apply_defaults(existing, defaults)
 
-        return obj
+        try:
+            return PersistedFolder.objects.create(team=team, user=user, type=folder_type, surface=surface, **defaults)
+        except IntegrityError:
+            # Lost a race with a concurrent create; fetch the winner and update it instead.
+            existing = PersistedFolder.objects.filter(
+                surface_q(surface), team=team, user=user, type=folder_type
+            ).first()
+            if existing is None:
+                raise
+            return self._apply_defaults(existing, defaults)
+
+    @staticmethod
+    def _apply_defaults(instance: PersistedFolder, defaults: dict[str, Any]) -> PersistedFolder:
+        instance.protocol = defaults["protocol"]
+        instance.path = defaults["path"]
+        instance.save(update_fields=["protocol", "path", "updated_at"])
+        return instance
 
 
+@extend_schema(extensions={"x-product": "core"})
 class PersistedFolderViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     queryset = PersistedFolder.objects.all()
     scope_object = "persisted_folder"
     serializer_class = PersistedFolderSerializer
+    # Product surface these folders serve. Subclass and override to expose a different surface
+    # (e.g. "desktop") on its own route. The default surface also matches legacy NULL rows.
+    file_system_surface: str = DEFAULT_SURFACE
 
-    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:  # noqa: D401
-        return queryset.filter(team=self.team, user=self.request.user).order_by(Lower("type"))
+    def get_serializer_context(self) -> dict[str, Any]:
+        context = super().get_serializer_context()
+        context["file_system_surface"] = self.file_system_surface
+        return context
+
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        return queryset.filter(surface_q(self.file_system_surface), team=self.team, user=self.request.user).order_by(
+            Lower("type")
+        )
+
+
+@extend_schema(extensions={"x-product": "core"})
+class DesktopPersistedFolderViewSet(PersistedFolderViewSet):
+    """
+    Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
+    but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+    "web" surface.
+    """
+
+    file_system_surface = "desktop"

--- a/posthog/api/file_system/test/test_file_system.py
+++ b/posthog/api/file_system/test/test_file_system.py
@@ -1918,3 +1918,38 @@ class TestDestroyRepairsLeftoverHogFunctions(APIBaseTest):
             "ref": str(feature.id),
             "path": fs_entry.path,
         }
+
+
+class TestDesktopFileSystemSurface(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.web_url = f"/api/projects/{self.team.id}/file_system/"
+        self.desktop_url = f"/api/projects/{self.team.id}/desktop_file_system/"
+
+    def test_routes_serve_isolated_trees(self):
+        self.client.post(self.web_url, {"path": "Web only", "type": "doc"})
+        self.client.post(self.desktop_url, {"path": "Desktop only", "type": "doc"})
+
+        web_paths = {r["path"] for r in self.client.get(self.web_url).json()["results"]}
+        desktop_paths = {r["path"] for r in self.client.get(self.desktop_url).json()["results"]}
+
+        self.assertEqual(web_paths, {"Web only"})
+        self.assertEqual(desktop_paths, {"Desktop only"})
+
+    def test_desktop_create_stamps_desktop_surface(self):
+        self.client.post(self.desktop_url, {"path": "Folder/Item", "type": "doc"})
+
+        surfaces = set(FileSystem.objects.filter(team=self.team).values_list("surface", flat=True))
+        # Both the leaf and the auto-created parent folder are stamped "desktop".
+        self.assertEqual(surfaces, {"desktop"})
+
+    def test_legacy_null_rows_appear_on_web_route_only(self):
+        FileSystem.objects.create(team=self.team, path="Legacy", type="doc", surface=None, created_by=self.user)
+
+        web_paths = {r["path"] for r in self.client.get(self.web_url).json()["results"]}
+        desktop_paths = {r["path"] for r in self.client.get(self.desktop_url).json()["results"]}
+
+        self.assertIn("Legacy", web_paths)
+        self.assertNotIn("Legacy", desktop_paths)

--- a/posthog/api/file_system/test/test_file_system_shortcut.py
+++ b/posthog/api/file_system/test/test_file_system_shortcut.py
@@ -168,3 +168,66 @@ class TestFileSystemShortcutAPI(APIBaseTest):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class TestFileSystemShortcutSurface(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.web_url = f"/api/projects/{self.team.id}/file_system_shortcut/"
+        self.desktop_url = f"/api/projects/{self.team.id}/desktop_file_system_shortcut/"
+
+    def test_routes_serve_isolated_shortcuts(self):
+        self.client.post(self.web_url, {"path": "Web pin", "type": "doc"})
+        self.client.post(self.desktop_url, {"path": "Desktop pin", "type": "doc"})
+
+        web_paths = {r["path"] for r in self.client.get(self.web_url).json()["results"]}
+        desktop_paths = {r["path"] for r in self.client.get(self.desktop_url).json()["results"]}
+
+        self.assertEqual(web_paths, {"Web pin"})
+        self.assertEqual(desktop_paths, {"Desktop pin"})
+
+    def test_web_create_stamps_web_surface(self):
+        self.client.post(self.web_url, {"path": "Web pin", "type": "doc"})
+        self.assertEqual(
+            FileSystemShortcut.objects.get(team=self.team, path="Web pin").surface,
+            "web",
+        )
+
+    def test_desktop_create_stamps_desktop_surface(self):
+        self.client.post(self.desktop_url, {"path": "Desktop pin", "type": "doc"})
+        self.assertEqual(
+            FileSystemShortcut.objects.get(team=self.team, path="Desktop pin").surface,
+            "desktop",
+        )
+
+    def test_legacy_null_shortcut_appears_on_web_route_only(self):
+        FileSystemShortcut.objects.create(team=self.team, path="Legacy pin", type="doc", user=self.user, surface=None)
+
+        web_paths = {r["path"] for r in self.client.get(self.web_url).json()["results"]}
+        desktop_paths = {r["path"] for r in self.client.get(self.desktop_url).json()["results"]}
+
+        self.assertIn("Legacy pin", web_paths)
+        self.assertNotIn("Legacy pin", desktop_paths)
+
+    def test_reorder_is_scoped_to_surface(self):
+        web = FileSystemShortcut.objects.create(team=self.team, path="Web", type="t", user=self.user, surface="web")
+        desktop = FileSystemShortcut.objects.create(
+            team=self.team, path="Desktop", type="t", user=self.user, surface="desktop"
+        )
+
+        # A desktop reorder must not recognise (or touch) a web shortcut id.
+        response = self.client.post(
+            f"{self.desktop_url}reorder/",
+            {"ordered_ids": [str(web.id)]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+        self.assertIn(str(web.id), response.json()["unknown_ids"])
+
+        # But it accepts its own surface's shortcut.
+        ok = self.client.post(
+            f"{self.desktop_url}reorder/",
+            {"ordered_ids": [str(desktop.id)]},
+            format="json",
+        )
+        self.assertEqual(ok.status_code, status.HTTP_200_OK, ok.json())

--- a/posthog/api/file_system/test/test_persisted_folder.py
+++ b/posthog/api/file_system/test/test_persisted_folder.py
@@ -64,3 +64,46 @@ class TestPersistedFolderAPI(_Base):
         self.assertEqual(rsp.status_code, status.HTTP_200_OK)
         self.assertEqual(len(rsp.data["results"]), 1)
         self.assertEqual(rsp.data["results"][0]["path"], "A")
+
+
+class TestPersistedFolderSurface(_Base):
+    def setUp(self) -> None:
+        super().setUp()
+        self.web_url = f"/api/projects/{self.team.id}/persisted_folder/"
+        self.desktop_url = f"/api/projects/{self.team.id}/desktop_persisted_folder/"
+
+    def test_same_type_coexists_across_surfaces(self) -> None:
+        # The same `type` ("home") is NOT surface-exclusive: each surface keeps its own row.
+        web = self.client.post(self.web_url, {"type": "home", "path": "Web home"}, format="json")
+        desktop = self.client.post(self.desktop_url, {"type": "home", "path": "Desktop home"}, format="json")
+
+        self.assertEqual(web.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(desktop.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(PersistedFolder.objects.filter(team=self.team, user=self.user, type="home").count(), 2)
+
+        web_paths = {r["path"] for r in self.client.get(self.web_url).data["results"]}
+        desktop_paths = {r["path"] for r in self.client.get(self.desktop_url).data["results"]}
+        self.assertEqual(web_paths, {"Web home"})
+        self.assertEqual(desktop_paths, {"Desktop home"})
+
+    def test_web_create_stamps_web_surface(self) -> None:
+        self.client.post(self.web_url, {"type": "home", "path": "Web home"}, format="json")
+        self.assertEqual(PersistedFolder.objects.get(team=self.team, user=self.user, type="home").surface, "web")
+
+    def test_desktop_create_stamps_desktop_surface(self) -> None:
+        self.client.post(self.desktop_url, {"type": "home", "path": "Desktop home"}, format="json")
+        self.assertEqual(PersistedFolder.objects.get(team=self.team, user=self.user, type="home").surface, "desktop")
+
+    def test_web_upsert_matches_legacy_null_row(self) -> None:
+        # A legacy row predates the surface column. A web upsert must update it in place rather
+        # than insert a second row that would collide under the coalescing unique index.
+        legacy = PersistedFolder.objects.create(
+            team=self.team, user=self.user, type="home", path="Legacy", surface=None
+        )
+
+        rsp = self.client.post(self.web_url, {"type": "home", "path": "Updated"}, format="json")
+
+        self.assertEqual(rsp.status_code, status.HTTP_201_CREATED, rsp.data)
+        self.assertEqual(PersistedFolder.objects.filter(team=self.team, user=self.user, type="home").count(), 1)
+        legacy.refresh_from_db()
+        self.assertEqual(legacy.path, "Updated")

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -217,9 +217,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'insight'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -2811,9 +2814,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'dashboard'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -2830,9 +2836,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'dashboard'
          AND NOT ("posthog_filesystemshortcut"."path" = 'dashboard'
@@ -6172,9 +6181,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'insight'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -7092,9 +7104,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'dashboard'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -7948,9 +7963,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'insight'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -9932,9 +9950,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'insight'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -12963,9 +12984,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'dashboard'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -12982,9 +13006,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'dashboard'
          AND NOT ("posthog_filesystemshortcut"."path" = 'dashboard-1'
@@ -14301,9 +14328,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'dashboard'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -15454,9 +15484,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'insight'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -18000,9 +18033,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'insight'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -18398,9 +18434,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'dashboard'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -19025,9 +19064,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'dashboard'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -19044,9 +19086,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'dashboard'
          AND NOT ("posthog_filesystemshortcut"."path" = 'private dashboard'
@@ -20034,9 +20079,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'dashboard'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -21215,9 +21263,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'dashboard'
          AND NOT ("posthog_filesystem"."shortcut"

--- a/posthog/api/test/notebooks/__snapshots__/test_notebook.ambr
+++ b/posthog/api/test/notebooks/__snapshots__/test_notebook.ambr
@@ -922,9 +922,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'notebook'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -941,9 +944,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'notebook'
          AND NOT ("posthog_filesystemshortcut"."path" = 'New title'
@@ -1683,9 +1689,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'notebook'
          AND NOT ("posthog_filesystem"."shortcut"

--- a/posthog/migrations/1197_filesystem_surface.py
+++ b/posthog/migrations/1197_filesystem_surface.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1196_team_llm_gateway_enabled_at"),
+    ]
+
+    operations = [
+        # Nullable with no DB-level default so the migration is metadata-only on
+        # PG 11+ (no table rewrite, no row backfill). Legacy rows stay NULL and are
+        # read as the default surface ("web") in code.
+        migrations.AddField(
+            model_name="filesystem",
+            name="surface",
+            field=models.CharField(blank=True, max_length=100, null=True),
+        ),
+    ]

--- a/posthog/migrations/1198_filesystem_surface_indexes.py
+++ b/posthog/migrations/1198_filesystem_surface_indexes.py
@@ -1,0 +1,75 @@
+from django.db import migrations, models
+from django.db.models.expressions import F
+
+from posthog.migration_helpers import CreateIndexConcurrently, DropIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # Concurrent index builds cannot run inside a transaction.
+    atomic = False
+
+    dependencies = [
+        ("posthog", "1197_filesystem_surface"),
+    ]
+
+    operations = [
+        # Re-front the composite indexes with `surface` so per-surface tree queries stay
+        # selective. Add the new (surface-fronted) indexes before dropping the old ones, so
+        # the table is never left without a covering index mid-deploy. The bare Django
+        # AddIndexConcurrently/RemoveIndexConcurrently ops are non-idempotent and blocked by
+        # CI; the helpers disable lock_timeout, recover from invalid leftovers, and emit
+        # IF [NOT] EXISTS. SeparateDatabaseAndState keeps Django's index state in sync.
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="filesystem",
+                    index=models.Index(F("team_id"), F("surface"), F("path"), name="posthog_fs_team_s_path"),
+                ),
+                migrations.AddIndex(
+                    model_name="filesystem",
+                    index=models.Index(F("team_id"), F("surface"), F("depth"), name="posthog_fs_team_s_depth"),
+                ),
+                migrations.AddIndex(
+                    model_name="filesystem",
+                    index=models.Index(
+                        F("team_id"), F("surface"), F("type"), F("ref"), name="posthog_fs_team_s_typeref"
+                    ),
+                ),
+                migrations.RemoveIndex(model_name="filesystem", name="posthog_fs_team_path"),
+                migrations.RemoveIndex(model_name="filesystem", name="posthog_fs_team_depth"),
+                migrations.RemoveIndex(model_name="filesystem", name="posthog_fs_team_typeref"),
+            ],
+            database_operations=[
+                CreateIndexConcurrently(
+                    index_name="posthog_fs_team_s_path",
+                    table_name="posthog_filesystem",
+                    columns="(team_id, surface, path)",
+                ),
+                CreateIndexConcurrently(
+                    index_name="posthog_fs_team_s_depth",
+                    table_name="posthog_filesystem",
+                    columns="(team_id, surface, depth)",
+                ),
+                CreateIndexConcurrently(
+                    index_name="posthog_fs_team_s_typeref",
+                    table_name="posthog_filesystem",
+                    columns="(team_id, surface, type, ref)",
+                ),
+                DropIndexConcurrently(
+                    index_name="posthog_fs_team_path",
+                    table_name="posthog_filesystem",
+                    columns="(team_id, path)",
+                ),
+                DropIndexConcurrently(
+                    index_name="posthog_fs_team_depth",
+                    table_name="posthog_filesystem",
+                    columns="(team_id, depth)",
+                ),
+                DropIndexConcurrently(
+                    index_name="posthog_fs_team_typeref",
+                    table_name="posthog_filesystem",
+                    columns="(team_id, type, ref)",
+                ),
+            ],
+        ),
+    ]

--- a/posthog/migrations/1199_filesystem_related_surface.py
+++ b/posthog/migrations/1199_filesystem_related_surface.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1198_filesystem_surface_indexes"),
+    ]
+
+    operations = [
+        # Nullable with no DB-level default so each add is metadata-only on PG 11+ (no table
+        # rewrite, no row backfill). Legacy rows stay NULL and are read as the default surface
+        # ("web") in code via surface_q().
+        migrations.AddField(
+            model_name="filesystemshortcut",
+            name="surface",
+            field=models.CharField(blank=True, max_length=100, null=True),
+        ),
+        migrations.AddField(
+            model_name="filesystemviewlog",
+            name="surface",
+            field=models.CharField(blank=True, max_length=100, null=True),
+        ),
+        migrations.AddField(
+            model_name="persistedfolder",
+            name="surface",
+            field=models.CharField(blank=True, max_length=100, null=True),
+        ),
+    ]

--- a/posthog/migrations/1200_persistedfolder_surface_unique.py
+++ b/posthog/migrations/1200_persistedfolder_surface_unique.py
@@ -1,0 +1,45 @@
+from django.db import migrations, models
+from django.db.models import Value
+from django.db.models.expressions import F
+from django.db.models.functions import Coalesce
+
+from posthog.migration_helpers import CreateIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # Concurrent index builds cannot run inside a transaction.
+    atomic = False
+
+    dependencies = [
+        ("posthog", "1199_filesystem_related_surface"),
+    ]
+
+    operations = [
+        # Add the surface-aware unique index BEFORE dropping the old (team, user, type) constraint
+        # (done in the next migration), so the table is never left without uniqueness protection.
+        # COALESCE(surface, 'web') matches the NULL == "web" read rule, so a legacy NULL row and a
+        # new explicit-"web" row can never both exist for the same (team, user, type). Build it
+        # concurrently via the helper (lock_timeout disabled, idempotent, invalid-leftover recovery).
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddConstraint(
+                    model_name="persistedfolder",
+                    constraint=models.UniqueConstraint(
+                        F("team_id"),
+                        F("user_id"),
+                        F("type"),
+                        Coalesce(F("surface"), Value("web")),
+                        name="posthog_pf_team_user_type_surface_uniq",
+                    ),
+                ),
+            ],
+            database_operations=[
+                CreateIndexConcurrently(
+                    index_name="posthog_pf_team_user_type_surface_uniq",
+                    table_name="posthog_persistedfolder",
+                    columns="(team_id, user_id, type, COALESCE(surface, 'web'))",
+                    unique=True,
+                ),
+            ],
+        ),
+    ]

--- a/posthog/migrations/1201_persistedfolder_drop_old_unique.py
+++ b/posthog/migrations/1201_persistedfolder_drop_old_unique.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1200_persistedfolder_surface_unique"),
+    ]
+
+    operations = [
+        # Drop the old (team, user, type) unique constraint now that the surface-aware unique index
+        # from the previous migration enforces uniqueness. DROP CONSTRAINT is a fast metadata-only
+        # operation (brief ACCESS EXCLUSIVE lock, no table scan), so it does not need CONCURRENTLY.
+        # Django resolves the auto-generated constraint name from its own state.
+        migrations.AlterUniqueTogether(
+            name="persistedfolder",
+            unique_together=set(),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1196_team_llm_gateway_enabled_at
+1201_persistedfolder_drop_old_unique

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -21,6 +21,7 @@ from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.constants import PropertyOperatorType
 from posthog.exceptions_capture import capture_exception
 from posthog.helpers.batch_iterators import ArrayBatchIterator, BatchIterator, FunctionBatchIterator
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.filters.filter import Filter
@@ -238,9 +239,9 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         return self.name or "Untitled cohort"
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Cohort"]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["Cohort"]:
         base_qs = cls.objects.filter(team=team, deleted=False)
-        return cls._filter_unfiled_queryset(base_qs, team, type="cohort", ref_field="id")
+        return cls._filter_unfiled_queryset(base_qs, team, type="cohort", ref_field="id", surface=surface)
 
     def get_file_system_representation(self) -> FileSystemRepresentation:
         return FileSystemRepresentation(

--- a/posthog/models/file_system/constants.py
+++ b/posthog/models/file_system/constants.py
@@ -1,0 +1,12 @@
+from django.db.models import Q
+
+# The product surface a FileSystem row belongs to. Legacy rows predate this column and are
+# stored as NULL; they are read as the default ("web"). New rows always store an explicit value.
+DEFAULT_SURFACE = "web"
+
+
+def surface_q(surface: str) -> Q:
+    """Build the read filter for a surface. The default surface also matches legacy NULL rows."""
+    if surface == DEFAULT_SURFACE:
+        return Q(surface__isnull=True) | Q(surface=DEFAULT_SURFACE)
+    return Q(surface=surface)

--- a/posthog/models/file_system/file_system.py
+++ b/posthog/models/file_system/file_system.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from django.db.models.expressions import F
 from django.utils import timezone
 
+from posthog.models.file_system.constants import DEFAULT_SURFACE, surface_q
 from posthog.models.file_system.file_system_shortcut import FileSystemShortcut
 from posthog.models.team import Team
 from posthog.models.user import User
@@ -28,6 +29,8 @@ class FileSystem(models.Model):
     meta = models.JSONField(default=dict, null=True, blank=True)
     created_at = models.DateTimeField(default=timezone.now, editable=False)
     created_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
+    # Product surface this row belongs to (e.g. "web", "desktop"). NULL == DEFAULT_SURFACE.
+    surface = models.CharField(max_length=100, null=True, blank=True)
 
     # DEPRECATED/UNUSED. It's all based on just the team_id.
     project = models.ForeignKey("Project", on_delete=models.CASCADE, null=True)
@@ -35,9 +38,9 @@ class FileSystem(models.Model):
     class Meta:
         indexes = [
             models.Index(fields=["team"]),
-            models.Index(F("team_id"), F("path"), name="posthog_fs_team_path"),
-            models.Index(F("team_id"), F("depth"), name="posthog_fs_team_depth"),
-            models.Index(F("team_id"), F("type"), F("ref"), name="posthog_fs_team_typeref"),
+            models.Index(F("team_id"), F("surface"), F("path"), name="posthog_fs_team_s_path"),
+            models.Index(F("team_id"), F("surface"), F("depth"), name="posthog_fs_team_s_depth"),
+            models.Index(F("team_id"), F("surface"), F("type"), F("ref"), name="posthog_fs_team_s_typeref"),
         ]
 
     def __str__(self):
@@ -55,9 +58,14 @@ def create_or_update_file(
     meta: dict,
     created_at: Optional[datetime] = None,
     created_by_id: Optional[int] = None,
+    surface: str = DEFAULT_SURFACE,
 ):
     has_existing = False
-    all_existing = FileSystem.objects.filter(team=team, type=file_type, ref=ref).filter(~Q(shortcut=True)).all()
+    all_existing = (
+        FileSystem.objects.filter(surface_q(surface), team=team, type=file_type, ref=ref)
+        .filter(~Q(shortcut=True))
+        .all()
+    )
     for existing in all_existing:
         has_existing = True
         segments = split_path(existing.path)
@@ -76,7 +84,7 @@ def create_or_update_file(
     if has_existing:
         path = escape_path(name)
         shortcuts = (
-            FileSystemShortcut.objects.filter(team=team, type=file_type, ref=ref)
+            FileSystemShortcut.objects.filter(surface_q(surface), team=team, type=file_type, ref=ref)
             .filter(~(Q(path=path) & Q(href=href)))
             .all()
         )
@@ -95,15 +103,16 @@ def create_or_update_file(
             href=href,
             meta=meta,
             shortcut=False,
+            surface=surface,
             created_by_id=created_by_id,
             created_at=created_at or timezone.now(),
         )
 
 
-def delete_file(*, team: Team, file_type: str, ref: str):
-    count, _ = FileSystem.objects.filter(team=team, type=file_type, ref=ref).delete()
+def delete_file(*, team: Team, file_type: str, ref: str, surface: str = DEFAULT_SURFACE):
+    count, _ = FileSystem.objects.filter(surface_q(surface), team=team, type=file_type, ref=ref).delete()
     if count > 0:
-        FileSystemShortcut.objects.filter(team=team, type=file_type, ref=ref).delete()
+        FileSystemShortcut.objects.filter(surface_q(surface), team=team, type=file_type, ref=ref).delete()
 
 
 def split_path(path: str) -> list[str]:

--- a/posthog/models/file_system/file_system_mixin.py
+++ b/posthog/models/file_system/file_system_mixin.py
@@ -10,6 +10,7 @@ from posthog.exceptions_capture import capture_exception
 
 if TYPE_CHECKING:
     from posthog.models.team import Team
+from posthog.models.file_system.constants import DEFAULT_SURFACE, surface_q
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 
 
@@ -40,7 +41,7 @@ class FileSystemSyncMixin(Model):
             try:
                 team = instance.team  # type: ignore
                 if fs_data.should_delete:
-                    delete_file(team=team, file_type=fs_data.type, ref=fs_data.ref)
+                    delete_file(team=team, file_type=fs_data.type, ref=fs_data.ref, surface=fs_data.surface)
                 else:
                     create_or_update_file(
                         team=team,
@@ -52,6 +53,7 @@ class FileSystemSyncMixin(Model):
                         meta=fs_data.meta,
                         created_at=fs_data.meta.get("created_at") or getattr(instance, "created_at", None),
                         created_by_id=fs_data.meta.get("created_by") or getattr(instance, "created_by_id", None),
+                        surface=fs_data.surface,
                     )
             except Exception as e:
                 # Don't raise exceptions in signals
@@ -65,7 +67,7 @@ class FileSystemSyncMixin(Model):
             fs_data = instance.get_file_system_representation()
             try:
                 team = instance.team  # type: ignore
-                delete_file(team=team, file_type=fs_data.type, ref=fs_data.ref)
+                delete_file(team=team, file_type=fs_data.type, ref=fs_data.ref, surface=fs_data.surface)
             except Team.DoesNotExist:
                 # Team was already deleted
                 pass
@@ -74,10 +76,10 @@ class FileSystemSyncMixin(Model):
                 capture_exception(e, additional_properties=dataclasses.asdict(fs_data))
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet[Any]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet[Any]:
         """
-        Models override this to return a queryset of items that do not yet have a FileSystem entry.
-        Typically calls `_filter_unfiled_queryset(base_qs, team, ref_field)`.
+        Models override this to return a queryset of items that do not yet have a FileSystem entry
+        for the given surface. Typically calls `_filter_unfiled_queryset(base_qs, team, ref_field, surface=surface)`.
         """
         raise NotImplementedError()
 
@@ -100,21 +102,22 @@ class FileSystemSyncMixin(Model):
         ref_field: str,
         type: Optional[str | list[str]] = None,
         type__startswith: Optional[str] = None,
+        surface: str = DEFAULT_SURFACE,
     ) -> QuerySet:
         """
         Given a base queryset `qs`, annotate a 'ref_id' from `ref_field`,
-        then exclude rows that are already saved to FileSystem for (team, file_type).
+        then exclude rows that are already saved to FileSystem for (team, surface, file_type).
         """
         from posthog.models.file_system.file_system import FileSystem
 
         if type:
             types = [type] if isinstance(type, str) else type
-            already_saved = FileSystem.objects.filter(team=team, type__in=types, ref=OuterRef("ref_id")).filter(
-                ~Q(shortcut=True)
-            )
+            already_saved = FileSystem.objects.filter(
+                surface_q(surface), team=team, type__in=types, ref=OuterRef("ref_id")
+            ).filter(~Q(shortcut=True))
         elif type__startswith:
             already_saved = FileSystem.objects.filter(
-                team=team, type__startswith=type__startswith, ref=OuterRef("ref_id")
+                surface_q(surface), team=team, type__startswith=type__startswith, ref=OuterRef("ref_id")
             ).filter(~Q(shortcut=True))
         else:
             raise ValueError("Either 'type' or 'type__startswith' must be provided")

--- a/posthog/models/file_system/file_system_representation.py
+++ b/posthog/models/file_system/file_system_representation.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from typing import Any
 
+from posthog.models.file_system.constants import DEFAULT_SURFACE
+
 
 @dataclass
 class FileSystemRepresentation:
@@ -15,6 +17,7 @@ class FileSystemRepresentation:
       - href
       - meta
       - should_delete: if True, we remove the entry instead of creating/updating
+      - surface: the product surface the entry belongs to (defaults to "web")
     """
 
     base_folder: str
@@ -24,3 +27,4 @@ class FileSystemRepresentation:
     href: str
     meta: dict[str, Any]
     should_delete: bool = False
+    surface: str = DEFAULT_SURFACE

--- a/posthog/models/file_system/file_system_shortcut.py
+++ b/posthog/models/file_system/file_system_shortcut.py
@@ -22,6 +22,8 @@ class FileSystemShortcut(models.Model):
     href = models.TextField(null=True, blank=True)
     order = models.IntegerField(default=0)
     created_at = models.DateTimeField(default=timezone.now, editable=False)
+    # Product surface this shortcut belongs to (e.g. "web", "desktop"). NULL == DEFAULT_SURFACE.
+    surface = models.CharField(max_length=100, null=True, blank=True)
 
     class Meta:
         indexes = [

--- a/posthog/models/file_system/file_system_view_log.py
+++ b/posthog/models/file_system/file_system_view_log.py
@@ -78,9 +78,10 @@ def log_file_system_view(
 
     now = viewed_at or timezone.now()
 
-    # (type, ref) is surface-exclusive, so surface is not part of the lookup — the existing
-    # (team, user, type, ref) unique constraint still identifies the row. New rows store an
-    # explicit surface so Recents can be filtered per-surface; legacy rows stay NULL (== web).
+    # The (team, user, type, ref) unique constraint allows one view-log row per item, so surface
+    # is not part of the lookup. The same (type, ref) can exist in more than one surface, so we
+    # refresh `surface` on every view: the row reflects the most recent view's surface, keeping
+    # Recents (filtered per-surface) and the delete-cleanup signal accurate. Legacy rows are NULL (== web).
     update_kwargs = {
         "team_id": resolved_team_id,
         "user_id": user.id,
@@ -89,7 +90,7 @@ def log_file_system_view(
     }
     surface = getattr(representation, "surface", DEFAULT_SURFACE)
 
-    updated = FileSystemViewLog.objects.filter(**update_kwargs).update(viewed_at=now)
+    updated = FileSystemViewLog.objects.filter(**update_kwargs).update(viewed_at=now, surface=surface)
 
     if updated:
         return
@@ -98,7 +99,7 @@ def log_file_system_view(
         FileSystemViewLog.objects.create(viewed_at=now, surface=surface, **update_kwargs)
     except IntegrityError:
         # Another request may have created the row after our update attempt.
-        FileSystemViewLog.objects.filter(**update_kwargs).update(viewed_at=now)
+        FileSystemViewLog.objects.filter(**update_kwargs).update(viewed_at=now, surface=surface)
 
 
 def annotate_file_system_with_view_logs(

--- a/posthog/models/file_system/file_system_view_log.py
+++ b/posthog/models/file_system/file_system_view_log.py
@@ -10,6 +10,7 @@ from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils import timezone
 
+from posthog.models.file_system.constants import DEFAULT_SURFACE, surface_q
 from posthog.models.file_system.file_system import FileSystem
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.utils import UUIDModel
@@ -24,6 +25,11 @@ class FileSystemViewLog(UUIDModel):
     type = models.CharField(max_length=150)
     ref = models.CharField(max_length=200)
     viewed_at = models.DateTimeField(default=timezone.now)
+    # Product surface this view belongs to (e.g. "web", "desktop"). NULL == DEFAULT_SURFACE.
+    # Not part of the unique constraint below: a (type, ref) item is exclusive to one surface,
+    # so (team, user, type, ref) already identifies a view uniquely. The column only lets us
+    # filter Recents to a single surface without joining back to FileSystem.
+    surface = models.CharField(max_length=100, null=True, blank=True)
 
     class Meta:
         indexes = [
@@ -42,13 +48,16 @@ def _drop_view_logs_when_file_deleted(sender, instance: FileSystem, **kwargs) ->
     # their canonical file, so we only act when the canonical row is gone.
     if not instance.ref or instance.type == "folder" or instance.shortcut:
         return
+    surface = instance.surface or DEFAULT_SURFACE
     if (
-        FileSystem.objects.filter(team_id=instance.team_id, type=instance.type, ref=instance.ref)
+        FileSystem.objects.filter(surface_q(surface), team_id=instance.team_id, type=instance.type, ref=instance.ref)
         .exclude(shortcut=True)
         .exists()
     ):
         return
-    FileSystemViewLog.objects.filter(team_id=instance.team_id, type=instance.type, ref=instance.ref).delete()
+    FileSystemViewLog.objects.filter(
+        surface_q(surface), team_id=instance.team_id, type=instance.type, ref=instance.ref
+    ).delete()
 
 
 def log_file_system_view(
@@ -69,12 +78,16 @@ def log_file_system_view(
 
     now = viewed_at or timezone.now()
 
+    # (type, ref) is surface-exclusive, so surface is not part of the lookup — the existing
+    # (team, user, type, ref) unique constraint still identifies the row. New rows store an
+    # explicit surface so Recents can be filtered per-surface; legacy rows stay NULL (== web).
     update_kwargs = {
         "team_id": resolved_team_id,
         "user_id": user.id,
         "type": representation.type,
         "ref": str(representation.ref),
     }
+    surface = getattr(representation, "surface", DEFAULT_SURFACE)
 
     updated = FileSystemViewLog.objects.filter(**update_kwargs).update(viewed_at=now)
 
@@ -82,7 +95,7 @@ def log_file_system_view(
         return
 
     try:
-        FileSystemViewLog.objects.create(viewed_at=now, **update_kwargs)
+        FileSystemViewLog.objects.create(viewed_at=now, surface=surface, **update_kwargs)
     except IntegrityError:
         # Another request may have created the row after our update attempt.
         FileSystemViewLog.objects.filter(**update_kwargs).update(viewed_at=now)

--- a/posthog/models/file_system/persisted_folder.py
+++ b/posthog/models/file_system/persisted_folder.py
@@ -1,7 +1,10 @@
 from django.db import models
+from django.db.models import Value
 from django.db.models.expressions import F
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.models.utils import uuid7
@@ -34,11 +37,26 @@ class PersistedFolder(models.Model):
     protocol: models.CharField = models.CharField(max_length=64, default="products://")
     path: models.TextField = models.TextField(blank=True, default="")
 
+    # Product surface this folder belongs to (e.g. "web", "desktop"). NULL == DEFAULT_SURFACE.
+    # Unlike FileSystem items, a folder `type` (home, pinned, …) is NOT surface-exclusive — each
+    # surface has its own "home" — so surface is part of the uniqueness below. The constraint
+    # coalesces NULL to the default surface, matching the NULL == "web" rule used for reads, so a
+    # legacy NULL row and an explicit "web" row can never both exist for the same (team, user, type).
+    surface: models.CharField = models.CharField(max_length=100, null=True, blank=True)
+
     created_at: models.DateTimeField = models.DateTimeField(default=timezone.now, editable=False)
     updated_at: models.DateTimeField = models.DateTimeField(auto_now=True)
 
     class Meta:
-        unique_together = (("team", "user", "type"),)
+        constraints = [
+            models.UniqueConstraint(
+                F("team_id"),
+                F("user_id"),
+                F("type"),
+                Coalesce(F("surface"), Value(DEFAULT_SURFACE)),
+                name="posthog_pf_team_user_type_surface_uniq",
+            ),
+        ]
         indexes = [
             models.Index(F("team_id"), F("user_id"), name="posthog_pf_team_user"),
             models.Index(F("team_id"), F("user_id"), F("type"), name="posthog_pf_team_user_type"),

--- a/posthog/models/file_system/test/test_file_system.py
+++ b/posthog/models/file_system/test/test_file_system.py
@@ -1,7 +1,16 @@
 from django.test import TestCase
 
 from posthog.models import Organization, Team, User
-from posthog.models.file_system.file_system import FileSystem, escape_path, join_path, split_path
+from posthog.models.file_system.file_system import (
+    DEFAULT_SURFACE,
+    FileSystem,
+    create_or_update_file,
+    delete_file,
+    escape_path,
+    join_path,
+    split_path,
+    surface_q,
+)
 from posthog.models.file_system.unfiled_file_saver import save_unfiled_files
 
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -183,3 +192,101 @@ class TestFileSystemModel(TestCase):
 
         # Confirm total in DB
         self.assertEqual(FileSystem.objects.count(), 2)
+
+
+class TestFileSystemSurface(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("surface@posthog.com", "testpassword", first_name="Sue")
+        self.organization = Organization.objects.create(name="Surface Org")
+        self.team = Team.objects.create(name="Surface Team", organization=self.organization)
+
+    def test_surface_q_default_matches_null_and_web(self):
+        legacy = FileSystem.objects.create(team=self.team, path="Legacy", type="insight", ref="1", surface=None)
+        web = FileSystem.objects.create(team=self.team, path="Web", type="insight", ref="2", surface="web")
+        FileSystem.objects.create(team=self.team, path="Desktop", type="insight", ref="3", surface="desktop")
+
+        web_ids = set(FileSystem.objects.filter(surface_q(DEFAULT_SURFACE)).values_list("id", flat=True))
+        self.assertEqual(web_ids, {legacy.id, web.id})
+
+        desktop_paths = set(FileSystem.objects.filter(surface_q("desktop")).values_list("path", flat=True))
+        self.assertEqual(desktop_paths, {"Desktop"})
+
+    def test_create_or_update_file_isolates_surfaces(self):
+        create_or_update_file(
+            team=self.team, base_folder="Web", name="Same", file_type="insight", ref="42", href="", meta={}
+        )
+        create_or_update_file(
+            team=self.team,
+            base_folder="Desktop",
+            name="Same",
+            file_type="insight",
+            ref="42",
+            href="",
+            meta={},
+            surface="desktop",
+        )
+
+        rows = FileSystem.objects.filter(type="insight", ref="42").order_by("surface")
+        self.assertEqual(rows.count(), 2)
+        self.assertEqual({r.surface for r in rows}, {"web", "desktop"})
+
+    def test_create_or_update_file_web_updates_legacy_null_row(self):
+        legacy = FileSystem.objects.create(
+            team=self.team, path="Old/Name", type="insight", ref="7", surface=None, shortcut=False
+        )
+
+        create_or_update_file(
+            team=self.team, base_folder="Old", name="New Name", file_type="insight", ref="7", href="", meta={}
+        )
+
+        legacy.refresh_from_db()
+        # The web write matched and renamed the legacy NULL row instead of creating a second one.
+        self.assertEqual(FileSystem.objects.filter(type="insight", ref="7").count(), 1)
+        self.assertEqual(legacy.path, "Old/New Name")
+
+    def test_delete_file_is_scoped_to_surface(self):
+        create_or_update_file(
+            team=self.team, base_folder="Web", name="Keep", file_type="insight", ref="9", href="", meta={}
+        )
+        create_or_update_file(
+            team=self.team,
+            base_folder="Desktop",
+            name="Keep",
+            file_type="insight",
+            ref="9",
+            href="",
+            meta={},
+            surface="desktop",
+        )
+
+        delete_file(team=self.team, file_type="insight", ref="9")
+
+        remaining = FileSystem.objects.filter(type="insight", ref="9")
+        self.assertEqual(remaining.count(), 1)
+        self.assertEqual(remaining.first().surface, "desktop")  # type: ignore
+
+    def test_mixin_models_default_to_web_surface(self):
+        FeatureFlag.objects.create(team=self.team, key="A Flag", created_by=self.user)
+        entry = FileSystem.objects.get(type="feature_flag")
+        self.assertEqual(entry.surface, DEFAULT_SURFACE)
+
+    def test_unfiled_saver_only_sweeps_requested_surface(self):
+        FeatureFlag.objects.create(team=self.team, key="Beta", created_by=self.user)
+        FileSystem.objects.all().delete()
+
+        # No models are registered for the desktop surface, so nothing is swept into it.
+        self.assertEqual(save_unfiled_files(self.team, self.user, surface="desktop"), [])
+        self.assertEqual(FileSystem.objects.count(), 0)
+
+        created = save_unfiled_files(self.team, self.user)
+        self.assertEqual(len(created), 1)
+        self.assertEqual(created[0].surface, DEFAULT_SURFACE)
+
+    def test_get_file_system_unfiled_scopes_exclusion_to_surface(self):
+        # Creating the flag files it into the web tree via the post_save signal.
+        FeatureFlag.objects.create(team=self.team, key="Gamma", created_by=self.user)
+
+        # The web exclusion sees it as already filed, so it is not unfiled for web...
+        self.assertEqual(FeatureFlag.get_file_system_unfiled(self.team, surface="web").count(), 0)
+        # ...but it is still unfiled for desktop, whose tree doesn't contain it.
+        self.assertEqual(FeatureFlag.get_file_system_unfiled(self.team, surface="desktop").count(), 1)

--- a/posthog/models/file_system/test/test_file_system_view_log.py
+++ b/posthog/models/file_system/test/test_file_system_view_log.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 from django.test import TestCase
 
 from posthog.models import FileSystem, FileSystemViewLog, Organization, Team, User
+from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.file_system.file_system_view_log import get_recent_file_system_items, log_file_system_view
 
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -103,3 +104,31 @@ class TestFileSystemViewLog(TestCase):
             logs.first().viewed_at if logs.first() else None,  # type: ignore
             datetime(2024, 2, 1, 10, 0, 10, tzinfo=UTC),
         )
+
+    def _representation(self, *, surface: str = "web", ref: str = "ref-1") -> FileSystemRepresentation:
+        return FileSystemRepresentation(base_folder="", type="doc", ref=ref, name="", href="", meta={}, surface=surface)
+
+    def test_view_log_stores_surface_from_representation(self) -> None:
+        log_file_system_view(user=self.user, obj=self._representation(surface="desktop"), team_id=self.team.id)
+
+        log = FileSystemViewLog.objects.get(team=self.team, user=self.user, type="doc", ref="ref-1")
+        self.assertEqual(log.surface, "desktop")
+
+    def test_view_log_defaults_to_web_surface(self) -> None:
+        log_file_system_view(user=self.user, obj=self._representation(surface="web"), team_id=self.team.id)
+
+        log = FileSystemViewLog.objects.get(team=self.team, user=self.user, type="doc", ref="ref-1")
+        self.assertEqual(log.surface, "web")
+
+    def test_delete_signal_only_drops_view_logs_for_the_deleted_surface(self) -> None:
+        # The (team, user, type, ref) unique constraint allows only one view log per item, so the
+        # surviving surface holds the single row. Deleting the other surface's file must scope its
+        # cleanup by surface and leave this row intact.
+        web_file = FileSystem.objects.create(team=self.team, path="Web", type="doc", ref="R", surface="web")
+        FileSystem.objects.create(team=self.team, path="Desktop", type="doc", ref="R", surface="desktop")
+        web_log = FileSystemViewLog.objects.create(team=self.team, user=self.user, type="doc", ref="R", surface="web")
+
+        FileSystem.objects.get(path="Desktop").delete()
+
+        self.assertTrue(FileSystemViewLog.objects.filter(pk=web_log.pk).exists())
+        self.assertTrue(FileSystem.objects.filter(pk=web_file.pk).exists())

--- a/posthog/models/file_system/test/test_file_system_view_log.py
+++ b/posthog/models/file_system/test/test_file_system_view_log.py
@@ -120,6 +120,16 @@ class TestFileSystemViewLog(TestCase):
         log = FileSystemViewLog.objects.get(team=self.team, user=self.user, type="doc", ref="ref-1")
         self.assertEqual(log.surface, "web")
 
+    def test_view_log_refreshes_surface_on_review_from_another_surface(self) -> None:
+        # The same (type, ref) can exist in two surfaces; the single view-log row must follow the
+        # most recent view's surface rather than keep the surface it was first logged under.
+        log_file_system_view(user=self.user, obj=self._representation(surface="web"), team_id=self.team.id)
+        log_file_system_view(user=self.user, obj=self._representation(surface="desktop"), team_id=self.team.id)
+
+        logs = FileSystemViewLog.objects.filter(team=self.team, user=self.user, type="doc", ref="ref-1")
+        self.assertEqual(logs.count(), 1)
+        self.assertEqual(logs.first().surface, "desktop")  # type: ignore
+
     def test_delete_signal_only_drops_view_logs_for_the_deleted_surface(self) -> None:
         # The (team, user, type, ref) unique constraint allows only one view log per item, so the
         # surviving surface holds the single row. Deleting the other surface's file must scope its

--- a/posthog/models/file_system/unfiled_file_saver.py
+++ b/posthog/models/file_system/unfiled_file_saver.py
@@ -5,6 +5,7 @@ from typing import Optional
 from django.utils import timezone
 
 from posthog.models.cohort import Cohort
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system import FileSystem, escape_path, split_path
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.team import Team
@@ -22,7 +23,7 @@ from products.notebooks.backend.models import Notebook
 from products.product_analytics.backend.models.insight import Insight
 from products.surveys.backend.models import Survey
 
-MIXIN_MODELS = {
+MIXIN_MODELS: dict[str, type[FileSystemSyncMixin]] = {
     "action": Action,
     "feature_flag": FeatureFlag,
     "experiment": Experiment,
@@ -37,6 +38,12 @@ MIXIN_MODELS = {
     "survey": Survey,
 }
 
+# Which models feed each surface's tree. New product surfaces register their own models here so
+# they are never swept into the default ("web") tree, and vice versa.
+MIXIN_MODELS_BY_SURFACE: dict[str, dict[str, type[FileSystemSyncMixin]]] = {
+    DEFAULT_SURFACE: MIXIN_MODELS,
+}
+
 
 class UnfiledFileSaver:
     """
@@ -44,13 +51,14 @@ class UnfiledFileSaver:
     haven't been put into FileSystem. Creates them with unique paths.
     """
 
-    def __init__(self, team: Team, user: User):
+    def __init__(self, team: Team, user: User, surface: str = DEFAULT_SURFACE):
         self.team = team
         self.user = user
+        self.surface = surface
         self._in_memory_paths: set[str] = set()
 
     def save_unfiled_for_model(self, model_cls: type[FileSystemSyncMixin]) -> list[FileSystem]:
-        unfiled_qs = model_cls.get_file_system_unfiled(self.team)
+        unfiled_qs = model_cls.get_file_system_unfiled(self.team, surface=self.surface)
         new_files: list[FileSystem] = []
         users_by_id: dict[int, User] = {}
         for obj in unfiled_qs:
@@ -85,6 +93,7 @@ class UnfiledFileSaver:
                     created_by=user,
                     created_at=created_at,
                     shortcut=False,
+                    surface=rep.surface,
                 )
             )
         FileSystem.objects.bulk_create(new_files)
@@ -92,17 +101,19 @@ class UnfiledFileSaver:
 
     def save_all_unfiled(self) -> list[FileSystem]:
         created_all = []
-        for model_cls in MIXIN_MODELS.values():
-            created_all.extend(self.save_unfiled_for_model(model_cls))  # type: ignore
+        for model_cls in MIXIN_MODELS_BY_SURFACE.get(self.surface, {}).values():
+            created_all.extend(self.save_unfiled_for_model(model_cls))
         return created_all
 
 
-def save_unfiled_files(team: Team, user: User, file_type: Optional[str] = None) -> list[FileSystem]:
-    saver = UnfiledFileSaver(team, user)
+def save_unfiled_files(
+    team: Team, user: User, file_type: Optional[str] = None, surface: str = DEFAULT_SURFACE
+) -> list[FileSystem]:
+    saver = UnfiledFileSaver(team, user, surface)
     if file_type is None:
         return saver.save_all_unfiled()
 
-    found_cls = MIXIN_MODELS.get(file_type)
+    found_cls = MIXIN_MODELS_BY_SURFACE.get(surface, {}).get(file_type)
     if not found_cls:
         return []
-    return saver.save_unfiled_for_model(found_cls)  # type: ignore
+    return saver.save_unfiled_for_model(found_cls)

--- a/posthog/models/filters/test/__snapshots__/test_filter.ambr
+++ b/posthog/models/filters/test/__snapshots__/test_filter.ambr
@@ -12,9 +12,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -68,9 +71,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -124,9 +130,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -146,9 +155,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -168,9 +180,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -190,9 +205,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"

--- a/posthog/session_recordings/models/session_recording_playlist.py
+++ b/posthog/session_recordings/models/session_recording_playlist.py
@@ -5,6 +5,7 @@ from django.db.models import QuerySet
 from django.db.models.indexes import Index
 from django.utils import timezone
 
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.utils import generate_short_id
@@ -58,9 +59,13 @@ class SessionRecordingPlaylist(FileSystemSyncMixin, models.Model):
         ]
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["SessionRecordingPlaylist"]:
+    def get_file_system_unfiled(
+        cls, team: "Team", surface: str = DEFAULT_SURFACE
+    ) -> QuerySet["SessionRecordingPlaylist"]:
         base_qs = cls.objects.filter(team=team, deleted=False)
-        return cls._filter_unfiled_queryset(base_qs, team, type="session_recording_playlist", ref_field="short_id")
+        return cls._filter_unfiled_queryset(
+            base_qs, team, type="session_recording_playlist", ref_field="short_id", surface=surface
+        )
 
     def get_file_system_representation(self) -> FileSystemRepresentation:
         href = (

--- a/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
@@ -12,9 +12,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'session_recording_playlist'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -34,9 +37,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'session_recording_playlist'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -674,9 +680,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'session_recording_playlist'
          AND NOT ("posthog_filesystem"."shortcut"

--- a/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
+++ b/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
@@ -12,9 +12,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -50,9 +53,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'feature_flag'
          AND NOT ("posthog_filesystemshortcut"."path" = 'flag-1'
@@ -728,9 +734,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -747,9 +756,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'feature_flag'
          AND NOT ("posthog_filesystemshortcut"."path" = 'flag-1'
@@ -1567,9 +1579,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"

--- a/posthog/temporal/tests/session_replay/count_playlist_items/__snapshots__/test_counting_logic.ambr
+++ b/posthog/temporal/tests/session_replay/count_playlist_items/__snapshots__/test_counting_logic.ambr
@@ -12,9 +12,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'session_recording_playlist'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -34,9 +37,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'session_recording_playlist'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -56,9 +62,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'session_recording_playlist'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -78,9 +87,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'session_recording_playlist'
          AND NOT ("posthog_filesystem"."shortcut"

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -12,9 +12,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -51,9 +54,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -90,9 +96,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -129,9 +138,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -195,9 +207,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -217,9 +232,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"

--- a/products/actions/backend/models/action.py
+++ b/products/actions/backend/models/action.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from posthog.hogql.errors import BaseHogQLError
 
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.signals import mutable_receiver
@@ -81,9 +82,9 @@ class Action(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.Mode
         super().save(*args, **kwargs)
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Action"]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["Action"]:
         base_qs = cls.objects.filter(team=team, deleted=False)
-        return cls._filter_unfiled_queryset(base_qs, team, type="action", ref_field="id")
+        return cls._filter_unfiled_queryset(base_qs, team, type="action", ref_field="id", surface=surface)
 
     def get_file_system_representation(self) -> FileSystemRepresentation:
         return FileSystemRepresentation(

--- a/products/cdp/backend/models/hog_functions/hog_function.py
+++ b/products/cdp/backend/models/hog_functions/hog_function.py
@@ -13,6 +13,7 @@ from prometheus_client import Counter
 
 from posthog.helpers.encrypted_fields import EncryptedJSONStringField
 from posthog.models.cohort.cohort import is_cohort_recalculation_only_save
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.signals import mutable_receiver
@@ -126,9 +127,11 @@ class HogFunction(FileSystemSyncMixin, UUIDTModel):
     )
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["HogFunction"]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["HogFunction"]:
         base_qs = HogFunction.objects.filter(team=team, deleted=False)
-        return cls._filter_unfiled_queryset(base_qs, team, type__startswith="hog_function/", ref_field="id")
+        return cls._filter_unfiled_queryset(
+            base_qs, team, type__startswith="hog_function/", ref_field="id", surface=surface
+        )
 
     def get_file_system_representation(self) -> FileSystemRepresentation:
         folder = "Unfiled/Destinations"

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1636,7 +1636,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             fs_data = insight.get_file_system_representation()
             try:
                 if fs_data.should_delete:
-                    delete_file(team=insight.team, file_type=fs_data.type, ref=fs_data.ref)
+                    delete_file(team=insight.team, file_type=fs_data.type, ref=fs_data.ref, surface=fs_data.surface)
                 else:
                     create_or_update_file(
                         team=insight.team,
@@ -1648,6 +1648,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
                         meta=fs_data.meta,
                         created_at=fs_data.meta.get("created_at") or insight.created_at,
                         created_by_id=fs_data.meta.get("created_by") or insight.created_by_id,
+                        surface=fs_data.surface,
                     )
             except Exception as exc:
                 # Mirror the signal-handler stance: never raise from sync, but surface it.

--- a/products/dashboards/backend/models/dashboard.py
+++ b/products/dashboards/backend/models/dashboard.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.db.models import QuerySet
 
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.utils import RootTeamManager, RootTeamMixin, sane_repr
@@ -120,9 +121,9 @@ class Dashboard(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.M
         return super().delete(*args, **kwargs)
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Dashboard"]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["Dashboard"]:
         base_qs = cls.objects.filter(team=team, deleted=False).exclude(creation_mode="template")
-        return cls._filter_unfiled_queryset(base_qs, team, type="dashboard", ref_field="id")
+        return cls._filter_unfiled_queryset(base_qs, team, type="dashboard", ref_field="id", surface=surface)
 
     def get_file_system_representation(self) -> FileSystemRepresentation:
         should_delete = self.deleted or (self.creation_mode == "template")

--- a/products/early_access_features/backend/models.py
+++ b/products/early_access_features/backend/models.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from django.db import models
 from django.db.models import QuerySet
 
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.utils import RootTeamMixin, UUIDTModel, sane_repr
@@ -55,9 +56,9 @@ class EarlyAccessFeature(FileSystemSyncMixin, RootTeamMixin, UUIDTModel):
     __repr__ = sane_repr("id", "name", "team_id", "stage")
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["EarlyAccessFeature"]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["EarlyAccessFeature"]:
         base_qs = cls.objects.filter(team=team)
-        return cls._filter_unfiled_queryset(base_qs, team, type="early_access_feature", ref_field="id")
+        return cls._filter_unfiled_queryset(base_qs, team, type="early_access_feature", ref_field="id", surface=surface)
 
     def get_file_system_representation(self) -> FileSystemRepresentation:
         return FileSystemRepresentation(

--- a/products/early_access_features/backend/test/__snapshots__/test_early_access_feature.ambr
+++ b/products/early_access_features/backend/test/__snapshots__/test_early_access_feature.ambr
@@ -12,9 +12,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -209,9 +212,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -267,9 +273,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'early_access_feature'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -289,9 +298,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'early_access_feature'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -364,9 +376,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -422,9 +437,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'early_access_feature'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -735,9 +753,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -793,9 +814,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'early_access_feature'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -908,9 +932,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -966,9 +993,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'early_access_feature'
          AND NOT ("posthog_filesystem"."shortcut"

--- a/products/experiments/backend/models/experiment.py
+++ b/products/experiments/backend/models/experiment.py
@@ -5,6 +5,7 @@ from django.db.models import QuerySet
 from django.utils import timezone
 
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.utils import RootTeamMixin, UUIDModel
@@ -163,9 +164,9 @@ class Experiment(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.
         return self.stats_config.get(key) if self.stats_config else None
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Experiment"]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["Experiment"]:
         base_qs = cls.objects.filter(team=team).exclude(deleted=True)
-        return cls._filter_unfiled_queryset(base_qs, team, type="experiment", ref_field="id")
+        return cls._filter_unfiled_queryset(base_qs, team, type="experiment", ref_field="id", surface=surface)
 
     def get_file_system_representation(self) -> FileSystemRepresentation:
         return FileSystemRepresentation(

--- a/products/feature_flags/backend/api/test/__snapshots__/test_feature_flag.ambr
+++ b/products/feature_flags/backend/api/test/__snapshots__/test_feature_flag.ambr
@@ -625,9 +625,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -644,9 +647,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'cohort'
          AND NOT ("posthog_filesystemshortcut"."path" = 'some cohort'
@@ -683,9 +689,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -702,9 +711,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'cohort'
          AND NOT ("posthog_filesystemshortcut"."path" = 'some cohort'
@@ -951,9 +963,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -970,9 +985,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'cohort'
          AND NOT ("posthog_filesystemshortcut"."path" = 'some cohort'
@@ -1156,9 +1174,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -1175,9 +1196,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'cohort'
          AND NOT ("posthog_filesystemshortcut"."path" = 'some cohort2'
@@ -1352,9 +1376,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -1371,9 +1398,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'cohort'
          AND NOT ("posthog_filesystemshortcut"."path" = 'some cohort'
@@ -1662,9 +1692,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -1681,9 +1714,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'cohort'
          AND NOT ("posthog_filesystemshortcut"."path" = 'some cohort'
@@ -1922,9 +1958,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -1944,9 +1983,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -1963,9 +2005,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'cohort'
          AND NOT ("posthog_filesystemshortcut"."path" = 'Users with feature flag some-feature enabled at 2021-01-01 00:00:00'
@@ -2315,9 +2360,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -2334,9 +2382,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'cohort'
          AND NOT ("posthog_filesystemshortcut"."path" = 'Users with feature flag some-feature enabled at 2021-01-01 00:00:00'

--- a/products/feature_flags/backend/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/products/feature_flags/backend/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -394,9 +394,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -534,9 +537,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'dashboard')
   '''
@@ -886,9 +892,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'dashboard')
   '''
@@ -1402,9 +1411,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'insight'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -2638,9 +2650,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'insight'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -3541,9 +3556,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'feature_flag'
          AND NOT ("posthog_filesystem"."shortcut"
@@ -3560,9 +3578,12 @@
          "posthog_filesystemshortcut"."ref",
          "posthog_filesystemshortcut"."href",
          "posthog_filesystemshortcut"."order",
-         "posthog_filesystemshortcut"."created_at"
+         "posthog_filesystemshortcut"."created_at",
+         "posthog_filesystemshortcut"."surface"
   FROM "posthog_filesystemshortcut"
-  WHERE ("posthog_filesystemshortcut"."ref" = '0001'
+  WHERE (("posthog_filesystemshortcut"."surface" IS NULL
+          OR "posthog_filesystemshortcut"."surface" = 'web')
+         AND "posthog_filesystemshortcut"."ref" = '0001'
          AND "posthog_filesystemshortcut"."team_id" = 99999
          AND "posthog_filesystemshortcut"."type" = 'feature_flag'
          AND NOT ("posthog_filesystemshortcut"."path" = 'copied-flag-key'

--- a/products/feature_flags/backend/models/feature_flag.py
+++ b/products/feature_flags/backend/models/feature_flag.py
@@ -19,6 +19,7 @@ from posthog.constants import ENRICHED_DASHBOARD_INSIGHT_IDENTIFIER, PropertyOpe
 from posthog.exceptions_capture import capture_exception
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
 from posthog.models.cohort import Cohort, CohortOrEmpty
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.property import GroupTypeIndex
@@ -154,9 +155,9 @@ class FeatureFlag(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models
             raise ValidationError("Encrypted payloads require the flag to be a remote configuration.")
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["FeatureFlag"]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["FeatureFlag"]:
         base_qs = cls.objects.filter(team=team, deleted=False)
-        return cls._filter_unfiled_queryset(base_qs, team, type="feature_flag", ref_field="id")
+        return cls._filter_unfiled_queryset(base_qs, team, type="feature_flag", ref_field="id", surface=surface)
 
     def get_file_system_representation(self) -> FileSystemRepresentation:
         return FileSystemRepresentation(

--- a/products/links/backend/models.py
+++ b/products/links/backend/models.py
@@ -3,6 +3,7 @@ from django.db.models import QuerySet
 
 import structlog
 
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.team import Team
@@ -59,9 +60,9 @@ class Link(FileSystemSyncMixin, CreatedMetaFields, UpdatedMetaFields, UUIDTModel
         return cls.objects.filter(team_id=team_id).order_by("-created_at")[offset : offset + limit]
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Link"]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["Link"]:
         base_qs = cls.objects.filter(team=team)
-        return cls._filter_unfiled_queryset(base_qs, team, type="link", ref_field="id")
+        return cls._filter_unfiled_queryset(base_qs, team, type="link", ref_field="id", surface=surface)
 
     def get_file_system_representation(self) -> FileSystemRepresentation:
         return FileSystemRepresentation(

--- a/products/notebooks/backend/models.py
+++ b/products/notebooks/backend/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.db.models import JSONField, QuerySet
 from django.utils import timezone
 
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.team import Team
@@ -47,9 +48,9 @@ class Notebook(FileSystemSyncMixin, RootTeamMixin, UUIDTModel):
         db_table = "posthog_notebook"
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Notebook"]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["Notebook"]:
         base_qs = cls.objects.filter(team=team, deleted=False)
-        return cls._filter_unfiled_queryset(base_qs, team, type="notebook", ref_field="short_id")
+        return cls._filter_unfiled_queryset(base_qs, team, type="notebook", ref_field="short_id", surface=surface)
 
     def get_file_system_representation(self) -> FileSystemRepresentation:
         return FileSystemRepresentation(

--- a/products/product_analytics/backend/api/test/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/api/test/__snapshots__/test_insight.ambr
@@ -2828,9 +2828,12 @@
          "posthog_filesystem"."meta",
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."surface",
          "posthog_filesystem"."project_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
+  WHERE (("posthog_filesystem"."surface" IS NULL
+          OR "posthog_filesystem"."surface" = 'web')
+         AND "posthog_filesystem"."ref" = '0001'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'insight'
          AND NOT ("posthog_filesystem"."shortcut"

--- a/products/product_analytics/backend/models/insight.py
+++ b/products/product_analytics/backend/models/insight.py
@@ -13,6 +13,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.exceptions_capture import capture_exception
 from posthog.logging.timing import timed
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.filters.utils import get_filter
@@ -153,9 +154,9 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
         super().save(*args, **kwargs)
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Insight"]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["Insight"]:
         base_qs = cls.objects.filter(team=team, deleted=False, saved=True)
-        return cls._filter_unfiled_queryset(base_qs, team, type="insight", ref_field="short_id")
+        return cls._filter_unfiled_queryset(base_qs, team, type="insight", ref_field="short_id", surface=surface)
 
     def get_file_system_representation(self) -> FileSystemRepresentation:
         should_delete = self.deleted or not self.saved

--- a/products/surveys/backend/models.py
+++ b/products/surveys/backend/models.py
@@ -12,6 +12,7 @@ from django.dispatch import receiver
 from dateutil.rrule import DAILY, rrule
 from django_deprecate_fields import deprecate_field
 
+from posthog.models.file_system.constants import DEFAULT_SURFACE
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.utils import RootTeamMixin, UUIDModel, UUIDTModel
@@ -301,9 +302,9 @@ class Survey(FileSystemSyncMixin, RootTeamMixin, UUIDTModel):
     actions = models.ManyToManyField(Action)
 
     @classmethod
-    def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Survey"]:
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["Survey"]:
         base_qs = cls.objects.filter(team=team)
-        return cls._filter_unfiled_queryset(base_qs, team, type="survey", ref_field="id")
+        return cls._filter_unfiled_queryset(base_qs, team, type="survey", ref_field="id", surface=surface)
 
     @classmethod
     def get_internal_flag_ids(

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -56,6 +56,87 @@ tools:
     delete-secret-token-backup-partial-update:
         operation: organizations_projects_delete_secret_token_backup_partial_update
         enabled: false
+    desktop-file-system-count-by-path-create:
+        operation: desktop_file_system_count_by_path_create
+        enabled: false
+    desktop-file-system-count-create:
+        operation: desktop_file_system_count_create
+        enabled: false
+    desktop-file-system-create:
+        operation: desktop_file_system_create
+        enabled: false
+    desktop-file-system-destroy:
+        operation: desktop_file_system_destroy
+        enabled: false
+    desktop-file-system-link-create:
+        operation: desktop_file_system_link_create
+        enabled: false
+    desktop-file-system-list:
+        operation: desktop_file_system_list
+        enabled: false
+    desktop-file-system-log-view-create:
+        operation: desktop_file_system_log_view_create
+        enabled: false
+    desktop-file-system-log-view-retrieve:
+        operation: desktop_file_system_log_view_retrieve
+        enabled: false
+    desktop-file-system-move-create:
+        operation: desktop_file_system_move_create
+        enabled: false
+    desktop-file-system-partial-update:
+        operation: desktop_file_system_partial_update
+        enabled: false
+    desktop-file-system-retrieve:
+        operation: desktop_file_system_retrieve
+        enabled: false
+    desktop-file-system-shortcut-create:
+        operation: desktop_file_system_shortcut_create
+        enabled: false
+    desktop-file-system-shortcut-destroy:
+        operation: desktop_file_system_shortcut_destroy
+        enabled: false
+    desktop-file-system-shortcut-list:
+        operation: desktop_file_system_shortcut_list
+        enabled: false
+    desktop-file-system-shortcut-partial-update:
+        operation: desktop_file_system_shortcut_partial_update
+        enabled: false
+    desktop-file-system-shortcut-reorder-create:
+        operation: desktop_file_system_shortcut_reorder_create
+        enabled: false
+    desktop-file-system-shortcut-retrieve:
+        operation: desktop_file_system_shortcut_retrieve
+        enabled: false
+    desktop-file-system-shortcut-update:
+        operation: desktop_file_system_shortcut_update
+        enabled: false
+    desktop-file-system-undo-delete-create:
+        operation: desktop_file_system_undo_delete_create
+        enabled: false
+    desktop-file-system-unfiled-retrieve:
+        operation: desktop_file_system_unfiled_retrieve
+        enabled: false
+    desktop-file-system-update:
+        operation: desktop_file_system_update
+        enabled: false
+    desktop-persisted-folder-create:
+        operation: desktop_persisted_folder_create
+        enabled: false
+    desktop-persisted-folder-destroy:
+        operation: desktop_persisted_folder_destroy
+        enabled: false
+    desktop-persisted-folder-list:
+        operation: desktop_persisted_folder_list
+        enabled: false
+    desktop-persisted-folder-partial-update:
+        operation: desktop_persisted_folder_partial_update
+        enabled: false
+    desktop-persisted-folder-retrieve:
+        operation: desktop_persisted_folder_retrieve
+        enabled: false
+    desktop-persisted-folder-update:
+        operation: desktop_persisted_folder_update
+        enabled: false
     domains-create:
         operation: domains_create
         enabled: false
@@ -128,6 +209,27 @@ tools:
     file-system-retrieve:
         operation: file_system_retrieve
         enabled: false
+    file-system-shortcut-create:
+        operation: file_system_shortcut_create
+        enabled: false
+    file-system-shortcut-destroy:
+        operation: file_system_shortcut_destroy
+        enabled: false
+    file-system-shortcut-list:
+        operation: file_system_shortcut_list
+        enabled: false
+    file-system-shortcut-partial-update:
+        operation: file_system_shortcut_partial_update
+        enabled: false
+    file-system-shortcut-reorder-create:
+        operation: file_system_shortcut_reorder_create
+        enabled: false
+    file-system-shortcut-retrieve:
+        operation: file_system_shortcut_retrieve
+        enabled: false
+    file-system-shortcut-update:
+        operation: file_system_shortcut_update
+        enabled: false
     file-system-undo-delete-create:
         operation: file_system_undo_delete_create
         enabled: false
@@ -193,6 +295,24 @@ tools:
         enabled: false
     organizations-projects-promoted-product-intent-retrieve:
         operation: organizations_projects_promoted_product_intent_retrieve
+        enabled: false
+    persisted-folder-create:
+        operation: persisted_folder_create
+        enabled: false
+    persisted-folder-destroy:
+        operation: persisted_folder_destroy
+        enabled: false
+    persisted-folder-list:
+        operation: persisted_folder_list
+        enabled: false
+    persisted-folder-partial-update:
+        operation: persisted_folder_partial_update
+        enabled: false
+    persisted-folder-retrieve:
+        operation: persisted_folder_retrieve
+        enabled: false
+    persisted-folder-update:
+        operation: persisted_folder_update
         enabled: false
     project-get:
         operation: organizations_projects_retrieve

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -45607,63 +45607,6 @@ export namespace Schemas {
     search?: string;
     };
 
-    export type DeploymentProjectsListParams = {
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number;
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number;
-    /**
-     * Which field to use when ordering the results.
-     */
-    ordering?: string;
-    /**
-     * A search term.
-     */
-    search?: string;
-    };
-
-    export type DeploymentProjectsDeploymentsListParams = {
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number;
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number;
-    /**
-     * Which field to use when ordering the results.
-     */
-    ordering?: string;
-    /**
-     * A search term.
-     */
-    search?: string;
-    };
-
-    export type DeploymentProjectsDeploymentsEventsListParams = {
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number;
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number;
-    /**
-     * Which field to use when ordering the results.
-     */
-    ordering?: string;
-    /**
-     * A search term.
-     */
-    search?: string;
-    };
-
     export type DesktopFileSystemListParams = {
     /**
      * Number of results to return per page.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -45607,6 +45607,63 @@ export namespace Schemas {
     search?: string;
     };
 
+    export type DeploymentProjectsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    /**
+     * Which field to use when ordering the results.
+     */
+    ordering?: string;
+    /**
+     * A search term.
+     */
+    search?: string;
+    };
+
+    export type DeploymentProjectsDeploymentsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    /**
+     * Which field to use when ordering the results.
+     */
+    ordering?: string;
+    /**
+     * A search term.
+     */
+    search?: string;
+    };
+
+    export type DeploymentProjectsDeploymentsEventsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    /**
+     * Which field to use when ordering the results.
+     */
+    ordering?: string;
+    /**
+     * A search term.
+     */
+    search?: string;
+    };
+
     export type DesktopFileSystemListParams = {
     /**
      * Number of results to return per page.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17693,17 +17693,26 @@ export namespace Schemas {
 
     export interface FileSystemShortcut {
       readonly id: string;
+      /** Display path of the shortcut in the sidebar. */
       path: string;
-      /** @maxLength 100 */
+      /**
+         * Type of the linked item (e.g. 'folder', 'insight'), or blank.
+         * @maxLength 100
+         */
       type?: string;
       /**
+         * Reference to the linked item, scoped to its type. Null for href-only shortcuts.
          * @maxLength 100
          * @nullable
          */
       ref?: string | null;
-      /** @nullable */
+      /**
+         * Destination URL the shortcut opens. Null when the shortcut points at an item by ref.
+         * @nullable
+         */
       href?: string | null;
       /**
+         * Display order within the user's shortcut list, ascending.
          * @minimum -2147483648
          * @maximum 2147483647
          */
@@ -23629,9 +23638,18 @@ export namespace Schemas {
 
     export interface PersistedFolder {
       readonly id: string;
+      /** Which persisted folder this is for the user (home, pinned, custom_products).
+
+      * `home` - Home
+      * `pinned` - Pinned
+      * `custom_products` - Custom Products */
       type: PersistedFolderTypeEnum;
-      /** @maxLength 64 */
+      /**
+         * Protocol prefix of the folder location, e.g. 'products://'.
+         * @maxLength 64
+         */
       protocol?: string;
+      /** Path within the protocol that the folder resolves to. */
       path?: string;
       readonly created_at: string;
       readonly updated_at: string;
@@ -28346,17 +28364,26 @@ export namespace Schemas {
 
     export interface PatchedFileSystemShortcut {
       readonly id?: string;
+      /** Display path of the shortcut in the sidebar. */
       path?: string;
-      /** @maxLength 100 */
+      /**
+         * Type of the linked item (e.g. 'folder', 'insight'), or blank.
+         * @maxLength 100
+         */
       type?: string;
       /**
+         * Reference to the linked item, scoped to its type. Null for href-only shortcuts.
          * @maxLength 100
          * @nullable
          */
       ref?: string | null;
-      /** @nullable */
+      /**
+         * Destination URL the shortcut opens. Null when the shortcut points at an item by ref.
+         * @nullable
+         */
       href?: string | null;
       /**
+         * Display order within the user's shortcut list, ascending.
          * @minimum -2147483648
          * @maximum 2147483647
          */
@@ -29416,9 +29443,18 @@ export namespace Schemas {
 
     export interface PatchedPersistedFolder {
       readonly id?: string;
+      /** Which persisted folder this is for the user (home, pinned, custom_products).
+
+      * `home` - Home
+      * `pinned` - Pinned
+      * `custom_products` - Custom Products */
       type?: PersistedFolderTypeEnum;
-      /** @maxLength 64 */
+      /**
+         * Protocol prefix of the folder location, e.g. 'products://'.
+         * @maxLength 64
+         */
       protocol?: string;
+      /** Path within the protocol that the folder resolves to. */
       path?: string;
       readonly created_at?: string;
       readonly updated_at?: string;
@@ -45569,6 +45605,100 @@ export namespace Schemas {
      * Search in name, description, or metadata
      */
     search?: string;
+    };
+
+    export type DeploymentProjectsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    /**
+     * Which field to use when ordering the results.
+     */
+    ordering?: string;
+    /**
+     * A search term.
+     */
+    search?: string;
+    };
+
+    export type DeploymentProjectsDeploymentsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    /**
+     * Which field to use when ordering the results.
+     */
+    ordering?: string;
+    /**
+     * A search term.
+     */
+    search?: string;
+    };
+
+    export type DeploymentProjectsDeploymentsEventsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    /**
+     * Which field to use when ordering the results.
+     */
+    ordering?: string;
+    /**
+     * A search term.
+     */
+    search?: string;
+    };
+
+    export type DesktopFileSystemListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    /**
+     * A search term.
+     */
+    search?: string;
+    };
+
+    export type DesktopFileSystemShortcutListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type DesktopPersistedFolderListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
     };
 
     export type DesktopRecordingsListParams = {


### PR DESCRIPTION
## human description

I want some sort of file categorization system in PostHog code. But I want it to be entirely separate from what people see and use in the web app, because we aren't even trying to consider migrating people over from the current web app to the new "PostHog v2.0" desktop (for now) experience. So I'm adding a field that says what surface the item should be used on - web or desktop, so we can load only the correct ones in.

Why use the same model instead of a fresh one? Because it's got a lot of what we need already and I don't want to reengineer it. And when we DO consider moving people over from one experience to the other, having the data in place already makes it easier. Though I'm open to alternative opinions.

---

AI content:

## Problem

We want to reuse the `FileSystem` model and its API for a second product surface. The two surfaces function almost identically — a navigable tree of items — but each item belongs to exactly one surface, and the existing tree must keep working unchanged. We need a way to differentiate items between use-cases without forking the model, the sync pipeline, or the access-control logic.

## Changes

Add a single nullable `surface` discriminator to `FileSystem` (and its adjacent models) and thread it through the existing pipeline:

- **Model** (`posthog/models/file_system/file_system.py`): new nullable `surface = CharField(max_length=100, null=True, blank=True)` with **no DB default**, so the column add is metadata-only (no table rewrite or long lock). `DEFAULT_SURFACE = "web"` plus a `surface_q()` helper encode the `NULL == "web"` rule in one place — a `web` read matches `surface IS NULL OR surface = 'web'`; any other surface is plain equality. `create_or_update_file()` / `delete_file()` take an optional `surface`, filter via `surface_q`, and always write an explicit value on create — so two surfaces never collide on the same `(team, type, ref)` key.
- **Sync pipeline**: `FileSystemRepresentation` gains `surface` (default `web`); the sync mixin threads it through `post_save`/`post_delete` and `_filter_unfiled_queryset`. All existing models keep the default with zero changes. The unfiled saver partitions models by surface.
- **Viewset**: `FileSystemViewSet` gets a server-controlled `file_system_surface` class attribute (not a forgeable query param); the `_scope_by_project` chokepoint filters by it, and the serializer receives it via context for folder/leaf creates. A `DesktopFileSystemViewSet` subclass is registered at `/api/projects/:team_id/desktop_file_system/`.
- **Adjacent models** carry `surface` too, so pinning and Recents are surface-aware from day one:
  - `FileSystemShortcut` — nullable `surface`; viewset scoped and stamped per surface, `reorder` scoped to surface, and a `DesktopFileSystemShortcutViewSet` route.
  - `FileSystemViewLog` (Recents) — nullable `surface` for per-surface filtering; kept **out** of the unique constraint because a `(type, ref)` item is exclusive to one surface, so `(team, user, type, ref)` already identifies a view uniquely.
  - `PersistedFolder` — nullable `surface`; the `unique_together(team, user, type)` is replaced with a **functional unique constraint** on `(team, user, type, COALESCE(surface, 'web'))`, because a folder `type` like `home` is *not* surface-exclusive (each surface has its own home). Coalescing `NULL → 'web'` keeps it consistent with the NULL-as-web rule and stops a legacy `NULL` row colliding with a new explicit-`web` row. A `DesktopPersistedFolderViewSet` route is registered.
- **Migrations**: `1193` adds the `FileSystem.surface` field; `1194` (`atomic = False`) re-fronts the three composite indexes as `(team_id, surface, ...)` concurrently; `1195` adds the three adjacent nullable columns; `1196` builds the PersistedFolder coalescing unique index concurrently; `1197` drops the old `unique_together`. All concurrent index work uses `posthog.migration_helpers.CreateIndexConcurrently` / `DropIndexConcurrently` wrapped in `SeparateDatabaseAndState`.

## How did you test this code?

I'm an agent. I could not run the test suite, `ruff`, or `makemigrations --check` in this environment (no Python/Django/ruff installed) — I verified every changed file with `python3 -m py_compile` and reviewed the full diff and the migration state progression by hand. CI is the real check. Automated tests added:

- **Model-level**: null-as-web behavior, cross-surface isolation, legacy-row update, surface-scoped delete, mixin default, unfiled partitioning, view-log surface persistence, and surface-scoped view-log delete cleanup.
- **API-level**: desktop route isolation and surface stamping for the file-system, shortcut, and persisted-folder routes; legacy rows surfacing only on `web`; per-surface `home` coexistence and the legacy-`NULL` upsert path for PersistedFolder; surface-scoped shortcut `reorder`.

`hogli build:openapi` still needs to run — the new desktop routes (`desktop_file_system`, `desktop_file_system_shortcut`, `desktop_persisted_folder`) add OpenAPI operations, and `help_text` / `x-product` were added to the shortcut and persisted-folder viewsets, so their generated frontend/MCP types will shift.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) via the PostHog Code agent harness.

Key design decisions:
- Chose a **single indexed discriminator column** over JSON tags, separate tables, or path-prefix conventions — items are exclusive to one surface and existing rows must default to the current tree, which a discriminator handles most simply.
- Made the column **nullable with no default** rather than `default="web"` so the migration is unambiguously metadata-only; the `NULL == "web"` rule is centralized in `surface_q()` and existing rows stay `NULL`.
- For `PersistedFolder`, surface must participate in uniqueness (a folder `type` is not surface-exclusive), so the new constraint coalesces `NULL → 'web'` — this both enforces one folder per surface and keeps legacy `NULL` rows from colliding with new explicit-`web` rows.
- Surface is **server-controlled** via a viewset class attribute / subclass rather than a request param, so a client can't read or write another surface's tree.
- Named it `surface` to avoid confusion with the viewset's existing `scope_object` (RBAC).

Agent-authored; requires human review. Do not self-merge.
