### PR TITLE
fix(tracing): UTC-pin time_bucket truncation to fix keyset pagination

### DIFF
--- a/products/tracing/backend/aggregation_query_runner.py
+++ b/products/tracing/backend/aggregation_query_runner.py
@@ -287,8 +287,8 @@ class TraceSpansAggregationQueryRunner(_SpanAggregationMixin, AnalyticsQueryRunn
                 countIf(status_code = 2) AS error_count
             FROM posthog.trace_spans
             WHERE {where}
-              AND toStartOfDay(time_bucket) >= toStartOfDay({date_from})
-              AND toStartOfDay(time_bucket) <= toStartOfDay({date_to})
+              AND toStartOfDay(time_bucket, 'UTC') >= toStartOfDay({date_from}, 'UTC')
+              AND toStartOfDay(time_bucket, 'UTC') <= toStartOfDay({date_to}, 'UTC')
               AND timestamp >= {date_from}
               AND timestamp < {date_to}
             GROUP BY service_name, name
@@ -350,8 +350,8 @@ class TraceSpansTreeQueryRunner(_SpanAggregationMixin, AnalyticsQueryRunner[Trac
                 WHERE {where}
                   AND name = {span_name}
                   AND service_name = {service_name}
-                  AND toStartOfDay(time_bucket) >= toStartOfDay({date_from})
-                  AND toStartOfDay(time_bucket) <= toStartOfDay({date_to})
+                  AND toStartOfDay(time_bucket, 'UTC') >= toStartOfDay({date_from}, 'UTC')
+                  AND toStartOfDay(time_bucket, 'UTC') <= toStartOfDay({date_to}, 'UTC')
                   AND timestamp >= {date_from}
                   AND timestamp < {date_to}
             ),
@@ -362,8 +362,8 @@ class TraceSpansTreeQueryRunner(_SpanAggregationMixin, AnalyticsQueryRunner[Trac
                 FROM posthog.trace_spans
                 WHERE trace_id IN (SELECT trace_id FROM matched_traces)
                   AND service_name = {service_name}
-                  AND toStartOfDay(time_bucket) >= toStartOfDay({date_from})
-                  AND toStartOfDay(time_bucket) <= toStartOfDay({date_to})
+                  AND toStartOfDay(time_bucket, 'UTC') >= toStartOfDay({date_from}, 'UTC')
+                  AND toStartOfDay(time_bucket, 'UTC') <= toStartOfDay({date_to}, 'UTC')
                   AND timestamp >= {date_from}
                   AND timestamp < {date_to}
             )

--- a/products/tracing/backend/aggregation_query_runner.py
+++ b/products/tracing/backend/aggregation_query_runner.py
@@ -53,7 +53,7 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.hogql_queries.utils.query_previous_period_date_range import QueryPreviousPeriodDateRange
 from posthog.models.filters.mixins.utils import cached_property
 
-from .logic import translate_span_filter
+from .logic import TIME_BUCKET_DATE_RANGE_WHERE, translate_span_filter
 
 if TYPE_CHECKING:
     from posthog.models import Team, User
@@ -287,8 +287,9 @@ class TraceSpansAggregationQueryRunner(_SpanAggregationMixin, AnalyticsQueryRunn
                 countIf(status_code = 2) AS error_count
             FROM posthog.trace_spans
             WHERE {where}
-              AND toStartOfDay(time_bucket, 'UTC') >= toStartOfDay({date_from}, 'UTC')
-              AND toStartOfDay(time_bucket, 'UTC') <= toStartOfDay({date_to}, 'UTC')
+              AND """
+            + TIME_BUCKET_DATE_RANGE_WHERE
+            + """
               AND timestamp >= {date_from}
               AND timestamp < {date_to}
             GROUP BY service_name, name
@@ -350,8 +351,9 @@ class TraceSpansTreeQueryRunner(_SpanAggregationMixin, AnalyticsQueryRunner[Trac
                 WHERE {where}
                   AND name = {span_name}
                   AND service_name = {service_name}
-                  AND toStartOfDay(time_bucket, 'UTC') >= toStartOfDay({date_from}, 'UTC')
-                  AND toStartOfDay(time_bucket, 'UTC') <= toStartOfDay({date_to}, 'UTC')
+                  AND """
+            + TIME_BUCKET_DATE_RANGE_WHERE
+            + """
                   AND timestamp >= {date_from}
                   AND timestamp < {date_to}
             ),
@@ -362,8 +364,9 @@ class TraceSpansTreeQueryRunner(_SpanAggregationMixin, AnalyticsQueryRunner[Trac
                 FROM posthog.trace_spans
                 WHERE trace_id IN (SELECT trace_id FROM matched_traces)
                   AND service_name = {service_name}
-                  AND toStartOfDay(time_bucket, 'UTC') >= toStartOfDay({date_from}, 'UTC')
-                  AND toStartOfDay(time_bucket, 'UTC') <= toStartOfDay({date_to}, 'UTC')
+                  AND """
+            + TIME_BUCKET_DATE_RANGE_WHERE
+            + """
                   AND timestamp >= {date_from}
                   AND timestamp < {date_to}
             )

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 # constants print UTC-pinned, while bare DateTime columns read in the session tz; pinning both
 # sides keeps them on the same day grid so a non-UTC session can't drop same-day rows (which
 # previously emptied keyset page 2).
-_TIME_BUCKET_DATE_RANGE_WHERE = (
+TIME_BUCKET_DATE_RANGE_WHERE = (
     "toStartOfDay(time_bucket, 'UTC') >= toStartOfDay({date_from}, 'UTC') "
     "and toStartOfDay(time_bucket, 'UTC') <= toStartOfDay({date_to}, 'UTC')"
 )
@@ -195,7 +195,7 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
 
         exprs.append(
             parse_expr(
-                _TIME_BUCKET_DATE_RANGE_WHERE,
+                TIME_BUCKET_DATE_RANGE_WHERE,
                 placeholders={
                     **self.query_date_range.to_placeholders(),
                 },
@@ -511,7 +511,7 @@ def run_service_names_query(
 
     exprs: list[ast.Expr] = [
         parse_expr(
-            _TIME_BUCKET_DATE_RANGE_WHERE,
+            TIME_BUCKET_DATE_RANGE_WHERE,
             placeholders={**query_date_range.to_placeholders()},
         ),
         ast.Placeholder(expr=ast.Field(chain=["filters"])),

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -49,6 +49,16 @@ if TYPE_CHECKING:
     from posthog.models import Team, User
 
 
+# Day-range bound on time_bucket, pinned to UTC. With convertToProjectTimezone=False the date
+# constants print UTC-pinned, while bare DateTime columns read in the session tz; pinning both
+# sides keeps them on the same day grid so a non-UTC session can't drop same-day rows (which
+# previously emptied keyset page 2).
+_TIME_BUCKET_DATE_RANGE_WHERE = (
+    "toStartOfDay(time_bucket, 'UTC') >= toStartOfDay({date_from}, 'UTC') "
+    "and toStartOfDay(time_bucket, 'UTC') <= toStartOfDay({date_to}, 'UTC')"
+)
+
+
 def _normalise_to_base64(value: str) -> str:
     try:
         int(value, 16)
@@ -185,7 +195,7 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
 
         exprs.append(
             parse_expr(
-                "toStartOfDay(time_bucket) >= toStartOfDay({date_from}) and toStartOfDay(time_bucket) <= toStartOfDay({date_to})",
+                _TIME_BUCKET_DATE_RANGE_WHERE,
                 placeholders={
                     **self.query_date_range.to_placeholders(),
                 },
@@ -390,11 +400,13 @@ class TraceSpansQueryRunner(TraceSpansQueryRunnerMixin, AnalyticsQueryRunner[Tra
         having_expr: ast.Expr | None = None
         if cursor is not None:
             cursor_ts, cursor_trace_id = cursor
-            # Scalar bound on time_bucket lets ClickHouse prune parts via the primary index;
-            # min(timestamp) of any kept trace is always within this bound.
+            # Coarse day bound on time_bucket lets ClickHouse prune parts via the primary index.
+            # Pin both sides to UTC for the same reason as the where() date bound: the cursor
+            # constant prints UTC-pinned, so an unpinned toStartOfDay would truncate on the
+            # session-tz day grid and drop same-day rows under a non-UTC session.
             subquery_where_exprs.append(
                 parse_expr(
-                    f"time_bucket {ts_op} toStartOfDay({{cursor_ts}})",
+                    f"toStartOfDay(time_bucket, 'UTC') {ts_op} toStartOfDay({{cursor_ts}}, 'UTC')",
                     placeholders={"cursor_ts": ast.Constant(value=cursor_ts)},
                 )
             )
@@ -499,7 +511,7 @@ def run_service_names_query(
 
     exprs: list[ast.Expr] = [
         parse_expr(
-            "toStartOfDay(time_bucket) >= toStartOfDay({date_from}) and toStartOfDay(time_bucket) <= toStartOfDay({date_to})",
+            _TIME_BUCKET_DATE_RANGE_WHERE,
             placeholders={**query_date_range.to_placeholders()},
         ),
         ast.Placeholder(expr=ast.Field(chain=["filters"])),

--- a/products/tracing/backend/tests/test_keyset_pagination.py
+++ b/products/tracing/backend/tests/test_keyset_pagination.py
@@ -1,0 +1,113 @@
+import json
+import base64
+import datetime as dt
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from parameterized import parameterized
+
+from posthog.schema import DateRange, TraceSpansQuery
+
+from posthog.hogql.constants import LimitContext
+from posthog.hogql.query import HogQLQueryExecutor
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import Workload
+from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.traces.spans import TRACE_SPANS_DISTRIBUTED_TABLE_SQL, TRACE_SPANS_TABLE_SQL
+
+from products.tracing.backend.logic import TraceSpansQueryRunner
+
+# 150 same-day root traces (i=0..149), timestamps increasing with i, newest-first ordering.
+# The 100th newest is i=50, so page 2 (after that cursor) should yield i=0..49 = 50 distinct traces.
+TOTAL_TRACES = 150
+PAGE_SIZE = 100
+CURSOR_INDEX = 50
+DATE_FROM = "2026-06-02T07:00:00Z"
+DATE_TO = "2026-06-02T09:00:00Z"
+CURSOR_TS_ISO = "2026-06-02T08:00:50+00:00"
+CURSOR_TRACE_ID_HEX = format(CURSOR_INDEX, "032x")
+
+
+def _b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii")
+
+
+class TestTraceSpansKeysetPaginationTimezone(ClickhouseTestMixin, APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = True
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        tag_queries(product="tracing", feature="query")
+        sync_execute("DROP TABLE IF EXISTS trace_spans_distributed")
+        sync_execute("DROP TABLE IF EXISTS trace_spans")
+        sync_execute(TRACE_SPANS_TABLE_SQL())
+        # is_root_span ships via a separate logs-cluster migration, not the Python DDL.
+        sync_execute(
+            "ALTER TABLE trace_spans ADD COLUMN IF NOT EXISTS "
+            "is_root_span Bool MATERIALIZED (replaceAll(trimRight(parent_span_id, '='), 'A', '')) = ''"
+        )
+        sync_execute(TRACE_SPANS_DISTRIBUTED_TABLE_SQL())
+
+        rows = []
+        base = dt.datetime(2026, 6, 2, 8, 0, 0)
+        for i in range(TOTAL_TRACES):
+            ts = base + dt.timedelta(seconds=i)
+            ts_str = ts.strftime("%Y-%m-%d %H:%M:%S.%f")
+            rows.append(
+                "("
+                f"'019e8754-0000-0000-0000-{i:012d}', {cls.team.id}, '{_b64(i.to_bytes(16, 'big'))}', "
+                f"'{_b64(i.to_bytes(8, 'big'))}', '', 'GET /api', 2, '{ts_str}', '{ts_str}', '{ts_str}', 0, 'web'"
+                ")"
+            )
+        sync_execute(
+            "INSERT INTO trace_spans (uuid, team_id, trace_id, span_id, parent_span_id, name, kind, "
+            "timestamp, end_time, observed_timestamp, status_code, service_name) VALUES " + ",".join(rows)
+        )
+
+    def _cursor(self) -> str:
+        return base64.b64encode(
+            json.dumps({"timestamp": CURSOR_TS_ISO, "trace_id": CURSOR_TRACE_ID_HEX}).encode("utf-8")
+        ).decode("utf-8")
+
+    def _distinct_trace_count(self, *, after: str | None, limit: int, session_timezone: str) -> int:
+        query = TraceSpansQuery(
+            dateRange=DateRange(date_from=DATE_FROM, date_to=DATE_TO),
+            orderBy="latest",
+            limit=limit,
+            after=after,
+            rootSpans=True,
+            prefetchSpans=20,
+        )
+        runner = TraceSpansQueryRunner(query, self.team)
+        sql, context = HogQLQueryExecutor(
+            query_type="TraceSpansQuery",
+            query=runner.to_query(),
+            modifiers=runner.modifiers,
+            team=self.team,
+            workload=Workload.LOGS,
+            timings=runner.timings,
+            limit_context=LimitContext.QUERY,
+        ).generate_clickhouse_sql()
+        results = sync_execute(
+            sql, context.values, workload=Workload.LOGS, settings={"session_timezone": session_timezone}
+        )
+        return len({row[1] for row in results})  # col 1 = hex(trace_id)
+
+    # The regression: a non-UTC session truncated time_bucket on a different day grid and emptied
+    # page 2. Both pages must return identical counts under UTC and a non-UTC session. Page 2 passes
+    # limit+1 because the view over-fetches one trace to compute has_more.
+    @parameterized.expand(
+        [
+            ("page1_utc", False, PAGE_SIZE, "UTC", PAGE_SIZE),
+            ("page1_non_utc", False, PAGE_SIZE, "US/Pacific", PAGE_SIZE),
+            ("page2_utc", True, PAGE_SIZE + 1, "UTC", TOTAL_TRACES - PAGE_SIZE),
+            ("page2_non_utc", True, PAGE_SIZE + 1, "US/Pacific", TOTAL_TRACES - PAGE_SIZE),
+        ]
+    )
+    def test_keyset_pagination_is_timezone_robust(self, _name, paginated, limit, session_timezone, expected):
+        after = self._cursor() if paginated else None
+        self.assertEqual(
+            self._distinct_trace_count(after=after, limit=limit, session_timezone=session_timezone), expected
+        )

--- a/products/tracing/backend/tests/test_keyset_pagination.py
+++ b/products/tracing/backend/tests/test_keyset_pagination.py
@@ -66,6 +66,16 @@ class TestTraceSpansKeysetPaginationTimezone(ClickhouseTestMixin, APIBaseTest):
             "timestamp, end_time, observed_timestamp, status_code, service_name) VALUES " + ",".join(rows)
         )
 
+    @classmethod
+    def tearDownClass(cls):
+        # Restore the standard Python DDL so a later test class in the same process doesn't inherit
+        # this class's modified schema. Drop the distributed table first (it depends on the base).
+        sync_execute("DROP TABLE IF EXISTS trace_spans_distributed")
+        sync_execute("DROP TABLE IF EXISTS trace_spans")
+        sync_execute(TRACE_SPANS_TABLE_SQL())
+        sync_execute(TRACE_SPANS_DISTRIBUTED_TABLE_SQL())
+        super().tearDownClass()
+
     def _cursor(self) -> str:
         return base64.b64encode(
             json.dumps({"timestamp": CURSOR_TS_ISO, "trace_id": CURSOR_TRACE_ID_HEX}).encode("utf-8")


### PR DESCRIPTION
## Problem

When a ClickHouse session is configured with a non-UTC timezone (e.g. `US/Pacific`), calls to `toStartOfDay(time_bucket)` truncate to the start of the local day rather than the UTC day. Because the date constants in queries are printed UTC-pinned, the two sides of the comparison operate on different day grids. This caused keyset-paginated page 2 results to be empty — the cursor-based `time_bucket` bound excluded all rows that should have been returned.

## Changes

All `toStartOfDay(time_bucket)` and `toStartOfDay({date_from/date_to})` calls are pinned to `'UTC'` explicitly. A shared constant `_TIME_BUCKET_DATE_RANGE_WHERE` is introduced in `logic.py` to centralise this pattern and avoid future drift. The same fix is applied to the cursor-based coarse bound used for ClickHouse part pruning in the keyset pagination path.

## How did you test this code?

A new integration test `TestTraceSpansKeysetPaginationTimezone` is added that:

- Inserts 150 same-day root traces into a local ClickHouse instance.
- Executes both page 1 and page 2 queries with an explicit cursor.
- Runs each page under both `UTC` and `US/Pacific` session timezones.
- Asserts that both sessions return identical, correct trace counts (100 on page 1, 50 on page 2).

This directly reproduces the regression where page 2 under a non-UTC session previously returned 0 traces.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

This fix was identified by tracing the empty-page-2 bug to a timezone mismatch in `toStartOfDay` comparisons. The decision was made to pin all `toStartOfDay` calls involving `time_bucket` and date range constants to `'UTC'` rather than relying on session timezone, since the date constants are always emitted UTC-pinned by the query planner. A shared string constant was introduced to avoid the same mistake recurring across the three call sites in `logic.py` and the two in `aggregation_query_runner.py`.