### PR TITLE
fix(agentic-provisioning): check all stripe signatures on rotation

### DIFF
--- a/ee/api/agentic_provisioning/signature.py
+++ b/ee/api/agentic_provisioning/signature.py
@@ -76,12 +76,19 @@ def verify_provisioning_signature(request: Request) -> Response | None:
             status=400,
         )
 
+    try:
+        decoded_body = body.decode("utf-8")
+    except UnicodeDecodeError as e:
+        _log_and_capture_event("body_not_decodable", 400, endpoint, reason=str(e))
+        return Response(
+            {"error": {"code": "body_not_decodable", "message": "Request body must be UTF-8 encoded"}},
+            status=400,
+        )
+
     sig_header = request.headers.get("stripe-signature", "")
     try:
-        stripe.WebhookSignature.verify_header(
-            body.decode("utf-8"), sig_header, secret, tolerance=MAX_TIMESTAMP_DRIFT_SECONDS
-        )
-    except (stripe.SignatureVerificationError, UnicodeDecodeError) as e:
+        stripe.WebhookSignature.verify_header(decoded_body, sig_header, secret, tolerance=MAX_TIMESTAMP_DRIFT_SECONDS)
+    except stripe.SignatureVerificationError as e:
         _log_and_capture_event("invalid_signature", 401, endpoint, reason=str(e))
         return Response(
             {"error": {"code": "invalid_signature", "message": "Signature verification failed"}}, status=401

--- a/ee/api/agentic_provisioning/signature.py
+++ b/ee/api/agentic_provisioning/signature.py
@@ -1,12 +1,12 @@
 import re
 import hmac
-import time
 import uuid
 import hashlib
 
 from django.conf import settings
 from django.http.request import RawPostDataException
 
+import stripe
 import structlog
 import posthoganalytics
 from rest_framework.request import Request
@@ -49,6 +49,12 @@ def verify_provisioning_signature(request: Request) -> Response | None:
 
     Returns None if verification passes, or an error Response if it fails.
     Called at the top of every view (Vercel-style, not middleware).
+
+    Delegates to the Stripe SDK, which checks the timestamp and every ``v1``
+    signature in the header. During a ``STRIPE_SIGNING_SECRET`` rotation the
+    sender dual-signs each request, so the header carries the old and new
+    signatures at once; matching against any of them keeps verification working
+    across the switch-over instead of breaking the moment the secret changes.
     """
     endpoint = request.path
 
@@ -56,28 +62,6 @@ def verify_provisioning_signature(request: Request) -> Response | None:
     if not secret:
         _log_and_capture_event("server_error", 500, endpoint)
         return Response({"error": {"code": "server_error", "message": "Signing secret not configured"}}, status=500)
-
-    sig_header = request.headers.get("stripe-signature", "")
-    parsed = _parse_signature_header(sig_header)
-    if parsed is None:
-        _log_and_capture_event("invalid_signature", 401, endpoint, reason="missing_or_malformed_header")
-        return Response(
-            {"error": {"code": "invalid_signature", "message": "Missing or malformed Stripe-Signature header"}},
-            status=401,
-        )
-
-    timestamp_str, signature_hex = parsed
-
-    now = int(time.time())
-    timestamp = int(timestamp_str)
-    if abs(now - timestamp) > MAX_TIMESTAMP_DRIFT_SECONDS:
-        _log_and_capture_event(
-            "invalid_signature", 401, endpoint, reason="timestamp_drift", drift_seconds=abs(now - timestamp)
-        )
-        return Response(
-            {"error": {"code": "invalid_signature", "message": "Timestamp too old or too far in the future"}},
-            status=401,
-        )
 
     body = _get_raw_body(request)
     if body is None:
@@ -92,10 +76,13 @@ def verify_provisioning_signature(request: Request) -> Response | None:
             status=400,
         )
 
-    expected_hex = _compute_hmac(secret, timestamp_str, body)
-
-    if not hmac.compare_digest(expected_hex.lower(), signature_hex.lower()):
-        _log_and_capture_event("invalid_signature", 401, endpoint, reason="hmac_mismatch")
+    sig_header = request.headers.get("stripe-signature", "")
+    try:
+        stripe.WebhookSignature.verify_header(
+            body.decode("utf-8"), sig_header, secret, tolerance=MAX_TIMESTAMP_DRIFT_SECONDS
+        )
+    except (stripe.SignatureVerificationError, UnicodeDecodeError) as e:
+        _log_and_capture_event("invalid_signature", 401, endpoint, reason=str(e))
         return Response(
             {"error": {"code": "invalid_signature", "message": "Signature verification failed"}}, status=401
         )

--- a/ee/api/agentic_provisioning/test/test_signature.py
+++ b/ee/api/agentic_provisioning/test/test_signature.py
@@ -170,32 +170,23 @@ class TestVerifySignatureAfterDRFParsing(TestCase):
         result = verify_provisioning_signature(drf_request)
         assert result is None
 
-    def test_rejects_when_no_signature_matches(self):
+    @parameterized.expand(
+        [
+            (
+                "no_signature_matches",
+                lambda body,
+                ts: f"t={ts},v1={compute_signature('wrong_a', ts, body)},v1={compute_signature('wrong_b', ts, body)}",
+            ),
+            ("stale_timestamp", lambda body, ts: f"t={ts - 301},v1={compute_signature(HMAC_SECRET, ts - 301, body)}"),
+            ("wrong_scheme_only", lambda body, ts: f"t={ts},v0={compute_signature(HMAC_SECRET, ts, body)}"),
+            ("missing_header", lambda body, ts: ""),
+        ]
+    )
+    def test_rejects_invalid_signature(self, _name, build_header):
         body = b'{"email":"test@example.com"}'
         ts = int(time.time())
-        wrong_a = compute_signature("wrong_secret_a", ts, body)
-        wrong_b = compute_signature("wrong_secret_b", ts, body)
 
-        drf_request = self._make_request(body, f"t={ts},v1={wrong_a},v1={wrong_b}")
-        result = verify_provisioning_signature(drf_request)
-        assert result is not None
-        assert result.status_code == 401
-        assert result.data["error"]["code"] == "invalid_signature"
-
-    def test_rejects_stale_timestamp(self):
-        body = b'{"email":"test@example.com"}'
-        ts = int(time.time()) - 301
-        sig = compute_signature(HMAC_SECRET, ts, body)
-
-        drf_request = self._make_request(body, f"t={ts},v1={sig}")
-        result = verify_provisioning_signature(drf_request)
-        assert result is not None
-        assert result.status_code == 401
-        assert result.data["error"]["code"] == "invalid_signature"
-
-    def test_rejects_missing_header(self):
-        body = b'{"email":"test@example.com"}'
-        drf_request = self._make_request(body, "")
+        drf_request = self._make_request(body, build_header(body, ts))
         result = verify_provisioning_signature(drf_request)
         assert result is not None
         assert result.status_code == 401

--- a/ee/api/agentic_provisioning/test/test_signature.py
+++ b/ee/api/agentic_provisioning/test/test_signature.py
@@ -142,3 +142,61 @@ class TestVerifySignatureAfterDRFParsing(TestCase):
         drf_request = Request(django_request, parsers=[JSONParser()])
         result = verify_provisioning_signature(drf_request)
         assert result is None
+
+    def _make_request(self, body: bytes, sig_header: str) -> Request:
+        django_request = HttpRequest()
+        django_request.method = "POST"
+        django_request.content_type = "application/json"
+        django_request.META = {
+            "REQUEST_METHOD": "POST",
+            "CONTENT_TYPE": "application/json",
+            "CONTENT_LENGTH": str(len(body)),
+            "HTTP_STRIPE_SIGNATURE": sig_header,
+        }
+        django_request._stream = io.BytesIO(body)
+        django_request._read_started = False  # type: ignore[attr-defined]
+        return Request(django_request, parsers=[JSONParser()])
+
+    def test_succeeds_with_multiple_signatures_during_rotation(self):
+        # Stripe dual-signs while a signing-secret rotation is in flight, so the header
+        # carries the stale (old secret) signature alongside the current one. The current
+        # signature appears second here to guard against only checking the first v1.
+        body = b'{"email":"test@example.com"}'
+        ts = int(time.time())
+        stale_sig = compute_signature("rotated_out_secret", ts, body)
+        current_sig = compute_signature(HMAC_SECRET, ts, body)
+
+        drf_request = self._make_request(body, f"t={ts},v1={stale_sig},v1={current_sig}")
+        result = verify_provisioning_signature(drf_request)
+        assert result is None
+
+    def test_rejects_when_no_signature_matches(self):
+        body = b'{"email":"test@example.com"}'
+        ts = int(time.time())
+        wrong_a = compute_signature("wrong_secret_a", ts, body)
+        wrong_b = compute_signature("wrong_secret_b", ts, body)
+
+        drf_request = self._make_request(body, f"t={ts},v1={wrong_a},v1={wrong_b}")
+        result = verify_provisioning_signature(drf_request)
+        assert result is not None
+        assert result.status_code == 401
+        assert result.data["error"]["code"] == "invalid_signature"
+
+    def test_rejects_stale_timestamp(self):
+        body = b'{"email":"test@example.com"}'
+        ts = int(time.time()) - 301
+        sig = compute_signature(HMAC_SECRET, ts, body)
+
+        drf_request = self._make_request(body, f"t={ts},v1={sig}")
+        result = verify_provisioning_signature(drf_request)
+        assert result is not None
+        assert result.status_code == 401
+        assert result.data["error"]["code"] == "invalid_signature"
+
+    def test_rejects_missing_header(self):
+        body = b'{"email":"test@example.com"}'
+        drf_request = self._make_request(body, "")
+        result = verify_provisioning_signature(drf_request)
+        assert result is not None
+        assert result.status_code == 401
+        assert result.data["error"]["code"] == "invalid_signature"

--- a/ee/api/agentic_provisioning/test/test_signature.py
+++ b/ee/api/agentic_provisioning/test/test_signature.py
@@ -155,7 +155,7 @@ class TestVerifySignatureAfterDRFParsing(TestCase):
         }
         django_request._stream = io.BytesIO(body)
         django_request._read_started = False  # type: ignore[attr-defined]
-        return Request(django_request, parsers=[JSONParser()])
+        return cast(Request, Request(django_request, parsers=[JSONParser()]))
 
     def test_succeeds_with_multiple_signatures_during_rotation(self):
         # Stripe dual-signs while a signing-secret rotation is in flight, so the header

--- a/ee/api/agentic_provisioning/test/test_signature.py
+++ b/ee/api/agentic_provisioning/test/test_signature.py
@@ -191,3 +191,13 @@ class TestVerifySignatureAfterDRFParsing(TestCase):
         assert result is not None
         assert result.status_code == 401
         assert result.data["error"]["code"] == "invalid_signature"
+
+    def test_non_utf8_body_is_a_bad_request_not_a_signature_failure(self):
+        body = b"\xff\xfe not valid utf-8"
+        ts = int(time.time())
+
+        drf_request = self._make_request(body, f"t={ts},v1={'ab' * 32}")
+        result = verify_provisioning_signature(drf_request)
+        assert result is not None
+        assert result.status_code == 400
+        assert result.data["error"]["code"] == "body_not_decodable"


### PR DESCRIPTION
## Problem

Agentic provisioning verifies every incoming request against a shared HMAC signing secret (`STRIPE_SIGNING_SECRET`). The verifier parsed the `Stripe-Signature` header with a regex that matched only the **first** `v1=` value.

When the signing secret is rotated, the signer dual-signs each request for an overlap window, so the header carries the old and new signatures together. Honoring only the first signature means verification fails as soon as a pod holds a secret that doesn't match that first signature, so the secret cannot be rotated without a tightly coordinated cutover (and risk of rejected requests mid-roll).

## Changes

`verify_provisioning_signature` now delegates to `stripe.WebhookSignature.verify_header`, which validates the timestamp and matches against **every** `v1` signature in the header. This is the same call already used for the install-link signature in `posthog/api/integration.py`, against the same secret.

With this, a rotation rolls out without coordination: each pod matches whichever signature corresponds to the secret it currently holds, so requests keep verifying throughout the overlap window.

The HMAC construction is byte-identical to Stripe's webhook scheme, so the `compute_signature` / `_compute_hmac` / `_parse_signature_header` helpers are kept — `authentication.py` (per-app secret path) and `billing_manager.py` (outbound signing) still import them.

Two intentional behavior changes:
- Telemetry `reason` for failures now carries the Stripe verifier's message string instead of the previous `timestamp_drift` / `hmac_mismatch` / `missing_or_malformed_header` labels. The message is a fixed descriptive string; it does not include the header or the secret.
- The Stripe verifier rejects only timestamps that are too old, not future-dated ones (the old code rejected both). Forging a future timestamp still requires the secret, and this matches the existing `integration.py` behavior.

**Out of scope (follow-up):** the per-app partner path in `ee/api/agentic_provisioning/authentication.py` (`_identify_hmac_partner` / `_verify_hmac`) still parses a single `v1` via `_parse_signature_header`. It uses a different secret (`provisioning_signing_secret`, per partner) with its own rotation story, so it is left unchanged here and can move to the same multi-signature check separately if partner-secret rotation needs it.

## How did you test this code?

I'm an agent (Claude Code); I did not perform manual testing. Automated checks run locally against this branch:

- `ee/api/agentic_provisioning/test/test_signature.py` — passed (incl. `test_succeeds_with_multiple_signatures_during_rotation`, which places the stale signature first and the current one second, the exact case the old regex failed, plus a parameterized `test_rejects_invalid_signature` covering no-match / stale-timestamp / wrong-scheme / missing-header). The earlier full run was green before the local ClickHouse test DB ran out of disk; the rejection/acceptance behavior of all five header shapes was then re-verified directly against `stripe.WebhookSignature.verify_header`.
- `test_provisioning_auth.py`, `test_health.py`, `test_authorize.py` — green except one unrelated, pre-existing failure (`test_full_a1_flow_with_token_exchange`, `OIDC_RSA_PRIVATE_KEY` not set in the local harness) that reproduces identically on unmodified `master`.
- `ruff check` and `ruff format` clean on both files.

CI is the real gate for the DB-backed tests and mypy.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The change came out of a request to make `STRIPE_SIGNING_SECRET` rotatable without breaking provisioning auth.

Decisions:
- Chose `stripe.WebhookSignature.verify_header` over a multi-signature regex so we reuse the SDK's battle-tested header parsing and match the existing `posthog/api/integration.py` install-signature check rather than maintaining a second hand-rolled verifier.
- Verified the SDK's signed-payload format (`{timestamp}.{body}`, sha256 hex, `v1`) is byte-identical to the existing `_compute_hmac`, so the test signer and the per-app/outbound helpers stay valid.
- Kept the body-read-then-verify ordering so the distinct `body_not_readable` (400) response is preserved.

Requires human review.
