### PR TITLE
feat(posthog-ai): sandbox slash-command filter and pre-warming

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -353,8 +353,11 @@ class ConversationViewSet(
         return False
 
     def check_throttles(self, request: Request):
-        # Only apply custom throttling for message-sending actions
-        if self.action not in ("create", "sandbox"):
+        # Apply the AI throttles to message-sending actions and to sandbox prewarm POSTs —
+        # warming provisions a real sandbox, so it must share the same rate limit. Release
+        # (DELETE) frees resources and keeps the default throttles.
+        is_prewarm_warm = self.action == "prewarm" and request.method == "POST"
+        if self.action not in ("create", "sandbox") and not is_prewarm_warm:
             return super().check_throttles(request)
 
         # Skip throttling in local development
@@ -736,6 +739,14 @@ class ConversationViewSet(
         if request.method == "DELETE":
             service.prewarm_release()
         else:
+            # Same billing gate as message-sending — warming launches a Run, so a quota-limited
+            # team must not be able to keep provisioning sandboxes via prewarm.
+            if is_team_limited(
+                self.team.api_token, QuotaResource.AI_CREDITS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+            ):
+                raise QuotaLimitExceeded(
+                    "Your organization reached its AI credit usage limit. Increase the limits in Billing settings, or ask an org admin to do so."
+                )
             service.prewarm()
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -709,6 +709,37 @@ class ConversationViewSet(
         return Response(result.model_dump(exclude={"attached_context_count"}), status=status.HTTP_200_OK)
 
     @extend_schema(
+        request=None,
+        responses={
+            204: OpenApiResponse(description="Sandbox warmed (booting or ready), or already warm / released."),
+            400: OpenApiResponse(description="Conversation is not on the sandbox runtime."),
+        },
+        description=(
+            "Eagerly provision a sandbox for a sandbox-runtime conversation while the user is typing. "
+            "POST warms a Run in-process (no pending message); DELETE releases it if the user abandons. "
+            "Both idempotent and sandbox runtime only."
+        ),
+    )
+    @action(detail=True, methods=["POST", "DELETE"], url_path="prewarm")
+    def prewarm(self, request: Request, *args, **kwargs):
+        """Per-conversation eager sandbox warm.
+
+        Sandbox runtime only. POST delegates to the in-process products/tasks warm
+        path; DELETE cancels a warm Run. No HTTP-to-self, no provisioning reimplemented.
+        """
+        conversation = self.get_object()
+        if conversation.agent_runtime != Conversation.AgentRuntime.SANDBOX:
+            raise exceptions.ValidationError("This conversation is not on the sandbox runtime.")
+
+        user = cast(User, request.user)
+        service = MessageRoutingService(conversation, user)
+        if request.method == "DELETE":
+            service.prewarm_release()
+        else:
+            service.prewarm()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
         description="Cancel the conversation's in-progress run (sandbox or LangGraph).",
         responses={
             200: SandboxCancelResponseSerializer,

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -1386,3 +1386,41 @@ class TestConversationSandboxRoute(APIBaseTest):
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         m_telemetry.assert_not_called()
+
+    def test_prewarm_post_delegates_to_warm_handler(self):
+        conversation = self._sandbox_conversation()
+        with patch("ee.api.conversation.MessageRoutingService") as m_service:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/prewarm/",
+            )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        # The service receives the resolved conversation, and POST warms (never releases).
+        passed_conversation = m_service.call_args[0][0]
+        self.assertEqual(passed_conversation.id, conversation.id)
+        m_service.return_value.prewarm.assert_called_once()
+        m_service.return_value.prewarm_release.assert_not_called()
+
+    def test_prewarm_delete_delegates_to_release_handler(self):
+        conversation = self._sandbox_conversation()
+        with patch("ee.api.conversation.MessageRoutingService") as m_service:
+            response = self.client.delete(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/prewarm/",
+            )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        m_service.return_value.prewarm_release.assert_called_once()
+        m_service.return_value.prewarm.assert_not_called()
+
+    def test_prewarm_rejects_langgraph_conversation(self):
+        conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            title="A chat",
+            type=Conversation.Type.ASSISTANT,
+            agent_runtime=Conversation.AgentRuntime.LANGGRAPH,
+        )
+        with patch("ee.api.conversation.MessageRoutingService") as m_service:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/prewarm/",
+            )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        m_service.assert_not_called()

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -10,6 +10,8 @@ from django.test import override_settings
 from django.utils import timezone
 
 from rest_framework import status
+from rest_framework.exceptions import Throttled
+from rest_framework.test import APIRequestFactory
 
 from posthog.schema import (
     AgentMode,
@@ -27,6 +29,7 @@ from posthog.schema import (
 
 from posthog.models.team.team import Team
 from posthog.models.user import User
+from posthog.rate_limit import AIBurstRateThrottle
 from posthog.temporal.ai.chat_agent import ChatAgentWorkflow, ChatAgentWorkflowInputs
 from posthog.temporal.ai.research_agent import ResearchAgentWorkflow, ResearchAgentWorkflowInputs
 
@@ -1424,3 +1427,65 @@ class TestConversationSandboxRoute(APIBaseTest):
             )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         m_service.assert_not_called()
+
+    def test_prewarm_post_blocked_when_quota_limited(self):
+        conversation = self._sandbox_conversation()
+        with (
+            patch("ee.api.conversation.is_team_limited", return_value=True),
+            patch("ee.api.conversation.MessageRoutingService") as m_service,
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/prewarm/",
+            )
+        self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
+        m_service.return_value.prewarm.assert_not_called()
+
+    def test_prewarm_release_is_not_quota_gated(self):
+        # Releasing frees a sandbox — a quota-limited team must still be able to do it.
+        conversation = self._sandbox_conversation()
+        with (
+            patch("ee.api.conversation.is_team_limited", return_value=True),
+            patch("ee.api.conversation.MessageRoutingService") as m_service,
+        ):
+            response = self.client.delete(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/prewarm/",
+            )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        m_service.return_value.prewarm_release.assert_called_once()
+
+    @override_settings(DEBUG=False)
+    def test_prewarm_post_applies_ai_throttles(self):
+        # Warming provisions a sandbox, so the POST takes the AI-throttle branch and is rejected
+        # once the burst throttle denies.
+        viewset = ConversationViewSet()
+        viewset.action = "prewarm"
+        viewset.team_id = self.team.id
+        viewset.organization = self.organization
+
+        warm = APIRequestFactory().post("/")
+        with (
+            patch.object(ConversationViewSet, "_is_research_request", return_value=False) as m_research,
+            patch.object(AIBurstRateThrottle, "allow_request", return_value=False),
+            patch.object(AIBurstRateThrottle, "wait", return_value=30),
+        ):
+            with self.assertRaises(Throttled):
+                viewset.check_throttles(warm)
+        m_research.assert_called_once()
+
+    @override_settings(DEBUG=False)
+    def test_prewarm_delete_uses_default_throttles(self):
+        # Release (DELETE) frees resources, so it falls through to the default throttles instead
+        # of the AI rate limit.
+        viewset = ConversationViewSet()
+        viewset.action = "prewarm"
+        viewset.team_id = self.team.id
+        viewset.organization = self.organization
+
+        release = APIRequestFactory().delete("/")
+        with (
+            patch.object(ConversationViewSet, "_is_research_request") as m_research,
+            patch("rest_framework.views.APIView.check_throttles") as m_super,
+        ):
+            viewset.check_throttles(release)
+        m_research.assert_not_called()
+        m_super.assert_called_once()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6674,6 +6674,23 @@ const api = {
         },
 
         /**
+         * Eagerly provision a sandbox while the user is typing. Sandbox runtime only; idempotent.
+         * Returns 204 — warms a Run in-process with no pending message so the session boots and
+         * idles awaiting input. Submitting later follows the in-progress branch.
+         */
+        prewarm(conversationId: string): Promise<void> {
+            return new ApiRequest().conversation(conversationId).withAction('prewarm').create()
+        },
+
+        /**
+         * Release / cancel an eager prewarm if the user abandons. Idempotent;
+         * a DELETE on a conversation with no warm Run is a no-op.
+         */
+        prewarmRelease(conversationId: string): Promise<void> {
+            return new ApiRequest().conversation(conversationId).withAction('prewarm').delete()
+        },
+
+        /**
          * Sandbox-runtime approval reply. Routes in-process to the products/tasks
          * `permission_response` command path. `customInput` carries the optional
          * `reject_with_feedback` text.

--- a/frontend/src/scenes/max/components/QuestionInput.test.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.test.tsx
@@ -3,6 +3,8 @@ import '@testing-library/jest-dom'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { BindLogic, Provider } from 'kea'
 
+import api from 'lib/api'
+
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
@@ -21,7 +23,7 @@ jest.mock(
     { virtual: true }
 )
 
-describe('QuestionInput slash command autocomplete', () => {
+describe('QuestionInput', () => {
     let maxLogicInstance: ReturnType<typeof maxLogic.build>
     let threadLogicInstance: ReturnType<typeof maxThreadLogic.build>
 
@@ -60,6 +62,40 @@ describe('QuestionInput slash command autocomplete', () => {
     })
 
     const slashCommandItem = (): HTMLElement | null => screen.queryByText('/init')
+
+    const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+    it('does not release a sandbox pre-warm when blur moves to the send button', async () => {
+        const releaseSpy = jest.spyOn(api.conversations, 'prewarmRelease').mockResolvedValue(undefined as any)
+        // Simulate a completed warm so a release would issue a DELETE.
+        threadLogicInstance.cache.prewarmed = true
+        threadLogicInstance.cache.prewarming = false
+
+        const input = screen.getByRole('textbox') as HTMLTextAreaElement
+        const sendButton = document.querySelector('[data-attr="max-send-message"]') as HTMLElement
+        expect(sendButton).not.toBeNull()
+
+        // Clicking send blurs the textarea before the click fires the send — the warm must survive.
+        fireEvent.blur(input, { relatedTarget: sendButton })
+        await flush()
+
+        expect(releaseSpy).not.toHaveBeenCalled()
+        expect(threadLogicInstance.cache.prewarmed).toBe(true)
+    })
+
+    it('releases a sandbox pre-warm when blur leaves the input for somewhere else', async () => {
+        const releaseSpy = jest.spyOn(api.conversations, 'prewarmRelease').mockResolvedValue(undefined as any)
+        threadLogicInstance.cache.prewarmed = true
+        threadLogicInstance.cache.prewarming = false
+
+        const input = screen.getByRole('textbox') as HTMLTextAreaElement
+
+        fireEvent.blur(input, { relatedTarget: null })
+        await flush()
+
+        expect(releaseSpy).toHaveBeenCalledTimes(1)
+        expect(threadLogicInstance.cache.prewarmed).toBe(false)
+    })
 
     it('reopens the popover after Escape dismisses it and a fresh slash is typed', async () => {
         const input = screen.getByRole('textbox') as HTMLTextAreaElement

--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -333,10 +333,20 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                                         ref={textAreaRef}
                                         value={isSharedThread ? '' : question}
                                         onChange={(value) => setQuestion(value)}
-                                        onBlur={() => {
+                                        onBlur={(e) => {
                                             // Release any sandbox pre-warm when the user leaves the
                                             // input without sending. No-op on LangGraph / unwarmed
                                             // conversations.
+                                            //
+                                            // But clicking the send button blurs the textarea *before*
+                                            // its onClick fires the send — releasing here would cancel
+                                            // the very warm Run the send is about to consume. When focus
+                                            // moves to the send button, skip the release and let the send
+                                            // path consume the warm (it does so without a DELETE).
+                                            const next = e.relatedTarget as HTMLElement | null
+                                            if (next?.closest('[data-attr="max-send-message"]')) {
+                                                return
+                                            }
                                             releaseSandboxPrewarm()
                                         }}
                                         onPressEnter={() => {

--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -164,8 +164,14 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
         queuedMessages,
         queueSubmitting,
     } = useValues(maxThreadLogic)
-    const { askMax, stopGeneration, completeThreadGeneration, setSupportOverrideEnabled, updateQueuedMessage } =
-        useActions(maxThreadLogic)
+    const {
+        askMax,
+        stopGeneration,
+        completeThreadGeneration,
+        setSupportOverrideEnabled,
+        updateQueuedMessage,
+        releaseSandboxPrewarm,
+    } = useActions(maxThreadLogic)
     const { isActive: handsFreeActive } = useValues(handsFreeLogic({ panelId: maxPanelId }))
     // Only the hands-free row needs bottom-aligned pills — it has the mic + submit pair
     // pinned to the bottom and pills sitting in normal flow look misaligned next to them.
@@ -327,6 +333,12 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                                         ref={textAreaRef}
                                         value={isSharedThread ? '' : question}
                                         onChange={(value) => setQuestion(value)}
+                                        onBlur={() => {
+                                            // Release any sandbox pre-warm when the user leaves the
+                                            // input without sending. No-op on LangGraph / unwarmed
+                                            // conversations.
+                                            releaseSandboxPrewarm()
+                                        }}
                                         onPressEnter={() => {
                                             if (
                                                 hasQuestion &&

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -1392,6 +1392,78 @@ describe('maxThreadLogic', () => {
         })
     })
 
+    describe('sandbox prewarm', () => {
+        const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+        function idleSandboxConversation(): ConversationDetail {
+            return {
+                id: MOCK_CONVERSATION_ID,
+                status: ConversationStatus.Idle,
+                title: 'Sandbox chat',
+                user: MOCK_DEFAULT_BASIC_USER,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                type: ConversationType.Assistant,
+                agent_runtime: 'sandbox',
+                task: { id: 'task-1', current_run_id: null },
+                messages: [],
+            }
+        }
+
+        async function mountIdleSandbox(): Promise<void> {
+            logic.unmount()
+            jest.spyOn(api.conversations, 'get').mockResolvedValue(idleSandboxConversation())
+            logic = maxThreadLogic({
+                conversationId: MOCK_CONVERSATION_ID,
+                panelId: 'test',
+                conversation: idleSandboxConversation(),
+            })
+            logic.mount()
+            await flush()
+        }
+
+        it('releases a warm sandbox abandoned while the warm POST was still in flight', async () => {
+            await mountIdleSandbox()
+
+            let resolvePrewarm: () => void = () => {}
+            const prewarmSpy = jest
+                .spyOn(api.conversations, 'prewarm')
+                .mockReturnValue(new Promise<void>((resolve) => (resolvePrewarm = resolve)) as any)
+            const releaseSpy = jest.spyOn(api.conversations, 'prewarmRelease').mockResolvedValue(undefined as any)
+
+            // Warm starts; the POST is in flight (not yet resolved).
+            logic.actions.prewarmSandbox()
+            await flush()
+            expect(prewarmSpy).toHaveBeenCalledTimes(1)
+
+            // User abandons the input before the warm resolves — the release can't issue a DELETE
+            // yet (nothing is warm), so it must be deferred, not dropped.
+            logic.actions.releaseSandboxPrewarm()
+            await flush()
+            expect(releaseSpy).not.toHaveBeenCalled()
+
+            // The warm POST resolves — the deferred release fires so the sandbox isn't leaked.
+            resolvePrewarm()
+            await flush()
+            await flush()
+            expect(releaseSpy).toHaveBeenCalledTimes(1)
+            expect(releaseSpy).toHaveBeenCalledWith(MOCK_CONVERSATION_ID)
+        })
+
+        it('does not release a warm that resolved with no pending abandon', async () => {
+            await mountIdleSandbox()
+
+            jest.spyOn(api.conversations, 'prewarm').mockResolvedValue(undefined as any)
+            const releaseSpy = jest.spyOn(api.conversations, 'prewarmRelease').mockResolvedValue(undefined as any)
+
+            logic.actions.prewarmSandbox()
+            await flush()
+            await flush()
+
+            expect(releaseSpy).not.toHaveBeenCalled()
+        })
+    })
+
     describe('filteredCommands runtime filter', () => {
         function setRuntime(runtime: 'langgraph' | 'sandbox'): void {
             logic.actions.setConversation({

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -1392,6 +1392,36 @@ describe('maxThreadLogic', () => {
         })
     })
 
+    describe('filteredCommands runtime filter', () => {
+        function setRuntime(runtime: 'langgraph' | 'sandbox'): void {
+            logic.actions.setConversation({
+                ...MOCK_IN_PROGRESS_CONVERSATION,
+                status: ConversationStatus.Idle,
+                agent_runtime: runtime,
+            } as Conversation)
+            // Empty question matches every command by prefix.
+            maxLogicInstance.actions.setQuestion('')
+        }
+
+        it('hides /init and /remember for sandbox conversations, keeps /usage and /feedback', async () => {
+            setRuntime('sandbox')
+            const names = logic.values.filteredCommands.map((c) => c.name)
+            expect(names).not.toContain(SlashCommandName.SlashInit)
+            expect(names).not.toContain(SlashCommandName.SlashRemember)
+            expect(names).toContain(SlashCommandName.SlashUsage)
+            expect(names).toContain(SlashCommandName.SlashFeedback)
+        })
+
+        it('keeps the full command set for langgraph conversations', async () => {
+            setRuntime('langgraph')
+            const names = logic.values.filteredCommands.map((c) => c.name)
+            expect(names).toContain(SlashCommandName.SlashInit)
+            expect(names).toContain(SlashCommandName.SlashRemember)
+            expect(names).toContain(SlashCommandName.SlashUsage)
+            expect(names).toContain(SlashCommandName.SlashFeedback)
+        })
+    })
+
     describe('command selection and activation', () => {
         beforeEach(() => {
             logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -278,6 +278,8 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         setPendingApproval: (proposalId: string) => ({ proposalId }),
         clearPendingApproval: true,
         appendSandboxEntry: (entry: LogEntry) => ({ entry }),
+        prewarmSandbox: true,
+        releaseSandboxPrewarm: true,
         refreshSandboxEntries: true,
         resetSandboxEntries: true,
         continueAfterForm: (formAnswers: MultiQuestionFormAnswers) => ({
@@ -966,6 +968,74 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             }
             // Note: pending approvals loading is handled in the reducer (pendingApprovalsData.setConversation)
         },
+        setQuestion: ({ question }) => {
+            // Sandbox pre-warming. Debounce on the first non-whitespace keystroke so the sandbox
+            // boots while the user is still typing; release if the input empties.
+            // LangGraph conversations are unaffected.
+            if (values.conversation?.agent_runtime !== 'sandbox') {
+                return
+            }
+            // Don't warm if a run is already active — the live Run is the desired state.
+            if (values.threadLoading) {
+                return
+            }
+            if (question.trim() === '') {
+                // Input emptied — cancel a pending warm trigger and schedule release after 5s.
+                cache.disposables.dispose('prewarm-debounce')
+                if (cache.prewarmed) {
+                    cache.disposables.add(() => {
+                        const timer = setTimeout(() => actions.releaseSandboxPrewarm(), 5000)
+                        return () => clearTimeout(timer)
+                    }, 'prewarm-release')
+                }
+                return
+            }
+            // Non-empty input: cancel any pending release, then debounce the warm.
+            cache.disposables.dispose('prewarm-release')
+            if (cache.prewarmed) {
+                return
+            }
+            cache.disposables.add(() => {
+                const timer = setTimeout(() => actions.prewarmSandbox(), 250)
+                return () => clearTimeout(timer)
+            }, 'prewarm-debounce')
+        },
+        prewarmSandbox: async () => {
+            cache.disposables.dispose('prewarm-debounce')
+            if (values.conversation?.agent_runtime !== 'sandbox' || !values.conversationId) {
+                return
+            }
+            // Guard against duplicate warms and warming over an active run.
+            if (cache.prewarmed || cache.prewarming || values.threadLoading) {
+                return
+            }
+            cache.prewarming = true
+            try {
+                await api.conversations.prewarm(values.conversationId)
+                cache.prewarmed = true
+            } catch (e) {
+                // Pre-warming is best-effort latency optimization; a failure just means the first
+                // message takes the cold path. Don't surface it to the user.
+                posthog.captureException(e)
+            } finally {
+                cache.prewarming = false
+            }
+        },
+        releaseSandboxPrewarm: async () => {
+            cache.disposables.dispose('prewarm-debounce')
+            cache.disposables.dispose('prewarm-release')
+            if (!cache.prewarmed || !values.conversationId) {
+                cache.prewarmed = false
+                return
+            }
+            // A warm consumed by a sent message must not be released — only release on abandon.
+            cache.prewarmed = false
+            try {
+                await api.conversations.prewarmRelease(values.conversationId)
+            } catch (e) {
+                posthog.captureException(e)
+            }
+        },
         enqueueQueuedMessage: async ({ content, contextualTools, uiContext, billingContext, agentMode }) => {
             if (!values.queueingEnabled || !values.conversation?.id) {
                 actions.setQueuedMessages([])
@@ -1096,6 +1166,12 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             if (values.conversationId !== values.activeThreadKey) {
                 return
             }
+            // A sent message consumes any sandbox pre-warm: the warm Run is the in-progress run the
+            // sandbox routing follows up on, so cancel pending timers and clear the flag WITHOUT
+            // issuing a release/DELETE.
+            cache.disposables.dispose('prewarm-debounce')
+            cache.disposables.dispose('prewarm-release')
+            cache.prewarmed = false
             const contextualTools = Object.fromEntries(values.tools.map((tool) => [tool.identifier, tool.context]))
             // Always send voice_mode as an explicit boolean when handsFreeLogic is mounted,
             // not just when active. Otherwise a typed turn following a spoken one inherits
@@ -1796,12 +1872,13 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         ],
 
         filteredCommands: [
-            (s) => [s.question, s.featureFlags, s.threadLoading, s.billingContext],
+            (s) => [s.question, s.featureFlags, s.threadLoading, s.billingContext, s.conversation],
             (
                 question: string,
                 featureFlags: Record<string, boolean | string>,
                 threadLoading: boolean,
-                billingContext: MaxBillingContext | null
+                billingContext: MaxBillingContext | null,
+                conversation: Conversation | null
             ): SlashCommand[] => {
                 const hasPaidPlan =
                     billingContext?.subscription_level === MaxBillingContextSubscriptionLevel.PAID ||
@@ -1809,12 +1886,16 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     billingContext?.trial?.is_active ||
                     process.env.NODE_ENV === 'development'
 
+                // Sandbox runtime drops core-memory commands; LangGraph keeps the full set.
+                const isSandboxRuntime = conversation?.agent_runtime === 'sandbox'
+
                 return MAX_SLASH_COMMANDS.filter(
                     (command) =>
                         command.name.toLowerCase().startsWith(question.toLowerCase()) &&
                         (!command.flag || featureFlags[command.flag]) &&
                         (!command.requiresIdle || !threadLoading) &&
-                        (!command.requiresPaidPlan || hasPaidPlan)
+                        (!command.requiresPaidPlan || hasPaidPlan) &&
+                        (!command.hiddenInSandbox || !isSandboxRuntime)
                 )
             },
         ],

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -1010,9 +1010,17 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 return
             }
             cache.prewarming = true
+            cache.pendingRelease = false
             try {
                 await api.conversations.prewarm(values.conversationId)
                 cache.prewarmed = true
+                // If the user abandoned the input while this POST was in flight, the blur/empty
+                // release hit the early-exit (nothing was warm yet). Honor it now so the freshly
+                // warmed sandbox isn't leaked until the agent-server's idle self-cancel.
+                if (cache.pendingRelease) {
+                    cache.pendingRelease = false
+                    actions.releaseSandboxPrewarm()
+                }
             } catch (e) {
                 // Pre-warming is best-effort latency optimization; a failure just means the first
                 // message takes the cold path. Don't surface it to the user.
@@ -1025,6 +1033,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             cache.disposables.dispose('prewarm-debounce')
             cache.disposables.dispose('prewarm-release')
             if (!cache.prewarmed || !values.conversationId) {
+                // A warm POST may still be in flight — record the intent so its success handler
+                // releases the sandbox instead of dropping the request on the floor.
+                if (cache.prewarming) {
+                    cache.pendingRelease = true
+                }
                 cache.prewarmed = false
                 return
             }
@@ -1172,6 +1185,9 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             cache.disposables.dispose('prewarm-debounce')
             cache.disposables.dispose('prewarm-release')
             cache.prewarmed = false
+            // A sent message consumes the warm — drop any in-flight release intent so the
+            // run the message follows up on isn't cancelled out from under it.
+            cache.pendingRelease = false
             const contextualTools = Object.fromEntries(values.tools.map((tool) => [tool.identifier, tool.context]))
             // Always send voice_mode as an explicit boolean when handsFreeLogic is mounted,
             // not just when active. Otherwise a typed turn following a spoken one inherits

--- a/frontend/src/scenes/max/slash-commands.tsx
+++ b/frontend/src/scenes/max/slash-commands.tsx
@@ -16,6 +16,12 @@ export interface SlashCommand {
     requiresIdle?: boolean
     /** If true, this command is only available for users on paid plans or with an active trial */
     requiresPaidPlan?: boolean
+    /**
+     * If true, this command is hidden for sandbox-runtime conversations.
+     * Core-memory commands (`/init`, `/remember`) are not yet supported under sandbox AI.
+     * LangGraph conversations are unaffected.
+     */
+    hiddenInSandbox?: boolean
 }
 
 export const MAX_SLASH_COMMANDS: SlashCommand[] = [
@@ -23,12 +29,14 @@ export const MAX_SLASH_COMMANDS: SlashCommand[] = [
         name: SlashCommandName.SlashInit,
         description: 'Set up knowledge about your product & business',
         icon: <IconRocket />,
+        hiddenInSandbox: true,
     },
     {
         name: SlashCommandName.SlashRemember,
         arg: '[information]',
         description: "Add [information] to PostHog AI's project-level memory",
         icon: <IconMemory />,
+        hiddenInSandbox: true,
     },
     {
         name: SlashCommandName.SlashUsage,

--- a/products/conversations/frontend/generated/api.ts
+++ b/products/conversations/frontend/generated/api.ts
@@ -208,6 +208,42 @@ export const conversationsPermissionCreate = async (
     })
 }
 
+export const getConversationsPrewarmCreateUrl = (projectId: string, conversation: string) => {
+    return `/api/environments/${projectId}/conversations/${conversation}/prewarm/`
+}
+
+/**
+ * Eagerly provision a sandbox for a sandbox-runtime conversation while the user is typing. POST warms a Run in-process (no pending message); DELETE releases it if the user abandons. Both idempotent and sandbox runtime only.
+ */
+export const conversationsPrewarmCreate = async (
+    projectId: string,
+    conversation: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getConversationsPrewarmCreateUrl(projectId, conversation), {
+        ...options,
+        method: 'POST',
+    })
+}
+
+export const getConversationsPrewarmDestroyUrl = (projectId: string, conversation: string) => {
+    return `/api/environments/${projectId}/conversations/${conversation}/prewarm/`
+}
+
+/**
+ * Eagerly provision a sandbox for a sandbox-runtime conversation while the user is typing. POST warms a Run in-process (no pending message); DELETE releases it if the user abandons. Both idempotent and sandbox runtime only.
+ */
+export const conversationsPrewarmDestroy = async (
+    projectId: string,
+    conversation: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getConversationsPrewarmDestroyUrl(projectId, conversation), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
 export const getConversationsQueueRetrieveUrl = (projectId: string, conversation: string) => {
     return `/api/environments/${projectId}/conversations/${conversation}/queue/`
 }

--- a/products/conversations/mcp/tools.yaml
+++ b/products/conversations/mcp/tools.yaml
@@ -27,6 +27,12 @@ tools:
     conversations-permission-create:
         operation: conversations_permission_create
         enabled: false
+    conversations-prewarm-create:
+        operation: conversations_prewarm_create
+        enabled: false
+    conversations-prewarm-destroy:
+        operation: conversations_prewarm_destroy
+        enabled: false
     conversations-queue-clear-create:
         operation: conversations_queue_clear_create
         enabled: false

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -212,6 +212,16 @@ class MessageRoutingService(BaseSandboxService):
         two tabs warming the same conversation cannot create two Runs. Idempotent: a
         non-terminal current Run is a no-op. Capped per user and per org.
         """
+        # Best-effort capacity guard. Counts cross-conversation runs that this conversation's row
+        # lock can't serialize anyway, so check it before taking the lock to keep the lock narrow.
+        if self._prewarm_at_capacity():
+            logger.info(
+                "sandbox_prewarm_capacity_reached",
+                conversation_id=str(self.conversation.id),
+                user_id=self.user.pk,
+            )
+            return
+
         system_prompt = PromptService(self.team, self.user).build()
 
         # Decide + write the warm Run under the conversation lock; start the workflow only
@@ -220,13 +230,6 @@ class MessageRoutingService(BaseSandboxService):
         with lock_conversation_for_followup(str(self.conversation.id), self.team.pk) as locked:
             current_run = locked.current_run
             if current_run is not None and current_run.status in self._IN_PROGRESS_STATUSES:
-                return
-            if self._prewarm_at_capacity():
-                logger.info(
-                    "sandbox_prewarm_capacity_reached",
-                    conversation_id=str(locked.id),
-                    user_id=self.user.pk,
-                )
                 return
             if locked.task_id is None:
                 dispatch = self._prewarm_first(locked, system_prompt)
@@ -308,15 +311,15 @@ class MessageRoutingService(BaseSandboxService):
         if task_run is None:
             raise exceptions.ValidationError("Failed to create sandbox prewarm run.")
 
-        run_state: dict[str, Any] = dict(task_run.state or {})
-        run_state.update(
-            {
-                "systemPrompt": system_prompt,
-                "initial_permission_mode": "default",
-                # No pending_user_message / attached_context: the session idles awaiting input.
-                "await_user_message": True,
-            }
+        # No pending_user_message / attached_context: the session idles awaiting input.
+        # `exclude_unset` keeps the merge to exactly these keys so model defaults don't leak.
+        ph_state = PostHogAIRunState(
+            system_prompt=system_prompt,
+            initial_permission_mode="default",
+            await_user_message=True,
         )
+        run_state: dict[str, Any] = dict(task_run.state or {})
+        run_state.update(ph_state.model_dump(mode="json", by_alias=True, exclude_unset=True))
         task_run.state = run_state
         task_run.save(update_fields=["state"])
         conversation.task = task
@@ -336,11 +339,12 @@ class MessageRoutingService(BaseSandboxService):
         if task is None:
             return None
 
-        extra_state: dict[str, Any] = {
-            "systemPrompt": system_prompt,
-            "initial_permission_mode": "default",
-            "await_user_message": True,
-        }
+        ph_state = PostHogAIRunState(
+            system_prompt=system_prompt,
+            initial_permission_mode="default",
+            await_user_message=True,
+        )
+        extra_state: dict[str, Any] = ph_state.model_dump(mode="json", by_alias=True, exclude_unset=True)
         if current_run is not None:
             extra_state["resume_from_run_id"] = str(current_run.id)
             snapshot_external_id = (current_run.state or {}).get("snapshot_external_id")

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -113,6 +113,11 @@ class MessageRoutingService(BaseSandboxService):
     # Run statuses that accept a follow-up signal without creating a successor Run.
     _IN_PROGRESS_STATUSES: frozenset[str] = frozenset({TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS})
 
+    # Caps on concurrent non-terminal sandbox Runs reachable via prewarm, bounding resource use
+    # from repeated warm / re-warm calls. Message-sending paths are separately quota-gated.
+    _PREWARM_MAX_PER_USER: int = 2
+    _PREWARM_MAX_PER_ORG: int = 10
+
     def __init__(self, conversation: "Conversation", user: User) -> None:
         super().__init__(team=conversation.team, user=user)
         self.conversation = conversation
@@ -203,20 +208,62 @@ class MessageRoutingService(BaseSandboxService):
         command. When the user submits, `handle` finds the Run in-progress and
         routes through the follow-up branch.
 
-        Idempotent: if the conversation already has a non-terminal current Run,
-        this is a no-op.
+        Serialized per conversation under the same row lock as a terminal resume, so
+        two tabs warming the same conversation cannot create two Runs. Idempotent: a
+        non-terminal current Run is a no-op. Capped per user and per org.
         """
-        if self.conversation.task_id is not None:
-            current_run = self.conversation.current_run
-            if current_run is not None and current_run.status in self._IN_PROGRESS_STATUSES:
-                return
-
         system_prompt = PromptService(self.team, self.user).build()
 
-        if self.conversation.task_id is None:
-            self._prewarm_first(system_prompt)
-        else:
-            self._prewarm_rewarm(system_prompt)
+        # Decide + write the warm Run under the conversation lock; start the workflow only
+        # after it commits so a rollback can't leave an orphaned sandbox.
+        dispatch: tuple[str, str] | None = None
+        with lock_conversation_for_followup(str(self.conversation.id), self.team.pk) as locked:
+            current_run = locked.current_run
+            if current_run is not None and current_run.status in self._IN_PROGRESS_STATUSES:
+                return
+            if self._prewarm_at_capacity():
+                logger.info(
+                    "sandbox_prewarm_capacity_reached",
+                    conversation_id=str(locked.id),
+                    user_id=self.user.pk,
+                )
+                return
+            if locked.task_id is None:
+                dispatch = self._prewarm_first(locked, system_prompt)
+            else:
+                dispatch = self._prewarm_rewarm(locked, current_run, system_prompt)
+
+        if dispatch is None:
+            return
+        task_id, run_id = dispatch
+        execute_task_processing_workflow(
+            task_id=task_id,
+            run_id=run_id,
+            team_id=self.team.id,
+            user_id=self.user.pk,
+            create_pr=False,
+            posthog_mcp_scopes="full",
+        )
+
+    def _prewarm_at_capacity(self) -> bool:
+        """True if the user or org already holds the max concurrent warm sandboxes.
+
+        Counts non-terminal PostHog AI Runs (queued / in-progress) across the user and the
+        org so a POST/DELETE re-warm loop can't spin up unbounded sandboxes. The cross-
+        conversation count isn't serialized, so it may overshoot slightly under heavy
+        concurrency — acceptable for a best-effort resource guard.
+        """
+        non_terminal = TaskRun.objects.filter(
+            task__origin_product=Task.OriginProduct.POSTHOG_AI,
+            status__in=self._IN_PROGRESS_STATUSES,
+        ).exclude(task__deleted=True)
+
+        if non_terminal.filter(task__created_by_id=self.user.pk).count() >= self._PREWARM_MAX_PER_USER:
+            return True
+        return (
+            non_terminal.filter(task__team__organization_id=self.team.organization_id).count()
+            >= self._PREWARM_MAX_PER_ORG
+        )
 
     def prewarm_release(self) -> None:
         """Release a warm Run if the user abandons the input.
@@ -237,9 +284,13 @@ class MessageRoutingService(BaseSandboxService):
 
         send_cancel(run)
 
-    def _prewarm_first(self, system_prompt: str) -> None:
+    def _prewarm_first(self, conversation: "Conversation", system_prompt: str) -> tuple[str, str]:
         """First warm — create the Task + Run, mirroring `_handle_first_message`
-        but without a pending user message or attached context."""
+        but without a pending user message or attached context.
+
+        DB writes only; runs inside the caller's conversation lock. Returns the
+        `(task_id, run_id)` the caller starts the workflow against after commit.
+        """
         task = Task.create_and_run(
             team=self.team,
             title="",
@@ -266,67 +317,38 @@ class MessageRoutingService(BaseSandboxService):
                 "await_user_message": True,
             }
         )
-        with transaction.atomic():
-            task_run.state = run_state
-            task_run.save(update_fields=["state"])
-            self.conversation.task = task
-            self.conversation.save(update_fields=["task", "updated_at"])
+        task_run.state = run_state
+        task_run.save(update_fields=["state"])
+        conversation.task = task
+        conversation.save(update_fields=["task", "updated_at"])
+        return str(task.id), str(task_run.id)
 
-        # Same write scopes as the first message — the warm Run becomes the run the
-        # user's first submit follows up on, so it must keep create scopes.
-        execute_task_processing_workflow(
-            task_id=str(task.id),
-            run_id=str(task_run.id),
-            team_id=self.team.id,
-            user_id=self.user.pk,
-            create_pr=False,
-            posthog_mcp_scopes="full",
-        )
-
-    def _prewarm_rewarm(self, system_prompt: str) -> None:
+    def _prewarm_rewarm(
+        self, conversation: "Conversation", current_run: "TaskRun | None", system_prompt: str
+    ) -> tuple[str, str] | None:
         """Re-warm on an existing Task whose current Run is terminal.
 
         Creates a fresh successor Run carrying the prior Run's snapshot so the warm
-        session reuses the filesystem, then starts its workflow. The successor
-        create runs under the same Conversation row lock as a terminal resume so a
-        concurrent prewarm / submit cannot create two successors.
+        session reuses the filesystem. DB writes only; runs inside the caller's
+        conversation lock. Returns the `(task_id, run_id)` to start after commit.
         """
-        task = self.conversation.task
+        task = conversation.task
         if task is None:
-            return
+            return None
 
-        new_run: TaskRun | None = None
-        with lock_conversation_for_followup(str(self.conversation.id), self.team.pk) as locked:
-            # Re-resolve under the lock: a concurrent prewarm / submit may have already
-            # created a live successor Run while this request waited.
-            current_run = locked.current_run
-            if current_run is not None and current_run.status in self._IN_PROGRESS_STATUSES:
-                return
+        extra_state: dict[str, Any] = {
+            "systemPrompt": system_prompt,
+            "initial_permission_mode": "default",
+            "await_user_message": True,
+        }
+        if current_run is not None:
+            extra_state["resume_from_run_id"] = str(current_run.id)
+            snapshot_external_id = (current_run.state or {}).get("snapshot_external_id")
+            if snapshot_external_id:
+                extra_state["snapshot_external_id"] = snapshot_external_id
 
-            extra_state: dict[str, Any] = {
-                "systemPrompt": system_prompt,
-                "initial_permission_mode": "default",
-                "await_user_message": True,
-            }
-            if current_run is not None:
-                extra_state["resume_from_run_id"] = str(current_run.id)
-                snapshot_external_id = (current_run.state or {}).get("snapshot_external_id")
-                if snapshot_external_id:
-                    extra_state["snapshot_external_id"] = snapshot_external_id
-
-            new_run = task.create_run(mode="interactive", extra_state=extra_state)
-
-        if new_run is None:
-            return
-
-        execute_task_processing_workflow(
-            task_id=str(task.id),
-            run_id=str(new_run.id),
-            team_id=self.team.id,
-            user_id=self.user.pk,
-            create_pr=False,
-            posthog_mcp_scopes="full",
-        )
+        new_run = task.create_run(mode="interactive", extra_state=extra_state)
+        return str(task.id), str(new_run.id)
 
     def _handle_first_message(
         self,

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -193,6 +193,141 @@ class MessageRoutingService(BaseSandboxService):
             cancel_requested=True,
         )
 
+    def prewarm(self) -> None:
+        """Eagerly provision a sandbox Run while the user is typing.
+
+        Boots the sandbox + ACP session ahead of the first submit so first-token
+        latency drops from a cold boot to roughly model-invocation time. The warm
+        Run carries the standard system prompt but no pending user message and no
+        attached context — it opens the session and idles awaiting a `user_message`
+        command. When the user submits, `handle` finds the Run in-progress and
+        routes through the follow-up branch.
+
+        Idempotent: if the conversation already has a non-terminal current Run,
+        this is a no-op.
+        """
+        if self.conversation.task_id is not None:
+            current_run = self.conversation.current_run
+            if current_run is not None and current_run.status in self._IN_PROGRESS_STATUSES:
+                return
+
+        system_prompt = PromptService(self.team, self.user).build()
+
+        if self.conversation.task_id is None:
+            self._prewarm_first(system_prompt)
+        else:
+            self._prewarm_rewarm(system_prompt)
+
+    def prewarm_release(self) -> None:
+        """Release a warm Run if the user abandons the input.
+
+        Cancels the conversation's current non-terminal Run via the in-process
+        command path, letting it transition to terminal; the conversation can warm
+        again on the next typing session. Idempotent: no warm Run is a no-op.
+        """
+        if self.conversation.task_id is None:
+            return
+
+        run = self.conversation.current_run
+        if run is None or run.is_terminal:
+            return
+
+        if run.status not in self._IN_PROGRESS_STATUSES:
+            return
+
+        send_cancel(run)
+
+    def _prewarm_first(self, system_prompt: str) -> None:
+        """First warm — create the Task + Run, mirroring `_handle_first_message`
+        but without a pending user message or attached context."""
+        task = Task.create_and_run(
+            team=self.team,
+            title="",
+            description="",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            user_id=self.user.pk,
+            repository=None,
+            create_pr=False,
+            mode="interactive",
+            # Defer the workflow so the initial run state can carry the PostHog AI keys.
+            start_workflow=False,
+        )
+
+        task_run = task.latest_run
+        if task_run is None:
+            raise exceptions.ValidationError("Failed to create sandbox prewarm run.")
+
+        run_state: dict[str, Any] = dict(task_run.state or {})
+        run_state.update(
+            {
+                "systemPrompt": system_prompt,
+                "initial_permission_mode": "default",
+                # No pending_user_message / attached_context: the session idles awaiting input.
+                "await_user_message": True,
+            }
+        )
+        with transaction.atomic():
+            task_run.state = run_state
+            task_run.save(update_fields=["state"])
+            self.conversation.task = task
+            self.conversation.save(update_fields=["task", "updated_at"])
+
+        # Same write scopes as the first message — the warm Run becomes the run the
+        # user's first submit follows up on, so it must keep create scopes.
+        execute_task_processing_workflow(
+            task_id=str(task.id),
+            run_id=str(task_run.id),
+            team_id=self.team.id,
+            user_id=self.user.pk,
+            create_pr=False,
+            posthog_mcp_scopes="full",
+        )
+
+    def _prewarm_rewarm(self, system_prompt: str) -> None:
+        """Re-warm on an existing Task whose current Run is terminal.
+
+        Creates a fresh successor Run carrying the prior Run's snapshot so the warm
+        session reuses the filesystem, then starts its workflow. The successor
+        create runs under the same Conversation row lock as a terminal resume so a
+        concurrent prewarm / submit cannot create two successors.
+        """
+        task = self.conversation.task
+        if task is None:
+            return
+
+        new_run: TaskRun | None = None
+        with lock_conversation_for_followup(str(self.conversation.id), self.team.pk) as locked:
+            # Re-resolve under the lock: a concurrent prewarm / submit may have already
+            # created a live successor Run while this request waited.
+            current_run = locked.current_run
+            if current_run is not None and current_run.status in self._IN_PROGRESS_STATUSES:
+                return
+
+            extra_state: dict[str, Any] = {
+                "systemPrompt": system_prompt,
+                "initial_permission_mode": "default",
+                "await_user_message": True,
+            }
+            if current_run is not None:
+                extra_state["resume_from_run_id"] = str(current_run.id)
+                snapshot_external_id = (current_run.state or {}).get("snapshot_external_id")
+                if snapshot_external_id:
+                    extra_state["snapshot_external_id"] = snapshot_external_id
+
+            new_run = task.create_run(mode="interactive", extra_state=extra_state)
+
+        if new_run is None:
+            return
+
+        execute_task_processing_workflow(
+            task_id=str(task.id),
+            run_id=str(new_run.id),
+            team_id=self.team.id,
+            user_id=self.user.pk,
+            create_pr=False,
+            posthog_mcp_scopes="full",
+        )
+
     def _handle_first_message(
         self,
         *,

--- a/products/posthog_ai/backend/run_state.py
+++ b/products/posthog_ai/backend/run_state.py
@@ -21,3 +21,6 @@ class PostHogAIRunState(RunState):
 
     system_prompt: str | None = Field(default=None, alias="systemPrompt")
     attached_context: list[AttachedContext] | None = None
+    # Set on a pre-warmed Run created with no pending user message: it tells the agent-server to
+    # open the ACP session and idle awaiting the first ``user_message`` rather than starting a turn.
+    await_user_message: bool = False

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -384,3 +384,115 @@ class TestLockConversationForFollowup(APIBaseTest):
 
         with lock_conversation_for_followup(str(conversation.id), self.team.id) as locked:
             self.assertEqual(locked.id, conversation.id)
+
+
+class TestSandboxPrewarm(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            agent_runtime=Conversation.AgentRuntime.SANDBOX,
+        )
+
+    def _service(self) -> MessageRoutingService:
+        return MessageRoutingService(self.conversation, self.user)
+
+    def _stub_task(self) -> tuple[Task, TaskRun]:
+        task = Task.objects.create(
+            team=self.team,
+            title="t",
+            description="d",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=self.user,
+        )
+        run = task.create_run(mode="interactive")
+        return task, run
+
+    def test_prewarm_first_creates_warm_run_without_pending_message(self):
+        task, run = self._stub_task()
+        with (
+            patch.object(Task, "create_and_run", return_value=task) as m_car,
+            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch.object(PromptService, "build", return_value="SYS"),
+        ):
+            self._service().prewarm()
+
+        m_car.assert_called_once()
+
+        run.refresh_from_db()
+        assert run.state["systemPrompt"] == "SYS"
+        assert run.state["await_user_message"] is True
+        # No pending message / attached context: the session boots and idles awaiting input.
+        assert "pending_user_message" not in run.state
+        assert "attached_context" not in run.state
+
+        self.conversation.refresh_from_db()
+        assert self.conversation.task_id == task.id
+        m_workflow.assert_called_once()
+
+    def test_prewarm_is_noop_when_run_already_in_progress(self):
+        task, run = self._stub_task()
+        run.status = TaskRun.Status.IN_PROGRESS
+        run.save(update_fields=["status"])
+        self.conversation.task = task
+        self.conversation.save(update_fields=["task"])
+
+        with (
+            patch.object(Task, "create_and_run") as m_car,
+            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch.object(PromptService, "build", return_value="SYS"),
+        ):
+            self._service().prewarm()
+
+        m_car.assert_not_called()
+        m_workflow.assert_not_called()
+
+    def test_prewarm_rewarms_after_terminal_run(self):
+        task, run = self._stub_task()
+        run.status = TaskRun.Status.COMPLETED
+        run.save(update_fields=["status"])
+        self.conversation.task = task
+        self.conversation.save(update_fields=["task"])
+
+        with (
+            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch.object(PromptService, "build", return_value="SYS"),
+        ):
+            self._service().prewarm()
+
+        self.conversation.refresh_from_db()
+        new_run = self.conversation.current_run
+        assert new_run is not None
+        assert new_run.id != run.id
+        assert new_run.state["await_user_message"] is True
+        assert new_run.state["resume_from_run_id"] == str(run.id)
+        m_workflow.assert_called_once()
+
+    def test_release_cancels_warm_run(self):
+        task, run = self._stub_task()
+        run.status = TaskRun.Status.IN_PROGRESS
+        run.save(update_fields=["status"])
+        self.conversation.task = task
+        self.conversation.save(update_fields=["task"])
+
+        with patch(f"{ROUTING}.send_cancel") as m_cancel:
+            self._service().prewarm_release()
+
+        m_cancel.assert_called_once()
+
+    def test_release_without_task_is_noop(self):
+        with patch(f"{ROUTING}.send_cancel") as m_cancel:
+            self._service().prewarm_release()
+        m_cancel.assert_not_called()
+
+    def test_release_terminal_run_is_noop(self):
+        task, run = self._stub_task()
+        run.status = TaskRun.Status.COMPLETED
+        run.save(update_fields=["status"])
+        self.conversation.task = task
+        self.conversation.save(update_fields=["task"])
+
+        with patch(f"{ROUTING}.send_cancel") as m_cancel:
+            self._service().prewarm_release()
+        m_cancel.assert_not_called()

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -496,3 +496,78 @@ class TestSandboxPrewarm(APIBaseTest):
         with patch(f"{ROUTING}.send_cancel") as m_cancel:
             self._service().prewarm_release()
         m_cancel.assert_not_called()
+
+    def _warm_run(self, *, created_by=None) -> TaskRun:
+        """A non-terminal sandbox run that counts toward the prewarm caps."""
+        task = Task.objects.create(
+            team=self.team,
+            title="",
+            description="",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=created_by or self.user,
+        )
+        return task.create_run(mode="interactive")  # QUEUED
+
+    def test_prewarm_skips_when_user_at_capacity(self):
+        for _ in range(MessageRoutingService._PREWARM_MAX_PER_USER):
+            self._warm_run()
+
+        with (
+            patch.object(Task, "create_and_run") as m_car,
+            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch.object(PromptService, "build", return_value="SYS"),
+        ):
+            self._service().prewarm()
+
+        m_car.assert_not_called()
+        m_workflow.assert_not_called()
+        self.conversation.refresh_from_db()
+        assert self.conversation.task_id is None
+
+    def test_prewarm_skips_when_org_at_capacity(self):
+        other = self._create_user("warmer@posthog.com")
+        # Stay under the per-user cap (a different creator) but fill the org cap.
+        for _ in range(MessageRoutingService._PREWARM_MAX_PER_ORG):
+            self._warm_run(created_by=other)
+
+        with (
+            patch.object(Task, "create_and_run") as m_car,
+            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch.object(PromptService, "build", return_value="SYS"),
+        ):
+            self._service().prewarm()
+
+        m_car.assert_not_called()
+        m_workflow.assert_not_called()
+
+    def test_prewarm_ignores_terminal_runs_for_capacity(self):
+        # Terminal runs don't hold a sandbox, so they must not count toward the cap.
+        for _ in range(MessageRoutingService._PREWARM_MAX_PER_USER + 1):
+            run = self._warm_run()
+            run.status = TaskRun.Status.COMPLETED
+            run.save(update_fields=["status"])
+
+        task, run = self._stub_task()
+        with (
+            patch.object(Task, "create_and_run", return_value=task) as m_car,
+            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch.object(PromptService, "build", return_value="SYS"),
+        ):
+            self._service().prewarm()
+
+        m_car.assert_called_once()
+        m_workflow.assert_called_once()
+
+    def test_prewarm_first_serializes_on_conversation_lock(self):
+        # The first warm runs under the same row lock as a terminal resume, so a second
+        # concurrent warm can't create a duplicate Task on a task-less conversation.
+        task, _ = self._stub_task()
+        with (
+            patch.object(Task, "create_and_run", return_value=task),
+            patch(f"{ROUTING}.execute_task_processing_workflow"),
+            patch.object(PromptService, "build", return_value="SYS"),
+            patch(f"{ROUTING}.lock_conversation_for_followup", wraps=lock_conversation_for_followup) as m_lock,
+        ):
+            self._service().prewarm()
+
+        m_lock.assert_called_once_with(str(self.conversation.id), self.team.pk)


### PR DESCRIPTION
## Problem

PR **I3.9** of the PostHog AI → sandbox-agent migration (`docs/internal/posthog-ai-migration/00_OVERVIEW.md` § 10) — the final UX-polish PR. Two things: slash commands that don't make sense on the sandbox runtime (core memory is dropped) should be hidden, and sandboxes should be pre-warmed while the user types so the first response isn't gated on a cold start.

> Stacked on **I2.7** (`feat/phai-i2.7-history-telemetry`). Auto-retargets to `feat/phai-sandbox-integration` once the chain merges.

## Changes

Coexistence throughout — sandbox-only branches, LangGraph untouched.

### Slash-command runtime filter (`02_CORE` § 8)
- `hiddenInSandbox` flag on `SlashCommand`, set for `/init` and `/remember`.
- `maxThreadLogic.filteredCommands` drops `hiddenInSandbox` commands for `agent_runtime === 'sandbox'`. Pure list filter — handlers unchanged. `/usage`, `/feedback`, `/ticket` and the full LangGraph set stay.

### Sandbox pre-warming (`05_SANDBOX` § 8)
- Backend `handle_sandbox_prewarm` (first warm via `Task.create_and_run` with no pending message; re-warm via `task.create_run` on a terminal Run) and `handle_sandbox_prewarm_release` (in-process `send_cancel`) — idempotent, in-process, no provisioning reimplemented.
- A single `@action(methods=["POST","DELETE"], url_path="prewarm")` with `@extend_schema` on the conversation viewset, gated to sandbox.
- `api.conversations.prewarm` / `prewarmRelease` + a kea hook: 250 ms-debounced warm on first keystroke for an idle sandbox conversation, release on blur / empty input, consumed (not released) on send; duplicate-call guards + `kea-disposables` timers.

## How did you test this code?

Automated only (I'm an agent):

- ruff clean; `makemigrations --check` no drift; `hogli build:openapi` regenerated the prewarm endpoint types (committed); scoped `tsc` 0 errors in changed files.
- 21 (`test_message_routing`) + 65 (`test_conversation`, incl. LangGraph regression) backend tests pass; 105 `maxThreadLogic` jest tests pass, incl. the new sandbox-vs-langgraph command-filter cases.

## 🤖 Agent context

Built by Claude Code (Opus 4.8) via a multi-agent workflow (implement → verify) in an isolated worktree stacked on I2.7. The warmed Run sets `state.await_user_message`; the agent-server side that honors an empty-initial-message warm is out of repo scope and unverified here. The sandbox-side idle self-cancel for a never-started warm (`05_SANDBOX` §8.1 Q9) is agent-server timer work, mitigated client-side by release-on-blur/empty. Requires human review; not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
