### PR TITLE
fix(data-warehouse): eagerly load import sources at worker boot

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -6,6 +6,7 @@ import datetime as dt
 import functools
 import threading
 import faulthandler
+import collections.abc
 from collections import defaultdict
 
 import structlog
@@ -48,6 +49,7 @@ from posthog.temporal.data_imports.settings import (
     EMIT_SIGNALS_WORKFLOWS as DATA_IMPORT_EMIT_SIGNALS_WORKFLOWS,
     WORKFLOWS as DATA_SYNC_WORKFLOWS,
 )
+from posthog.temporal.data_imports.sources import load_all_sources
 from posthog.temporal.data_modeling import (
     ACTIVITIES as DATA_MODELING_ACTIVITIES,
     WORKFLOWS as DATA_MODELING_WORKFLOWS,
@@ -371,6 +373,11 @@ WORKFLOWS_DICT = _workflows
 ACTIVITIES_DICT = _activities
 
 
+def workflows_include_data_import_syncs(workflows: collections.abc.Iterable[type]) -> bool:
+    """True when this worker runs data-warehouse source syncs and must eagerly load the sources."""
+    return any(wf in DATA_SYNC_WORKFLOWS for wf in workflows)
+
+
 if settings.DEBUG:
     TASK_QUEUE_METRIC_PREFIXES = {}
 else:
@@ -503,6 +510,16 @@ class Command(BaseCommand):
             activities = list(ACTIVITIES_DICT[task_queue])
         except KeyError:
             raise ValueError(f'Task queue "{task_queue}" not found in WORKFLOWS_DICT or ACTIVITIES_DICT')
+
+        # Data-import source modules import vendor SDKs (google-ads, etc.) at module scope, and those
+        # SDKs register protobuf descriptors into a process-global pool that rejects a second
+        # registration of the same symbol. They must be imported exactly once per process. Do it here
+        # — synchronously, at worker boot, on the main thread — for any queue that runs data syncs.
+        # Deferring to the first SourceRegistry.get_source() at runtime (the lazy path) let the
+        # registration recur and broke unrelated syncs with "duplicate symbol". Other workers never
+        # import the vendor SDKs, so they keep their fast startup.
+        if workflows_include_data_import_syncs(workflows):
+            load_all_sources()
 
         if options["client_key"]:
             options["client_key"] = "--SECRET--"

--- a/posthog/management/commands/test/test_start_temporal_worker.py
+++ b/posthog/management/commands/test/test_start_temporal_worker.py
@@ -1,0 +1,25 @@
+import pytest
+
+from posthog.management.commands.start_temporal_worker import DATA_SYNC_WORKFLOWS, workflows_include_data_import_syncs
+
+
+class _NotADataSyncWorkflow:
+    pass
+
+
+# Data-import sources import vendor SDKs (google-ads, etc.) that register protobuf descriptors into a
+# process-global pool exactly once. The worker eagerly loads them at boot only for queues that run
+# data syncs; everything else stays lazy to keep startup fast. Queue settings collapse to a single
+# dev queue under DEBUG, so assert the gating predicate directly against workflow sets.
+@pytest.mark.parametrize(
+    "workflows,expected",
+    [
+        (list(DATA_SYNC_WORKFLOWS), True),
+        ([DATA_SYNC_WORKFLOWS[0]], True),
+        ([DATA_SYNC_WORKFLOWS[0], _NotADataSyncWorkflow], True),
+        ([_NotADataSyncWorkflow], False),
+        ([], False),
+    ],
+)
+def test_only_data_import_queues_warm_sources(workflows: list[type], expected: bool) -> None:
+    assert workflows_include_data_import_syncs(workflows) is expected


### PR DESCRIPTION
## Problem

External data syncs are failing with `Couldn't build proto file into descriptor pool: duplicate symbol 'google.ads.googleads.v23.services.ApplyRecommendationRequest'` — and notably this hits syncs for sources that have nothing to do with Google Ads (e.g. a Postgres source).

Root cause is #60635, which moved data-import source loading off the Django startup path. Sources now self-register lazily on the first `SourceRegistry.get_source()` instead of at import time. That call runs inside the data-import workflow at runtime, so the vendor SDKs (google-ads, etc.) first import there rather than once at process boot. The google-ads SDK registers protobuf descriptors into a process-global pool that rejects a second registration of the same symbol — and because `get_source()` loads *every* source, any sync (including Postgres) now triggers the google-ads import and can hit the duplicate registration.

## Changes

`start_temporal_worker` now eagerly loads all data-import sources once, synchronously, at worker boot — but only for workers whose queue runs data-sync workflows. The gate is a `workflows_include_data_import_syncs` predicate, so any data-sync queue is covered automatically without hardcoding queue names.

This restores the pre-#60635 invariant (register once, deterministically, on the main thread) for the workers that actually need it. Other workers stay lazy and keep the faster startup #60635 bought — so this is strictly narrower than the old eager-everywhere import, not a full revert.

## How did you test this code?

I'm an agent (Claude Code), so no manual testing — here's what I actually ran:

- Added `test_start_temporal_worker.py` (5 parametrized cases) asserting the gating predicate: data-sync workflow sets warm sources, other workflows don't. Green locally.
- Reproduced the protobuf error class in isolation (re-importing the google-ads modules after they're registered throws the same error), and ruled out concurrency (8 threads → 0 errors) and the registry's retry path (a plain re-import is `sys.modules`-cached and safe) as the trigger.

The duplicate-symbol itself can't be cleanly unit-tested without artificial `sys.modules` surgery, so the automated test covers the fix's gating rather than the runtime registration race.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus), agent-assisted; human author owns review and merge.

Investigation: traced the failure to #60635 by code reading (the lazy `SourceRegistry._ensure_loaded` → `load_all_sources` path, `get_source()` called inside `ExternalDataJobWorkflow`, unsandboxed worker), an isolated protobuf reproduction, and a targeted web search ([protobuf#18463](https://github.com/protocolbuffers/protobuf/issues/18463), [proto-plus#490](https://github.com/googleapis/proto-plus-python/issues/490)) confirming the global descriptor pool rejects double registration by design.

Two fixes were considered: (1) eager warm-up at worker boot — this PR, the minimal low-risk revert of the regression; (2) make `get_source()` import only the requested source so non-google-ads syncs never touch the SDK. Chose (1) for the hotfix and recommend (2) as a follow-up to remove the cross-source coupling entirely.

Caveat: the exact runtime double-registration trigger wasn't pinned from static code alone; this restores the known-good "import once at boot" invariant that held before #60635.
