### PR TITLE
fix(quill): handle null Select onValueChange value

### DIFF
--- a/packages/quill/packages/components/src/date-time-picker.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.tsx
@@ -261,7 +261,11 @@ function Calendar({
                 </Button>
                 <Select
                     value={currentKey}
-                    onValueChange={(v: number) => handleMonthYearSelect(v)}
+                    onValueChange={(v) => {
+                        if (v !== null) {
+                            handleMonthYearSelect(v)
+                        }
+                    }}
                 >
                     <SelectTrigger size="sm" aria-label="Month and year" className="h-6 px-2 text-xs">
                         <SelectValue>


### PR DESCRIPTION
## Problem

`@base-ui/react@1.4.0` (pinned on master) types `Select`'s `onValueChange` callback as `(value: T | null, eventDetails: SelectRootChangeEventDetails) => void` for single-select. The month/year picker in `date-time-picker.tsx` still passed `(v: number) => ...`, which rejects the `null` case. This `TS2322` is a pre-existing failure on master, breaking the EE jest shard / "Frontend Tests Pass" check.

## Changes

- Update the month/year `<Select onValueChange>` consumer to accept `number | null` and guard against `null` before calling `handleMonthYearSelect`.
- No other consumers needed changes: the `set(...)`-based `InputGroupNumberInput` handlers already accept `number | null`, and the `SelectValue` render prop is typed `(value: any)`.

## How did you test this code?

I'm an agent; no manual UI testing. Reproduced with the repo-pinned `typescript@6.0.3` against the quill components tsconfig:
- Before: `date-time-picker.tsx(264,21): error TS2322: Type '(v: number) => void' is not assignable to type '(value: number | null, eventDetails: SelectRootChangeEventDetails) => void'`.
- After: error resolved.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) on a fresh worktree off `master`. Confirmed the broken signature originates from `@base-ui/react@1.4.0`'s `Select.Root`, located the single offending consumer, and verified the fix with a before/after `tsc` reproduction using the lockfile-pinned TypeScript. Considered touching the `SelectValue` render prop and the `set`-based handlers but ruled both out as already type-correct. Requires human review.
