### PR TITLE
fix: sampling rate remove tag

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1975,7 +1975,7 @@ snapshots:
     filters-taxonomic-filter-headless--properties--dark:
         hash: v1.k794b7964.4ee695e5751c6f73e9742ab0cfeecf61b5adfe829cf3a0d49ab2877cae8b212f.jPN9l5TDgLRy9NzHenXHCU903UDg8-GdeGpf4PXt7aA
     filters-taxonomic-filter-headless--properties--light:
-        hash: v1.k794b7964.afa422fd784363e602da5668ab488a823260acba8c2b1168dc85bcbf434d3ddf.Wjl32UIE5KhBda_SpJYwXKZ2FGmnlFbtzv4uKDaJRIs
+        hash: v1.k794b7964.7af6b884e5d826df422db99e4a99d2172f3316561a499dbe386ea098b1fc54a9.rti2DMpqC0WEtd_AtG838vQlgQMHfwjBAR4uLN_HnUk
     filters-taxonomic-filter-headless--suggested-filters-with-recents--dark:
         hash: v1.k794b7964.f524f5031bba44f2753215e83b93aa50741a3efc012fcddcc61025e4f851ba2c.sm5eih05jClMTS8zKltGelRiDYSI_2RmOFRZjjLwsAc
     filters-taxonomic-filter-headless--suggested-filters-with-recents--light:
@@ -5847,9 +5847,9 @@ snapshots:
     scenes-app-settings-environment--settings-environment-product-analytics--light:
         hash: v1.k794b7964.aca97c2f3f2c3d586afe0857d263b02dfc4e5da285af0b01a8ad85b7dacc1fe1.4_xQIv2S7e__70a2uoP7VTgnAbcNEp7Ru69bYAI7ui4
     scenes-app-settings-environment--settings-environment-replay--dark:
-        hash: v1.k794b7964.e481f083c188f157aa04348cb1d39d43d678b0b300257a9734cdde123cb1af1c.mhb-1n8ZYYE8GEMx98SwSSu0zkJ3Tq0SvFhOFQ_uCec
+        hash: v1.k794b7964.4df03c96b50885fb6e1633e50bab9593430a5a4fbaaa43d0327e55e1fa6bd6f3.iT3E_SB1DnzfuRg17nE2fj2iQwk_egMbHzMws0UIG8M
     scenes-app-settings-environment--settings-environment-replay--light:
-        hash: v1.k794b7964.1dcebd8abf0431bd151da3ad4a6c71857dd36a933b4063046319c4b8ad03df2c.FJwp18K9ue_QSD52yhGyn9Zbw11kVw2fbHXRjo32Nnc
+        hash: v1.k794b7964.b2fddc5ad9628b3ef7fa04a8f1ddcb4af64d44ebeeb7919e83c02e10da1b7672.VR-ZGUFT3YKzi3t1CBNhggsVvq13kw7N2O0sFujcU0w
     scenes-app-settings-environment--settings-environment-revenue-analytics--dark:
         hash: v1.k794b7964.980cbfdfcbd7d401d160fefd51f013f5c7309795b81a7d61f92b2e8ce74155cb.aYb6nHQqhXhZTLgcMzoDCestcjXn1OhtigeOBqfG9Oo
     scenes-app-settings-environment--settings-environment-revenue-analytics--light:
@@ -5919,9 +5919,9 @@ snapshots:
     scenes-app-settings-project--settings-project-product-analytics--light:
         hash: v1.k794b7964.2f116183a3a68830761984d2d230c17ae9ad03541d7e81bbc2c65e66eb8075d2.DW9Up0fKJg5m6WbGcAnB-KjGaQZH42RpN325J5mry64
     scenes-app-settings-project--settings-project-replay--dark:
-        hash: v1.k794b7964.e481f083c188f157aa04348cb1d39d43d678b0b300257a9734cdde123cb1af1c.vVOWeQuEljXgm-YAy2xP0VvVojFqizqYVMAQJtbNzW0
+        hash: v1.k794b7964.4df03c96b50885fb6e1633e50bab9593430a5a4fbaaa43d0327e55e1fa6bd6f3.gLzG-s2u0WCI2B6MtiUVVz-3AMtua_O8EOig6g5NNVc
     scenes-app-settings-project--settings-project-replay--light:
-        hash: v1.k794b7964.1dcebd8abf0431bd151da3ad4a6c71857dd36a933b4063046319c4b8ad03df2c.3fIJBqgv3voDAlJRadXdd8Y0osFT0-tWuNAdlT1cz78
+        hash: v1.k794b7964.b2fddc5ad9628b3ef7fa04a8f1ddcb4af64d44ebeeb7919e83c02e10da1b7672.ECtkbwoXoHJpT4tlv33rxPA48hDRbpHwwn2tR1OWsRI
     scenes-app-settings-project--settings-project-surveys--dark:
         hash: v1.k794b7964.8e49a3862c115fe5d5b74a541f1ca3bc5253d77310bae3edc5108a7b9e03c953.urBirOCb8iTMvzen5XzAk4YSP3H4Ws8lipTDtVloSgE
     scenes-app-settings-project--settings-project-surveys--light:

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -443,13 +443,7 @@ export function ReplayTriggers(): JSX.Element {
                             panels={[
                                 {
                                     key: 'sampling',
-                                    header: (
-                                        <TriggerPanelHeader
-                                            title="Sampling"
-                                            status={statuses.samplingStatus}
-                                            showMatchTag
-                                        />
-                                    ),
+                                    header: <TriggerPanelHeader title="Sampling" status={statuses.samplingStatus} />,
                                     content: <Sampling />,
                                 },
                                 {


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/59089 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/60353) 

Sampling rate applies to all replays, should display the tag for this setting. 

## Changes
removed the AND/OR from sampling rate setting in replay settings. 

## How did you test this code?
It's a ver small change

## Automatic notifications

- [ x] Publish to changelog?
- [ x] Alert Sales and Marketing teams?

## Docs update

no

## 🤖 Agent context
none 