### PR TITLE
fix(data-warehouse): cap channel list on Slack webhook setup page

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/WebhookSetupForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/WebhookSetupForm.tsx
@@ -13,6 +13,8 @@ import { SourceConfig, SourceFieldConfig } from '~/queries/schema/schema-general
 
 import { sourceFieldToElement } from './SourceForm'
 
+const MAX_VISIBLE_WEBHOOK_TABLES = 20
+
 export interface WebhookCreateResult {
     success: boolean
     webhook_url: string
@@ -56,12 +58,20 @@ export function WebhookSetupForm({
     const webhookTablesList =
         webhookTables && webhookTables.length > 0 ? (
             <div className="space-y-1">
-                <p className="font-semibold text-sm mb-1">Tables using webhook sync:</p>
+                <p className="font-semibold text-sm mb-1">
+                    {webhookTables.length.toLocaleString()} {webhookTables.length === 1 ? 'table' : 'tables'} using
+                    webhook sync:
+                </p>
                 <ul className="list-disc list-inside text-sm">
-                    {webhookTables.map((t) => (
+                    {webhookTables.slice(0, MAX_VISIBLE_WEBHOOK_TABLES).map((t) => (
                         <li key={t.name}>{t.label || t.name}</li>
                     ))}
                 </ul>
+                {webhookTables.length > MAX_VISIBLE_WEBHOOK_TABLES && (
+                    <p className="text-sm text-muted">
+                        …and {(webhookTables.length - MAX_VISIBLE_WEBHOOK_TABLES).toLocaleString()} more
+                    </p>
+                )}
             </div>
         ) : null
 


### PR DESCRIPTION
## Problem

PostHog models each Slack channel as its own data-warehouse table (schema). When a workspace has many channels (e.g. 4000), the new-source wizard's **webhook setup step** rendered *every* selected channel as a flat, unbounded `<ul>`. That dumps thousands of `<li>` nodes into the DOM — useless to read and capable of locking the browser tab.

## Changes

`WebhookSetupForm` now shows a count and a truncated preview instead of the full list:

- Header reads e.g. `4,000 tables using webhook sync:` (with singular/plural handling).
- Only the first 20 channels render as list items.
- An `…and N more` line appears when the list exceeds the cap.

The list is purely informational (it confirms which tables sync via webhook — the channels were already chosen in the schema-selection step), so a full render adds no value over a count. Lists of ≤20 are unchanged. The fix lives in the shared `webhookTablesList` block, so it applies to all states of the form (initial / creating / success / pending) and the webhook settings tab.

## How did you test this code?

I'm an agent. I have **not** run the frontend tooling — `node_modules` and `oxfmt`/`oxlint`/`tsc` for the frontend workspace were unavailable in my environment, so `typescript:check` and `format` were not run, and there was no existing test/story for this component. The change is small and self-contained (no new imports or types; `slice` + `toLocaleString` + standard JSX). Please rely on CI for type-check/lint, and a quick manual check of the webhook setup step with a large channel count.

## 🤖 Agent context

Authored with Claude Code (PostHog Code). The reporter linked the Slack new-source webhook setup page and noted that ~4000 channels were all listed at once.

Exploration confirmed the root cause is the channel-as-schema model combined with the unbounded `<ul>` in `WebhookSetupForm.tsx`. Considered a collapsible full list and an inline-searchable list; chose the count + truncated-preview approach as the lowest-risk fix that fully removes the perf hazard, since the list is informational only. Scope was deliberately limited to the webhook step — the schema-selection step (step 3) is already paginated and filterable.
