### PR TITLE
feat(signals): skip Slack pings for non-actionable inbox reports

### DIFF
--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -5,7 +5,9 @@ suggested reviewers from its `suggested_reviewers` artefact, resolve them to
 PostHog users, and dispatch a Slack message to each user that has configured a
 Slack channel and integration in their `SignalUserAutonomyConfig`.
 
-Each user's `slack_notification_min_priority` filters out reports below the
+Reports the research flow judged non-actionable or already addressed never ping
+Slack — they still land in the inbox, but a notification would be noise. Each
+user's `slack_notification_min_priority` then filters out reports below the
 configured threshold (P0 is highest). When the report has no priority
 judgement, we notify regardless of the user's threshold — the inbox should
 not silently swallow these.
@@ -36,6 +38,7 @@ from products.signals.backend.models import (
     SignalSourceConfig,
     SignalUserAutonomyConfig,
 )
+from products.signals.backend.report_generation.research import ActionabilityChoice
 from products.signals.backend.report_generation.resolve_reviewers import (
     enrich_reviewer_dicts_with_org_members,
     normalized_github_logins_from_suggested_reviewer_artefacts,
@@ -104,22 +107,44 @@ def _meets_min_priority(report_priority: str | None, min_priority: str | None) -
     return report_rank <= min_rank
 
 
-def _latest_priority(report: SignalReport) -> str | None:
-    art = (
-        report.artefacts.filter(type=SignalReportArtefact.ArtefactType.PRIORITY_JUDGMENT)
-        .order_by("-created_at")
-        .first()
-    )
+def _latest_judgment(report: SignalReport, artefact_type: SignalReportArtefact.ArtefactType) -> dict | None:
+    """Parse the most recent artefact of the given type into a dict, or None if absent/malformed."""
+    art = report.artefacts.filter(type=artefact_type).order_by("-created_at").first()
     if art is None:
         return None
     try:
         data = json.loads(art.content)
     except (json.JSONDecodeError, TypeError, ValueError):
         return None
-    if not isinstance(data, dict):
-        return None
-    value = data.get("priority")
+    return data if isinstance(data, dict) else None
+
+
+def _latest_priority(report: SignalReport) -> str | None:
+    data = _latest_judgment(report, SignalReportArtefact.ArtefactType.PRIORITY_JUDGMENT)
+    value = data.get("priority") if data else None
     return value if isinstance(value, str) else None
+
+
+def _warrants_notification(report: SignalReport) -> bool:
+    """Whether a ready report represents outstanding, actionable work worth a Slack ping.
+
+    Notifications are for work a reviewer can act on. We suppress reports the research
+    flow judged non-actionable or already addressed — they still land in the inbox, but
+    shouldn't ping reviewers in Slack. When there's no actionability judgment we notify,
+    mirroring the priority filter: never silently swallow a new inbox item.
+    """
+    data = _latest_judgment(report, SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT)
+    if data is None:
+        return True
+    # `already_addressed` does the real work today: only immediately-actionable reports
+    # reach this dispatch path, so the actionability arm below is a forward-looking guard
+    # in case non-actionable reports ever become notifiable.
+    if data.get("already_addressed") is True:
+        return False
+    actionability = data.get("actionability")
+    if isinstance(actionability, str) and actionability != ActionabilityChoice.IMMEDIATELY_ACTIONABLE.value:
+        return False
+    return True
 
 
 @dataclass(frozen=True)
@@ -345,6 +370,13 @@ def dispatch_inbox_item_notifications(
     except SignalReport.DoesNotExist:
         logger.warning(
             "dispatch_inbox_item_notifications: report not found",
+            extra={"report_id": report_id, "team_id": team_id},
+        )
+        return 0
+
+    if not _warrants_notification(report):
+        logger.info(
+            "signals_inbox_slack_notification_suppressed_not_actionable",
             extra={"report_id": report_id, "team_id": team_id},
         )
         return 0

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -108,7 +108,6 @@ def _meets_min_priority(report_priority: str | None, min_priority: str | None) -
 
 
 def _latest_judgment(report: SignalReport, artefact_type: SignalReportArtefact.ArtefactType) -> dict | None:
-    """Parse the most recent artefact of the given type into a dict, or None if absent/malformed."""
     art = report.artefacts.filter(type=artefact_type).order_by("-created_at").first()
     if art is None:
         return None

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -16,6 +16,7 @@ from products.signals.backend.models import (
     SignalReportTask,
     SignalUserAutonomyConfig,
 )
+from products.signals.backend.report_generation.research import ActionabilityChoice
 from products.signals.backend.slack_inbox_notifications import (
     _build_message_blocks,
     _meets_min_priority,
@@ -445,12 +446,14 @@ def test_dispatch_continues_after_per_user_failure(org_and_team):
     ("actionability", "already_addressed", "should_notify"),
     [
         # Real, outstanding work → notify
-        ("immediately_actionable", False, True),
+        (ActionabilityChoice.IMMEDIATELY_ACTIONABLE.value, False, True),
         # Already addressed → suppress even if nominally actionable
-        ("immediately_actionable", True, False),
+        (ActionabilityChoice.IMMEDIATELY_ACTIONABLE.value, True, False),
+        # Already addressed with no actionability field → still suppress
+        (None, True, False),
         # Non-actionable judgments → suppress
-        ("not_actionable", False, False),
-        ("requires_human_input", False, False),
+        (ActionabilityChoice.NOT_ACTIONABLE.value, False, False),
+        (ActionabilityChoice.REQUIRES_HUMAN_INPUT.value, False, False),
         # No actionability judgment at all → notify (don't silently swallow)
         (None, None, True),
     ],

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -221,6 +221,8 @@ def _make_ready_report(
     summary: str = "Summary text",
     priority: str | None = None,
     suggested_logins: list[str] | None = None,
+    actionability: str | None = None,
+    already_addressed: bool | None = None,
 ) -> SignalReport:
     report = SignalReport.objects.create(
         team=team, status=SignalReport.Status.READY, title=title, summary=summary, signal_count=3, total_weight=1.0
@@ -231,6 +233,18 @@ def _make_ready_report(
             report=report,
             type=SignalReportArtefact.ArtefactType.PRIORITY_JUDGMENT,
             content=json.dumps({"priority": priority}),
+        )
+    if actionability is not None or already_addressed is not None:
+        content: dict = {"explanation": "test"}
+        if actionability is not None:
+            content["actionability"] = actionability
+        if already_addressed is not None:
+            content["already_addressed"] = already_addressed
+        SignalReportArtefact.objects.create(
+            team=team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT,
+            content=json.dumps(content),
         )
     if suggested_logins:
         SignalReportArtefact.objects.create(
@@ -424,3 +438,52 @@ def test_dispatch_continues_after_per_user_failure(org_and_team):
 
     assert sent == 1
     assert fake_client.chat_postMessage.call_count == 2
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("actionability", "already_addressed", "should_notify"),
+    [
+        # Real, outstanding work → notify
+        ("immediately_actionable", False, True),
+        # Already addressed → suppress even if nominally actionable
+        ("immediately_actionable", True, False),
+        # Non-actionable judgments → suppress
+        ("not_actionable", False, False),
+        ("requires_human_input", False, False),
+        # No actionability judgment at all → notify (don't silently swallow)
+        (None, None, True),
+    ],
+)
+def test_dispatch_suppresses_non_actionable_reports(
+    org_and_team, actionability: str | None, already_addressed: bool | None, should_notify: bool
+):
+    org, team = org_and_team
+    user = _make_reviewer_user(org, f"actionability-{actionability}-{already_addressed}@example.com", "action-bot")
+    integration = _make_slack_integration(team, user)
+    SignalUserAutonomyConfig.objects.create(
+        user=user,
+        slack_notification_integration=integration,
+        slack_notification_channel="C123|#inbox",
+    )
+    report = _make_ready_report(
+        team,
+        suggested_logins=["action-bot"],
+        actionability=actionability,
+        already_addressed=already_addressed,
+    )
+
+    fake_client = MagicMock()
+    with (
+        patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
+        patch(
+            "products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email",
+            return_value=None,
+        ),
+    ):
+        slack_cls.return_value.client = fake_client
+        sent = dispatch_inbox_item_notifications(str(report.id), team.id)
+
+    expected_sent = 1 if should_notify else 0
+    assert sent == expected_sent
+    assert fake_client.chat_postMessage.call_count == expected_sent


### PR DESCRIPTION
## Problem

Signal reports that conclude with no real, actionable work — e.g. "expected behavior, no captured error, no code action" — were still pinging suggested reviewers in Slack. These notifications are noise: the inbox item has no fix to make, yet it interrupts the reviewer. As one dogfooder put it, frequent non-actionable pings train you to ignore the channel entirely.

## Changes

Suppress inbox Slack notifications for reports the research flow judged non-actionable or already addressed. The report still lands in the inbox — only the Slack ping is skipped — so nothing is lost, it just stops interrupting reviewers.

The check lives at the notification dispatch layer (`dispatch_inbox_item_notifications`) rather than in the Temporal workflow. That placement is deliberate: the workflow's non-READY branches reset reports to `POTENTIAL`, which would remove them from the inbox entirely. We want to keep the inbox item and only drop the Slack ping.

In practice the field doing the work today is `already_addressed`: only `immediately_actionable` reports reach this dispatch path, so genuinely non-actionable choices never get here. The `already_addressed` verdict was previously computed by the research flow and carried through `RunAgenticReportOutput` but never used to gate anything — this wires it up. The actionability arm is kept as a forward-looking guard in case non-actionable reports ever become notifiable. When a report has no actionability judgment at all, we still notify, mirroring the existing priority filter's "never silently swallow a new inbox item" principle.

This is the MVP the noise complaint asked for ("just always exclude them"). A per-user filter/toggle can come later if needed.

## How did you test this code?

I'm an agent (PostHog Code). I added a parametrized unit test (`test_dispatch_suppresses_non_actionable_reports`) covering the matrix: `immediately_actionable` + not-addressed → notify; `already_addressed` → suppress; `not_actionable` / `requires_human_input` → suppress; and no actionability judgment → notify. I could not run the suite in this environment (no Python venv with deps available), so the tests have not been executed locally — they need to run in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by PostHog Code (Claude) at a maintainer's request, prompted by a dogfooding complaint that non-actionable signal reports were sending noisy Slack notifications.

Key decisions:
- **Placement at the notification layer, not the workflow.** Moving suppression into the Temporal summary workflow was considered and rejected: its non-READY branches reset to `POTENTIAL` and would drop the report from the inbox, contradicting the goal of keeping the inbox item while only suppressing the ping.
- **Lenient dict parsing over `ActionabilityAssessment.model_validate`.** The pydantic model throws on malformed/legacy artefacts (report.py already guards for this); the lenient dict access never throws and matches the sibling `_latest_priority` and the serializer.
- **Notify on unknown.** Malformed or absent actionability judgments fall through to "notify", consistent with the module's existing "never silently swallow" stance.
- Ran a cleanup pass that extracted the shared `_latest_judgment` artefact-load helper (previously duplicated across `_latest_priority` and the new code).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
