### PR TITLE
chore(error-tracking): collapse per-issue rate-limit app_metrics2 rows

### DIFF
--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -316,6 +316,9 @@ export class ErrorTrackingConsumer {
                     const scopeKey = preCymbalGroupKey(input.event)
                     return scopeKey ? `${input.team.id}:exceptions:issue:${scopeKey}` : null
                 },
+                // Per-issue keys are high-cardinality; collapse every issue's outcomes into a
+                // single app_metrics2 row per team rather than one row per issue.
+                getAppSourceId: (input) => `${input.team.id}:exceptions:per_issue`,
                 getTeamId: (input) => input.team.id,
                 reportingMode: this.config.rateLimiterReportingMode,
                 dropReason: 'rate_limited:per_issue',

--- a/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.test.ts
+++ b/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.test.ts
@@ -201,33 +201,50 @@ describe('createKeyedRateLimiterStep', () => {
         })
     })
 
-    it('collapses high-cardinality keys under getAppSourceId for app_metrics2', async () => {
-        const aggregator = mkAggregator()
-        const step = createKeyedRateLimiterStep<Input>(
-            baseOpts({
-                rateLimiter: mkLimiter({}),
-                appMetricsAggregator: aggregator,
-                reportingMode: true,
-                getAppSourceId: (i) => `${i.teamId}:exceptions:per_issue`,
-            })
-        )
+    // Three distinct per-issue keys must collapse into one row per outcome under
+    // getAppSourceId — never one row per key — regardless of the outcome mix.
+    it.each([
+        ['all allowed', {}, [{ metric_name: 'allowed', count: 3 }]],
+        [
+            'mixed outcomes',
+            { '1:exceptions:issue:aaa': true },
+            [
+                { metric_name: 'allowed', count: 2 },
+                { metric_name: 'rate_limited', count: 1 },
+            ],
+        ],
+    ] as const)(
+        'collapses high-cardinality keys under getAppSourceId for app_metrics2 (%s)',
+        async (_label, decisions, expectedRows) => {
+            const aggregator = mkAggregator()
+            const step = createKeyedRateLimiterStep<Input>(
+                baseOpts({
+                    rateLimiter: mkLimiter(decisions),
+                    appMetricsAggregator: aggregator,
+                    reportingMode: true,
+                    getAppSourceId: (i) => `${i.teamId}:exceptions:per_issue`,
+                })
+            )
 
-        await step([
-            { teamId: 1, key: '1:exceptions:issue:aaa' },
-            { teamId: 1, key: '1:exceptions:issue:bbb' },
-            { teamId: 1, key: '1:exceptions:issue:ccc' },
-        ])
+            await step([
+                { teamId: 1, key: '1:exceptions:issue:aaa' },
+                { teamId: 1, key: '1:exceptions:issue:bbb' },
+                { teamId: 1, key: '1:exceptions:issue:ccc' },
+            ])
 
-        expect(aggregator.queue).toHaveBeenCalledTimes(1)
-        expect(aggregator.queue).toHaveBeenCalledWith({
-            team_id: 1,
-            app_source: 'exceptions',
-            app_source_id: '1:exceptions:per_issue',
-            metric_kind: 'rate_limiting',
-            metric_name: 'allowed',
-            count: 3,
-        })
-    })
+            expect(aggregator.queue).toHaveBeenCalledTimes(expectedRows.length)
+            for (const { metric_name, count } of expectedRows) {
+                expect(aggregator.queue).toHaveBeenCalledWith({
+                    team_id: 1,
+                    app_source: 'exceptions',
+                    app_source_id: '1:exceptions:per_issue',
+                    metric_kind: 'rate_limiting',
+                    metric_name,
+                    count,
+                })
+            }
+        }
+    )
 
     it('does not emit metrics when aggregator is undefined', async () => {
         const limiter = mkLimiter({ a: true })

--- a/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.test.ts
+++ b/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.test.ts
@@ -201,6 +201,34 @@ describe('createKeyedRateLimiterStep', () => {
         })
     })
 
+    it('collapses high-cardinality keys under getAppSourceId for app_metrics2', async () => {
+        const aggregator = mkAggregator()
+        const step = createKeyedRateLimiterStep<Input>(
+            baseOpts({
+                rateLimiter: mkLimiter({}),
+                appMetricsAggregator: aggregator,
+                reportingMode: true,
+                getAppSourceId: (i) => `${i.teamId}:exceptions:per_issue`,
+            })
+        )
+
+        await step([
+            { teamId: 1, key: '1:exceptions:issue:aaa' },
+            { teamId: 1, key: '1:exceptions:issue:bbb' },
+            { teamId: 1, key: '1:exceptions:issue:ccc' },
+        ])
+
+        expect(aggregator.queue).toHaveBeenCalledTimes(1)
+        expect(aggregator.queue).toHaveBeenCalledWith({
+            team_id: 1,
+            app_source: 'exceptions',
+            app_source_id: '1:exceptions:per_issue',
+            metric_kind: 'rate_limiting',
+            metric_name: 'allowed',
+            count: 3,
+        })
+    })
+
     it('does not emit metrics when aggregator is undefined', async () => {
         const limiter = mkLimiter({ a: true })
         const step = createKeyedRateLimiterStep<Input>(

--- a/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.test.ts
+++ b/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.test.ts
@@ -201,8 +201,6 @@ describe('createKeyedRateLimiterStep', () => {
         })
     })
 
-    // Three distinct per-issue keys must collapse into one row per outcome under
-    // getAppSourceId — never one row per key — regardless of the outcome mix.
     it.each([
         ['all allowed', {}, [{ metric_name: 'allowed', count: 3 }]],
         [

--- a/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.ts
+++ b/nodejs/src/ingestion/error-tracking/keyed-rate-limiter-step.ts
@@ -23,6 +23,12 @@ export interface KeyedRateLimiterStepOptions<T> {
     appSource: string
     /** Extract a stable rate-limit key from each input. Return null to skip rate-limiting that input. */
     getKey: (input: T) => string | null
+    /**
+     * Override the `app_source_id` written to `app_metrics2`. Defaults to the rate-limit key.
+     * Use this when the key is high-cardinality (e.g. a per-issue key) and you want every row
+     * collapsed under one stable id — `getKey` still drives the actual rate-limit bucket.
+     */
+    getAppSourceId?: (input: T) => string
     /** Cost per input. Defaults to 1 — override for byte-based limits etc. */
     getCost?: (input: T) => number
     /** Team id used when emitting `app_metrics2` rows. */
@@ -104,7 +110,7 @@ export function createKeyedRateLimiterStep<T>(opts: KeyedRateLimiterStepOptions<
 
         const outcomeBuckets = new Map<
             string,
-            { teamId: number; key: string; outcome: RateLimitOutcome; count: number }
+            { teamId: number; appSourceId: string; outcome: RateLimitOutcome; count: number }
         >()
         for (let i = 0; i < inputs.length; i++) {
             const key = keyForInput[i]
@@ -116,22 +122,23 @@ export function createKeyedRateLimiterStep<T>(opts: KeyedRateLimiterStepOptions<
 
             if (opts.appMetricsAggregator) {
                 const teamId = opts.getTeamId(inputs[i])
-                const bucketKey = `${teamId}|${key}|${outcome}`
+                const appSourceId = opts.getAppSourceId ? opts.getAppSourceId(inputs[i]) : key
+                const bucketKey = `${teamId}|${appSourceId}|${outcome}`
                 const existing = outcomeBuckets.get(bucketKey)
                 if (existing) {
                     existing.count++
                 } else {
-                    outcomeBuckets.set(bucketKey, { teamId, key, outcome, count: 1 })
+                    outcomeBuckets.set(bucketKey, { teamId, appSourceId, outcome, count: 1 })
                 }
             }
         }
 
         if (opts.appMetricsAggregator) {
-            for (const { teamId, key, outcome, count } of outcomeBuckets.values()) {
+            for (const { teamId, appSourceId, outcome, count } of outcomeBuckets.values()) {
                 opts.appMetricsAggregator.queue({
                     team_id: teamId,
                     app_source: opts.appSource,
-                    app_source_id: key,
+                    app_source_id: appSourceId,
                     metric_kind: 'rate_limiting',
                     metric_name: outcome,
                     count,


### PR DESCRIPTION
## Problem

The per-issue exception rate limiter writes its high-cardinality rate-limit key (`{team}:exceptions:issue:{scope}`) straight into `app_source_id`, so `app_metrics2` gets one row per issue. That granularity is unnecessary for monitoring how much per-issue limiting a team is seeing.

## Changes

Add an optional `getAppSourceId` to the keyed rate limiter step that overrides the emitted `app_source_id` while leaving `getKey` (the actual Redis bucket) untouched. The per-issue limiter now reports under a single `{team}:exceptions:per_issue` id, collapsing all issues for a team into one row per outcome. Team-global limiting is unchanged.

## How did you test this code?

I'm an agent. Added a unit test in `keyed-rate-limiter-step.test.ts` asserting distinct issue keys collapse into one `:per_issue` row; did not run the suite or any manual testing.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The rate-limit key has to stay per-issue for correct bucketing, so rather than change the key we decoupled the metric label from it via `getAppSourceId`. Kept the team id in the collapsed id for symmetry with the existing `:global` row format.
