### PR TITLE
chore(replay-vision): rename "Ask Max" to "Ask PostHog AI" in summarizer chat

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/SummarizerMaxChat.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/SummarizerMaxChat.tsx
@@ -9,7 +9,7 @@ import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 
 import { replayScannerLogic } from '../replayScannerLogic'
 
-/** "Ask Max" entry point for summarizer scanners — lets the user chat about / digest the per-session summaries. */
+/** PostHog AI entry point for summarizer scanners — lets the user chat about / digest the per-session summaries. */
 export function SummarizerMaxChat({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element | null {
     const { scanner } = useValues(replayScannerLogic({ id: scannerId, tabId }))
     const isSummarizer = scanner?.scanner_type === 'summarizer'
@@ -33,11 +33,11 @@ export function SummarizerMaxChat({ scannerId, tabId }: { scannerId: string; tab
             <div>
                 <h3 className="text-base font-semibold mb-1">Chat about these summaries</h3>
                 <p className="text-sm text-muted m-0">
-                    Ask Max to find themes and patterns across this scanner's session summaries.
+                    Ask PostHog AI to find themes and patterns across this scanner's session summaries.
                 </p>
             </div>
             <LemonButton type="primary" icon={<IconAI />} onClick={() => openMax()} className="shrink-0">
-                Ask Max
+                Ask PostHog AI
             </LemonButton>
         </div>
     )


### PR DESCRIPTION
## Problem

The AI assistant is branded **PostHog AI** in user-facing copy, but the Replay Vision summarizer chat banner still said "Max".

## Changes

In `SummarizerMaxChat.tsx`, rename the user-facing copy from "Max" to "PostHog AI":

- Button: "Ask Max" → "Ask PostHog AI"
- Subheader: "Ask **PostHog AI** to find themes and patterns across this scanner's session summaries."

Internal identifiers (`useMaxTool`, `openMax`, the `summarize_replay_vision_summaries` tool id) are intentionally unchanged — they're the internal API, not user-facing. No behavior change; the subheader wording is otherwise unchanged.

## How did you test this code?

I'm an agent (PostHog Code). Copy-only change; `pnpm --filter=@posthog/frontend format` is clean. Confirmed against `origin/master` that no teammate had already renamed this copy. Not browser-tested.

## 🤖 Agent context

Authored with PostHog Code (Claude). An earlier iteration expanded the subheader to mention chatting about specific sessions/behaviors, but I reverted that: the chat tool (`SummarizeReplayVisionSummariesTool`) digests the latest ~100 summary texts and does **not** use embeddings or semantic search, and summarizer embeddings are off by default — so richer "search all sessions" copy would over-promise. This PR is therefore the pure branding rename. A genuine semantic-search-over-all-summaries tool was discussed as a separate future feature. Requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
