### PR TITLE
feat(replay-vision): bootstrap scanner reconciler schedule on worker startup

### DIFF
--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -77,6 +77,7 @@ from posthog.temporal.warehouse_sources_queue_partition_management.schedule impo
 )
 from posthog.temporal.weekly_digest.types import WeeklyDigestInput
 
+from products.replay_vision.backend.temporal.reconciler import create_replay_vision_reconciler_schedule
 from products.signals.backend.temporal.agentic.schedule import create_signals_scout_coordinator_schedule
 from products.web_analytics.backend.temporal.weekly_digest.types import WAWeeklyDigestInput
 
@@ -610,6 +611,7 @@ schedules = [
     create_run_investigation_safety_net_schedule,
     create_cleanup_alert_checks_schedule,
     create_signals_scout_coordinator_schedule,
+    create_replay_vision_reconciler_schedule,
 ]
 
 if settings.CLOUD_DEPLOYMENT:

--- a/products/replay_vision/backend/temporal/reconciler.py
+++ b/products/replay_vision/backend/temporal/reconciler.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from temporalio import workflow
@@ -22,6 +23,9 @@ from products.replay_vision.backend.temporal.reconciler_types import (
     ReconcileScannerSchedulesResult,
     UpsertScannerScheduleActivityInputs,
 )
+
+if TYPE_CHECKING:
+    from temporalio.client import Client
 
 # `activities` pulls in Django, which the workflow sandbox can't safely re-import.
 with workflow.unsafe.imports_passed_through():
@@ -107,3 +111,49 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
         # return_exceptions so one scanner's failure doesn't block the others.
         results = await asyncio.gather(*(make_coro(sid) for sid in scanner_ids), return_exceptions=True)
         return [not isinstance(r, BaseException) for r in results]
+
+
+async def create_replay_vision_reconciler_schedule(client: "Client") -> None:
+    """Upsert the global reconciler schedule. Called from worker startup."""
+    # Function-local: this module contains `@workflow.defn`, and the Temporal sandbox can't
+    # re-import django.conf or unrelated temporalio.client types when validating the workflow.
+    from django.conf import settings  # noqa: PLC0415
+
+    from temporalio.client import (  # noqa: PLC0415
+        Schedule,
+        ScheduleActionStartWorkflow,
+        ScheduleIntervalSpec,
+        ScheduleOverlapPolicy,
+        SchedulePolicy,
+        ScheduleSpec,
+    )
+
+    from posthog.temporal.common.schedule import (  # noqa: PLC0415
+        a_create_schedule,
+        a_schedule_exists,
+        a_update_schedule,
+    )
+
+    from products.replay_vision.backend.temporal.constants import (  # noqa: PLC0415
+        RECONCILER_EXECUTION_TIMEOUT,
+        RECONCILER_INTERVAL,
+        RECONCILER_SCHEDULE_ID,
+        RECONCILER_WORKFLOW_ID,
+    )
+
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            RECONCILER_WORKFLOW_NAME,
+            ReconcileScannerSchedulesInputs(),
+            id=RECONCILER_WORKFLOW_ID,
+            task_queue=settings.REPLAY_VISION_TASK_QUEUE,
+            execution_timeout=RECONCILER_EXECUTION_TIMEOUT,
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        ),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=RECONCILER_INTERVAL)]),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP, catchup_window=RECONCILER_INTERVAL),
+    )
+    if await a_schedule_exists(client, RECONCILER_SCHEDULE_ID):
+        await a_update_schedule(client, RECONCILER_SCHEDULE_ID, schedule)
+    else:
+        await a_create_schedule(client, RECONCILER_SCHEDULE_ID, schedule, trigger_immediately=True)

--- a/products/replay_vision/backend/tests/test_reconciler.py
+++ b/products/replay_vision/backend/tests/test_reconciler.py
@@ -5,8 +5,11 @@ from typing import Any
 import pytest
 from unittest.mock import AsyncMock, patch
 
+from django.conf import settings
+
 from asgiref.sync import sync_to_async
 from parameterized import parameterized
+from temporalio.client import ScheduleOverlapPolicy
 from temporalio.common import SearchAttributePair, TypedSearchAttributes
 from temporalio.exceptions import ApplicationError
 
@@ -20,8 +23,19 @@ from products.replay_vision.backend.temporal.activities import (
     list_scanner_schedules_activity,
     upsert_scanner_schedule_activity,
 )
-from products.replay_vision.backend.temporal.constants import SCANNER_SCHEDULE_ID_PREFIX, SWEEP_SCANNER_WORKFLOW_NAME
-from products.replay_vision.backend.temporal.reconciler import ReconcileScannerSchedulesWorkflow
+from products.replay_vision.backend.temporal.constants import (
+    RECONCILER_EXECUTION_TIMEOUT,
+    RECONCILER_INTERVAL,
+    RECONCILER_SCHEDULE_ID,
+    RECONCILER_WORKFLOW_ID,
+    RECONCILER_WORKFLOW_NAME,
+    SCANNER_SCHEDULE_ID_PREFIX,
+    SWEEP_SCANNER_WORKFLOW_NAME,
+)
+from products.replay_vision.backend.temporal.reconciler import (
+    ReconcileScannerSchedulesWorkflow,
+    create_replay_vision_reconciler_schedule,
+)
 from products.replay_vision.backend.temporal.reconciler_types import (
     EnabledScannerEntry,
     ReconcileScannerSchedulesInputs,
@@ -341,3 +355,32 @@ async def test_reconcile_workflow(_name: str, build: Callable[[], tuple[_Reconci
 
 def test_reconcile_parse_inputs() -> None:
     assert ReconcileScannerSchedulesWorkflow.parse_inputs([]) == ReconcileScannerSchedulesInputs()
+
+
+@pytest.mark.asyncio
+@parameterized.expand([("missing", False, "create"), ("present", True, "update")])
+async def test_create_reconciler_schedule_routes_by_existence(_name: str, exists: bool, expected: str) -> None:
+    schedule_mod = "posthog.temporal.common.schedule"
+    with (
+        patch(f"{schedule_mod}.a_schedule_exists", AsyncMock(return_value=exists)),
+        patch(f"{schedule_mod}.a_create_schedule", AsyncMock()) as create,
+        patch(f"{schedule_mod}.a_update_schedule", AsyncMock()) as update,
+    ):
+        await create_replay_vision_reconciler_schedule(AsyncMock())
+    called, skipped = (create, update) if expected == "create" else (update, create)
+    called.assert_awaited_once()
+    skipped.assert_not_awaited()
+    assert called.call_args.args[1] == RECONCILER_SCHEDULE_ID
+    schedule = called.call_args.args[2]
+    assert schedule.action.workflow == RECONCILER_WORKFLOW_NAME
+    assert schedule.action.id == RECONCILER_WORKFLOW_ID
+    assert schedule.action.task_queue == settings.REPLAY_VISION_TASK_QUEUE
+    assert schedule.action.execution_timeout == RECONCILER_EXECUTION_TIMEOUT
+    assert schedule.action.retry_policy.maximum_attempts == 1
+    assert schedule.spec.intervals[0].every == RECONCILER_INTERVAL
+    assert schedule.policy.overlap == ScheduleOverlapPolicy.SKIP
+    assert schedule.policy.catchup_window == RECONCILER_INTERVAL
+    if expected == "create":
+        assert called.call_args.kwargs["trigger_immediately"] is True
+    else:
+        assert "trigger_immediately" not in called.call_args.kwargs


### PR DESCRIPTION
Stacked on **#61066**.

## Problem

`ReconcileScannerSchedulesWorkflow` (#61066) is registered on the worker but never ticks — there's no Temporal Schedule firing it.

## Changes

`create_replay_vision_reconciler_schedule(client)` builds the singleton schedule (1-min interval, `overlap=SKIP`, `catchup_window=RECONCILER_INTERVAL`) and is registered in `posthog/temporal/schedule.py` alongside the other startup-time schedules.

## How did you test this code?

Agent. Two unit tests assert the schedule is created (with `trigger_immediately=True`) when missing, and updated when present — verifying schedule id, workflow name/id, and interval.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Claude. Mirrors `create_summarization_sweep_reconciler_schedule`.