### PR TITLE
feat(data-warehouse): drop auto paginator, mark custom source alpha

### DIFF
--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_valida
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -205,7 +206,7 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.CUSTOM,
             label="Custom REST source",
-            releaseStatus="alpha",
+            releaseStatus=ReleaseStatus.ALPHA,
             caption=(
                 "Set up a source using custom configured mappings. "
                 "Define a REST API source by providing a manifest that follows the same shape "

--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -205,6 +205,7 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.CUSTOM,
             label="Custom REST source",
+            releaseStatus="alpha",
             caption=(
                 "Set up a source using custom configured mappings. "
                 "Define a REST API source by providing a manifest that follows the same shape "

--- a/products/data_warehouse/frontend/shared/components/forms/CustomSourceManifestBuilder.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/CustomSourceManifestBuilder.tsx
@@ -32,7 +32,6 @@ import {
 // customSourceManifest.ts; only the labels live here, so the allowed values can't
 // drift between the type, the parser, and these selects.
 const PAGINATOR_LABELS: Record<PaginatorType, string> = {
-    auto: 'Auto-detect',
     single_page: 'Single page (no pagination)',
     json_response: 'JSON body next-URL',
     cursor: 'Cursor in JSON body',
@@ -375,7 +374,6 @@ function PaginatorSection({
 }): JSX.Element {
     const switchType = (type: Paginator['type']): void => {
         switch (type) {
-            case 'auto':
             case 'single_page':
                 onUpdate({ type })
                 return

--- a/products/data_warehouse/frontend/shared/components/forms/__tests__/customSourceManifest.test.ts
+++ b/products/data_warehouse/frontend/shared/components/forms/__tests__/customSourceManifest.test.ts
@@ -227,13 +227,6 @@ describe('buildManifest', () => {
         const desc = buildManifest(descState) as any
         expect(desc.resources[0].sort_mode).toBe('desc')
     })
-
-    it('serializes the auto paginator to type-only', () => {
-        const state = baseState()
-        state.streams[0].paginator = { type: 'auto' }
-        const manifest = buildManifest(state) as any
-        expect(manifest.resources[0].endpoint.paginator).toEqual({ type: 'auto' })
-    })
 })
 
 describe('parseManifestIntoState', () => {
@@ -335,13 +328,16 @@ describe('parseManifestIntoState', () => {
         expect(state.auth_api_key_location).toBe('query')
     })
 
-    it('parses the auto paginator type when the manifest declares it', () => {
+    it("folds a legacy 'auto' paginator to single_page on parse", () => {
+        // 'auto' was a no-op alias for single_page (it mapped to no paginator on
+        // the backend) and is no longer offered. Manifests authored before it was
+        // removed should still parse without surfacing the dead type.
         const manifestJson = JSON.stringify({
             client: { base_url: 'https://x' },
             resources: [{ name: 'r', endpoint: { path: '/r', paginator: { type: 'auto' } } }],
         })
         const state = parseManifestIntoState(manifestJson)
-        expect(state.streams[0].paginator.type).toBe('auto')
+        expect(state.streams[0].paginator.type).toBe('single_page')
     })
 
     it.each(['date', 'timestamp', 'integer'] as const)(
@@ -397,7 +393,7 @@ describe('parseManifestIntoState', () => {
                 method: 'GET',
                 data_selector: 'data',
                 primary_key: 'id',
-                paginator: { type: 'auto' },
+                paginator: { type: 'single_page' },
                 sort_mode: 'desc',
                 incremental_enabled: true,
                 cursor_path: 'updated_at',

--- a/products/data_warehouse/frontend/shared/components/forms/customSourceManifest.ts
+++ b/products/data_warehouse/frontend/shared/components/forms/customSourceManifest.ts
@@ -16,7 +16,6 @@ export const API_KEY_LOCATIONS = ['header', 'query', 'cookie'] as const
 export type ApiKeyLocation = (typeof API_KEY_LOCATIONS)[number]
 
 export const PAGINATOR_TYPES = [
-    'auto',
     'single_page',
     'json_response',
     'cursor',
@@ -27,7 +26,6 @@ export const PAGINATOR_TYPES = [
 export type PaginatorType = (typeof PAGINATOR_TYPES)[number]
 
 export type Paginator =
-    | { type: 'auto' }
     | { type: 'single_page' }
     | { type: 'json_response'; next_url_path?: string }
     | { type: 'cursor'; cursor_path?: string; cursor_param?: string }
@@ -241,8 +239,6 @@ export function extractAuthSecrets(state: ManifestState): AuthSecrets {
 
 function serializePaginator(paginator: Paginator): Record<string, unknown> {
     switch (paginator.type) {
-        case 'auto':
-            return { type: 'auto' }
         case 'json_response':
             return {
                 type: 'json_response',


### PR DESCRIPTION
## Problem

The Custom REST source's manifest builder offered an **"Auto-detect"** paginator option, but it doesn't actually auto-detect anything. On the backend it maps to `None` in the shared `rest_source` framework (`config_setup.py`), and a `None` paginator makes the REST client fetch a single page and stop — so functionally `auto` is identical to `single_page`. The "Auto-detect" label is a holdover from dlt's upstream `RESTClient` (which does sniff the response shape); PostHog's reimplementation dropped that detection. The option is therefore misleading: users picking it expecting multi-page collection get a single page.

Separately, the Custom REST source was shipped without a release tag even though it's brand new and lightly tested — it should be marked **alpha** like other new sources.

## Changes

- **Remove the `auto` paginator option** from the Custom REST source manifest builder (frontend only): dropped from the `PAGINATOR_TYPES` tuple, the `Paginator` union, the UI label/select, and `serializePaginator`.
- **Backward compatibility:** the manifest parser already falls back to `single_page` for any unrecognized paginator type, so manifests previously saved with `type: "auto"` keep working and simply surface as `single_page` in the builder (which matches their actual runtime behavior). Added a regression test for this fold.
- **Left the shared `rest_source` backend untouched** — `auto` there is the dlt-derived framework default used by *all* REST connectors, and it still accepts a legacy `auto` value harmlessly (maps to `None`). Removing it from the framework would be a wider, riskier change and isn't needed to fix the user-facing surface.
- **Mark the Custom REST source as `releaseStatus="alpha"`** so it gets the Alpha tag in the source list, consistent with how other new sources (e.g. TikTok/Reddit/LinkedIn Ads use `beta`) are tagged.

## How did you test this code?

I'm an agent. I ran the automated tests and checks only — no manual UI testing:

- `customSourceManifest.test.ts` jest suite — 50/50 pass, including the new "folds a legacy 'auto' paginator to single_page on parse" regression test.
- `tsc --noEmit` — no errors in the touched frontend files.
- `ruff check` on the backend file — clean.
- Pre-commit hooks (`ty check`, python + js format/lint) passed on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at the request of @MarconLP. The starting point was a question about what "auto mode" in the paginator does; investigation showed it's a no-op alias for `single_page` (backend maps it to `None`, which fetches one page and stops), and that Airbyte's declarative framework has no auto-detect equivalent either — pagination must be declared explicitly.

Key decision: scope the removal to the **frontend builder** rather than the shared `rest_source` backend. The backend `auto` is the dlt framework default shared across every REST connector, so removing it there would be a broader change with cross-connector risk; keeping it means legacy `auto` manifests still run unchanged. The parser's existing unknown-type fallback to `single_page` gives clean backward compatibility for the UI with no migration.
