### PR TITLE
feat(tracing): enhance user action reporting in tracing views

### DIFF
--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -36,6 +36,7 @@ from posthog.api.documentation import _FallbackSerializer
 from posthog.api.mixins import PydanticModelMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.query_tagging import Feature, tag_queries
+from posthog.event_usage import report_user_action
 from posthog.hogql_queries.query_runner import ExecutionMode
 
 from ..logic import (
@@ -361,6 +362,23 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             next_cursor = base64.b64encode(
                 json.dumps({"timestamp": boundary_ts.isoformat(), "trace_id": boundary_trace_id}).encode("utf-8")
             ).decode("utf-8")
+
+        report_user_action(
+            request.user,
+            "tracing query executed",
+            {
+                "traces_count": len(kept_trace_ids),
+                "spans_count": len(results),
+                "has_more": has_more,
+                "has_filter_group": bool(query_data.get("filterGroup")),
+                "service_names_count": len(query_data.get("serviceNames") or []),
+                "status_codes_count": len(query_data.get("statusCodes") or []),
+                "order_by": order_by,
+                "is_paginated": bool(after_cursor),
+            },
+            team=self.team,
+            request=request,
+        )
 
         return Response(
             {

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -1,5 +1,6 @@
 import { actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -498,9 +499,18 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
             }
             actions.setSpanTreeAbortController(controller)
         },
+        fetchSpansSuccess: () => {
+            const tracesCount = values.rootSpans.length
+            if (tracesCount === 0) {
+                posthog.capture('tracing no results returned')
+            } else {
+                posthog.capture('tracing results returned', { count: tracesCount })
+            }
+        },
         fetchSpansFailure: ({ error }) => {
             if (!isUserInitiatedError(error)) {
                 lemonToast.error(`Failed to load traces: ${error}`)
+                posthog.capture('tracing query failed', { query_type: 'spans', error_message: String(error) })
             }
         },
         fetchSparklineFailure: ({ error }) => {

--- a/products/tracing/frontend/tracingSceneLogic.ts
+++ b/products/tracing/frontend/tracingSceneLogic.ts
@@ -1,6 +1,7 @@
 import equal from 'fast-deep-equal'
 import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
+import posthog from 'posthog-js'
 
 import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
@@ -70,6 +71,7 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
         openCompareFlame: (spanName: string, serviceName: string) => ({ spanName, serviceName }),
         closeCompareFlame: true,
         syncUrlAndRunQuery: true,
+        handleFilterChange: (filterType: string, extraProps?: Record<string, unknown>) => ({ filterType, extraProps }),
     }),
 
     reducers({
@@ -129,6 +131,7 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
 
     listeners(({ actions, values }) => ({
         openTraceModal: ({ traceId }) => {
+            posthog.capture('tracing trace opened')
             const prefetchedSpans = values.spans.filter((s: Span) => s.trace_id === traceId)
             if (prefetchedSpans.length >= PREFETCH_SPANS) {
                 actions.loadTraceSpans(traceId)
@@ -137,21 +140,15 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
         openCompareFlame: ({ spanName, serviceName }) => {
             actions.fetchSpanTree({ spanName, serviceName })
         },
-        setDateRange: () => {
+        handleFilterChange: ({ filterType, extraProps }) => {
+            posthog.capture('tracing filter changed', { filter_type: filterType, ...extraProps })
             actions.syncUrlAndRunQuery()
         },
-        setServiceNames: () => {
-            actions.syncUrlAndRunQuery()
-        },
-        setFilterGroup: () => {
-            actions.syncUrlAndRunQuery()
-        },
-        setOrderBy: () => {
-            actions.syncUrlAndRunQuery()
-        },
-        setCompareMode: () => {
-            actions.syncUrlAndRunQuery()
-        },
+        setDateRange: () => actions.handleFilterChange('date_range'),
+        setServiceNames: () => actions.handleFilterChange('service_names'),
+        setFilterGroup: () => actions.handleFilterChange('filter_group'),
+        setOrderBy: () => actions.handleFilterChange('order_by'),
+        setCompareMode: ({ compareMode }) => actions.handleFilterChange('compare_mode', { enabled: compareMode }),
         setOverlayWindows: () => {
             // Overlay drags only refetch the aggregation — the sparkline canvas range
             // stays fixed while the user moves windows around within it. If the compare-flame


### PR DESCRIPTION
## Problem

We have no visibility into how users are interacting with the tracing product — whether queries are succeeding, what filters are being applied, or whether results are being returned. This makes it difficult to understand usage patterns and identify pain points.

## Changes

Adds PostHog event capture across the tracing product to track key user interactions:

**Backend (`views.py`)**
- Reports a `tracing query executed` event after each successful query, including traces count, spans count, pagination state, and which filters were active (filter group, service names, status codes, order by).

**Frontend (`tracingDataLogic.ts`)**
- Captures `tracing results returned` (with count) or `tracing no results returned` after a successful spans fetch.
- Captures `tracing query failed` with error details on fetch failure.

**Frontend (`tracingSceneLogic.ts`)**
- Captures `tracing trace opened` when a user opens a trace modal.
- Introduces a `handleFilterChange` action that captures a `tracing filter changed` event with the filter type and any extra properties, then consolidates the previously duplicated `syncUrlAndRunQuery` calls for `setDateRange`, `setServiceNames`, `setFilterGroup`, `setOrderBy`, and `setCompareMode` through this single handler.

## How did you test this code?

Verified the consolidated filter listeners behave identically to the previous individual listeners. The backend reporting call is placed after all query logic completes, so it does not affect query results or error handling.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update