### PR TITLE
chore(modeling): add status index to jobs

### DIFF
--- a/products/data_modeling/backend/migrations/0024_datamodelingjob_team_status_idx.py
+++ b/products/data_modeling/backend/migrations/0024_datamodelingjob_team_status_idx.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("data_modeling", "0023_migrate_data_modeling_models"),
+        ("posthog", "1193_oauthaccesstoken_label_oauthapplication_scopes"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="datamodelingjob",
+            index=models.Index(fields=["team", "status"], name="datamodelingjob_team_status"),
+        ),
+    ]

--- a/products/data_modeling/backend/migrations/0024_datamodelingjob_team_status_idx.py
+++ b/products/data_modeling/backend/migrations/0024_datamodelingjob_team_status_idx.py
@@ -1,6 +1,7 @@
 from django.conf import settings
-from django.contrib.postgres.operations import AddIndexConcurrently
 from django.db import migrations, models
+
+from posthog.migration_helpers import CreateIndexConcurrently
 
 
 class Migration(migrations.Migration):
@@ -13,8 +14,19 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        AddIndexConcurrently(
-            model_name="datamodelingjob",
-            index=models.Index(fields=["team", "status"], name="datamodelingjob_team_status"),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="datamodelingjob",
+                    index=models.Index(fields=["team", "status"], name="datamodelingjob_team_status"),
+                ),
+            ],
+            database_operations=[
+                CreateIndexConcurrently(
+                    index_name="datamodelingjob_team_status",
+                    table_name="posthog_datamodelingjob",
+                    columns="(team_id, status)",
+                ),
+            ],
         ),
     ]

--- a/products/data_modeling/backend/migrations/max_migration.txt
+++ b/products/data_modeling/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0023_migrate_data_modeling_models
+0024_datamodelingjob_team_status_idx

--- a/products/data_modeling/backend/models/data_modeling_job.py
+++ b/products/data_modeling/backend/models/data_modeling_job.py
@@ -35,3 +35,7 @@ class DataModelingJob(CreatedMetaFields, UpdatedMetaFields, UUIDTModel):
 
     class Meta:
         db_table = "posthog_datamodelingjob"
+        indexes = [
+            # serves to cut lookup times for pre-existing running jobs during the preempt stage
+            models.Index(fields=["team", "status"], name="datamodelingjob_team_status"),
+        ]


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

no index on job status for modeling -> slower than necessary lookups for "running" jobs for example

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

add an index

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

didn't

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->

<!-- gg:stack-start -->
## gg stack

- **#61171 `andrew/status-index-on-jobs` 👈 this PR**
<!-- gg:stack-end -->
