### PR TITLE
feat(tasks): support dual sandbox JWT keys for zero-downtime rotation

### DIFF
--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -79,6 +79,9 @@ For the safety of your instance, you must generate and set a unique key.
 # Used to sign tokens; public key is derived from this and injected into sandboxes for verification
 SANDBOX_JWT_PRIVATE_KEY: str | None = os.getenv("SANDBOX_JWT_PRIVATE_KEY")
 
+# Additional RS256 private key accepted during key rotation of SANDBOX_JWT_PRIVATE_KEY
+SANDBOX_JWT_PRIVATE_KEY_SECONDARY: str | None = os.getenv("SANDBOX_JWT_PRIVATE_KEY_SECONDARY")
+
 # These are legacy values only kept around for backwards compatibility with self hosted versions
 SALT_KEY = get_list(os.getenv("SALT_KEY", "0123456789abcdefghijklmnopqrstuvwxyz"))
 # We provide a default as it is needed for hobby deployments

--- a/products/tasks/backend/services/connection_token.py
+++ b/products/tasks/backend/services/connection_token.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from functools import lru_cache
@@ -22,6 +23,8 @@ SANDBOX_EVENT_INGEST_AUDIENCE = "posthog:sandbox_event_ingest"
 SANDBOX_EVENT_INGEST_TOKEN_TTL_BUFFER = timedelta(hours=1)
 SANDBOX_EVENT_INGEST_TOKEN_TTL = timedelta(seconds=SANDBOX_TTL_SECONDS) + SANDBOX_EVENT_INGEST_TOKEN_TTL_BUFFER
 
+SANDBOX_JWT_STATE_KID_KEY = "sandbox_jwt_kid"
+
 
 @dataclass(frozen=True)
 class SandboxEventIngestTokenPayload:
@@ -30,26 +33,97 @@ class SandboxEventIngestTokenPayload:
     team_id: int
 
 
+@dataclass(frozen=True)
+class _SandboxJwtKey:
+    kid: str
+    private_key_pem: str
+    public_key_pem: str
+
+
 def _normalize_pem_key(key: str) -> str:
     """Convert escaped newlines to actual newlines in PEM keys from env vars."""
     return key.replace("\\n", "\n")
 
 
+def _derive_public_key_pem(private_key_pem: str) -> str:
+    private_key = serialization.load_pem_private_key(private_key_pem.encode(), password=None, backend=default_backend())
+    return (
+        private_key.public_key()
+        .public_bytes(encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo)
+        .decode()
+    )
+
+
+def _compute_kid(public_key_pem: str) -> str:
+    """Stable short fingerprint of a public key, used as the JWT kid.
+
+    The value is persisted on ``TaskRun.state`` at provision
+    time and matched back when signing that run's tokens.
+    """
+    public_key = serialization.load_pem_public_key(public_key_pem.encode(), backend=default_backend())
+    der = public_key.public_bytes(
+        encoding=serialization.Encoding.DER, format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    return hashlib.sha256(der).hexdigest()[:16]
+
+
+def _build_key(private_key_pem: str) -> _SandboxJwtKey:
+    normalized = _normalize_pem_key(private_key_pem)
+    public_key_pem = _derive_public_key_pem(normalized)
+    return _SandboxJwtKey(kid=_compute_kid(public_key_pem), private_key_pem=normalized, public_key_pem=public_key_pem)
+
+
 @lru_cache(maxsize=1)
-def get_sandbox_jwt_public_key() -> str:
+def _key_registry() -> tuple[_SandboxJwtKey, dict[str, _SandboxJwtKey]]:
+    """Return ``(primary_signing_key, {kid: key})`` for all configured sandbox JWT keys.
+
+    The primary key (``SANDBOX_JWT_PRIVATE_KEY``) signs newly provisioned runs. The
+    optional secondary key (``SANDBOX_JWT_PRIVATE_KEY_SECONDARY``) is additionally
+    trusted for verification and signs runs whose sandbox was provisioned under it,
+    this is what makes zero-downtime rotation of the primary key possible.
     """
-    Derive and cache the public key from the private key.
-    """
-    private_key_pem = settings.SANDBOX_JWT_PRIVATE_KEY
-    if not private_key_pem:
+    primary_pem = settings.SANDBOX_JWT_PRIVATE_KEY
+    if not primary_pem:
         raise ValueError("SANDBOX_JWT_PRIVATE_KEY setting is required")
 
-    private_key_pem = _normalize_pem_key(private_key_pem)
-    private_key = serialization.load_pem_private_key(private_key_pem.encode(), password=None, backend=default_backend())
-    public_key = private_key.public_key()
-    return public_key.public_bytes(
-        encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo
-    ).decode()
+    primary = _build_key(primary_pem)
+    registry: dict[str, _SandboxJwtKey] = {primary.kid: primary}
+
+    secondary_pem = getattr(settings, "SANDBOX_JWT_PRIVATE_KEY_SECONDARY", None)
+    if secondary_pem:
+        secondary = _build_key(secondary_pem)
+        registry.setdefault(secondary.kid, secondary)
+
+    return primary, registry
+
+
+def _primary_key() -> _SandboxJwtKey:
+    return _key_registry()[0]
+
+
+def get_primary_sandbox_jwt_kid() -> str:
+    """``kid`` of the key newly provisioned sandboxes trust.
+
+    Persist this on ``TaskRun.state`` at provision time so the run's tokens are later
+    signed with the matching key even after the primary key is rotated.
+    """
+    return _primary_key().kid
+
+
+def get_sandbox_jwt_public_key() -> str:
+    """Public key (PEM) baked into newly provisioned sandboxes for verifying connection tokens."""
+    return _primary_key().public_key_pem
+
+
+get_sandbox_jwt_public_key.cache_clear = _key_registry.cache_clear  # type: ignore[attr-defined]
+
+
+def _signing_key_for_run(task_run: TaskRun) -> _SandboxJwtKey:
+    _, registry = _key_registry()
+    kid = (task_run.state or {}).get(SANDBOX_JWT_STATE_KID_KEY)
+    if kid and kid in registry:
+        return registry[kid]
+    return _primary_key()
 
 
 def create_sandbox_connection_token(task_run: TaskRun, user_id: int, distinct_id: str) -> str:
@@ -67,11 +141,7 @@ def create_sandbox_connection_token(task_run: TaskRun, user_id: int, distinct_id
     Returns:
         A signed JWT token valid for 24 hours
     """
-    private_key = settings.SANDBOX_JWT_PRIVATE_KEY
-    if not private_key:
-        raise ValueError("SANDBOX_JWT_PRIVATE_KEY setting is required for sandbox connection tokens")
-
-    private_key = _normalize_pem_key(private_key)
+    key = _signing_key_for_run(task_run)
     payload = {
         "run_id": str(task_run.id),
         "task_id": str(task_run.task_id),
@@ -83,7 +153,7 @@ def create_sandbox_connection_token(task_run: TaskRun, user_id: int, distinct_id
         "aud": SANDBOX_CONNECTION_AUDIENCE,
     }
 
-    return jwt.encode(payload, private_key, algorithm="RS256")
+    return jwt.encode(payload, key.private_key_pem, algorithm="RS256", headers={"kid": key.kid})
 
 
 def create_sandbox_event_ingest_token(task_run: TaskRun, ttl: timedelta = SANDBOX_EVENT_INGEST_TOKEN_TTL) -> str:
@@ -93,11 +163,6 @@ def create_sandbox_event_ingest_token(task_run: TaskRun, ttl: timedelta = SANDBO
     This token intentionally carries no user identity and grants one capability:
     appending ordered live events for this task run.
     """
-    private_key = settings.SANDBOX_JWT_PRIVATE_KEY
-    if not private_key:
-        raise ValueError("SANDBOX_JWT_PRIVATE_KEY setting is required for sandbox event ingest tokens")
-
-    private_key = _normalize_pem_key(private_key)
     now = datetime.now(tz=UTC)
     payload = {
         "run_id": str(task_run.id),
@@ -108,13 +173,13 @@ def create_sandbox_event_ingest_token(task_run: TaskRun, ttl: timedelta = SANDBO
         "aud": SANDBOX_EVENT_INGEST_AUDIENCE,
     }
 
-    return jwt.encode(payload, private_key, algorithm="RS256")
+    return jwt.encode(payload, _primary_key().private_key_pem, algorithm="RS256")
 
 
 def validate_sandbox_event_ingest_token(token: str) -> SandboxEventIngestTokenPayload:
     payload = jwt.decode(
         token,
-        get_sandbox_jwt_public_key(),
+        _primary_key().public_key_pem,
         algorithms=["RS256"],
         audience=SANDBOX_EVENT_INGEST_AUDIENCE,
     )

--- a/products/tasks/backend/services/connection_token.py
+++ b/products/tasks/backend/services/connection_token.py
@@ -115,7 +115,9 @@ def get_sandbox_jwt_public_key() -> str:
     return _primary_key().public_key_pem
 
 
-get_sandbox_jwt_public_key.cache_clear = _key_registry.cache_clear  # type: ignore[attr-defined]
+def reset_sandbox_jwt_key_cache() -> None:
+    """Clear the cached key registry. Used by tests after overriding the key settings."""
+    _key_registry.cache_clear()
 
 
 def _signing_key_for_run(task_run: TaskRun) -> _SandboxJwtKey:

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -9,7 +9,11 @@ from temporalio import activity
 from posthog.temporal.common.utils import asyncify
 
 from products.tasks.backend.models import SandboxSnapshot, Task, TaskRun
-from products.tasks.backend.services.connection_token import get_primary_sandbox_jwt_kid, get_sandbox_jwt_public_key
+from products.tasks.backend.services.connection_token import (
+    SANDBOX_JWT_STATE_KID_KEY,
+    get_primary_sandbox_jwt_kid,
+    get_sandbox_jwt_public_key,
+)
 from products.tasks.backend.services.sandbox import (
     Sandbox,
     SandboxConfig,
@@ -321,7 +325,7 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
         sandbox_state = {
             "sandbox_id": sandbox.id,
             "sandbox_url": credentials.url,
-            "sandbox_jwt_kid": get_primary_sandbox_jwt_kid(),
+            SANDBOX_JWT_STATE_KID_KEY: get_primary_sandbox_jwt_kid(),
         }
         if credentials.token:
             sandbox_state["sandbox_connect_token"] = credentials.token

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -9,7 +9,7 @@ from temporalio import activity
 from posthog.temporal.common.utils import asyncify
 
 from products.tasks.backend.models import SandboxSnapshot, Task, TaskRun
-from products.tasks.backend.services.connection_token import get_sandbox_jwt_public_key
+from products.tasks.backend.services.connection_token import get_primary_sandbox_jwt_kid, get_sandbox_jwt_public_key
 from products.tasks.backend.services.sandbox import (
     Sandbox,
     SandboxConfig,
@@ -321,6 +321,7 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
         sandbox_state = {
             "sandbox_id": sandbox.id,
             "sandbox_url": credentials.url,
+            "sandbox_jwt_kid": get_primary_sandbox_jwt_kid(),
         }
         if credentials.token:
             sandbox_state["sandbox_connect_token"] = credentials.token

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -10,7 +10,7 @@ from posthog.temporal.common.utils import asyncify
 
 from products.tasks.backend.models import SandboxSnapshot, Task, TaskRun
 from products.tasks.backend.services.agentsh import ENV_FILE
-from products.tasks.backend.services.connection_token import get_sandbox_jwt_public_key
+from products.tasks.backend.services.connection_token import get_primary_sandbox_jwt_kid, get_sandbox_jwt_public_key
 from products.tasks.backend.services.sandbox import Sandbox, SandboxConfig, SandboxTemplate
 from products.tasks.backend.temporal.exceptions import GitHubAuthenticationError, OAuthTokenError, TaskNotFoundError
 from products.tasks.backend.temporal.metrics import StepTimer, increment_snapshot_usage
@@ -363,6 +363,7 @@ def create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cre
             sandbox_state = {
                 "sandbox_id": sandbox.id,
                 "sandbox_url": credentials.url,
+                "sandbox_jwt_kid": get_primary_sandbox_jwt_kid(),
             }
             if credentials.token:
                 sandbox_state["sandbox_connect_token"] = credentials.token

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -10,7 +10,11 @@ from posthog.temporal.common.utils import asyncify
 
 from products.tasks.backend.models import SandboxSnapshot, Task, TaskRun
 from products.tasks.backend.services.agentsh import ENV_FILE
-from products.tasks.backend.services.connection_token import get_primary_sandbox_jwt_kid, get_sandbox_jwt_public_key
+from products.tasks.backend.services.connection_token import (
+    SANDBOX_JWT_STATE_KID_KEY,
+    get_primary_sandbox_jwt_kid,
+    get_sandbox_jwt_public_key,
+)
 from products.tasks.backend.services.sandbox import Sandbox, SandboxConfig, SandboxTemplate
 from products.tasks.backend.temporal.exceptions import GitHubAuthenticationError, OAuthTokenError, TaskNotFoundError
 from products.tasks.backend.temporal.metrics import StepTimer, increment_snapshot_usage
@@ -363,7 +367,7 @@ def create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cre
             sandbox_state = {
                 "sandbox_id": sandbox.id,
                 "sandbox_url": credentials.url,
-                "sandbox_jwt_kid": get_primary_sandbox_jwt_kid(),
+                SANDBOX_JWT_STATE_KID_KEY: get_primary_sandbox_jwt_kid(),
             }
             if credentials.token:
                 sandbox_state["sandbox_connect_token"] = credentials.token

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -40,7 +40,7 @@ from products.tasks.backend.serializers import (
     TASK_RUN_PDF_ARTIFACT_MAX_SIZE_BYTES,
     TaskAutomationSerializer,
 )
-from products.tasks.backend.services.connection_token import get_sandbox_jwt_public_key
+from products.tasks.backend.services.connection_token import get_sandbox_jwt_public_key, reset_sandbox_jwt_key_cache
 from products.tasks.backend.services.staged_artifacts import (
     RUN_ARTIFACT_TTL_DAYS,
     build_task_artifact_entry,
@@ -4690,7 +4690,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_connection_token_returns_jwt(self):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
 
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
@@ -4717,7 +4717,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_connection_token_has_correct_expiry(self):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
 
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
@@ -4739,7 +4739,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_connection_token_includes_distinct_id(self):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
 
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
@@ -5656,7 +5656,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_rejects_unknown_artifact_ids(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         task = self.create_task()
         run = self._create_run_with_sandbox(task)
 
@@ -5679,7 +5679,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_proxies_cancel(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(
             mock_post,
             {
@@ -5704,7 +5704,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_proxies_close(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(
             mock_post,
             {
@@ -5729,7 +5729,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_proxies_permission_response(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(
             mock_post,
             {"jsonrpc": "2.0", "id": "req-4", "result": {"acknowledged": True}},
@@ -5758,7 +5758,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_proxies_set_config_option(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(
             mock_post,
             {"jsonrpc": "2.0", "id": "req-5", "result": {"updated": True}},
@@ -5850,7 +5850,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_passes_modal_connect_token_as_query_param(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(mock_post, {"jsonrpc": "2.0", "result": {}})
 
         task = self.create_task()
@@ -5874,7 +5874,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_no_query_params_for_docker(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(mock_post, {"jsonrpc": "2.0", "result": {}})
 
         task = self.create_task()
@@ -5893,7 +5893,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_returns_502_on_connection_error(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         mock_post.side_effect = __import__("requests").ConnectionError("Connection refused")
 
         task = self.create_task()
@@ -5911,7 +5911,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_returns_504_on_timeout(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         mock_post.side_effect = __import__("requests").Timeout("Request timed out")
 
         task = self.create_task()
@@ -5929,7 +5929,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_forwards_agent_server_auth_error(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(
             mock_post,
             {"error": "Missing authorization header"},
@@ -5951,7 +5951,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_forwards_agent_server_no_session_error(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(
             mock_post,
             {"error": "No active session for this run"},
@@ -5973,7 +5973,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_sends_jwt_with_correct_claims(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(mock_post, {"jsonrpc": "2.0", "result": {}})
 
         task = self.create_task()
@@ -6005,7 +6005,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_posts_to_correct_url(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(mock_post, {"jsonrpc": "2.0", "result": {}})
 
         task = self.create_task()
@@ -6063,7 +6063,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_with_trailing_slash_sandbox_url(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(mock_post, {"jsonrpc": "2.0", "result": {}})
 
         task = self.create_task()
@@ -6081,7 +6081,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_accepts_numeric_id(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(mock_post, {"jsonrpc": "2.0", "id": 42, "result": {}})
 
         task = self.create_task()
@@ -6100,7 +6100,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_uses_600s_timeout(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(mock_post, {"jsonrpc": "2.0", "result": {}})
 
         task = self.create_task()
@@ -6118,7 +6118,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_omits_params_for_cancel(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(mock_post, {"jsonrpc": "2.0", "result": {"cancelled": True}})
 
         task = self.create_task()
@@ -6174,7 +6174,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_allows_valid_sandbox_urls(self, _name, valid_url, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(mock_post, {"jsonrpc": "2.0", "result": {}})
 
         task = self.create_task()
@@ -6208,7 +6208,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_accepts_id_zero(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self._mock_agent_response(mock_post, {"jsonrpc": "2.0", "id": 0, "result": {}})
 
         task = self.create_task()
@@ -6227,7 +6227,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     @patch("products.tasks.backend.api.http_requests.post")
     def test_command_generic_error_does_not_leak_details(self, mock_post):
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         mock_post.side_effect = RuntimeError("internal DNS resolve failed for secret-host.internal:8080")
 
         task = self.create_task()

--- a/products/tasks/backend/tests/test_connection_token.py
+++ b/products/tasks/backend/tests/test_connection_token.py
@@ -16,6 +16,7 @@ from products.tasks.backend.services.connection_token import (
     create_sandbox_event_ingest_token,
     get_primary_sandbox_jwt_kid,
     get_sandbox_jwt_public_key,
+    reset_sandbox_jwt_key_cache,
     validate_sandbox_event_ingest_token,
 )
 
@@ -47,15 +48,15 @@ def _fake_run(state: dict | None = None) -> SimpleNamespace:
 class TestSandboxJwtRotation(SimpleTestCase):
     def setUp(self) -> None:
         super().setUp()
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
 
     def tearDown(self) -> None:
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         super().tearDown()
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_A, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=None)
     def test_primary_only_signs_and_verifies_with_primary(self) -> None:
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self.assertEqual(get_primary_sandbox_jwt_kid(), KID_A)
 
         token = create_sandbox_connection_token(_fake_run(), user_id=1, distinct_id="d")
@@ -67,7 +68,7 @@ class TestSandboxJwtRotation(SimpleTestCase):
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_B, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=KEY_A)
     def test_connection_token_signed_with_run_stored_kid(self) -> None:
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         # Primary is now KEY_B, but this run's sandbox was provisioned under KEY_A.
         run = _fake_run({SANDBOX_JWT_STATE_KID_KEY: KID_A})
         token = create_sandbox_connection_token(run, user_id=1, distinct_id="d")
@@ -81,13 +82,13 @@ class TestSandboxJwtRotation(SimpleTestCase):
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_A, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=None)
     def test_fallback_to_primary_when_no_kid_stored(self) -> None:
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         token = create_sandbox_connection_token(_fake_run({}), user_id=1, distinct_id="d")
         self.assertEqual(jwt.get_unverified_header(token)["kid"], KID_A)
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_B, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=KEY_A)
     def test_ingest_token_always_uses_primary_ignoring_run_kid(self) -> None:
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         # The ingest path is single-key: it signs/validates with the primary key only and
         # ignores the run's stored kid (unlike the connection token).
         token = create_sandbox_event_ingest_token(_fake_run({SANDBOX_JWT_STATE_KID_KEY: KID_A}))
@@ -99,17 +100,17 @@ class TestSandboxJwtRotation(SimpleTestCase):
         # Ingest is intentionally NOT rotation-safe: a token signed under the old primary
         # stops validating once the primary is rotated, even if the old key is kept as secondary.
         with override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_A, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=None):
-            get_sandbox_jwt_public_key.cache_clear()
+            reset_sandbox_jwt_key_cache()
             token = create_sandbox_event_ingest_token(_fake_run())
 
         with override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_B, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=KEY_A):
-            get_sandbox_jwt_public_key.cache_clear()
+            reset_sandbox_jwt_key_cache()
             with self.assertRaises(jwt.InvalidTokenError):
                 validate_sandbox_event_ingest_token(token)
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_A, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=None)
     def test_connection_token_rejected_as_ingest_token(self) -> None:
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         # A connection-audience token must not pass ingest validation (wrong audience).
         token = create_sandbox_connection_token(_fake_run(), user_id=1, distinct_id="d")
         with self.assertRaises(jwt.InvalidTokenError):
@@ -117,7 +118,7 @@ class TestSandboxJwtRotation(SimpleTestCase):
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_A, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=KEY_A)
     def test_duplicate_primary_and_secondary_collapse_to_one_key(self) -> None:
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         token = create_sandbox_event_ingest_token(_fake_run({SANDBOX_JWT_STATE_KID_KEY: KID_A}))
         payload = validate_sandbox_event_ingest_token(token)
         self.assertEqual(payload.team_id, 1)

--- a/products/tasks/backend/tests/test_connection_token.py
+++ b/products/tasks/backend/tests/test_connection_token.py
@@ -1,0 +1,125 @@
+import uuid
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase, override_settings
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from products.tasks.backend.services.connection_token import (
+    SANDBOX_CONNECTION_AUDIENCE,
+    SANDBOX_JWT_STATE_KID_KEY,
+    _compute_kid,
+    _derive_public_key_pem,
+    create_sandbox_connection_token,
+    create_sandbox_event_ingest_token,
+    get_primary_sandbox_jwt_kid,
+    get_sandbox_jwt_public_key,
+    validate_sandbox_event_ingest_token,
+)
+
+
+def _generate_private_key_pem() -> str:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+
+KEY_A = _generate_private_key_pem()
+KEY_B = _generate_private_key_pem()
+KID_A = _compute_kid(_derive_public_key_pem(KEY_A))
+
+
+def _fake_run(state: dict | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        task_id=uuid.uuid4(),
+        team_id=1,
+        mode="background",
+        state=state if state is not None else {},
+    )
+
+
+class TestSandboxJwtRotation(SimpleTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        get_sandbox_jwt_public_key.cache_clear()
+
+    def tearDown(self) -> None:
+        get_sandbox_jwt_public_key.cache_clear()
+        super().tearDown()
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_A, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=None)
+    def test_primary_only_signs_and_verifies_with_primary(self) -> None:
+        get_sandbox_jwt_public_key.cache_clear()
+        self.assertEqual(get_primary_sandbox_jwt_kid(), KID_A)
+
+        token = create_sandbox_connection_token(_fake_run(), user_id=1, distinct_id="d")
+        decoded = jwt.decode(
+            token, _derive_public_key_pem(KEY_A), algorithms=["RS256"], audience=SANDBOX_CONNECTION_AUDIENCE
+        )
+        self.assertEqual(jwt.get_unverified_header(token)["kid"], KID_A)
+        self.assertEqual(decoded["aud"], SANDBOX_CONNECTION_AUDIENCE)
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_B, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=KEY_A)
+    def test_connection_token_signed_with_run_stored_kid(self) -> None:
+        get_sandbox_jwt_public_key.cache_clear()
+        # Primary is now KEY_B, but this run's sandbox was provisioned under KEY_A.
+        run = _fake_run({SANDBOX_JWT_STATE_KID_KEY: KID_A})
+        token = create_sandbox_connection_token(run, user_id=1, distinct_id="d")
+
+        self.assertEqual(jwt.get_unverified_header(token)["kid"], KID_A)
+        # Verifies against the old (KEY_A) public key the sandbox still holds...
+        jwt.decode(token, _derive_public_key_pem(KEY_A), algorithms=["RS256"], audience=SANDBOX_CONNECTION_AUDIENCE)
+        # ...and is rejected by the new primary key.
+        with self.assertRaises(jwt.InvalidSignatureError):
+            jwt.decode(token, _derive_public_key_pem(KEY_B), algorithms=["RS256"], audience=SANDBOX_CONNECTION_AUDIENCE)
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_A, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=None)
+    def test_fallback_to_primary_when_no_kid_stored(self) -> None:
+        get_sandbox_jwt_public_key.cache_clear()
+        token = create_sandbox_connection_token(_fake_run({}), user_id=1, distinct_id="d")
+        self.assertEqual(jwt.get_unverified_header(token)["kid"], KID_A)
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_B, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=KEY_A)
+    def test_ingest_token_always_uses_primary_ignoring_run_kid(self) -> None:
+        get_sandbox_jwt_public_key.cache_clear()
+        # The ingest path is single-key: it signs/validates with the primary key only and
+        # ignores the run's stored kid (unlike the connection token).
+        token = create_sandbox_event_ingest_token(_fake_run({SANDBOX_JWT_STATE_KID_KEY: KID_A}))
+        self.assertNotIn("kid", jwt.get_unverified_header(token))
+        payload = validate_sandbox_event_ingest_token(token)
+        self.assertEqual(payload.team_id, 1)
+
+    def test_ingest_token_rejected_after_primary_rotation(self) -> None:
+        # Ingest is intentionally NOT rotation-safe: a token signed under the old primary
+        # stops validating once the primary is rotated, even if the old key is kept as secondary.
+        with override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_A, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=None):
+            get_sandbox_jwt_public_key.cache_clear()
+            token = create_sandbox_event_ingest_token(_fake_run())
+
+        with override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_B, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=KEY_A):
+            get_sandbox_jwt_public_key.cache_clear()
+            with self.assertRaises(jwt.InvalidTokenError):
+                validate_sandbox_event_ingest_token(token)
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_A, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=None)
+    def test_connection_token_rejected_as_ingest_token(self) -> None:
+        get_sandbox_jwt_public_key.cache_clear()
+        # A connection-audience token must not pass ingest validation (wrong audience).
+        token = create_sandbox_connection_token(_fake_run(), user_id=1, distinct_id="d")
+        with self.assertRaises(jwt.InvalidTokenError):
+            validate_sandbox_event_ingest_token(token)
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=KEY_A, SANDBOX_JWT_PRIVATE_KEY_SECONDARY=KEY_A)
+    def test_duplicate_primary_and_secondary_collapse_to_one_key(self) -> None:
+        get_sandbox_jwt_public_key.cache_clear()
+        token = create_sandbox_event_ingest_token(_fake_run({SANDBOX_JWT_STATE_KID_KEY: KID_A}))
+        payload = validate_sandbox_event_ingest_token(token)
+        self.assertEqual(payload.team_id, 1)
+        self.assertEqual(get_primary_sandbox_jwt_kid(), KID_A)
+        self.assertEqual(get_sandbox_jwt_public_key(), _derive_public_key_pem(KEY_A))

--- a/products/tasks/backend/tests/test_connection_token.py
+++ b/products/tasks/backend/tests/test_connection_token.py
@@ -1,5 +1,6 @@
 import uuid
 from types import SimpleNamespace
+from typing import cast
 
 from django.test import SimpleTestCase, override_settings
 
@@ -7,6 +8,7 @@ import jwt
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+from products.tasks.backend.models import TaskRun
 from products.tasks.backend.services.connection_token import (
     SANDBOX_CONNECTION_AUDIENCE,
     SANDBOX_JWT_STATE_KID_KEY,
@@ -35,13 +37,18 @@ KEY_B = _generate_private_key_pem()
 KID_A = _compute_kid(_derive_public_key_pem(KEY_A))
 
 
-def _fake_run(state: dict | None = None) -> SimpleNamespace:
-    return SimpleNamespace(
-        id=uuid.uuid4(),
-        task_id=uuid.uuid4(),
-        team_id=1,
-        mode="background",
-        state=state if state is not None else {},
+def _fake_run(state: dict | None = None) -> TaskRun:
+    # Only the attributes the token helpers read are needed, so a lightweight stand-in
+    # avoids the DB; cast keeps the call sites type-correct.
+    return cast(
+        TaskRun,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            task_id=uuid.uuid4(),
+            team_id=1,
+            mode="background",
+            state=state if state is not None else {},
+        ),
     )
 
 

--- a/products/tasks/backend/tests/test_event_ingest.py
+++ b/products/tasks/backend/tests/test_event_ingest.py
@@ -17,7 +17,7 @@ from products.tasks.backend.services.connection_token import (
     SANDBOX_EVENT_INGEST_TOKEN_TTL,
     create_sandbox_connection_token,
     create_sandbox_event_ingest_token,
-    get_sandbox_jwt_public_key,
+    reset_sandbox_jwt_key_cache,
 )
 from products.tasks.backend.services.sandbox_config import SANDBOX_TTL_SECONDS
 from products.tasks.backend.stream.event_ingest import (
@@ -41,7 +41,7 @@ class TestTaskRunEventIngest(TransactionTestCase):
     def setUp(self) -> None:
         super().setUp()
         TEST_clear_clients()
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         self.organization = Organization.objects.create(name="Test Org")
         self.team = Team.objects.create(organization=self.organization, name="Test Team")
         self.task = Task.objects.create(
@@ -56,7 +56,7 @@ class TestTaskRunEventIngest(TransactionTestCase):
     def tearDown(self) -> None:
         self._delete_run_stream()
         TEST_clear_clients()
-        get_sandbox_jwt_public_key.cache_clear()
+        reset_sandbox_jwt_key_cache()
         super().tearDown()
 
     def _delete_run_stream(self) -> None:


### PR DESCRIPTION
## Problem

Rotating `SANDBOX_JWT_PRIVATE_KEY` is currently a breaking operation against running cloud runs, each sandbox has a single public key baked into its env at provision time and verifies connection tokens against only that key, so the moment Django starts signing with a new key, every in-flight sandbox rejects new connection tokens (followups, credential refresh, relay). We want to rotate the key on a routine basis without disrupting running task sessions.

## Changes

* added optional dual-key support for the sandbox connection token
- each sandbox still bakes exactly one public key. At provision we persist that key's `kid` on `TaskRun.state`, and connection tokens for the run are signed with the key the run's sandbox actually trusts (falling back to primary). A run stays internally key-consistent for its whole life, so the primary key can rotate while old sandboxes keep working until they drain (`SANDBOX_TTL_SECONDS`)
