### PR TITLE
feat(dashboard): add ctrl+s shortcut to toggle pinned dashboard

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -327,6 +327,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setLayoutZoom: (layoutZoom: number) => ({ layoutZoom }),
         /** Optimistic pin/unpin toggle. */
         togglePinned: true,
+        /** Pin/unpin toggle triggered by the Ctrl/Cmd+S keyboard shortcut, which also surfaces a toast on completion. */
+        togglePinnedFromShortcut: true,
         /** Open/close the Terraform export modal. */
         setTerraformModalOpen: (open: boolean) => ({ open }),
 
@@ -1764,7 +1766,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             },
         ],
     })),
-    events(({ actions, props, values }) => ({
+    events(({ actions, props, values, cache }) => ({
         afterMount: () => {
             // NOTE: initial dashboard load is done after variables are loaded in initialVariablesLoaded
             if (props.id) {
@@ -1806,6 +1808,31 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     }
                 }
             }
+
+            // Ctrl/Cmd+S toggles whether this dashboard is pinned (starred). Only active on the
+            // dashboard page itself, never on embedded placements (homepage, exports, etc.).
+            cache.disposables.add(() => {
+                const handleKeyDown = (event: KeyboardEvent): void => {
+                    if (event.key.toLowerCase() !== 's' || !(event.ctrlKey || event.metaKey) || event.altKey) {
+                        return
+                    }
+                    if (values.placement !== DashboardPlacement.Dashboard || !values.dashboard) {
+                        return
+                    }
+                    // Don't hijack the shortcut while the user is typing in an input.
+                    const target = event.target as HTMLElement | null
+                    if (
+                        target &&
+                        (['input', 'textarea'].includes(target.tagName.toLowerCase()) || target.isContentEditable)
+                    ) {
+                        return
+                    }
+                    event.preventDefault()
+                    actions.togglePinnedFromShortcut()
+                }
+                window.addEventListener('keydown', handleKeyDown)
+                return () => window.removeEventListener('keydown', handleKeyDown)
+            }, 'togglePinnedShortcut')
         },
         beforeUnmount: () => {
             actions.abortAnyRunningQuery()
@@ -1853,6 +1880,26 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 } else {
                     dashboardsModel.actions.unpinDashboard(values.dashboard.id, DashboardEventSource.SceneCommonButtons)
                 }
+            }
+        },
+        togglePinnedFromShortcut: () => {
+            if (!values.dashboard) {
+                return
+            }
+            // Flag so the model's pin/unpin success below knows to surface a toast for this dashboard.
+            cache.pinToggledFromShortcut = true
+            actions.togglePinned()
+        },
+        [dashboardsModel.actionTypes.pinDashboardSuccess]: ({ dashboard }) => {
+            if (cache.pinToggledFromShortcut && dashboard?.id === values.dashboard?.id) {
+                cache.pinToggledFromShortcut = false
+                lemonToast.success('Dashboard pinned')
+            }
+        },
+        [dashboardsModel.actionTypes.unpinDashboardSuccess]: ({ dashboard }) => {
+            if (cache.pinToggledFromShortcut && dashboard?.id === values.dashboard?.id) {
+                cache.pinToggledFromShortcut = false
+                lemonToast.success('Dashboard unpinned')
             }
         },
         setAnalysisRating: ({ rating }) => {


### PR DESCRIPTION
## Problem

There's no keyboard shortcut to pin (star) the dashboard you're currently viewing — you have to reach for the pin button in the scene menu. This adds a quick `Ctrl/Cmd + S` shortcut to toggle the current dashboard's pinned state from anywhere on the page.

## Changes

- Add a `Ctrl/Cmd + S` keyboard shortcut on the dashboard scene that toggles whether the dashboard is pinned (the "starred"/pinned state surfaced by the existing pin button).
- Show a success toast on completion — `Dashboard pinned` / `Dashboard unpinned` — fired only after the pin/unpin request to the API succeeds.
- All wiring lives in `dashboardLogic`:
  - New `togglePinnedFromShortcut` action.
  - A `keydown` listener registered via `cache.disposables` (auto-cleaned on unmount, pauses on hidden tab) that only fires on `Ctrl/Cmd + S`, only on the standalone `DashboardPlacement.Dashboard` (not homepage/exports/embeds), ignores keystrokes while typing in inputs/textareas/contentEditable, and calls `preventDefault()` to suppress the browser's native "Save page" dialog.
  - The toast is tied to the model's `pinDashboardSuccess` / `unpinDashboardSuccess`, gated by a cache flag and dashboard-id match so it only toasts for the shortcut on the current dashboard (the existing pin button is unaffected).

Note: PostHog's data model and UI call this concept "pinning" (the button reads Pin/Unpin), so the shortcut drives the same pin/unpin action and the toasts use that wording.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual/browser testing. Automated checks I ran locally:

- Regenerated kea types with `kea-typegen write` — the new `togglePinnedFromShortcut` action is present in the generated `dashboardLogicType`.
- Ran `tsc --noEmit`: no type errors in the changed regions of `dashboardLogic.tsx`, and no errors referencing the new symbols. (The fresh clone has a large pre-existing baseline of unrelated errors because not all generated `*Type.ts` files ship in the repo; those are independent of this change.)
- `oxfmt` reports the file is already correctly formatted.

Suggested manual verification: open a dashboard, press `Ctrl/Cmd + S`, confirm the pin state toggles, the toast appears, and the browser save dialog does not open; confirm the shortcut does nothing while focused in a filter/search input.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by an agent (PostHog Code, Claude) at Matt Pua's request: "add a keyboard shortcut on the dashboard page to use Ctrl+S to toggle that dashboard as a starred dashboard; on completion set an appropriate toast."

Key decisions:
- Implemented the listener inside `dashboardLogic` via `cache.disposables` rather than a React `useKeyboardHotkeys` hook, to follow the repo conventions (business logic in kea, disposables for `addEventListener`).
- Bypassing the existing `useKeyboardHotkeys` was deliberate — that hook skips Ctrl/Cmd combos unless `willHandleEvent` is set and wouldn't let us both intercept Ctrl/Cmd+S and `preventDefault` the browser save dialog cleanly.
- Scoped the toast to the shortcut (cache flag + dashboard-id match) so the existing pin button's behavior is unchanged, and tied it to the model's pin/unpin *success* so it reflects actual completion rather than an optimistic toggle.

Requires human review; not manually tested in-browser by the agent.
