### PR TITLE
chore: deflake hog-chart tooltip hover race

### DIFF
--- a/frontend/src/lib/hog-charts/testing/index.ts
+++ b/frontend/src/lib/hog-charts/testing/index.ts
@@ -1,5 +1,5 @@
 export { dimensions, ensureJsdom, makeSeries, mockRect, setupJsdom, setupSyncRaf } from './jsdom'
-export { clickAtIndex, hoverAtIndex } from './interactions'
+export { clickAtIndex, hoverAtIndex, hoverUntilTooltip } from './interactions'
 export { getHogChart } from './accessor'
 export type { GetHogChartOptions, HogChart, TooltipSnapshot } from './accessor'
 export { renderHogChart } from './render'

--- a/frontend/src/lib/hog-charts/testing/interactions.ts
+++ b/frontend/src/lib/hog-charts/testing/interactions.ts
@@ -1,7 +1,7 @@
-import { act, fireEvent } from '@testing-library/react'
+import { act, fireEvent, waitFor } from '@testing-library/react'
 
 import { dimensions } from './jsdom'
-import { waitForHogChartTooltip } from './tooltip'
+import { getHogChartTooltip } from './tooltip'
 
 /** Fire a mouseMove on a chart wrapper element at the pixel position
  *  corresponding to the given label index. */
@@ -15,10 +15,36 @@ export function hoverAtIndex(wrapper: HTMLElement, index: number, totalLabels: n
     })
 }
 
+/** Hover at the given label index, re-dispatching the mouseMove until the chart's
+ *  tooltip portal mounts. The chart commits its scales/dimensions in a post-render
+ *  effect (useChartCanvas), and onMouseMove is a no-op until that commit lands — so
+ *  a single hover fired before the chart settles is silently dropped and the tooltip
+ *  never appears. Polling the *trigger* (not just the result) makes the hover
+ *  deterministic regardless of when the chart settles, without inflating timeouts. */
+export async function hoverUntilTooltip(
+    wrapper: HTMLElement,
+    index: number,
+    totalLabels: number,
+    timeout = 3000
+): Promise<HTMLElement> {
+    let tooltip!: HTMLElement
+    await waitFor(
+        () => {
+            hoverAtIndex(wrapper, index, totalLabels)
+            const el = getHogChartTooltip()
+            if (!el) {
+                throw new Error('tooltip not yet rendered')
+            }
+            tooltip = el
+        },
+        { timeout, interval: 10 }
+    )
+    return tooltip
+}
+
 export async function clickAtIndex(wrapper: HTMLElement, index: number, totalLabels: number): Promise<void> {
-    hoverAtIndex(wrapper, index, totalLabels)
-    // Wait for the hover state to flush — onClick reads tooltipCtx synchronously
-    // to decide between pinning and onPointClick, and a stale null takes the wrong branch.
-    await waitForHogChartTooltip()
+    // Re-hover until the tooltip flushes — onClick reads tooltipCtx synchronously to decide
+    // between pinning and onPointClick, and a stale null takes the wrong branch.
+    await hoverUntilTooltip(wrapper, index, totalLabels)
     fireEvent.click(wrapper)
 }

--- a/frontend/src/lib/hog-charts/testing/interactions.ts
+++ b/frontend/src/lib/hog-charts/testing/interactions.ts
@@ -1,7 +1,7 @@
-import { act, fireEvent, waitFor } from '@testing-library/react'
+import { act, fireEvent } from '@testing-library/react'
 
 import { dimensions } from './jsdom'
-import { getHogChartTooltip } from './tooltip'
+import { waitForHogChartTooltip } from './tooltip'
 
 /** Fire a mouseMove on a chart wrapper element at the pixel position
  *  corresponding to the given label index. */
@@ -27,19 +27,7 @@ export async function hoverUntilTooltip(
     totalLabels: number,
     timeout = 3000
 ): Promise<HTMLElement> {
-    let tooltip!: HTMLElement
-    await waitFor(
-        () => {
-            hoverAtIndex(wrapper, index, totalLabels)
-            const el = getHogChartTooltip()
-            if (!el) {
-                throw new Error('tooltip not yet rendered')
-            }
-            tooltip = el
-        },
-        { timeout, interval: 10 }
-    )
-    return tooltip
+    return waitForHogChartTooltip(timeout, () => hoverAtIndex(wrapper, index, totalLabels))
 }
 
 export async function clickAtIndex(wrapper: HTMLElement, index: number, totalLabels: number): Promise<void> {

--- a/frontend/src/lib/hog-charts/testing/tooltip.ts
+++ b/frontend/src/lib/hog-charts/testing/tooltip.ts
@@ -29,14 +29,17 @@ export function getHogChartTooltip(): HTMLElement | null {
     return document.querySelector(HOG_CHARTS_TOOLTIP_SELECTOR)
 }
 
-/** Wait until a chart tooltip is present in the document and return it. */
-export async function waitForHogChartTooltip(timeout = 3000): Promise<HTMLElement> {
+/** Wait until a chart tooltip is present in the document and return it. `beforePoll`, if given,
+ *  runs at the start of each poll attempt — used to re-dispatch a triggering event (e.g. a hover)
+ *  that the chart may have dropped before it became interactive. */
+export async function waitForHogChartTooltip(timeout = 3000, beforePoll?: () => void): Promise<HTMLElement> {
     // Flush pending microtasks so React portal commits complete before polling.
     await new Promise((r) => setTimeout(r, 0))
 
     let tooltip!: HTMLElement
     await waitFor(
         () => {
+            beforePoll?.()
             const el = getHogChartTooltip()
             if (!el) {
                 throw new Error('tooltip not yet rendered')

--- a/frontend/src/test/insight-testing/interactions.ts
+++ b/frontend/src/test/insight-testing/interactions.ts
@@ -1,7 +1,7 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { clickAtIndex, getHogChartTooltip, hoverAtIndex, waitForHogChartTooltip } from 'lib/hog-charts/testing'
+import { clickAtIndex, getHogChartTooltip, hoverUntilTooltip, waitForHogChartTooltip } from 'lib/hog-charts/testing'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import { IndexedTrendResult } from 'scenes/trends/types'
@@ -144,8 +144,7 @@ export const chart = {
     ): Promise<InsightTooltipAccessor> {
         const canvas = await screen.findByRole('img', { name: /chart with/i }, { timeout: DEBOUNCE_TIMEOUT })
         const wrapper = canvas.parentElement!
-        hoverAtIndex(wrapper, index, totalLabels)
-        const tooltip = await waitForHogChartTooltip()
+        const tooltip = await hoverUntilTooltip(wrapper, index, totalLabels)
         return createInsightTooltipAccessor(tooltip)
     },
     async clickAtIndex(index: number, totalLabels = trendsSeries.pageviews.labels.length): Promise<void> {


### PR DESCRIPTION
## Problem

Insight chart click/hover tests flaked with "tooltip not yet rendered". The chart commits its scales/dimensions in a post-render effect, and the pointer handler is a no-op until then. The helpers fired a single `mouseMove` and polled for the tooltip — if that hover landed before the chart settled it was dropped, nothing re-fired it, and the poll timed out.

## Changes

- `waitForHogChartTooltip` gains an optional `beforePoll` action run on each poll attempt.
- New `hoverUntilTooltip` re-dispatches the hover via `beforePoll` until the tooltip mounts (polls the trigger, not just the result; no timeout inflation), reusing the single poll loop rather than duplicating it.
- `clickAtIndex` and the insight `chart.hoverTooltip` route through it.

Test helpers only — no production changes.

## How did you test this code?

Agent-run automated tests only (no manual testing):
- Reproduced deterministically by deferring the dimensions commit past the first hover — old helper failed, new helper passed.
- Flaky suite 12/12 green; sweep across `waitForHogChartTooltip` callers (stickiness, trends, funnels, box plot, `src/lib/hog-charts`) passes.

## 🤖 Agent context

Authored by Claude Code. Traced the race to `onMouseMove` bailing on null scales while the helper fired only one hover. Chose re-firing the hover over a chart-specific settled-DOM signal. `accessor.ts` `clickAtIndex` left single-fire on purpose (its synchronous `renderHogChart` tests aren't racy). A follow-up `/simplify` pass folded the duplicated poll loop into `waitForHogChartTooltip`. Requires human review.
