### PR TITLE
fix(mcp): Fix default(null) injection in generated tool schemas that allow null

### DIFF
--- a/services/mcp/scripts/generate-orval-schemas.mjs
+++ b/services/mcp/scripts/generate-orval-schemas.mjs
@@ -74,11 +74,41 @@ function parseToolDefinition(filePath) {
 // ------------------------------------------------------------------
 
 /**
+ * Checks if the schema allows null in any of the following ways:
+ * - `nullable: true` (OpenAPI 3.0)
+ * - `type: 'null'` (OpenAPI 3.1 / JSON Schema)
+ * - `type: ['string', 'null']` (OpenAPI 3.1 / JSON Schema)
+ * - `anyOf: [{ type: 'string' }, { type: 'null' }]` (OpenAPI 3.1 / JSON Schema)
+ * - `oneOf: [{ type: 'string' }, { type: 'null' }]` (OpenAPI 3.1 / JSON Schema)
+ */
+function schemaAllowsNull(schema) {
+    if (!schema || typeof schema !== 'object') {
+        return false
+    }
+    if (schema.nullable === true || schema.type === 'null') {
+        return true
+    }
+    if (Array.isArray(schema.type) && schema.type.includes('null')) {
+        return true
+    }
+    for (const key of ['anyOf', 'oneOf']) {
+        const variants = schema[key]
+        if (Array.isArray(variants) && variants.some(schemaAllowsNull)) {
+            return true
+        }
+    }
+    return false
+}
+
+/**
  * Strip 'default: null' from nullable properties in OpenAPI schemas.
  *
- * Orval generates invalid Zod like `.string().default(null)` when it sees
- * `nullable: true` with `default: null`. Removing the null default causes
- * Orval to correctly generate `.nullable()` instead.
+ * Orval mirrors `default: null` into `.default(null)`, which makes Zod fill the
+ * field with `null` whenever the caller omits it (`safeParse` applies defaults).
+ * For request schemas that turns "field not sent" into "field sent as null",
+ * which the backend then rejects (`extra="forbid"`) or silently overwrites.
+ * Removing the null default lets Orval emit a plain `.nullable()` instead, so an
+ * omitted field stays omitted while an explicit `null` still parses.
  */
 function stripNullDefaults(obj) {
     if (!obj || typeof obj !== 'object') {
@@ -89,8 +119,8 @@ function stripNullDefaults(obj) {
     }
     const result = {}
     for (const [key, value] of Object.entries(obj)) {
-        // Skip 'default' key if value is null and sibling 'nullable' is true
-        if (key === 'default' && value === null && obj.nullable === true) {
+        // Skip injecting `default: null` if schema permits null
+        if (key === 'default' && value === null && schemaAllowsNull(obj)) {
             continue
         }
         result[key] = stripNullDefaults(value)

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -29,194 +29,32 @@ export const AlertsCreateParams = /* @__PURE__ */ zod.object({
         ),
 })
 
-export const alertsCreateBodyThresholdOneConfigurationOneBoundsOneLowerDefault = null
-export const alertsCreateBodyThresholdOneConfigurationOneBoundsOneUpperDefault = null
-export const alertsCreateBodyThresholdOneConfigurationOneBoundsDefault = null
-export const alertsCreateBodyConfigOneCheckOngoingIntervalDefault = null
 export const alertsCreateBodyConfigOneTypeDefault = `TrendsAlertConfig`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneTypeDefault = `zscore`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoTypeDefault = `mad`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemThreeMultiplierDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemThreeTypeDefault = `iqr`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemThreeWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFourLowerBoundDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFourTypeDefault = `threshold`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFourUpperBoundDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFiveThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFiveTypeDefault = `ecod`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemFiveWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSixThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSixTypeDefault = `copod`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSixWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenNEstimatorsDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenTypeDefault = `isolation_forest`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemEightMethodDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemEightNNeighborsDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemEightThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemEightTypeDefault = `knn`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemEightWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemNineNBinsDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemNineThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemNineTypeDefault = `hbos`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemNineWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroNNeighborsDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroTypeDefault = `lof`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneoneKernelDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneoneNuDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneoneThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneoneTypeDefault = `ocsvm`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOneoneWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoTypeDefault = `pca`
-export const alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoWindowDefault = null
 export const alertsCreateBodyDetectorConfigOneOneTypeDefault = `ensemble`
-export const alertsCreateBodyDetectorConfigOneTwoPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneTwoPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneTwoPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneTwoPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneTwoThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneTwoTypeDefault = `zscore`
-export const alertsCreateBodyDetectorConfigOneTwoWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneThreePreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneThreePreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneThreePreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneThreePreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneThreeThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneThreeTypeDefault = `mad`
-export const alertsCreateBodyDetectorConfigOneThreeWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneFourMultiplierDefault = null
-export const alertsCreateBodyDetectorConfigOneFourPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneFourPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneFourPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneFourPreprocessingDefault = null
 export const alertsCreateBodyDetectorConfigOneFourTypeDefault = `iqr`
-export const alertsCreateBodyDetectorConfigOneFourWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneFiveLowerBoundDefault = null
-export const alertsCreateBodyDetectorConfigOneFivePreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneFivePreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneFivePreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneFivePreprocessingDefault = null
 export const alertsCreateBodyDetectorConfigOneFiveTypeDefault = `threshold`
-export const alertsCreateBodyDetectorConfigOneFiveUpperBoundDefault = null
-export const alertsCreateBodyDetectorConfigOneSixPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneSixPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneSixPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneSixPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneSixThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneSixTypeDefault = `ecod`
-export const alertsCreateBodyDetectorConfigOneSixWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneSevenPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneSevenPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneSevenPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneSevenPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneSevenThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneSevenTypeDefault = `copod`
-export const alertsCreateBodyDetectorConfigOneSevenWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneEightNEstimatorsDefault = null
-export const alertsCreateBodyDetectorConfigOneEightPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneEightPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneEightPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneEightPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneEightThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneEightTypeDefault = `isolation_forest`
-export const alertsCreateBodyDetectorConfigOneEightWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneNineMethodDefault = null
-export const alertsCreateBodyDetectorConfigOneNineNNeighborsDefault = null
-export const alertsCreateBodyDetectorConfigOneNinePreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneNinePreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneNinePreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneNinePreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneNineThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneNineTypeDefault = `knn`
-export const alertsCreateBodyDetectorConfigOneNineWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOnezeroNBinsDefault = null
-export const alertsCreateBodyDetectorConfigOneOnezeroPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOnezeroPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOnezeroPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOnezeroPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOnezeroThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOnezeroTypeDefault = `hbos`
-export const alertsCreateBodyDetectorConfigOneOnezeroWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOneoneNNeighborsDefault = null
-export const alertsCreateBodyDetectorConfigOneOneonePreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneonePreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneonePreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOneonePreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOneoneThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOneoneTypeDefault = `lof`
-export const alertsCreateBodyDetectorConfigOneOneoneWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOnetwoKernelDefault = null
-export const alertsCreateBodyDetectorConfigOneOnetwoNuDefault = null
-export const alertsCreateBodyDetectorConfigOneOnetwoPreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOnetwoPreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOnetwoPreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOnetwoPreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOnetwoThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOnetwoTypeDefault = `ocsvm`
-export const alertsCreateBodyDetectorConfigOneOnetwoWindowDefault = null
-export const alertsCreateBodyDetectorConfigOneOnethreePreprocessingOneDiffsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOnethreePreprocessingOneLagsNDefault = null
-export const alertsCreateBodyDetectorConfigOneOnethreePreprocessingOneSmoothNDefault = null
-export const alertsCreateBodyDetectorConfigOneOnethreePreprocessingDefault = null
-export const alertsCreateBodyDetectorConfigOneOnethreeThresholdDefault = null
 export const alertsCreateBodyDetectorConfigOneOnethreeTypeDefault = `pca`
-export const alertsCreateBodyDetectorConfigOneOnethreeWindowDefault = null
 
 export const AlertsCreateBody = /* @__PURE__ */ zod.object({
     insight: zod
@@ -238,16 +76,16 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                             zod.object({
                                 lower: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(alertsCreateBodyThresholdOneConfigurationOneBoundsOneLowerDefault)
+                                    .optional()
                                     .describe('Alert fires when the value drops below this number.'),
                                 upper: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(alertsCreateBodyThresholdOneConfigurationOneBoundsOneUpperDefault)
+                                    .optional()
                                     .describe('Alert fires when the value exceeds this number.'),
                             }),
                             zod.null(),
                         ])
-                        .default(alertsCreateBodyThresholdOneConfigurationOneBoundsDefault),
+                        .optional(),
                     type: zod
                         .enum(['absolute', 'percentage'])
                         .describe(
@@ -276,7 +114,7 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
             zod.object({
                 check_ongoing_interval: zod
                     .union([zod.boolean(), zod.null()])
-                    .default(alertsCreateBodyConfigOneCheckOngoingIntervalDefault)
+                    .optional()
                     .describe(
                         'When true, evaluate the current (still incomplete) time interval in addition to completed ones.'
                     ),
@@ -305,40 +143,30 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOneThresholdDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                                             ),
@@ -347,7 +175,7 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                             .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemOneTypeDefault),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemOneWindowDefault)
+                                            .optional()
                                             .describe('Rolling window size for calculating mean/std (default: 30)'),
                                     }),
                                     zod.object({
@@ -356,40 +184,30 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoThresholdDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                                             ),
@@ -398,15 +216,13 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                             .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoTypeDefault),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemTwoWindowDefault)
+                                            .optional()
                                             .describe('Rolling window size for calculating median/MAD (default: 30)'),
                                     }),
                                     zod.object({
                                         multiplier: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemThreeMultiplierDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)'
                                             ),
@@ -415,94 +231,72 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         type: zod
                                             .literal('iqr')
                                             .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemThreeTypeDefault),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemThreeWindowDefault
-                                            )
+                                            .optional()
                                             .describe('Rolling window size for calculating quartiles (default: 30)'),
                                     }),
                                     zod.object({
                                         lower_bound: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemFourLowerBoundDefault
-                                            )
+                                            .optional()
                                             .describe('Lower bound - values below this are anomalies'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         type: zod
                                             .literal('threshold')
                                             .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemFourTypeDefault),
                                         upper_bound: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemFourUpperBoundDefault
-                                            )
+                                            .optional()
                                             .describe('Upper bound - values above this are anomalies'),
                                     }),
                                     zod.object({
@@ -511,47 +305,37 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemFiveThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('ecod')
                                             .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemFiveTypeDefault),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemFiveWindowDefault)
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -562,47 +346,37 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemSixThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('copod')
                                             .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemSixTypeDefault),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemSixWindowDefault)
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -610,58 +384,44 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                     zod.object({
                                         n_estimators: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenNEstimatorsDefault
-                                            )
+                                            .optional()
                                             .describe('Number of trees in the forest (default: 100)'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('isolation_forest')
                                             .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenTypeDefault),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -669,66 +429,50 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                     zod.object({
                                         method: zod
                                             .union([zod.enum(['largest', 'mean', 'median']), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemEightMethodDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Distance method: 'largest', 'mean', 'median' (default: 'largest')"
                                             ),
                                         n_neighbors: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemEightNNeighborsDefault
-                                            )
+                                            .optional()
                                             .describe('Number of neighbors to consider (default: 5)'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemEightThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('knn')
                                             .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemEightTypeDefault),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemEightWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -736,54 +480,44 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                     zod.object({
                                         n_bins: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemNineNBinsDefault)
+                                            .optional()
                                             .describe('Number of histogram bins (default: 10)'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemNineThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('hbos')
                                             .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemNineTypeDefault),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemNineWindowDefault)
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -791,49 +525,37 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                     zod.object({
                                         n_neighbors: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroNNeighborsDefault
-                                            )
+                                            .optional()
                                             .describe('Number of neighbors for LOF (default: 20)'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('lof')
@@ -842,9 +564,7 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -852,53 +572,41 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                     zod.object({
                                         kernel: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOneoneKernelDefault
-                                            )
+                                            .optional()
                                             .describe('SVM kernel type (default: "rbf")'),
                                         nu: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemOneoneNuDefault)
+                                            .optional()
                                             .describe('Upper bound on training errors fraction (default: 0.1)'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOneoneThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('ocsvm')
@@ -907,9 +615,7 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOneoneWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -920,40 +626,30 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('pca')
@@ -962,9 +658,7 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -981,37 +675,37 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneTwoPreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneTwoPreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneTwoPreprocessingOneSmoothNDefault)
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneTwoPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneTwoThresholdDefault)
+                            .optional()
                             .describe(
                                 'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                             ),
                         type: zod.literal('zscore').default(alertsCreateBodyDetectorConfigOneTwoTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneTwoWindowDefault)
+                            .optional()
                             .describe('Rolling window size for calculating mean/std (default: 30)'),
                     }),
                     zod.object({
@@ -1020,111 +714,111 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneThreePreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneThreePreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneThreePreprocessingOneSmoothNDefault)
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneThreePreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneThreeThresholdDefault)
+                            .optional()
                             .describe(
                                 'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                             ),
                         type: zod.literal('mad').default(alertsCreateBodyDetectorConfigOneThreeTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneThreeWindowDefault)
+                            .optional()
                             .describe('Rolling window size for calculating median/MAD (default: 30)'),
                     }),
                     zod.object({
                         multiplier: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneFourMultiplierDefault)
+                            .optional()
                             .describe('IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneFourPreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneFourPreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneFourPreprocessingOneSmoothNDefault)
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneFourPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         type: zod.literal('iqr').default(alertsCreateBodyDetectorConfigOneFourTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneFourWindowDefault)
+                            .optional()
                             .describe('Rolling window size for calculating quartiles (default: 30)'),
                     }),
                     zod.object({
                         lower_bound: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneFiveLowerBoundDefault)
+                            .optional()
                             .describe('Lower bound - values below this are anomalies'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneFivePreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneFivePreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneFivePreprocessingOneSmoothNDefault)
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneFivePreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         type: zod.literal('threshold').default(alertsCreateBodyDetectorConfigOneFiveTypeDefault),
                         upper_bound: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneFiveUpperBoundDefault)
+                            .optional()
                             .describe('Upper bound - values above this are anomalies'),
                     }),
                     zod.object({
@@ -1133,35 +827,35 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneSixPreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneSixPreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneSixPreprocessingOneSmoothNDefault)
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneSixPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneSixThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('ecod').default(alertsCreateBodyDetectorConfigOneSixTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneSixWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -1172,35 +866,35 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneSevenPreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneSevenPreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneSevenPreprocessingOneSmoothNDefault)
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneSevenPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneSevenThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('copod').default(alertsCreateBodyDetectorConfigOneSevenTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneSevenWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -1208,44 +902,44 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     zod.object({
                         n_estimators: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneEightNEstimatorsDefault)
+                            .optional()
                             .describe('Number of trees in the forest (default: 100)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneEightPreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneEightPreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneEightPreprocessingOneSmoothNDefault)
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneEightPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneEightThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod
                             .literal('isolation_forest')
                             .default(alertsCreateBodyDetectorConfigOneEightTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneEightWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -1253,46 +947,46 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     zod.object({
                         method: zod
                             .union([zod.enum(['largest', 'mean', 'median']), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneNineMethodDefault)
+                            .optional()
                             .describe("Distance method: 'largest', 'mean', 'median' (default: 'largest')"),
                         n_neighbors: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneNineNNeighborsDefault)
+                            .optional()
                             .describe('Number of neighbors to consider (default: 5)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneNinePreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneNinePreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneNinePreprocessingOneSmoothNDefault)
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneNinePreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneNineThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('knn').default(alertsCreateBodyDetectorConfigOneNineTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneNineWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -1300,42 +994,42 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     zod.object({
                         n_bins: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOnezeroNBinsDefault)
+                            .optional()
                             .describe('Number of histogram bins (default: 10)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneOnezeroPreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneOnezeroPreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneOnezeroPreprocessingOneSmoothNDefault)
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneOnezeroPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOnezeroThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('hbos').default(alertsCreateBodyDetectorConfigOneOnezeroTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOnezeroWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -1343,42 +1037,42 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     zod.object({
                         n_neighbors: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOneoneNNeighborsDefault)
+                            .optional()
                             .describe('Number of neighbors for LOF (default: 20)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneOneonePreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneOneonePreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneOneonePreprocessingOneSmoothNDefault)
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneOneonePreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOneoneThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('lof').default(alertsCreateBodyDetectorConfigOneOneoneTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOneoneWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -1386,46 +1080,46 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     zod.object({
                         kernel: zod
                             .union([zod.string(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOnetwoKernelDefault)
+                            .optional()
                             .describe('SVM kernel type (default: "rbf")'),
                         nu: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOnetwoNuDefault)
+                            .optional()
                             .describe('Upper bound on training errors fraction (default: 0.1)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneOnetwoPreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneOnetwoPreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneOnetwoPreprocessingOneSmoothNDefault)
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneOnetwoPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOnetwoThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('ocsvm').default(alertsCreateBodyDetectorConfigOneOnetwoTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOnetwoWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -1436,37 +1130,35 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneOnethreePreprocessingOneDiffsNDefault)
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(alertsCreateBodyDetectorConfigOneOnethreePreprocessingOneLagsNDefault)
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsCreateBodyDetectorConfigOneOnethreePreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsCreateBodyDetectorConfigOneOnethreePreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOnethreeThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('pca').default(alertsCreateBodyDetectorConfigOneOnethreeTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsCreateBodyDetectorConfigOneOnethreeWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -1585,194 +1277,32 @@ export const AlertsPartialUpdateParams = /* @__PURE__ */ zod.object({
         ),
 })
 
-export const alertsPartialUpdateBodyThresholdOneConfigurationOneBoundsOneLowerDefault = null
-export const alertsPartialUpdateBodyThresholdOneConfigurationOneBoundsOneUpperDefault = null
-export const alertsPartialUpdateBodyThresholdOneConfigurationOneBoundsDefault = null
-export const alertsPartialUpdateBodyConfigOneCheckOngoingIntervalDefault = null
 export const alertsPartialUpdateBodyConfigOneTypeDefault = `TrendsAlertConfig`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneTypeDefault = `zscore`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoTypeDefault = `mad`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreeMultiplierDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreeTypeDefault = `iqr`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreeWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourLowerBoundDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourTypeDefault = `threshold`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourUpperBoundDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFiveThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFiveTypeDefault = `ecod`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFiveWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixTypeDefault = `copod`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenNEstimatorsDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenTypeDefault = `isolation_forest`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightMethodDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightNNeighborsDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightTypeDefault = `knn`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNineNBinsDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNineThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNineTypeDefault = `hbos`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNineWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroNNeighborsDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroTypeDefault = `lof`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneoneKernelDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneoneNuDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneoneThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneoneTypeDefault = `ocsvm`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneoneWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoTypeDefault = `pca`
-export const alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoWindowDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneTypeDefault = `ensemble`
-export const alertsPartialUpdateBodyDetectorConfigOneTwoPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneTwoPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneTwoPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneTwoPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneTwoThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneTwoTypeDefault = `zscore`
-export const alertsPartialUpdateBodyDetectorConfigOneTwoWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneThreePreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneThreePreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneThreePreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneThreePreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneThreeThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneThreeTypeDefault = `mad`
-export const alertsPartialUpdateBodyDetectorConfigOneThreeWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneFourMultiplierDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneFourPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneFourPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneFourPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneFourPreprocessingDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneFourTypeDefault = `iqr`
-export const alertsPartialUpdateBodyDetectorConfigOneFourWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneFiveLowerBoundDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneFivePreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneFivePreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneFivePreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneFivePreprocessingDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneFiveTypeDefault = `threshold`
-export const alertsPartialUpdateBodyDetectorConfigOneFiveUpperBoundDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneSixPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneSixPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneSixPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneSixPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneSixThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneSixTypeDefault = `ecod`
-export const alertsPartialUpdateBodyDetectorConfigOneSixWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneSevenPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneSevenPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneSevenPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneSevenPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneSevenThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneSevenTypeDefault = `copod`
-export const alertsPartialUpdateBodyDetectorConfigOneSevenWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneEightNEstimatorsDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneEightPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneEightPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneEightPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneEightPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneEightThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneEightTypeDefault = `isolation_forest`
-export const alertsPartialUpdateBodyDetectorConfigOneEightWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneNineMethodDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneNineNNeighborsDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneNinePreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneNinePreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneNinePreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneNinePreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneNineThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneNineTypeDefault = `knn`
-export const alertsPartialUpdateBodyDetectorConfigOneNineWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnezeroNBinsDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnezeroPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnezeroPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnezeroPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnezeroPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnezeroThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOnezeroTypeDefault = `hbos`
-export const alertsPartialUpdateBodyDetectorConfigOneOnezeroWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneoneNNeighborsDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneonePreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneonePreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneonePreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneonePreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOneoneThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOneoneTypeDefault = `lof`
-export const alertsPartialUpdateBodyDetectorConfigOneOneoneWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnetwoKernelDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnetwoNuDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnetwoPreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnetwoPreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnetwoPreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnetwoPreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnetwoThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOnetwoTypeDefault = `ocsvm`
-export const alertsPartialUpdateBodyDetectorConfigOneOnetwoWindowDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnethreePreprocessingOneDiffsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnethreePreprocessingOneLagsNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnethreePreprocessingOneSmoothNDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnethreePreprocessingDefault = null
-export const alertsPartialUpdateBodyDetectorConfigOneOnethreeThresholdDefault = null
 export const alertsPartialUpdateBodyDetectorConfigOneOnethreeTypeDefault = `pca`
-export const alertsPartialUpdateBodyDetectorConfigOneOnethreeWindowDefault = null
 
 export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
     insight: zod
@@ -1796,16 +1326,16 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                             zod.object({
                                 lower: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(alertsPartialUpdateBodyThresholdOneConfigurationOneBoundsOneLowerDefault)
+                                    .optional()
                                     .describe('Alert fires when the value drops below this number.'),
                                 upper: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(alertsPartialUpdateBodyThresholdOneConfigurationOneBoundsOneUpperDefault)
+                                    .optional()
                                     .describe('Alert fires when the value exceeds this number.'),
                             }),
                             zod.null(),
                         ])
-                        .default(alertsPartialUpdateBodyThresholdOneConfigurationOneBoundsDefault),
+                        .optional(),
                     type: zod
                         .enum(['absolute', 'percentage'])
                         .describe(
@@ -1835,7 +1365,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
             zod.object({
                 check_ongoing_interval: zod
                     .union([zod.boolean(), zod.null()])
-                    .default(alertsPartialUpdateBodyConfigOneCheckOngoingIntervalDefault)
+                    .optional()
                     .describe(
                         'When true, evaluate the current (still incomplete) time interval in addition to completed ones.'
                     ),
@@ -1864,40 +1394,30 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneThresholdDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                                             ),
@@ -1908,9 +1428,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneWindowDefault
-                                            )
+                                            .optional()
                                             .describe('Rolling window size for calculating mean/std (default: 30)'),
                                     }),
                                     zod.object({
@@ -1919,40 +1437,30 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoThresholdDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                                             ),
@@ -1963,17 +1471,13 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemTwoWindowDefault
-                                            )
+                                            .optional()
                                             .describe('Rolling window size for calculating median/MAD (default: 30)'),
                                     }),
                                     zod.object({
                                         multiplier: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreeMultiplierDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)'
                                             ),
@@ -1982,34 +1486,26 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         type: zod
                                             .literal('iqr')
@@ -2018,51 +1514,39 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemThreeWindowDefault
-                                            )
+                                            .optional()
                                             .describe('Rolling window size for calculating quartiles (default: 30)'),
                                     }),
                                     zod.object({
                                         lower_bound: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourLowerBoundDefault
-                                            )
+                                            .optional()
                                             .describe('Lower bound - values below this are anomalies'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         type: zod
                                             .literal('threshold')
@@ -2071,9 +1555,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         upper_bound: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFourUpperBoundDefault
-                                            )
+                                            .optional()
                                             .describe('Upper bound - values above this are anomalies'),
                                     }),
                                     zod.object({
@@ -2082,40 +1564,30 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFiveThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('ecod')
@@ -2124,9 +1596,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFiveWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -2137,40 +1607,30 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('copod')
@@ -2179,9 +1639,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -2189,49 +1647,37 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.object({
                                         n_estimators: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenNEstimatorsDefault
-                                            )
+                                            .optional()
                                             .describe('Number of trees in the forest (default: 100)'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('isolation_forest')
@@ -2240,9 +1686,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -2250,57 +1694,43 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.object({
                                         method: zod
                                             .union([zod.enum(['largest', 'mean', 'median']), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightMethodDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Distance method: 'largest', 'mean', 'median' (default: 'largest')"
                                             ),
                                         n_neighbors: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightNNeighborsDefault
-                                            )
+                                            .optional()
                                             .describe('Number of neighbors to consider (default: 5)'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('knn')
@@ -2309,9 +1739,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -2319,49 +1747,37 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.object({
                                         n_bins: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNineNBinsDefault
-                                            )
+                                            .optional()
                                             .describe('Number of histogram bins (default: 10)'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNineThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('hbos')
@@ -2370,9 +1786,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNineWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -2380,49 +1794,37 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.object({
                                         n_neighbors: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroNNeighborsDefault
-                                            )
+                                            .optional()
                                             .describe('Number of neighbors for LOF (default: 20)'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('lof')
@@ -2431,9 +1833,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -2441,55 +1841,41 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.object({
                                         kernel: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneoneKernelDefault
-                                            )
+                                            .optional()
                                             .describe('SVM kernel type (default: "rbf")'),
                                         nu: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneoneNuDefault
-                                            )
+                                            .optional()
                                             .describe('Upper bound on training errors fraction (default: 0.1)'),
                                         preprocessing: zod
                                             .union([
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneoneThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('ocsvm')
@@ -2498,9 +1884,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneoneWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -2511,40 +1895,30 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 zod.object({
                                                     diffs_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneDiffsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                         ),
                                                     lags_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneLagsNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                         ),
                                                     smooth_n: zod
                                                         .union([zod.number(), zod.null()])
-                                                        .default(
-                                                            alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneSmoothNDefault
-                                                        )
+                                                        .optional()
                                                         .describe(
                                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                         ),
                                                 }),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingDefault
-                                            )
+                                            .optional()
                                             .describe('Preprocessing transforms applied before detection'),
                                         threshold: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoThresholdDefault
-                                            )
+                                            .optional()
                                             .describe('Anomaly probability threshold (default: 0.9)'),
                                         type: zod
                                             .literal('pca')
@@ -2553,9 +1927,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                         window: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoWindowDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                             ),
@@ -2572,43 +1944,37 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneTwoPreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneTwoPreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneTwoPreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneTwoPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneTwoThresholdDefault)
+                            .optional()
                             .describe(
                                 'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                             ),
                         type: zod.literal('zscore').default(alertsPartialUpdateBodyDetectorConfigOneTwoTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneTwoWindowDefault)
+                            .optional()
                             .describe('Rolling window size for calculating mean/std (default: 30)'),
                     }),
                     zod.object({
@@ -2617,129 +1983,111 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneThreePreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneThreePreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneThreePreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneThreePreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneThreeThresholdDefault)
+                            .optional()
                             .describe(
                                 'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                             ),
                         type: zod.literal('mad').default(alertsPartialUpdateBodyDetectorConfigOneThreeTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneThreeWindowDefault)
+                            .optional()
                             .describe('Rolling window size for calculating median/MAD (default: 30)'),
                     }),
                     zod.object({
                         multiplier: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneFourMultiplierDefault)
+                            .optional()
                             .describe('IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneFourPreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneFourPreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneFourPreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneFourPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         type: zod.literal('iqr').default(alertsPartialUpdateBodyDetectorConfigOneFourTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneFourWindowDefault)
+                            .optional()
                             .describe('Rolling window size for calculating quartiles (default: 30)'),
                     }),
                     zod.object({
                         lower_bound: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneFiveLowerBoundDefault)
+                            .optional()
                             .describe('Lower bound - values below this are anomalies'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneFivePreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneFivePreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneFivePreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneFivePreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         type: zod.literal('threshold').default(alertsPartialUpdateBodyDetectorConfigOneFiveTypeDefault),
                         upper_bound: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneFiveUpperBoundDefault)
+                            .optional()
                             .describe('Upper bound - values above this are anomalies'),
                     }),
                     zod.object({
@@ -2748,41 +2096,35 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneSixPreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneSixPreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneSixPreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneSixPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneSixThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('ecod').default(alertsPartialUpdateBodyDetectorConfigOneSixTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneSixWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -2793,41 +2135,35 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneSevenPreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneSevenPreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneSevenPreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneSevenPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneSevenThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('copod').default(alertsPartialUpdateBodyDetectorConfigOneSevenTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneSevenWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -2835,50 +2171,44 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     zod.object({
                         n_estimators: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneEightNEstimatorsDefault)
+                            .optional()
                             .describe('Number of trees in the forest (default: 100)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneEightPreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneEightPreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneEightPreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneEightPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneEightThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod
                             .literal('isolation_forest')
                             .default(alertsPartialUpdateBodyDetectorConfigOneEightTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneEightWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -2886,52 +2216,46 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     zod.object({
                         method: zod
                             .union([zod.enum(['largest', 'mean', 'median']), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneNineMethodDefault)
+                            .optional()
                             .describe("Distance method: 'largest', 'mean', 'median' (default: 'largest')"),
                         n_neighbors: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneNineNNeighborsDefault)
+                            .optional()
                             .describe('Number of neighbors to consider (default: 5)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneNinePreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneNinePreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneNinePreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneNinePreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneNineThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('knn').default(alertsPartialUpdateBodyDetectorConfigOneNineTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneNineWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -2939,48 +2263,42 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     zod.object({
                         n_bins: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnezeroNBinsDefault)
+                            .optional()
                             .describe('Number of histogram bins (default: 10)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOnezeroPreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOnezeroPreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOnezeroPreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnezeroPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnezeroThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('hbos').default(alertsPartialUpdateBodyDetectorConfigOneOnezeroTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnezeroWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -2988,48 +2306,42 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     zod.object({
                         n_neighbors: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOneoneNNeighborsDefault)
+                            .optional()
                             .describe('Number of neighbors for LOF (default: 20)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOneonePreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOneonePreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOneonePreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOneonePreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOneoneThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('lof').default(alertsPartialUpdateBodyDetectorConfigOneOneoneTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOneoneWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -3037,52 +2349,46 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     zod.object({
                         kernel: zod
                             .union([zod.string(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnetwoKernelDefault)
+                            .optional()
                             .describe('SVM kernel type (default: "rbf")'),
                         nu: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnetwoNuDefault)
+                            .optional()
                             .describe('Upper bound on training errors fraction (default: 0.1)'),
                         preprocessing: zod
                             .union([
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOnetwoPreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOnetwoPreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOnetwoPreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnetwoPreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnetwoThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('ocsvm').default(alertsPartialUpdateBodyDetectorConfigOneOnetwoTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnetwoWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -3093,41 +2399,35 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 zod.object({
                                     diffs_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOnethreePreprocessingOneDiffsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                         ),
                                     lags_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOnethreePreprocessingOneLagsNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                         ),
                                     smooth_n: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            alertsPartialUpdateBodyDetectorConfigOneOnethreePreprocessingOneSmoothNDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                         ),
                                 }),
                                 zod.null(),
                             ])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnethreePreprocessingDefault)
+                            .optional()
                             .describe('Preprocessing transforms applied before detection'),
                         threshold: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnethreeThresholdDefault)
+                            .optional()
                             .describe('Anomaly probability threshold (default: 0.9)'),
                         type: zod.literal('pca').default(alertsPartialUpdateBodyDetectorConfigOneOnethreeTypeDefault),
                         window: zod
                             .union([zod.number(), zod.null()])
-                            .default(alertsPartialUpdateBodyDetectorConfigOneOnethreeWindowDefault)
+                            .optional()
                             .describe(
                                 'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                             ),
@@ -3225,189 +2525,31 @@ export const AlertsSimulateCreateParams = /* @__PURE__ */ zod.object({
         ),
 })
 
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneTypeDefault = `zscore`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoTypeDefault = `mad`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreeMultiplierDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreeTypeDefault = `iqr`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreeWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourLowerBoundDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourTypeDefault = `threshold`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourUpperBoundDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFiveThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFiveTypeDefault = `ecod`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFiveWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixTypeDefault = `copod`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenNEstimatorsDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenTypeDefault = `isolation_forest`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightMethodDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightNNeighborsDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightTypeDefault = `knn`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNineNBinsDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNineThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNineTypeDefault = `hbos`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNineWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroNNeighborsDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroTypeDefault = `lof`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneKernelDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneNuDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneTypeDefault = `ocsvm`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoTypeDefault = `pca`
-export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoWindowDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneTypeDefault = `ensemble`
-export const alertsSimulateCreateBodyDetectorConfigOneTwoPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneTwoPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneTwoPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneTwoPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneTwoThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneTwoTypeDefault = `zscore`
-export const alertsSimulateCreateBodyDetectorConfigOneTwoWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneThreePreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneThreePreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneThreePreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneThreePreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneThreeThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneThreeTypeDefault = `mad`
-export const alertsSimulateCreateBodyDetectorConfigOneThreeWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneFourMultiplierDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneFourPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneFourPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneFourPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneFourPreprocessingDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneFourTypeDefault = `iqr`
-export const alertsSimulateCreateBodyDetectorConfigOneFourWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneFiveLowerBoundDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneFivePreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneFivePreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneFivePreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneFivePreprocessingDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneFiveTypeDefault = `threshold`
-export const alertsSimulateCreateBodyDetectorConfigOneFiveUpperBoundDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneSixPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneSixPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneSixPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneSixPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneSixThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneSixTypeDefault = `ecod`
-export const alertsSimulateCreateBodyDetectorConfigOneSixWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneSevenPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneSevenPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneSevenPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneSevenPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneSevenThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneSevenTypeDefault = `copod`
-export const alertsSimulateCreateBodyDetectorConfigOneSevenWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneEightNEstimatorsDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneEightPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneEightPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneEightPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneEightPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneEightThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneEightTypeDefault = `isolation_forest`
-export const alertsSimulateCreateBodyDetectorConfigOneEightWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneNineMethodDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneNineNNeighborsDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneNinePreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneNinePreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneNinePreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneNinePreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneNineThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneNineTypeDefault = `knn`
-export const alertsSimulateCreateBodyDetectorConfigOneNineWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnezeroNBinsDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnezeroPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnezeroPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnezeroPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnezeroPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnezeroThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOnezeroTypeDefault = `hbos`
-export const alertsSimulateCreateBodyDetectorConfigOneOnezeroWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneoneNNeighborsDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneonePreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneonePreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneonePreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneonePreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOneoneThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOneoneTypeDefault = `lof`
-export const alertsSimulateCreateBodyDetectorConfigOneOneoneWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnetwoKernelDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnetwoNuDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnetwoPreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnetwoPreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnetwoPreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnetwoPreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnetwoThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOnetwoTypeDefault = `ocsvm`
-export const alertsSimulateCreateBodyDetectorConfigOneOnetwoWindowDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnethreePreprocessingOneDiffsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnethreePreprocessingOneLagsNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnethreePreprocessingOneSmoothNDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnethreePreprocessingDefault = null
-export const alertsSimulateCreateBodyDetectorConfigOneOnethreeThresholdDefault = null
 export const alertsSimulateCreateBodyDetectorConfigOneOnethreeTypeDefault = `pca`
-export const alertsSimulateCreateBodyDetectorConfigOneOnethreeWindowDefault = null
 export const alertsSimulateCreateBodySeriesIndexDefault = 0
 
 export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
@@ -3424,40 +2566,30 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnePreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 threshold: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneThresholdDefault
-                                    )
+                                    .optional()
                                     .describe(
                                         'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                                     ),
@@ -3466,7 +2598,7 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneTypeDefault),
                                 window: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneWindowDefault)
+                                    .optional()
                                     .describe('Rolling window size for calculating mean/std (default: 30)'),
                             }),
                             zod.object({
@@ -3475,40 +2607,30 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoPreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 threshold: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoThresholdDefault
-                                    )
+                                    .optional()
                                     .describe(
                                         'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                                     ),
@@ -3517,15 +2639,13 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoTypeDefault),
                                 window: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoWindowDefault)
+                                    .optional()
                                     .describe('Rolling window size for calculating median/MAD (default: 30)'),
                             }),
                             zod.object({
                                 multiplier: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreeMultiplierDefault
-                                    )
+                                    .optional()
                                     .describe(
                                         'IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)'
                                     ),
@@ -3534,94 +2654,72 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreePreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 type: zod
                                     .literal('iqr')
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreeTypeDefault),
                                 window: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreeWindowDefault
-                                    )
+                                    .optional()
                                     .describe('Rolling window size for calculating quartiles (default: 30)'),
                             }),
                             zod.object({
                                 lower_bound: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourLowerBoundDefault
-                                    )
+                                    .optional()
                                     .describe('Lower bound - values below this are anomalies'),
                                 preprocessing: zod
                                     .union([
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourPreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 type: zod
                                     .literal('threshold')
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourTypeDefault),
                                 upper_bound: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourUpperBoundDefault
-                                    )
+                                    .optional()
                                     .describe('Upper bound - values above this are anomalies'),
                             }),
                             zod.object({
@@ -3630,47 +2728,37 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFivePreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 threshold: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFiveThresholdDefault
-                                    )
+                                    .optional()
                                     .describe('Anomaly probability threshold (default: 0.9)'),
                                 type: zod
                                     .literal('ecod')
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFiveTypeDefault),
                                 window: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFiveWindowDefault)
+                                    .optional()
                                     .describe(
                                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                     ),
@@ -3681,47 +2769,37 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixPreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 threshold: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixThresholdDefault
-                                    )
+                                    .optional()
                                     .describe('Anomaly probability threshold (default: 0.9)'),
                                 type: zod
                                     .literal('copod')
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixTypeDefault),
                                 window: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixWindowDefault)
+                                    .optional()
                                     .describe(
                                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                     ),
@@ -3729,58 +2807,44 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                             zod.object({
                                 n_estimators: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenNEstimatorsDefault
-                                    )
+                                    .optional()
                                     .describe('Number of trees in the forest (default: 100)'),
                                 preprocessing: zod
                                     .union([
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenPreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 threshold: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenThresholdDefault
-                                    )
+                                    .optional()
                                     .describe('Anomaly probability threshold (default: 0.9)'),
                                 type: zod
                                     .literal('isolation_forest')
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenTypeDefault),
                                 window: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenWindowDefault
-                                    )
+                                    .optional()
                                     .describe(
                                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                     ),
@@ -3788,64 +2852,48 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                             zod.object({
                                 method: zod
                                     .union([zod.enum(['largest', 'mean', 'median']), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightMethodDefault
-                                    )
+                                    .optional()
                                     .describe("Distance method: 'largest', 'mean', 'median' (default: 'largest')"),
                                 n_neighbors: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightNNeighborsDefault
-                                    )
+                                    .optional()
                                     .describe('Number of neighbors to consider (default: 5)'),
                                 preprocessing: zod
                                     .union([
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightPreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 threshold: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightThresholdDefault
-                                    )
+                                    .optional()
                                     .describe('Anomaly probability threshold (default: 0.9)'),
                                 type: zod
                                     .literal('knn')
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightTypeDefault),
                                 window: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightWindowDefault
-                                    )
+                                    .optional()
                                     .describe(
                                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                     ),
@@ -3853,54 +2901,44 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                             zod.object({
                                 n_bins: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNineNBinsDefault)
+                                    .optional()
                                     .describe('Number of histogram bins (default: 10)'),
                                 preprocessing: zod
                                     .union([
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNinePreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 threshold: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNineThresholdDefault
-                                    )
+                                    .optional()
                                     .describe('Anomaly probability threshold (default: 0.9)'),
                                 type: zod
                                     .literal('hbos')
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNineTypeDefault),
                                 window: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNineWindowDefault)
+                                    .optional()
                                     .describe(
                                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                     ),
@@ -3908,49 +2946,37 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                             zod.object({
                                 n_neighbors: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroNNeighborsDefault
-                                    )
+                                    .optional()
                                     .describe('Number of neighbors for LOF (default: 20)'),
                                 preprocessing: zod
                                     .union([
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroPreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 threshold: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroThresholdDefault
-                                    )
+                                    .optional()
                                     .describe('Anomaly probability threshold (default: 0.9)'),
                                 type: zod
                                     .literal('lof')
@@ -3959,9 +2985,7 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                     ),
                                 window: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroWindowDefault
-                                    )
+                                    .optional()
                                     .describe(
                                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                     ),
@@ -3969,53 +2993,41 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                             zod.object({
                                 kernel: zod
                                     .union([zod.string(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneKernelDefault
-                                    )
+                                    .optional()
                                     .describe('SVM kernel type (default: "rbf")'),
                                 nu: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneNuDefault)
+                                    .optional()
                                     .describe('Upper bound on training errors fraction (default: 0.1)'),
                                 preprocessing: zod
                                     .union([
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneonePreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 threshold: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneThresholdDefault
-                                    )
+                                    .optional()
                                     .describe('Anomaly probability threshold (default: 0.9)'),
                                 type: zod
                                     .literal('ocsvm')
@@ -4024,9 +3036,7 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                     ),
                                 window: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneWindowDefault
-                                    )
+                                    .optional()
                                     .describe(
                                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                     ),
@@ -4037,40 +3047,30 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                         zod.object({
                                             diffs_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneDiffsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
                                                 ),
                                             lags_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneLagsNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                                 ),
                                             smooth_n: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingOneSmoothNDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                                 ),
                                         }),
                                         zod.null(),
                                     ])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoPreprocessingDefault
-                                    )
+                                    .optional()
                                     .describe('Preprocessing transforms applied before detection'),
                                 threshold: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoThresholdDefault
-                                    )
+                                    .optional()
                                     .describe('Anomaly probability threshold (default: 0.9)'),
                                 type: zod
                                     .literal('pca')
@@ -4079,9 +3079,7 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                     ),
                                 window: zod
                                     .union([zod.number(), zod.null()])
-                                    .default(
-                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoWindowDefault
-                                    )
+                                    .optional()
                                     .describe(
                                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                     ),
@@ -4098,35 +3096,35 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneTwoPreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneTwoPreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneTwoPreprocessingOneSmoothNDefault)
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneTwoPreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 threshold: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneTwoThresholdDefault)
+                    .optional()
                     .describe(
                         'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                     ),
                 type: zod.literal('zscore').default(alertsSimulateCreateBodyDetectorConfigOneTwoTypeDefault),
                 window: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneTwoWindowDefault)
+                    .optional()
                     .describe('Rolling window size for calculating mean/std (default: 30)'),
             }),
             zod.object({
@@ -4135,105 +3133,105 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneThreePreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneThreePreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneThreePreprocessingOneSmoothNDefault)
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneThreePreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 threshold: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneThreeThresholdDefault)
+                    .optional()
                     .describe(
                         'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
                     ),
                 type: zod.literal('mad').default(alertsSimulateCreateBodyDetectorConfigOneThreeTypeDefault),
                 window: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneThreeWindowDefault)
+                    .optional()
                     .describe('Rolling window size for calculating median/MAD (default: 30)'),
             }),
             zod.object({
                 multiplier: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneFourMultiplierDefault)
+                    .optional()
                     .describe('IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)'),
                 preprocessing: zod
                     .union([
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneFourPreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneFourPreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneFourPreprocessingOneSmoothNDefault)
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneFourPreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 type: zod.literal('iqr').default(alertsSimulateCreateBodyDetectorConfigOneFourTypeDefault),
                 window: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneFourWindowDefault)
+                    .optional()
                     .describe('Rolling window size for calculating quartiles (default: 30)'),
             }),
             zod.object({
                 lower_bound: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneFiveLowerBoundDefault)
+                    .optional()
                     .describe('Lower bound - values below this are anomalies'),
                 preprocessing: zod
                     .union([
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneFivePreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneFivePreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneFivePreprocessingOneSmoothNDefault)
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneFivePreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 type: zod.literal('threshold').default(alertsSimulateCreateBodyDetectorConfigOneFiveTypeDefault),
                 upper_bound: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneFiveUpperBoundDefault)
+                    .optional()
                     .describe('Upper bound - values above this are anomalies'),
             }),
             zod.object({
@@ -4242,33 +3240,33 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneSixPreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneSixPreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneSixPreprocessingOneSmoothNDefault)
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneSixPreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 threshold: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneSixThresholdDefault)
+                    .optional()
                     .describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.literal('ecod').default(alertsSimulateCreateBodyDetectorConfigOneSixTypeDefault),
                 window: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneSixWindowDefault)
+                    .optional()
                     .describe(
                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                     ),
@@ -4279,33 +3277,33 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneSevenPreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneSevenPreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneSevenPreprocessingOneSmoothNDefault)
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneSevenPreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 threshold: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneSevenThresholdDefault)
+                    .optional()
                     .describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.literal('copod').default(alertsSimulateCreateBodyDetectorConfigOneSevenTypeDefault),
                 window: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneSevenWindowDefault)
+                    .optional()
                     .describe(
                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                     ),
@@ -4313,42 +3311,42 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
             zod.object({
                 n_estimators: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneEightNEstimatorsDefault)
+                    .optional()
                     .describe('Number of trees in the forest (default: 100)'),
                 preprocessing: zod
                     .union([
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneEightPreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneEightPreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneEightPreprocessingOneSmoothNDefault)
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneEightPreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 threshold: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneEightThresholdDefault)
+                    .optional()
                     .describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod
                     .literal('isolation_forest')
                     .default(alertsSimulateCreateBodyDetectorConfigOneEightTypeDefault),
                 window: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneEightWindowDefault)
+                    .optional()
                     .describe(
                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                     ),
@@ -4356,44 +3354,44 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
             zod.object({
                 method: zod
                     .union([zod.enum(['largest', 'mean', 'median']), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneNineMethodDefault)
+                    .optional()
                     .describe("Distance method: 'largest', 'mean', 'median' (default: 'largest')"),
                 n_neighbors: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneNineNNeighborsDefault)
+                    .optional()
                     .describe('Number of neighbors to consider (default: 5)'),
                 preprocessing: zod
                     .union([
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneNinePreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneNinePreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneNinePreprocessingOneSmoothNDefault)
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneNinePreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 threshold: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneNineThresholdDefault)
+                    .optional()
                     .describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.literal('knn').default(alertsSimulateCreateBodyDetectorConfigOneNineTypeDefault),
                 window: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneNineWindowDefault)
+                    .optional()
                     .describe(
                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                     ),
@@ -4401,40 +3399,40 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
             zod.object({
                 n_bins: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnezeroNBinsDefault)
+                    .optional()
                     .describe('Number of histogram bins (default: 10)'),
                 preprocessing: zod
                     .union([
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneOnezeroPreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneOnezeroPreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneOnezeroPreprocessingOneSmoothNDefault)
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnezeroPreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 threshold: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnezeroThresholdDefault)
+                    .optional()
                     .describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.literal('hbos').default(alertsSimulateCreateBodyDetectorConfigOneOnezeroTypeDefault),
                 window: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnezeroWindowDefault)
+                    .optional()
                     .describe(
                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                     ),
@@ -4442,85 +3440,82 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
             zod.object({
                 n_neighbors: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOneoneNNeighborsDefault)
+                    .optional()
                     .describe('Number of neighbors for LOF (default: 20)'),
                 preprocessing: zod
                     .union([
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneOneonePreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneOneonePreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneOneonePreprocessingOneSmoothNDefault)
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOneonePreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 threshold: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOneoneThresholdDefault)
+                    .optional()
                     .describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.literal('lof').default(alertsSimulateCreateBodyDetectorConfigOneOneoneTypeDefault),
                 window: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOneoneWindowDefault)
+                    .optional()
                     .describe(
                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                     ),
             }),
             zod.object({
-                kernel: zod
-                    .union([zod.string(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnetwoKernelDefault)
-                    .describe('SVM kernel type (default: "rbf")'),
+                kernel: zod.union([zod.string(), zod.null()]).optional().describe('SVM kernel type (default: "rbf")'),
                 nu: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnetwoNuDefault)
+                    .optional()
                     .describe('Upper bound on training errors fraction (default: 0.1)'),
                 preprocessing: zod
                     .union([
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneOnetwoPreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneOnetwoPreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneOnetwoPreprocessingOneSmoothNDefault)
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnetwoPreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 threshold: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnetwoThresholdDefault)
+                    .optional()
                     .describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.literal('ocsvm').default(alertsSimulateCreateBodyDetectorConfigOneOnetwoTypeDefault),
                 window: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnetwoWindowDefault)
+                    .optional()
                     .describe(
                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                     ),
@@ -4531,35 +3526,33 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                         zod.object({
                             diffs_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneOnethreePreprocessingOneDiffsNDefault)
+                                .optional()
                                 .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
                             lags_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(alertsSimulateCreateBodyDetectorConfigOneOnethreePreprocessingOneLagsNDefault)
+                                .optional()
                                 .describe(
                                     'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
                                 ),
                             smooth_n: zod
                                 .union([zod.number(), zod.null()])
-                                .default(
-                                    alertsSimulateCreateBodyDetectorConfigOneOnethreePreprocessingOneSmoothNDefault
-                                )
+                                .optional()
                                 .describe(
                                     'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
                                 ),
                         }),
                         zod.null(),
                     ])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnethreePreprocessingDefault)
+                    .optional()
                     .describe('Preprocessing transforms applied before detection'),
                 threshold: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnethreeThresholdDefault)
+                    .optional()
                     .describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.literal('pca').default(alertsSimulateCreateBodyDetectorConfigOneOnethreeTypeDefault),
                 window: zod
                     .union([zod.number(), zod.null()])
-                    .default(alertsSimulateCreateBodyDetectorConfigOneOnethreeWindowDefault)
+                    .optional()
                     .describe(
                         'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                     ),

--- a/services/mcp/src/generated/cohorts/api.ts
+++ b/services/mcp/src/generated/cohorts/api.ts
@@ -33,33 +33,9 @@ export const cohortsCreateBodyNameMax = 400
 
 export const cohortsCreateBodyDescriptionMax = 1000
 
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneBytecodeDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneBytecodeErrorDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneConditionHashDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneTimeValueDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneTimeIntervalDefault = null
 export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneNegationDefault = false
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneOperatorDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneOperatorValueDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneSeqTimeIntervalDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneSeqTimeValueDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneSeqEventDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneSeqEventTypeDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneTotalPeriodsDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneMinPeriodsDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneEventFiltersOneItemOneOperatorDefault = null
 export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneEventFiltersOneItemTwoValueDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneEventFiltersDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneExplicitDatetimeDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneExplicitDatetimeToDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemTwoBytecodeDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemTwoBytecodeErrorDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemTwoConditionHashDefault = null
 export const cohortsCreateBodyFiltersOnePropertiesValuesItemTwoNegationDefault = false
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemThreeBytecodeDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemThreeBytecodeErrorDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemThreeConditionHashDefault = null
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemThreeOperatorDefault = null
 export const cohortsCreateBodyFiltersOnePropertiesValuesItemThreeValueDefault = null
 export const cohortsCreateBodyFiltersOnePropertiesValuesItemThreeNegationDefault = false
 export const cohortsCreateBodyCreateStaticPersonIdsDefault = []
@@ -76,60 +52,26 @@ export const CohortsCreateBody = /* @__PURE__ */ zod.object({
                         values: zod.array(
                             zod.union([
                                 zod.object({
-                                    bytecode: zod
-                                        .union([zod.array(zod.unknown()), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemOneBytecodeDefault),
-                                    bytecode_error: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsCreateBodyFiltersOnePropertiesValuesItemOneBytecodeErrorDefault
-                                        ),
-                                    conditionHash: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsCreateBodyFiltersOnePropertiesValuesItemOneConditionHashDefault
-                                        ),
+                                    bytecode: zod.union([zod.array(zod.unknown()), zod.null()]).optional(),
+                                    bytecode_error: zod.union([zod.string(), zod.null()]).optional(),
+                                    conditionHash: zod.union([zod.string(), zod.null()]).optional(),
                                     type: zod.literal('behavioral'),
                                     key: zod.union([zod.string(), zod.number()]),
                                     value: zod.string(),
                                     event_type: zod.string(),
-                                    time_value: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemOneTimeValueDefault),
-                                    time_interval: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemOneTimeIntervalDefault),
+                                    time_value: zod.union([zod.number(), zod.null()]).optional(),
+                                    time_interval: zod.union([zod.string(), zod.null()]).optional(),
                                     negation: zod
                                         .boolean()
                                         .default(cohortsCreateBodyFiltersOnePropertiesValuesItemOneNegationDefault),
-                                    operator: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemOneOperatorDefault),
-                                    operator_value: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(
-                                            cohortsCreateBodyFiltersOnePropertiesValuesItemOneOperatorValueDefault
-                                        ),
-                                    seq_time_interval: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsCreateBodyFiltersOnePropertiesValuesItemOneSeqTimeIntervalDefault
-                                        ),
-                                    seq_time_value: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemOneSeqTimeValueDefault),
-                                    seq_event: zod
-                                        .union([zod.string(), zod.number(), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemOneSeqEventDefault),
-                                    seq_event_type: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemOneSeqEventTypeDefault),
-                                    total_periods: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemOneTotalPeriodsDefault),
-                                    min_periods: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemOneMinPeriodsDefault),
+                                    operator: zod.union([zod.string(), zod.null()]).optional(),
+                                    operator_value: zod.union([zod.number(), zod.null()]).optional(),
+                                    seq_time_interval: zod.union([zod.string(), zod.null()]).optional(),
+                                    seq_time_value: zod.union([zod.number(), zod.null()]).optional(),
+                                    seq_event: zod.union([zod.string(), zod.number(), zod.null()]).optional(),
+                                    seq_event_type: zod.union([zod.string(), zod.null()]).optional(),
+                                    total_periods: zod.union([zod.number(), zod.null()]).optional(),
+                                    min_periods: zod.union([zod.number(), zod.null()]).optional(),
                                     event_filters: zod
                                         .union([
                                             zod.array(
@@ -138,11 +80,7 @@ export const CohortsCreateBody = /* @__PURE__ */ zod.object({
                                                         type: zod.enum(['event', 'element']),
                                                         key: zod.string(),
                                                         value: zod.unknown(),
-                                                        operator: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                cohortsCreateBodyFiltersOnePropertiesValuesItemOneEventFiltersOneItemOneOperatorDefault
-                                                            ),
+                                                        operator: zod.union([zod.string(), zod.null()]).optional(),
                                                     }),
                                                     zod.object({
                                                         type: zod.literal('hogql'),
@@ -157,32 +95,14 @@ export const CohortsCreateBody = /* @__PURE__ */ zod.object({
                                             ),
                                             zod.null(),
                                         ])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemOneEventFiltersDefault),
-                                    explicit_datetime: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsCreateBodyFiltersOnePropertiesValuesItemOneExplicitDatetimeDefault
-                                        ),
-                                    explicit_datetime_to: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsCreateBodyFiltersOnePropertiesValuesItemOneExplicitDatetimeToDefault
-                                        ),
+                                        .optional(),
+                                    explicit_datetime: zod.union([zod.string(), zod.null()]).optional(),
+                                    explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
                                 }),
                                 zod.object({
-                                    bytecode: zod
-                                        .union([zod.array(zod.unknown()), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemTwoBytecodeDefault),
-                                    bytecode_error: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsCreateBodyFiltersOnePropertiesValuesItemTwoBytecodeErrorDefault
-                                        ),
-                                    conditionHash: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsCreateBodyFiltersOnePropertiesValuesItemTwoConditionHashDefault
-                                        ),
+                                    bytecode: zod.union([zod.array(zod.unknown()), zod.null()]).optional(),
+                                    bytecode_error: zod.union([zod.string(), zod.null()]).optional(),
+                                    conditionHash: zod.union([zod.string(), zod.null()]).optional(),
                                     type: zod.literal('cohort'),
                                     key: zod.literal('id'),
                                     value: zod.number(),
@@ -191,24 +111,12 @@ export const CohortsCreateBody = /* @__PURE__ */ zod.object({
                                         .default(cohortsCreateBodyFiltersOnePropertiesValuesItemTwoNegationDefault),
                                 }),
                                 zod.object({
-                                    bytecode: zod
-                                        .union([zod.array(zod.unknown()), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemThreeBytecodeDefault),
-                                    bytecode_error: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsCreateBodyFiltersOnePropertiesValuesItemThreeBytecodeErrorDefault
-                                        ),
-                                    conditionHash: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsCreateBodyFiltersOnePropertiesValuesItemThreeConditionHashDefault
-                                        ),
+                                    bytecode: zod.union([zod.array(zod.unknown()), zod.null()]).optional(),
+                                    bytecode_error: zod.union([zod.string(), zod.null()]).optional(),
+                                    conditionHash: zod.union([zod.string(), zod.null()]).optional(),
                                     type: zod.literal('person'),
                                     key: zod.string(),
-                                    operator: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemThreeOperatorDefault),
+                                    operator: zod.union([zod.string(), zod.null()]).optional(),
                                     value: zod
                                         .unknown()
                                         .default(cohortsCreateBodyFiltersOnePropertiesValuesItemThreeValueDefault),
@@ -269,33 +177,9 @@ export const cohortsPartialUpdateBodyNameMax = 400
 
 export const cohortsPartialUpdateBodyDescriptionMax = 1000
 
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneBytecodeDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneBytecodeErrorDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneConditionHashDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneTimeValueDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneTimeIntervalDefault = null
 export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneNegationDefault = false
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneOperatorDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneOperatorValueDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneSeqTimeIntervalDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneSeqTimeValueDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneSeqEventDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneSeqEventTypeDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneTotalPeriodsDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneMinPeriodsDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneEventFiltersOneItemOneOperatorDefault = null
 export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneEventFiltersOneItemTwoValueDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneEventFiltersDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneExplicitDatetimeDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneExplicitDatetimeToDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemTwoBytecodeDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemTwoBytecodeErrorDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemTwoConditionHashDefault = null
 export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemTwoNegationDefault = false
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeBytecodeDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeBytecodeErrorDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeConditionHashDefault = null
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeOperatorDefault = null
 export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeValueDefault = null
 export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeNegationDefault = false
 
@@ -312,80 +196,28 @@ export const CohortsPartialUpdateBody = /* @__PURE__ */ zod.object({
                         values: zod.array(
                             zod.union([
                                 zod.object({
-                                    bytecode: zod
-                                        .union([zod.array(zod.unknown()), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneBytecodeDefault
-                                        ),
-                                    bytecode_error: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneBytecodeErrorDefault
-                                        ),
-                                    conditionHash: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneConditionHashDefault
-                                        ),
+                                    bytecode: zod.union([zod.array(zod.unknown()), zod.null()]).optional(),
+                                    bytecode_error: zod.union([zod.string(), zod.null()]).optional(),
+                                    conditionHash: zod.union([zod.string(), zod.null()]).optional(),
                                     type: zod.literal('behavioral'),
                                     key: zod.union([zod.string(), zod.number()]),
                                     value: zod.string(),
                                     event_type: zod.string(),
-                                    time_value: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneTimeValueDefault
-                                        ),
-                                    time_interval: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneTimeIntervalDefault
-                                        ),
+                                    time_value: zod.union([zod.number(), zod.null()]).optional(),
+                                    time_interval: zod.union([zod.string(), zod.null()]).optional(),
                                     negation: zod
                                         .boolean()
                                         .default(
                                             cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneNegationDefault
                                         ),
-                                    operator: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneOperatorDefault
-                                        ),
-                                    operator_value: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneOperatorValueDefault
-                                        ),
-                                    seq_time_interval: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneSeqTimeIntervalDefault
-                                        ),
-                                    seq_time_value: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneSeqTimeValueDefault
-                                        ),
-                                    seq_event: zod
-                                        .union([zod.string(), zod.number(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneSeqEventDefault
-                                        ),
-                                    seq_event_type: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneSeqEventTypeDefault
-                                        ),
-                                    total_periods: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneTotalPeriodsDefault
-                                        ),
-                                    min_periods: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneMinPeriodsDefault
-                                        ),
+                                    operator: zod.union([zod.string(), zod.null()]).optional(),
+                                    operator_value: zod.union([zod.number(), zod.null()]).optional(),
+                                    seq_time_interval: zod.union([zod.string(), zod.null()]).optional(),
+                                    seq_time_value: zod.union([zod.number(), zod.null()]).optional(),
+                                    seq_event: zod.union([zod.string(), zod.number(), zod.null()]).optional(),
+                                    seq_event_type: zod.union([zod.string(), zod.null()]).optional(),
+                                    total_periods: zod.union([zod.number(), zod.null()]).optional(),
+                                    min_periods: zod.union([zod.number(), zod.null()]).optional(),
                                     event_filters: zod
                                         .union([
                                             zod.array(
@@ -394,11 +226,7 @@ export const CohortsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                         type: zod.enum(['event', 'element']),
                                                         key: zod.string(),
                                                         value: zod.unknown(),
-                                                        operator: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneEventFiltersOneItemOneOperatorDefault
-                                                            ),
+                                                        operator: zod.union([zod.string(), zod.null()]).optional(),
                                                     }),
                                                     zod.object({
                                                         type: zod.literal('hogql'),
@@ -413,36 +241,14 @@ export const CohortsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             ),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneEventFiltersDefault
-                                        ),
-                                    explicit_datetime: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneExplicitDatetimeDefault
-                                        ),
-                                    explicit_datetime_to: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneExplicitDatetimeToDefault
-                                        ),
+                                        .optional(),
+                                    explicit_datetime: zod.union([zod.string(), zod.null()]).optional(),
+                                    explicit_datetime_to: zod.union([zod.string(), zod.null()]).optional(),
                                 }),
                                 zod.object({
-                                    bytecode: zod
-                                        .union([zod.array(zod.unknown()), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemTwoBytecodeDefault
-                                        ),
-                                    bytecode_error: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemTwoBytecodeErrorDefault
-                                        ),
-                                    conditionHash: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemTwoConditionHashDefault
-                                        ),
+                                    bytecode: zod.union([zod.array(zod.unknown()), zod.null()]).optional(),
+                                    bytecode_error: zod.union([zod.string(), zod.null()]).optional(),
+                                    conditionHash: zod.union([zod.string(), zod.null()]).optional(),
                                     type: zod.literal('cohort'),
                                     key: zod.literal('id'),
                                     value: zod.number(),
@@ -453,28 +259,12 @@ export const CohortsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         ),
                                 }),
                                 zod.object({
-                                    bytecode: zod
-                                        .union([zod.array(zod.unknown()), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeBytecodeDefault
-                                        ),
-                                    bytecode_error: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeBytecodeErrorDefault
-                                        ),
-                                    conditionHash: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeConditionHashDefault
-                                        ),
+                                    bytecode: zod.union([zod.array(zod.unknown()), zod.null()]).optional(),
+                                    bytecode_error: zod.union([zod.string(), zod.null()]).optional(),
+                                    conditionHash: zod.union([zod.string(), zod.null()]).optional(),
                                     type: zod.literal('person'),
                                     key: zod.string(),
-                                    operator: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeOperatorDefault
-                                        ),
+                                    operator: zod.union([zod.string(), zod.null()]).optional(),
                                     value: zod
                                         .unknown()
                                         .default(

--- a/services/mcp/src/generated/endpoints/api.ts
+++ b/services/mcp/src/generated/endpoints/api.ts
@@ -202,100 +202,38 @@ export const EndpointsRunCreateParams = /* @__PURE__ */ zod.object({
         ),
 })
 
-export const endpointsRunCreateBodyClientQueryIdDefault = null
 export const endpointsRunCreateBodyDebugDefault = false
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownGroupTypeIndexDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownHideOtherAggregationDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownHistogramBinCountDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownLimitDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownNormalizeUrlDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownPathCleaningDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownTypeDefault = `event`
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownsOneItemGroupTypeIndexDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownsOneItemHistogramBinCountDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownsOneItemNormalizeUrlDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownsOneItemTypeDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownsOneMax = 3
 
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownsDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneDateFromDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneDateToDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOneExplicitDateDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneOperatorDefault = `exact`
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneTypeDefault = `event`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwoLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwoTypeDefault = `person`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwoValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemThreeLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemThreeTypeDefault = `element`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemThreeValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemFourLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemFourTypeDefault = `event_metadata`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemFourValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemFiveLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemFiveTypeDefault = `session`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemFiveValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSixCohortNameDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSixKeyDefault = `id`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSixLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSixOperatorDefault = `in`
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSixTypeDefault = `cohort`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSevenLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSevenTypeDefault = `recording`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSevenValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemEightLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemEightTypeDefault = `log_entry`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemEightValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemNineGroupKeyNamesDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemNineGroupTypeIndexDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemNineLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemNineTypeDefault = `group`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemNineValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnezeroLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnezeroTypeDefault = `feature`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnezeroValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneoneLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneoneOperatorDefault = `flag_evaluates_to`
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneoneTypeDefault = `flag`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnetwoLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnetwoTypeDefault = `hogql`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnetwoValueDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnethreeTypeDefault = `empty`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnefourLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnefourTypeDefault = `data_warehouse`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnefourValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnefiveLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnefiveTypeDefault = `data_warehouse_person_property`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnefiveValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnesixLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnesixTypeDefault = `error_tracking_issue`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnesixValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnesevenLabelDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnesevenValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneeightLabelDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneeightValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnenineLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnenineTypeDefault = `revenue_analytics`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnenineValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwozeroLabelDefault = null
 export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwozeroTypeDefault = `workflow_variable`
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwozeroValueDefault = null
-export const endpointsRunCreateBodyFiltersOverrideOnePropertiesDefault = null
-export const endpointsRunCreateBodyFiltersOverrideDefault = null
-export const endpointsRunCreateBodyLimitDefault = null
-export const endpointsRunCreateBodyOffsetDefault = null
 export const endpointsRunCreateBodyRefreshDefault = `cache`
-export const endpointsRunCreateBodyVariablesDefault = null
-export const endpointsRunCreateBodyVersionDefault = null
 
 export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
     client_query_id: zod
         .union([zod.string(), zod.null()])
-        .default(endpointsRunCreateBodyClientQueryIdDefault)
+        .optional()
         .describe('Client provided query ID. Can be used to retrieve the status or cancel the query.'),
     debug: zod
         .union([zod.boolean(), zod.null()])
@@ -314,37 +252,13 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                     zod.number(),
                                     zod.null(),
                                 ])
-                                .default(endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownDefault),
-                            breakdown_group_type_index: zod
-                                .union([zod.number(), zod.null()])
-                                .default(
-                                    endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownGroupTypeIndexDefault
-                                ),
-                            breakdown_hide_other_aggregation: zod
-                                .union([zod.boolean(), zod.null()])
-                                .default(
-                                    endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownHideOtherAggregationDefault
-                                ),
-                            breakdown_histogram_bin_count: zod
-                                .union([zod.number(), zod.null()])
-                                .default(
-                                    endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownHistogramBinCountDefault
-                                ),
-                            breakdown_limit: zod
-                                .union([zod.number(), zod.null()])
-                                .default(
-                                    endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownLimitDefault
-                                ),
-                            breakdown_normalize_url: zod
-                                .union([zod.boolean(), zod.null()])
-                                .default(
-                                    endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownNormalizeUrlDefault
-                                ),
-                            breakdown_path_cleaning: zod
-                                .union([zod.boolean(), zod.null()])
-                                .default(
-                                    endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownPathCleaningDefault
-                                ),
+                                .optional(),
+                            breakdown_group_type_index: zod.union([zod.number(), zod.null()]).optional(),
+                            breakdown_hide_other_aggregation: zod.union([zod.boolean(), zod.null()]).optional(),
+                            breakdown_histogram_bin_count: zod.union([zod.number(), zod.null()]).optional(),
+                            breakdown_limit: zod.union([zod.number(), zod.null()]).optional(),
+                            breakdown_normalize_url: zod.union([zod.boolean(), zod.null()]).optional(),
+                            breakdown_path_cleaning: zod.union([zod.boolean(), zod.null()]).optional(),
                             breakdown_type: zod
                                 .union([
                                     zod.enum([
@@ -369,21 +283,9 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                     zod
                                         .array(
                                             zod.object({
-                                                group_type_index: zod
-                                                    .union([zod.number(), zod.null()])
-                                                    .default(
-                                                        endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownsOneItemGroupTypeIndexDefault
-                                                    ),
-                                                histogram_bin_count: zod
-                                                    .union([zod.number(), zod.null()])
-                                                    .default(
-                                                        endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownsOneItemHistogramBinCountDefault
-                                                    ),
-                                                normalize_url: zod
-                                                    .union([zod.boolean(), zod.null()])
-                                                    .default(
-                                                        endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownsOneItemNormalizeUrlDefault
-                                                    ),
+                                                group_type_index: zod.union([zod.number(), zod.null()]).optional(),
+                                                histogram_bin_count: zod.union([zod.number(), zod.null()]).optional(),
+                                                normalize_url: zod.union([zod.boolean(), zod.null()]).optional(),
                                                 property: zod.union([zod.string(), zod.number()]),
                                                 type: zod
                                                     .union([
@@ -401,9 +303,7 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                                         ]),
                                                         zod.null(),
                                                     ])
-                                                    .default(
-                                                        endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownsOneItemTypeDefault
-                                                    ),
+                                                    .optional(),
                                             })
                                         )
                                         .max(
@@ -411,31 +311,21 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                         ),
                                     zod.null(),
                                 ])
-                                .default(endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterOneBreakdownsDefault),
+                                .optional(),
                         }),
                         zod.null(),
                     ])
-                    .default(endpointsRunCreateBodyFiltersOverrideOneBreakdownFilterDefault),
-                date_from: zod
-                    .union([zod.string(), zod.null()])
-                    .default(endpointsRunCreateBodyFiltersOverrideOneDateFromDefault),
-                date_to: zod
-                    .union([zod.string(), zod.null()])
-                    .default(endpointsRunCreateBodyFiltersOverrideOneDateToDefault),
-                explicitDate: zod
-                    .union([zod.boolean(), zod.null()])
-                    .default(endpointsRunCreateBodyFiltersOverrideOneExplicitDateDefault),
+                    .optional(),
+                date_from: zod.union([zod.string(), zod.null()]).optional(),
+                date_to: zod.union([zod.string(), zod.null()]).optional(),
+                explicitDate: zod.union([zod.boolean(), zod.null()]).optional(),
                 properties: zod
                     .union([
                         zod.array(
                             zod.union([
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod
                                         .union([
                                             zod.enum([
@@ -493,17 +383,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwoLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -554,17 +438,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwoValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.enum(['tag_name', 'text', 'href', 'selector']),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemThreeLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -614,17 +492,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemThreeValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemFourLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -674,17 +546,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemFourValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemFiveLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -734,26 +600,16 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemFiveValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
-                                    cohort_name: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSixCohortNameDefault
-                                        ),
+                                    cohort_name: zod.union([zod.string(), zod.null()]).optional(),
                                     key: zod
                                         .literal('id')
                                         .default(
                                             endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSixKeyDefault
                                         ),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSixLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod
                                         .union([
                                             zod.enum([
@@ -809,11 +665,7 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                         zod.enum(['duration', 'active_seconds', 'inactive_seconds']),
                                         zod.string(),
                                     ]),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSevenLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -863,17 +715,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemSevenValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemEightLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -923,27 +769,15 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemEightValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     group_key_names: zod
                                         .union([zod.record(zod.string(), zod.string()), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemNineGroupKeyNamesDefault
-                                        ),
-                                    group_type_index: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemNineGroupTypeIndexDefault
-                                        ),
+                                        .optional(),
+                                    group_type_index: zod.union([zod.number(), zod.null()]).optional(),
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemNineLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -993,17 +827,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemNineValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnezeroLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -1054,17 +882,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnezeroValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string().describe('The key should be the flag ID'),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneoneLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod
                                         .literal('flag_evaluates_to')
                                         .default(
@@ -1083,11 +905,7 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnetwoLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     type: zod
                                         .literal('hogql')
                                         .default(
@@ -1101,9 +919,7 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnetwoValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     type: zod
@@ -1114,11 +930,7 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnefourLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -1168,17 +980,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnefourValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnefiveLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -1228,17 +1034,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnefiveValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnesixLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -1288,17 +1088,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnesixValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnesevenLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -1344,17 +1138,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnesevenValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneeightLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -1400,17 +1188,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOneeightValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnenineLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -1460,17 +1242,11 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemOnenineValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                                 zod.object({
                                     key: zod.string(),
-                                    label: zod
-                                        .union([zod.string(), zod.null()])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwozeroLabelDefault
-                                        ),
+                                    label: zod.union([zod.string(), zod.null()]).optional(),
                                     operator: zod.enum([
                                         'exact',
                                         'is_not',
@@ -1520,39 +1296,37 @@ export const EndpointsRunCreateBody = /* @__PURE__ */ zod.object({
                                             zod.boolean(),
                                             zod.null(),
                                         ])
-                                        .default(
-                                            endpointsRunCreateBodyFiltersOverrideOnePropertiesOneItemTwozeroValueDefault
-                                        ),
+                                        .optional(),
                                 }),
                             ])
                         ),
                         zod.null(),
                     ])
-                    .default(endpointsRunCreateBodyFiltersOverrideOnePropertiesDefault),
+                    .optional(),
             }),
             zod.null(),
         ])
-        .default(endpointsRunCreateBodyFiltersOverrideDefault),
+        .optional(),
     limit: zod
         .union([zod.number(), zod.null()])
-        .default(endpointsRunCreateBodyLimitDefault)
+        .optional()
         .describe('Maximum number of results to return. If not provided, returns all results.'),
     offset: zod
         .union([zod.number(), zod.null()])
-        .default(endpointsRunCreateBodyOffsetDefault)
+        .optional()
         .describe('Number of results to skip. Must be used together with limit. Only supported for HogQL endpoints.'),
     refresh: zod
         .union([zod.enum(['cache', 'force', 'direct']), zod.null()])
         .default(endpointsRunCreateBodyRefreshDefault),
     variables: zod
         .union([zod.record(zod.string(), zod.unknown()), zod.null()])
-        .default(endpointsRunCreateBodyVariablesDefault)
+        .optional()
         .describe(
             'Variables to parameterize the endpoint query. The key is the variable name and the value is the variable value.\n\nFor HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`\n\nFor non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`\n\nFor materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.\n\nUnknown variable names will return a 400 error.'
         ),
     version: zod
         .union([zod.number(), zod.null()])
-        .default(endpointsRunCreateBodyVersionDefault)
+        .optional()
         .describe('Specific endpoint version to execute. If not provided, the latest version is used.'),
 })
 

--- a/services/mcp/src/generated/error_tracking/api.ts
+++ b/services/mcp/src/generated/error_tracking/api.ts
@@ -29,67 +29,28 @@ export const ErrorTrackingAssignmentRulesCreateParams = /* @__PURE__ */ zod.obje
         ),
 })
 
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwoLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwoOperatorDefault = `exact`
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwoTypeDefault = `event`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwoValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemThreeLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemThreeTypeDefault = `person`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemThreeValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemFourLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemFourTypeDefault = `element`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemFourValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemFiveLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemFiveTypeDefault = `event_metadata`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemFiveValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSixLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSixTypeDefault = `session`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSixValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSevenCohortNameDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSevenKeyDefault = `id`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSevenLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSevenOperatorDefault = `in`
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSevenTypeDefault = `cohort`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemEightLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemEightTypeDefault = `recording`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemEightValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemNineLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemNineTypeDefault = `log_entry`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemNineValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnezeroLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnezeroTypeDefault = `group`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnezeroValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOneoneLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOneoneTypeDefault = `feature`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOneoneValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnetwoLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnetwoOperatorDefault = `flag_evaluates_to`
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnetwoTypeDefault = `flag`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnethreeLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnethreeTypeDefault = `hogql`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnethreeValueDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnefourTypeDefault = `empty`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnefiveLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnefiveTypeDefault = `data_warehouse`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnefiveValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnesixLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnesixTypeDefault = `data_warehouse_person_property`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnesixValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnesevenLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnesevenTypeDefault = `error_tracking_issue`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnesevenValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOneeightLabelDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOneeightValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnenineLabelDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnenineValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwozeroLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwozeroTypeDefault = `revenue_analytics`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwozeroValueDefault = null
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwooneLabelDefault = null
 export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwooneTypeDefault = `workflow_variable`
-export const errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwooneValueDefault = null
 
 export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object({
     filters: zod
@@ -100,9 +61,7 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                     zod.unknown(),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwoLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .union([
                                 zod.enum([
@@ -156,13 +115,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwoValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemThreeLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -211,13 +168,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemThreeValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.enum(['tag_name', 'text', 'href', 'selector']),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemFourLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -265,13 +220,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemFourValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemFiveLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -319,13 +272,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemFiveValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSixLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -373,18 +324,14 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSixValueDefault),
+                            .optional(),
                     }),
                     zod.object({
-                        cohort_name: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSevenCohortNameDefault),
+                        cohort_name: zod.union([zod.string(), zod.null()]).optional(),
                         key: zod
                             .literal('id')
                             .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSevenKeyDefault),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemSevenLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .union([
                                 zod.enum([
@@ -433,9 +380,7 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                     }),
                     zod.object({
                         key: zod.union([zod.enum(['duration', 'active_seconds', 'inactive_seconds']), zod.string()]),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemEightLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -483,13 +428,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemEightValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemNineLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -537,23 +480,13 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemNineValueDefault),
+                            .optional(),
                     }),
                     zod.object({
-                        group_key_names: zod
-                            .union([zod.record(zod.string(), zod.string()), zod.null()])
-                            .default(
-                                errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault
-                            ),
-                        group_type_index: zod
-                            .union([zod.number(), zod.null()])
-                            .default(
-                                errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault
-                            ),
+                        group_key_names: zod.union([zod.record(zod.string(), zod.string()), zod.null()]).optional(),
+                        group_type_index: zod.union([zod.number(), zod.null()]).optional(),
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnezeroLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -601,13 +534,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnezeroValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOneoneLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -656,13 +587,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOneoneValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string().describe('The key should be the flag ID'),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnetwoLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .literal('flag_evaluates_to')
                             .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnetwoOperatorDefault)
@@ -677,9 +606,7 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnethreeLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         type: zod
                             .literal('hogql')
                             .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnethreeTypeDefault),
@@ -691,7 +618,7 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnethreeValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         type: zod
@@ -700,9 +627,7 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnefiveLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -750,13 +675,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnefiveValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnesixLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -804,13 +727,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnesixValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnesevenLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -858,13 +779,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnesevenValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOneeightLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -910,13 +829,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOneeightValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnenineLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -962,13 +879,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemOnenineValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwozeroLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1016,13 +931,11 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwozeroValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwooneLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1070,7 +983,7 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingAssignmentRulesCreateBodyFiltersOneValuesItemTwooneValueDefault),
+                            .optional(),
                     }),
                 ])
             ),
@@ -1107,67 +1020,28 @@ export const ErrorTrackingGroupingRulesCreateParams = /* @__PURE__ */ zod.object
         ),
 })
 
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwoLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwoOperatorDefault = `exact`
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwoTypeDefault = `event`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwoValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemThreeLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemThreeTypeDefault = `person`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemThreeValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFourLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFourTypeDefault = `element`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFourValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFiveLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFiveTypeDefault = `event_metadata`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFiveValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSixLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSixTypeDefault = `session`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSixValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenCohortNameDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenKeyDefault = `id`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenOperatorDefault = `in`
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenTypeDefault = `cohort`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemEightLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemEightTypeDefault = `recording`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemEightValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemNineLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemNineTypeDefault = `log_entry`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemNineValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnezeroLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnezeroTypeDefault = `group`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnezeroValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOneoneLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOneoneTypeDefault = `feature`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOneoneValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnetwoLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnetwoOperatorDefault = `flag_evaluates_to`
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnetwoTypeDefault = `flag`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnethreeLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnethreeTypeDefault = `hogql`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnethreeValueDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnefourTypeDefault = `empty`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnefiveLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnefiveTypeDefault = `data_warehouse`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnefiveValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesixLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesixTypeDefault = `data_warehouse_person_property`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesixValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesevenLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesevenTypeDefault = `error_tracking_issue`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesevenValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOneeightLabelDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOneeightValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnenineLabelDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnenineValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwozeroLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwozeroTypeDefault = `revenue_analytics`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwozeroValueDefault = null
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwooneLabelDefault = null
 export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwooneTypeDefault = `workflow_variable`
-export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwooneValueDefault = null
 
 export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
     filters: zod
@@ -1178,9 +1052,7 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                     zod.unknown(),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwoLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .union([
                                 zod.enum([
@@ -1234,13 +1106,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwoValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemThreeLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1289,13 +1159,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemThreeValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.enum(['tag_name', 'text', 'href', 'selector']),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFourLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1343,13 +1211,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFourValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFiveLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1397,13 +1263,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFiveValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSixLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1451,18 +1315,14 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSixValueDefault),
+                            .optional(),
                     }),
                     zod.object({
-                        cohort_name: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenCohortNameDefault),
+                        cohort_name: zod.union([zod.string(), zod.null()]).optional(),
                         key: zod
                             .literal('id')
                             .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenKeyDefault),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .union([
                                 zod.enum([
@@ -1511,9 +1371,7 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                     }),
                     zod.object({
                         key: zod.union([zod.enum(['duration', 'active_seconds', 'inactive_seconds']), zod.string()]),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemEightLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1561,13 +1419,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemEightValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemNineLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1615,23 +1471,13 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemNineValueDefault),
+                            .optional(),
                     }),
                     zod.object({
-                        group_key_names: zod
-                            .union([zod.record(zod.string(), zod.string()), zod.null()])
-                            .default(
-                                errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault
-                            ),
-                        group_type_index: zod
-                            .union([zod.number(), zod.null()])
-                            .default(
-                                errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault
-                            ),
+                        group_key_names: zod.union([zod.record(zod.string(), zod.string()), zod.null()]).optional(),
+                        group_type_index: zod.union([zod.number(), zod.null()]).optional(),
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnezeroLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1679,13 +1525,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnezeroValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOneoneLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1734,13 +1578,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOneoneValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string().describe('The key should be the flag ID'),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnetwoLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .literal('flag_evaluates_to')
                             .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnetwoOperatorDefault)
@@ -1755,9 +1597,7 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnethreeLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         type: zod
                             .literal('hogql')
                             .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnethreeTypeDefault),
@@ -1769,7 +1609,7 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnethreeValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         type: zod
@@ -1778,9 +1618,7 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnefiveLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1828,13 +1666,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnefiveValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesixLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1882,13 +1718,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesixValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesevenLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1936,13 +1770,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesevenValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOneeightLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -1988,13 +1820,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOneeightValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnenineLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -2040,13 +1870,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnenineValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwozeroLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -2094,13 +1922,11 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwozeroValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwooneLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -2148,7 +1974,7 @@ export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwooneValueDefault),
+                            .optional(),
                     }),
                 ])
             ),
@@ -2186,67 +2012,28 @@ export const ErrorTrackingGroupingRulesUpdateParams = /* @__PURE__ */ zod.object
         ),
 })
 
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoOperatorDefault = `exact`
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoTypeDefault = `event`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemThreeLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemThreeTypeDefault = `person`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemThreeValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFourLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFourTypeDefault = `element`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFourValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFiveLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFiveTypeDefault = `event_metadata`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFiveValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSixLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSixTypeDefault = `session`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSixValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenCohortNameDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenKeyDefault = `id`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenOperatorDefault = `in`
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenTypeDefault = `cohort`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemEightLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemEightTypeDefault = `recording`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemEightValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemNineLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemNineTypeDefault = `log_entry`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemNineValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroTypeDefault = `group`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneoneLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneoneTypeDefault = `feature`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneoneValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnetwoLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnetwoOperatorDefault = `flag_evaluates_to`
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnetwoTypeDefault = `flag`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeTypeDefault = `hogql`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeValueDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefourTypeDefault = `empty`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefiveLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefiveTypeDefault = `data_warehouse`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefiveValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesixLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesixTypeDefault = `data_warehouse_person_property`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesixValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesevenLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesevenTypeDefault = `error_tracking_issue`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesevenValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneeightLabelDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneeightValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnenineLabelDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnenineValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroTypeDefault = `revenue_analytics`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroValueDefault = null
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwooneLabelDefault = null
 export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwooneTypeDefault = `workflow_variable`
-export const errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwooneValueDefault = null
 
 export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
     filters: zod
@@ -2258,9 +2045,7 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                         zod.unknown(),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod
                                 .union([
                                     zod.enum([
@@ -2314,13 +2099,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwoValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemThreeLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -2369,13 +2152,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemThreeValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.enum(['tag_name', 'text', 'href', 'selector']),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFourLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -2423,13 +2204,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFourValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFiveLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -2477,13 +2256,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemFiveValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSixLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -2531,20 +2308,14 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSixValueDefault),
+                                .optional(),
                         }),
                         zod.object({
-                            cohort_name: zod
-                                .union([zod.string(), zod.null()])
-                                .default(
-                                    errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenCohortNameDefault
-                                ),
+                            cohort_name: zod.union([zod.string(), zod.null()]).optional(),
                             key: zod
                                 .literal('id')
                                 .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenKeyDefault),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemSevenLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod
                                 .union([
                                     zod.enum([
@@ -2596,9 +2367,7 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                 zod.enum(['duration', 'active_seconds', 'inactive_seconds']),
                                 zod.string(),
                             ]),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemEightLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -2646,13 +2415,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemEightValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemNineLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -2700,23 +2467,13 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemNineValueDefault),
+                                .optional(),
                         }),
                         zod.object({
-                            group_key_names: zod
-                                .union([zod.record(zod.string(), zod.string()), zod.null()])
-                                .default(
-                                    errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault
-                                ),
-                            group_type_index: zod
-                                .union([zod.number(), zod.null()])
-                                .default(
-                                    errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault
-                                ),
+                            group_key_names: zod.union([zod.record(zod.string(), zod.string()), zod.null()]).optional(),
+                            group_type_index: zod.union([zod.number(), zod.null()]).optional(),
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -2764,13 +2521,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnezeroValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneoneLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -2819,13 +2574,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneoneValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string().describe('The key should be the flag ID'),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnetwoLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod
                                 .literal('flag_evaluates_to')
                                 .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnetwoOperatorDefault)
@@ -2840,9 +2593,7 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             type: zod
                                 .literal('hogql')
                                 .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeTypeDefault),
@@ -2854,7 +2605,7 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnethreeValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             type: zod
@@ -2863,9 +2614,7 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefiveLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -2913,13 +2662,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnefiveValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesixLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -2967,13 +2714,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesixValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesevenLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -3021,13 +2766,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnesevenValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneeightLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -3073,13 +2816,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOneeightValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnenineLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -3125,13 +2866,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemOnenineValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -3179,13 +2918,11 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwozeroValueDefault),
+                                .optional(),
                         }),
                         zod.object({
                             key: zod.string(),
-                            label: zod
-                                .union([zod.string(), zod.null()])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwooneLabelDefault),
+                            label: zod.union([zod.string(), zod.null()]).optional(),
                             operator: zod.enum([
                                 'exact',
                                 'is_not',
@@ -3233,7 +2970,7 @@ export const ErrorTrackingGroupingRulesUpdateBody = /* @__PURE__ */ zod.object({
                                     zod.boolean(),
                                     zod.null(),
                                 ])
-                                .default(errorTrackingGroupingRulesUpdateBodyFiltersOneValuesItemTwooneValueDefault),
+                                .optional(),
                         }),
                     ])
                 ),
@@ -3804,67 +3541,28 @@ export const ErrorTrackingSuppressionRulesCreateParams = /* @__PURE__ */ zod.obj
         ),
 })
 
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwoLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwoOperatorDefault = `exact`
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwoTypeDefault = `event`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwoValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemThreeLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemThreeTypeDefault = `person`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemThreeValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemFourLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemFourTypeDefault = `element`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemFourValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemFiveLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemFiveTypeDefault = `event_metadata`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemFiveValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSixLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSixTypeDefault = `session`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSixValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSevenCohortNameDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSevenKeyDefault = `id`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSevenLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSevenOperatorDefault = `in`
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSevenTypeDefault = `cohort`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemEightLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemEightTypeDefault = `recording`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemEightValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemNineLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemNineTypeDefault = `log_entry`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemNineValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnezeroLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnezeroTypeDefault = `group`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnezeroValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOneoneLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOneoneTypeDefault = `feature`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOneoneValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnetwoLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnetwoOperatorDefault = `flag_evaluates_to`
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnetwoTypeDefault = `flag`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnethreeLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnethreeTypeDefault = `hogql`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnethreeValueDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnefourTypeDefault = `empty`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnefiveLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnefiveTypeDefault = `data_warehouse`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnefiveValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnesixLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnesixTypeDefault = `data_warehouse_person_property`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnesixValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnesevenLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnesevenTypeDefault = `error_tracking_issue`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnesevenValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOneeightLabelDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOneeightValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnenineLabelDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnenineValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwozeroLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwozeroTypeDefault = `revenue_analytics`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwozeroValueDefault = null
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwooneLabelDefault = null
 export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwooneTypeDefault = `workflow_variable`
-export const errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwooneValueDefault = null
 export const errorTrackingSuppressionRulesCreateBodySamplingRateDefault = 1
 export const errorTrackingSuppressionRulesCreateBodySamplingRateMin = 0
 export const errorTrackingSuppressionRulesCreateBodySamplingRateMax = 1
@@ -3878,9 +3576,7 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                     zod.unknown(),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwoLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .union([
                                 zod.enum([
@@ -3934,13 +3630,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwoValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemThreeLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -3989,13 +3683,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemThreeValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.enum(['tag_name', 'text', 'href', 'selector']),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemFourLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4043,13 +3735,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemFourValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemFiveLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4097,13 +3787,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemFiveValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSixLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4151,18 +3839,14 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSixValueDefault),
+                            .optional(),
                     }),
                     zod.object({
-                        cohort_name: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSevenCohortNameDefault),
+                        cohort_name: zod.union([zod.string(), zod.null()]).optional(),
                         key: zod
                             .literal('id')
                             .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSevenKeyDefault),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemSevenLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .union([
                                 zod.enum([
@@ -4211,9 +3895,7 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                     }),
                     zod.object({
                         key: zod.union([zod.enum(['duration', 'active_seconds', 'inactive_seconds']), zod.string()]),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemEightLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4261,13 +3943,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemEightValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemNineLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4315,23 +3995,13 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemNineValueDefault),
+                            .optional(),
                     }),
                     zod.object({
-                        group_key_names: zod
-                            .union([zod.record(zod.string(), zod.string()), zod.null()])
-                            .default(
-                                errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault
-                            ),
-                        group_type_index: zod
-                            .union([zod.number(), zod.null()])
-                            .default(
-                                errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault
-                            ),
+                        group_key_names: zod.union([zod.record(zod.string(), zod.string()), zod.null()]).optional(),
+                        group_type_index: zod.union([zod.number(), zod.null()]).optional(),
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnezeroLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4379,13 +4049,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnezeroValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOneoneLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4434,13 +4102,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOneoneValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string().describe('The key should be the flag ID'),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnetwoLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .literal('flag_evaluates_to')
                             .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnetwoOperatorDefault)
@@ -4455,9 +4121,7 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnethreeLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         type: zod
                             .literal('hogql')
                             .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnethreeTypeDefault),
@@ -4469,7 +4133,7 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnethreeValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         type: zod
@@ -4478,9 +4142,7 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnefiveLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4528,13 +4190,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnefiveValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnesixLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4582,13 +4242,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnesixValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnesevenLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4636,13 +4294,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnesevenValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOneeightLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4688,13 +4344,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOneeightValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnenineLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4740,13 +4394,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemOnenineValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwozeroLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4794,13 +4446,11 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwozeroValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwooneLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -4848,7 +4498,7 @@ export const ErrorTrackingSuppressionRulesCreateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesCreateBodyFiltersOneValuesItemTwooneValueDefault),
+                            .optional(),
                     }),
                 ])
             ),
@@ -4876,67 +4526,28 @@ export const ErrorTrackingSuppressionRulesUpdateParams = /* @__PURE__ */ zod.obj
         ),
 })
 
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwoLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwoOperatorDefault = `exact`
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwoTypeDefault = `event`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwoValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemThreeLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemThreeTypeDefault = `person`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemThreeValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemFourLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemFourTypeDefault = `element`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemFourValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemFiveLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemFiveTypeDefault = `event_metadata`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemFiveValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSixLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSixTypeDefault = `session`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSixValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSevenCohortNameDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSevenKeyDefault = `id`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSevenLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSevenOperatorDefault = `in`
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSevenTypeDefault = `cohort`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemEightLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemEightTypeDefault = `recording`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemEightValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemNineLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemNineTypeDefault = `log_entry`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemNineValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnezeroLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnezeroTypeDefault = `group`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnezeroValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOneoneLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOneoneTypeDefault = `feature`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOneoneValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnetwoLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnetwoOperatorDefault = `flag_evaluates_to`
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnetwoTypeDefault = `flag`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnethreeLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnethreeTypeDefault = `hogql`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnethreeValueDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnefourTypeDefault = `empty`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnefiveLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnefiveTypeDefault = `data_warehouse`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnefiveValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnesixLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnesixTypeDefault = `data_warehouse_person_property`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnesixValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnesevenLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnesevenTypeDefault = `error_tracking_issue`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnesevenValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOneeightLabelDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOneeightValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnenineLabelDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnenineValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwozeroLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwozeroTypeDefault = `revenue_analytics`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwozeroValueDefault = null
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwooneLabelDefault = null
 export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwooneTypeDefault = `workflow_variable`
-export const errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwooneValueDefault = null
 export const errorTrackingSuppressionRulesUpdateBodySamplingRateMin = 0
 export const errorTrackingSuppressionRulesUpdateBodySamplingRateMax = 1
 
@@ -4949,9 +4560,7 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                     zod.unknown(),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwoLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .union([
                                 zod.enum([
@@ -5005,13 +4614,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwoValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemThreeLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5060,13 +4667,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemThreeValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.enum(['tag_name', 'text', 'href', 'selector']),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemFourLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5114,13 +4719,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemFourValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemFiveLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5168,13 +4771,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemFiveValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSixLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5222,18 +4823,14 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSixValueDefault),
+                            .optional(),
                     }),
                     zod.object({
-                        cohort_name: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSevenCohortNameDefault),
+                        cohort_name: zod.union([zod.string(), zod.null()]).optional(),
                         key: zod
                             .literal('id')
                             .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSevenKeyDefault),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemSevenLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .union([
                                 zod.enum([
@@ -5282,9 +4879,7 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                     }),
                     zod.object({
                         key: zod.union([zod.enum(['duration', 'active_seconds', 'inactive_seconds']), zod.string()]),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemEightLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5332,13 +4927,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemEightValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemNineLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5386,23 +4979,13 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemNineValueDefault),
+                            .optional(),
                     }),
                     zod.object({
-                        group_key_names: zod
-                            .union([zod.record(zod.string(), zod.string()), zod.null()])
-                            .default(
-                                errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnezeroGroupKeyNamesDefault
-                            ),
-                        group_type_index: zod
-                            .union([zod.number(), zod.null()])
-                            .default(
-                                errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnezeroGroupTypeIndexDefault
-                            ),
+                        group_key_names: zod.union([zod.record(zod.string(), zod.string()), zod.null()]).optional(),
+                        group_type_index: zod.union([zod.number(), zod.null()]).optional(),
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnezeroLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5450,13 +5033,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnezeroValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOneoneLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5505,13 +5086,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOneoneValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string().describe('The key should be the flag ID'),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnetwoLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod
                             .literal('flag_evaluates_to')
                             .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnetwoOperatorDefault)
@@ -5526,9 +5105,7 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnethreeLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         type: zod
                             .literal('hogql')
                             .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnethreeTypeDefault),
@@ -5540,7 +5117,7 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnethreeValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         type: zod
@@ -5549,9 +5126,7 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnefiveLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5599,13 +5174,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnefiveValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnesixLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5653,13 +5226,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnesixValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnesevenLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5707,13 +5278,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnesevenValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOneeightLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5759,13 +5328,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOneeightValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnenineLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5811,13 +5378,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemOnenineValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwozeroLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5865,13 +5430,11 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwozeroValueDefault),
+                            .optional(),
                     }),
                     zod.object({
                         key: zod.string(),
-                        label: zod
-                            .union([zod.string(), zod.null()])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwooneLabelDefault),
+                        label: zod.union([zod.string(), zod.null()]).optional(),
                         operator: zod.enum([
                             'exact',
                             'is_not',
@@ -5919,7 +5482,7 @@ export const ErrorTrackingSuppressionRulesUpdateBody = /* @__PURE__ */ zod.objec
                                 zod.boolean(),
                                 zod.null(),
                             ])
-                            .default(errorTrackingSuppressionRulesUpdateBodyFiltersOneValuesItemTwooneValueDefault),
+                            .optional(),
                     }),
                 ])
             ),

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -160,241 +160,72 @@ export const experimentsCreateBodyNameMax = 400
 
 export const experimentsCreateBodyDescriptionMax = 3000
 
-export const experimentsCreateBodyParametersOneExcludedVariantsDefault = null
-export const experimentsCreateBodyParametersOneFeatureFlagVariantsOneItemNameDefault = null
-export const experimentsCreateBodyParametersOneFeatureFlagVariantsOneItemRolloutPercentageDefault = null
-export const experimentsCreateBodyParametersOneFeatureFlagVariantsOneItemSplitPercentDefault = null
-export const experimentsCreateBodyParametersOneFeatureFlagVariantsDefault = null
-export const experimentsCreateBodyParametersOneMinimumDetectableEffectDefault = null
-export const experimentsCreateBodyParametersOneRolloutPercentageDefault = null
 export const experimentsCreateBodyArchivedDefault = false
 export const experimentsCreateBodyExposureCriteriaOneExposureConfigOneKindDefault = `ExperimentEventExposureConfig`
-export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemLabelDefault = null
 export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOperatorDefault = `exact`
 export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTypeDefault = `event`
-export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemValueDefault = null
-export const experimentsCreateBodyExposureCriteriaOneExposureConfigDefault = null
-export const experimentsCreateBodyExposureCriteriaOneFilterTestAccountsDefault = null
-export const experimentsCreateBodyMetricsOneItemCompletionEventOneEventDefault = null
-export const experimentsCreateBodyMetricsOneItemCompletionEventOneIdDefault = null
-export const experimentsCreateBodyMetricsOneItemCompletionEventOneMathDefault = null
-export const experimentsCreateBodyMetricsOneItemCompletionEventOneMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsOneItemCompletionEventOneMathHogqlDefault = null
-export const experimentsCreateBodyMetricsOneItemCompletionEventOneMathPropertyDefault = null
-export const experimentsCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsOneItemCompletionEventOnePropertiesDefault = null
-export const experimentsCreateBodyMetricsOneItemCompletionEventDefault = null
-export const experimentsCreateBodyMetricsOneItemConversionWindowDefault = null
-export const experimentsCreateBodyMetricsOneItemDenominatorOneEventDefault = null
-export const experimentsCreateBodyMetricsOneItemDenominatorOneIdDefault = null
-export const experimentsCreateBodyMetricsOneItemDenominatorOneMathDefault = null
-export const experimentsCreateBodyMetricsOneItemDenominatorOneMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsOneItemDenominatorOneMathHogqlDefault = null
-export const experimentsCreateBodyMetricsOneItemDenominatorOneMathPropertyDefault = null
-export const experimentsCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsOneItemDenominatorOnePropertiesDefault = null
-export const experimentsCreateBodyMetricsOneItemDenominatorDefault = null
-export const experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault = null
 export const experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault = null
-export const experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingDefault = null
-export const experimentsCreateBodyMetricsOneItemGoalDefault = null
-export const experimentsCreateBodyMetricsOneItemIgnoreZerosDefault = null
 export const experimentsCreateBodyMetricsOneItemKindDefault = `ExperimentMetric`
 export const experimentsCreateBodyMetricsOneItemLowerBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsOneItemLowerBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsOneItemLowerBoundPercentileDefault = null
-export const experimentsCreateBodyMetricsOneItemNameDefault = null
-export const experimentsCreateBodyMetricsOneItemNumeratorOneEventDefault = null
-export const experimentsCreateBodyMetricsOneItemNumeratorOneIdDefault = null
-export const experimentsCreateBodyMetricsOneItemNumeratorOneMathDefault = null
-export const experimentsCreateBodyMetricsOneItemNumeratorOneMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsOneItemNumeratorOneMathHogqlDefault = null
-export const experimentsCreateBodyMetricsOneItemNumeratorOneMathPropertyDefault = null
-export const experimentsCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsOneItemNumeratorOnePropertiesDefault = null
-export const experimentsCreateBodyMetricsOneItemNumeratorDefault = null
-export const experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault = null
 export const experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault = null
-export const experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingDefault = null
-export const experimentsCreateBodyMetricsOneItemRetentionWindowEndDefault = null
-export const experimentsCreateBodyMetricsOneItemRetentionWindowStartDefault = null
-export const experimentsCreateBodyMetricsOneItemRetentionWindowUnitDefault = null
-export const experimentsCreateBodyMetricsOneItemSeriesOneItemEventDefault = null
-export const experimentsCreateBodyMetricsOneItemSeriesOneItemIdDefault = null
-export const experimentsCreateBodyMetricsOneItemSeriesOneItemMathDefault = null
-export const experimentsCreateBodyMetricsOneItemSeriesOneItemMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsOneItemSeriesOneItemMathHogqlDefault = null
-export const experimentsCreateBodyMetricsOneItemSeriesOneItemMathPropertyDefault = null
-export const experimentsCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsOneItemSeriesOneItemPropertiesDefault = null
-export const experimentsCreateBodyMetricsOneItemSeriesDefault = null
-export const experimentsCreateBodyMetricsOneItemSourceOneEventDefault = null
-export const experimentsCreateBodyMetricsOneItemSourceOneIdDefault = null
-export const experimentsCreateBodyMetricsOneItemSourceOneMathDefault = null
-export const experimentsCreateBodyMetricsOneItemSourceOneMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsOneItemSourceOneMathHogqlDefault = null
-export const experimentsCreateBodyMetricsOneItemSourceOneMathPropertyDefault = null
-export const experimentsCreateBodyMetricsOneItemSourceOnePropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsOneItemSourceOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsOneItemSourceOnePropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsOneItemSourceOnePropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsOneItemSourceOnePropertiesDefault = null
-export const experimentsCreateBodyMetricsOneItemSourceDefault = null
-export const experimentsCreateBodyMetricsOneItemStartEventOneEventDefault = null
-export const experimentsCreateBodyMetricsOneItemStartEventOneIdDefault = null
-export const experimentsCreateBodyMetricsOneItemStartEventOneMathDefault = null
-export const experimentsCreateBodyMetricsOneItemStartEventOneMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsOneItemStartEventOneMathHogqlDefault = null
-export const experimentsCreateBodyMetricsOneItemStartEventOneMathPropertyDefault = null
-export const experimentsCreateBodyMetricsOneItemStartEventOnePropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsOneItemStartEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsOneItemStartEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsOneItemStartEventOnePropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsOneItemStartEventOnePropertiesDefault = null
-export const experimentsCreateBodyMetricsOneItemStartEventDefault = null
-export const experimentsCreateBodyMetricsOneItemStartHandlingDefault = null
 export const experimentsCreateBodyMetricsOneItemUpperBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsOneItemUpperBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsOneItemUpperBoundPercentileDefault = null
-export const experimentsCreateBodyMetricsOneItemUuidDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneEventDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneIdDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneMathDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneMathHogqlDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneMathPropertyDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemCompletionEventDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemConversionWindowDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneEventDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneIdDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneMathDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneMathHogqlDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneMathPropertyDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemGoalDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemIgnoreZerosDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemKindDefault = `ExperimentMetric`
 export const experimentsCreateBodyMetricsSecondaryOneItemLowerBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsSecondaryOneItemLowerBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsSecondaryOneItemLowerBoundPercentileDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNameDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneEventDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneIdDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneMathDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneMathHogqlDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneMathPropertyDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemRetentionWindowEndDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemRetentionWindowStartDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemRetentionWindowUnitDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemEventDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemIdDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemMathDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemMathHogqlDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemMathPropertyDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSeriesDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSourceOneEventDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSourceOneIdDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSourceOneMathDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSourceOneMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSourceOneMathHogqlDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSourceOneMathPropertyDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSourceOnePropertiesDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemSourceDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemStartEventOneEventDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemStartEventOneIdDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemStartEventOneMathDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemStartEventOneMathGroupTypeIndexDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemStartEventOneMathHogqlDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemStartEventOneMathPropertyDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemLabelDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemValueDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemStartEventDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemStartHandlingDefault = null
 export const experimentsCreateBodyMetricsSecondaryOneItemUpperBoundPercentileOneMin = 0
 export const experimentsCreateBodyMetricsSecondaryOneItemUpperBoundPercentileOneMax = 1
 
-export const experimentsCreateBodyMetricsSecondaryOneItemUpperBoundPercentileDefault = null
-export const experimentsCreateBodyMetricsSecondaryOneItemUuidDefault = null
 export const experimentsCreateBodyAllowUnknownEventsDefault = false
 export const experimentsCreateBodyUpdateFeatureFlagParamsDefault = false
 
@@ -419,7 +250,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                 zod.object({
                     excluded_variants: zod
                         .union([zod.array(zod.string()), zod.null()])
-                        .default(experimentsCreateBodyParametersOneExcludedVariantsDefault)
+                        .optional()
                         .describe(
                             'Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis.'
                         ),
@@ -434,20 +265,12 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                         ),
                                     name: zod
                                         .union([zod.string(), zod.null()])
-                                        .default(
-                                            experimentsCreateBodyParametersOneFeatureFlagVariantsOneItemNameDefault
-                                        )
+                                        .optional()
                                         .describe('Human-readable variant name.'),
-                                    rollout_percentage: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(
-                                            experimentsCreateBodyParametersOneFeatureFlagVariantsOneItemRolloutPercentageDefault
-                                        ),
+                                    rollout_percentage: zod.union([zod.number(), zod.null()]).optional(),
                                     split_percent: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            experimentsCreateBodyParametersOneFeatureFlagVariantsOneItemSplitPercentDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Percentage of users assigned to this variant (0–100). All variants must sum to 100. One of split_percent (recommended) or rollout_percentage must be provided.'
                                         ),
@@ -455,19 +278,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                             ),
                             zod.null(),
                         ])
-                        .default(experimentsCreateBodyParametersOneFeatureFlagVariantsDefault)
+                        .optional()
                         .describe(
                             "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
                         ),
                     minimum_detectable_effect: zod
                         .union([zod.number(), zod.null()])
-                        .default(experimentsCreateBodyParametersOneMinimumDetectableEffectDefault)
+                        .optional()
                         .describe(
                             'Minimum detectable effect as a percentage. Lower values need more users but catch smaller changes. Suggest 20–30% for most experiments.'
                         ),
                     rollout_percentage: zod
                         .union([zod.number(), zod.null()])
-                        .default(experimentsCreateBodyParametersOneRolloutPercentageDefault)
+                        .optional()
                         .describe(
                             'Overall rollout percentage (0-100). Controls what fraction of all users enter the experiment. Users outside the rollout never see any variant and are excluded from analysis. Default: 100.'
                         ),
@@ -511,11 +334,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                     .array(
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .union([
                                                     zod.enum([
@@ -573,19 +392,15 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemValueDefault
-                                                ),
+                                                .optional(),
                                         })
                                     )
                                     .describe('Event property filters. Pass an empty array if no filters needed.'),
                             }),
                             zod.null(),
                         ])
-                        .default(experimentsCreateBodyExposureCriteriaOneExposureConfigDefault),
-                    filterTestAccounts: zod
-                        .union([zod.boolean(), zod.null()])
-                        .default(experimentsCreateBodyExposureCriteriaOneFilterTestAccountsDefault),
+                        .optional(),
+                    filterTestAccounts: zod.union([zod.boolean(), zod.null()]).optional(),
                 }),
                 zod.null(),
             ])
@@ -601,11 +416,11 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemCompletionEventOneEventDefault)
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemCompletionEventOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -623,7 +438,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsCreateBodyMetricsOneItemCompletionEventOneMathDefault)
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -638,25 +453,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemCompletionEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemCompletionEventOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemCompletionEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -665,11 +474,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -733,36 +538,32 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemCompletionEventOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsOneItemCompletionEventDefault)
+                                .optional()
                                 .describe('For retention metrics: completion event.'),
                             conversion_window: zod
                                 .union([zod.number(), zod.null()])
-                                .default(experimentsCreateBodyMetricsOneItemConversionWindowDefault)
+                                .optional()
                                 .describe('Conversion window duration.'),
                             denominator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemDenominatorOneEventDefault)
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemDenominatorOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -780,7 +581,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsCreateBodyMetricsOneItemDenominatorOneMathDefault)
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -795,23 +596,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemDenominatorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemDenominatorOneMathHogqlDefault)
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemDenominatorOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -820,11 +617,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -888,28 +681,22 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsCreateBodyMetricsOneItemDenominatorOnePropertiesDefault)
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsOneItemDenominatorDefault)
+                                .optional()
                                 .describe('For ratio metrics: denominator source.'),
                             denominator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -922,9 +709,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -940,26 +725,24 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsOneItemDenominatorOutlierHandlingDefault)
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the denominator aggregate. Leave unset for a binomial-style denominator, which is never clamped.'
                                 ),
                             goal: zod
                                 .union([zod.enum(['increase', 'decrease']), zod.null()])
-                                .default(experimentsCreateBodyMetricsOneItemGoalDefault)
+                                .optional()
                                 .describe('Whether higher or lower values indicate success.'),
                             ignore_zeros: zod
                                 .union([zod.boolean(), zod.null()])
-                                .default(experimentsCreateBodyMetricsOneItemIgnoreZerosDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: exclude zero values when computing the winsorization percentile thresholds.'
                                 ),
@@ -974,25 +757,25 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                         .max(experimentsCreateBodyMetricsOneItemLowerBoundPercentileOneMax),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsOneItemLowerBoundPercentileDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). Per-user values below this percentile are clamped to it before aggregation.'
                                 ),
                             metric_type: zod.enum(['funnel', 'mean', 'ratio', 'retention']),
                             name: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsCreateBodyMetricsOneItemNameDefault)
+                                .optional()
                                 .describe('Human-readable metric name.'),
                             numerator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemNumeratorOneEventDefault)
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemNumeratorOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -1010,7 +793,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsCreateBodyMetricsOneItemNumeratorOneMathDefault)
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -1025,21 +808,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemNumeratorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemNumeratorOneMathHogqlDefault)
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemNumeratorOneMathPropertyDefault)
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -1048,11 +829,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -1116,28 +893,22 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsCreateBodyMetricsOneItemNumeratorOnePropertiesDefault)
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsOneItemNumeratorDefault)
+                                .optional()
                                 .describe('For ratio metrics: numerator source.'),
                             numerator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -1150,9 +921,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -1168,39 +937,33 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsOneItemNumeratorOutlierHandlingDefault)
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the numerator aggregate, independently of the denominator and each with its own percentile thresholds.'
                                 ),
-                            retention_window_end: zod
-                                .union([zod.number(), zod.null()])
-                                .default(experimentsCreateBodyMetricsOneItemRetentionWindowEndDefault),
-                            retention_window_start: zod
-                                .union([zod.number(), zod.null()])
-                                .default(experimentsCreateBodyMetricsOneItemRetentionWindowStartDefault),
+                            retention_window_end: zod.union([zod.number(), zod.null()]).optional(),
+                            retention_window_start: zod.union([zod.number(), zod.null()]).optional(),
                             retention_window_unit: zod
                                 .union([zod.enum(['second', 'minute', 'hour', 'day', 'week', 'month']), zod.null()])
-                                .default(experimentsCreateBodyMetricsOneItemRetentionWindowUnitDefault),
+                                .optional(),
                             series: zod
                                 .union([
                                     zod.array(
                                         zod.object({
                                             event: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(experimentsCreateBodyMetricsOneItemSeriesOneItemEventDefault)
+                                                .optional()
                                                 .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                             id: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(experimentsCreateBodyMetricsOneItemSeriesOneItemIdDefault)
+                                                .optional()
                                                 .describe('Action ID. Required for ActionsNode.'),
                                             kind: zod.enum(['EventsNode', 'ActionsNode']),
                                             math: zod
@@ -1218,7 +981,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(experimentsCreateBodyMetricsOneItemSeriesOneItemMathDefault)
+                                                .optional()
                                                 .describe(
                                                     "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                                 ),
@@ -1233,25 +996,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsCreateBodyMetricsOneItemSeriesOneItemMathGroupTypeIndexDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Group type index to aggregate over. Required when math is 'unique_group'."
                                                 ),
                                             math_hogql: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsCreateBodyMetricsOneItemSeriesOneItemMathHogqlDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                                 ),
                                             math_property: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsCreateBodyMetricsOneItemSeriesOneItemMathPropertyDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                                 ),
@@ -1260,11 +1017,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     zod.array(
                                                         zod.object({
                                                             key: zod.string(),
-                                                            label: zod
-                                                                .union([zod.string(), zod.null()])
-                                                                .default(
-                                                                    experimentsCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemLabelDefault
-                                                                ),
+                                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                                             operator: zod
                                                                 .union([
                                                                     zod.enum([
@@ -1328,33 +1081,29 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                     zod.boolean(),
                                                                     zod.null(),
                                                                 ])
-                                                                .default(
-                                                                    experimentsCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemValueDefault
-                                                                ),
+                                                                .optional(),
                                                         })
                                                     ),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsCreateBodyMetricsOneItemSeriesOneItemPropertiesDefault
-                                                )
+                                                .optional()
                                                 .describe('Event property filters to narrow which events are counted.'),
                                         })
                                     ),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsOneItemSeriesDefault)
+                                .optional()
                                 .describe('For funnel metrics: array of EventsNode/ActionsNode steps.'),
                             source: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemSourceOneEventDefault)
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemSourceOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -1372,7 +1121,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsCreateBodyMetricsOneItemSourceOneMathDefault)
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -1387,21 +1136,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemSourceOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemSourceOneMathHogqlDefault)
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemSourceOneMathPropertyDefault)
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -1410,11 +1157,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsOneItemSourceOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -1478,30 +1221,28 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsOneItemSourceOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsCreateBodyMetricsOneItemSourceOnePropertiesDefault)
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsOneItemSourceDefault)
+                                .optional()
                                 .describe('For mean metrics: event source.'),
                             start_event: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemStartEventOneEventDefault)
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemStartEventOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -1519,7 +1260,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsCreateBodyMetricsOneItemStartEventOneMathDefault)
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -1534,23 +1275,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemStartEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsOneItemStartEventOneMathHogqlDefault)
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsOneItemStartEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -1559,11 +1296,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsOneItemStartEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -1627,23 +1360,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsOneItemStartEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsCreateBodyMetricsOneItemStartEventOnePropertiesDefault)
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsOneItemStartEventDefault)
+                                .optional()
                                 .describe('For retention metrics: start event.'),
-                            start_handling: zod
-                                .union([zod.enum(['first_seen', 'last_seen']), zod.null()])
-                                .default(experimentsCreateBodyMetricsOneItemStartHandlingDefault),
+                            start_handling: zod.union([zod.enum(['first_seen', 'last_seen']), zod.null()]).optional(),
                             upper_bound_percentile: zod
                                 .union([
                                     zod
@@ -1652,13 +1381,13 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                         .max(experimentsCreateBodyMetricsOneItemUpperBoundPercentileOneMax),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsOneItemUpperBoundPercentileDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). Per-user values above this percentile are clamped to it before aggregation.'
                                 ),
                             uuid: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsCreateBodyMetricsOneItemUuidDefault)
+                                .optional()
                                 .describe('Unique identifier. Auto-generated if omitted.'),
                         })
                     )
@@ -1679,15 +1408,11 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -1705,9 +1430,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -1722,25 +1445,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -1749,11 +1466,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -1817,40 +1530,32 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemCompletionEventDefault)
+                                .optional()
                                 .describe('For retention metrics: completion event.'),
                             conversion_window: zod
                                 .union([zod.number(), zod.null()])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemConversionWindowDefault)
+                                .optional()
                                 .describe('Conversion window duration.'),
                             denominator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -1868,9 +1573,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -1885,25 +1588,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -1912,11 +1609,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -1980,30 +1673,22 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemDenominatorDefault)
+                                .optional()
                                 .describe('For ratio metrics: denominator source.'),
                             denominator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -2016,9 +1701,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -2034,26 +1717,24 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingDefault)
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the denominator aggregate. Leave unset for a binomial-style denominator, which is never clamped.'
                                 ),
                             goal: zod
                                 .union([zod.enum(['increase', 'decrease']), zod.null()])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemGoalDefault)
+                                .optional()
                                 .describe('Whether higher or lower values indicate success.'),
                             ignore_zeros: zod
                                 .union([zod.boolean(), zod.null()])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemIgnoreZerosDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: exclude zero values when computing the winsorization percentile thresholds.'
                                 ),
@@ -2068,27 +1749,25 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                         .max(experimentsCreateBodyMetricsSecondaryOneItemLowerBoundPercentileOneMax),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemLowerBoundPercentileDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). Per-user values below this percentile are clamped to it before aggregation.'
                                 ),
                             metric_type: zod.enum(['funnel', 'mean', 'ratio', 'retention']),
                             name: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemNameDefault)
+                                .optional()
                                 .describe('Human-readable metric name.'),
                             numerator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -2106,9 +1785,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -2123,25 +1800,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemNumeratorOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -2150,11 +1821,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -2218,30 +1885,22 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemNumeratorDefault)
+                                .optional()
                                 .describe('For ratio metrics: numerator source.'),
                             numerator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -2254,9 +1913,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -2272,43 +1929,33 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingDefault)
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the numerator aggregate, independently of the denominator and each with its own percentile thresholds.'
                                 ),
-                            retention_window_end: zod
-                                .union([zod.number(), zod.null()])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemRetentionWindowEndDefault),
-                            retention_window_start: zod
-                                .union([zod.number(), zod.null()])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemRetentionWindowStartDefault),
+                            retention_window_end: zod.union([zod.number(), zod.null()]).optional(),
+                            retention_window_start: zod.union([zod.number(), zod.null()]).optional(),
                             retention_window_unit: zod
                                 .union([zod.enum(['second', 'minute', 'hour', 'day', 'week', 'month']), zod.null()])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemRetentionWindowUnitDefault),
+                                .optional(),
                             series: zod
                                 .union([
                                     zod.array(
                                         zod.object({
                                             event: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemEventDefault
-                                                )
+                                                .optional()
                                                 .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                             id: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemIdDefault
-                                                )
+                                                .optional()
                                                 .describe('Action ID. Required for ActionsNode.'),
                                             kind: zod.enum(['EventsNode', 'ActionsNode']),
                                             math: zod
@@ -2326,9 +1973,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemMathDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                                 ),
@@ -2343,25 +1988,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemMathGroupTypeIndexDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Group type index to aggregate over. Required when math is 'unique_group'."
                                                 ),
                                             math_hogql: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemMathHogqlDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                                 ),
                                             math_property: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemMathPropertyDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                                 ),
@@ -2370,11 +2009,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                     zod.array(
                                                         zod.object({
                                                             key: zod.string(),
-                                                            label: zod
-                                                                .union([zod.string(), zod.null()])
-                                                                .default(
-                                                                    experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemLabelDefault
-                                                                ),
+                                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                                             operator: zod
                                                                 .union([
                                                                     zod.enum([
@@ -2438,33 +2073,29 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                     zod.boolean(),
                                                                     zod.null(),
                                                                 ])
-                                                                .default(
-                                                                    experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemValueDefault
-                                                                ),
+                                                                .optional(),
                                                         })
                                                     ),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesDefault
-                                                )
+                                                .optional()
                                                 .describe('Event property filters to narrow which events are counted.'),
                                         })
                                     ),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemSeriesDefault)
+                                .optional()
                                 .describe('For funnel metrics: array of EventsNode/ActionsNode steps.'),
                             source: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsSecondaryOneItemSourceOneEventDefault)
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsSecondaryOneItemSourceOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -2482,7 +2113,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsCreateBodyMetricsSecondaryOneItemSourceOneMathDefault)
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -2497,25 +2128,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemSourceOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemSourceOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemSourceOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -2524,11 +2149,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -2592,34 +2213,28 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemSourceOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemSourceDefault)
+                                .optional()
                                 .describe('For mean metrics: event source.'),
                             start_event: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemStartEventOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsCreateBodyMetricsSecondaryOneItemStartEventOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -2637,9 +2252,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemStartEventOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -2654,25 +2267,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemStartEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemStartEventOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemStartEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -2681,11 +2288,7 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -2749,25 +2352,19 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemStartEventDefault)
+                                .optional()
                                 .describe('For retention metrics: start event.'),
-                            start_handling: zod
-                                .union([zod.enum(['first_seen', 'last_seen']), zod.null()])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemStartHandlingDefault),
+                            start_handling: zod.union([zod.enum(['first_seen', 'last_seen']), zod.null()]).optional(),
                             upper_bound_percentile: zod
                                 .union([
                                     zod
@@ -2776,13 +2373,13 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                         .max(experimentsCreateBodyMetricsSecondaryOneItemUpperBoundPercentileOneMax),
                                     zod.null(),
                                 ])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemUpperBoundPercentileDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). Per-user values above this percentile are clamped to it before aggregation.'
                                 ),
                             uuid: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsCreateBodyMetricsSecondaryOneItemUuidDefault)
+                                .optional()
                                 .describe('Unique identifier. Auto-generated if omitted.'),
                         })
                     )
@@ -2854,244 +2451,70 @@ export const experimentsPartialUpdateBodyNameMax = 400
 
 export const experimentsPartialUpdateBodyDescriptionMax = 3000
 
-export const experimentsPartialUpdateBodyParametersOneExcludedVariantsDefault = null
-export const experimentsPartialUpdateBodyParametersOneFeatureFlagVariantsOneItemNameDefault = null
-export const experimentsPartialUpdateBodyParametersOneFeatureFlagVariantsOneItemRolloutPercentageDefault = null
-export const experimentsPartialUpdateBodyParametersOneFeatureFlagVariantsOneItemSplitPercentDefault = null
-export const experimentsPartialUpdateBodyParametersOneFeatureFlagVariantsDefault = null
-export const experimentsPartialUpdateBodyParametersOneMinimumDetectableEffectDefault = null
-export const experimentsPartialUpdateBodyParametersOneRolloutPercentageDefault = null
 export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOneKindDefault = `ExperimentEventExposureConfig`
-export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemLabelDefault = null
 export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemValueDefault = null
-export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigDefault = null
-export const experimentsPartialUpdateBodyExposureCriteriaOneFilterTestAccountsDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneEventDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneIdDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneMathDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOnePropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOnePropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOnePropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemConversionWindowDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOneEventDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOneIdDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOneMathDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOneMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOneMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOneMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOnePropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOnePropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOnePropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemGoalDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemIgnoreZerosDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemKindDefault = `ExperimentMetric`
 export const experimentsPartialUpdateBodyMetricsOneItemLowerBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsOneItemLowerBoundPercentileOneMax = 1
 
-export const experimentsPartialUpdateBodyMetricsOneItemLowerBoundPercentileDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNameDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOneEventDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOneIdDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOneMathDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOneMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOneMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOneMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOnePropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOnePropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOnePropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemRetentionWindowEndDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemRetentionWindowStartDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemRetentionWindowUnitDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemEventDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemIdDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemMathDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemPropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemPropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemPropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemPropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemPropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSeriesDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSourceOneEventDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSourceOneIdDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSourceOneMathDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSourceOneMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSourceOneMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSourceOneMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSourceOnePropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemSourceOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsOneItemSourceOnePropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsOneItemSourceOnePropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSourceOnePropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemSourceDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemStartEventOneEventDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemStartEventOneIdDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemStartEventOneMathDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemStartEventOneMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemStartEventOneMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemStartEventOneMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemStartEventOnePropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemStartEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsOneItemStartEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsOneItemStartEventOnePropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemStartEventOnePropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemStartEventDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemStartHandlingDefault = null
 export const experimentsPartialUpdateBodyMetricsOneItemUpperBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsOneItemUpperBoundPercentileOneMax = 1
 
-export const experimentsPartialUpdateBodyMetricsOneItemUpperBoundPercentileDefault = null
-export const experimentsPartialUpdateBodyMetricsOneItemUuidDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneEventDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneIdDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneMathDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemConversionWindowDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneEventDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneIdDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneMathDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOnePropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault =
-    null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault =
-    null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemGoalDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemIgnoreZerosDefault = null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemKindDefault = `ExperimentMetric`
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemLowerBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemLowerBoundPercentileOneMax = 1
 
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemLowerBoundPercentileDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNameDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneEventDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneIdDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneMathDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOnePropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault =
-    null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault =
-    null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemRetentionWindowEndDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemRetentionWindowStartDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemRetentionWindowUnitDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemEventDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemIdDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemMathDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneEventDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneIdDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneMathDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOnePropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneEventDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneIdDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneMathDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneMathGroupTypeIndexDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneMathHogqlDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneMathPropertyDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemLabelDefault = null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemValueDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOnePropertiesDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartHandlingDefault = null
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemUpperBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemUpperBoundPercentileOneMax = 1
-
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemUpperBoundPercentileDefault = null
-export const experimentsPartialUpdateBodyMetricsSecondaryOneItemUuidDefault = null
 
 export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
     .object({
@@ -3115,7 +2538,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                 zod.object({
                     excluded_variants: zod
                         .union([zod.array(zod.string()), zod.null()])
-                        .default(experimentsPartialUpdateBodyParametersOneExcludedVariantsDefault)
+                        .optional()
                         .describe(
                             'Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis.'
                         ),
@@ -3130,20 +2553,12 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                         ),
                                     name: zod
                                         .union([zod.string(), zod.null()])
-                                        .default(
-                                            experimentsPartialUpdateBodyParametersOneFeatureFlagVariantsOneItemNameDefault
-                                        )
+                                        .optional()
                                         .describe('Human-readable variant name.'),
-                                    rollout_percentage: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(
-                                            experimentsPartialUpdateBodyParametersOneFeatureFlagVariantsOneItemRolloutPercentageDefault
-                                        ),
+                                    rollout_percentage: zod.union([zod.number(), zod.null()]).optional(),
                                     split_percent: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            experimentsPartialUpdateBodyParametersOneFeatureFlagVariantsOneItemSplitPercentDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Percentage of users assigned to this variant (0–100). All variants must sum to 100. One of split_percent (recommended) or rollout_percentage must be provided.'
                                         ),
@@ -3151,19 +2566,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                             ),
                             zod.null(),
                         ])
-                        .default(experimentsPartialUpdateBodyParametersOneFeatureFlagVariantsDefault)
+                        .optional()
                         .describe(
                             "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
                         ),
                     minimum_detectable_effect: zod
                         .union([zod.number(), zod.null()])
-                        .default(experimentsPartialUpdateBodyParametersOneMinimumDetectableEffectDefault)
+                        .optional()
                         .describe(
                             'Minimum detectable effect as a percentage. Lower values need more users but catch smaller changes. Suggest 20–30% for most experiments.'
                         ),
                     rollout_percentage: zod
                         .union([zod.number(), zod.null()])
-                        .default(experimentsPartialUpdateBodyParametersOneRolloutPercentageDefault)
+                        .optional()
                         .describe(
                             'Overall rollout percentage (0-100). Controls what fraction of all users enter the experiment. Users outside the rollout never see any variant and are excluded from analysis. Default: 100.'
                         ),
@@ -3206,11 +2621,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                     .array(
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .union([
                                                     zod.enum([
@@ -3268,19 +2679,15 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemValueDefault
-                                                ),
+                                                .optional(),
                                         })
                                     )
                                     .describe('Event property filters. Pass an empty array if no filters needed.'),
                             }),
                             zod.null(),
                         ])
-                        .default(experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigDefault),
-                    filterTestAccounts: zod
-                        .union([zod.boolean(), zod.null()])
-                        .default(experimentsPartialUpdateBodyExposureCriteriaOneFilterTestAccountsDefault),
+                        .optional(),
+                    filterTestAccounts: zod.union([zod.boolean(), zod.null()]).optional(),
                 }),
                 zod.null(),
             ])
@@ -3296,15 +2703,11 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -3322,9 +2725,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -3339,25 +2740,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemCompletionEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -3366,11 +2761,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsOneItemCompletionEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -3434,38 +2825,32 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsOneItemCompletionEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemCompletionEventOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemCompletionEventDefault)
+                                .optional()
                                 .describe('For retention metrics: completion event.'),
                             conversion_window: zod
                                 .union([zod.number(), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemConversionWindowDefault)
+                                .optional()
                                 .describe('Conversion window duration.'),
                             denominator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemDenominatorOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsPartialUpdateBodyMetricsOneItemDenominatorOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -3483,9 +2868,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemDenominatorOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -3500,25 +2883,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemDenominatorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemDenominatorOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemDenominatorOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -3527,11 +2904,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsOneItemDenominatorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -3595,30 +2968,22 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsOneItemDenominatorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemDenominatorOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemDenominatorDefault)
+                                .optional()
                                 .describe('For ratio metrics: denominator source.'),
                             denominator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -3631,9 +2996,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -3649,26 +3012,24 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemDenominatorOutlierHandlingDefault)
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the denominator aggregate. Leave unset for a binomial-style denominator, which is never clamped.'
                                 ),
                             goal: zod
                                 .union([zod.enum(['increase', 'decrease']), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemGoalDefault)
+                                .optional()
                                 .describe('Whether higher or lower values indicate success.'),
                             ignore_zeros: zod
                                 .union([zod.boolean(), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemIgnoreZerosDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: exclude zero values when computing the winsorization percentile thresholds.'
                                 ),
@@ -3683,25 +3044,25 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                         .max(experimentsPartialUpdateBodyMetricsOneItemLowerBoundPercentileOneMax),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemLowerBoundPercentileDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). Per-user values below this percentile are clamped to it before aggregation.'
                                 ),
                             metric_type: zod.enum(['funnel', 'mean', 'ratio', 'retention']),
                             name: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemNameDefault)
+                                .optional()
                                 .describe('Human-readable metric name.'),
                             numerator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsPartialUpdateBodyMetricsOneItemNumeratorOneEventDefault)
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsPartialUpdateBodyMetricsOneItemNumeratorOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -3719,7 +3080,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsPartialUpdateBodyMetricsOneItemNumeratorOneMathDefault)
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -3734,25 +3095,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemNumeratorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemNumeratorOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemNumeratorOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -3761,11 +3116,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsOneItemNumeratorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -3829,30 +3180,22 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsOneItemNumeratorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemNumeratorOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemNumeratorDefault)
+                                .optional()
                                 .describe('For ratio metrics: numerator source.'),
                             numerator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -3865,9 +3208,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -3883,43 +3224,33 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemNumeratorOutlierHandlingDefault)
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the numerator aggregate, independently of the denominator and each with its own percentile thresholds.'
                                 ),
-                            retention_window_end: zod
-                                .union([zod.number(), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemRetentionWindowEndDefault),
-                            retention_window_start: zod
-                                .union([zod.number(), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemRetentionWindowStartDefault),
+                            retention_window_end: zod.union([zod.number(), zod.null()]).optional(),
+                            retention_window_start: zod.union([zod.number(), zod.null()]).optional(),
                             retention_window_unit: zod
                                 .union([zod.enum(['second', 'minute', 'hour', 'day', 'week', 'month']), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemRetentionWindowUnitDefault),
+                                .optional(),
                             series: zod
                                 .union([
                                     zod.array(
                                         zod.object({
                                             event: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemEventDefault
-                                                )
+                                                .optional()
                                                 .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                             id: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemIdDefault
-                                                )
+                                                .optional()
                                                 .describe('Action ID. Required for ActionsNode.'),
                                             kind: zod.enum(['EventsNode', 'ActionsNode']),
                                             math: zod
@@ -3937,9 +3268,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemMathDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                                 ),
@@ -3954,25 +3283,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemMathGroupTypeIndexDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Group type index to aggregate over. Required when math is 'unique_group'."
                                                 ),
                                             math_hogql: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemMathHogqlDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                                 ),
                                             math_property: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemMathPropertyDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                                 ),
@@ -3981,11 +3304,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     zod.array(
                                                         zod.object({
                                                             key: zod.string(),
-                                                            label: zod
-                                                                .union([zod.string(), zod.null()])
-                                                                .default(
-                                                                    experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemPropertiesOneItemLabelDefault
-                                                                ),
+                                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                                             operator: zod
                                                                 .union([
                                                                     zod.enum([
@@ -4049,33 +3368,29 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                     zod.boolean(),
                                                                     zod.null(),
                                                                 ])
-                                                                .default(
-                                                                    experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemPropertiesOneItemValueDefault
-                                                                ),
+                                                                .optional(),
                                                         })
                                                     ),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsOneItemSeriesOneItemPropertiesDefault
-                                                )
+                                                .optional()
                                                 .describe('Event property filters to narrow which events are counted.'),
                                         })
                                     ),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemSeriesDefault)
+                                .optional()
                                 .describe('For funnel metrics: array of EventsNode/ActionsNode steps.'),
                             source: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsPartialUpdateBodyMetricsOneItemSourceOneEventDefault)
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsPartialUpdateBodyMetricsOneItemSourceOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -4093,7 +3408,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsPartialUpdateBodyMetricsOneItemSourceOneMathDefault)
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -4108,25 +3423,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemSourceOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemSourceOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemSourceOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -4135,11 +3444,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsOneItemSourceOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -4203,34 +3508,28 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsOneItemSourceOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemSourceOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemSourceDefault)
+                                .optional()
                                 .describe('For mean metrics: event source.'),
                             start_event: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemStartEventOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsPartialUpdateBodyMetricsOneItemStartEventOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -4248,7 +3547,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsPartialUpdateBodyMetricsOneItemStartEventOneMathDefault)
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -4263,25 +3562,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemStartEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemStartEventOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemStartEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -4290,11 +3583,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsOneItemStartEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -4358,25 +3647,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsOneItemStartEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsOneItemStartEventOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemStartEventDefault)
+                                .optional()
                                 .describe('For retention metrics: start event.'),
-                            start_handling: zod
-                                .union([zod.enum(['first_seen', 'last_seen']), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemStartHandlingDefault),
+                            start_handling: zod.union([zod.enum(['first_seen', 'last_seen']), zod.null()]).optional(),
                             upper_bound_percentile: zod
                                 .union([
                                     zod
@@ -4385,13 +3668,13 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                         .max(experimentsPartialUpdateBodyMetricsOneItemUpperBoundPercentileOneMax),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemUpperBoundPercentileDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). Per-user values above this percentile are clamped to it before aggregation.'
                                 ),
                             uuid: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsOneItemUuidDefault)
+                                .optional()
                                 .describe('Unique identifier. Auto-generated if omitted.'),
                         })
                     )
@@ -4412,15 +3695,11 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -4438,9 +3717,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -4455,25 +3732,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -4482,11 +3753,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -4550,40 +3817,32 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemCompletionEventDefault)
+                                .optional()
                                 .describe('For retention metrics: completion event.'),
                             conversion_window: zod
                                 .union([zod.number(), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemConversionWindowDefault)
+                                .optional()
                                 .describe('Conversion window duration.'),
                             denominator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -4601,9 +3860,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -4618,25 +3875,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -4645,11 +3896,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -4713,30 +3960,22 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorDefault)
+                                .optional()
                                 .describe('For ratio metrics: denominator source.'),
                             denominator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -4749,9 +3988,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -4767,28 +4004,24 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(
-                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingDefault
-                                )
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the denominator aggregate. Leave unset for a binomial-style denominator, which is never clamped.'
                                 ),
                             goal: zod
                                 .union([zod.enum(['increase', 'decrease']), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemGoalDefault)
+                                .optional()
                                 .describe('Whether higher or lower values indicate success.'),
                             ignore_zeros: zod
                                 .union([zod.boolean(), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemIgnoreZerosDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: exclude zero values when computing the winsorization percentile thresholds.'
                                 ),
@@ -4807,29 +4040,25 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                         ),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemLowerBoundPercentileDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). Per-user values below this percentile are clamped to it before aggregation.'
                                 ),
                             metric_type: zod.enum(['funnel', 'mean', 'ratio', 'retention']),
                             name: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemNameDefault)
+                                .optional()
                                 .describe('Human-readable metric name.'),
                             numerator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -4847,9 +4076,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -4864,25 +4091,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -4891,11 +4112,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -4959,30 +4176,22 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorDefault)
+                                .optional()
                                 .describe('For ratio metrics: numerator source.'),
                             numerator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -4995,9 +4204,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -5013,47 +4220,33 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(
-                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingDefault
-                                )
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the numerator aggregate, independently of the denominator and each with its own percentile thresholds.'
                                 ),
-                            retention_window_end: zod
-                                .union([zod.number(), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemRetentionWindowEndDefault),
-                            retention_window_start: zod
-                                .union([zod.number(), zod.null()])
-                                .default(
-                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemRetentionWindowStartDefault
-                                ),
+                            retention_window_end: zod.union([zod.number(), zod.null()]).optional(),
+                            retention_window_start: zod.union([zod.number(), zod.null()]).optional(),
                             retention_window_unit: zod
                                 .union([zod.enum(['second', 'minute', 'hour', 'day', 'week', 'month']), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemRetentionWindowUnitDefault),
+                                .optional(),
                             series: zod
                                 .union([
                                     zod.array(
                                         zod.object({
                                             event: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemEventDefault
-                                                )
+                                                .optional()
                                                 .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                             id: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemIdDefault
-                                                )
+                                                .optional()
                                                 .describe('Action ID. Required for ActionsNode.'),
                                             kind: zod.enum(['EventsNode', 'ActionsNode']),
                                             math: zod
@@ -5071,9 +4264,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemMathDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                                 ),
@@ -5088,25 +4279,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemMathGroupTypeIndexDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Group type index to aggregate over. Required when math is 'unique_group'."
                                                 ),
                                             math_hogql: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemMathHogqlDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                                 ),
                                             math_property: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemMathPropertyDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                                 ),
@@ -5115,11 +4300,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                     zod.array(
                                                         zod.object({
                                                             key: zod.string(),
-                                                            label: zod
-                                                                .union([zod.string(), zod.null()])
-                                                                .default(
-                                                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemLabelDefault
-                                                                ),
+                                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                                             operator: zod
                                                                 .union([
                                                                     zod.enum([
@@ -5183,37 +4364,29 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                     zod.boolean(),
                                                                     zod.null(),
                                                                 ])
-                                                                .default(
-                                                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemValueDefault
-                                                                ),
+                                                                .optional(),
                                                         })
                                                     ),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesDefault
-                                                )
+                                                .optional()
                                                 .describe('Event property filters to narrow which events are counted.'),
                                         })
                                     ),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemSeriesDefault)
+                                .optional()
                                 .describe('For funnel metrics: array of EventsNode/ActionsNode steps.'),
                             source: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -5231,9 +4404,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -5248,25 +4419,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -5275,11 +4440,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -5343,36 +4504,28 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemSourceDefault)
+                                .optional()
                                 .describe('For mean metrics: event source.'),
                             start_event: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -5390,9 +4543,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -5407,25 +4558,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -5434,11 +4579,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -5502,25 +4643,19 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventDefault)
+                                .optional()
                                 .describe('For retention metrics: start event.'),
-                            start_handling: zod
-                                .union([zod.enum(['first_seen', 'last_seen']), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemStartHandlingDefault),
+                            start_handling: zod.union([zod.enum(['first_seen', 'last_seen']), zod.null()]).optional(),
                             upper_bound_percentile: zod
                                 .union([
                                     zod
@@ -5533,13 +4668,13 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                         ),
                                     zod.null(),
                                 ])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemUpperBoundPercentileDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). Per-user values above this percentile are clamped to it before aggregation.'
                                 ),
                             uuid: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsPartialUpdateBodyMetricsSecondaryOneItemUuidDefault)
+                                .optional()
                                 .describe('Unique identifier. Auto-generated if omitted.'),
                         })
                     )
@@ -5631,245 +4766,72 @@ export const experimentsDuplicateCreateBodyNameMax = 400
 
 export const experimentsDuplicateCreateBodyDescriptionMax = 3000
 
-export const experimentsDuplicateCreateBodyParametersOneExcludedVariantsDefault = null
-export const experimentsDuplicateCreateBodyParametersOneFeatureFlagVariantsOneItemNameDefault = null
-export const experimentsDuplicateCreateBodyParametersOneFeatureFlagVariantsOneItemRolloutPercentageDefault = null
-export const experimentsDuplicateCreateBodyParametersOneFeatureFlagVariantsOneItemSplitPercentDefault = null
-export const experimentsDuplicateCreateBodyParametersOneFeatureFlagVariantsDefault = null
-export const experimentsDuplicateCreateBodyParametersOneMinimumDetectableEffectDefault = null
-export const experimentsDuplicateCreateBodyParametersOneRolloutPercentageDefault = null
 export const experimentsDuplicateCreateBodyArchivedDefault = false
 export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOneKindDefault = `ExperimentEventExposureConfig`
-export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemLabelDefault = null
 export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemValueDefault = null
-export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigDefault = null
-export const experimentsDuplicateCreateBodyExposureCriteriaOneFilterTestAccountsDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOnePropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemConversionWindowDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOnePropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemGoalDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemIgnoreZerosDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemKindDefault = `ExperimentMetric`
 export const experimentsDuplicateCreateBodyMetricsOneItemLowerBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsOneItemLowerBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsOneItemLowerBoundPercentileDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNameDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOnePropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemRetentionWindowEndDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemRetentionWindowStartDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemRetentionWindowUnitDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemPropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSeriesDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSourceOneEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSourceOneIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSourceOneMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSourceOneMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSourceOneMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSourceOneMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSourceOnePropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemSourceOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsOneItemSourceOnePropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsOneItemSourceOnePropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSourceOnePropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemSourceDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemStartEventOneEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemStartEventOneIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemStartEventOneMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemStartEventOneMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemStartEventOneMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemStartEventOneMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemStartEventOnePropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemStartEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsOneItemStartEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsOneItemStartEventOnePropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemStartEventOnePropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemStartEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemStartHandlingDefault = null
 export const experimentsDuplicateCreateBodyMetricsOneItemUpperBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsOneItemUpperBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsOneItemUpperBoundPercentileDefault = null
-export const experimentsDuplicateCreateBodyMetricsOneItemUuidDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemConversionWindowDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault =
-    null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault =
-    null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemGoalDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemIgnoreZerosDefault = null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemKindDefault = `ExperimentMetric`
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemLowerBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemLowerBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemLowerBoundPercentileDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNameDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault = null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault =
-    null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault =
-    null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemRetentionWindowEndDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemRetentionWindowStartDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemRetentionWindowUnitDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOnePropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneIdDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneMathDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneMathGroupTypeIndexDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneMathHogqlDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneMathPropertyDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemLabelDefault = null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemTypeDefault = `event`
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemValueDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartHandlingDefault = null
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemUpperBoundPercentileOneMin = 0
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemUpperBoundPercentileOneMax = 1
 
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemUpperBoundPercentileDefault = null
-export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemUuidDefault = null
 export const experimentsDuplicateCreateBodyAllowUnknownEventsDefault = false
 export const experimentsDuplicateCreateBodyUpdateFeatureFlagParamsDefault = false
 
@@ -5894,7 +4856,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                 zod.object({
                     excluded_variants: zod
                         .union([zod.array(zod.string()), zod.null()])
-                        .default(experimentsDuplicateCreateBodyParametersOneExcludedVariantsDefault)
+                        .optional()
                         .describe(
                             'Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis.'
                         ),
@@ -5909,20 +4871,12 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                         ),
                                     name: zod
                                         .union([zod.string(), zod.null()])
-                                        .default(
-                                            experimentsDuplicateCreateBodyParametersOneFeatureFlagVariantsOneItemNameDefault
-                                        )
+                                        .optional()
                                         .describe('Human-readable variant name.'),
-                                    rollout_percentage: zod
-                                        .union([zod.number(), zod.null()])
-                                        .default(
-                                            experimentsDuplicateCreateBodyParametersOneFeatureFlagVariantsOneItemRolloutPercentageDefault
-                                        ),
+                                    rollout_percentage: zod.union([zod.number(), zod.null()]).optional(),
                                     split_percent: zod
                                         .union([zod.number(), zod.null()])
-                                        .default(
-                                            experimentsDuplicateCreateBodyParametersOneFeatureFlagVariantsOneItemSplitPercentDefault
-                                        )
+                                        .optional()
                                         .describe(
                                             'Percentage of users assigned to this variant (0–100). All variants must sum to 100. One of split_percent (recommended) or rollout_percentage must be provided.'
                                         ),
@@ -5930,19 +4884,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                             ),
                             zod.null(),
                         ])
-                        .default(experimentsDuplicateCreateBodyParametersOneFeatureFlagVariantsDefault)
+                        .optional()
                         .describe(
                             "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
                         ),
                     minimum_detectable_effect: zod
                         .union([zod.number(), zod.null()])
-                        .default(experimentsDuplicateCreateBodyParametersOneMinimumDetectableEffectDefault)
+                        .optional()
                         .describe(
                             'Minimum detectable effect as a percentage. Lower values need more users but catch smaller changes. Suggest 20–30% for most experiments.'
                         ),
                     rollout_percentage: zod
                         .union([zod.number(), zod.null()])
-                        .default(experimentsDuplicateCreateBodyParametersOneRolloutPercentageDefault)
+                        .optional()
                         .describe(
                             'Overall rollout percentage (0-100). Controls what fraction of all users enter the experiment. Users outside the rollout never see any variant and are excluded from analysis. Default: 100.'
                         ),
@@ -5988,11 +4942,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                     .array(
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .union([
                                                     zod.enum([
@@ -6050,19 +5000,15 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemValueDefault
-                                                ),
+                                                .optional(),
                                         })
                                     )
                                     .describe('Event property filters. Pass an empty array if no filters needed.'),
                             }),
                             zod.null(),
                         ])
-                        .default(experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigDefault),
-                    filterTestAccounts: zod
-                        .union([zod.boolean(), zod.null()])
-                        .default(experimentsDuplicateCreateBodyExposureCriteriaOneFilterTestAccountsDefault),
+                        .optional(),
+                    filterTestAccounts: zod.union([zod.boolean(), zod.null()]).optional(),
                 }),
                 zod.null(),
             ])
@@ -6078,15 +5024,11 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -6104,9 +5046,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -6121,25 +5061,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -6148,11 +5082,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -6216,40 +5146,32 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemCompletionEventDefault)
+                                .optional()
                                 .describe('For retention metrics: completion event.'),
                             conversion_window: zod
                                 .union([zod.number(), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemConversionWindowDefault)
+                                .optional()
                                 .describe('Conversion window duration.'),
                             denominator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -6267,9 +5189,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -6284,25 +5204,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -6311,11 +5225,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -6379,30 +5289,22 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemDenominatorDefault)
+                                .optional()
                                 .describe('For ratio metrics: denominator source.'),
                             denominator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -6415,9 +5317,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -6433,26 +5333,24 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemDenominatorOutlierHandlingDefault)
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the denominator aggregate. Leave unset for a binomial-style denominator, which is never clamped.'
                                 ),
                             goal: zod
                                 .union([zod.enum(['increase', 'decrease']), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemGoalDefault)
+                                .optional()
                                 .describe('Whether higher or lower values indicate success.'),
                             ignore_zeros: zod
                                 .union([zod.boolean(), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemIgnoreZerosDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: exclude zero values when computing the winsorization percentile thresholds.'
                                 ),
@@ -6467,27 +5365,25 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                         .max(experimentsDuplicateCreateBodyMetricsOneItemLowerBoundPercentileOneMax),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemLowerBoundPercentileDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). Per-user values below this percentile are clamped to it before aggregation.'
                                 ),
                             metric_type: zod.enum(['funnel', 'mean', 'ratio', 'retention']),
                             name: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemNameDefault)
+                                .optional()
                                 .describe('Human-readable metric name.'),
                             numerator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -6505,9 +5401,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -6522,25 +5416,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemNumeratorOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -6549,11 +5437,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -6617,30 +5501,22 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsOneItemNumeratorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemNumeratorOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemNumeratorDefault)
+                                .optional()
                                 .describe('For ratio metrics: numerator source.'),
                             numerator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -6653,9 +5529,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -6671,43 +5545,33 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemNumeratorOutlierHandlingDefault)
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the numerator aggregate, independently of the denominator and each with its own percentile thresholds.'
                                 ),
-                            retention_window_end: zod
-                                .union([zod.number(), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemRetentionWindowEndDefault),
-                            retention_window_start: zod
-                                .union([zod.number(), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemRetentionWindowStartDefault),
+                            retention_window_end: zod.union([zod.number(), zod.null()]).optional(),
+                            retention_window_start: zod.union([zod.number(), zod.null()]).optional(),
                             retention_window_unit: zod
                                 .union([zod.enum(['second', 'minute', 'hour', 'day', 'week', 'month']), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemRetentionWindowUnitDefault),
+                                .optional(),
                             series: zod
                                 .union([
                                     zod.array(
                                         zod.object({
                                             event: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemEventDefault
-                                                )
+                                                .optional()
                                                 .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                             id: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemIdDefault
-                                                )
+                                                .optional()
                                                 .describe('Action ID. Required for ActionsNode.'),
                                             kind: zod.enum(['EventsNode', 'ActionsNode']),
                                             math: zod
@@ -6725,9 +5589,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemMathDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                                 ),
@@ -6742,25 +5604,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemMathGroupTypeIndexDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Group type index to aggregate over. Required when math is 'unique_group'."
                                                 ),
                                             math_hogql: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemMathHogqlDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                                 ),
                                             math_property: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemMathPropertyDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                                 ),
@@ -6769,11 +5625,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     zod.array(
                                                         zod.object({
                                                             key: zod.string(),
-                                                            label: zod
-                                                                .union([zod.string(), zod.null()])
-                                                                .default(
-                                                                    experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemLabelDefault
-                                                                ),
+                                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                                             operator: zod
                                                                 .union([
                                                                     zod.enum([
@@ -6837,33 +5689,29 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                     zod.boolean(),
                                                                     zod.null(),
                                                                 ])
-                                                                .default(
-                                                                    experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemPropertiesOneItemValueDefault
-                                                                ),
+                                                                .optional(),
                                                         })
                                                     ),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsOneItemSeriesOneItemPropertiesDefault
-                                                )
+                                                .optional()
                                                 .describe('Event property filters to narrow which events are counted.'),
                                         })
                                     ),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemSeriesDefault)
+                                .optional()
                                 .describe('For funnel metrics: array of EventsNode/ActionsNode steps.'),
                             source: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(experimentsDuplicateCreateBodyMetricsOneItemSourceOneEventDefault)
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsDuplicateCreateBodyMetricsOneItemSourceOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -6881,7 +5729,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(experimentsDuplicateCreateBodyMetricsOneItemSourceOneMathDefault)
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -6896,25 +5744,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemSourceOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemSourceOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemSourceOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -6923,11 +5765,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsOneItemSourceOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -6991,34 +5829,28 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsOneItemSourceOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemSourceOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemSourceDefault)
+                                .optional()
                                 .describe('For mean metrics: event source.'),
                             start_event: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemStartEventOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(experimentsDuplicateCreateBodyMetricsOneItemStartEventOneIdDefault)
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -7036,9 +5868,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemStartEventOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -7053,25 +5883,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemStartEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemStartEventOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemStartEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -7080,11 +5904,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsOneItemStartEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -7148,25 +5968,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsOneItemStartEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsOneItemStartEventOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemStartEventDefault)
+                                .optional()
                                 .describe('For retention metrics: start event.'),
-                            start_handling: zod
-                                .union([zod.enum(['first_seen', 'last_seen']), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemStartHandlingDefault),
+                            start_handling: zod.union([zod.enum(['first_seen', 'last_seen']), zod.null()]).optional(),
                             upper_bound_percentile: zod
                                 .union([
                                     zod
@@ -7175,13 +5989,13 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                         .max(experimentsDuplicateCreateBodyMetricsOneItemUpperBoundPercentileOneMax),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemUpperBoundPercentileDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). Per-user values above this percentile are clamped to it before aggregation.'
                                 ),
                             uuid: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsOneItemUuidDefault)
+                                .optional()
                                 .describe('Unique identifier. Auto-generated if omitted.'),
                         })
                     )
@@ -7202,15 +6016,11 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -7228,9 +6038,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -7245,25 +6053,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -7272,11 +6074,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -7340,40 +6138,32 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemCompletionEventDefault)
+                                .optional()
                                 .describe('For retention metrics: completion event.'),
                             conversion_window: zod
                                 .union([zod.number(), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemConversionWindowDefault)
+                                .optional()
                                 .describe('Conversion window duration.'),
                             denominator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -7391,9 +6181,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -7408,25 +6196,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -7435,11 +6217,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -7503,30 +6281,22 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorDefault)
+                                .optional()
                                 .describe('For ratio metrics: denominator source.'),
                             denominator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -7539,9 +6309,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -7557,28 +6325,24 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(
-                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemDenominatorOutlierHandlingDefault
-                                )
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the denominator aggregate. Leave unset for a binomial-style denominator, which is never clamped.'
                                 ),
                             goal: zod
                                 .union([zod.enum(['increase', 'decrease']), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemGoalDefault)
+                                .optional()
                                 .describe('Whether higher or lower values indicate success.'),
                             ignore_zeros: zod
                                 .union([zod.boolean(), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemIgnoreZerosDefault)
+                                .optional()
                                 .describe(
                                     'For mean metrics: exclude zero values when computing the winsorization percentile thresholds.'
                                 ),
@@ -7597,31 +6361,25 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                         ),
                                     zod.null(),
                                 ])
-                                .default(
-                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemLowerBoundPercentileDefault
-                                )
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). Per-user values below this percentile are clamped to it before aggregation.'
                                 ),
                             metric_type: zod.enum(['funnel', 'mean', 'ratio', 'retention']),
                             name: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemNameDefault)
+                                .optional()
                                 .describe('Human-readable metric name.'),
                             numerator: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -7639,9 +6397,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -7656,25 +6412,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -7683,11 +6433,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -7751,30 +6497,22 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorDefault)
+                                .optional()
                                 .describe('For ratio metrics: numerator source.'),
                             numerator_outlier_handling: zod
                                 .union([
                                     zod.object({
-                                        ignore_zeros: zod
-                                            .union([zod.boolean(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneIgnoreZerosDefault
-                                            ),
+                                        ignore_zeros: zod.union([zod.boolean(), zod.null()]).optional(),
                                         lower_bound_percentile: zod
                                             .union([
                                                 zod
@@ -7787,9 +6525,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneLowerBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile).'
                                             ),
@@ -7805,51 +6541,33 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingOneUpperBoundPercentileDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 'Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile).'
                                             ),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(
-                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemNumeratorOutlierHandlingDefault
-                                )
+                                .optional()
                                 .describe(
                                     'For ratio metrics: winsorization applied to the numerator aggregate, independently of the denominator and each with its own percentile thresholds.'
                                 ),
-                            retention_window_end: zod
-                                .union([zod.number(), zod.null()])
-                                .default(
-                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemRetentionWindowEndDefault
-                                ),
-                            retention_window_start: zod
-                                .union([zod.number(), zod.null()])
-                                .default(
-                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemRetentionWindowStartDefault
-                                ),
+                            retention_window_end: zod.union([zod.number(), zod.null()]).optional(),
+                            retention_window_start: zod.union([zod.number(), zod.null()]).optional(),
                             retention_window_unit: zod
                                 .union([zod.enum(['second', 'minute', 'hour', 'day', 'week', 'month']), zod.null()])
-                                .default(
-                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemRetentionWindowUnitDefault
-                                ),
+                                .optional(),
                             series: zod
                                 .union([
                                     zod.array(
                                         zod.object({
                                             event: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemEventDefault
-                                                )
+                                                .optional()
                                                 .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                             id: zod
                                                 .union([zod.number(), zod.null()])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemIdDefault
-                                                )
+                                                .optional()
                                                 .describe('Action ID. Required for ActionsNode.'),
                                             kind: zod.enum(['EventsNode', 'ActionsNode']),
                                             math: zod
@@ -7867,9 +6585,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemMathDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                                 ),
@@ -7884,25 +6600,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     ]),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemMathGroupTypeIndexDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Group type index to aggregate over. Required when math is 'unique_group'."
                                                 ),
                                             math_hogql: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemMathHogqlDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                                 ),
                                             math_property: zod
                                                 .union([zod.string(), zod.null()])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemMathPropertyDefault
-                                                )
+                                                .optional()
                                                 .describe(
                                                     "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                                 ),
@@ -7911,11 +6621,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                     zod.array(
                                                         zod.object({
                                                             key: zod.string(),
-                                                            label: zod
-                                                                .union([zod.string(), zod.null()])
-                                                                .default(
-                                                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemLabelDefault
-                                                                ),
+                                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                                             operator: zod
                                                                 .union([
                                                                     zod.enum([
@@ -7979,37 +6685,29 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                     zod.boolean(),
                                                                     zod.null(),
                                                                 ])
-                                                                .default(
-                                                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesOneItemValueDefault
-                                                                ),
+                                                                .optional(),
                                                         })
                                                     ),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesOneItemPropertiesDefault
-                                                )
+                                                .optional()
                                                 .describe('Event property filters to narrow which events are counted.'),
                                         })
                                     ),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemSeriesDefault)
+                                .optional()
                                 .describe('For funnel metrics: array of EventsNode/ActionsNode steps.'),
                             source: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -8027,9 +6725,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -8044,25 +6740,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -8071,11 +6761,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -8139,36 +6825,28 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemSourceDefault)
+                                .optional()
                                 .describe('For mean metrics: event source.'),
                             start_event: zod
                                 .union([
                                     zod.object({
                                         event: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneEventDefault
-                                            )
+                                            .optional()
                                             .describe("Event name, e.g. '$pageview'. Required for EventsNode."),
                                         id: zod
                                             .union([zod.number(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneIdDefault
-                                            )
+                                            .optional()
                                             .describe('Action ID. Required for ActionsNode.'),
                                         kind: zod.enum(['EventsNode', 'ActionsNode']),
                                         math: zod
@@ -8186,9 +6864,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneMathDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             ),
@@ -8203,25 +6879,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 ]),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneMathGroupTypeIndexDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Group type index to aggregate over. Required when math is 'unique_group'."
                                             ),
                                         math_hogql: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneMathHogqlDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             ),
                                         math_property: zod
                                             .union([zod.string(), zod.null()])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOneMathPropertyDefault
-                                            )
+                                            .optional()
                                             .describe(
                                                 "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             ),
@@ -8230,11 +6900,7 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                 zod.array(
                                                     zod.object({
                                                         key: zod.string(),
-                                                        label: zod
-                                                            .union([zod.string(), zod.null()])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemLabelDefault
-                                                            ),
+                                                        label: zod.union([zod.string(), zod.null()]).optional(),
                                                         operator: zod
                                                             .union([
                                                                 zod.enum([
@@ -8298,25 +6964,19 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                                                 zod.boolean(),
                                                                 zod.null(),
                                                             ])
-                                                            .default(
-                                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemValueDefault
-                                                            ),
+                                                            .optional(),
                                                     })
                                                 ),
                                                 zod.null(),
                                             ])
-                                            .default(
-                                                experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventOnePropertiesDefault
-                                            )
+                                            .optional()
                                             .describe('Event property filters to narrow which events are counted.'),
                                     }),
                                     zod.null(),
                                 ])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartEventDefault)
+                                .optional()
                                 .describe('For retention metrics: start event.'),
-                            start_handling: zod
-                                .union([zod.enum(['first_seen', 'last_seen']), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemStartHandlingDefault),
+                            start_handling: zod.union([zod.enum(['first_seen', 'last_seen']), zod.null()]).optional(),
                             upper_bound_percentile: zod
                                 .union([
                                     zod
@@ -8329,15 +6989,13 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                         ),
                                     zod.null(),
                                 ])
-                                .default(
-                                    experimentsDuplicateCreateBodyMetricsSecondaryOneItemUpperBoundPercentileDefault
-                                )
+                                .optional()
                                 .describe(
                                     'For mean metrics: winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). Per-user values above this percentile are clamped to it before aggregation.'
                                 ),
                             uuid: zod
                                 .union([zod.string(), zod.null()])
-                                .default(experimentsDuplicateCreateBodyMetricsSecondaryOneItemUuidDefault)
+                                .optional()
                                 .describe('Unique identifier. Auto-generated if omitted.'),
                         })
                     )

--- a/services/mcp/src/generated/logs/api.ts
+++ b/services/mcp/src/generated/logs/api.ts
@@ -32,70 +32,28 @@ export const LogsAlertsCreateParams = /* @__PURE__ */ zod.object({
 export const logsAlertsCreateBodyNameMax = 255
 
 export const logsAlertsCreateBodyEnabledDefault = true
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoOperatorDefault = `exact`
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoTypeDefault = `event`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeTypeDefault = `person`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourTypeDefault = `element`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveTypeDefault = `event_metadata`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixTypeDefault = `session`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenCohortNameDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenKeyDefault = `id`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenOperatorDefault = `in`
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenTypeDefault = `cohort`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightTypeDefault = `recording`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineTypeDefault = `log_entry`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupKeyNamesDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupTypeIndexDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroTypeDefault = `group`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneTypeDefault = `feature`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoOperatorDefault = `flag_evaluates_to`
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoTypeDefault = `flag`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeTypeDefault = `hogql`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeValueDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefourTypeDefault = `empty`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveTypeDefault = `data_warehouse`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixTypeDefault = `data_warehouse_person_property`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenTypeDefault = `error_tracking_issue`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightLabelDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineLabelDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroTypeDefault = `revenue_analytics`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneLabelDefault = null
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneTypeDefault = `workflow_variable`
-export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneValueDefault = null
-export const logsAlertsCreateBodyFiltersOneFilterGroupDefault = null
-export const logsAlertsCreateBodyFiltersOneServiceNamesDefault = null
-export const logsAlertsCreateBodyFiltersOneSeverityLevelsDefault = null
 export const logsAlertsCreateBodyThresholdCountDefault = 100
 export const logsAlertsCreateBodyThresholdCountMin = 0
 
@@ -134,11 +92,7 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                         zod.unknown(),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .union([
                                                     zod.enum([
@@ -196,17 +150,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -257,17 +205,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.enum(['tag_name', 'text', 'href', 'selector']),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -317,17 +259,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -377,17 +313,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -437,26 +367,16 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
-                                            cohort_name: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenCohortNameDefault
-                                                ),
+                                            cohort_name: zod.union([zod.string(), zod.null()]).optional(),
                                             key: zod
                                                 .literal('id')
                                                 .default(
                                                     logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenKeyDefault
                                                 ),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .union([
                                                     zod.enum([
@@ -512,11 +432,7 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                 zod.enum(['duration', 'active_seconds', 'inactive_seconds']),
                                                 zod.string(),
                                             ]),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -566,17 +482,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -626,27 +536,15 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             group_key_names: zod
                                                 .union([zod.record(zod.string(), zod.string()), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupKeyNamesDefault
-                                                ),
-                                            group_type_index: zod
-                                                .union([zod.number(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupTypeIndexDefault
-                                                ),
+                                                .optional(),
+                                            group_type_index: zod.union([zod.number(), zod.null()]).optional(),
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -696,17 +594,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -757,17 +649,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string().describe('The key should be the flag ID'),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .literal('flag_evaluates_to')
                                                 .default(
@@ -788,11 +674,7 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             type: zod
                                                 .literal('hogql')
                                                 .default(
@@ -806,9 +688,7 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             type: zod
@@ -819,11 +699,7 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -873,17 +749,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -933,17 +803,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -993,17 +857,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -1049,17 +907,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -1105,17 +957,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -1165,17 +1011,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -1225,9 +1065,7 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                     ])
                                 ),
@@ -1236,13 +1074,11 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
                     }),
                     zod.null(),
                 ])
-                .default(logsAlertsCreateBodyFiltersOneFilterGroupDefault),
-            serviceNames: zod
-                .union([zod.array(zod.string()), zod.null()])
-                .default(logsAlertsCreateBodyFiltersOneServiceNamesDefault),
+                .optional(),
+            serviceNames: zod.union([zod.array(zod.string()), zod.null()]).optional(),
             severityLevels: zod
                 .union([zod.array(zod.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])), zod.null()])
-                .default(logsAlertsCreateBodyFiltersOneSeverityLevelsDefault),
+                .optional(),
         })
         .optional()
         .describe(
@@ -1309,70 +1145,28 @@ export const LogsAlertsPartialUpdateParams = /* @__PURE__ */ zod.object({
 
 export const logsAlertsPartialUpdateBodyNameMax = 255
 
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoOperatorDefault = `exact`
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoTypeDefault = `event`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeTypeDefault = `person`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourTypeDefault = `element`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveTypeDefault = `event_metadata`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixTypeDefault = `session`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenCohortNameDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenKeyDefault = `id`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenOperatorDefault = `in`
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenTypeDefault = `cohort`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightTypeDefault = `recording`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineTypeDefault = `log_entry`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupKeyNamesDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupTypeIndexDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroTypeDefault = `group`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneTypeDefault = `feature`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoOperatorDefault = `flag_evaluates_to`
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoTypeDefault = `flag`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeTypeDefault = `hogql`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeValueDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefourTypeDefault = `empty`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveTypeDefault = `data_warehouse`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixTypeDefault = `data_warehouse_person_property`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenTypeDefault = `error_tracking_issue`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightLabelDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineLabelDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroTypeDefault = `revenue_analytics`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneLabelDefault = null
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneTypeDefault = `workflow_variable`
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneValueDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneServiceNamesDefault = null
-export const logsAlertsPartialUpdateBodyFiltersOneSeverityLevelsDefault = null
 export const logsAlertsPartialUpdateBodyThresholdCountMin = 0
 
 export const logsAlertsPartialUpdateBodyEvaluationPeriodsMax = 10
@@ -1405,11 +1199,7 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         zod.unknown(),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .union([
                                                     zod.enum([
@@ -1467,17 +1257,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -1528,17 +1312,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.enum(['tag_name', 'text', 'href', 'selector']),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -1588,17 +1366,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -1648,17 +1420,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -1708,26 +1474,16 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
-                                            cohort_name: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenCohortNameDefault
-                                                ),
+                                            cohort_name: zod.union([zod.string(), zod.null()]).optional(),
                                             key: zod
                                                 .literal('id')
                                                 .default(
                                                     logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenKeyDefault
                                                 ),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .union([
                                                     zod.enum([
@@ -1783,11 +1539,7 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 zod.enum(['duration', 'active_seconds', 'inactive_seconds']),
                                                 zod.string(),
                                             ]),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -1837,17 +1589,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -1897,27 +1643,15 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             group_key_names: zod
                                                 .union([zod.record(zod.string(), zod.string()), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupKeyNamesDefault
-                                                ),
-                                            group_type_index: zod
-                                                .union([zod.number(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupTypeIndexDefault
-                                                ),
+                                                .optional(),
+                                            group_type_index: zod.union([zod.number(), zod.null()]).optional(),
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -1967,17 +1701,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -2028,17 +1756,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string().describe('The key should be the flag ID'),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .literal('flag_evaluates_to')
                                                 .default(
@@ -2059,11 +1781,7 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             type: zod
                                                 .literal('hogql')
                                                 .default(
@@ -2077,9 +1795,7 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             type: zod
@@ -2090,11 +1806,7 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -2144,17 +1856,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -2204,17 +1910,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -2264,17 +1964,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -2320,17 +2014,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -2376,17 +2064,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -2436,17 +2118,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -2496,9 +2172,7 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                     ])
                                 ),
@@ -2507,13 +2181,11 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     }),
                     zod.null(),
                 ])
-                .default(logsAlertsPartialUpdateBodyFiltersOneFilterGroupDefault),
-            serviceNames: zod
-                .union([zod.array(zod.string()), zod.null()])
-                .default(logsAlertsPartialUpdateBodyFiltersOneServiceNamesDefault),
+                .optional(),
+            serviceNames: zod.union([zod.array(zod.string()), zod.null()]).optional(),
             severityLevels: zod
                 .union([zod.array(zod.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])), zod.null()])
-                .default(logsAlertsPartialUpdateBodyFiltersOneSeverityLevelsDefault),
+                .optional(),
         })
         .optional()
         .describe(
@@ -2642,70 +2314,28 @@ export const LogsAlertsSimulateCreateParams = /* @__PURE__ */ zod.object({
         ),
 })
 
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoOperatorDefault = `exact`
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoTypeDefault = `event`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeTypeDefault = `person`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourTypeDefault = `element`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveTypeDefault = `event_metadata`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixTypeDefault = `session`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenCohortNameDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenKeyDefault = `id`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenOperatorDefault = `in`
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenTypeDefault = `cohort`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightTypeDefault = `recording`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineTypeDefault = `log_entry`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupKeyNamesDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupTypeIndexDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroTypeDefault = `group`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneTypeDefault = `feature`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoOperatorDefault = `flag_evaluates_to`
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoTypeDefault = `flag`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeTypeDefault = `hogql`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeValueDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefourTypeDefault = `empty`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveTypeDefault = `data_warehouse`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixTypeDefault = `data_warehouse_person_property`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenTypeDefault = `error_tracking_issue`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightLabelDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineLabelDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroTypeDefault = `revenue_analytics`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneLabelDefault = null
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneTypeDefault = `workflow_variable`
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneValueDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneServiceNamesDefault = null
-export const logsAlertsSimulateCreateBodyFiltersOneSeverityLevelsDefault = null
 export const logsAlertsSimulateCreateBodyThresholdCountMin = 0
 
 export const logsAlertsSimulateCreateBodyCheckIntervalMinutesDefault = 5
@@ -2735,11 +2365,7 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                         zod.unknown(),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .union([
                                                     zod.enum([
@@ -2797,17 +2423,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwoValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -2858,17 +2478,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemThreeValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.enum(['tag_name', 'text', 'href', 'selector']),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -2918,17 +2532,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFourValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -2978,17 +2586,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemFiveValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3038,26 +2640,16 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSixValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
-                                            cohort_name: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenCohortNameDefault
-                                                ),
+                                            cohort_name: zod.union([zod.string(), zod.null()]).optional(),
                                             key: zod
                                                 .literal('id')
                                                 .default(
                                                     logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenKeyDefault
                                                 ),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemSevenLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .union([
                                                     zod.enum([
@@ -3113,11 +2705,7 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                 zod.enum(['duration', 'active_seconds', 'inactive_seconds']),
                                                 zod.string(),
                                             ]),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3167,17 +2755,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemEightValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3227,27 +2809,15 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemNineValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             group_key_names: zod
                                                 .union([zod.record(zod.string(), zod.string()), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupKeyNamesDefault
-                                                ),
-                                            group_type_index: zod
-                                                .union([zod.number(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroGroupTypeIndexDefault
-                                                ),
+                                                .optional(),
+                                            group_type_index: zod.union([zod.number(), zod.null()]).optional(),
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3297,17 +2867,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnezeroValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3358,17 +2922,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneoneValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string().describe('The key should be the flag ID'),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnetwoLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod
                                                 .literal('flag_evaluates_to')
                                                 .default(
@@ -3389,11 +2947,7 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             type: zod
                                                 .literal('hogql')
                                                 .default(
@@ -3407,9 +2961,7 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnethreeValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             type: zod
@@ -3420,11 +2972,7 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3474,17 +3022,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnefiveValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3534,17 +3076,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesixValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3594,17 +3130,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnesevenValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3650,17 +3180,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOneeightValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3706,17 +3230,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemOnenineValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3766,17 +3284,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwozeroValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                         zod.object({
                                             key: zod.string(),
-                                            label: zod
-                                                .union([zod.string(), zod.null()])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneLabelDefault
-                                                ),
+                                            label: zod.union([zod.string(), zod.null()]).optional(),
                                             operator: zod.enum([
                                                 'exact',
                                                 'is_not',
@@ -3826,9 +3338,7 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.boolean(),
                                                     zod.null(),
                                                 ])
-                                                .default(
-                                                    logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwooneValueDefault
-                                                ),
+                                                .optional(),
                                         }),
                                     ])
                                 ),
@@ -3837,13 +3347,11 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                     }),
                     zod.null(),
                 ])
-                .default(logsAlertsSimulateCreateBodyFiltersOneFilterGroupDefault),
-            serviceNames: zod
-                .union([zod.array(zod.string()), zod.null()])
-                .default(logsAlertsSimulateCreateBodyFiltersOneServiceNamesDefault),
+                .optional(),
+            serviceNames: zod.union([zod.array(zod.string()), zod.null()]).optional(),
             severityLevels: zod
                 .union([zod.array(zod.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])), zod.null()])
-                .default(logsAlertsSimulateCreateBodyFiltersOneSeverityLevelsDefault),
+                .optional(),
         })
         .describe('Filter criteria — same format as LogsAlertConfiguration.filters.'),
     threshold_count: zod

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-create.json
@@ -37,7 +37,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "When true, evaluate the current (still incomplete) time interval in addition to completed ones."
                         },
                         "series_index": {
@@ -84,7 +83,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -96,7 +94,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -108,7 +105,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -118,7 +114,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -130,7 +125,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                                                     },
                                                     "type": {
@@ -147,7 +141,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size for calculating mean/std (default: 30)"
                                                     }
                                                 },
@@ -168,7 +161,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -180,7 +172,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -192,7 +183,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -202,7 +192,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -214,7 +203,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                                                     },
                                                     "type": {
@@ -231,7 +219,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size for calculating median/MAD (default: 30)"
                                                     }
                                                 },
@@ -248,7 +235,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)"
                                                     },
                                                     "preprocessing": {
@@ -264,7 +250,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -276,7 +261,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -288,7 +272,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -298,7 +281,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "type": {
@@ -315,7 +297,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size for calculating quartiles (default: 30)"
                                                     }
                                                 },
@@ -332,7 +313,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Lower bound - values below this are anomalies"
                                                     },
                                                     "preprocessing": {
@@ -348,7 +328,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -360,7 +339,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -372,7 +350,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -382,7 +359,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "type": {
@@ -399,7 +375,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Upper bound - values above this are anomalies"
                                                     }
                                                 },
@@ -420,7 +395,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -432,7 +406,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -444,7 +417,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -454,7 +426,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -466,7 +437,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -483,7 +453,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -504,7 +473,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -516,7 +484,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -528,7 +495,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -538,7 +504,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -550,7 +515,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -567,7 +531,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -584,7 +547,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Number of trees in the forest (default: 100)"
                                                     },
                                                     "preprocessing": {
@@ -600,7 +562,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -612,7 +573,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -624,7 +584,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -634,7 +593,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -646,7 +604,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -663,7 +620,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -681,7 +637,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Distance method: 'largest', 'mean', 'median' (default: 'largest')"
                                                     },
                                                     "n_neighbors": {
@@ -693,7 +648,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Number of neighbors to consider (default: 5)"
                                                     },
                                                     "preprocessing": {
@@ -709,7 +663,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -721,7 +674,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -733,7 +685,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -743,7 +694,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -755,7 +705,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -772,7 +721,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -789,7 +737,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Number of histogram bins (default: 10)"
                                                     },
                                                     "preprocessing": {
@@ -805,7 +752,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -817,7 +763,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -829,7 +774,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -839,7 +783,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -851,7 +794,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -868,7 +810,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -885,7 +826,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Number of neighbors for LOF (default: 20)"
                                                     },
                                                     "preprocessing": {
@@ -901,7 +841,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -913,7 +852,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -925,7 +863,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -935,7 +872,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -947,7 +883,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -964,7 +899,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -981,7 +915,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "SVM kernel type (default: \"rbf\")"
                                                     },
                                                     "nu": {
@@ -993,7 +926,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Upper bound on training errors fraction (default: 0.1)"
                                                     },
                                                     "preprocessing": {
@@ -1009,7 +941,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -1021,7 +952,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -1033,7 +963,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -1043,7 +972,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -1055,7 +983,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -1072,7 +999,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -1093,7 +1019,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -1105,7 +1030,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -1117,7 +1041,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -1127,7 +1050,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -1139,7 +1061,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -1156,7 +1077,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -1195,7 +1115,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1207,7 +1126,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1219,7 +1137,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1229,7 +1146,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1241,7 +1157,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                                 },
                                 "type": {
@@ -1258,7 +1173,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size for calculating mean/std (default: 30)"
                                 }
                             },
@@ -1279,7 +1193,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1291,7 +1204,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1303,7 +1215,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1313,7 +1224,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1325,7 +1235,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                                 },
                                 "type": {
@@ -1342,7 +1251,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size for calculating median/MAD (default: 30)"
                                 }
                             },
@@ -1359,7 +1267,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)"
                                 },
                                 "preprocessing": {
@@ -1375,7 +1282,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1387,7 +1293,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1399,7 +1304,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1409,7 +1313,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "type": {
@@ -1426,7 +1329,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size for calculating quartiles (default: 30)"
                                 }
                             },
@@ -1443,7 +1345,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Lower bound - values below this are anomalies"
                                 },
                                 "preprocessing": {
@@ -1459,7 +1360,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1471,7 +1371,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1483,7 +1382,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1493,7 +1391,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "type": {
@@ -1510,7 +1407,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Upper bound - values above this are anomalies"
                                 }
                             },
@@ -1531,7 +1427,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1543,7 +1438,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1555,7 +1449,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1565,7 +1458,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1577,7 +1469,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -1594,7 +1485,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -1615,7 +1505,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1627,7 +1516,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1639,7 +1527,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1649,7 +1536,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1661,7 +1547,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -1678,7 +1563,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -1695,7 +1579,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Number of trees in the forest (default: 100)"
                                 },
                                 "preprocessing": {
@@ -1711,7 +1594,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1723,7 +1605,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1735,7 +1616,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1745,7 +1625,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1757,7 +1636,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -1774,7 +1652,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -1792,7 +1669,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Distance method: 'largest', 'mean', 'median' (default: 'largest')"
                                 },
                                 "n_neighbors": {
@@ -1804,7 +1680,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Number of neighbors to consider (default: 5)"
                                 },
                                 "preprocessing": {
@@ -1820,7 +1695,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1832,7 +1706,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1844,7 +1717,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1854,7 +1726,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1866,7 +1737,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -1883,7 +1753,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -1900,7 +1769,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Number of histogram bins (default: 10)"
                                 },
                                 "preprocessing": {
@@ -1916,7 +1784,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1928,7 +1795,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1940,7 +1806,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1950,7 +1815,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1962,7 +1826,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -1979,7 +1842,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -1996,7 +1858,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Number of neighbors for LOF (default: 20)"
                                 },
                                 "preprocessing": {
@@ -2012,7 +1873,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -2024,7 +1884,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -2036,7 +1895,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -2046,7 +1904,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -2058,7 +1915,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -2075,7 +1931,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -2092,7 +1947,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "SVM kernel type (default: \"rbf\")"
                                 },
                                 "nu": {
@@ -2104,7 +1958,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Upper bound on training errors fraction (default: 0.1)"
                                 },
                                 "preprocessing": {
@@ -2120,7 +1973,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -2132,7 +1984,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -2144,7 +1995,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -2154,7 +2004,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -2166,7 +2015,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -2183,7 +2031,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -2204,7 +2051,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -2216,7 +2062,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -2228,7 +2073,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -2238,7 +2082,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -2250,7 +2093,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -2267,7 +2109,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -2386,7 +2227,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Alert fires when the value drops below this number."
                                         },
                                         "upper": {
@@ -2398,7 +2238,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Alert fires when the value exceeds this number."
                                         }
                                     },
@@ -2407,8 +2246,7 @@
                                 {
                                     "type": "null"
                                 }
-                            ],
-                            "default": null
+                            ]
                         },
                         "type": {
                             "description": "Whether bounds are compared as absolute values or as percentage change from the previous interval.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-simulate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-simulate.json
@@ -35,7 +35,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -47,7 +46,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -59,7 +57,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -69,7 +66,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "threshold": {
@@ -81,7 +77,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                                             },
                                             "type": {
@@ -98,7 +93,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Rolling window size for calculating mean/std (default: 30)"
                                             }
                                         },
@@ -119,7 +113,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -131,7 +124,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -143,7 +135,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -153,7 +144,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "threshold": {
@@ -165,7 +155,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                                             },
                                             "type": {
@@ -182,7 +171,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Rolling window size for calculating median/MAD (default: 30)"
                                             }
                                         },
@@ -199,7 +187,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)"
                                             },
                                             "preprocessing": {
@@ -215,7 +202,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -227,7 +213,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -239,7 +224,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -249,7 +233,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "type": {
@@ -266,7 +249,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Rolling window size for calculating quartiles (default: 30)"
                                             }
                                         },
@@ -283,7 +265,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Lower bound - values below this are anomalies"
                                             },
                                             "preprocessing": {
@@ -299,7 +280,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -311,7 +291,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -323,7 +302,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -333,7 +311,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "type": {
@@ -350,7 +327,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Upper bound - values above this are anomalies"
                                             }
                                         },
@@ -371,7 +347,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -383,7 +358,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -395,7 +369,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -405,7 +378,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "threshold": {
@@ -417,7 +389,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Anomaly probability threshold (default: 0.9)"
                                             },
                                             "type": {
@@ -434,7 +405,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
@@ -455,7 +425,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -467,7 +436,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -479,7 +447,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -489,7 +456,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "threshold": {
@@ -501,7 +467,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Anomaly probability threshold (default: 0.9)"
                                             },
                                             "type": {
@@ -518,7 +483,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
@@ -535,7 +499,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Number of trees in the forest (default: 100)"
                                             },
                                             "preprocessing": {
@@ -551,7 +514,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -563,7 +525,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -575,7 +536,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -585,7 +545,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "threshold": {
@@ -597,7 +556,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Anomaly probability threshold (default: 0.9)"
                                             },
                                             "type": {
@@ -614,7 +572,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
@@ -632,7 +589,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Distance method: 'largest', 'mean', 'median' (default: 'largest')"
                                             },
                                             "n_neighbors": {
@@ -644,7 +600,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Number of neighbors to consider (default: 5)"
                                             },
                                             "preprocessing": {
@@ -660,7 +615,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -672,7 +626,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -684,7 +637,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -694,7 +646,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "threshold": {
@@ -706,7 +657,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Anomaly probability threshold (default: 0.9)"
                                             },
                                             "type": {
@@ -723,7 +673,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
@@ -740,7 +689,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Number of histogram bins (default: 10)"
                                             },
                                             "preprocessing": {
@@ -756,7 +704,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -768,7 +715,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -780,7 +726,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -790,7 +735,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "threshold": {
@@ -802,7 +746,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Anomaly probability threshold (default: 0.9)"
                                             },
                                             "type": {
@@ -819,7 +762,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
@@ -836,7 +778,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Number of neighbors for LOF (default: 20)"
                                             },
                                             "preprocessing": {
@@ -852,7 +793,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -864,7 +804,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -876,7 +815,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -886,7 +824,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "threshold": {
@@ -898,7 +835,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Anomaly probability threshold (default: 0.9)"
                                             },
                                             "type": {
@@ -915,7 +851,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
@@ -932,7 +867,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "SVM kernel type (default: \"rbf\")"
                                             },
                                             "nu": {
@@ -944,7 +878,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Upper bound on training errors fraction (default: 0.1)"
                                             },
                                             "preprocessing": {
@@ -960,7 +893,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -972,7 +904,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -984,7 +915,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -994,7 +924,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "threshold": {
@@ -1006,7 +935,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Anomaly probability threshold (default: 0.9)"
                                             },
                                             "type": {
@@ -1023,7 +951,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
@@ -1044,7 +971,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                             },
                                                             "lags_n": {
@@ -1056,7 +982,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                             },
                                                             "smooth_n": {
@@ -1068,7 +993,6 @@
                                                                         "type": "null"
                                                                     }
                                                                 ],
-                                                                "default": null,
                                                                 "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                             }
                                                         },
@@ -1078,7 +1002,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Preprocessing transforms applied before detection"
                                             },
                                             "threshold": {
@@ -1090,7 +1013,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Anomaly probability threshold (default: 0.9)"
                                             },
                                             "type": {
@@ -1107,7 +1029,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
@@ -1146,7 +1067,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -1158,7 +1078,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -1170,7 +1089,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -1180,7 +1098,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "threshold": {
@@ -1192,7 +1109,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                         },
                         "type": {
@@ -1209,7 +1125,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Rolling window size for calculating mean/std (default: 30)"
                         }
                     },
@@ -1230,7 +1145,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -1242,7 +1156,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -1254,7 +1167,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -1264,7 +1176,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "threshold": {
@@ -1276,7 +1187,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                         },
                         "type": {
@@ -1293,7 +1203,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Rolling window size for calculating median/MAD (default: 30)"
                         }
                     },
@@ -1310,7 +1219,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)"
                         },
                         "preprocessing": {
@@ -1326,7 +1234,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -1338,7 +1245,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -1350,7 +1256,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -1360,7 +1265,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "type": {
@@ -1377,7 +1281,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Rolling window size for calculating quartiles (default: 30)"
                         }
                     },
@@ -1394,7 +1297,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Lower bound - values below this are anomalies"
                         },
                         "preprocessing": {
@@ -1410,7 +1312,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -1422,7 +1323,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -1434,7 +1334,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -1444,7 +1343,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "type": {
@@ -1461,7 +1359,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Upper bound - values above this are anomalies"
                         }
                     },
@@ -1482,7 +1379,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -1494,7 +1390,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -1506,7 +1401,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -1516,7 +1410,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "threshold": {
@@ -1528,7 +1421,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Anomaly probability threshold (default: 0.9)"
                         },
                         "type": {
@@ -1545,7 +1437,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
@@ -1566,7 +1457,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -1578,7 +1468,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -1590,7 +1479,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -1600,7 +1488,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "threshold": {
@@ -1612,7 +1499,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Anomaly probability threshold (default: 0.9)"
                         },
                         "type": {
@@ -1629,7 +1515,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
@@ -1646,7 +1531,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Number of trees in the forest (default: 100)"
                         },
                         "preprocessing": {
@@ -1662,7 +1546,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -1674,7 +1557,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -1686,7 +1568,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -1696,7 +1577,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "threshold": {
@@ -1708,7 +1588,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Anomaly probability threshold (default: 0.9)"
                         },
                         "type": {
@@ -1725,7 +1604,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
@@ -1743,7 +1621,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Distance method: 'largest', 'mean', 'median' (default: 'largest')"
                         },
                         "n_neighbors": {
@@ -1755,7 +1632,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Number of neighbors to consider (default: 5)"
                         },
                         "preprocessing": {
@@ -1771,7 +1647,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -1783,7 +1658,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -1795,7 +1669,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -1805,7 +1678,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "threshold": {
@@ -1817,7 +1689,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Anomaly probability threshold (default: 0.9)"
                         },
                         "type": {
@@ -1834,7 +1705,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
@@ -1851,7 +1721,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Number of histogram bins (default: 10)"
                         },
                         "preprocessing": {
@@ -1867,7 +1736,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -1879,7 +1747,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -1891,7 +1758,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -1901,7 +1767,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "threshold": {
@@ -1913,7 +1778,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Anomaly probability threshold (default: 0.9)"
                         },
                         "type": {
@@ -1930,7 +1794,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
@@ -1947,7 +1810,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Number of neighbors for LOF (default: 20)"
                         },
                         "preprocessing": {
@@ -1963,7 +1825,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -1975,7 +1836,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -1987,7 +1847,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -1997,7 +1856,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "threshold": {
@@ -2009,7 +1867,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Anomaly probability threshold (default: 0.9)"
                         },
                         "type": {
@@ -2026,7 +1883,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
@@ -2043,7 +1899,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "SVM kernel type (default: \"rbf\")"
                         },
                         "nu": {
@@ -2055,7 +1910,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Upper bound on training errors fraction (default: 0.1)"
                         },
                         "preprocessing": {
@@ -2071,7 +1925,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -2083,7 +1936,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -2095,7 +1947,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -2105,7 +1956,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "threshold": {
@@ -2117,7 +1967,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Anomaly probability threshold (default: 0.9)"
                         },
                         "type": {
@@ -2134,7 +1983,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
@@ -2155,7 +2003,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                         },
                                         "lags_n": {
@@ -2167,7 +2014,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                         },
                                         "smooth_n": {
@@ -2179,7 +2025,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                         }
                                     },
@@ -2189,7 +2034,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Preprocessing transforms applied before detection"
                         },
                         "threshold": {
@@ -2201,7 +2045,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Anomaly probability threshold (default: 0.9)"
                         },
                         "type": {
@@ -2218,7 +2061,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/alert-update.json
@@ -37,7 +37,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "When true, evaluate the current (still incomplete) time interval in addition to completed ones."
                         },
                         "series_index": {
@@ -84,7 +83,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -96,7 +94,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -108,7 +105,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -118,7 +114,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -130,7 +125,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                                                     },
                                                     "type": {
@@ -147,7 +141,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size for calculating mean/std (default: 30)"
                                                     }
                                                 },
@@ -168,7 +161,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -180,7 +172,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -192,7 +183,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -202,7 +192,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -214,7 +203,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                                                     },
                                                     "type": {
@@ -231,7 +219,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size for calculating median/MAD (default: 30)"
                                                     }
                                                 },
@@ -248,7 +235,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)"
                                                     },
                                                     "preprocessing": {
@@ -264,7 +250,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -276,7 +261,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -288,7 +272,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -298,7 +281,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "type": {
@@ -315,7 +297,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size for calculating quartiles (default: 30)"
                                                     }
                                                 },
@@ -332,7 +313,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Lower bound - values below this are anomalies"
                                                     },
                                                     "preprocessing": {
@@ -348,7 +328,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -360,7 +339,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -372,7 +350,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -382,7 +359,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "type": {
@@ -399,7 +375,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Upper bound - values above this are anomalies"
                                                     }
                                                 },
@@ -420,7 +395,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -432,7 +406,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -444,7 +417,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -454,7 +426,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -466,7 +437,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -483,7 +453,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -504,7 +473,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -516,7 +484,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -528,7 +495,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -538,7 +504,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -550,7 +515,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -567,7 +531,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -584,7 +547,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Number of trees in the forest (default: 100)"
                                                     },
                                                     "preprocessing": {
@@ -600,7 +562,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -612,7 +573,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -624,7 +584,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -634,7 +593,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -646,7 +604,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -663,7 +620,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -681,7 +637,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Distance method: 'largest', 'mean', 'median' (default: 'largest')"
                                                     },
                                                     "n_neighbors": {
@@ -693,7 +648,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Number of neighbors to consider (default: 5)"
                                                     },
                                                     "preprocessing": {
@@ -709,7 +663,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -721,7 +674,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -733,7 +685,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -743,7 +694,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -755,7 +705,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -772,7 +721,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -789,7 +737,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Number of histogram bins (default: 10)"
                                                     },
                                                     "preprocessing": {
@@ -805,7 +752,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -817,7 +763,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -829,7 +774,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -839,7 +783,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -851,7 +794,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -868,7 +810,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -885,7 +826,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Number of neighbors for LOF (default: 20)"
                                                     },
                                                     "preprocessing": {
@@ -901,7 +841,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -913,7 +852,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -925,7 +863,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -935,7 +872,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -947,7 +883,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -964,7 +899,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -981,7 +915,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "SVM kernel type (default: \"rbf\")"
                                                     },
                                                     "nu": {
@@ -993,7 +926,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Upper bound on training errors fraction (default: 0.1)"
                                                     },
                                                     "preprocessing": {
@@ -1009,7 +941,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -1021,7 +952,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -1033,7 +963,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -1043,7 +972,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -1055,7 +983,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -1072,7 +999,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -1093,7 +1019,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                                     },
                                                                     "lags_n": {
@@ -1105,7 +1030,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                                     },
                                                                     "smooth_n": {
@@ -1117,7 +1041,6 @@
                                                                                 "type": "null"
                                                                             }
                                                                         ],
-                                                                        "default": null,
                                                                         "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                                     }
                                                                 },
@@ -1127,7 +1050,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Preprocessing transforms applied before detection"
                                                     },
                                                     "threshold": {
@@ -1139,7 +1061,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Anomaly probability threshold (default: 0.9)"
                                                     },
                                                     "type": {
@@ -1156,7 +1077,6 @@
                                                                 "type": "null"
                                                             }
                                                         ],
-                                                        "default": null,
                                                         "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
@@ -1195,7 +1115,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1207,7 +1126,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1219,7 +1137,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1229,7 +1146,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1241,7 +1157,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                                 },
                                 "type": {
@@ -1258,7 +1173,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size for calculating mean/std (default: 30)"
                                 }
                             },
@@ -1279,7 +1193,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1291,7 +1204,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1303,7 +1215,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1313,7 +1224,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1325,7 +1235,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
                                 },
                                 "type": {
@@ -1342,7 +1251,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size for calculating median/MAD (default: 30)"
                                 }
                             },
@@ -1359,7 +1267,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)"
                                 },
                                 "preprocessing": {
@@ -1375,7 +1282,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1387,7 +1293,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1399,7 +1304,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1409,7 +1313,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "type": {
@@ -1426,7 +1329,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size for calculating quartiles (default: 30)"
                                 }
                             },
@@ -1443,7 +1345,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Lower bound - values below this are anomalies"
                                 },
                                 "preprocessing": {
@@ -1459,7 +1360,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1471,7 +1371,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1483,7 +1382,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1493,7 +1391,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "type": {
@@ -1510,7 +1407,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Upper bound - values above this are anomalies"
                                 }
                             },
@@ -1531,7 +1427,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1543,7 +1438,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1555,7 +1449,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1565,7 +1458,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1577,7 +1469,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -1594,7 +1485,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -1615,7 +1505,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1627,7 +1516,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1639,7 +1527,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1649,7 +1536,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1661,7 +1547,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -1678,7 +1563,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -1695,7 +1579,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Number of trees in the forest (default: 100)"
                                 },
                                 "preprocessing": {
@@ -1711,7 +1594,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1723,7 +1605,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1735,7 +1616,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1745,7 +1625,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1757,7 +1636,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -1774,7 +1652,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -1792,7 +1669,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Distance method: 'largest', 'mean', 'median' (default: 'largest')"
                                 },
                                 "n_neighbors": {
@@ -1804,7 +1680,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Number of neighbors to consider (default: 5)"
                                 },
                                 "preprocessing": {
@@ -1820,7 +1695,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1832,7 +1706,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1844,7 +1717,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1854,7 +1726,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1866,7 +1737,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -1883,7 +1753,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -1900,7 +1769,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Number of histogram bins (default: 10)"
                                 },
                                 "preprocessing": {
@@ -1916,7 +1784,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -1928,7 +1795,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -1940,7 +1806,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -1950,7 +1815,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -1962,7 +1826,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -1979,7 +1842,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -1996,7 +1858,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Number of neighbors for LOF (default: 20)"
                                 },
                                 "preprocessing": {
@@ -2012,7 +1873,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -2024,7 +1884,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -2036,7 +1895,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -2046,7 +1904,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -2058,7 +1915,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -2075,7 +1931,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -2092,7 +1947,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "SVM kernel type (default: \"rbf\")"
                                 },
                                 "nu": {
@@ -2104,7 +1958,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Upper bound on training errors fraction (default: 0.1)"
                                 },
                                 "preprocessing": {
@@ -2120,7 +1973,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -2132,7 +1984,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -2144,7 +1995,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -2154,7 +2004,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -2166,7 +2015,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -2183,7 +2031,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -2204,7 +2051,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
                                                 },
                                                 "lags_n": {
@@ -2216,7 +2062,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
                                                 },
                                                 "smooth_n": {
@@ -2228,7 +2073,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
                                                 }
                                             },
@@ -2238,7 +2082,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Preprocessing transforms applied before detection"
                                 },
                                 "threshold": {
@@ -2250,7 +2093,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Anomaly probability threshold (default: 0.9)"
                                 },
                                 "type": {
@@ -2267,7 +2109,6 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "default": null,
                                     "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
@@ -2390,7 +2231,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Alert fires when the value drops below this number."
                                         },
                                         "upper": {
@@ -2402,7 +2242,6 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "default": null,
                                             "description": "Alert fires when the value exceeds this number."
                                         }
                                     },
@@ -2411,8 +2250,7 @@
                                 {
                                     "type": "null"
                                 }
-                            ],
-                            "default": null
+                            ]
                         },
                         "type": {
                             "description": "Whether bounds are compared as absolute values or as percentage change from the previous interval.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-create.json
@@ -47,8 +47,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "bytecode_error": {
                                                         "anyOf": [
@@ -58,8 +57,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "conditionHash": {
                                                         "anyOf": [
@@ -69,8 +67,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "event_filters": {
                                                         "anyOf": [
@@ -90,8 +87,7 @@
                                                                                         {
                                                                                             "type": "null"
                                                                                         }
-                                                                                    ],
-                                                                                    "default": null
+                                                                                    ]
                                                                                 },
                                                                                 "type": {
                                                                                     "enum": ["event", "element"],
@@ -125,8 +121,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "event_type": {
                                                         "type": "string"
@@ -139,8 +134,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "explicit_datetime_to": {
                                                         "anyOf": [
@@ -150,8 +144,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "key": {
                                                         "anyOf": [
@@ -171,8 +164,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "negation": {
                                                         "default": false,
@@ -186,8 +178,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "operator_value": {
                                                         "anyOf": [
@@ -197,8 +188,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "seq_event": {
                                                         "anyOf": [
@@ -211,8 +201,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "seq_event_type": {
                                                         "anyOf": [
@@ -222,8 +211,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "seq_time_interval": {
                                                         "anyOf": [
@@ -233,8 +221,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "seq_time_value": {
                                                         "anyOf": [
@@ -244,8 +231,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "time_interval": {
                                                         "anyOf": [
@@ -255,8 +241,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "time_value": {
                                                         "anyOf": [
@@ -266,8 +251,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "total_periods": {
                                                         "anyOf": [
@@ -277,8 +261,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "type": {
                                                         "const": "behavioral",
@@ -302,8 +285,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "bytecode_error": {
                                                         "anyOf": [
@@ -313,8 +295,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "conditionHash": {
                                                         "anyOf": [
@@ -324,8 +305,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "key": {
                                                         "const": "id",
@@ -357,8 +337,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "bytecode_error": {
                                                         "anyOf": [
@@ -368,8 +347,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "conditionHash": {
                                                         "anyOf": [
@@ -379,8 +357,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "key": {
                                                         "type": "string"
@@ -397,8 +374,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "type": {
                                                         "const": "person",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-partial-update.json
@@ -50,8 +50,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "bytecode_error": {
                                                         "anyOf": [
@@ -61,8 +60,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "conditionHash": {
                                                         "anyOf": [
@@ -72,8 +70,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "event_filters": {
                                                         "anyOf": [
@@ -93,8 +90,7 @@
                                                                                         {
                                                                                             "type": "null"
                                                                                         }
-                                                                                    ],
-                                                                                    "default": null
+                                                                                    ]
                                                                                 },
                                                                                 "type": {
                                                                                     "enum": ["event", "element"],
@@ -128,8 +124,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "event_type": {
                                                         "type": "string"
@@ -142,8 +137,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "explicit_datetime_to": {
                                                         "anyOf": [
@@ -153,8 +147,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "key": {
                                                         "anyOf": [
@@ -174,8 +167,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "negation": {
                                                         "default": false,
@@ -189,8 +181,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "operator_value": {
                                                         "anyOf": [
@@ -200,8 +191,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "seq_event": {
                                                         "anyOf": [
@@ -214,8 +204,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "seq_event_type": {
                                                         "anyOf": [
@@ -225,8 +214,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "seq_time_interval": {
                                                         "anyOf": [
@@ -236,8 +224,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "seq_time_value": {
                                                         "anyOf": [
@@ -247,8 +234,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "time_interval": {
                                                         "anyOf": [
@@ -258,8 +244,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "time_value": {
                                                         "anyOf": [
@@ -269,8 +254,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "total_periods": {
                                                         "anyOf": [
@@ -280,8 +264,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "type": {
                                                         "const": "behavioral",
@@ -305,8 +288,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "bytecode_error": {
                                                         "anyOf": [
@@ -316,8 +298,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "conditionHash": {
                                                         "anyOf": [
@@ -327,8 +308,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "key": {
                                                         "const": "id",
@@ -360,8 +340,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "bytecode_error": {
                                                         "anyOf": [
@@ -371,8 +350,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "conditionHash": {
                                                         "anyOf": [
@@ -382,8 +360,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "key": {
                                                         "type": "string"
@@ -400,8 +377,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "type": {
                                                         "const": "person",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/endpoint-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/endpoint-run.json
@@ -10,7 +10,6 @@
                     "type": "null"
                 }
             ],
-            "default": null,
             "description": "Maximum number of results to return. If not provided, returns all results."
         },
         "name": {
@@ -25,7 +24,6 @@
                     "type": "null"
                 }
             ],
-            "default": null,
             "description": "Number of results to skip. Must be used together with limit. Only supported for HogQL endpoints."
         },
         "refresh": {
@@ -53,7 +51,6 @@
                     "type": "null"
                 }
             ],
-            "default": null,
             "description": "Key-value pairs to parameterize the query. For HogQL endpoints, keys match variable code_name (e.g. {\"event_name\": \"$pageview\"}). For insight endpoints with breakdowns, use the breakdown property name as key."
         }
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-assignment-rules-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-assignment-rules-create.json
@@ -48,8 +48,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "anyOf": [
@@ -134,8 +133,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key"],
@@ -154,8 +152,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -232,8 +229,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -253,8 +249,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -330,8 +325,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -350,8 +344,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -427,8 +420,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -447,8 +439,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -524,8 +515,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -541,8 +531,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "key": {
                                         "const": "id",
@@ -557,8 +546,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "anyOf": [
@@ -640,8 +628,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -717,8 +704,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -737,8 +723,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -814,8 +799,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -837,8 +821,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "group_type_index": {
                                         "anyOf": [
@@ -848,8 +831,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "key": {
                                         "type": "string"
@@ -862,8 +844,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -939,8 +920,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -959,8 +939,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1037,8 +1016,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1058,8 +1036,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "const": "flag_evaluates_to",
@@ -1101,8 +1078,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "type": {
                                         "const": "hogql",
@@ -1139,8 +1115,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key"],
@@ -1169,8 +1144,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1246,8 +1220,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1266,8 +1239,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1343,8 +1315,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1363,8 +1334,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1440,8 +1410,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1460,8 +1429,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1536,8 +1504,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator", "type"],
@@ -1556,8 +1523,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1632,8 +1598,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator", "type"],
@@ -1652,8 +1617,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1729,8 +1693,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1749,8 +1712,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1826,8 +1788,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-grouping-rules-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-grouping-rules-create.json
@@ -66,8 +66,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "anyOf": [
@@ -152,8 +151,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key"],
@@ -172,8 +170,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -250,8 +247,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -271,8 +267,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -348,8 +343,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -368,8 +362,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -445,8 +438,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -465,8 +457,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -542,8 +533,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -559,8 +549,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "key": {
                                         "const": "id",
@@ -575,8 +564,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "anyOf": [
@@ -658,8 +646,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -735,8 +722,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -755,8 +741,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -832,8 +817,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -855,8 +839,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "group_type_index": {
                                         "anyOf": [
@@ -866,8 +849,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "key": {
                                         "type": "string"
@@ -880,8 +862,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -957,8 +938,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -977,8 +957,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1055,8 +1034,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1076,8 +1054,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "const": "flag_evaluates_to",
@@ -1119,8 +1096,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "type": {
                                         "const": "hogql",
@@ -1157,8 +1133,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key"],
@@ -1187,8 +1162,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1264,8 +1238,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1284,8 +1257,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1361,8 +1333,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1381,8 +1352,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1458,8 +1428,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1478,8 +1447,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1554,8 +1522,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator", "type"],
@@ -1574,8 +1541,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1650,8 +1616,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator", "type"],
@@ -1670,8 +1635,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1747,8 +1711,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1767,8 +1730,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1844,8 +1806,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-grouping-rules-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-grouping-rules-update.json
@@ -26,8 +26,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "anyOf": [
@@ -112,8 +111,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key"],
@@ -132,8 +130,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -210,8 +207,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -231,8 +227,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -308,8 +303,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -328,8 +322,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -405,8 +398,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -425,8 +417,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -502,8 +493,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -519,8 +509,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "key": {
                                                 "const": "id",
@@ -535,8 +524,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "anyOf": [
@@ -618,8 +606,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -695,8 +682,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -715,8 +701,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -792,8 +777,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -815,8 +799,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "group_type_index": {
                                                 "anyOf": [
@@ -826,8 +809,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "key": {
                                                 "type": "string"
@@ -840,8 +822,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -917,8 +898,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -937,8 +917,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -1015,8 +994,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -1036,8 +1014,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "const": "flag_evaluates_to",
@@ -1079,8 +1056,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "type": {
                                                 "const": "hogql",
@@ -1117,8 +1093,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key"],
@@ -1147,8 +1122,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -1224,8 +1198,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -1244,8 +1217,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -1321,8 +1293,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -1341,8 +1312,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -1418,8 +1388,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -1438,8 +1407,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -1514,8 +1482,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator", "type"],
@@ -1534,8 +1501,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -1610,8 +1576,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator", "type"],
@@ -1630,8 +1595,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -1707,8 +1671,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],
@@ -1727,8 +1690,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "operator": {
                                                 "enum": [
@@ -1804,8 +1766,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             }
                                         },
                                         "required": ["key", "operator"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-suppression-rules-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-suppression-rules-create.json
@@ -25,8 +25,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "anyOf": [
@@ -111,8 +110,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key"],
@@ -131,8 +129,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -209,8 +206,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -230,8 +226,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -307,8 +302,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -327,8 +321,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -404,8 +397,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -424,8 +416,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -501,8 +492,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -518,8 +508,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "key": {
                                         "const": "id",
@@ -534,8 +523,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "anyOf": [
@@ -617,8 +605,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -694,8 +681,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -714,8 +700,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -791,8 +776,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -814,8 +798,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "group_type_index": {
                                         "anyOf": [
@@ -825,8 +808,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "key": {
                                         "type": "string"
@@ -839,8 +821,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -916,8 +897,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -936,8 +916,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1014,8 +993,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1035,8 +1013,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "const": "flag_evaluates_to",
@@ -1078,8 +1055,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "type": {
                                         "const": "hogql",
@@ -1116,8 +1092,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key"],
@@ -1146,8 +1121,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1223,8 +1197,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1243,8 +1216,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1320,8 +1292,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1340,8 +1311,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1417,8 +1387,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1437,8 +1406,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1513,8 +1481,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator", "type"],
@@ -1533,8 +1500,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1609,8 +1575,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator", "type"],
@@ -1629,8 +1594,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1706,8 +1670,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1726,8 +1689,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1803,8 +1765,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-suppression-rules-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-suppression-rules-update.json
@@ -25,8 +25,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "anyOf": [
@@ -111,8 +110,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key"],
@@ -131,8 +129,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -209,8 +206,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -230,8 +226,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -307,8 +302,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -327,8 +321,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -404,8 +397,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -424,8 +416,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -501,8 +492,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -518,8 +508,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "key": {
                                         "const": "id",
@@ -534,8 +523,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "anyOf": [
@@ -617,8 +605,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -694,8 +681,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -714,8 +700,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -791,8 +776,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -814,8 +798,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "group_type_index": {
                                         "anyOf": [
@@ -825,8 +808,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "key": {
                                         "type": "string"
@@ -839,8 +821,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -916,8 +897,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -936,8 +916,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1014,8 +993,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1035,8 +1013,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "const": "flag_evaluates_to",
@@ -1078,8 +1055,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "type": {
                                         "const": "hogql",
@@ -1116,8 +1092,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key"],
@@ -1146,8 +1121,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1223,8 +1197,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1243,8 +1216,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1320,8 +1292,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1340,8 +1311,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1417,8 +1387,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1437,8 +1406,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1513,8 +1481,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator", "type"],
@@ -1533,8 +1500,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1609,8 +1575,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator", "type"],
@@ -1629,8 +1594,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1706,8 +1670,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],
@@ -1726,8 +1689,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     },
                                     "operator": {
                                         "enum": [
@@ -1803,8 +1765,7 @@
                                             {
                                                 "type": "null"
                                             }
-                                        ],
-                                        "default": null
+                                        ]
                                     }
                                 },
                                 "required": ["key", "operator"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-create.json
@@ -50,8 +50,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "operator": {
                                                         "anyOf": [
@@ -136,8 +135,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["key"],
@@ -152,8 +150,7 @@
                                 {
                                     "type": "null"
                                 }
-                            ],
-                            "default": null
+                            ]
                         },
                         "filterTestAccounts": {
                             "anyOf": [
@@ -163,8 +160,7 @@
                                 {
                                     "type": "null"
                                 }
-                            ],
-                            "default": null
+                            ]
                         }
                     },
                     "type": "object"
@@ -211,7 +207,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis."
                         },
                         "feature_flag_variants": {
@@ -232,7 +227,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Human-readable variant name."
                                             },
                                             "rollout_percentage": {
@@ -243,8 +237,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "split_percent": {
                                                 "anyOf": [
@@ -255,7 +248,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Percentage of users assigned to this variant (0–100). All variants must sum to 100. One of split_percent (recommended) or rollout_percentage must be provided."
                                             }
                                         },
@@ -268,7 +260,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
                         },
                         "minimum_detectable_effect": {
@@ -280,7 +271,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Minimum detectable effect as a percentage. Lower values need more users but catch smaller changes. Suggest 20–30% for most experiments."
                         },
                         "rollout_percentage": {
@@ -292,7 +282,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Overall rollout percentage (0-100). Controls what fraction of all users enter the experiment. Users outside the rollout never see any variant and are excluded from analysis. Default: 100."
                         }
                     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-duplicate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-duplicate.json
@@ -101,8 +101,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     },
                                                     "operator": {
                                                         "anyOf": [
@@ -187,8 +186,7 @@
                                                             {
                                                                 "type": "null"
                                                             }
-                                                        ],
-                                                        "default": null
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["key"],
@@ -203,8 +201,7 @@
                                 {
                                     "type": "null"
                                 }
-                            ],
-                            "default": null
+                            ]
                         },
                         "filterTestAccounts": {
                             "anyOf": [
@@ -214,8 +211,7 @@
                                 {
                                     "type": "null"
                                 }
-                            ],
-                            "default": null
+                            ]
                         }
                     },
                     "type": "object"
@@ -265,7 +261,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -277,7 +272,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -304,7 +298,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -337,7 +330,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -349,7 +341,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -361,7 +352,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -380,8 +370,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -466,8 +455,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -479,7 +467,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -490,7 +477,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For retention metrics: completion event."
                             },
                             "conversion_window": {
@@ -502,7 +488,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Conversion window duration."
                             },
                             "denominator": {
@@ -518,7 +503,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -530,7 +514,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -557,7 +540,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -590,7 +572,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -602,7 +583,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -614,7 +594,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -633,8 +612,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -719,8 +697,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -732,7 +709,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -743,7 +719,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: denominator source."
                             },
                             "denominator_outlier_handling": {
@@ -758,8 +733,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "lower_bound_percentile": {
                                                 "anyOf": [
@@ -772,7 +746,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile)."
                                             },
                                             "upper_bound_percentile": {
@@ -786,7 +759,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile)."
                                             }
                                         },
@@ -796,7 +768,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: winsorization applied to the denominator aggregate. Leave unset for a binomial-style denominator, which is never clamped."
                             },
                             "goal": {
@@ -809,7 +780,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Whether higher or lower values indicate success."
                             },
                             "ignore_zeros": {
@@ -821,7 +791,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: exclude zero values when computing the winsorization percentile thresholds."
                             },
                             "kind": {
@@ -840,7 +809,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). Per-user values below this percentile are clamped to it before aggregation."
                             },
                             "metric_type": {
@@ -856,7 +824,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Human-readable metric name."
                             },
                             "numerator": {
@@ -872,7 +839,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -884,7 +850,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -911,7 +876,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -944,7 +908,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -956,7 +919,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -968,7 +930,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -987,8 +948,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -1073,8 +1033,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -1086,7 +1045,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -1097,7 +1055,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: numerator source."
                             },
                             "numerator_outlier_handling": {
@@ -1112,8 +1069,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "lower_bound_percentile": {
                                                 "anyOf": [
@@ -1126,7 +1082,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile)."
                                             },
                                             "upper_bound_percentile": {
@@ -1140,7 +1095,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile)."
                                             }
                                         },
@@ -1150,7 +1104,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: winsorization applied to the numerator aggregate, independently of the denominator and each with its own percentile thresholds."
                             },
                             "retention_window_end": {
@@ -1161,8 +1114,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "retention_window_start": {
                                 "anyOf": [
@@ -1172,8 +1124,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "retention_window_unit": {
                                 "anyOf": [
@@ -1184,8 +1135,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "series": {
                                 "anyOf": [
@@ -1201,7 +1151,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                                 },
                                                 "id": {
@@ -1213,7 +1162,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Action ID. Required for ActionsNode."
                                                 },
                                                 "kind": {
@@ -1240,7 +1188,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                                 },
                                                 "math_group_type_index": {
@@ -1273,7 +1220,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                                 },
                                                 "math_hogql": {
@@ -1285,7 +1231,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                                 },
                                                 "math_property": {
@@ -1297,7 +1242,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                                 },
                                                 "properties": {
@@ -1316,8 +1260,7 @@
                                                                             {
                                                                                 "type": "null"
                                                                             }
-                                                                        ],
-                                                                        "default": null
+                                                                        ]
                                                                     },
                                                                     "operator": {
                                                                         "anyOf": [
@@ -1402,8 +1345,7 @@
                                                                             {
                                                                                 "type": "null"
                                                                             }
-                                                                        ],
-                                                                        "default": null
+                                                                        ]
                                                                     }
                                                                 },
                                                                 "required": ["key"],
@@ -1415,7 +1357,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Event property filters to narrow which events are counted."
                                                 }
                                             },
@@ -1428,7 +1369,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For funnel metrics: array of EventsNode/ActionsNode steps."
                             },
                             "source": {
@@ -1444,7 +1384,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -1456,7 +1395,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -1483,7 +1421,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -1516,7 +1453,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -1528,7 +1464,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -1540,7 +1475,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -1559,8 +1493,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -1645,8 +1578,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -1658,7 +1590,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -1669,7 +1600,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: event source."
                             },
                             "start_event": {
@@ -1685,7 +1615,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -1697,7 +1626,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -1724,7 +1652,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -1757,7 +1684,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -1769,7 +1695,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -1781,7 +1706,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -1800,8 +1724,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -1886,8 +1809,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -1899,7 +1821,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -1910,7 +1831,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For retention metrics: start event."
                             },
                             "start_handling": {
@@ -1922,8 +1842,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "upper_bound_percentile": {
                                 "anyOf": [
@@ -1936,7 +1855,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). Per-user values above this percentile are clamped to it before aggregation."
                             },
                             "uuid": {
@@ -1948,7 +1866,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Unique identifier. Auto-generated if omitted."
                             }
                         },
@@ -1982,7 +1899,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -1994,7 +1910,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -2021,7 +1936,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -2054,7 +1968,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -2066,7 +1979,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -2078,7 +1990,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -2097,8 +2008,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -2183,8 +2093,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -2196,7 +2105,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -2207,7 +2115,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For retention metrics: completion event."
                             },
                             "conversion_window": {
@@ -2219,7 +2126,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Conversion window duration."
                             },
                             "denominator": {
@@ -2235,7 +2141,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -2247,7 +2152,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -2274,7 +2178,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -2307,7 +2210,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -2319,7 +2221,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -2331,7 +2232,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -2350,8 +2250,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -2436,8 +2335,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -2449,7 +2347,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -2460,7 +2357,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: denominator source."
                             },
                             "denominator_outlier_handling": {
@@ -2475,8 +2371,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "lower_bound_percentile": {
                                                 "anyOf": [
@@ -2489,7 +2384,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile)."
                                             },
                                             "upper_bound_percentile": {
@@ -2503,7 +2397,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile)."
                                             }
                                         },
@@ -2513,7 +2406,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: winsorization applied to the denominator aggregate. Leave unset for a binomial-style denominator, which is never clamped."
                             },
                             "goal": {
@@ -2526,7 +2418,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Whether higher or lower values indicate success."
                             },
                             "ignore_zeros": {
@@ -2538,7 +2429,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: exclude zero values when computing the winsorization percentile thresholds."
                             },
                             "kind": {
@@ -2557,7 +2447,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). Per-user values below this percentile are clamped to it before aggregation."
                             },
                             "metric_type": {
@@ -2573,7 +2462,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Human-readable metric name."
                             },
                             "numerator": {
@@ -2589,7 +2477,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -2601,7 +2488,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -2628,7 +2514,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -2661,7 +2546,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -2673,7 +2557,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -2685,7 +2568,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -2704,8 +2586,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -2790,8 +2671,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -2803,7 +2683,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -2814,7 +2693,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: numerator source."
                             },
                             "numerator_outlier_handling": {
@@ -2829,8 +2707,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "lower_bound_percentile": {
                                                 "anyOf": [
@@ -2843,7 +2720,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile)."
                                             },
                                             "upper_bound_percentile": {
@@ -2857,7 +2733,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile)."
                                             }
                                         },
@@ -2867,7 +2742,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: winsorization applied to the numerator aggregate, independently of the denominator and each with its own percentile thresholds."
                             },
                             "retention_window_end": {
@@ -2878,8 +2752,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "retention_window_start": {
                                 "anyOf": [
@@ -2889,8 +2762,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "retention_window_unit": {
                                 "anyOf": [
@@ -2901,8 +2773,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "series": {
                                 "anyOf": [
@@ -2918,7 +2789,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                                 },
                                                 "id": {
@@ -2930,7 +2800,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Action ID. Required for ActionsNode."
                                                 },
                                                 "kind": {
@@ -2957,7 +2826,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                                 },
                                                 "math_group_type_index": {
@@ -2990,7 +2858,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                                 },
                                                 "math_hogql": {
@@ -3002,7 +2869,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                                 },
                                                 "math_property": {
@@ -3014,7 +2880,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                                 },
                                                 "properties": {
@@ -3033,8 +2898,7 @@
                                                                             {
                                                                                 "type": "null"
                                                                             }
-                                                                        ],
-                                                                        "default": null
+                                                                        ]
                                                                     },
                                                                     "operator": {
                                                                         "anyOf": [
@@ -3119,8 +2983,7 @@
                                                                             {
                                                                                 "type": "null"
                                                                             }
-                                                                        ],
-                                                                        "default": null
+                                                                        ]
                                                                     }
                                                                 },
                                                                 "required": ["key"],
@@ -3132,7 +2995,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Event property filters to narrow which events are counted."
                                                 }
                                             },
@@ -3145,7 +3007,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For funnel metrics: array of EventsNode/ActionsNode steps."
                             },
                             "source": {
@@ -3161,7 +3022,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -3173,7 +3033,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -3200,7 +3059,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -3233,7 +3091,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -3245,7 +3102,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -3257,7 +3113,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -3276,8 +3131,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -3362,8 +3216,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -3375,7 +3228,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -3386,7 +3238,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: event source."
                             },
                             "start_event": {
@@ -3402,7 +3253,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -3414,7 +3264,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -3441,7 +3290,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -3474,7 +3322,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -3486,7 +3333,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -3498,7 +3344,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -3517,8 +3362,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -3603,8 +3447,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -3616,7 +3459,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -3627,7 +3469,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For retention metrics: start event."
                             },
                             "start_handling": {
@@ -3639,8 +3480,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "upper_bound_percentile": {
                                 "anyOf": [
@@ -3653,7 +3493,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). Per-user values above this percentile are clamped to it before aggregation."
                             },
                             "uuid": {
@@ -3665,7 +3504,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Unique identifier. Auto-generated if omitted."
                             }
                         },
@@ -3704,7 +3542,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis."
                         },
                         "feature_flag_variants": {
@@ -3725,7 +3562,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Human-readable variant name."
                                             },
                                             "rollout_percentage": {
@@ -3736,8 +3572,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "split_percent": {
                                                 "anyOf": [
@@ -3748,7 +3583,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Percentage of users assigned to this variant (0–100). All variants must sum to 100. One of split_percent (recommended) or rollout_percentage must be provided."
                                             }
                                         },
@@ -3761,7 +3595,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
                         },
                         "minimum_detectable_effect": {
@@ -3773,7 +3606,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Minimum detectable effect as a percentage. Lower values need more users but catch smaller changes. Suggest 20–30% for most experiments."
                         },
                         "rollout_percentage": {
@@ -3785,7 +3617,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Overall rollout percentage (0-100). Controls what fraction of all users enter the experiment. Users outside the rollout never see any variant and are excluded from analysis. Default: 100."
                         }
                     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
@@ -79,7 +79,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -91,7 +90,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -118,7 +116,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -151,7 +148,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -163,7 +159,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -175,7 +170,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -194,8 +188,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -280,8 +273,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -293,7 +285,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -304,7 +295,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For retention metrics: completion event."
                             },
                             "conversion_window": {
@@ -316,7 +306,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Conversion window duration."
                             },
                             "denominator": {
@@ -332,7 +321,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -344,7 +332,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -371,7 +358,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -404,7 +390,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -416,7 +401,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -428,7 +412,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -447,8 +430,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -533,8 +515,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -546,7 +527,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -557,7 +537,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: denominator source."
                             },
                             "denominator_outlier_handling": {
@@ -572,8 +551,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "lower_bound_percentile": {
                                                 "anyOf": [
@@ -586,7 +564,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile)."
                                             },
                                             "upper_bound_percentile": {
@@ -600,7 +577,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile)."
                                             }
                                         },
@@ -610,7 +586,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: winsorization applied to the denominator aggregate. Leave unset for a binomial-style denominator, which is never clamped."
                             },
                             "goal": {
@@ -623,7 +598,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Whether higher or lower values indicate success."
                             },
                             "ignore_zeros": {
@@ -635,7 +609,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: exclude zero values when computing the winsorization percentile thresholds."
                             },
                             "kind": {
@@ -654,7 +627,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). Per-user values below this percentile are clamped to it before aggregation."
                             },
                             "metric_type": {
@@ -670,7 +642,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Human-readable metric name."
                             },
                             "numerator": {
@@ -686,7 +657,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -698,7 +668,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -725,7 +694,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -758,7 +726,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -770,7 +737,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -782,7 +748,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -801,8 +766,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -887,8 +851,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -900,7 +863,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -911,7 +873,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: numerator source."
                             },
                             "numerator_outlier_handling": {
@@ -926,8 +887,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "lower_bound_percentile": {
                                                 "anyOf": [
@@ -940,7 +900,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile)."
                                             },
                                             "upper_bound_percentile": {
@@ -954,7 +913,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile)."
                                             }
                                         },
@@ -964,7 +922,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: winsorization applied to the numerator aggregate, independently of the denominator and each with its own percentile thresholds."
                             },
                             "retention_window_end": {
@@ -975,8 +932,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "retention_window_start": {
                                 "anyOf": [
@@ -986,8 +942,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "retention_window_unit": {
                                 "anyOf": [
@@ -998,8 +953,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "series": {
                                 "anyOf": [
@@ -1015,7 +969,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                                 },
                                                 "id": {
@@ -1027,7 +980,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Action ID. Required for ActionsNode."
                                                 },
                                                 "kind": {
@@ -1054,7 +1006,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                                 },
                                                 "math_group_type_index": {
@@ -1087,7 +1038,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                                 },
                                                 "math_hogql": {
@@ -1099,7 +1049,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                                 },
                                                 "math_property": {
@@ -1111,7 +1060,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                                 },
                                                 "properties": {
@@ -1130,8 +1078,7 @@
                                                                             {
                                                                                 "type": "null"
                                                                             }
-                                                                        ],
-                                                                        "default": null
+                                                                        ]
                                                                     },
                                                                     "operator": {
                                                                         "anyOf": [
@@ -1216,8 +1163,7 @@
                                                                             {
                                                                                 "type": "null"
                                                                             }
-                                                                        ],
-                                                                        "default": null
+                                                                        ]
                                                                     }
                                                                 },
                                                                 "required": ["key"],
@@ -1229,7 +1175,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Event property filters to narrow which events are counted."
                                                 }
                                             },
@@ -1242,7 +1187,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For funnel metrics: array of EventsNode/ActionsNode steps."
                             },
                             "source": {
@@ -1258,7 +1202,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -1270,7 +1213,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -1297,7 +1239,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -1330,7 +1271,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -1342,7 +1282,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -1354,7 +1293,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -1373,8 +1311,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -1459,8 +1396,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -1472,7 +1408,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -1483,7 +1418,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: event source."
                             },
                             "start_event": {
@@ -1499,7 +1433,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -1511,7 +1444,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -1538,7 +1470,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -1571,7 +1502,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -1583,7 +1513,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -1595,7 +1524,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -1614,8 +1542,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -1700,8 +1627,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -1713,7 +1639,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -1724,7 +1649,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For retention metrics: start event."
                             },
                             "start_handling": {
@@ -1736,8 +1660,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "upper_bound_percentile": {
                                 "anyOf": [
@@ -1750,7 +1673,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). Per-user values above this percentile are clamped to it before aggregation."
                             },
                             "uuid": {
@@ -1762,7 +1684,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Unique identifier. Auto-generated if omitted."
                             }
                         },
@@ -1796,7 +1717,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -1808,7 +1728,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -1835,7 +1754,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -1868,7 +1786,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -1880,7 +1797,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -1892,7 +1808,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -1911,8 +1826,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -1997,8 +1911,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -2010,7 +1923,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -2021,7 +1933,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For retention metrics: completion event."
                             },
                             "conversion_window": {
@@ -2033,7 +1944,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Conversion window duration."
                             },
                             "denominator": {
@@ -2049,7 +1959,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -2061,7 +1970,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -2088,7 +1996,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -2121,7 +2028,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -2133,7 +2039,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -2145,7 +2050,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -2164,8 +2068,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -2250,8 +2153,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -2263,7 +2165,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -2274,7 +2175,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: denominator source."
                             },
                             "denominator_outlier_handling": {
@@ -2289,8 +2189,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "lower_bound_percentile": {
                                                 "anyOf": [
@@ -2303,7 +2202,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile)."
                                             },
                                             "upper_bound_percentile": {
@@ -2317,7 +2215,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile)."
                                             }
                                         },
@@ -2327,7 +2224,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: winsorization applied to the denominator aggregate. Leave unset for a binomial-style denominator, which is never clamped."
                             },
                             "goal": {
@@ -2340,7 +2236,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Whether higher or lower values indicate success."
                             },
                             "ignore_zeros": {
@@ -2352,7 +2247,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: exclude zero values when computing the winsorization percentile thresholds."
                             },
                             "kind": {
@@ -2371,7 +2265,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). Per-user values below this percentile are clamped to it before aggregation."
                             },
                             "metric_type": {
@@ -2387,7 +2280,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Human-readable metric name."
                             },
                             "numerator": {
@@ -2403,7 +2295,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -2415,7 +2306,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -2442,7 +2332,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -2475,7 +2364,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -2487,7 +2375,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -2499,7 +2386,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -2518,8 +2404,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -2604,8 +2489,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -2617,7 +2501,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -2628,7 +2511,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: numerator source."
                             },
                             "numerator_outlier_handling": {
@@ -2643,8 +2525,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "lower_bound_percentile": {
                                                 "anyOf": [
@@ -2657,7 +2538,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile)."
                                             },
                                             "upper_bound_percentile": {
@@ -2671,7 +2551,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile)."
                                             }
                                         },
@@ -2681,7 +2560,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For ratio metrics: winsorization applied to the numerator aggregate, independently of the denominator and each with its own percentile thresholds."
                             },
                             "retention_window_end": {
@@ -2692,8 +2570,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "retention_window_start": {
                                 "anyOf": [
@@ -2703,8 +2580,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "retention_window_unit": {
                                 "anyOf": [
@@ -2715,8 +2591,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "series": {
                                 "anyOf": [
@@ -2732,7 +2607,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                                 },
                                                 "id": {
@@ -2744,7 +2618,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Action ID. Required for ActionsNode."
                                                 },
                                                 "kind": {
@@ -2771,7 +2644,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                                 },
                                                 "math_group_type_index": {
@@ -2804,7 +2676,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                                 },
                                                 "math_hogql": {
@@ -2816,7 +2687,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                                 },
                                                 "math_property": {
@@ -2828,7 +2698,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                                 },
                                                 "properties": {
@@ -2847,8 +2716,7 @@
                                                                             {
                                                                                 "type": "null"
                                                                             }
-                                                                        ],
-                                                                        "default": null
+                                                                        ]
                                                                     },
                                                                     "operator": {
                                                                         "anyOf": [
@@ -2933,8 +2801,7 @@
                                                                             {
                                                                                 "type": "null"
                                                                             }
-                                                                        ],
-                                                                        "default": null
+                                                                        ]
                                                                     }
                                                                 },
                                                                 "required": ["key"],
@@ -2946,7 +2813,6 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "default": null,
                                                     "description": "Event property filters to narrow which events are counted."
                                                 }
                                             },
@@ -2959,7 +2825,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For funnel metrics: array of EventsNode/ActionsNode steps."
                             },
                             "source": {
@@ -2975,7 +2840,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -2987,7 +2851,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -3014,7 +2877,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -3047,7 +2909,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -3059,7 +2920,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -3071,7 +2931,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -3090,8 +2949,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -3176,8 +3034,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -3189,7 +3046,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -3200,7 +3056,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: event source."
                             },
                             "start_event": {
@@ -3216,7 +3071,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event name, e.g. '$pageview'. Required for EventsNode."
                                             },
                                             "id": {
@@ -3228,7 +3082,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Action ID. Required for ActionsNode."
                                             },
                                             "kind": {
@@ -3255,7 +3108,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'."
                                             },
                                             "math_group_type_index": {
@@ -3288,7 +3140,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Group type index to aggregate over. Required when math is 'unique_group'."
                                             },
                                             "math_hogql": {
@@ -3300,7 +3151,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum."
                                             },
                                             "math_property": {
@@ -3312,7 +3162,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue')."
                                             },
                                             "properties": {
@@ -3331,8 +3180,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 },
                                                                 "operator": {
                                                                     "anyOf": [
@@ -3417,8 +3265,7 @@
                                                                         {
                                                                             "type": "null"
                                                                         }
-                                                                    ],
-                                                                    "default": null
+                                                                    ]
                                                                 }
                                                             },
                                                             "required": ["key"],
@@ -3430,7 +3277,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Event property filters to narrow which events are counted."
                                             }
                                         },
@@ -3441,7 +3287,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For retention metrics: start event."
                             },
                             "start_handling": {
@@ -3453,8 +3298,7 @@
                                     {
                                         "type": "null"
                                     }
-                                ],
-                                "default": null
+                                ]
                             },
                             "upper_bound_percentile": {
                                 "anyOf": [
@@ -3467,7 +3311,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "For mean metrics: winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). Per-user values above this percentile are clamped to it before aggregation."
                             },
                             "uuid": {
@@ -3479,7 +3322,6 @@
                                         "type": "null"
                                     }
                                 ],
-                                "default": null,
                                 "description": "Unique identifier. Auto-generated if omitted."
                             }
                         },
@@ -3515,7 +3357,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis."
                         },
                         "feature_flag_variants": {
@@ -3536,7 +3377,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Human-readable variant name."
                                             },
                                             "rollout_percentage": {
@@ -3547,8 +3387,7 @@
                                                     {
                                                         "type": "null"
                                                     }
-                                                ],
-                                                "default": null
+                                                ]
                                             },
                                             "split_percent": {
                                                 "anyOf": [
@@ -3559,7 +3398,6 @@
                                                         "type": "null"
                                                     }
                                                 ],
-                                                "default": null,
                                                 "description": "Percentage of users assigned to this variant (0–100). All variants must sum to 100. One of split_percent (recommended) or rollout_percentage must be provided."
                                             }
                                         },
@@ -3572,7 +3410,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20."
                         },
                         "minimum_detectable_effect": {
@@ -3584,7 +3421,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Minimum detectable effect as a percentage. Lower values need more users but catch smaller changes. Suggest 20–30% for most experiments."
                         },
                         "rollout_percentage": {
@@ -3596,7 +3432,6 @@
                                     "type": "null"
                                 }
                             ],
-                            "default": null,
                             "description": "Overall rollout percentage (0-100). Controls what fraction of all users enter the experiment. Users outside the rollout never see any variant and are excluded from analysis. Default: 100."
                         }
                     },

--- a/services/mcp/tests/unit/experiments-metric-null-injection.test.ts
+++ b/services/mcp/tests/unit/experiments-metric-null-injection.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Runtime regression test for the metric null-injection bug.
+ *
+ * The generated zod for `metrics` is one flattened object holding every
+ * metric-type field, each carrying `.default(null)`. In tool mode the server
+ * runs `schema.safeParse(args)`, so zod fills every omitted field with `null`.
+ * A clean mean metric then arrives at the API with `series`, `numerator`,
+ * `denominator`, `completion_event`, `retention_window_*`, … all set to null,
+ * and the backend (pydantic `extra="forbid"`) rejects them as `extra_forbidden`.
+ *
+ * These tests parse a minimal, valid metric and assert the parser does NOT
+ * invent fields the caller never sent.
+ */
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { GENERATED_TOOLS } from '@/tools/generated/experiments'
+import type { ToolBase, ZodObjectAny } from '@/tools/types'
+
+function updateSchema(): z.ZodTypeAny {
+    const factory = GENERATED_TOOLS['experiment-update'] as () => ToolBase<ZodObjectAny>
+    return factory().schema as z.ZodTypeAny
+}
+
+/** Keys present-and-null in `parsed` that were absent from `sent` — i.e. invented by zod. */
+function injectedNullKeys(sent: Record<string, unknown>, parsed: Record<string, unknown>): string[] {
+    return Object.entries(parsed)
+        .filter(([k, v]) => v === null && !(k in sent))
+        .map(([k]) => k)
+        .sort()
+}
+
+const CLEAN_METRICS: Array<[string, Record<string, unknown>]> = [
+    [
+        'mean',
+        {
+            kind: 'ExperimentMetric',
+            metric_type: 'mean',
+            name: 'clean mean',
+            source: { kind: 'EventsNode', event: '$pageview', math: 'total' },
+        },
+    ],
+    [
+        'funnel',
+        {
+            kind: 'ExperimentMetric',
+            metric_type: 'funnel',
+            name: 'clean funnel',
+            series: [{ kind: 'EventsNode', event: '$pageview' }],
+        },
+    ],
+    [
+        'ratio',
+        {
+            kind: 'ExperimentMetric',
+            metric_type: 'ratio',
+            name: 'clean ratio',
+            numerator: { kind: 'EventsNode', event: '$pageview', math: 'total' },
+            denominator: { kind: 'EventsNode', event: '$pageview', math: 'total' },
+        },
+    ],
+    [
+        'retention',
+        {
+            kind: 'ExperimentMetric',
+            metric_type: 'retention',
+            name: 'clean retention',
+            start_event: { kind: 'EventsNode', event: '$pageview' },
+            completion_event: { kind: 'EventsNode', event: '$pageview' },
+            retention_window_start: 0,
+            retention_window_end: 7,
+            retention_window_unit: 'day',
+            start_handling: 'first_seen',
+        },
+    ],
+]
+
+describe('experiment-update metric null injection', () => {
+    it.each(CLEAN_METRICS)('does not inject foreign null fields into a %s metric', (_type, metric) => {
+        const parsed = updateSchema().parse({ id: 123, metrics: [metric] }) as Record<string, unknown>
+        const parsedMetric = (parsed.metrics as Record<string, unknown>[])[0]!
+        expect(injectedNullKeys(metric, parsedMetric)).toEqual([])
+    })
+
+    it('still preserves explicit nulls the caller sends', () => {
+        // conversion_window is a valid mean field; an explicit null must survive.
+        const metric = {
+            kind: 'ExperimentMetric',
+            metric_type: 'mean',
+            name: 'explicit null',
+            source: { kind: 'EventsNode', event: '$pageview', math: 'total' },
+            conversion_window: null,
+        }
+        const parsed = updateSchema().parse({ id: 123, metrics: [metric] }) as Record<string, unknown>
+        const parsedMetric = (parsed.metrics as Record<string, unknown>[])[0]!
+        expect(parsedMetric).toHaveProperty('conversion_window', null)
+    })
+})


### PR DESCRIPTION
## Problem

In "tools" mode the MCP server validates arguments with `schema.safeParse(...)`, which applies Zod defaults. Nullable-optional fields carried `.default(null)` (from the OpenAPI codegen), so any field the caller omitted was filled with `null`.

For experiment metrics, a discriminated union where each variant forbids unknown fields, this meant a clean metric arrived with every other variant's fields set to null and was rejected as `extra_forbidden`. Adding/updating a metric via `experiment-update` failed for tool-mode clients.

The `stripNullDefaults` codegen step that should prevent this only handled OpenAPI 3.0 `nullable: true`, missing the 3.1 `anyOf: [..., { type: "null" }]` shape pydantic emits.

## Changes

- Extend `stripNullDefaults` to match all nullability shapes
- Regenerate the affected Zod schemas + snapshots. Omitted nullable fields now stay omitted, explicit nulls still parse
- Add a runtime regression test across all four metric types

## How did you test this code?

- Runtime before/after test for experiment metrics: before, all four metric types inject foreign nulls; after, none do and explicit nulls are preserved
- Full MCP unit suite green (1376/1376); `tsc` clean
- Diff audit: only `default: null` removals — zero `required` additions, zero `.default(...)` additions

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Root-cause fix in the codegen; rejected backend `extra="ignore"` and handler-level null-stripping as treating the symptom. Agent-authored; requires human review.
