### PR TITLE
feat(replay-vision): scanner schedule reconciler workflow

### DIFF
--- a/products/replay_vision/backend/temporal/__init__.py
+++ b/products/replay_vision/backend/temporal/__init__.py
@@ -6,22 +6,27 @@ from products.replay_vision.backend.temporal.activities import (
     call_scanner_provider_activity,
     cleanup_gemini_file_activity,
     create_observation_activity,
+    delete_scanner_schedule_activity,
     embed_summarizer_observation_activity,
     emit_classifier_tags_activity,
     emit_observation_event_activity,
     ensure_session_asset_activity,
     fetch_session_events_activity,
     find_scanner_candidates_activity,
+    list_enabled_scanners_activity,
+    list_scanner_schedules_activity,
     mark_observation_failed_activity,
     mark_observation_ineligible_activity,
     mark_observation_running_activity,
     mark_observation_succeeded_activity,
     upload_video_to_gemini_activity,
+    upsert_scanner_schedule_activity,
 )
+from products.replay_vision.backend.temporal.reconciler import ReconcileScannerSchedulesWorkflow
 from products.replay_vision.backend.temporal.sweep_workflow import SweepScannerWorkflow
 from products.replay_vision.backend.temporal.workflow import ApplyScannerWorkflow
 
-WORKFLOWS = [ApplyScannerWorkflow, SweepScannerWorkflow]
+WORKFLOWS = [ApplyScannerWorkflow, ReconcileScannerSchedulesWorkflow, SweepScannerWorkflow]
 ACTIVITIES: list[Callable[..., Any]] = [
     create_observation_activity,
     mark_observation_running_activity,
@@ -38,26 +43,35 @@ ACTIVITIES: list[Callable[..., Any]] = [
     cleanup_gemini_file_activity,
     find_scanner_candidates_activity,
     advance_scanner_watermark_activity,
+    list_enabled_scanners_activity,
+    list_scanner_schedules_activity,
+    upsert_scanner_schedule_activity,
+    delete_scanner_schedule_activity,
 ]
 
 __all__ = [
     "ACTIVITIES",
     "WORKFLOWS",
     "ApplyScannerWorkflow",
+    "ReconcileScannerSchedulesWorkflow",
     "SweepScannerWorkflow",
     "advance_scanner_watermark_activity",
     "call_scanner_provider_activity",
     "cleanup_gemini_file_activity",
     "create_observation_activity",
+    "delete_scanner_schedule_activity",
     "embed_summarizer_observation_activity",
     "emit_classifier_tags_activity",
     "emit_observation_event_activity",
     "ensure_session_asset_activity",
     "fetch_session_events_activity",
     "find_scanner_candidates_activity",
+    "list_enabled_scanners_activity",
+    "list_scanner_schedules_activity",
     "mark_observation_failed_activity",
     "mark_observation_ineligible_activity",
     "mark_observation_running_activity",
     "mark_observation_succeeded_activity",
     "upload_video_to_gemini_activity",
+    "upsert_scanner_schedule_activity",
 ]

--- a/products/replay_vision/backend/temporal/activities/__init__.py
+++ b/products/replay_vision/backend/temporal/activities/__init__.py
@@ -18,6 +18,12 @@ from products.replay_vision.backend.temporal.activities.observation_state import
     mark_observation_running_activity,
     mark_observation_succeeded_activity,
 )
+from products.replay_vision.backend.temporal.activities.reconciler_activities import (
+    delete_scanner_schedule_activity,
+    list_enabled_scanners_activity,
+    list_scanner_schedules_activity,
+    upsert_scanner_schedule_activity,
+)
 from products.replay_vision.backend.temporal.activities.upload_video_to_gemini import upload_video_to_gemini_activity
 
 __all__ = [
@@ -25,15 +31,19 @@ __all__ = [
     "call_scanner_provider_activity",
     "cleanup_gemini_file_activity",
     "create_observation_activity",
+    "delete_scanner_schedule_activity",
     "embed_summarizer_observation_activity",
     "emit_classifier_tags_activity",
     "emit_observation_event_activity",
     "ensure_session_asset_activity",
     "fetch_session_events_activity",
     "find_scanner_candidates_activity",
+    "list_enabled_scanners_activity",
+    "list_scanner_schedules_activity",
     "mark_observation_failed_activity",
     "mark_observation_ineligible_activity",
     "mark_observation_running_activity",
     "mark_observation_succeeded_activity",
     "upload_video_to_gemini_activity",
+    "upsert_scanner_schedule_activity",
 ]

--- a/products/replay_vision/backend/temporal/activities/reconciler_activities.py
+++ b/products/replay_vision/backend/temporal/activities/reconciler_activities.py
@@ -1,0 +1,80 @@
+from uuid import UUID
+
+import structlog
+from temporalio import activity
+
+from posthog.sync import database_sync_to_async
+from posthog.temporal.common.client import async_connect
+from posthog.temporal.common.search_attributes import POSTHOG_SCHEDULE_FINGERPRINT_KEY
+
+from products.replay_vision.backend.temporal.constants import (
+    SCANNER_SCHEDULE_ID_PREFIX,
+    SCANNER_SCHEDULE_TYPE,
+    SWEEP_SCANNER_WORKFLOW_NAME,
+)
+from products.replay_vision.backend.temporal.reconciler_types import (
+    DeleteScannerScheduleActivityInputs,
+    EnabledScannerEntry,
+    ScannerScheduleEntry,
+    UpsertScannerScheduleActivityInputs,
+)
+from products.replay_vision.backend.temporal.schedule import (
+    a_delete_scanner_schedule,
+    a_upsert_scanner_schedule,
+    load_enabled_scanner_fingerprints,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+@activity.defn
+async def list_enabled_scanners_activity() -> list[EnabledScannerEntry]:
+    """Every enabled ReplayScanner with its current fingerprint."""
+    rows = await database_sync_to_async(load_enabled_scanner_fingerprints)()
+    return [EnabledScannerEntry(scanner_id=sid, team_id=team_id, fingerprint=fp) for sid, (team_id, fp) in rows.items()]
+
+
+def _schedule_fingerprint(listing: object) -> str | None:
+    # Distinguish missing attribute (Temporal shape change) from unstamped (legacy schedule).
+    try:
+        attrs = listing.typed_search_attributes  # type: ignore[attr-defined]
+    except AttributeError:
+        logger.warning(
+            "replay_vision.reconciler.listing_missing_search_attributes",
+            schedule_id=getattr(listing, "id", "<unknown>"),
+        )
+        return None
+    for pair in attrs:
+        if pair.key.name == POSTHOG_SCHEDULE_FINGERPRINT_KEY.name:
+            return pair.value
+    return None
+
+
+@activity.defn
+async def list_scanner_schedules_activity() -> list[ScannerScheduleEntry]:
+    """Existing per-scanner schedules in Temporal; fingerprint is None for legacy schedules."""
+    client = await async_connect()
+    prefix = f"{SCANNER_SCHEDULE_ID_PREFIX}-"
+    entries: list[ScannerScheduleEntry] = []
+    async for listing in await client.list_schedules(query=f'PostHogScheduleType = "{SCANNER_SCHEDULE_TYPE}"'):
+        if not listing.id.startswith(prefix):
+            continue
+        if getattr(getattr(listing.schedule, "action", None), "workflow", None) != SWEEP_SCANNER_WORKFLOW_NAME:
+            continue
+        try:
+            scanner_id = UUID(listing.id[len(prefix) :])
+        except ValueError:
+            logger.warning("replay_vision.reconciler.unparseable_schedule_id", schedule_id=listing.id)
+            continue
+        entries.append(ScannerScheduleEntry(scanner_id=scanner_id, fingerprint=_schedule_fingerprint(listing)))
+    return entries
+
+
+@activity.defn
+async def upsert_scanner_schedule_activity(inputs: UpsertScannerScheduleActivityInputs) -> None:
+    await a_upsert_scanner_schedule(inputs.scanner_id, inputs.team_id)
+
+
+@activity.defn
+async def delete_scanner_schedule_activity(inputs: DeleteScannerScheduleActivityInputs) -> None:
+    await a_delete_scanner_schedule(inputs.scanner_id)

--- a/products/replay_vision/backend/temporal/constants.py
+++ b/products/replay_vision/backend/temporal/constants.py
@@ -18,6 +18,19 @@ def scanner_schedule_id(scanner_id: UUID) -> str:
     return f"{SCANNER_SCHEDULE_ID_PREFIX}-{scanner_id}"
 
 
+RECONCILER_WORKFLOW_NAME = "replay-vision-reconcile-scanner-schedules"
+RECONCILER_WORKFLOW_ID = "replay-vision-scanner-reconciler"
+RECONCILER_SCHEDULE_ID = "replay-vision-scanner-reconciler-schedule"
+
+# Worst-case latency between a UI scanner edit and its first per-scanner tick.
+RECONCILER_INTERVAL = dt.timedelta(minutes=1)
+RECONCILER_EXECUTION_TIMEOUT = dt.timedelta(minutes=5)
+
+LIST_ENABLED_SCANNERS_TIMEOUT = dt.timedelta(seconds=60)
+LIST_SCANNER_SCHEDULES_TIMEOUT = dt.timedelta(seconds=120)
+RECONCILE_SCHEDULE_OP_TIMEOUT = dt.timedelta(seconds=60)
+
+
 # Capped so `replay-vision-apply-scanner-{scanner_uuid:36}-{session_id}` fits the 255-char `ReplayObservation.workflow_id` column.
 MAX_SESSION_ID_LENGTH = 128
 

--- a/products/replay_vision/backend/temporal/reconciler.py
+++ b/products/replay_vision/backend/temporal/reconciler.py
@@ -1,0 +1,109 @@
+"""Syncs per-scanner schedules with the ReplayScanner table on every tick."""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from uuid import UUID
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+from temporalio.exceptions import ApplicationError
+
+from posthog.temporal.common.base import PostHogWorkflow
+
+from products.replay_vision.backend.temporal.constants import (
+    LIST_ENABLED_SCANNERS_TIMEOUT,
+    LIST_SCANNER_SCHEDULES_TIMEOUT,
+    RECONCILE_SCHEDULE_OP_TIMEOUT,
+    RECONCILER_WORKFLOW_NAME,
+)
+from products.replay_vision.backend.temporal.reconciler_types import (
+    DeleteScannerScheduleActivityInputs,
+    ReconcileScannerSchedulesInputs,
+    ReconcileScannerSchedulesResult,
+    UpsertScannerScheduleActivityInputs,
+)
+
+# `activities` pulls in Django, which the workflow sandbox can't safely re-import.
+with workflow.unsafe.imports_passed_through():
+    from products.replay_vision.backend.temporal.activities import (
+        delete_scanner_schedule_activity,
+        list_enabled_scanners_activity,
+        list_scanner_schedules_activity,
+        upsert_scanner_schedule_activity,
+    )
+
+
+@workflow.defn(name=RECONCILER_WORKFLOW_NAME)
+class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
+    inputs_cls = ReconcileScannerSchedulesInputs
+    inputs_optional = True
+
+    @workflow.run
+    async def run(self, inputs: ReconcileScannerSchedulesInputs) -> ReconcileScannerSchedulesResult:
+        # A scanner toggled between the two listings recovers on the next tick.
+        enabled_entries, existing_entries = await asyncio.gather(
+            workflow.execute_activity(
+                list_enabled_scanners_activity,
+                start_to_close_timeout=LIST_ENABLED_SCANNERS_TIMEOUT,
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            ),
+            workflow.execute_activity(
+                list_scanner_schedules_activity,
+                start_to_close_timeout=LIST_SCANNER_SCHEDULES_TIMEOUT,
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            ),
+        )
+        enabled = {entry.scanner_id: entry for entry in enabled_entries}
+        # Legacy untagged schedules surface as None and naturally drift on first tick.
+        existing = {entry.scanner_id: entry.fingerprint for entry in existing_entries}
+        drifted = {sid for sid in enabled.keys() & existing.keys() if existing[sid] != enabled[sid].fingerprint}
+        to_upsert = sorted((enabled.keys() - existing.keys()) | drifted)
+        to_delete = sorted(existing.keys() - enabled.keys())
+
+        upsert_results, delete_results = await asyncio.gather(
+            self._fan_out(
+                to_upsert,
+                lambda sid: workflow.execute_activity(
+                    upsert_scanner_schedule_activity,
+                    UpsertScannerScheduleActivityInputs(scanner_id=sid, team_id=enabled[sid].team_id),
+                    start_to_close_timeout=RECONCILE_SCHEDULE_OP_TIMEOUT,
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                ),
+            ),
+            self._fan_out(
+                to_delete,
+                lambda sid: workflow.execute_activity(
+                    delete_scanner_schedule_activity,
+                    DeleteScannerScheduleActivityInputs(scanner_id=sid),
+                    start_to_close_timeout=RECONCILE_SCHEDULE_OP_TIMEOUT,
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                ),
+            ),
+        )
+        result = ReconcileScannerSchedulesResult(
+            upserted=[sid for sid, ok in zip(to_upsert, upsert_results) if ok],
+            deleted=[sid for sid, ok in zip(to_delete, delete_results) if ok],
+            failed_upsert=[sid for sid, ok in zip(to_upsert, upsert_results) if not ok],
+            failed_delete=[sid for sid, ok in zip(to_delete, delete_results) if not ok],
+        )
+        if result.failed_upsert or result.failed_delete:
+            workflow.logger.warning(
+                "replay_vision.reconcile_partial_failure",
+                extra={
+                    "failed_upsert": [str(s) for s in result.failed_upsert],
+                    "failed_delete": [str(s) for s in result.failed_delete],
+                },
+            )
+        # Total failure across both fan-outs is likely systemic — surface it so Temporal retries.
+        attempted = len(to_upsert) + len(to_delete)
+        succeeded = len(result.upserted) + len(result.deleted)
+        if attempted > 0 and succeeded == 0:
+            raise ApplicationError(f"reconciler: all {attempted} fan-out activities failed")
+        return result
+
+    async def _fan_out(self, scanner_ids: list[UUID], make_coro: Callable[[UUID], Awaitable[None]]) -> list[bool]:
+        if not scanner_ids:
+            return []
+        # return_exceptions so one scanner's failure doesn't block the others.
+        results = await asyncio.gather(*(make_coro(sid) for sid in scanner_ids), return_exceptions=True)
+        return [not isinstance(r, BaseException) for r in results]

--- a/products/replay_vision/backend/temporal/reconciler_types.py
+++ b/products/replay_vision/backend/temporal/reconciler_types.py
@@ -1,0 +1,37 @@
+"""Reconciler-only Temporal types — split from `types.py` to avoid a circular import."""
+
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class EnabledScannerEntry(BaseModel, frozen=True):
+    scanner_id: UUID
+    team_id: int
+    fingerprint: str
+
+
+class ScannerScheduleEntry(BaseModel, frozen=True):
+    scanner_id: UUID
+    # None for legacy schedules without a stamped fingerprint; treated as drift.
+    fingerprint: str | None
+
+
+class UpsertScannerScheduleActivityInputs(BaseModel, frozen=True):
+    scanner_id: UUID
+    team_id: int
+
+
+class DeleteScannerScheduleActivityInputs(BaseModel, frozen=True):
+    scanner_id: UUID
+
+
+class ReconcileScannerSchedulesInputs(BaseModel, frozen=True):
+    pass
+
+
+class ReconcileScannerSchedulesResult(BaseModel, frozen=True):
+    upserted: list[UUID] = []
+    deleted: list[UUID] = []
+    failed_upsert: list[UUID] = []
+    failed_delete: list[UUID] = []

--- a/products/replay_vision/backend/temporal/schedule.py
+++ b/products/replay_vision/backend/temporal/schedule.py
@@ -90,6 +90,15 @@ def _load_fingerprint(scanner_id: UUID) -> str | None:
     return compute_schedule_fingerprint(dict(row)) if row else None
 
 
+def load_enabled_scanner_fingerprints() -> dict[UUID, tuple[int, str]]:
+    """Bulk variant for the reconciler: returns `{scanner_id: (team_id, fingerprint)}`."""
+    rows = ReplayScanner.objects.filter(enabled=True).values("id", "team_id", *_FINGERPRINT_FIELDS)
+    return {
+        row["id"]: (row["team_id"], compute_schedule_fingerprint({k: row[k] for k in _FINGERPRINT_FIELDS}))
+        for row in rows
+    }
+
+
 async def a_upsert_scanner_schedule(scanner_id: UUID, team_id: int) -> None:
     """Reflect current scanner state in Temporal: upsert when enabled, delete otherwise."""
     fingerprint = await database_sync_to_async(_load_fingerprint)(scanner_id)

--- a/products/replay_vision/backend/tests/test_reconciler.py
+++ b/products/replay_vision/backend/tests/test_reconciler.py
@@ -1,0 +1,343 @@
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from asgiref.sync import sync_to_async
+from parameterized import parameterized
+from temporalio.common import SearchAttributePair, TypedSearchAttributes
+from temporalio.exceptions import ApplicationError
+
+from posthog.models import Organization, Team
+from posthog.temporal.common.search_attributes import POSTHOG_SCHEDULE_FINGERPRINT_KEY
+
+from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerModel, ScannerType
+from products.replay_vision.backend.temporal.activities import (
+    delete_scanner_schedule_activity,
+    list_enabled_scanners_activity,
+    list_scanner_schedules_activity,
+    upsert_scanner_schedule_activity,
+)
+from products.replay_vision.backend.temporal.constants import SCANNER_SCHEDULE_ID_PREFIX, SWEEP_SCANNER_WORKFLOW_NAME
+from products.replay_vision.backend.temporal.reconciler import ReconcileScannerSchedulesWorkflow
+from products.replay_vision.backend.temporal.reconciler_types import (
+    EnabledScannerEntry,
+    ReconcileScannerSchedulesInputs,
+    ScannerScheduleEntry,
+)
+from products.replay_vision.backend.temporal.schedule import (
+    compute_schedule_fingerprint,
+    load_enabled_scanner_fingerprints,
+)
+
+
+@pytest.fixture
+def org_team(db) -> tuple[Organization, Team]:
+    org = Organization.objects.create(name="vision-reconciler-test-org")
+    team = Team.objects.create(organization=org, name="vision-reconciler-test-team")
+    return org, team
+
+
+def _make_scanner(team: Team, **overrides: Any) -> ReplayScanner:
+    defaults: dict[str, Any] = {
+        "team": team,
+        "name": "reconciler-scanner",
+        "scanner_type": ScannerType.MONITOR,
+        "scanner_config": {"prompt": "p"},
+        "model": ScannerModel.GEMINI_3_FLASH,
+    }
+    defaults.update(overrides)
+    return ReplayScanner.objects.create(**defaults)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_load_enabled_scanner_fingerprints_includes_only_enabled(org_team) -> None:
+    _, team = org_team
+    enabled = _make_scanner(team)
+    _make_scanner(team, name="disabled", enabled=False)
+    fingerprints = load_enabled_scanner_fingerprints()
+    assert set(fingerprints.keys()) == {enabled.id}
+    team_id, fingerprint = fingerprints[enabled.id]
+    assert team_id == team.id
+    assert isinstance(fingerprint, str) and fingerprint
+
+
+@pytest.mark.django_db(transaction=True)
+def test_load_enabled_scanner_fingerprints_changes_with_config(org_team) -> None:
+    _, team = org_team
+    scanner = _make_scanner(team, scanner_config={"prompt": "a"})
+    before = load_enabled_scanner_fingerprints()[scanner.id][1]
+    scanner.scanner_config = {"prompt": "b"}
+    scanner.save(update_fields=["scanner_config"])
+    after = load_enabled_scanner_fingerprints()[scanner.id][1]
+    assert before != after
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_list_enabled_scanners_activity_returns_enabled_only(org_team) -> None:
+    _, team = org_team
+    enabled = await sync_to_async(_make_scanner)(team)
+    await sync_to_async(_make_scanner)(team, name="disabled", enabled=False)
+    entries = await list_enabled_scanners_activity()
+    assert {e.scanner_id for e in entries} == {enabled.id}
+    [entry] = entries
+    assert entry.team_id == team.id
+    assert entry.fingerprint
+
+
+def _fake_listing(*, schedule_id: str, workflow_name: str, fingerprint: str | None) -> Any:
+    listing = type("ScheduleListing", (), {})()
+    listing.id = schedule_id
+    action = type("Action", (), {"workflow": workflow_name})()
+    listing.schedule = type("Schedule", (), {"action": action})()
+    pairs = (
+        [SearchAttributePair(key=POSTHOG_SCHEDULE_FINGERPRINT_KEY, value=fingerprint)]
+        if fingerprint is not None
+        else []
+    )
+    listing.typed_search_attributes = TypedSearchAttributes(search_attributes=pairs)
+    return listing
+
+
+async def _async_iter(items: list[Any]):
+    for item in items:
+        yield item
+
+
+async def _run_list_schedules(listings: list[Any]) -> list[Any]:
+    client = AsyncMock()
+    client.list_schedules = AsyncMock(return_value=_async_iter(listings))
+    with patch(
+        "products.replay_vision.backend.temporal.activities.reconciler_activities.async_connect",
+        AsyncMock(return_value=client),
+    ):
+        return await list_scanner_schedules_activity()
+
+
+_PARSEABLE_SCANNER_ID = uuid.uuid4()
+
+
+def _listing_cases() -> list[tuple[str, list[Any], list[tuple[uuid.UUID, str | None]]]]:
+    return [
+        (
+            "parses_stamped_listing",
+            [
+                _fake_listing(
+                    schedule_id=f"{SCANNER_SCHEDULE_ID_PREFIX}-{_PARSEABLE_SCANNER_ID}",
+                    workflow_name=SWEEP_SCANNER_WORKFLOW_NAME,
+                    fingerprint="abc",
+                )
+            ],
+            [(_PARSEABLE_SCANNER_ID, "abc")],
+        ),
+        (
+            "treats_untagged_legacy_as_none",
+            [
+                _fake_listing(
+                    schedule_id=f"{SCANNER_SCHEDULE_ID_PREFIX}-{_PARSEABLE_SCANNER_ID}",
+                    workflow_name=SWEEP_SCANNER_WORKFLOW_NAME,
+                    fingerprint=None,
+                )
+            ],
+            [(_PARSEABLE_SCANNER_ID, None)],
+        ),
+        (
+            "skips_wrong_prefix_workflow_and_uuid",
+            [
+                _fake_listing(
+                    schedule_id="some-other-prefix-foo",
+                    workflow_name=SWEEP_SCANNER_WORKFLOW_NAME,
+                    fingerprint="x",
+                ),
+                _fake_listing(
+                    schedule_id=f"{SCANNER_SCHEDULE_ID_PREFIX}-{uuid.uuid4()}",
+                    workflow_name="some-other-workflow",
+                    fingerprint="x",
+                ),
+                _fake_listing(
+                    schedule_id=f"{SCANNER_SCHEDULE_ID_PREFIX}-not-a-uuid",
+                    workflow_name=SWEEP_SCANNER_WORKFLOW_NAME,
+                    fingerprint="x",
+                ),
+            ],
+            [],
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+@parameterized.expand(_listing_cases())
+async def test_list_scanner_schedules_activity(
+    _name: str, listings: list[Any], expected: list[tuple[uuid.UUID, str | None]]
+) -> None:
+    entries = await _run_list_schedules(listings)
+    assert [(e.scanner_id, e.fingerprint) for e in entries] == expected
+
+
+class _ReconcileMocks:
+    def __init__(
+        self,
+        *,
+        enabled: list[EnabledScannerEntry],
+        existing: list[ScannerScheduleEntry],
+        upsert_errors_for_ids: set[uuid.UUID] | None = None,
+        delete_errors_for_ids: set[uuid.UUID] | None = None,
+    ) -> None:
+        self.enabled = enabled
+        self.existing = existing
+        self.upsert_errors = upsert_errors_for_ids or set()
+        self.delete_errors = delete_errors_for_ids or set()
+        self.upserted: list[uuid.UUID] = []
+        self.deleted: list[uuid.UUID] = []
+
+    async def execute_activity(self, activity_fn: Any, activity_input: Any = None, **_: Any) -> Any:
+        if activity_fn is list_enabled_scanners_activity:
+            return self.enabled
+        if activity_fn is list_scanner_schedules_activity:
+            return self.existing
+        if activity_fn is upsert_scanner_schedule_activity:
+            if activity_input.scanner_id in self.upsert_errors:
+                raise RuntimeError(f"upsert boom for {activity_input.scanner_id}")
+            self.upserted.append(activity_input.scanner_id)
+            return None
+        if activity_fn is delete_scanner_schedule_activity:
+            if activity_input.scanner_id in self.delete_errors:
+                raise RuntimeError(f"delete boom for {activity_input.scanner_id}")
+            self.deleted.append(activity_input.scanner_id)
+            return None
+        raise AssertionError(f"unexpected activity: {activity_fn!r}")
+
+
+async def _run_reconcile(mocks: _ReconcileMocks):
+    # `workflow.logger` reaches into the workflow runtime, which isn't set up here.
+    fake_logger = type("Logger", (), {"warning": staticmethod(lambda *_a, **_kw: None)})()
+    with (
+        patch("temporalio.workflow.execute_activity", side_effect=mocks.execute_activity),
+        patch("temporalio.workflow.logger", fake_logger),
+    ):
+        return await ReconcileScannerSchedulesWorkflow().run(ReconcileScannerSchedulesInputs())
+
+
+def _enabled(*entries: tuple[uuid.UUID, int, str]) -> list[EnabledScannerEntry]:
+    return [EnabledScannerEntry(scanner_id=sid, team_id=tid, fingerprint=fp) for sid, tid, fp in entries]
+
+
+def _existing(*entries: tuple[uuid.UUID, str | None]) -> list[ScannerScheduleEntry]:
+    return [ScannerScheduleEntry(scanner_id=sid, fingerprint=fp) for sid, fp in entries]
+
+
+def _new_and_orphan() -> tuple[_ReconcileMocks, dict[str, Any]]:
+    sid_new, sid_in_sync, sid_orphan = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    fp = compute_schedule_fingerprint({"sample_rate": 0.5})
+    return (
+        _ReconcileMocks(
+            enabled=_enabled((sid_new, 1, fp), (sid_in_sync, 2, fp)),
+            existing=_existing((sid_in_sync, fp), (sid_orphan, fp)),
+        ),
+        {"upserted": [sid_new], "deleted": [sid_orphan]},
+    )
+
+
+def _in_sync() -> tuple[_ReconcileMocks, dict[str, Any]]:
+    sid_a, sid_b = uuid.uuid4(), uuid.uuid4()
+    fp = compute_schedule_fingerprint({"sample_rate": 0.1})
+    return (
+        _ReconcileMocks(
+            enabled=_enabled((sid_a, 1, fp), (sid_b, 2, fp)),
+            existing=_existing((sid_a, fp), (sid_b, fp)),
+        ),
+        {"upserted": [], "deleted": []},
+    )
+
+
+def _drift_and_legacy() -> tuple[_ReconcileMocks, dict[str, Any]]:
+    sid_legacy, sid_stale, sid_clean, sid_new = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    current_fp = compute_schedule_fingerprint({"sample_rate": 0.5})
+    stale_fp = compute_schedule_fingerprint({"sample_rate": 0.1})
+    return (
+        _ReconcileMocks(
+            enabled=_enabled(
+                (sid_legacy, 1, current_fp),
+                (sid_stale, 2, current_fp),
+                (sid_clean, 3, current_fp),
+                (sid_new, 4, current_fp),
+            ),
+            existing=_existing((sid_legacy, None), (sid_stale, stale_fp), (sid_clean, current_fp)),
+        ),
+        {"upserted_set": {sid_legacy, sid_stale, sid_new}, "deleted": []},
+    )
+
+
+def _per_scanner_failure() -> tuple[_ReconcileMocks, dict[str, Any]]:
+    sid_a, sid_b, sid_c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    fp = compute_schedule_fingerprint({})
+    return (
+        _ReconcileMocks(
+            enabled=_enabled((sid_a, 1, fp), (sid_b, 2, fp), (sid_c, 3, fp)),
+            existing=_existing(),
+            upsert_errors_for_ids={sid_b},
+        ),
+        {"upserted_set": {sid_a, sid_c}, "failed_upsert": [sid_b]},
+    )
+
+
+def _all_failures() -> tuple[_ReconcileMocks, dict[str, Any]]:
+    sid_a, sid_b, sid_c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    fp = compute_schedule_fingerprint({})
+    return (
+        _ReconcileMocks(
+            enabled=_enabled((sid_a, 1, fp)),
+            existing=_existing((sid_b, fp), (sid_c, fp)),
+            upsert_errors_for_ids={sid_a},
+            delete_errors_for_ids={sid_b, sid_c},
+        ),
+        {"raises": ApplicationError},
+    )
+
+
+def _partial_failure() -> tuple[_ReconcileMocks, dict[str, Any]]:
+    sid_ok, sid_fail = uuid.uuid4(), uuid.uuid4()
+    fp = compute_schedule_fingerprint({})
+    return (
+        _ReconcileMocks(
+            enabled=_enabled((sid_ok, 1, fp), (sid_fail, 2, fp)),
+            existing=_existing(),
+            upsert_errors_for_ids={sid_fail},
+        ),
+        {"upserted": [sid_ok], "failed_upsert": [sid_fail]},
+    )
+
+
+@pytest.mark.asyncio
+@parameterized.expand(
+    [
+        ("new_and_orphan", _new_and_orphan),
+        ("in_sync", _in_sync),
+        ("drift_and_legacy", _drift_and_legacy),
+        ("per_scanner_failure_isolated", _per_scanner_failure),
+        ("all_failures_raise", _all_failures),
+        ("partial_failure_returns_partial", _partial_failure),
+    ]
+)
+async def test_reconcile_workflow(_name: str, build: Callable[[], tuple[_ReconcileMocks, dict[str, Any]]]) -> None:
+    mocks, expected = build()
+    if expected.get("raises"):
+        with pytest.raises(expected["raises"]):
+            await _run_reconcile(mocks)
+        return
+    result = await _run_reconcile(mocks)
+    if "upserted_set" in expected:
+        assert set(result.upserted) == expected["upserted_set"]
+    elif "upserted" in expected:
+        assert result.upserted == expected["upserted"]
+    if "deleted" in expected:
+        assert result.deleted == expected["deleted"]
+    assert result.failed_upsert == expected.get("failed_upsert", [])
+    assert result.failed_delete == expected.get("failed_delete", [])
+
+
+def test_reconcile_parse_inputs() -> None:
+    assert ReconcileScannerSchedulesWorkflow.parse_inputs([]) == ReconcileScannerSchedulesInputs()


### PR DESCRIPTION
## Problem

Per-scanner Temporal schedules (#60873) are written by the API config-change path, but nothing reconciles them with the `ReplayScanner` table afterwards. Out-of-band drift (worker downtime, lost delete RPCs, namespace restore) leaves the two sides out of sync with no convergence path.

## Changes

`ReconcileScannerSchedulesWorkflow` runs every `RECONCILER_INTERVAL` (1 min): lists enabled scanners + existing schedules in parallel, diffs by fingerprint, and fans out `upsert` / `delete` activities. Per-scanner failures don't block siblings (`return_exceptions=True`); a total failure raises `ApplicationError`.

Workflow + four activities are registered on the replay-vision task queue. The reconciler schedule itself is the next PR.

## How did you test this code?

Agent. `products/replay_vision/backend/tests/test_reconciler.py` — 13 cases covering the bulk fingerprint helper, both list activities (Django-backed + listing parsing edge cases), and the workflow diff/fan-out (in-sync, drift+legacy rewrite, per-scanner failure isolation, total-failure raise, partial-failure success).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Claude. Mirrors `posthog/temporal/session_replay/summarization_sweep/reconciler.py`.