### PR TITLE
refactor: Support for multiple encryption keys in nodejs Temporal

### DIFF
--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/codec.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/codec.test.ts
@@ -12,9 +12,18 @@ const PYTHON_FIXTURE = {
 
 const te = new TextEncoder()
 const td = new TextDecoder()
+const TEST_SECRET_KEY = 'test-secret-key-for-codec-000000'
+
+function restoreNodeEnv(nodeEnv: string | undefined): void {
+    if (nodeEnv === undefined) {
+        delete process.env.NODE_ENV
+        return
+    }
+    process.env.NODE_ENV = nodeEnv
+}
 
 describe('EncryptionCodec', () => {
-    const codec = new EncryptionCodec(PYTHON_FIXTURE.secretKey)
+    const codec = new EncryptionCodec(TEST_SECRET_KEY)
 
     it('round-trips encode then decode', async () => {
         const original = {
@@ -33,17 +42,64 @@ describe('EncryptionCodec', () => {
     })
 
     it('decodes a token encrypted by the Python EncryptionCodec', async () => {
-        const encryptedToken = Buffer.from(PYTHON_FIXTURE.encryptedTokenB64, 'base64')
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+        try {
+            const pythonCodec = new EncryptionCodec(PYTHON_FIXTURE.secretKey)
+            const encryptedToken = Buffer.from(PYTHON_FIXTURE.encryptedTokenB64, 'base64')
 
-        const outerPayload = {
-            metadata: { encoding: te.encode('binary/encrypted') },
-            data: encryptedToken,
+            const outerPayload = {
+                metadata: { encoding: te.encode('binary/encrypted') },
+                data: encryptedToken,
+            }
+
+            const decoded = await pythonCodec.decode([outerPayload])
+            expect(decoded).toHaveLength(1)
+            expect(td.decode(decoded[0].metadata!['encoding']!)).toBe('json/plain')
+            expect(td.decode(decoded[0].data!)).toBe('{"key":"value"}')
+            expect(warnSpy).toHaveBeenCalledWith(
+                'EncryptionCodec: secret key is only 25 bytes; use a 32-byte key in production'
+            )
+        } finally {
+            warnSpy.mockRestore()
         }
+    })
 
-        const decoded = await codec.decode([outerPayload])
+    it('decodes payloads encrypted with fallback keys', async () => {
+        const original = {
+            metadata: { encoding: te.encode('json/plain') },
+            data: te.encode('{"rotated":true}'),
+        }
+        const oldSecretKey = 'old-secret-key-for-codec-0000000'
+        const oldCodec = new EncryptionCodec(oldSecretKey)
+        const rotatedCodec = new EncryptionCodec('new-secret-key-for-codec-0000000', [
+            'older-secret-key-for-codec-00000',
+            oldSecretKey,
+        ])
+
+        const encodedWithOldKey = await oldCodec.encode([original])
+        const decoded = await rotatedCodec.decode(encodedWithOldKey)
+
         expect(decoded).toHaveLength(1)
         expect(td.decode(decoded[0].metadata!['encoding']!)).toBe('json/plain')
-        expect(td.decode(decoded[0].data!)).toBe('{"key":"value"}')
+        expect(td.decode(decoded[0].data!)).toBe('{"rotated":true}')
+    })
+
+    it('encrypts with the primary key instead of fallback keys', async () => {
+        const original = {
+            metadata: { encoding: te.encode('json/plain') },
+            data: te.encode('{"primary":true}'),
+        }
+        const primarySecretKey = 'new-secret-key-for-codec-0000000'
+        const oldSecretKey = 'old-secret-key-for-codec-0000000'
+        const primaryCodec = new EncryptionCodec(primarySecretKey)
+        const oldCodec = new EncryptionCodec(oldSecretKey)
+        const rotatedCodec = new EncryptionCodec(primarySecretKey, [oldSecretKey])
+
+        const encoded = await rotatedCodec.encode([original])
+
+        const decodedWithPrimary = await primaryCodec.decode(encoded)
+        expect(td.decode(decodedWithPrimary[0].data!)).toBe('{"primary":true}')
+        await expect(oldCodec.decode(encoded)).rejects.toThrow('HMAC verification failed')
     })
 
     it('passes through payloads without encrypted encoding', async () => {
@@ -118,28 +174,65 @@ describe('EncryptionCodec', () => {
         await expect(codec.decode([tooShort])).rejects.toThrow('Fernet token too short')
     })
 
-    it('round-trips with short secret keys (padding)', async () => {
-        const shortCodec = new EncryptionCodec('ab')
-        const original = {
-            metadata: { encoding: te.encode('json/plain') },
-            data: te.encode('test'),
-        }
+    it('rejects empty secret keys', () => {
+        expect(() => new EncryptionCodec('')).toThrow('EncryptionCodec: empty secret key is not allowed')
+        expect(() => new EncryptionCodec(TEST_SECRET_KEY, [''])).toThrow(
+            'EncryptionCodec: empty secret key is not allowed'
+        )
+    })
 
-        const encoded = await shortCodec.encode([original])
-        const decoded = await shortCodec.decode(encoded)
-        expect(td.decode(decoded[0].data!)).toBe('test')
+    it('rejects short secret keys in production', () => {
+        const originalNodeEnv = process.env.NODE_ENV
+        process.env.NODE_ENV = 'production'
+
+        try {
+            expect(() => new EncryptionCodec('ab')).toThrow(
+                'EncryptionCodec: secret key must be at least 32 bytes in production (got 2)'
+            )
+        } finally {
+            restoreNodeEnv(originalNodeEnv)
+        }
+    })
+
+    it('round-trips with short secret keys (padding)', async () => {
+        const originalNodeEnv = process.env.NODE_ENV
+        process.env.NODE_ENV = 'test'
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+        try {
+            const shortCodec = new EncryptionCodec('ab')
+            const original = {
+                metadata: { encoding: te.encode('json/plain') },
+                data: te.encode('test'),
+            }
+
+            const encoded = await shortCodec.encode([original])
+            const decoded = await shortCodec.decode(encoded)
+            expect(td.decode(decoded[0].data!)).toBe('test')
+            expect(warnSpy).toHaveBeenCalledWith(
+                'EncryptionCodec: secret key is only 2 bytes; use a 32-byte key in production'
+            )
+        } finally {
+            warnSpy.mockRestore()
+            restoreNodeEnv(originalNodeEnv)
+        }
     })
 
     it('round-trips with long secret keys (truncation)', async () => {
-        const longCodec = new EncryptionCodec('a'.repeat(100))
-        const original = {
-            metadata: { encoding: te.encode('json/plain') },
-            data: te.encode('test'),
-        }
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+        try {
+            const longCodec = new EncryptionCodec('a'.repeat(100))
+            const original = {
+                metadata: { encoding: te.encode('json/plain') },
+                data: te.encode('test'),
+            }
 
-        const encoded = await longCodec.encode([original])
-        const decoded = await longCodec.decode(encoded)
-        expect(td.decode(decoded[0].data!)).toBe('test')
+            const encoded = await longCodec.encode([original])
+            const decoded = await longCodec.decode(encoded)
+            expect(td.decode(decoded[0].data!)).toBe('test')
+            expect(warnSpy).toHaveBeenCalledWith('EncryptionCodec: secret key is 100 bytes, truncating to 32')
+        } finally {
+            warnSpy.mockRestore()
+        }
     })
 
     it('produces base64url-encoded tokens that decode to Fernet version 0x80', async () => {

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/codec.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/codec.test.ts
@@ -13,6 +13,9 @@ const PYTHON_FIXTURE = {
 const te = new TextEncoder()
 const td = new TextDecoder()
 const TEST_SECRET_KEY = 'test-secret-key-for-codec-000000'
+const ENCODED_KEY_BYTES = Buffer.from('decaf???'.repeat(4), 'utf-8')
+const ENCODED_KEY_BASE64 = ENCODED_KEY_BYTES.toString('base64')
+const ENCODED_KEY_BASE64_URLSAFE = ENCODED_KEY_BASE64.replace(/\+/g, '-').replace(/\//g, '_')
 
 function restoreNodeEnv(nodeEnv: string | undefined): void {
     if (nodeEnv === undefined) {
@@ -82,6 +85,24 @@ describe('EncryptionCodec', () => {
         expect(decoded).toHaveLength(1)
         expect(td.decode(decoded[0].metadata!['encoding']!)).toBe('json/plain')
         expect(td.decode(decoded[0].data!)).toBe('{"rotated":true}')
+    })
+
+    it.each([
+        { encoding: 'hex', secretKey: `hex:${ENCODED_KEY_BYTES.toString('hex')}` },
+        { encoding: 'base64-urlsafe', secretKey: `base64-urlsafe:${ENCODED_KEY_BASE64_URLSAFE}` },
+        { encoding: 'base64', secretKey: `base64:${ENCODED_KEY_BASE64}` },
+    ])('loads $encoding secret keys as decoded bytes', async ({ secretKey }) => {
+        const original = {
+            metadata: { encoding: te.encode('json/plain') },
+            data: te.encode('{"encoded":true}'),
+        }
+        const legacyCodec = new EncryptionCodec(ENCODED_KEY_BYTES.toString('utf-8'))
+        const encodedKeyCodec = new EncryptionCodec(secretKey)
+
+        const encodedWithLegacyKey = await legacyCodec.encode([original])
+        const decoded = await encodedKeyCodec.decode(encodedWithLegacyKey)
+
+        expect(td.decode(decoded[0].data!)).toBe('{"encoded":true}')
     })
 
     it('encrypts with the primary key instead of fallback keys', async () => {
@@ -189,9 +210,20 @@ describe('EncryptionCodec', () => {
             expect(() => new EncryptionCodec('ab')).toThrow(
                 'EncryptionCodec: secret key must be at least 32 bytes in production (got 2)'
             )
+            expect(() => new EncryptionCodec('base64:YWI=')).toThrow(
+                'EncryptionCodec: secret key must be at least 32 bytes in production (got 2)'
+            )
         } finally {
             restoreNodeEnv(originalNodeEnv)
         }
+    })
+
+    it.each([
+        { secretKey: 'hex:not-hex', error: 'EncryptionCodec: invalid hex secret key' },
+        { secretKey: 'base64:not-base64!', error: 'EncryptionCodec: invalid base64 secret key' },
+        { secretKey: 'base64-urlsafe:not/base64url', error: 'EncryptionCodec: invalid base64-urlsafe secret key' },
+    ])('rejects invalid encoded secret keys', ({ secretKey, error }) => {
+        expect(() => new EncryptionCodec(secretKey)).toThrow(error)
     })
 
     it('round-trips with short secret keys (padding)', async () => {

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/config.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/config.test.ts
@@ -1,4 +1,5 @@
 import { buildCaptureConfig, buildPlayerConfig, validateInput } from '../capture/config'
+import { parseList } from '../config'
 import { RasterizeRecordingInput } from '../types'
 
 function baseInput(overrides: Partial<RasterizeRecordingInput> = {}): RasterizeRecordingInput {
@@ -12,6 +13,35 @@ function baseInput(overrides: Partial<RasterizeRecordingInput> = {}): RasterizeR
 }
 
 describe('config', () => {
+    describe('parseList', () => {
+        it.each([
+            { text: undefined, expected: [] },
+            { text: '', expected: [] },
+            { text: 'a,b, c ', expected: ['a', 'b', 'c'] },
+            { text: 'a,,b', expected: ['a', '', 'b'] },
+        ])('parses $text', ({ text, expected }) => {
+            expect(parseList(text)).toEqual(expected)
+        })
+
+        it('filters empty fallback keys from config', async () => {
+            const originalFallbackKeys = process.env.TEMPORAL_FALLBACK_KEYS
+            process.env.TEMPORAL_FALLBACK_KEYS = 'a,,b,'
+
+            try {
+                jest.resetModules()
+                const { config } = await import('../config.js')
+                expect(config.fallbackKeys).toEqual(['a', 'b'])
+            } finally {
+                if (originalFallbackKeys === undefined) {
+                    delete process.env.TEMPORAL_FALLBACK_KEYS
+                } else {
+                    process.env.TEMPORAL_FALLBACK_KEYS = originalFallbackKeys
+                }
+                jest.resetModules()
+            }
+        })
+    })
+
     describe('validateInput', () => {
         it('accepts valid input', () => {
             expect(() => validateInput(baseInput())).not.toThrow()

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/config.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/config.test.ts
@@ -24,8 +24,8 @@ describe('config', () => {
         })
 
         it('filters empty fallback keys from config', async () => {
-            const originalFallbackKeys = process.env.TEMPORAL_FALLBACK_KEYS
-            process.env.TEMPORAL_FALLBACK_KEYS = 'a,,b,'
+            const originalFallbackKeys = process.env.TEMPORAL_FALLBACK_SECRET_KEYS
+            process.env.TEMPORAL_FALLBACK_SECRET_KEYS = 'a,,b,'
 
             try {
                 jest.resetModules()
@@ -33,9 +33,9 @@ describe('config', () => {
                 expect(config.fallbackKeys).toEqual(['a', 'b'])
             } finally {
                 if (originalFallbackKeys === undefined) {
-                    delete process.env.TEMPORAL_FALLBACK_KEYS
+                    delete process.env.TEMPORAL_FALLBACK_SECRET_KEYS
                 } else {
-                    process.env.TEMPORAL_FALLBACK_KEYS = originalFallbackKeys
+                    process.env.TEMPORAL_FALLBACK_SECRET_KEYS = originalFallbackKeys
                 }
                 jest.resetModules()
             }

--- a/nodejs/src/session-replay/recording-rasterizer/config.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/config.ts
@@ -1,3 +1,10 @@
+export function parseList(text: string | undefined): string[] {
+    if (!text) {
+        return []
+    }
+    return text.split(',').map((item) => item.trim())
+}
+
 export const config = {
     // Temporal
     temporalHost: process.env.TEMPORAL_HOST || '127.0.0.1',
@@ -19,7 +26,8 @@ export const config = {
     metricsPort: parseInt(process.env.METRICS_PORT || '6738', 10),
 
     // Encryption
-    secretKey: process.env.SECRET_KEY,
+    secretKey: process.env.TEMPORAL_SECRET_KEY || process.env.SECRET_KEY,
+    fallbackKeys: parseList(process.env.TEMPORAL_FALLBACK_KEYS ?? process.env.SECRET_KEY).filter(Boolean),
 
     // S3
     s3Endpoint: process.env.VIDEO_EXPORT_OBJECT_STORAGE_ENDPOINT,

--- a/nodejs/src/session-replay/recording-rasterizer/config.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/config.ts
@@ -27,7 +27,7 @@ export const config = {
 
     // Encryption
     secretKey: process.env.TEMPORAL_SECRET_KEY || process.env.SECRET_KEY,
-    fallbackKeys: parseList(process.env.TEMPORAL_FALLBACK_KEYS ?? process.env.SECRET_KEY).filter(Boolean),
+    fallbackKeys: parseList(process.env.TEMPORAL_FALLBACK_SECRET_KEYS ?? process.env.SECRET_KEY).filter(Boolean),
 
     // S3
     s3Endpoint: process.env.VIDEO_EXPORT_OBJECT_STORAGE_ENDPOINT,

--- a/nodejs/src/session-replay/recording-rasterizer/temporal/codec.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/temporal/codec.ts
@@ -9,30 +9,56 @@ const FERNET_VERSION = 0x80
 const FERNET_HEADER_SIZE = 1 + 8 + 16 // version + timestamp + IV
 const HMAC_SIZE = 32
 
+type FernetKey = {
+    signingKey: Buffer
+    encryptionKey: Buffer
+}
+
 /**
  * Fernet-compatible encryption codec that matches PostHog's Python EncryptionCodec.
  *
- * The Python side (posthog/temporal/common/codec.py) derives a Fernet key from
- * Django's SECRET_KEY: zero-pad to 32 bytes, base64url-encode. The first 16 bytes
- * of the decoded key are the HMAC-SHA256 signing key, the last 16 bytes are the
- * AES-128-CBC encryption key.
+ * The Python side (posthog/temporal/common/codec.py) derives each Fernet key by
+ * zero-padding to 32 bytes, then base64url-encoding. The first 16 decoded bytes
+ * are the HMAC-SHA256 signing key, and the last 16 are the AES-128-CBC key.
  */
 export class EncryptionCodec implements PayloadCodec {
-    private signingKey: Buffer
-    private encryptionKey: Buffer
+    private primaryKey: FernetKey
+    private fallbackKeys: FernetKey[]
 
-    constructor(secretKey: string) {
+    constructor(secretKey: string, fallbackKeys: string[] = []) {
+        this.primaryKey = this.prepareKey(secretKey)
+        this.fallbackKeys = fallbackKeys.map((fallbackKey) => this.prepareKey(fallbackKey))
+    }
+
+    private prepareKey(secretKey: string): FernetKey {
+        if (!secretKey) {
+            throw new Error('EncryptionCodec: empty secret key is not allowed')
+        }
+
+        const keyBytes = Buffer.from(secretKey, 'utf-8')
+        if (keyBytes.length < 32 && process.env.NODE_ENV === 'production') {
+            throw new Error(
+                `EncryptionCodec: secret key must be at least 32 bytes in production (got ${keyBytes.length})`
+            )
+        }
+        if (keyBytes.length < 32) {
+            console.warn(
+                `EncryptionCodec: secret key is only ${keyBytes.length} bytes; use a 32-byte key in production`
+            )
+        }
+
         // Match Python: pad with null bytes on the left, truncate to 32 bytes
         const padded = Buffer.alloc(32)
-        const keyBytes = Buffer.from(secretKey, 'utf-8')
         if (keyBytes.length > 32) {
             console.warn(`EncryptionCodec: secret key is ${keyBytes.length} bytes, truncating to 32`)
         }
         const padLen = Math.max(32 - keyBytes.length, 0)
         keyBytes.copy(padded, padLen, 0, Math.min(keyBytes.length, 32))
 
-        this.signingKey = padded.subarray(0, 16)
-        this.encryptionKey = padded.subarray(16, 32)
+        return {
+            signingKey: padded.subarray(0, 16),
+            encryptionKey: padded.subarray(16, 32),
+        }
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
@@ -59,7 +85,7 @@ export class EncryptionCodec implements PayloadCodec {
         const iv = crypto.randomBytes(16)
         const timestamp = BigInt(Math.floor(Date.now() / 1000))
 
-        const cipher = crypto.createCipheriv('aes-128-cbc', this.encryptionKey, iv)
+        const cipher = crypto.createCipheriv('aes-128-cbc', this.primaryKey.encryptionKey, iv)
         const ciphertext = Buffer.concat([cipher.update(data), cipher.final()])
 
         // Fernet token: version || timestamp (big-endian 64-bit) || IV || ciphertext
@@ -69,7 +95,7 @@ export class EncryptionCodec implements PayloadCodec {
         iv.copy(body, 9)
         ciphertext.copy(body, FERNET_HEADER_SIZE)
 
-        const hmac = crypto.createHmac('sha256', this.signingKey).update(body).digest()
+        const hmac = crypto.createHmac('sha256', this.primaryKey.signingKey).update(body).digest()
         const raw = Buffer.concat([body, hmac])
 
         // Python's Fernet expects base64url with padding — use standard base64
@@ -89,16 +115,26 @@ export class EncryptionCodec implements PayloadCodec {
 
         const body = buf.subarray(0, buf.length - HMAC_SIZE)
         const providedHmac = buf.subarray(buf.length - HMAC_SIZE)
-        const computedHmac = crypto.createHmac('sha256', this.signingKey).update(body).digest()
+        let decryptError: Error | undefined
 
-        if (!crypto.timingSafeEqual(providedHmac, computedHmac)) {
-            throw new Error('Fernet HMAC verification failed')
+        for (const key of [this.primaryKey, ...this.fallbackKeys]) {
+            const computedHmac = crypto.createHmac('sha256', key.signingKey).update(body).digest()
+
+            if (!crypto.timingSafeEqual(providedHmac, computedHmac)) {
+                continue
+            }
+
+            const iv = buf.subarray(9, 25)
+            const ciphertext = buf.subarray(FERNET_HEADER_SIZE, buf.length - HMAC_SIZE)
+
+            try {
+                const decipher = crypto.createDecipheriv('aes-128-cbc', key.encryptionKey, iv)
+                return Buffer.concat([decipher.update(ciphertext), decipher.final()])
+            } catch (error) {
+                decryptError = error instanceof Error ? error : new Error(String(error))
+            }
         }
 
-        const iv = buf.subarray(9, 25)
-        const ciphertext = buf.subarray(FERNET_HEADER_SIZE, buf.length - HMAC_SIZE)
-
-        const decipher = crypto.createDecipheriv('aes-128-cbc', this.encryptionKey, iv)
-        return Buffer.concat([decipher.update(ciphertext), decipher.final()])
+        throw decryptError ?? new Error('Fernet HMAC verification failed')
     }
 }

--- a/nodejs/src/session-replay/recording-rasterizer/temporal/codec.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/temporal/codec.ts
@@ -14,6 +14,30 @@ type FernetKey = {
     encryptionKey: Buffer
 }
 
+type RawSecretKey = string | Uint8Array
+
+function decodeHex(secret: string): Buffer {
+    const normalized = secret.replace(/\s/g, '')
+    if (normalized.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(normalized)) {
+        throw new Error('EncryptionCodec: invalid hex secret key')
+    }
+    return Buffer.from(normalized, 'hex')
+}
+
+function decodeBase64(secret: string): Buffer {
+    if (secret.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(secret)) {
+        throw new Error('EncryptionCodec: invalid base64 secret key')
+    }
+    return Buffer.from(secret, 'base64')
+}
+
+function decodeBase64Urlsafe(secret: string): Buffer {
+    if (secret.length % 4 !== 0 || !/^[A-Za-z0-9_-]*={0,2}$/.test(secret)) {
+        throw new Error('EncryptionCodec: invalid base64-urlsafe secret key')
+    }
+    return Buffer.from(secret, 'base64url')
+}
+
 /**
  * Fernet-compatible encryption codec that matches PostHog's Python EncryptionCodec.
  *
@@ -25,17 +49,44 @@ export class EncryptionCodec implements PayloadCodec {
     private primaryKey: FernetKey
     private fallbackKeys: FernetKey[]
 
-    constructor(secretKey: string, fallbackKeys: string[] = []) {
+    constructor(secretKey: RawSecretKey, fallbackKeys: RawSecretKey[] = []) {
         this.primaryKey = this.prepareKey(secretKey)
         this.fallbackKeys = fallbackKeys.map((fallbackKey) => this.prepareKey(fallbackKey))
     }
 
-    private prepareKey(secretKey: string): FernetKey {
-        if (!secretKey) {
+    private loadAsBytes(raw: RawSecretKey): Buffer {
+        if (raw instanceof Uint8Array) {
+            return Buffer.from(raw)
+        }
+
+        const separatorIndex = raw.indexOf(':')
+        if (separatorIndex === -1) {
+            return Buffer.from(raw, 'utf-8')
+        }
+
+        const prefix = raw.slice(0, separatorIndex)
+        const secret = raw.slice(separatorIndex + 1)
+
+        switch (prefix) {
+            case 'hex':
+                return decodeHex(secret)
+            case 'base64-urlsafe':
+                return decodeBase64Urlsafe(secret)
+            case 'base64':
+                return decodeBase64(secret)
+            default:
+                // Legacy format, kept for compatibility with Python's _load_as_bytes.
+                return Buffer.from(raw, 'utf-8')
+        }
+    }
+
+    private prepareKey(secretKey: RawSecretKey): FernetKey {
+        const keyBytes = this.loadAsBytes(secretKey)
+
+        if (keyBytes.length === 0) {
             throw new Error('EncryptionCodec: empty secret key is not allowed')
         }
 
-        const keyBytes = Buffer.from(secretKey, 'utf-8')
         if (keyBytes.length < 32 && process.env.NODE_ENV === 'production') {
             throw new Error(
                 `EncryptionCodec: secret key must be at least 32 bytes in production (got ${keyBytes.length})`

--- a/nodejs/src/session-replay/recording-rasterizer/temporal/worker.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/temporal/worker.ts
@@ -125,7 +125,9 @@ async function main(): Promise<void> {
         taskQueue: config.taskQueue,
         activities: createActivities(pool, playerHtml),
         maxConcurrentActivityTaskExecutions: config.maxConcurrentActivities,
-        dataConverter: config.secretKey ? { payloadCodecs: [new EncryptionCodec(config.secretKey)] } : undefined,
+        dataConverter: config.secretKey
+            ? { payloadCodecs: [new EncryptionCodec(config.secretKey, config.fallbackKeys)] }
+            : undefined,
         // Throttle heartbeat *server flushes* (not heartbeat() calls) to 2s. Without
         // this override, the SDK throttles to 80% of the activity's heartbeat_timeout
         // (30s → 24s), which means capture-phase frame progress never reaches the


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Mimic the changes in https://github.com/PostHog/posthog/pull/61080 for the Nodejs codec. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are adding support for rotating the Temporal secret key (and moving it away from using the Django secret key).

This PR mimics the new behavior in the Python codec.


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

New unit tests.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

I gave the robot my Python PR and told it to mimic it in nodejs.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
