### PR TITLE
chore(playwright): deflake google login auth test

### DIFF
--- a/playwright/e2e/auth.spec.ts
+++ b/playwright/e2e/auth.spec.ts
@@ -1,5 +1,3 @@
-import { PreflightStatus } from '~/types'
-
 import { LoginPage } from '../page-models/loginPage'
 import { LOGIN_PASSWORD, LOGIN_USERNAME, expect, test } from '../utils/playwright-test-base'
 
@@ -32,13 +30,27 @@ test.describe('Auth', () => {
     })
 
     test('Logout and verify Google login button has correct link', async ({ page }) => {
-        await page.locator('[data-attr=new-account-menu-logout-button]').click()
+        // available_social_auth_providers comes from POSTHOG_APP_CONTEXT, which is server-rendered into the
+        // login page HTML and read directly by preflightLogic on mount — so API mocks don't apply. Patch the
+        // context before the page scripts run; mutating it after logout (as setAppContext did) is racy and
+        // only renders the button on lucky timing.
+        await page.addInitScript(() => {
+            let _context: any = undefined
+            Object.defineProperty(window, 'POSTHOG_APP_CONTEXT', {
+                get() {
+                    if (_context?.preflight?.available_social_auth_providers) {
+                        _context.preflight.available_social_auth_providers['google-oauth2'] = true
+                    }
+                    return _context
+                },
+                set(value) {
+                    _context = value
+                },
+                configurable: true,
+            })
+        })
 
-        await page.setAppContext('preflight', {
-            available_social_auth_providers: {
-                'google-oauth2': true,
-            },
-        } as Partial<PreflightStatus> as PreflightStatus)
+        await page.locator('[data-attr=new-account-menu-logout-button]').click()
 
         await expect(page.locator('a[href="/login/google-oauth2/"]')).toBeVisible()
     })

--- a/playwright/e2e/auth.spec.ts
+++ b/playwright/e2e/auth.spec.ts
@@ -32,8 +32,8 @@ test.describe('Auth', () => {
     test('Logout and verify Google login button has correct link', async ({ page }) => {
         // available_social_auth_providers comes from POSTHOG_APP_CONTEXT, which is server-rendered into the
         // login page HTML and read directly by preflightLogic on mount — so API mocks don't apply. Patch the
-        // context before the page scripts run; mutating it after logout (as setAppContext did) is racy and
-        // only renders the button on lucky timing.
+        // context before the page scripts run; mutating it after the page has loaded is racy and only
+        // renders the button on lucky timing.
         await page.addInitScript(() => {
             let _context: any = undefined
             Object.defineProperty(window, 'POSTHOG_APP_CONTEXT', {

--- a/playwright/e2e/auth.spec.ts
+++ b/playwright/e2e/auth.spec.ts
@@ -38,7 +38,8 @@ test.describe('Auth', () => {
             let _context: any = undefined
             Object.defineProperty(window, 'POSTHOG_APP_CONTEXT', {
                 get() {
-                    if (_context?.preflight?.available_social_auth_providers) {
+                    if (_context?.preflight) {
+                        _context.preflight.available_social_auth_providers ??= {}
                         _context.preflight.available_social_auth_providers['google-oauth2'] = true
                     }
                     return _context

--- a/playwright/utils/playwright-test-core.ts
+++ b/playwright/utils/playwright-test-core.ts
@@ -1,19 +1,12 @@
 import { Page, test as base } from '@playwright/test'
 
-import { AppContext } from '~/types'
-
 import { Identifier, Navigation } from './navigation'
 
 export const LOGIN_USERNAME = process.env.LOGIN_USERNAME || 'test@posthog.com'
 export const LOGIN_PASSWORD = process.env.LOGIN_PASSWORD || '12345678'
 
-export type WindowWithPostHog = typeof globalThis & {
-    POSTHOG_APP_CONTEXT: AppContext
-}
-
 declare module '@playwright/test' {
     interface Page {
-        setAppContext<K extends keyof AppContext>(key: K, value: AppContext[K]): Promise<void>
         goToMenuItem(name: string): Promise<void>
     }
 }
@@ -25,16 +18,6 @@ declare module '@playwright/test' {
 export const test = base.extend<{ page: Page }>({
     page: async ({ page }, use) => {
         // Add custom methods to the page object
-        page.setAppContext = async function <K extends keyof AppContext>(key: K, value: AppContext[K]): Promise<void> {
-            await page.evaluate(
-                ([key, value]) => {
-                    const appContext = (window as WindowWithPostHog).POSTHOG_APP_CONTEXT
-                    // @ts-expect-error - Type safety is handled by the generic constraint
-                    appContext[key] = value
-                },
-                [key, value]
-            )
-        }
         page.goToMenuItem = async function (name: Identifier): Promise<void> {
             await new Navigation(page).openMenuItem(name)
         }


### PR DESCRIPTION
## Problem

The e2e test `auth.spec.ts` › "Logout and verify Google login button has correct link" is flaky. It set the Google OAuth provider with `page.setAppContext('preflight', …)` **after** clicking logout — mutating `window.POSTHOG_APP_CONTEXT` in a way that races `preflightLogic`'s mount. `preflightLogic` reads the server-rendered context directly on mount (it only fetches `/_preflight/` when the context has no preflight), so when mount wins the race the provider is missing, the button never renders, and the assertion times out.

## Changes

- Patch the provider via `page.addInitScript` + an `Object.defineProperty` getter on `window.POSTHOG_APP_CONTEXT`, before any page script runs — deterministic, so the value is in place by the time the login page hydrates. Mirrors the existing idiom in `playwright/e2e/surveys/quickcreate.spec.ts`. Drops the now-unused `PreflightStatus` import.
- Remove the orphaned `setAppContext` helper (and unused `WindowWithPostHog` type) from `playwright/utils/playwright-test-core.ts` — it did the same post-load mutation that caused this flake and had no remaining callers. `goToMenuItem` untouched.

## How did you test this code?

Agent (Claude Code), automated tests only, against a local e2e env:

- `auth.spec.ts -g "Google login button" --repeat-each 10` → **10/10 passed** (flake gate)
- Full `auth.spec.ts`, before and after the helper removal → **8/8 each**
- `oxlint` on both files → clean

## 🤖 Agent context

First tried mocking the `/_preflight/` API — rejected, the intercept never fired because the provider comes from the SSR-injected `POSTHOG_APP_CONTEXT`, not the API. Switched to the `addInitScript` context patch, validated with a 10× repeat-each loop; a cleanup pass then removed the now-dead `setAppContext` helper.

Agent-authored; requires human review — do not self-merge.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a race condition in the Google OAuth login Playwright test by replacing a post-navigation `setAppContext` mutation with a `page.addInitScript` that patches `window.POSTHOG_APP_CONTEXT` via `Object.defineProperty` before any page script runs. Also removes the now-dead `setAppContext` helper and its associated types.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e75c020416e1f2fec94b713252143b28e39a838c.</sup>
<!-- /MENDRAL_SUMMARY -->