### PR TITLE
fix(modeling): move to database async pool

### DIFF
--- a/posthog/temporal/data_modeling/activities/create_data_modeling_job.py
+++ b/posthog/temporal/data_modeling/activities/create_data_modeling_job.py
@@ -4,7 +4,7 @@ from structlog import get_logger
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
-from posthog.sync import database_sync_to_async
+from posthog.sync import database_sync_to_async_pool
 
 from products.data_modeling.backend.models import Node
 from products.data_modeling.backend.models.data_modeling_job import DataModelingJob, DataModelingJobEngine
@@ -21,7 +21,7 @@ class CreateDataModelingJobInputs:
     parent_workflow_id: str | None = None
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _create_data_modeling_job(inputs: CreateDataModelingJobInputs, workflow_id: str, workflow_run_id: str) -> str:
     node = Node.objects.prefetch_related("saved_query").get(
         id=inputs.node_id, team_id=inputs.team_id, dag_id=inputs.dag_id

--- a/posthog/temporal/data_modeling/activities/fail_materialization.py
+++ b/posthog/temporal/data_modeling/activities/fail_materialization.py
@@ -7,7 +7,7 @@ from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
 from posthog.exceptions_capture import capture_exception
-from posthog.sync import database_sync_to_async
+from posthog.sync import database_sync_to_async_pool
 
 from products.data_modeling.backend.models import Node
 from products.data_modeling.backend.models.data_modeling_job import DataModelingJob, DataModelingJobStatus
@@ -62,7 +62,7 @@ class FailMaterializationInputs:
     update_node: bool = True
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _fail_node_and_data_modeling_job(inputs: FailMaterializationInputs):
     # strip hostnames from error for user-facing storage while preserving original for logging
     sanitized_error = strip_hostname_from_error(inputs.error)
@@ -93,14 +93,14 @@ def _fail_node_and_data_modeling_job(inputs: FailMaterializationInputs):
     return node, job
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _get_saved_query_for_job(job: DataModelingJob) -> DataWarehouseSavedQuery | None:
     if not job.saved_query_id:
         return None
     return DataWarehouseSavedQuery.objects.exclude(deleted=True).filter(id=job.saved_query_id).first()
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _maybe_pause_schedule_on_timeout(job: DataModelingJob, saved_query: DataWarehouseSavedQuery) -> bool:
     """Pause the schedule only if the previous N jobs all failed due to timeouts.
 
@@ -119,7 +119,7 @@ def _maybe_pause_schedule_on_timeout(job: DataModelingJob, saved_query: DataWare
     return True
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _revert_materialization_on_unknown_table(job: DataModelingJob, saved_query: DataWarehouseSavedQuery) -> None:
     saved_query.revert_materialization()
     # we can use this specific language in the error to add these jobs to the daily email digest later

--- a/posthog/temporal/data_modeling/activities/get_dag_structure.py
+++ b/posthog/temporal/data_modeling/activities/get_dag_structure.py
@@ -2,7 +2,7 @@ import dataclasses
 
 from temporalio import activity
 
-from posthog.sync import database_sync_to_async
+from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.logger import get_logger
 
 from products.data_modeling.backend.models import Edge, Node, NodeType
@@ -37,7 +37,7 @@ class DAG:
     ephemeral_nodes: list[str] = dataclasses.field(default_factory=list)
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _get_dag_structure_async(team_id: int, dag_id: str) -> DAG:
     """Retrieve all nodes and edges for a DAG from the database."""
     nodes = Node.objects.filter(team_id=team_id, dag_id=dag_id)

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -25,7 +25,7 @@ from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models import Team
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.settings.base_variables import TEST
-from posthog.sync import database_sync_to_async
+from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.clickhouse import get_client as get_clickhouse_client
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger
@@ -273,9 +273,9 @@ async def get_query_row_count(
         limit_top_select=False,
     )
     context.output_format = "TabSeparated"
-    context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
+    context.database = await database_sync_to_async_pool(Database.create_for)(team=team, modifiers=context.modifiers)
 
-    prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
+    prepared_hogql_query = await database_sync_to_async_pool(prepare_ast_for_printing)(
         query_node,
         context=context,
         dialect="clickhouse",
@@ -287,7 +287,7 @@ async def get_query_row_count(
     if prepared_hogql_query is None:
         raise EmptyHogQLResponseColumnsError()
 
-    printed = await database_sync_to_async(print_prepared_ast)(
+    printed = await database_sync_to_async_pool(print_prepared_ast)(
         prepared_hogql_query,
         context=context,
         dialect="clickhouse",
@@ -331,10 +331,10 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
         enable_select_queries=True,
         limit_top_select=False,
     )
-    context.database = await database_sync_to_async(Database.create_for)(team=team, modifiers=context.modifiers)
+    context.database = await database_sync_to_async_pool(Database.create_for)(team=team, modifiers=context.modifiers)
 
     factory = bounded_resolver_factory_for_view(view_name)
-    prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
+    prepared_hogql_query = await database_sync_to_async_pool(prepare_ast_for_printing)(
         query_node,
         context=context,
         dialect="clickhouse",
@@ -345,7 +345,7 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
     if prepared_hogql_query is None:
         raise EmptyHogQLResponseColumnsError()
 
-    printed = await database_sync_to_async(print_prepared_ast)(
+    printed = await database_sync_to_async_pool(print_prepared_ast)(
         prepared_hogql_query,
         context=context,
         dialect="clickhouse",
@@ -413,7 +413,7 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
     context.output_format = "ArrowStream"
     settings.preferred_block_size_bytes = MB_100_IN_BYTES
 
-    arrow_prepared_hogql_query = await database_sync_to_async(prepare_ast_for_printing)(
+    arrow_prepared_hogql_query = await database_sync_to_async_pool(prepare_ast_for_printing)(
         query_node,
         context=context,
         dialect="clickhouse",
@@ -425,7 +425,7 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
     if arrow_prepared_hogql_query is None:
         raise EmptyHogQLResponseColumnsError()
 
-    arrow_printed = await database_sync_to_async(print_prepared_ast)(
+    arrow_printed = await database_sync_to_async_pool(print_prepared_ast)(
         arrow_prepared_hogql_query, context=context, dialect="clickhouse", stack=[], settings=settings
     )
 
@@ -467,7 +467,7 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
             yield (empty_batch, ch_typings_pairs)
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _get_matview_input_objects(
     inputs: MaterializeViewInputs,
 ) -> tuple[Team, Node, DataWarehouseSavedQuery, DataModelingJob]:
@@ -521,11 +521,11 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
             rows_expected = await get_query_row_count(hogql_query, team, logger, view_name=saved_query.name)
             await logger.ainfo(f"Expected rows: {rows_expected}")
             job.rows_expected = rows_expected
-            await database_sync_to_async(job.save)()
+            await database_sync_to_async_pool(job.save)()
         except Exception as e:
             await logger.awarning(f"Failed to get expected row count: {str(e)}. Continuing without progress tracking.")
             job.rows_expected = None
-            await database_sync_to_async(job.save)()
+            await database_sync_to_async_pool(job.save)()
 
         row_count = 0
         storage_options = _get_aws_storage_options()
@@ -567,7 +567,7 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
                 )
             row_count = row_count + batch.num_rows
             job.rows_materialized = row_count
-            await database_sync_to_async(job.save)()
+            await database_sync_to_async_pool(job.save)()
 
         await logger.ainfo(f"Finished writing to delta table. row_count={row_count}")
         # row count validation warning

--- a/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
@@ -10,7 +10,7 @@ from temporalio import activity
 from posthog.ducklake.common import get_duckgres_server_for_organization, is_dev_mode
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
-from posthog.sync import database_sync_to_async
+from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.logger import get_logger
 
 from products.data_modeling.backend.models import Node, NodeType
@@ -90,7 +90,7 @@ def _compile_hogql_to_postgres_sql(hogql_query: str, team_id: int) -> tuple[str,
     return postgres_sql, values
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _get_shadow_input_objects(
     inputs: DuckgresShadowInputs,
 ) -> tuple[Team, Node, DataWarehouseSavedQuery]:
@@ -112,11 +112,11 @@ def _get_shadow_input_objects(
 @activity.defn
 async def check_duckgres_shadow_enabled_activity(team_id: int) -> bool:
     """Check whether the duckgres shadow flag is enabled for a team."""
-    team = await database_sync_to_async(Team.objects.get)(id=team_id)
-    return await database_sync_to_async(_is_duckgres_shadow_enabled)(team)
+    team = await database_sync_to_async_pool(Team.objects.get)(id=team_id)
+    return await database_sync_to_async_pool(_is_duckgres_shadow_enabled)(team)
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _resolve_duckgres_job(job_id: str, result: "DuckgresShadowResult") -> None:
     """Update the duckgres job to its terminal state based on the result."""
     job = DataModelingJob.objects.get(id=job_id)
@@ -164,12 +164,12 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
         if inputs.dangerously_execute_raw_sql:
             sql = hogql_query
         else:
-            sql, values = await database_sync_to_async(_compile_hogql_to_postgres_sql)(hogql_query, team.pk)
+            sql, values = await database_sync_to_async_pool(_compile_hogql_to_postgres_sql)(hogql_query, team.pk)
         await logger.adebug("Duckgres shadow SQL generated", sql=sql)
 
         from posthog.ducklake.client import execute_ducklake_create_table
 
-        result = await database_sync_to_async(execute_ducklake_create_table)(
+        result = await database_sync_to_async_pool(execute_ducklake_create_table)(
             team.pk, sql, schema_name, table_name, values
         )
         duration = time.monotonic() - start_time

--- a/posthog/temporal/data_modeling/activities/preempt_dag_run.py
+++ b/posthog/temporal/data_modeling/activities/preempt_dag_run.py
@@ -5,7 +5,7 @@ from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
 from posthog.exceptions_capture import capture_exception
-from posthog.sync import database_sync_to_async
+from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.client import async_connect
 
 from products.data_modeling.backend.models.data_modeling_job import DataModelingJob, DataModelingJobStatus
@@ -21,7 +21,7 @@ class PreemptDAGRunInputs:
     dag_id: str
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _get_running_jobs_for_dag(team_id: int, dag_id: str) -> list[DataModelingJob]:
     """Find RUNNING DataModelingJob records belonging to a previous run of this DAG.
 
@@ -37,7 +37,7 @@ def _get_running_jobs_for_dag(team_id: int, dag_id: str) -> list[DataModelingJob
     )
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _mark_jobs_as_preempted(job_ids: list[str]) -> int:
     return DataModelingJob.objects.filter(id__in=job_ids, status=DataModelingJobStatus.RUNNING).update(
         status=DataModelingJobStatus.FAILED,

--- a/posthog/temporal/data_modeling/activities/prepare_queryable_table.py
+++ b/posthog/temporal/data_modeling/activities/prepare_queryable_table.py
@@ -4,7 +4,7 @@ from structlog import get_logger
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
-from posthog.sync import database_sync_to_async
+from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.data_imports.util import prepare_s3_files_for_querying
 
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
@@ -24,7 +24,7 @@ class PrepareQueryableTableInputs:
     row_count: int
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _get_saved_query_with_table(inputs: PrepareQueryableTableInputs) -> DataWarehouseSavedQuery:
     saved_query = (
         DataWarehouseSavedQuery.objects.select_related("team", "table")
@@ -34,7 +34,7 @@ def _get_saved_query_with_table(inputs: PrepareQueryableTableInputs) -> DataWare
     return saved_query
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _update_saved_query_with_table(
     inputs: PrepareQueryableTableInputs, saved_query: DataWarehouseSavedQuery, saved_query_table: DataWarehouseTable
 ):

--- a/posthog/temporal/data_modeling/activities/succeed_materialization.py
+++ b/posthog/temporal/data_modeling/activities/succeed_materialization.py
@@ -5,7 +5,7 @@ from structlog import get_logger
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
-from posthog.sync import database_sync_to_async
+from posthog.sync import database_sync_to_async_pool
 
 from products.data_modeling.backend.models import Node
 from products.data_modeling.backend.models.data_modeling_job import DataModelingJob, DataModelingJobStatus
@@ -26,7 +26,7 @@ class SucceedMaterializationInputs:
     update_node: bool = True
 
 
-@database_sync_to_async
+@database_sync_to_async_pool
 def _succeed_node_and_data_modeling_job(inputs: SucceedMaterializationInputs):
     node = None
     if inputs.update_node:


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

long running cpu bound tasks like hogql resolution, Database.create_for, etc. run on database_sync_to_async and hold the cpu for too long. this prevents short running tasks like
Team.objects.get() or DataModelingJob.objects.select_for_update() from running before their start to close timeout in temporal

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

switch to database_sync_to_async_pool

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

existing unit tests. this approach also closely follows the approach in the data_imports product so its relatively "proven." depends on landing the charts
change first to explicitly limit activity concurrency and pg client connection limit.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->

<!-- gg:stack-start -->
## gg stack

- **#61181 `andrew/database-async-pool` 👈 this PR**
<!-- gg:stack-end -->
