### PR TITLE
fix(tracing): capture results events in compare mode

### DIFF
--- a/products/tracing/frontend/tracingDataLogic.test.ts
+++ b/products/tracing/frontend/tracingDataLogic.test.ts
@@ -1,8 +1,22 @@
+import posthog from 'posthog-js'
+
+import { AggregatedSpanRow } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 
 import { tracingDataLogic } from './tracingDataLogic'
 import { tracingFiltersLogic } from './tracingFiltersLogic'
 import type { Span } from './types'
+
+const createMockAggregatedRow = (name: string): AggregatedSpanRow => ({
+    service_name: 'svc',
+    name,
+    count: 1,
+    total_duration_nano: 1000,
+    avg_duration_nano: 1000,
+    p50_duration_nano: 1000,
+    p95_duration_nano: 1000,
+    error_count: 0,
+})
 
 const TEST_TAB = 'test-tab'
 
@@ -122,6 +136,48 @@ describe('tracingDataLogic', () => {
             logic.actions.clearSpans()
             expect(logic.values.visibleRowRange).toBeNull()
             expect(logic.values.visibleRowDateRange).toBeNull()
+        })
+    })
+
+    describe('results tracking', () => {
+        let captureSpy: jest.SpyInstance
+
+        beforeEach(() => {
+            logic = mountWithSpans([])
+            captureSpy = jest.spyOn(posthog, 'capture').mockImplementation(() => undefined as any)
+        })
+
+        afterEach(() => {
+            captureSpy.mockRestore()
+        })
+
+        it('captures results returned for spans with a count', () => {
+            logic.actions.fetchSpansSuccess(mockSpans)
+            expect(captureSpy).toHaveBeenCalledWith('tracing results returned', {
+                count: mockSpans.length,
+                query_type: 'spans',
+            })
+        })
+
+        it('captures no results returned for empty spans', () => {
+            logic.actions.fetchSpansSuccess([])
+            expect(captureSpy).toHaveBeenCalledWith('tracing no results returned', { query_type: 'spans' })
+        })
+
+        it('captures results returned for aggregation with a count', () => {
+            logic.actions.fetchAggregationSuccess({
+                current: [createMockAggregatedRow('op-1'), createMockAggregatedRow('op-2')],
+                previous: null,
+            })
+            expect(captureSpy).toHaveBeenCalledWith('tracing results returned', {
+                count: 2,
+                query_type: 'aggregation',
+            })
+        })
+
+        it('captures no results returned for empty aggregation', () => {
+            logic.actions.fetchAggregationSuccess({ current: [], previous: null })
+            expect(captureSpy).toHaveBeenCalledWith('tracing no results returned', { query_type: 'aggregation' })
         })
     })
 })

--- a/products/tracing/frontend/tracingDataLogic.test.ts
+++ b/products/tracing/frontend/tracingDataLogic.test.ts
@@ -151,33 +151,38 @@ describe('tracingDataLogic', () => {
             captureSpy.mockRestore()
         })
 
-        it('captures results returned for spans with a count', () => {
-            logic.actions.fetchSpansSuccess(mockSpans)
-            expect(captureSpy).toHaveBeenCalledWith('tracing results returned', {
-                count: mockSpans.length,
-                query_type: 'spans',
-            })
-        })
-
-        it('captures no results returned for empty spans', () => {
-            logic.actions.fetchSpansSuccess([])
-            expect(captureSpy).toHaveBeenCalledWith('tracing no results returned', { query_type: 'spans' })
-        })
-
-        it('captures results returned for aggregation with a count', () => {
-            logic.actions.fetchAggregationSuccess({
-                current: [createMockAggregatedRow('op-1'), createMockAggregatedRow('op-2')],
-                previous: null,
-            })
-            expect(captureSpy).toHaveBeenCalledWith('tracing results returned', {
-                count: 2,
-                query_type: 'aggregation',
-            })
-        })
-
-        it('captures no results returned for empty aggregation', () => {
-            logic.actions.fetchAggregationSuccess({ current: [], previous: null })
-            expect(captureSpy).toHaveBeenCalledWith('tracing no results returned', { query_type: 'aggregation' })
+        it.each([
+            {
+                name: 'spans with a count',
+                dispatch: (l: typeof logic) => l.actions.fetchSpansSuccess(mockSpans),
+                event: 'tracing results returned',
+                properties: { count: mockSpans.length, query_type: 'spans' },
+            },
+            {
+                name: 'empty spans',
+                dispatch: (l: typeof logic) => l.actions.fetchSpansSuccess([]),
+                event: 'tracing no results returned',
+                properties: { query_type: 'spans' },
+            },
+            {
+                name: 'aggregation with a count',
+                dispatch: (l: typeof logic) =>
+                    l.actions.fetchAggregationSuccess({
+                        current: [createMockAggregatedRow('op-1'), createMockAggregatedRow('op-2')],
+                        previous: null,
+                    }),
+                event: 'tracing results returned',
+                properties: { count: 2, query_type: 'aggregation' },
+            },
+            {
+                name: 'empty aggregation',
+                dispatch: (l: typeof logic) => l.actions.fetchAggregationSuccess({ current: [], previous: null }),
+                event: 'tracing no results returned',
+                properties: { query_type: 'aggregation' },
+            },
+        ])('captures the right event for $name', ({ dispatch, event, properties }) => {
+            dispatch(logic)
+            expect(captureSpy).toHaveBeenCalledWith(event, properties)
         })
     })
 })

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -47,6 +47,14 @@ function isUserInitiatedError(error: unknown): boolean {
     return error === NEW_QUERY_STARTED_ERROR_MESSAGE || errorStr.includes('abort')
 }
 
+function captureTracingResults(count: number, queryType: 'spans' | 'aggregation'): void {
+    if (count === 0) {
+        posthog.capture('tracing no results returned', { query_type: queryType })
+    } else {
+        posthog.capture('tracing results returned', { count, query_type: queryType })
+    }
+}
+
 export interface TracingDataLogicProps {
     tabId?: string
 }
@@ -500,20 +508,10 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
             actions.setSpanTreeAbortController(controller)
         },
         fetchSpansSuccess: () => {
-            const tracesCount = values.rootSpans.length
-            if (tracesCount === 0) {
-                posthog.capture('tracing no results returned', { query_type: 'spans' })
-            } else {
-                posthog.capture('tracing results returned', { count: tracesCount, query_type: 'spans' })
-            }
+            captureTracingResults(values.rootSpans.length, 'spans')
         },
         fetchAggregationSuccess: ({ aggregation }) => {
-            const resultsCount = aggregation.current.length
-            if (resultsCount === 0) {
-                posthog.capture('tracing no results returned', { query_type: 'aggregation' })
-            } else {
-                posthog.capture('tracing results returned', { count: resultsCount, query_type: 'aggregation' })
-            }
+            captureTracingResults(aggregation.current.length, 'aggregation')
         },
         fetchSpansFailure: ({ error }) => {
             if (!isUserInitiatedError(error)) {

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -502,9 +502,17 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
         fetchSpansSuccess: () => {
             const tracesCount = values.rootSpans.length
             if (tracesCount === 0) {
-                posthog.capture('tracing no results returned')
+                posthog.capture('tracing no results returned', { query_type: 'spans' })
             } else {
-                posthog.capture('tracing results returned', { count: tracesCount })
+                posthog.capture('tracing results returned', { count: tracesCount, query_type: 'spans' })
+            }
+        },
+        fetchAggregationSuccess: ({ aggregation }) => {
+            const resultsCount = aggregation.current.length
+            if (resultsCount === 0) {
+                posthog.capture('tracing no results returned', { query_type: 'aggregation' })
+            } else {
+                posthog.capture('tracing results returned', { count: resultsCount, query_type: 'aggregation' })
             }
         },
         fetchSpansFailure: ({ error }) => {


### PR DESCRIPTION
## Problem

In `tracingDataLogic`, `runQuery` branches on `compareMode`: when compare mode is **on** it dispatches `fetchAggregation`, otherwise `fetchSpans`. The results-tracking analytics (`tracing results returned` / `tracing no results returned`) lived only in the `fetchSpansSuccess` listener, so in compare mode neither event was ever captured — even though the backend `tracing query executed` event still fired for the same HTTP call. This left compare-mode sessions blind in results tracking and created a backend/frontend asymmetry where the backend saw the query but the frontend never reported whether results came back.

## Changes

- Add a `fetchAggregationSuccess` listener mirroring `fetchSpansSuccess`, capturing `tracing results returned` (with `count`) or `tracing no results returned` based on the aggregation result count (`aggregation.current.length`).
- Tag both code paths with a `query_type` property (`spans` / `aggregation`) so the events remain distinguishable — consistent with the existing `tracing query failed` event, which already carries `query_type`.

## How did you test this code?

I'm an agent. I added and ran automated tests; I did not perform manual UI testing.

- Added unit tests in `tracingDataLogic.test.ts` covering both listeners (results returned with a count, and the empty/no-results case) for spans and aggregation. All 12 tests in the file pass via jest.
- Ran kea typegen and confirmed `tsc --noEmit` reports no errors in the tracing frontend files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus) in response to a code-review finding that compare mode left results tracking blind. The fix mirrors the existing spans-path analytics into a new `fetchAggregationSuccess` listener rather than moving the tracking into the shared `runQuery` listener, because the two paths return different shapes (root spans vs aggregated rows) and the success listeners are where the result counts are naturally available. Added a `query_type` discriminator so the two paths stay separable in analytics.
