### PR TITLE
feat(data-warehouse): release WorkOS source

### DIFF
--- a/posthog/temporal/data_imports/sources/workos/source.py
+++ b/posthog/temporal/data_imports/sources/workos/source.py
@@ -34,7 +34,6 @@ class WorkOSSource(ResumableSource[WorkOSSourceConfig, WorkOSResumeConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.WORK_OS,
             label="WorkOS",
-            unreleasedSource=True,
             releaseStatus="alpha",
             caption="""Enter your WorkOS API key to sync your WorkOS data into the PostHog Data warehouse.
 


### PR DESCRIPTION
## Problem

The WorkOS data warehouse source was registered as an *unreleased* source (`unreleasedSource=True`). That generic flag on the shared `SourceConfig` hides a source from the inline setup and onboarding flows and renders it as a "coming soon / Roadmap" item in the data pipelines UI, rather than a connectable source.

WorkOS already has working sync logic, credential validation, and `releaseStatus="alpha"`, so it should be connectable.

## Changes

Removed the `unreleasedSource=True` line from `WorkOSSource.get_source_config` in `posthog/temporal/data_imports/sources/workos/source.py`. The field defaults to `None`, so omitting it marks the source as released. `releaseStatus="alpha"` is left in place so it still surfaces as an alpha source.

No other files change: `unreleasedSource` is a generic `SourceConfig` field shared by ~100 sources (not removed from the schema), and the source config is generated at runtime and read dynamically by the frontend — so no generated types need regenerating.

## How did you test this code?

I'm an agent. The dev toolchain (ruff / hogli / flox) was not available in my environment, so I could not run the linters or test suite. I verified the file still parses (`ast.parse`) and reviewed the diff. The WorkOS source tests live at `posthog/temporal/data_imports/sources/workos/tests/` and should be run in CI; no test or snapshot asserts on the `unreleasedSource` value.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored with Claude Code (Claude Code CLI). The request was to remove the `unreleasedSource` field from the WorkOS source. I confirmed via codebase exploration that `unreleasedSource` is a generic `SourceConfig` flag rather than WorkOS-specific, so the change is scoped to WorkOS's `get_source_config` only and does not touch the schema or generated frontend types. I verified no tests or `.ambr` snapshots assert on the WorkOS `unreleasedSource` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
