### PR TITLE
fix(billing): default usage report date

### DIFF
--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 
 from posthog.tasks.usage_report import send_all_org_usage_reports
 
@@ -23,7 +24,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
-        date = options["date"]
+        date = options["date"] or timezone.now().date().isoformat()
         skip_capture_event = options["skip_capture_event"]
         run_async = options["async"]
         org_ids_str = options.get("org_ids")

--- a/posthog/management/commands/test/test_send_usage_report.py
+++ b/posthog/management/commands/test/test_send_usage_report.py
@@ -1,0 +1,30 @@
+from freezegun import freeze_time
+from unittest.mock import patch
+
+from django.core.management import call_command
+
+
+@freeze_time("2026-06-02T12:00:00Z")
+def test_send_usage_report_defaults_to_current_date() -> None:
+    with patch("posthog.management.commands.send_usage_report.send_all_org_usage_reports") as mock_send_reports:
+        call_command("send_usage_report")
+
+    mock_send_reports.assert_called_once_with(
+        dry_run=None,
+        at="2026-06-02",
+        skip_capture_event=None,
+        organization_ids=None,
+    )
+
+
+@freeze_time("2026-06-02T12:00:00Z")
+def test_send_usage_report_preserves_passed_date() -> None:
+    with patch("posthog.management.commands.send_usage_report.send_all_org_usage_reports") as mock_send_reports:
+        call_command("send_usage_report", "--date=2026-05-31")
+
+    mock_send_reports.assert_called_once_with(
+        dry_run=None,
+        at="2026-05-31",
+        skip_capture_event=None,
+        organization_ids=None,
+    )


### PR DESCRIPTION
## Problem

The `send_usage_report` management command accepted an optional `--date`, but when omitted it forwarded `None` to the usage report task. Operators running the command manually should get a concrete current-date run without needing to pass the date each time.

## Changes

- Default `send_usage_report --date` to the current UTC date when the option is omitted.
- Keep explicitly passed dates unchanged.
- Add focused management-command tests for both paths.

## How did you test this code?

Agent-run automated checks:

- `flox activate -- bash -c "./bin/hogli test posthog/management/commands/test/test_send_usage_report.py"`
- `flox activate -- bash -c "ruff check posthog/management/commands/send_usage_report.py posthog/management/commands/test/test_send_usage_report.py"`
- Commit hooks also ran Python lint, Python format, and `uv run ty check`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. This is a management-command behavior fix.

## 🤖 Agent context

Codex authored this change in the local PostHog worktree after fast-forwarding to the latest `origin/master`. The implementation keeps the behavior at the command boundary so the underlying usage-report task continues to own report-period calculation.

A code-review subagent reviewed the commit range before PR creation and found no Critical, Important, or Minor issues.