### PR TITLE
feat(insights): toggle to stack breakdown values on bar-value chart

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -31,6 +31,7 @@ import { ShowLegendFilter } from 'scenes/insights/EditorFilters/ShowLegendFilter
 import { ShowMultipleYAxesFilter } from 'scenes/insights/EditorFilters/ShowMultipleYAxesFilter'
 import { ShowPieTotalFilter } from 'scenes/insights/EditorFilters/ShowPieTotalFilter'
 import { ShowTrendLinesFilter } from 'scenes/insights/EditorFilters/ShowTrendLinesFilter'
+import { StackBreakdownFilter } from 'scenes/insights/EditorFilters/StackBreakdownFilter'
 import { ValueOnSeriesFilter } from 'scenes/insights/EditorFilters/ValueOnSeriesFilter'
 import { InsightDateFilter } from 'scenes/insights/filters/InsightDateFilter'
 import { RetentionChartPicker } from 'scenes/insights/filters/RetentionChartPicker'
@@ -93,6 +94,7 @@ export function InsightDisplayConfig(): JSX.Element {
         supportsValueOnSeries,
         showPercentStackView,
         supportsPercentStackView,
+        supportsBarValueStacking,
         supportsResultCustomizationBy,
         yAxisScaleType,
         showMultipleYAxes,
@@ -204,6 +206,7 @@ export function InsightDisplayConfig(): JSX.Element {
                                 ...(isLifecycle ? [{ label: () => <LifecycleStackingFilter /> }] : []),
                                 ...(supportsValueOnSeries ? [{ label: () => <ValueOnSeriesFilter /> }] : []),
                                 ...(supportsPercentStackView ? [{ label: () => <PercentStackViewFilter /> }] : []),
+                                ...(supportsBarValueStacking ? [{ label: () => <StackBreakdownFilter /> }] : []),
                                 ...(hasLegend ? [{ label: () => <ShowLegendFilter /> }] : []),
                                 ...(display === ChartDisplayType.ActionsPie
                                     ? [{ label: () => <ShowPieTotalFilter /> }]

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -41121,6 +41121,11 @@
                     "$ref": "#/definitions/integer",
                     "default": 1
                 },
+                "stackBreakdownValues": {
+                    "default": false,
+                    "description": "On the horizontal bar-value chart, stack a series' breakdown values into a single bar instead of rendering one bar per breakdown value.",
+                    "type": "boolean"
+                },
                 "xAxisLabel": {
                     "description": "Custom label rendered under the X axis.",
                     "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1449,6 +1449,10 @@ export type TrendsFilter = {
     showLabelsOnSeries?: TrendsFilterLegacy['show_labels_on_series']
     /** @default false */
     showPercentStackView?: TrendsFilterLegacy['show_percent_stack_view']
+    /** On the horizontal bar-value chart, stack a series' breakdown values into a single bar
+     *  instead of rendering one bar per breakdown value.
+     * @default false */
+    stackBreakdownValues?: boolean
     yAxisScaleType?: TrendsFilterLegacy['y_axis_scale_type']
     /** @default false */
     showMultipleYAxes?: TrendsFilterLegacy['show_multiple_y_axes']
@@ -1501,6 +1505,7 @@ export const TRENDS_FILTER_PROPERTIES = new Set<keyof TrendsFilter>([
     'showValuesOnSeries',
     'showLabelsOnSeries',
     'showPercentStackView',
+    'stackBreakdownValues',
     'yAxisScaleType',
     'hiddenLegendIndexes',
     'excludeBoxPlotOutliers',

--- a/frontend/src/queries/utils.test.ts
+++ b/frontend/src/queries/utils.test.ts
@@ -5,6 +5,7 @@ import { getAppContext } from 'lib/utils/getAppContext'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { DataTableNode, DataVisualizationNode, NodeKind } from '~/queries/schema/schema-general'
+import type { InsightQueryNode } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { AppContext, ChartDisplayType, TeamType } from '~/types'
 
@@ -13,6 +14,7 @@ import {
     escapeDottedHogQLIdentifier,
     escapeHogQLString,
     hogql,
+    supportsBarValueStacking,
 } from './utils'
 
 window.POSTHOG_APP_CONTEXT = { current_team: { id: MOCK_TEAM_ID } } as unknown as AppContext
@@ -163,5 +165,47 @@ describe('convertDataTableNodeToDataVisualizationNode', () => {
                 columns: [{ column: 'event' }],
             },
         })
+    })
+})
+
+describe('supportsBarValueStacking', () => {
+    const breakdown = { breakdown: '$browser', breakdown_type: 'event' as const }
+    const trends = (display: ChartDisplayType, withBreakdown: boolean): InsightQueryNode =>
+        ({
+            kind: NodeKind.TrendsQuery,
+            series: [],
+            trendsFilter: { display },
+            ...(withBreakdown ? { breakdownFilter: breakdown } : {}),
+        }) as InsightQueryNode
+
+    it.each([
+        {
+            name: 'trends + bar-value + breakdown',
+            query: trends(ChartDisplayType.ActionsBarValue, true),
+            expected: true,
+        },
+        {
+            name: 'trends + bar-value without breakdown',
+            query: trends(ChartDisplayType.ActionsBarValue, false),
+            expected: false,
+        },
+        {
+            name: 'trends + vertical bar + breakdown',
+            query: trends(ChartDisplayType.ActionsBar, true),
+            expected: false,
+        },
+        {
+            name: 'trends + line + breakdown',
+            query: trends(ChartDisplayType.ActionsLineGraph, true),
+            expected: false,
+        },
+        {
+            name: 'funnels + breakdown',
+            query: { kind: NodeKind.FunnelsQuery, series: [], breakdownFilter: breakdown } as InsightQueryNode,
+            expected: false,
+        },
+        { name: 'null query', query: null, expected: false },
+    ])('returns $expected for $name', ({ query, expected }) => {
+        expect(supportsBarValueStacking(query)).toBe(expected)
     })
 })

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -661,6 +661,12 @@ export const supportsPercentStackView = (q: InsightQueryNode | null | undefined)
 export const getShowPercentStackView = (query: InsightQueryNode): boolean | undefined =>
     supportsPercentStackView(query) && (query as TrendsQuery)?.trendsFilter?.showPercentStackView
 
+export const supportsBarValueStacking = (q: InsightQueryNode | null | undefined): boolean =>
+    isTrendsQuery(q) && getDisplay(q) === ChartDisplayType.ActionsBarValue && hasBreakdownFilter(getBreakdown(q))
+
+export const getStackBreakdownValues = (query: InsightQueryNode): boolean | undefined =>
+    supportsBarValueStacking(query) && (query as TrendsQuery)?.trendsFilter?.stackBreakdownValues
+
 export const nodeKindToFilterProperty: Record<ProductAnalyticsInsightNodeKind, InsightFilterProperty> = {
     [NodeKind.TrendsQuery]: 'trendsFilter',
     [NodeKind.FunnelsQuery]: 'funnelsFilter',

--- a/frontend/src/scenes/insights/EditorFilters/StackBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/StackBreakdownFilter.tsx
@@ -1,0 +1,24 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
+import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
+
+import { insightLogic } from '../insightLogic'
+
+export function StackBreakdownFilter(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter } = useValues(trendsDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(trendsDataLogic(insightProps))
+
+    return (
+        <LemonCheckbox
+            className="p-1 px-2"
+            checked={!!trendsFilter?.stackBreakdownValues}
+            onChange={(checked) => {
+                updateInsightFilter({ stackBreakdownValues: checked })
+            }}
+            label={<span className="font-normal">Stack breakdown values</span>}
+            size="small"
+        />
+    )
+}

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -94,6 +94,7 @@ import {
     isWebOverviewQuery,
     isWebStatsTableQuery,
     nodeKindToFilterProperty,
+    supportsBarValueStacking,
     supportsPercentStackView,
 } from '~/queries/utils'
 import { BaseMathType, ChartDisplayType, InsightLogicProps, LabelGroupType, SlowQueryPossibilities } from '~/types'
@@ -214,6 +215,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                 dateRange?.date_from !== 'all',
         ],
         supportsPercentStackView: [(s) => [s.querySource], (q) => supportsPercentStackView(q)],
+        supportsBarValueStacking: [(s) => [s.querySource], (q) => supportsBarValueStacking(q)],
         supportsValueOnSeries: [
             (s) => [s.isTrends, s.isFunnels, s.isStickiness, s.isLifecycle, s.display],
             (isTrends, isFunnels, isStickiness, isLifecycle, display) => {

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -227,6 +227,7 @@ export const cleanInsightQuery = (query: InsightQueryNode, opts?: CompareQueryOp
             ...insightFilter,
             showLegend: undefined,
             showPercentStackView: undefined,
+            stackBreakdownValues: undefined,
             showValuesOnSeries: undefined,
             aggregationAxisFormat: undefined,
             aggregationAxisPrefix: undefined,

--- a/frontend/src/test/insight-testing/mocks.ts
+++ b/frontend/src/test/insight-testing/mocks.ts
@@ -73,7 +73,9 @@ function buildTrendsResponse(series: SeriesData[]): TrendsQueryResponse {
                 id: `$${s.label.toLowerCase().replace(/\s+/g, '_')}`,
                 type: 'events',
                 name: s.label,
-                order: s.compare ? 0 : i,
+                // Breakdown rows of a single series share the series' order (as the real query
+                // runner does); only distinct series get distinct orders.
+                order: s.compare || s.breakdown_value != null ? 0 : i,
             },
             label: s.label,
             count: s.data.reduce((a, b) => a + b, 0),

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -9595,6 +9595,13 @@ class TrendsFilter(BaseModel):
     showTrendLines: bool | None = None
     showValuesOnSeries: bool | None = False
     smoothingIntervals: int | None = 1
+    stackBreakdownValues: bool | None = Field(
+        default=False,
+        description=(
+            "On the horizontal bar-value chart, stack a series' breakdown values into a"
+            " single bar instead of rendering one bar per breakdown value."
+        ),
+    )
     xAxisLabel: str | None = Field(default=None, description="Custom label rendered under the X axis.")
     yAxisLabel: str | None = Field(default=None, description="Custom label rendered alongside the Y axis.")
     yAxisScaleType: YAxisScaleType | None = YAxisScaleType.LINEAR

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -85,6 +85,7 @@ def to_dict(query: BaseModel) -> dict:
                     not in [
                         "showLegend",
                         "showPercentStackView",
+                        "stackBreakdownValues",
                         "showValuesOnSeries",
                         "aggregationAxisFormat",
                         "aggregationAxisPrefix",

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -1870,6 +1870,8 @@ export interface TrendsFilterApi {
     showTrendLines?: boolean | null
     showValuesOnSeries?: boolean | null
     smoothingIntervals?: number | null
+    /** On the horizontal bar-value chart, stack a series' breakdown values into a single bar instead of rendering one bar per breakdown value. */
+    stackBreakdownValues?: boolean | null
     /** Custom label rendered under the X axis. */
     xAxisLabel?: string | null
     /** Custom label rendered alongside the Y axis. */

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -1563,6 +1563,8 @@ export interface TrendsFilterApi {
     showTrendLines?: boolean | null
     showValuesOnSeries?: boolean | null
     smoothingIntervals?: number | null
+    /** On the horizontal bar-value chart, stack a series' breakdown values into a single bar instead of rendering one bar per breakdown value. */
+    stackBreakdownValues?: boolean | null
     /** Custom label rendered under the X axis. */
     xAxisLabel?: string | null
     /** Custom label rendered alongside the Y axis. */

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
@@ -316,7 +316,6 @@ describe('TrendsBarChart (ActionsBarValue)', () => {
 
         await waitFor(
             () => {
-                // Five hedgehog breakdowns of one series collapse onto a single category band.
                 expect(getHogChart().yTicks()).toHaveLength(1)
             },
             { timeout: 5000 }

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
@@ -283,6 +283,46 @@ describe('TrendsBarChart (ActionsBarValue)', () => {
         )
     })
 
+    it('labels each aggregated breakdown bar by its breakdown value, one band per value by default', async () => {
+        renderInsight({
+            query: aggregatedBar({
+                series: [{ kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' }],
+                breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
+            }),
+            featureFlags: HOG_CHARTS_FLAG,
+        })
+        await screen.findByRole('img', { name: /chart with 5 data series/i }, { timeout: 5000 })
+
+        await waitFor(
+            () => {
+                const ticks = getHogChart().yTicks()
+                expect(ticks).toEqual(expect.arrayContaining(['Spike']))
+                expect(ticks).toHaveLength(5)
+            },
+            { timeout: 5000 }
+        )
+    })
+
+    it('collapses breakdown bars onto one band when stackBreakdownValues is set', async () => {
+        renderInsight({
+            query: aggregatedBar({
+                series: [{ kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' }],
+                breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
+                trendsFilter: { display: ChartDisplayType.ActionsBarValue, stackBreakdownValues: true },
+            }),
+            featureFlags: HOG_CHARTS_FLAG,
+        })
+        await screen.findByRole('img', { name: /chart with 5 data series/i }, { timeout: 5000 })
+
+        await waitFor(
+            () => {
+                // Five hedgehog breakdowns of one series collapse onto a single category band.
+                expect(getHogChart().yTicks()).toHaveLength(1)
+            },
+            { timeout: 5000 }
+        )
+    })
+
     it('omits the header from the tooltip', async () => {
         renderInsight({
             query: aggregatedBar(),

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -16,12 +16,15 @@ import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisForma
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+import { formatBreakdownLabel, getDisplayNameFromEntityFilter } from 'scenes/insights/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import type { IndexedTrendResult } from 'scenes/trends/types'
 
+import { cohortsModel } from '~/models/cohortsModel'
 import { groupsModel } from '~/models/groupsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { ChartDisplayType } from '~/types'
@@ -98,6 +101,8 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
     } = useValues(trendsDataLogic(insightProps))
     const { timezone, weekStartDay, baseCurrency } = useValues(teamLogic)
     const { aggregationLabel } = useValues(groupsModel)
+    const { allCohorts } = useValues(cohortsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
     const isAggregated = display === ChartDisplayType.ActionsBarValue
     const isGrouped = display === ChartDisplayType.ActionsUnstackedBar
@@ -113,12 +118,38 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
               )
             : !!indexedResults[0].data && indexedResults.some((r: IndexedTrendResult) => r.count !== 0))
 
+    const stackBreakdowns = !!trendsFilter?.stackBreakdownValues
+
+    const getAggregatedDisplayLabel = useCallback(
+        (r: IndexedTrendResult): string => {
+            if (stackBreakdowns) {
+                // Stacked mode labels the whole band by the series/formula name; individual
+                // breakdown values are distinguished by color and the tooltip.
+                return getDisplayNameFromEntityFilter(r.action) ?? r.label ?? ''
+            }
+            if (r.breakdown_value != null) {
+                return formatBreakdownLabel(
+                    r.breakdown_value,
+                    breakdownFilter,
+                    allCohorts?.results,
+                    formatPropertyValueForDisplay,
+                    undefined,
+                    r.label
+                )
+            }
+            return r.label ?? ''
+        },
+        [stackBreakdowns, breakdownFilter, allCohorts?.results, formatPropertyValueForDisplay]
+    )
+
     const { series, labels, displayLabels } = useMemo(() => {
         if (isAggregated) {
             return buildTrendsBarAggregatedSeries<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
                 getColor: getTrendsColor,
                 getHidden: getTrendsHidden,
                 buildMeta: buildTrendsSeriesMeta,
+                stackBreakdowns,
+                getDisplayLabel: getAggregatedDisplayLabel,
             })
         }
         const timeSeries = buildTrendsBarTimeSeries<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
@@ -131,7 +162,15 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
             labels: currentPeriodResult?.labels ?? EMPTY_LABELS,
             displayLabels: undefined,
         }
-    }, [isAggregated, indexedResults, getTrendsColor, getTrendsHidden, currentPeriodResult?.labels])
+    }, [
+        isAggregated,
+        indexedResults,
+        getTrendsColor,
+        getTrendsHidden,
+        currentPeriodResult?.labels,
+        stackBreakdowns,
+        getAggregatedDisplayLabel,
+    ])
 
     const valueLabelFormatter = useCallback(
         (value: number) => {

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -27,6 +27,7 @@ import { groupsModel } from '~/models/groupsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
+import { getStackBreakdownValues } from '~/queries/utils'
 import { ChartDisplayType } from '~/types'
 
 import { AnnotationsLayer } from '../shared/AnnotationsLayer'
@@ -118,13 +119,12 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
               )
             : !!indexedResults[0].data && indexedResults.some((r: IndexedTrendResult) => r.count !== 0))
 
-    const stackBreakdowns = !!trendsFilter?.stackBreakdownValues
+    const stackBreakdowns = !!querySource && !!getStackBreakdownValues(querySource)
 
     const getAggregatedDisplayLabel = useCallback(
         (r: IndexedTrendResult): string => {
             if (stackBreakdowns) {
-                // Stacked mode labels the whole band by the series/formula name; individual
-                // breakdown values are distinguished by color and the tooltip.
+                // Breakdown values within the band are distinguished by color and the tooltip.
                 return getDisplayNameFromEntityFilter(r.action) ?? r.label ?? ''
             }
             if (r.breakdown_value != null) {

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
@@ -106,19 +106,19 @@ describe('buildTrendsBarAggregatedSeries', () => {
         ['Runtime & Code', 2],
     ]
 
-    it('gives each breakdown row of a formula its own band by default (separate bars)', () => {
+    it.each([
+        { name: 'separate by default — one band per breakdown value', stackBreakdowns: undefined, expectedBands: 7 },
+        { name: 'one band per formula when stackBreakdowns is set', stackBreakdowns: true, expectedBands: 3 },
+    ])('formula breakdown rows: $name', ({ stackBreakdowns, expectedBands }) => {
         const results = formulaBreakdownSpec.map(([label, order], i) => mkResult({ id: `r${i}`, label, order }))
-        const { labels, displayLabels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED })
-        expect(displayLabels).toEqual(formulaBreakdownSpec.map(([label]) => label))
-        // 7 results → 7 distinct bands: one bar per breakdown value.
-        expect(new Set(labels).size).toBe(7)
+        const { labels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED, stackBreakdowns })
+        expect(new Set(labels).size).toBe(expectedBands)
     })
 
-    it("collapses a formula's breakdown rows onto one band per formula when stackBreakdowns is set", () => {
+    it('keeps each result label as its band display label in separate mode', () => {
         const results = formulaBreakdownSpec.map(([label, order], i) => mkResult({ id: `r${i}`, label, order }))
-        const { labels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED, stackBreakdowns: true })
-        // 7 results, but only 3 band slots — one per formula.
-        expect(new Set(labels).size).toBe(3)
+        const { displayLabels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED })
+        expect(displayLabels).toEqual(formulaBreakdownSpec.map(([label]) => label))
     })
 
     it('keeps current and previous on separate bands in stacked mode even at the same order', () => {

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
@@ -128,7 +128,6 @@ describe('buildTrendsBarAggregatedSeries', () => {
             mkResult({ id: 'c', label: 'F', order: 0, compare_label: 'previous', breakdown_value: 'Chrome' }),
         ]
         const { labels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED, stackBreakdowns: true })
-        // The two current rows share a band; previous gets its own → 2 bands.
         expect(new Set(labels).size).toBe(2)
     })
 

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
@@ -94,23 +94,51 @@ describe('buildTrendsBarAggregatedSeries', () => {
         expect(new Set(labels).size).toBe(4)
     })
 
-    it('groups same-label breakdown rows of one series onto one band (overlap layout preserved)', () => {
-        // Formula+breakdown shape: each formula carries a top-level `order`; breakdown rows of
-        // the same formula share it, so they share a band and the overlap-on-top visual holds.
-        const spec: [string, number][] = [
-            ['Binary Size', 0],
-            ['Binary Size', 0],
-            ['Binary Size', 0],
-            ['Embedded Assets', 1],
-            ['Embedded Assets', 1],
-            ['Runtime & Code', 2],
-            ['Runtime & Code', 2],
-        ]
-        const results = spec.map(([label, order], i) => mkResult({ id: `r${i}`, label, order }))
+    // Formula+breakdown shape: each formula carries a top-level `order`; breakdown rows of the
+    // same formula share both the formula label and the order. They must NOT collapse by default.
+    const formulaBreakdownSpec: [string, number][] = [
+        ['Binary Size', 0],
+        ['Binary Size', 0],
+        ['Binary Size', 0],
+        ['Embedded Assets', 1],
+        ['Embedded Assets', 1],
+        ['Runtime & Code', 2],
+        ['Runtime & Code', 2],
+    ]
+
+    it('gives each breakdown row of a formula its own band by default (separate bars)', () => {
+        const results = formulaBreakdownSpec.map(([label, order], i) => mkResult({ id: `r${i}`, label, order }))
         const { labels, displayLabels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED })
-        expect(displayLabels).toEqual(spec.map(([label]) => label))
-        // 7 results, but only 3 distinct band slots — one per formula.
+        expect(displayLabels).toEqual(formulaBreakdownSpec.map(([label]) => label))
+        // 7 results → 7 distinct bands: one bar per breakdown value.
+        expect(new Set(labels).size).toBe(7)
+    })
+
+    it("collapses a formula's breakdown rows onto one band per formula when stackBreakdowns is set", () => {
+        const results = formulaBreakdownSpec.map(([label, order], i) => mkResult({ id: `r${i}`, label, order }))
+        const { labels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED, stackBreakdowns: true })
+        // 7 results, but only 3 band slots — one per formula.
         expect(new Set(labels).size).toBe(3)
+    })
+
+    it('keeps current and previous on separate bands in stacked mode even at the same order', () => {
+        const results = [
+            mkResult({ id: 'a', label: 'F', order: 0, compare_label: 'current', breakdown_value: 'Chrome' }),
+            mkResult({ id: 'b', label: 'F', order: 0, compare_label: 'current', breakdown_value: 'Safari' }),
+            mkResult({ id: 'c', label: 'F', order: 0, compare_label: 'previous', breakdown_value: 'Chrome' }),
+        ]
+        const { labels } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED, stackBreakdowns: true })
+        // The two current rows share a band; previous gets its own → 2 bands.
+        expect(new Set(labels).size).toBe(2)
+    })
+
+    it('uses getDisplayLabel for the category label when provided', () => {
+        const results = [mkResult({ id: 'a', label: 'Formula (A + B)', breakdown_value: 'Chrome' })]
+        const { displayLabels } = buildTrendsBarAggregatedSeries(results, {
+            getColor: () => RED,
+            getDisplayLabel: (r) => String(r.breakdown_value),
+        })
+        expect(displayLabels).toEqual(['Chrome'])
     })
 
     it('places each aggregated_value at the index matching its own band — zero everywhere else', () => {

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
@@ -31,6 +31,17 @@ export interface BuildTrendsBarSeriesOpts<R extends TrendsBarResultLike, M = unk
     buildMeta?: (r: R, index: number) => M
 }
 
+export interface BuildTrendsBarAggregatedSeriesOpts<
+    R extends TrendsBarResultLike,
+    M = unknown,
+> extends BuildTrendsBarSeriesOpts<R, M> {
+    // When true, breakdown rows of a series/formula share a band and stack into a single bar.
+    // When false (default), each result gets its own band — one bar per breakdown value.
+    stackBreakdowns?: boolean
+    // Human-readable category label for a result. Defaults to the raw result label.
+    getDisplayLabel?: (r: R, index: number) => string
+}
+
 function buildMainTrendsBarSeries<R extends TrendsBarResultLike, M = unknown>(
     r: R,
     index: number,
@@ -106,20 +117,25 @@ const BAND_KEY_SEP = '\u001f'
 // Trade-off: only the last series gets rounded-corner caps.
 export function buildTrendsBarAggregatedSeries<R extends TrendsBarResultLike, M = unknown>(
     results: R[],
-    opts: BuildTrendsBarSeriesOpts<R, M>
+    opts: BuildTrendsBarAggregatedSeriesOpts<R, M>
 ): { series: Series<M>[]; labels: string[]; displayLabels: string[] } {
     // Hidden results are dropped entirely — keeping them as `excluded` series would leave
     // a phantom band on the category axis with no bar.
     const visible = opts.getHidden ? results.filter((r, i) => !opts.getHidden!(r, i)) : results
-    const displayLabels = visible.map((r) => {
-        const base = r.label ?? ''
+    const displayLabels = visible.map((r, i) => {
+        const base = opts.getDisplayLabel ? opts.getDisplayLabel(r, i) : (r.label ?? '')
         return r.compare_label ? `${base} - ${r.compare_label}` : base
     })
-    // Suffix the band key with the series identity so duplicate display labels from
-    // different series get distinct bands (breakdowns of one series still share a band).
+    // Band key strategy:
+    // - separate (default): unique per result, so every breakdown value gets its own band.
+    // - stacked: one band per series/formula (keyed by order + compare_label) so a series'
+    //   breakdown values collapse onto one band and stack into a single bar.
     const labels = visible.map((r, i) => {
+        if (!opts.stackBreakdowns) {
+            return String(i)
+        }
         const seriesId = r.action?.order ?? r.order ?? 0
-        return `${displayLabels[i]}${BAND_KEY_SEP}${seriesId}`
+        return `${seriesId}${BAND_KEY_SEP}${r.compare_label ?? ''}`
     })
     const n = visible.length
     const series = visible.map((r, index) => {

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
@@ -35,10 +35,7 @@ export interface BuildTrendsBarAggregatedSeriesOpts<
     R extends TrendsBarResultLike,
     M = unknown,
 > extends BuildTrendsBarSeriesOpts<R, M> {
-    // When true, breakdown rows of a series/formula share a band and stack into a single bar.
-    // When false (default), each result gets its own band — one bar per breakdown value.
     stackBreakdowns?: boolean
-    // Human-readable category label for a result. Defaults to the raw result label.
     getDisplayLabel?: (r: R, index: number) => string
 }
 
@@ -109,7 +106,7 @@ export function buildTrendsBarTimeSeriesConfig(opts: BuildTrendsBarTimeSeriesCon
     }
 }
 
-/** Separator between display label and series id in synthetic band keys. */
+/** Separator between the series id and compare label in synthetic stacked-mode band keys. */
 const BAND_KEY_SEP = '\u001f'
 
 // Sparse-stacked: hog-charts BarChart allows one color per series, so we emit N series with

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2173,6 +2173,8 @@ export namespace Schemas {
       showTrendLines?: boolean | null;
       showValuesOnSeries?: boolean | null;
       smoothingIntervals?: number | null;
+      /** On the horizontal bar-value chart, stack a series' breakdown values into a single bar instead of rendering one bar per breakdown value. */
+      stackBreakdownValues?: boolean | null;
       /** Custom label rendered under the X axis. */
       xAxisLabel?: string | null;
       /** Custom label rendered alongside the Y axis. */


### PR DESCRIPTION
## Problem

Users want to be able to stack the breakdown values in the horizontal bar chart view. Parituclarly useful in forumla mode, and you want to see a break down of the series for a formula

## Changes
Just add a toggle in display settings:
<img width="961" height="706" alt="Screenshot 2026-06-02 at 13 04 09" src="https://github.com/user-attachments/assets/dd9fe98c-7727-4fe9-8865-5f26d438804a" />

<img width="1265" height="599" alt="Screenshot 2026-06-02 at 13 07 22" src="https://github.com/user-attachments/assets/0015138e-25fb-445c-a0e6-71b08d12b42e" />

## How did you test this code?
Locally

- `trendsBarChartTransforms.test.ts` (band-key separate vs stacked, compare separation, label callback) — pass.
- `TrendsBarChart.test.tsx` (breakdown renders one band per value by default; collapses to one band when `stackBreakdownValues` is set) — pass.
- Re-ran the other suites using the shared mock (TrendsLineChart, TrendsLifecycleChart, FunnelLineChart, LineGraph, TaxonomicBreakdownFilter, ActionFilterRow) — 150 tests pass, no regressions.
- Per-file type diagnostics clean on all touched files.
- Visual check in the running app: the checkbox appears only for bar-value + breakdown, the chart renders breakdown-aware labels, and toggling switches the band label from the breakdown value to the series name with no refetch or console errors.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Root-caused the collapse to the band-key in `buildTrendsBarAggregatedSeries` (introduced in #60488), confirmed via the backend trends query runner that real breakdown rows of one series share `action.order`/`series_order` while the formula path sets `label` to the formula name and `order` to the formula index. Chose a display toggle over flipping the default outright because both layouts are wanted by different users; default is the legacy "separate bars" so the reported regression is fixed out of the box. The shared test mock was assigning a distinct `order` per breakdown row (unrealistic), so it was corrected to match the query runner — verified no downstream test regressions.

Note: existing insights relying on the old auto-collapse will render separate bars until the new toggle is enabled.