### PR TITLE
chore(batch-import-worker): test ENCRYPTION_KEYS multi-key rotation

### DIFF
--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -917,4 +917,98 @@ mod tests {
             }
         }
     }
+
+    // ---- ENCRYPTION_KEYS multi-key / two-step rotation ----
+    // The batch-import-worker shares the key material that Django/Node expose as ENCRYPTION_SALT_KEYS
+    // (here it's the ENCRYPTION_KEYS env var). It only decrypts BatchImport.secrets. These tests mirror
+    // the Python/Node coverage so all three implementations are verified against the same contract:
+    // the first key encrypts, every key is tried for decryption.
+
+    fn old_key() -> String {
+        "o".repeat(32)
+    }
+
+    fn new_key() -> String {
+        "n".repeat(32)
+    }
+
+    fn sample_secrets() -> JobSecrets {
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            "api_key".to_string(),
+            Value::String("super-secret-value".to_string()),
+        );
+        JobSecrets { secrets }
+    }
+
+    // Simulate a writer app (Django/Node) running with the given key list: the first key encrypts, and
+    // each raw 32-byte key is base64-urlsafe-encoded before Fernet — matching JobSecrets::decrypt.
+    fn encrypt_with(key_list: &[String], secrets: &JobSecrets) -> String {
+        let fernets: Vec<_> = key_list
+            .iter()
+            .map(|k| BASE64_URL_SAFE.encode(k.as_bytes()))
+            .filter_map(|k| fernet::Fernet::new(&k))
+            .collect();
+        let serialized = serde_json::to_vec(&secrets.secrets).unwrap();
+        MultiFernet::new(fernets).encrypt(&serialized)
+    }
+
+    #[test]
+    fn test_decrypt_tries_every_key_in_the_list() {
+        let secrets = sample_secrets();
+        let token = encrypt_with(&[new_key()], &secrets);
+
+        for reader in [vec![new_key(), old_key()], vec![old_key(), new_key()]] {
+            let decrypted = JobSecrets::decrypt(&token, &reader).unwrap();
+            assert_eq!(decrypted.secrets, secrets.secrets);
+        }
+    }
+
+    #[test]
+    fn test_two_step_rotation_coexisting_apps_decrypt_each_others_writes() {
+        // step 1: [old] -> [old, new]      new added for decryption; old still encrypts
+        // step 2: [old, new] -> [new, old] new now encrypts; old kept for decryption
+        let secrets = sample_secrets();
+        let steps = [
+            ("step 1", vec![vec![old_key()], vec![old_key(), new_key()]]),
+            (
+                "step 2",
+                vec![vec![old_key(), new_key()], vec![new_key(), old_key()]],
+            ),
+        ];
+
+        for (name, coexisting) in steps {
+            for writer in &coexisting {
+                let token = encrypt_with(writer, &secrets);
+                for reader in &coexisting {
+                    let decrypted = JobSecrets::decrypt(&token, reader).unwrap_or_else(|e| {
+                        panic!("{name}: reader {reader:?} could not decrypt writer {writer:?}: {e}")
+                    });
+                    assert_eq!(decrypted.secrets, secrets.secrets);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_step_1_apps_always_encrypt_with_the_old_key() {
+        // While [old] and [old, new] apps coexist, old is always first, so no app emits new-encrypted
+        // data that an un-upgraded [old]-only app could not read.
+        let secrets = sample_secrets();
+
+        for writer in [vec![old_key()], vec![old_key(), new_key()]] {
+            let token = encrypt_with(&writer, &secrets);
+            assert!(JobSecrets::decrypt(&token, &[old_key()]).is_ok());
+            assert!(JobSecrets::decrypt(&token, &[new_key()]).is_err());
+        }
+    }
+
+    #[test]
+    fn test_skipping_step_1_breaks_un_upgraded_worker() {
+        // A writer that jumped straight to [new, old] encrypts with new; a worker still on [old] cannot read it.
+        let secrets = sample_secrets();
+        let token = encrypt_with(&[new_key(), old_key()], &secrets);
+
+        assert!(JobSecrets::decrypt(&token, &[old_key()]).is_err());
+    }
 }


### PR DESCRIPTION
## Problem

`ENCRYPTION_SALT_KEYS` is consumed by three independent implementations of the same Fernet key scheme: Django (`MultiFernet`), the Node.js services (`fernet-nodejs`), and the Rust `batch-import-worker`. The Python and Node implementations already have rotation coverage (merged separately). The Rust worker — which reads the same key material under the `ENCRYPTION_KEYS` env var and decrypts `BatchImport` secrets — had none, so a rotation could silently diverge there.

## Changes

Tests only — no production code changes.

Add coverage to `rust/batch-import-worker/src/job/config.rs` for `JobSecrets`, mirroring the Python/Node suites so all three implementations are verified against the same contract:

- the **first** key encrypts; **every** key is tried for decryption;
- the two-step rollout `[old] → [old,new] → [new,old]` lets every coexisting app decrypt whatever any other writes during each step's mixed-version window;
- a direct one-step jump (`[old] → [new,old]`) would break an un-upgraded `[old]`-only worker — the negative case that justifies the two-step.

The worker only decrypts in production (Django/Node write the secrets), so these assert the decrypt side against writer tokens produced with the same raw-key → base64-urlsafe → Fernet derivation the worker uses.

## How did you test this code?

I'm an agent (Claude Code). No manual testing — only the automated tests below, run locally and passing:

- `cargo test -p batch-import-worker job::config::tests` — 24 passed (incl. the 4 new rotation tests)
- `cargo fmt -p batch-import-worker -- --check` and `cargo clippy -p batch-import-worker --tests` — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Tests only; no docs impact.

## 🤖 Agent context

Authored with Claude Code (Opus) as a follow-up to the merged Python/Node rotation tests. While inventorying which services consume this key, we found the `batch-import-worker` is a third implementation reading the value under a *different* env-var name (`ENCRYPTION_KEYS`, no `SALT`); these tests bring it to parity. The "writer" side is simulated in-test with the worker's own key derivation (raw 32-byte string → base64-urlsafe → Fernet), since the worker only decrypts in production. Agent-authored; requires human review.

Note: `JobSecrets::encrypt` has a pre-existing asymmetry (it skips the base64 step that `decrypt` applies) — out of scope here and left for a separate ticket, since the worker only decrypts in production.
