### PR TITLE
chore(ci): lead debugging-ci-failures skill with ci:insights

### DIFF
--- a/.agents/skills/debugging-ci-failures/SKILL.md
+++ b/.agents/skills/debugging-ci-failures/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: debugging-ci-failures
 description: >
-  Debugs failing GitHub Actions CI runs for PostHog PRs, commits, and branches.
-  Use when the user asks why CI is red, mentions a failing check, GitHub Actions
-  run, Depot runner, workflow, job, shard, flaky test, lint failure, typecheck
+  Debugs failing GitHub Actions CI runs for PostHog PRs, commits, and branches,
+  and answers broad CI-health questions ("is CI red?", "is master green today?",
+  "what's broken right now?"). Use when the user asks why CI is red, asks for the
+  current CI or master status, or mentions a failing check, GitHub Actions run,
+  Depot runner, workflow, job, shard, flaky test, lint failure, typecheck
   failure, snapshot diff, migration check, generated types drift, or skills
-  build failure. Guides read-only inspection, failure classification, a check
-  for an existing CI-insights hypothesis, smallest local reproduction with
-  hogli, and safe reporting without rerunning CI or posting to GitHub.
+  build failure. Start with the `hogli ci:insights` digest (aggregated cross-run
+  CI intelligence), then guides read-only inspection, failure classification,
+  smallest local reproduction with hogli, and safe reporting without rerunning CI
+  or posting to GitHub.
 ---
 
 # Debugging PostHog CI failures
@@ -15,6 +18,10 @@ description: >
 Find the first meaningful failure, classify it, reproduce the smallest useful
 case locally when appropriate, and report the result. Avoid public-visible or
 irreversible actions unless the user explicitly asks.
+
+Always start with the `hogli ci:insights` digest. It is the institutional,
+cross-run source of truth, and it is fresher and more reliable than scraping
+`gh run list` / the GitHub Actions API, which can lag or rate-limit.
 
 ## Safety rules
 
@@ -33,6 +40,36 @@ change local Git state, make sure it is necessary for the task and does not
 overwrite unrelated work.
 
 ## Workflow
+
+### 1. Start with CI insights (always first)
+
+`hogli ci:insights` is the institutional CI-intelligence backend. It aggregates
+cross-run history — recurring flakes, occurrence counts, confidence, and any
+proposed or merged fix — that a single run can't show. Consult it before any raw
+`gh` log archaeology; the raw GitHub Actions API can lag or rate-limit, while the
+insights digest is the freshest aggregated view.
+
+```bash
+hogli ci:insights                                # digest for the current repo + branch
+hogli ci:insights search "<error or test name>"  # match a specific failure
+hogli ci:insights view <id>                       # one insight + its remediation actions
+hogli ci:insights plan <id>                       # print the recommended fix plan (does not apply it)
+```
+
+- Broad question ("is CI red?", "is master green today?", "what's broken right
+  now?"): the no-arg digest answers directly — it lists open / in-progress /
+  resolved counts and the most recent insights with severity and confidence. You
+  often do not need a target PR or run at all; report from the digest.
+- Specific failure: run `search "<error>"` to match it before reading logs. When
+  a matching insight exists, weigh its confidence and occurrence history, and note
+  whether a fix is already merged (the failure may already be resolved on
+  `master`) or proposed (a plan you can adapt).
+
+`hogli ci:insights` prints a setup hint if the backend isn't installed or
+authenticated — if so, fall back to the `gh`-based inspection below. Surface what
+you find per the Safety rules — do not auto-apply a fix.
+
+### 2. Find the failing run (for a specific failure)
 
 Determine the target in this order:
 
@@ -87,26 +124,6 @@ explains the run's conclusion. Keep excerpts under 40 lines.
 If multiple signals match, choose the most specific class. For example, prefer
 codegen drift over lint, migration over typecheck, and snapshot / visual over a
 generic Playwright test failure.
-
-## Check existing CI insights first
-
-Before reproducing locally, check whether our CI-insights backend already has a
-hypothesis for this failure. It aggregates cross-run history — recurring flakes,
-occurrence counts, confidence — that a single run can't show, and may already
-carry a proposed or merged fix.
-
-```bash
-hogli ci:insights                                # insights for the current repo + branch
-hogli ci:insights search "<error or test name>"  # match this specific failure
-hogli ci:insights view <id>                       # one insight + its remediation actions
-hogli ci:insights plan <id>                       # print the recommended fix plan (does not apply it)
-```
-
-`hogli ci:insights` prints a setup hint if the backend isn't installed or
-authenticated — if so, skip this step. When a matching insight exists, weigh its
-confidence and occurrence history, and note whether a fix is already merged (the
-failure may already be resolved on `master`) or proposed (a plan you can adapt).
-Surface what you find per the Safety rules — do not auto-apply a fix.
 
 ## Local reproduction
 


### PR DESCRIPTION
## Problem

`hogli ci:insights` (the institutional cross-run CI digest) was buried mid-workflow in the `debugging-ci-failures` skill, framed only as a check for one failing run. Broad "is CI red / is master green today / what's broken" questions didn't route to the skill at all, so the digest got skipped in favor of slower, less reliable raw `gh` Actions-API queries.

## Changes

- Promote `hogli ci:insights` to step 1 ("always first") of the skill workflow, before any `gh` log archaeology.
- Broaden the skill description so broad CI-health questions trigger it.
- Note the no-arg digest answers "is master green" directly (no target PR/run needed), and that the raw Actions API can lag or rate-limit.
- Drop the now-duplicate mid-workflow section.

Docs/skill only — no runtime code changed.

## How did you test this code?

I'm an agent. Ran `hogli lint:skills` — all 48 skills pass. No automated suite is relevant (skill prose only).

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Prompted when a CI-status question led me to raw `gh run list` archaeology instead of `hogli ci:insights`; the user flagged the miss and asked to encode the preference more directly. Fixed in the skill rather than as a one-off instruction (per the repo's automation hierarchy, and because `tools/hogli-commands/hogli_commands/ci_insights.py` already names this skill as its documented consumer). Also confirmed empirically that the raw Actions API returned stale data in this environment while the insights digest was fresh — extra justification for leading with insights.
