### PR TITLE
fix(tasks): skip credential refresh for stopped sandbox instead of failing

### DIFF
--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -62,6 +62,7 @@ from products.tasks.backend.temporal.exceptions import (
     SandboxCleanupError,
     SandboxExecutionError,
     SandboxNotFoundError,
+    SandboxNotRunningError,
     SandboxProvisionError,
     SandboxTimeoutError,
     SnapshotCreationError,
@@ -413,7 +414,7 @@ class ModalSandbox(SandboxBase):
         timeout_seconds: int | None = None,
     ) -> ExecutionResult:
         if not self.is_running():
-            raise SandboxExecutionError(
+            raise SandboxNotRunningError(
                 f"Sandbox not in running state.",
                 {"sandbox_id": self.id},
                 cause=RuntimeError(f"Sandbox {self.id} is not running"),
@@ -465,7 +466,7 @@ class ModalSandbox(SandboxBase):
         timeout_seconds: int | None = None,
     ) -> ExecutionStream:
         if not self.is_running():
-            raise SandboxExecutionError(
+            raise SandboxNotRunningError(
                 f"Sandbox not in running state.",
                 {"sandbox_id": self.id},
                 cause=RuntimeError(f"Sandbox {self.id} is not running"),
@@ -530,7 +531,7 @@ class ModalSandbox(SandboxBase):
 
     def write_file(self, path: str, payload: bytes) -> ExecutionResult:
         if not self.is_running():
-            raise SandboxExecutionError(
+            raise SandboxNotRunningError(
                 "Sandbox not in running state.",
                 {"sandbox_id": self.id},
                 cause=RuntimeError(f"Sandbox {self.id} is not running"),
@@ -789,7 +790,7 @@ class ModalSandbox(SandboxBase):
 
     def create_snapshot(self) -> str:
         if not self.is_running():
-            raise SandboxExecutionError(
+            raise SandboxNotRunningError(
                 f"Sandbox not in running state.",
                 {"sandbox_id": self.id},
                 cause=RuntimeError(f"Sandbox {self.id} is not running"),

--- a/products/tasks/backend/temporal/exceptions.py
+++ b/products/tasks/backend/temporal/exceptions.py
@@ -57,6 +57,12 @@ class SandboxExecutionError(ProcessTaskTransientError):
     pass
 
 
+class SandboxNotRunningError(SandboxExecutionError):
+    """Sandbox is not in a running state."""
+
+    pass
+
+
 class SandboxTimeoutError(ProcessTaskTransientError):
     """Sandbox operation timed out."""
 

--- a/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
@@ -9,7 +9,7 @@ from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.services.agent_command import send_refresh_session
 from products.tasks.backend.services.connection_token import create_sandbox_connection_token
 from products.tasks.backend.services.sandbox import Sandbox
-from products.tasks.backend.temporal.exceptions import TaskNotFoundError
+from products.tasks.backend.temporal.exceptions import SandboxExecutionError, TaskNotFoundError
 from products.tasks.backend.temporal.metrics import increment_credential_refresh
 from products.tasks.backend.temporal.observability import log_activity_execution, track_event
 from products.tasks.backend.temporal.process_task.sandbox_credentials import (
@@ -85,9 +85,28 @@ def refresh_sandbox_credentials(input: RefreshSandboxCredentialsInput) -> Refres
         next_refresh = DEFAULT_REFRESH_INTERVAL_SECONDS
         intervals: list[float] = []
 
+        if not sandbox.is_running():
+            for credential in build_sandbox_credentials(ctx):
+                increment_credential_refresh(credential.kind, "skipped")
+            logger.info(
+                "sandbox_credentials_refresh_skipped_not_running",
+                sandbox_id=input.sandbox_id,
+                run_id=ctx.run_id,
+            )
+            return RefreshSandboxCredentialsOutput(next_refresh_seconds=next_refresh, refreshed_kinds=[])
+
         for credential in build_sandbox_credentials(ctx):
             try:
                 outcome = credential.refresh(sandbox, ctx, task)
+            except SandboxExecutionError:
+                logger.info(
+                    "sandbox_credential_refresh_skipped_not_running",
+                    kind=credential.kind,
+                    sandbox_id=input.sandbox_id,
+                    run_id=ctx.run_id,
+                )
+                increment_credential_refresh(credential.kind, "skipped")
+                break
             except Exception:
                 logger.warning(
                     "sandbox_credential_refresh_failed",

--- a/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
@@ -9,7 +9,7 @@ from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.services.agent_command import send_refresh_session
 from products.tasks.backend.services.connection_token import create_sandbox_connection_token
 from products.tasks.backend.services.sandbox import Sandbox
-from products.tasks.backend.temporal.exceptions import SandboxExecutionError, TaskNotFoundError
+from products.tasks.backend.temporal.exceptions import SandboxNotRunningError, TaskNotFoundError
 from products.tasks.backend.temporal.metrics import increment_credential_refresh
 from products.tasks.backend.temporal.observability import log_activity_execution, track_event
 from products.tasks.backend.temporal.process_task.sandbox_credentials import (
@@ -84,9 +84,10 @@ def refresh_sandbox_credentials(input: RefreshSandboxCredentialsInput) -> Refres
         refreshed_kinds: list[str] = []
         next_refresh = DEFAULT_REFRESH_INTERVAL_SECONDS
         intervals: list[float] = []
+        credentials = build_sandbox_credentials(ctx)
 
         if not sandbox.is_running():
-            for credential in build_sandbox_credentials(ctx):
+            for credential in credentials:
                 increment_credential_refresh(credential.kind, "skipped")
             logger.info(
                 "sandbox_credentials_refresh_skipped_not_running",
@@ -95,17 +96,17 @@ def refresh_sandbox_credentials(input: RefreshSandboxCredentialsInput) -> Refres
             )
             return RefreshSandboxCredentialsOutput(next_refresh_seconds=next_refresh, refreshed_kinds=[])
 
-        for credential in build_sandbox_credentials(ctx):
+        for index, credential in enumerate(credentials):
             try:
                 outcome = credential.refresh(sandbox, ctx, task)
-            except SandboxExecutionError:
+            except SandboxNotRunningError:
                 logger.info(
-                    "sandbox_credential_refresh_skipped_not_running",
-                    kind=credential.kind,
+                    "sandbox_credentials_refresh_skipped_not_running",
                     sandbox_id=input.sandbox_id,
                     run_id=ctx.run_id,
                 )
-                increment_credential_refresh(credential.kind, "skipped")
+                for skipped in credentials[index:]:
+                    increment_credential_refresh(skipped.kind, "skipped")
                 break
             except Exception:
                 logger.warning(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from asgiref.sync import async_to_sync
 
 from products.tasks.backend.services.sandbox import ExecutionResult
+from products.tasks.backend.temporal.exceptions import SandboxExecutionError
 from products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials import (
     RefreshSandboxCredentialsInput,
     refresh_sandbox_credentials,
@@ -16,6 +17,7 @@ class TestRefreshSandboxCredentialsActivity:
     @pytest.fixture
     def sandbox(self):
         fake = MagicMock()
+        fake.is_running.return_value = True
         fake.execute.return_value = ExecutionResult(stdout="", stderr="", exit_code=0)
         fake.write_file.return_value = ExecutionResult(stdout="", stderr="", exit_code=0)
         return fake
@@ -74,3 +76,57 @@ class TestRefreshSandboxCredentialsActivity:
         assert output.refreshed_kinds == []
         # All credentials failed -> no per-token interval, so fall back to the default cadence.
         assert output.next_refresh_seconds == DEFAULT_REFRESH_INTERVAL_SECONDS
+
+    def test_skips_refresh_when_sandbox_not_running(self, activity_environment, task_context, test_task, sandbox):
+        sandbox.is_running.return_value = False
+        with (
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.Sandbox.get_by_id",
+                return_value=sandbox,
+            ),
+            patch(
+                "products.tasks.backend.temporal.process_task.sandbox_credentials.get_sandbox_github_token"
+            ) as get_token,
+            patch("products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.track_event"),
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.increment_credential_refresh"
+            ) as increment,
+        ):
+            output = async_to_sync(activity_environment.run)(
+                refresh_sandbox_credentials,
+                RefreshSandboxCredentialsInput(context=task_context, sandbox_id="sandbox-abc"),
+            )
+
+        assert output.refreshed_kinds == []
+        assert output.next_refresh_seconds == DEFAULT_REFRESH_INTERVAL_SECONDS
+        get_token.assert_not_called()
+        sandbox.execute.assert_not_called()
+        increment.assert_called_once_with("github", "skipped")
+
+    def test_sandbox_stopped_mid_refresh_counts_as_skipped(
+        self, activity_environment, task_context, test_task, sandbox
+    ):
+        sandbox.execute.side_effect = SandboxExecutionError(
+            "Sandbox not in running state.", {"sandbox_id": "sandbox-abc"}, cause=RuntimeError("not running")
+        )
+        with (
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.Sandbox.get_by_id",
+                return_value=sandbox,
+            ),
+            patch(
+                "products.tasks.backend.temporal.process_task.sandbox_credentials.get_sandbox_github_token",
+                return_value="ghs_fresh",
+            ),
+            patch("products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.track_event"),
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.increment_credential_refresh"
+            ) as increment,
+        ):
+            output = async_to_sync(activity_environment.run)(
+                refresh_sandbox_credentials,
+                RefreshSandboxCredentialsInput(context=task_context, sandbox_id="sandbox-abc"),
+            )
+
+        assert output.refreshed_kinds == []
+        increment.assert_called_once_with("github", "skipped")

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_refresh_sandbox_credentials.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from asgiref.sync import async_to_sync
 
 from products.tasks.backend.services.sandbox import ExecutionResult
-from products.tasks.backend.temporal.exceptions import SandboxExecutionError
+from products.tasks.backend.temporal.exceptions import SandboxExecutionError, SandboxNotRunningError
 from products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials import (
     RefreshSandboxCredentialsInput,
     refresh_sandbox_credentials,
@@ -106,7 +106,7 @@ class TestRefreshSandboxCredentialsActivity:
     def test_sandbox_stopped_mid_refresh_counts_as_skipped(
         self, activity_environment, task_context, test_task, sandbox
     ):
-        sandbox.execute.side_effect = SandboxExecutionError(
+        sandbox.execute.side_effect = SandboxNotRunningError(
             "Sandbox not in running state.", {"sandbox_id": "sandbox-abc"}, cause=RuntimeError("not running")
         )
         with (
@@ -130,3 +130,29 @@ class TestRefreshSandboxCredentialsActivity:
 
         assert output.refreshed_kinds == []
         increment.assert_called_once_with("github", "skipped")
+
+    def test_genuine_execution_error_counts_as_failed(self, activity_environment, task_context, test_task, sandbox):
+        sandbox.execute.side_effect = SandboxExecutionError(
+            "Failed to execute command", {"sandbox_id": "sandbox-abc"}, cause=RuntimeError("network blip")
+        )
+        with (
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.Sandbox.get_by_id",
+                return_value=sandbox,
+            ),
+            patch(
+                "products.tasks.backend.temporal.process_task.sandbox_credentials.get_sandbox_github_token",
+                return_value="ghs_fresh",
+            ),
+            patch("products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.track_event"),
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.refresh_sandbox_credentials.increment_credential_refresh"
+            ) as increment,
+        ):
+            output = async_to_sync(activity_environment.run)(
+                refresh_sandbox_credentials,
+                RefreshSandboxCredentialsInput(context=task_context, sandbox_id="sandbox-abc"),
+            )
+
+        assert output.refreshed_kinds == []
+        increment.assert_called_once_with("github", "failed")


### PR DESCRIPTION
## Problem

sandbox credential-refresh loop fires a GitHub-token refresh on a token-aware cadence for the life of a run.

let's stop minting on non-running sandboxes.
