### PR TITLE
feat(web-analytics): use hog-charts Metric for overview tiles

### DIFF
--- a/frontend/src/queries/nodes/OverviewGrid/OverviewGrid.tsx
+++ b/frontend/src/queries/nodes/OverviewGrid/OverviewGrid.tsx
@@ -268,10 +268,14 @@ export const getOverviewItemTooltip = (item: OverviewItem, label: string, curren
         return `${label}: ${item.value >= item.previous ? 'increased' : 'decreased'} by ${formatPercentage(
             Math.abs(item.changeFromPreviousPct),
             { precise: true }
-        )}, to ${formatItem(item.value, item.kind, { precise: true, currency })} from ${formatItem(item.previous, item.kind, {
-            precise: true,
-            currency,
-        })}`
+        )}, to ${formatItem(item.value, item.kind, { precise: true, currency })} from ${formatItem(
+            item.previous,
+            item.kind,
+            {
+                precise: true,
+                currency,
+            }
+        )}`
     }
     if (isNotNil(item.value) && isNotNil(item.previous) && Math.abs(item.changeFromPreviousPct || 0) >= 999999) {
         return `${label}: ${formatItem(item.value, item.kind, { precise: true, currency })} (was 0 in previous period)`

--- a/frontend/src/queries/nodes/OverviewGrid/OverviewGrid.tsx
+++ b/frontend/src/queries/nodes/OverviewGrid/OverviewGrid.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import { useValues } from 'kea'
+import { Fragment } from 'react'
 
 import { IconTrending, IconWarning } from '@posthog/icons'
 import { LemonBanner, LemonSkeleton, Link } from '@posthog/lemon-ui'
@@ -50,6 +51,15 @@ interface OverviewGridProps {
     labelFromKey: (key: string) => string
     filterEmptyItems?: (item: OverviewItem) => boolean
     compact?: boolean
+    /** Optional override for how each item is rendered. When omitted, the default centered cell is used. */
+    renderItem?: (item: OverviewItem, helpers: OverviewItemRenderHelpers) => JSX.Element
+}
+
+export interface OverviewItemRenderHelpers {
+    label: string
+    usedPreAggregatedTables: boolean
+    usedLazyPrecompute: boolean
+    compact: boolean
 }
 
 export function OverviewGrid({
@@ -62,6 +72,7 @@ export function OverviewGrid({
     labelFromKey,
     filterEmptyItems = () => true,
     compact = false,
+    renderItem,
 }: OverviewGridProps): JSX.Element {
     const filteredItems = items.filter(filterEmptyItems)
 
@@ -78,16 +89,27 @@ export function OverviewGrid({
             >
                 {loading
                     ? range(numSkeletons).map((i) => <OverviewItemCellSkeleton key={i} compact={compact} />)
-                    : filteredItems.map((item) => (
-                          <OverviewItemCell
-                              key={item.key}
-                              item={item}
-                              usedPreAggregatedTables={usedPreAggregatedTables}
-                              usedLazyPrecompute={usedLazyPrecompute}
-                              labelFromKey={labelFromKey}
-                              compact={compact}
-                          />
-                      ))}
+                    : filteredItems.map((item) =>
+                          renderItem ? (
+                              <Fragment key={item.key}>
+                                  {renderItem(item, {
+                                      label: labelFromKey(item.key),
+                                      usedPreAggregatedTables,
+                                      usedLazyPrecompute,
+                                      compact,
+                                  })}
+                              </Fragment>
+                          ) : (
+                              <OverviewItemCell
+                                  key={item.key}
+                                  item={item}
+                                  usedPreAggregatedTables={usedPreAggregatedTables}
+                                  usedLazyPrecompute={usedLazyPrecompute}
+                                  labelFromKey={labelFromKey}
+                                  compact={compact}
+                              />
+                          )
+                      )}
             </EvenlyDistributedRows>
             {samplingRate && !(samplingRate.numerator === 1 && (samplingRate.denominator ?? 1) === 1) ? (
                 <LemonBanner type="info" className="my-4">
@@ -159,29 +181,7 @@ const OverviewItemCell = ({
                     }
             : undefined
 
-    // Handle tooltip logic with special cases for zero values and small changes
-    const tooltip =
-        isNotNil(item.value) &&
-        isNotNil(item.previous) &&
-        isNotNil(item.changeFromPreviousPct) &&
-        Math.abs(item.changeFromPreviousPct) < 999999
-            ? item.value === 0 && item.previous === 0
-                ? `${label}: No change (0 in both periods)`
-                : Math.abs(item.changeFromPreviousPct) < 1
-                  ? `${label}: No impactful change, less than 1%`
-                  : `${label}: ${item.value >= item.previous ? 'increased' : 'decreased'} by ${formatPercentage(
-                        Math.abs(item.changeFromPreviousPct),
-                        { precise: true }
-                    )}, to ${formatItem(item.value, item.kind, { precise: true, currency: baseCurrency })} from ${formatItem(
-                        item.previous,
-                        item.kind,
-                        { precise: true, currency: baseCurrency }
-                    )}`
-            : isNotNil(item.value) && isNotNil(item.previous) && Math.abs(item.changeFromPreviousPct || 0) >= 999999
-              ? `${label}: ${formatItem(item.value, item.kind, { precise: true, currency: baseCurrency })} (was 0 in previous period)`
-              : isNotNil(item.value)
-                ? `${label}: ${formatItem(item.value, item.kind, { precise: true, currency: baseCurrency })}`
-                : 'No data'
+    const tooltip = getOverviewItemTooltip(item, label, baseCurrency)
 
     return (
         <div
@@ -251,6 +251,37 @@ const OverviewItemCell = ({
     )
 }
 
+// Builds the hover tooltip for an overview metric, with special cases for zero values and small changes
+export const getOverviewItemTooltip = (item: OverviewItem, label: string, currency: string): string => {
+    if (
+        isNotNil(item.value) &&
+        isNotNil(item.previous) &&
+        isNotNil(item.changeFromPreviousPct) &&
+        Math.abs(item.changeFromPreviousPct) < 999999
+    ) {
+        if (item.value === 0 && item.previous === 0) {
+            return `${label}: No change (0 in both periods)`
+        }
+        if (Math.abs(item.changeFromPreviousPct) < 1) {
+            return `${label}: No impactful change, less than 1%`
+        }
+        return `${label}: ${item.value >= item.previous ? 'increased' : 'decreased'} by ${formatPercentage(
+            Math.abs(item.changeFromPreviousPct),
+            { precise: true }
+        )}, to ${formatItem(item.value, item.kind, { precise: true, currency })} from ${formatItem(item.previous, item.kind, {
+            precise: true,
+            currency,
+        })}`
+    }
+    if (isNotNil(item.value) && isNotNil(item.previous) && Math.abs(item.changeFromPreviousPct || 0) >= 999999) {
+        return `${label}: ${formatItem(item.value, item.kind, { precise: true, currency })} (was 0 in previous period)`
+    }
+    if (isNotNil(item.value)) {
+        return `${label}: ${formatItem(item.value, item.kind, { precise: true, currency })}`
+    }
+    return 'No data'
+}
+
 const formatUnit = (x: number, options?: { precise?: boolean }): string => {
     if (options?.precise) {
         return x.toLocaleString()
@@ -258,7 +289,7 @@ const formatUnit = (x: number, options?: { precise?: boolean }): string => {
     return humanFriendlyLargeNumber(x)
 }
 
-const formatItem = (
+export const formatItem = (
     value: number | string | undefined,
     kind: WebAnalyticsItemKind,
     options?: { precise?: boolean; currency?: string }

--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -135,27 +135,33 @@ function WebOverviewMetric({ item, helpers }: { item: OverviewItem; helpers: Ove
     )
 
     return (
-        <Tooltip title={getOverviewItemTooltip(item, label, baseCurrency)}>
-            <div className="relative flex-1 min-w-[10rem] border bg-surface-primary rounded p-3">
-                {usedLazyPrecompute ? (
-                    <PreAggregatedBadge variant="precomputed" />
-                ) : usedPreAggregatedTables ? (
-                    <PreAggregatedBadge variant="preagg" />
-                ) : null}
-                <Metric
-                    title={title}
-                    value={numericValue ?? 0}
-                    change={change}
-                    goodDirection={item.isIncreaseBad ? 'down' : 'up'}
-                    formatValue={(v) => (numericValue == null ? '-' : formatItem(v, item.kind, { currency: baseCurrency }))}
-                    subtitle={
-                        isNotNil(item.previous)
-                            ? `vs. ${formatItem(item.previous, item.kind, { currency: baseCurrency })} previous`
-                            : undefined
-                    }
-                />
-            </div>
-        </Tooltip>
+        <div className="relative flex-1 min-w-[10rem] border bg-surface-primary rounded p-3">
+            {/* Rendered as a sibling of the Tooltip trigger so hovering the badge
+                does not also surface the cell's metric tooltip. */}
+            {usedLazyPrecompute ? (
+                <PreAggregatedBadge variant="precomputed" />
+            ) : usedPreAggregatedTables ? (
+                <PreAggregatedBadge variant="preagg" />
+            ) : null}
+            <Tooltip title={getOverviewItemTooltip(item, label, baseCurrency)}>
+                <div className="w-full">
+                    <Metric
+                        title={title}
+                        value={numericValue ?? 0}
+                        change={change}
+                        goodDirection={item.isIncreaseBad ? 'down' : 'up'}
+                        formatValue={(v) =>
+                            numericValue == null ? '-' : formatItem(v, item.kind, { currency: baseCurrency })
+                        }
+                        subtitle={
+                            isNotNil(item.previous)
+                                ? `vs. ${formatItem(item.previous, item.kind, { currency: baseCurrency })} previous`
+                                : undefined
+                        }
+                    />
+                </div>
+            </Tooltip>
+        </div>
     )
 }
 

--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -1,17 +1,33 @@
 import { BuiltLogic, LogicWrapper, useValues } from 'kea'
 import { useState } from 'react'
 
+import { IconWarning } from '@posthog/icons'
+import { Link } from '@posthog/lemon-ui'
+
+import { PreAggregatedBadge } from 'lib/components/PreAggregatedBadge'
 import { reverseProxyCheckerLogic } from 'lib/components/ReverseProxyChecker/reverseProxyCheckerLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { Metric } from 'lib/hog-charts'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
-import { capitalizeFirstLetter } from 'lib/utils'
+import { capitalizeFirstLetter, isNotNil } from 'lib/utils'
+import { teamLogic } from 'scenes/teamLogic'
 
-import { OverviewGrid, OverviewItem } from '~/queries/nodes/OverviewGrid/OverviewGrid'
+import {
+    formatItem,
+    getOverviewItemTooltip,
+    OverviewGrid,
+    OverviewItem,
+    OverviewItemRenderHelpers,
+} from '~/queries/nodes/OverviewGrid/OverviewGrid'
 import { AnyResponseType, WebOverviewQuery, WebOverviewQueryResponse } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
+
+// Sentinel value the backend emits for changeFromPreviousPct when the previous period was 0
+const CHANGE_UNAVAILABLE = 999999
 
 let uniqueNode = 0
 
@@ -77,7 +93,69 @@ export function WebOverview(props: {
             usedPreAggregatedTables={usedWebAnalyticsPreAggregatedTables}
             usedLazyPrecompute={usedWebAnalyticsLazyPrecompute}
             labelFromKey={labelFromKey}
+            renderItem={(item, helpers) => <WebOverviewMetric item={item} helpers={helpers} />}
         />
+    )
+}
+
+function WebOverviewMetric({ item, helpers }: { item: OverviewItem; helpers: OverviewItemRenderHelpers }): JSX.Element {
+    const { baseCurrency } = useValues(teamLogic)
+    const { label, usedPreAggregatedTables, usedLazyPrecompute } = helpers
+
+    const numericValue = typeof item.value === 'number' ? item.value : undefined
+
+    // The change pill is hidden when there's nothing to compare against or the backend signals it's unavailable
+    const hasChange = isNotNil(item.changeFromPreviousPct) && Math.abs(item.changeFromPreviousPct) < CHANGE_UNAVAILABLE
+    const change = hasChange ? { value: item.changeFromPreviousPct as number } : null
+
+    const title = (
+        <span className="inline-flex items-center gap-1">
+            {label}
+            {item.warning && (
+                <Tooltip
+                    interactive={!!item.warningLink}
+                    title={
+                        <div>
+                            {item.warning}
+                            {item.warningLink && (
+                                <>
+                                    {' '}
+                                    <Link to={item.warningLink} className="text-link">
+                                        Learn more
+                                    </Link>
+                                </>
+                            )}
+                        </div>
+                    }
+                >
+                    <IconWarning className="text-warning h-3.5 w-3.5 cursor-pointer" />
+                </Tooltip>
+            )}
+        </span>
+    )
+
+    return (
+        <Tooltip title={getOverviewItemTooltip(item, label, baseCurrency)}>
+            <div className="relative flex-1 min-w-[10rem] border bg-surface-primary rounded p-3">
+                {usedLazyPrecompute ? (
+                    <PreAggregatedBadge variant="precomputed" />
+                ) : usedPreAggregatedTables ? (
+                    <PreAggregatedBadge variant="preagg" />
+                ) : null}
+                <Metric
+                    title={title}
+                    value={numericValue ?? 0}
+                    change={change}
+                    goodDirection={item.isIncreaseBad ? 'down' : 'up'}
+                    formatValue={(v) => (numericValue == null ? '-' : formatItem(v, item.kind, { currency: baseCurrency }))}
+                    subtitle={
+                        isNotNil(item.previous)
+                            ? `vs. ${formatItem(item.previous, item.kind, { currency: baseCurrency })} previous`
+                            : undefined
+                    }
+                />
+            </div>
+        </Tooltip>
     )
 }
 


### PR DESCRIPTION
## Problem

We recently merged the new `Metric` block into `lib/hog-charts` (#61006). The top-of-page Web analytics overview still uses the older bespoke centered cell. This PR starts adopting the shared component so the overview tiles match the new charting design language and benefit from its built-in change pill and styling.

## Changes

- **`OverviewGrid` (shared)** — added an optional `renderItem` prop (`OverviewItemRenderHelpers`). When omitted, the existing centered cell renders exactly as before, so marketing analytics and session recordings are unaffected. Exported `formatItem` (per-`kind` value formatting) and extracted the hover-tooltip logic into an exported `getOverviewItemTooltip` helper (the default cell uses it too — no behavior change).
- **`WebOverview` (web-analytics only)** — each metric now renders via `<Metric>` from `lib/hog-charts`:
  - title = metric label, with the reverse-proxy warning icon inline when present
  - value formatted by `kind` + the team's base currency
  - change pill from `changeFromPreviousPct`, hidden when there's no comparison or the backend sends the `999999` "previous period was 0" sentinel
  - `goodDirection` flips to `down` for bounce rate (`isIncreaseBad`) so an increase reads as red
  - subtitle shows the previous-period value when comparing
- Feature parity preserved: precise comparison tooltip, pre-aggregation badges, loading skeletons, and the sampling-rate banner (the last three come for free from `OverviewGrid`).

This is an intentional visual change, so the visual-regression snapshot for the `Scenes-App/Web Analytics` story (`WebAnalyticsDashboard`) will need regenerating. The loading-state story is unchanged (skeletons untouched).

## How did you test this code?

I'm an agent. I could not run lint / typecheck / build / Storybook locally — this environment has no installed frontend dependencies. The change follows existing patterns in the same files and CI will validate. No jest/RTL test asserts on the overview tile markup; the only affected test surface is the one visual-regression snapshot noted above, which a maintainer will need to regenerate.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8) at a human author's direction.

Key decisions:
- **Scoped the change via an additive `renderItem` prop rather than editing the shared cell in place.** `OverviewGrid` is also used by marketing analytics and session recordings; making the override opt-in keeps their rendering byte-for-byte identical.
- **Reused `OverviewGrid`'s grid/skeleton/sampling machinery** instead of duplicating a web-specific grid, to avoid regressing the loading and sampling-banner behavior.
- **Extracted `formatItem` + `getOverviewItemTooltip`** so the new web cell shares formatting and the precise comparison tooltip with the legacy cell.
- Considered enriching the `WebOverview.json` story mock with `previous`/`changeFromPreviousPct` so the snapshot exercises the new change pills; left out of this PR to keep it focused — easy follow-up.
