### PR TITLE
fix(sql-editor): Speed up the sql editor for lengthy queries

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/multiQueryUtils.ts
+++ b/frontend/src/scenes/data-warehouse/editor/multiQueryUtils.ts
@@ -195,13 +195,22 @@ function collectSelectNodesAtOffset(node: unknown, targetOffset: number, results
  * @param cursorOffset - Cursor position in the full editor text
  * @param queryStartOffset - Where this query starts in the full editor text
  */
+
+let astCache: { query: string; ast: ASTNode } | null = null
+
 export async function findInnermostSelectAtOffset(
     query: string,
     cursorOffset: number,
     queryStartOffset: number
 ): Promise<QueryRange | null> {
     try {
-        const ast: ASTNode = JSON.parse(await parseSelect(query))
+        let ast: ASTNode
+        if (astCache && astCache.query === query) {
+            ast = astCache.ast
+        } else {
+            ast = JSON.parse(await parseSelect(query))
+            astCache = { query, ast }
+        }
         if (ast.error || (ast.node !== 'SelectQuery' && ast.node !== 'SelectSetQuery')) {
             return null
         }

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -1917,8 +1917,13 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             // everything whenever the editor content changes.
             cache.subqueryValidationCache?.clear()
 
-            // Decorations are cheap and visual — update immediately for responsiveness.
-            cache.updateActiveQueryDecoration?.()
+            if (cache.activeQueryDecorationDebounceTimeout) {
+                window.clearTimeout(cache.activeQueryDecorationDebounceTimeout)
+            }
+            cache.activeQueryDecorationDebounceTimeout = window.setTimeout(() => {
+                cache.activeQueryDecorationDebounceTimeout = null
+                cache.updateActiveQueryDecoration?.()
+            }, 150)
 
             // Skip re-parsing if the text hasn't changed since the last parse.
             if (cache.lastParsedQueryInput === queryInput && cache.lastParsedQueryResult !== undefined) {


### PR DESCRIPTION
## Problem

User experiencing slowness: https://posthoghelp.zendesk.com/agent/tickets/58094 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/63945)

I'm not sure if there's a better way to do the debounce here but at the very minimum I am seeing improvements in responsiveness from these changes.

Closes #60974

## Changes

- sqlEditorLogic.tsx - debounce the decoration trigger on every keystroke
- multiQueryUtils.ts - cache the parsed AST by query text

## How did you test this code?

Ran it locally and used Chrome's dev tools performance testing. It's much more responsive now but I'm not sure if there are other issues this could introduce.

## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

