### PR TITLE
chore(hogql): failing test for aliased events predicate pushdown alias leak

### DIFF
--- a/posthog/hogql/transforms/test/test_events_predicate_pushdown.py
+++ b/posthog/hogql/transforms/test/test_events_predicate_pushdown.py
@@ -49,6 +49,34 @@ class TestEventsPredicatePushdownTransform(BaseTest):
         )
         assert printed == self.snapshot
 
+    def test_aliased_events_pushdown_does_not_reference_outer_alias_in_subquery(self):
+        # Regression for the aliased-events pushdown bug.
+        #
+        # When the events table is aliased (FROM events AS e), the predicate pushed into
+        # the wrapping subquery must be scoped to the inner `events` table, not to the
+        # outer subquery alias `e`. The alias `e` only exists in the outer query's scope;
+        # inside `FROM events` it is an unknown identifier, so a leaked reference like
+        # `e.timestamp` produces SQL that ClickHouse rejects at runtime ("Unknown
+        # identifier e.timestamp"). The printer renders a field from its resolved type,
+        # not its chain, so stripping the chain prefix alone is not enough.
+        printed = self._print_select(
+            "SELECT e.event, session.$session_duration FROM events AS e WHERE e.timestamp >= '2024-01-01'"
+        )
+
+        # Isolate the pushed-down events subquery: `FROM ( <subquery> ) AS e LEFT JOIN ...`
+        assert "FROM (" in printed and ") AS e LEFT JOIN" in printed, printed
+        events_subquery = printed.split("FROM (", 1)[1].split(") AS e LEFT JOIN", 1)[0]
+
+        # The timestamp predicate was pushed into this subquery; it must reference the
+        # inner `events` table, never the outer alias `e`.
+        assert "e.timestamp" not in events_subquery, (
+            "predicate pushdown leaked the outer table alias `e` into the events subquery "
+            "(`e` is out of scope inside `FROM events`):\n" + events_subquery
+        )
+        assert "events.timestamp" in events_subquery, (
+            "expected the pushed-down predicate to reference the inner `events` table:\n" + events_subquery
+        )
+
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_events_without_join_no_pushdown(self):
         """No pushdown when there are no lazy joins."""


### PR DESCRIPTION
## Problem

This is the **red** half of a red/green pair for a correctness bug found while reviewing the predicate-pushdown work in #45786.

When the events table is **aliased** (`FROM events AS e`), `EventsPredicatePushdownTransform` wraps it in a pre-filtering subquery but leaves the pushed-down predicate referencing the **outer** alias inside the subquery:

```sql
SELECT e.event AS event, e__session.`$session_duration` AS `$session_duration`
FROM (
  SELECT events.`$session_id` AS `$session_id`, events.event AS event
  FROM events
  WHERE and(equals(events.team_id, 420),
            greaterOrEquals(toTimeZone(e.timestamp, …), …))   -- ⚠️ e.timestamp
) AS e LEFT JOIN ( … ) AS e__session ON …
```

Inside `FROM events` the alias `e` does not exist (it only names the subquery in the *outer* scope), so `e.timestamp` is an unknown identifier and ClickHouse rejects the query at runtime. The non-aliased path works only because the field type happens to point at table `events`, which collides with the auto-generated subquery alias.

Root cause: the ClickHouse printer renders a field from its resolved **type** (`FieldType.table_type`), not its chain. `TableAliasPrefixRemover` rewrites only the chain, and `TypeRewriter` re-points a field's type only when the column is in `columns_in_scope` (the projected columns). A column that is filtered-but-not-selected (the common date filter) is never re-typed, so it keeps the outer-alias type and prints `e.timestamp`.

This is invisible today because the transform's tests are **string snapshot tests** that never execute the generated SQL — the buggy output is even baked into `test_events_with_alias_and_session_join.ambr` as the expected snapshot.

## Changes

Adds one focused regression test, `test_aliased_events_pushdown_does_not_reference_outer_alias_in_subquery`, that:

- prints the aliased query with `pushDownPredicates=True`,
- isolates the generated events subquery, and
- asserts the pushed-down predicate references the inner `events` table (`events.timestamp`) and **not** the outer alias (`e.timestamp`).

It **fails on the current code** (red) and will pass once the alias is rewritten to the inner table type (green). No production code is changed.

## How did you test this code?

I could not run the suite in this environment (no Docker → no Postgres/ClickHouse, and Python `==3.12.12` isn't available as a `python-build-standalone` build here). Instead I verified the test is red by replaying its exact string logic against the committed `_print_select` output recorded in `test_events_predicate_pushdown.ambr`:

- isolated events subquery → `… WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(e.timestamp, …), …))`
- `"e.timestamp" not in events_subquery` → **False** → assertion fails ✅ (red)
- `"events.timestamp" in events_subquery` → **False** → assertion fails ✅ (red)

Please run `pytest posthog/hogql/transforms/test/test_events_predicate_pushdown.py::TestEventsPredicatePushdownTransform::test_aliased_events_pushdown_does_not_reference_outer_alias_in_subquery` in a full environment to confirm red, then implement the fix to turn it green.

## Publish to changelog?

no

## 🤖 Agent context

Opened as a **draft** against the feature branch `pawel/feat/hogql/push-events-predicate-down-transform` (not `master`) so the test stacks directly on the PR it concerns (#45786). This is intentionally a failing-only ("red") test — it documents and pins the aliased-events alias-leak bug surfaced during a multi-agent QA review of #45786. The suggested fix is to make the alias rewrite operate on the field **type** for every events-table field in the pushed predicate (not only columns in `columns_in_scope`), so the inner subquery references the inner `events` table. A companion concern worth covering in the same fix: columns referenced only in the (already-split-out) WHERE/PREWHERE are never collected/projected, which is the mechanism that leaves them mis-typed.

https://claude.ai/code/session_01FX1yPnh6w3dLhLsynx618g

---
_Generated by [Claude Code](https://claude.ai/code/session_01FX1yPnh6w3dLhLsynx618g)_