### PR TITLE
feat(replay-vision): connect estimate API to UI

### DIFF
--- a/products/replay_vision/backend/queries/scanner_volume_estimate.py
+++ b/products/replay_vision/backend/queries/scanner_volume_estimate.py
@@ -7,6 +7,7 @@ from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models import Team
 from posthog.session_recordings.queries.session_recording_list_from_query import SessionRecordingListFromQuery
 
@@ -69,6 +70,7 @@ def estimate_scanner_session_volume(*, team: Team, query: RecordingsQuery) -> Sc
         ),
     )
 
+    tag_queries(team_id=team.id, product=Product.REPLAY_VISION, feature=Feature.QUERY)
     response = execute_hogql_query(
         query=combined_query,
         team=team,

--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -75,7 +75,7 @@ export function ReplayScannerSceneComponent({ tabId }: { tabId: string }): JSX.E
             key: 'configuration',
             label: 'Configuration',
             content: (
-                <div className="space-y-6 max-w-3xl">
+                <div className="space-y-6 max-w-3xl pb-8">
                     <div>
                         <h3 className="text-base font-semibold mb-1">Details</h3>
                         <p className="text-sm text-muted m-0">

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
@@ -1,5 +1,7 @@
 import { useValues } from 'kea'
 
+import { Spinner } from '@posthog/lemon-ui'
+
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 
 import { replayScannerLogic } from '../replayScannerLogic'
@@ -10,7 +12,7 @@ interface Props {
 }
 
 export function ScannerQuotaForecast({ scannerId, tabId }: Props): JSX.Element | null {
-    const { scanner } = useValues(replayScannerLogic({ id: scannerId, tabId }))
+    const { scanner, scannerEstimate, scannerEstimateLoading } = useValues(replayScannerLogic({ id: scannerId, tabId }))
 
     if (!scanner) {
         return null
@@ -18,30 +20,33 @@ export function ScannerQuotaForecast({ scannerId, tabId }: Props): JSX.Element |
 
     const samplingRatio = Math.max(0, Math.min(scanner.sampling_rate, 1))
     const samplingPercent = Math.round(samplingRatio * 1000) / 10
-    const oneInN = samplingRatio > 0 ? Math.max(1, Math.round(1 / samplingRatio)) : null
+    const samplingLabel = samplingPercent.toFixed(samplingPercent < 1 ? 2 : 1)
 
     return (
         <div className="border rounded p-3 bg-bg-light space-y-2">
             <div className="flex items-center justify-between">
-                <span className="text-sm font-medium">Quota impact</span>
-                <span className="text-sm tabular-nums">{samplingPercent.toFixed(samplingPercent < 1 ? 2 : 1)}%</span>
+                <span className="text-sm font-medium">Estimated impact</span>
+                <span className="text-sm tabular-nums text-muted">{samplingLabel}% sampling</span>
             </div>
             <LemonProgress percent={Math.round(samplingRatio * 100)} />
-            <div className="text-xs text-muted">
-                {oneInN === null ? (
-                    <span className="text-danger">Sampling is 0%. This scanner will not produce any observations.</span>
-                ) : oneInN === 1 ? (
-                    <>
-                        Every matching recording produces one observation. Each one counts against your monthly
-                        observation quota.
-                    </>
-                ) : (
-                    <>
-                        About <strong>1 in {oneInN.toLocaleString()}</strong> matching recordings will be observed.
-                        Lower this slider to reduce monthly quota consumption; raise it for denser coverage.
-                    </>
-                )}
-            </div>
+            {samplingRatio === 0 ? (
+                <div className="text-xs text-danger">
+                    Sampling is 0%. This scanner will not produce any observations.
+                </div>
+            ) : scannerEstimateLoading && !scannerEstimate ? (
+                <div className="text-xs text-muted flex items-center gap-2">
+                    <Spinner /> Estimating from your filters…
+                </div>
+            ) : scannerEstimate ? (
+                <div className="text-xs text-muted">
+                    About <strong>{scannerEstimate.estimated_observations_per_month.toLocaleString()}</strong>{' '}
+                    observations a month at this sampling. Based on{' '}
+                    <strong>{scannerEstimate.matched_sessions_in_window.toLocaleString()}</strong> matching recordings
+                    in the last {scannerEstimate.window_days} days.
+                </div>
+            ) : (
+                <div className="text-xs text-muted">Estimate unavailable — try adjusting your filters.</div>
+            )}
         </div>
     )
 }

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
 import { Field } from 'kea-forms'
 
-import { LemonInput } from '@posthog/lemon-ui'
+import { LemonDivider, LemonInput } from '@posthog/lemon-ui'
 
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -97,6 +97,7 @@ export function ScannerTriggers({ scannerId, tabId }: { scannerId: string; tabId
                 }}
             </Field>
 
+            <LemonDivider className="my-0" />
             <ScannerQuotaForecast scannerId={scannerId} tabId={tabId} />
         </div>
     )

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -600,6 +600,9 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 }
                 // eslint-disable-next-line no-console
                 console.warn('[replay-vision] scanner estimate failed', error)
+                if (values.estimateRequestVersion !== version) {
+                    return
+                }
                 actions.loadScannerEstimateFailure()
             }
         },

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -13,11 +13,12 @@ import { NodeKind } from '~/queries/schema/schema-general'
 import {
     visionScannersCreate,
     visionScannersDestroy,
+    visionScannersEstimateCreate,
     visionScannersObservationsList,
     visionScannersPartialUpdate,
     visionScannersRetrieve,
 } from '../generated/api'
-import type { ReplayObservationApi } from '../generated/api.schemas'
+import type { EstimateResponseApi, ReplayObservationApi } from '../generated/api.schemas'
 import { scheduleObservationPoll } from '../logics/observationPolling'
 import { readFixedTags, readFreeformTags, readModelOutput, readTags, readVerdict } from '../utils/observation'
 import type { replayScannerLogicType } from './replayScannerLogicType'
@@ -130,6 +131,10 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
         setObservationTagFilter: (values: string[]) => ({ values }),
         clearObservationFilters: true,
         setChartDateRange: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
+        requestScannerEstimate: true,
+        loadScannerEstimate: true,
+        loadScannerEstimateSuccess: (estimate: EstimateResponseApi) => ({ estimate }),
+        loadScannerEstimateFailure: true,
     }),
 
     forms(({ props }) => ({
@@ -206,6 +211,21 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 loadObservations: () => true,
                 loadObservationsSuccess: () => false,
                 loadObservationsFailure: () => false,
+            },
+        ],
+        scannerEstimate: [
+            null as EstimateResponseApi | null,
+            {
+                loadScannerEstimateSuccess: (_, { estimate }) => estimate,
+                loadScannerEstimateFailure: () => null,
+            },
+        ],
+        scannerEstimateLoading: [
+            false,
+            {
+                loadScannerEstimate: () => true,
+                loadScannerEstimateSuccess: () => false,
+                loadScannerEstimateFailure: () => false,
             },
         ],
         observationStatusFilter: [
@@ -529,10 +549,44 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
 
         loadScannerSuccess: ({ scanner }) => {
             actions.setScannerValues(scanner)
+            actions.requestScannerEstimate()
         },
 
         setScannerType: ({ scannerType }) => {
             actions.setScannerValues({ scanner_type: scannerType, scanner_config: defaultConfigForType(scannerType) })
+        },
+
+        // kea-forms fires setScannerValue(s) on every field change. Debounce the estimate so slider drags
+        // and rapid filter edits don't fire one request per tick.
+        setScannerValue: () => actions.requestScannerEstimate(),
+        setScannerValues: () => actions.requestScannerEstimate(),
+        submitScannerSuccess: () => actions.requestScannerEstimate(),
+
+        requestScannerEstimate: () => {
+            cache.disposables.add(() => {
+                const id = setTimeout(() => actions.loadScannerEstimate(), 300)
+                return () => clearTimeout(id)
+            }, 'scannerEstimateDebounce')
+        },
+
+        loadScannerEstimate: async () => {
+            const teamId = teamLogic.values.currentTeamId
+            const scanner = values.scanner
+            if (!teamId || !scanner) {
+                actions.loadScannerEstimateFailure()
+                return
+            }
+            try {
+                const response = await visionScannersEstimateCreate(String(teamId), {
+                    query: scanner.query ?? undefined,
+                    sampling_rate: scanner.sampling_rate,
+                })
+                actions.loadScannerEstimateSuccess(response)
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.warn('[replay-vision] scanner estimate failed', error)
+                actions.loadScannerEstimateFailure()
+            }
         },
 
         deleteScanner: async () => {

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, isBreakpoint, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { router } from 'kea-router'
 
@@ -223,6 +223,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
         scannerEstimateLoading: [
             false,
             {
+                requestScannerEstimate: () => true,
                 loadScannerEstimate: () => true,
                 loadScannerEstimateSuccess: () => false,
                 loadScannerEstimateFailure: () => false,
@@ -569,7 +570,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
             }, 'scannerEstimateDebounce')
         },
 
-        loadScannerEstimate: async () => {
+        loadScannerEstimate: async (_, breakpoint) => {
             const teamId = teamLogic.values.currentTeamId
             const scanner = values.scanner
             if (!teamId || !scanner) {
@@ -581,8 +582,14 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     query: scanner.query ?? undefined,
                     sampling_rate: scanner.sampling_rate,
                 })
+                // If a newer loadScannerEstimate fired while this one was in flight, abort so
+                // the slower response can't overwrite the newer one. Re-thrown by `breakpoint()`.
+                breakpoint()
                 actions.loadScannerEstimateSuccess(response)
             } catch (error) {
+                if (isBreakpoint(error)) {
+                    throw error
+                }
                 // eslint-disable-next-line no-console
                 console.warn('[replay-vision] scanner estimate failed', error)
                 actions.loadScannerEstimateFailure()

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -229,6 +229,12 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 loadScannerEstimateFailure: () => false,
             },
         ],
+        estimateRequestVersion: [
+            0,
+            {
+                requestScannerEstimate: (state: number) => state + 1,
+            },
+        ],
         observationStatusFilter: [
             [] as ObservationStatusValue[],
             {
@@ -577,14 +583,16 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 actions.loadScannerEstimateFailure()
                 return
             }
+            const version = values.estimateRequestVersion
             try {
                 const response = await visionScannersEstimateCreate(String(teamId), {
                     query: scanner.query ?? undefined,
                     sampling_rate: scanner.sampling_rate,
                 })
-                // If a newer loadScannerEstimate fired while this one was in flight, abort so
-                // the slower response can't overwrite the newer one. Re-thrown by `breakpoint()`.
                 breakpoint()
+                if (values.estimateRequestVersion !== version) {
+                    return
+                }
                 actions.loadScannerEstimateSuccess(response)
             } catch (error) {
                 if (error instanceof Error && isBreakpoint(error)) {

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -587,7 +587,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 breakpoint()
                 actions.loadScannerEstimateSuccess(response)
             } catch (error) {
-                if (isBreakpoint(error)) {
+                if (error instanceof Error && isBreakpoint(error)) {
                     throw error
                 }
                 // eslint-disable-next-line no-console


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Estimate API for replay vision was not hooked to the UI on config page

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Connect the estimate API to actually be called on the UI

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
