### PR TITLE
feat(slack-app): prompt to connect GitHub when ask needs a repo

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -416,7 +416,28 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                 if cascade.mode == "auto":
                     repository = cascade.repository
                 elif cascade.mode == "no_repo":
+                    # Cascade only emits `no_repo` when neither the team nor the
+                    # mentioning user has any GitHub install. Classify first so
+                    # non-coding asks ("how do I configure retention?") still
+                    # answer with no repo; coding asks surface the connect-personal-
+                    # GitHub prompt instead of silently no-op'ing.
                     repository = None
+                    if workflow.patched("posthog-code-classify-before-gate-2026-06"):
+                        needs_repo = await _execute_posthog_code_activity(
+                            classify_posthog_code_task_needs_repo_activity,
+                            event.get("text", ""),
+                            thread_messages,
+                        )
+                        if needs_repo:
+                            blocked = await _execute_posthog_code_activity(
+                                block_posthog_code_task_if_no_personal_github_activity,
+                                inputs,
+                                channel,
+                                thread_ts,
+                                user_id,
+                            )
+                            if blocked:
+                                return
                 elif cascade.mode == "needs_user_github":
                     # Team has GitHub, but the mentioning user hasn't connected their
                     # personal install. Fire the gate so they get the Connect button


### PR DESCRIPTION
## Problem

When the cascade returns `no_repo` (neither the team nor the mentioning user has any GitHub install), the `@PostHog` Slack bot silently creates a task with `repository = None`. A user asking "fix the broken checkout" gets no useful response and no hint that connecting GitHub would unblock them.

## Changes

On the `no_repo` cascade branch, run `classify_posthog_code_task_needs_repo_activity` (the Haiku check already used on `agent_needed`). If the task actually needs a repo, call the existing `block_posthog_code_task_if_no_personal_github_activity` — same activity, same "Connect GitHub" Slack block, same deep link to `/settings/user-personal-integrations` as the `needs_user_github` branch. Non-coding asks still fall through to `repository = None`.

`_get_full_repo_names` only ever reads `UserIntegration` (personal), so personal install is the single path that actually populates repos — using the personal-GitHub block for both states is the right UX.

Gated behind a new `workflow.patched("posthog-code-classify-before-gate-2026-06")` so in-flight workflows that recorded the old activity sequence stay deterministic on replay.

`needs_user_github` and `agent_needed` branches are unchanged.

### Repo selection states

The `cascade_posthog_code_repository_activity` is a deterministic fast-path (DB lookups, no LLM) that classifies the mention into one of four modes based on what GitHub state exists for the team and the mentioning user. `(*)` marks the branches added in this PR.

```
cascade ──┬── auto                [1 repo OR `org/repo` in the message matches a connected repo]
          │     └──> create task with that repo
          │
          ├── no_repo (*)         [team has no GitHub Integration AND user has no personal UserIntegration]
          │     └──> classify ──┬── yes  (coding ask)     ──> block (*): "connect your personal GitHub"
          │                     └── no   (non-coding)     ──> create task with repo=None
          │
          ├── needs_user_github   [team HAS a GitHub Integration BUT user has no personal install]
          │     └──> block: "connect your personal GitHub"
          │
          └── agent_needed        [user has >1 personal repo AND no explicit `org/repo` mention]
                └──> classify ──┬── no  (non-coding)      ──> create task with repo=None
                                └── yes (coding ask)      ──> discovery agent ──┬── found     ──> create task with the discovered repo
                                                                                ├── no_match  ──> create task with repo=None
                                                                                └── failed    ──> repo picker (user selects)
```

The `no_repo` and `needs_user_github` branches both surface the same "connect your personal GitHub" prompt because `_get_full_repo_names` only ever reads `UserIntegration` — the team-level GitHub row exists but doesn't drive what repos the bot can see. The single block activity reused here is the existing `block_posthog_code_task_if_no_personal_github_activity`.

Notes on the classifier: it's a cheap Haiku call gated behind `classify_posthog_code_task_needs_repo_activity`, asking "does the user's ask require a code repository to act on?" — useful for separating "how do I configure retention?" (no repo needed) from "fix the broken checkout flow" (needs a repo). It's run after the cascade so the deterministic happy paths (`auto`) pay no Haiku tax.

## How did you test this code?

Tested locally.

## 🤖 Agent context

Done with Claude.