### PR TITLE
test(batch-exports): add frontend per-destination regression tests

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4182,10 +4182,42 @@ snapshots:
         hash: v1.k794b7964.05d7f391fdbe1f565e9329575dd8fff8c86069cff8345c39c05c1a4f286df301.AM7OsTQnhgqypXvL58dwrdjoxBeSBt7EvF7GdNKix_U
     scenes-app-batchexports--metrics--light:
         hash: v1.k794b7964.2a35529dda76e924c361be19057499c3aa72c98fc7b86e31184b1ccb7acbc938.6UBr4F4PNQVWEwdoGsRsEkA_af40UyfrYI7v2EyyWJ0
+    scenes-app-batchexports--new-azure-blob-export--dark:
+        hash: v1.k794b7964.d889b4305b0056ccfa2c51d2e6f1e6eb1ae6d5264cea194e3215d100e62818c7.6JLJrVz0vp_ceIn4eG6qqj6yHEkGmVAIbQXDD0e2OYY
+    scenes-app-batchexports--new-azure-blob-export--light:
+        hash: v1.k794b7964.2f4fa15b571bd753e50ecc95371b3312d2ae007f94c60d23242ba50be982667c.8AmhbsCHMfm--TPjY0Iv3SS4xSIYXjGgAs1hEn6eudE
+    scenes-app-batchexports--new-big-query-export--dark:
+        hash: v1.k794b7964.46c1bbbfd1614c8e98ed13cf8158a6c06e13db9d6b7998ac9993f18f226fabca.1lULOvQgq6-NHwB6ywiUHZlQanVlslaBGlx_YuuXH9s
+    scenes-app-batchexports--new-big-query-export--light:
+        hash: v1.k794b7964.a7f74ef88efd16339eb283b55c2522f1cb5f12f7b8712d6daa86cce126406892.jV4L5DRuUxqr-uKjYNPeyNTrBNqzH_LmFca8lhKanaY
+    scenes-app-batchexports--new-big-query-export-with-integration--dark:
+        hash: v1.k794b7964.b0017a9704d860ae6dbefea6e35ad51210bcd9b0d1b9e880b40bff062ef0313e.4ZitrIL91s40q-7PAttfTwKJR6m7_7AuVnJ3tdjCrm8
+    scenes-app-batchexports--new-big-query-export-with-integration--light:
+        hash: v1.k794b7964.d74e0bf9deea6e90d2f919bcf36fd70546c91c7aef5fc6068ca8ec5ac8e5212e.pL2_3mN2nQvLGMs44hBLwFItesrAIlMK_NTNB-umOfE
+    scenes-app-batchexports--new-databricks-export--dark:
+        hash: v1.k794b7964.d54b3f7c4845b3c5f945b45689f5917c9bcde6a4ac4f72bf40d161f10d4f55fd.93WWAtDciTnt8SaNbW7U0AbnWuGyrb3Y3ZE3AvW6NVI
+    scenes-app-batchexports--new-databricks-export--light:
+        hash: v1.k794b7964.25a8b8417770d57fedd4a87ea1e565d8749e57e64511036f79ffa3e00cc3ac88.-rGyOuxDyRv6LxIlt41gnX8xgcfyPDo4_XPadJsX_1A
+    scenes-app-batchexports--new-http-export--dark:
+        hash: v1.k794b7964.8a51cbc65d54323ce7921415a5addf2ef6636ae025e7f1ebd90bc779ef6340bd.5bsQAoyEK02dWepnexFwFlknBQaHA_rxqmzG8_VuYR8
+    scenes-app-batchexports--new-http-export--light:
+        hash: v1.k794b7964.41b85adf2c732f7993fe8dafa8761d769de9e825b07a27e04bfd30a4b4e1e331.AeuHOHQ083cCjRCL8jgGsQBNUGtTY-v-lsEDL2brjM0
+    scenes-app-batchexports--new-postgres-export--dark:
+        hash: v1.k794b7964.e561016272750fba9398c089d1eab97ab0ef03b7c3097979f54ec5d012af2d95.3yAd7b56ixt10f9MJGGNsNdz6HnrVbQ6AoBB_F8wSBU
+    scenes-app-batchexports--new-postgres-export--light:
+        hash: v1.k794b7964.3c78b42055b7d98c09546dfc41b4fc0f0e0cce043d9447f06b86733fd0503af8.dcAy1PghWvnE-NjkzKk17akgZdR7-tImG-BE9VjtDlM
+    scenes-app-batchexports--new-redshift-export--dark:
+        hash: v1.k794b7964.0aac5a33d0d3acc010704bffeca2e41830ccadd9bfd6261ea9790ef91f403a13.3Edh4xHy7pPf3pRzqlryayXIsh_YDLrer5tyix2_jHE
+    scenes-app-batchexports--new-redshift-export--light:
+        hash: v1.k794b7964.6856b135d2cee2cbd2a1a9527aa85b1e90a707f3e2d885cc23291c0187950727.a2O1CYhMK8AU6b6Q2aqUmzSvdaVKa04jeFBJSppqBhU
     scenes-app-batchexports--new-s-3-export--dark:
         hash: v1.k794b7964.16c44e9771d0e22656f294bf4a3f8496f74d884e55f4c1975c32ff9db8575995.dhas1f5NftAK5emoP0pwlGK5BbXgVftA5e1z7fbCh48
     scenes-app-batchexports--new-s-3-export--light:
         hash: v1.k794b7964.9beb1795f4cea49e745ddda559a7af22233c7a2b9cd177f9f11c687ad867e730.pUIek5HBtefgmROQr34mIxWgg-9c71ZgpRBVtRazuG4
+    scenes-app-batchexports--new-snowflake-export--dark:
+        hash: v1.k794b7964.d71afa50deeeff7b2e20d1bb35276409fab5c04a9980d5ed7e922389bf7214a7.n6T6TEpb1Mc_77pKNgeGCh0Ew5SbetLpN-ToCJ0YCWU
+    scenes-app-batchexports--new-snowflake-export--light:
+        hash: v1.k794b7964.23fe84ba49bf8a12e4b838d8a6cd092df08d8b917fa8c698bb8a7559f6c78e9f.F8cBpNu2gGhWQXzUgS-aLEcHjZjP-5RQSd30eoh99qA
     scenes-app-batchexports--runs-empty--dark:
         hash: v1.k794b7964.103efa98046087636634d3cdeac2bcf9018b137397177e8bb3b43354de35afa1.5-pXsFef6HCA_Z08n1pVKjgb1GnnOrpo--4lrN1EKts
     scenes-app-batchexports--runs-empty--light:

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.stories.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { App } from 'scenes/App'
 import { urls } from 'scenes/urls'
 
@@ -31,6 +32,9 @@ const meta: Meta = {
                 '/api/environments/:team_id/batch_exports/test/': { steps: [] },
                 [`/api/environments/:team_id/batch_exports/${EXISTING_EXPORT.id}/runs/`]: { results: [] },
                 [`/api/environments/:team_id/batch_exports/${EXISTING_EXPORT.id}/backfills/`]: { results: [] },
+                // Integration-backed destinations (Databricks, AzureBlob, BigQuery) render IntegrationChoice.
+                '/api/environments/:team_id/integrations': { results: [] },
+                '/api/projects/:team_id/integrations': { results: [] },
             },
         }),
     ],
@@ -39,9 +43,64 @@ export default meta
 
 type Story = StoryObj<{}>
 
+// One new-export story per destination so visual regression covers each destination's
+// edit form (the per-destination `Fields` components in destinations/). The default
+// configuration drives any conditional UI: Redshift defaults to COPY (shows the S3
+// staging section), Snowflake to password auth.
 export const NewS3Export: Story = {
     parameters: {
         pageUrl: urls.batchExportNew('s3'),
+    },
+}
+
+export const NewSnowflakeExport: Story = {
+    parameters: {
+        pageUrl: urls.batchExportNew('snowflake'),
+    },
+}
+
+export const NewPostgresExport: Story = {
+    parameters: {
+        pageUrl: urls.batchExportNew('postgres'),
+    },
+}
+
+export const NewRedshiftExport: Story = {
+    parameters: {
+        pageUrl: urls.batchExportNew('redshift'),
+    },
+}
+
+export const NewHTTPExport: Story = {
+    parameters: {
+        pageUrl: urls.batchExportNew('http'),
+    },
+}
+
+export const NewDatabricksExport: Story = {
+    parameters: {
+        pageUrl: urls.batchExportNew('databricks'),
+    },
+}
+
+export const NewAzureBlobExport: Story = {
+    parameters: {
+        pageUrl: urls.batchExportNew('azureblob'),
+    },
+}
+
+// BigQuery has two variants gated on BATCH_EXPORTS_BIGQUERY_INTEGRATION: the JSON key-file
+// upload (flag off) and the IntegrationChoice picker (flag on).
+export const NewBigQueryExport: Story = {
+    parameters: {
+        pageUrl: urls.batchExportNew('bigquery'),
+    },
+}
+
+export const NewBigQueryExportWithIntegration: Story = {
+    parameters: {
+        pageUrl: urls.batchExportNew('bigquery'),
+        featureFlags: [FEATURE_FLAGS.BATCH_EXPORTS_BIGQUERY_INTEGRATION],
     },
 }
 

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
@@ -76,6 +76,22 @@ const BIGQUERY_BATCH_EXPORT = fixture('test-bq-id', 'BigQuery Export', {
     },
 })
 
+// Integration-backed BigQuery: carries `integration` and omits the service-account fields,
+// so its wire shape differs from the legacy JSON-key-file variant above.
+const BIGQUERY_INTEGRATION_BATCH_EXPORT = fixture('test-bq-integration-id', 'BigQuery Integration Export', {
+    type: 'BigQuery',
+    integration: 7,
+    // Integration-backed config legitimately omits the service-account fields that
+    // BatchExportServiceBigQuery['config'] declares, so the cast keeps the fixture honest.
+    config: {
+        dataset_id: 'test_dataset',
+        table_id: 'events',
+        exclude_events: [],
+        include_events: [],
+        use_json_type: false,
+    } as any,
+})
+
 const POSTGRES_BATCH_EXPORT = fixture('fixture-postgres', 'Postgres Export', {
     type: 'Postgres',
     config: {
@@ -253,6 +269,7 @@ const AZUREBLOB_BATCH_EXPORT = fixture('fixture-azureblob', 'Azure Blob Export',
 const ALL_BATCH_EXPORTS: BatchExportConfiguration[] = [
     S3_BATCH_EXPORT,
     BIGQUERY_BATCH_EXPORT,
+    BIGQUERY_INTEGRATION_BATCH_EXPORT,
     POSTGRES_BATCH_EXPORT,
     SNOWFLAKE_PASSWORD_BATCH_EXPORT,
     SNOWFLAKE_KEYPAIR_BATCH_EXPORT,
@@ -885,6 +902,7 @@ describe('batchExportConfigFormLogic', () => {
         it.each([
             { name: 'S3', fixture: S3_BATCH_EXPORT },
             { name: 'BigQuery', fixture: BIGQUERY_BATCH_EXPORT },
+            { name: 'BigQuery (integration)', fixture: BIGQUERY_INTEGRATION_BATCH_EXPORT },
             { name: 'Postgres', fixture: POSTGRES_BATCH_EXPORT },
             { name: 'Snowflake (password)', fixture: SNOWFLAKE_PASSWORD_BATCH_EXPORT },
             { name: 'Snowflake (keypair)', fixture: SNOWFLAKE_KEYPAIR_BATCH_EXPORT },

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
@@ -1,6 +1,8 @@
 import { router } from 'kea-router'
 import { expectLogic, partial } from 'kea-test-utils'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -14,71 +16,253 @@ import {
     getDefaultConfiguration,
 } from './batchExportConfigFormLogic'
 
-const MOCK_S3_BATCH_EXPORT: BatchExportConfiguration = {
-    id: 'test-s3-id',
-    team_id: 997,
-    name: 'S3 Export',
-    destination: {
-        type: 'S3',
-        config: {
-            bucket_name: 'test-bucket',
-            region: 'us-east-1',
-            prefix: 'posthog-events/',
-            aws_access_key_id: 'AKIAIOSFODNN7EXAMPLE',
-            aws_secret_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-            exclude_events: [],
-            include_events: [],
-            compression: 'gzip',
-            encryption: null,
-            kms_key_id: null,
-            endpoint_url: null,
-            file_format: 'Parquet',
-            max_file_size_mb: null,
-            use_virtual_style_addressing: false,
-        },
-    },
-    interval: 'hour',
-    timezone: null,
-    offset_day: null,
-    offset_hour: null,
-    created_at: '2024-01-01T00:00:00Z',
-    start_at: null,
-    end_at: null,
-    paused: false,
-    model: 'events',
-    filters: [],
+// Builds a BatchExportConfiguration with shared defaults so each fixture only declares its destination.
+function fixture<T extends BatchExportConfiguration['destination']>(
+    id: string,
+    name: string,
+    destination: T
+): BatchExportConfiguration {
+    return {
+        id,
+        team_id: 997,
+        name,
+        destination: destination as BatchExportConfiguration['destination'],
+        interval: 'hour',
+        timezone: null,
+        offset_day: null,
+        offset_hour: null,
+        created_at: '2024-01-01T00:00:00Z',
+        start_at: null,
+        end_at: null,
+        paused: false,
+        model: 'events',
+        filters: [],
+    }
 }
 
-const MOCK_BIGQUERY_BATCH_EXPORT: BatchExportConfiguration = {
-    id: 'test-bq-id',
-    team_id: 997,
-    name: 'BigQuery Export',
-    destination: {
-        type: 'BigQuery',
+const S3_BATCH_EXPORT = fixture('test-s3-id', 'S3 Export', {
+    type: 'S3',
+    config: {
+        bucket_name: 'test-bucket',
+        region: 'us-east-1',
+        prefix: 'posthog-events/',
+        aws_access_key_id: 'AKIAIOSFODNN7EXAMPLE',
+        aws_secret_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        exclude_events: [],
+        include_events: [],
+        compression: 'gzip',
+        encryption: null,
+        kms_key_id: null,
+        endpoint_url: null,
+        file_format: 'Parquet',
+        max_file_size_mb: null,
+        use_virtual_style_addressing: false,
+    },
+})
+
+const BIGQUERY_BATCH_EXPORT = fixture('test-bq-id', 'BigQuery Export', {
+    type: 'BigQuery',
+    config: {
+        project_id: 'test_project',
+        private_key: 'test-key',
+        private_key_id: 'key-id',
+        client_email: 'test@test.iam.gserviceaccount.com',
+        token_uri: 'https://oauth2.googleapis.com/token',
+        dataset_id: 'test_dataset',
+        table_id: 'events',
+        exclude_events: [],
+        include_events: [],
+        use_json_type: false,
+    },
+})
+
+const POSTGRES_BATCH_EXPORT = fixture('fixture-postgres', 'Postgres Export', {
+    type: 'Postgres',
+    config: {
+        user: 'pg-user',
+        password: 'pg-pass',
+        host: 'pg-host',
+        port: 5432,
+        database: 'pg-db',
+        schema: 'public',
+        table_name: 'events',
+        has_self_signed_cert: false,
+        exclude_events: [],
+        include_events: [],
+    },
+})
+
+const SNOWFLAKE_PASSWORD_BATCH_EXPORT = fixture('fixture-snowflake-password', 'Snowflake Password Export', {
+    type: 'Snowflake',
+    config: {
+        account: 'sf-account',
+        database: 'sf-db',
+        warehouse: 'sf-wh',
+        user: 'sf-user',
+        authentication_type: 'password',
+        password: 'sf-pass',
+        private_key: null,
+        private_key_passphrase: null,
+        schema: 'public',
+        table_name: 'events',
+        role: null,
+        exclude_events: [],
+        include_events: [],
+    },
+})
+
+const SNOWFLAKE_KEYPAIR_BATCH_EXPORT = fixture('fixture-snowflake-keypair', 'Snowflake Keypair Export', {
+    type: 'Snowflake',
+    config: {
+        account: 'sf-account',
+        database: 'sf-db',
+        warehouse: 'sf-wh',
+        user: 'sf-user',
+        authentication_type: 'keypair',
+        password: null,
+        private_key: 'priv-key',
+        private_key_passphrase: 'priv-pass',
+        schema: 'public',
+        table_name: 'events',
+        role: null,
+        exclude_events: [],
+        include_events: [],
+    },
+})
+
+// Note: `authorization_mode` is intentionally absent from these Redshift fixtures' config —
+// it is a form-only field and is dropped on save.
+const REDSHIFT_INSERT_BATCH_EXPORT = fixture('fixture-redshift-insert', 'Redshift INSERT Export', {
+    type: 'Redshift',
+    config: {
+        user: 'rs-user',
+        password: 'rs-pass',
+        host: 'rs-host',
+        port: 5439,
+        database: 'rs-db',
+        schema: 'public',
+        table_name: 'events',
+        properties_data_type: 'SUPER' as any,
+        mode: 'INSERT',
+        copy_inputs: null,
+        exclude_events: [],
+        include_events: [],
+    } as any,
+})
+
+const REDSHIFT_COPY_IAM_BATCH_EXPORT = fixture('fixture-redshift-copy-iam', 'Redshift COPY IAM Export', {
+    type: 'Redshift',
+    config: {
+        user: 'rs-user',
+        password: 'rs-pass',
+        host: 'rs-host',
+        port: 5439,
+        database: 'rs-db',
+        schema: 'public',
+        table_name: 'events',
+        properties_data_type: 'SUPER' as any,
+        mode: 'COPY',
+        copy_inputs: {
+            s3_bucket: 'rs-staging',
+            s3_key_prefix: 'rs/copy/',
+            region_name: 'us-east-1',
+            authorization: 'arn:aws:iam::123:role/rs-copy',
+            bucket_credentials: {
+                aws_access_key_id: 'AKIA-bucket',
+                aws_secret_access_key: 'bucket-secret',
+            },
+        },
+        exclude_events: [],
+        include_events: [],
+    } as any,
+})
+
+const REDSHIFT_COPY_CREDENTIALS_BATCH_EXPORT = fixture(
+    'fixture-redshift-copy-creds',
+    'Redshift COPY Credentials Export',
+    {
+        type: 'Redshift',
         config: {
-            project_id: 'test_project',
-            private_key: 'test-key',
-            private_key_id: 'key-id',
-            client_email: 'test@test.iam.gserviceaccount.com',
-            token_uri: 'https://oauth2.googleapis.com/token',
-            dataset_id: 'test_dataset',
-            table_id: 'events',
+            user: 'rs-user',
+            password: 'rs-pass',
+            host: 'rs-host',
+            port: 5439,
+            database: 'rs-db',
+            schema: 'public',
+            table_name: 'events',
+            properties_data_type: 'SUPER' as any,
+            mode: 'COPY',
+            copy_inputs: {
+                s3_bucket: 'rs-staging',
+                s3_key_prefix: 'rs/copy/',
+                region_name: 'us-east-1',
+                authorization: {
+                    aws_access_key_id: 'AKIA-auth',
+                    aws_secret_access_key: 'auth-secret',
+                },
+                bucket_credentials: {
+                    aws_access_key_id: 'AKIA-bucket',
+                    aws_secret_access_key: 'bucket-secret',
+                },
+            },
             exclude_events: [],
             include_events: [],
-            use_json_type: false,
-        },
+        } as any,
+    }
+)
+
+const HTTP_BATCH_EXPORT = fixture('fixture-http', 'HTTP Export', {
+    type: 'HTTP',
+    config: {
+        url: 'https://us.i.posthog.com/batch/',
+        token: 'phc_test',
+        exclude_events: [],
+        include_events: [],
     },
-    interval: 'hour',
-    timezone: null,
-    offset_day: null,
-    offset_hour: null,
-    created_at: '2024-01-01T00:00:00Z',
-    start_at: null,
-    end_at: null,
-    paused: false,
-    model: 'events',
-    filters: [],
-}
+})
+
+const DATABRICKS_BATCH_EXPORT = fixture('fixture-databricks', 'Databricks Export', {
+    type: 'Databricks',
+    integration: 42,
+    config: {
+        http_path: '/sql/1.0/warehouses/abc123',
+        catalog: 'workspace',
+        schema: 'default',
+        table_name: 'events',
+        use_variant_type: true,
+        exclude_events: [],
+        include_events: [],
+    },
+})
+
+const AZUREBLOB_BATCH_EXPORT = fixture('fixture-azureblob', 'Azure Blob Export', {
+    type: 'AzureBlob',
+    integration: 99,
+    config: {
+        container_name: 'my-container',
+        prefix: 'posthog/events/',
+        compression: 'zstd',
+        file_format: 'Parquet',
+        max_file_size_mb: null,
+        exclude_events: [],
+        include_events: [],
+    },
+})
+
+// Single map keyed by id; used to register GET + PATCH mocks dynamically below.
+const ALL_BATCH_EXPORTS: BatchExportConfiguration[] = [
+    S3_BATCH_EXPORT,
+    BIGQUERY_BATCH_EXPORT,
+    POSTGRES_BATCH_EXPORT,
+    SNOWFLAKE_PASSWORD_BATCH_EXPORT,
+    SNOWFLAKE_KEYPAIR_BATCH_EXPORT,
+    REDSHIFT_INSERT_BATCH_EXPORT,
+    REDSHIFT_COPY_IAM_BATCH_EXPORT,
+    REDSHIFT_COPY_CREDENTIALS_BATCH_EXPORT,
+    HTTP_BATCH_EXPORT,
+    DATABRICKS_BATCH_EXPORT,
+    AZUREBLOB_BATCH_EXPORT,
+]
 
 jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
     lemonToast: {
@@ -95,28 +279,39 @@ describe('batchExportConfigFormLogic', () => {
     let logic: ReturnType<typeof batchExportConfigFormLogic.build>
     let lastPostBody: Record<string, any> | null = null
     let lastPatchBody: Record<string, any> | null = null
+    const patchBodiesById: Record<string, Record<string, any>> = {}
 
     beforeEach(() => {
         lastPostBody = null
         lastPatchBody = null
+        for (const id of Object.keys(patchBodiesById)) {
+            delete patchBodiesById[id]
+        }
+        // Register a GET + PATCH mock for every fixture so any round-trip test can load its
+        // own fixture by id and look up the captured request body via patchBodiesById[fx.id].
+        const getMocks: Record<string, BatchExportConfiguration> = {}
+        const patchMocks: Record<string, (req: any) => Promise<[number, BatchExportConfiguration]>> = {}
+        for (const fx of ALL_BATCH_EXPORTS) {
+            getMocks[`/api/environments/:team_id/batch_exports/${fx.id}`] = fx
+            patchMocks[`/api/environments/:team_id/batch_exports/${fx.id}/`] = async (req) => {
+                const body = await req.json()
+                lastPatchBody = body
+                patchBodiesById[fx.id] = body
+                return [200, fx]
+            }
+        }
         useMocks({
             get: {
-                '/api/environments/:team_id/batch_exports/test-s3-id': MOCK_S3_BATCH_EXPORT,
-                '/api/environments/:team_id/batch_exports/test-bq-id': MOCK_BIGQUERY_BATCH_EXPORT,
+                ...getMocks,
                 '/api/environments/:team_id/batch_exports/test': { steps: [] },
             },
             post: {
                 '/api/environments/:team_id/batch_exports/': async (req) => {
                     lastPostBody = await req.json()
-                    return [200, { ...MOCK_S3_BATCH_EXPORT, id: 'new-export-id' }]
+                    return [200, { ...S3_BATCH_EXPORT, id: 'new-export-id' }]
                 },
             },
-            patch: {
-                '/api/environments/:team_id/batch_exports/test-s3-id/': async (req) => {
-                    lastPatchBody = await req.json()
-                    return [200, MOCK_S3_BATCH_EXPORT]
-                },
-            },
+            patch: patchMocks,
         })
         initKeaTests()
     })
@@ -129,7 +324,7 @@ describe('batchExportConfigFormLogic', () => {
     }
 
     describe('new batch export config initialization', () => {
-        it('sets isNew to true and loads S3 defaults', async () => {
+        it('sets isNew to true and loads defaults', async () => {
             await initLogic({ service: 'S3', id: null })
 
             await expectLogic(logic).toMatchValues({
@@ -163,13 +358,13 @@ describe('batchExportConfigFormLogic', () => {
     })
 
     describe('required fields validation', () => {
+        // Expected required fields are hardcoded so this suite is decoupled from the implementation
+        // and runs unchanged before and after the destination-registry refactor.
+        const GENERAL_REQUIRED_FIELDS = ['interval', 'name', 'model']
         it.each([
             {
                 service: 'S3' as const,
-                expectedFields: [
-                    'interval',
-                    'name',
-                    'model',
+                fields: [
                     'bucket_name',
                     'region',
                     'prefix',
@@ -180,84 +375,37 @@ describe('batchExportConfigFormLogic', () => {
             },
             {
                 service: 'Postgres' as const,
-                expectedFields: [
-                    'interval',
-                    'name',
-                    'model',
-                    'user',
-                    'password',
-                    'host',
-                    'port',
-                    'database',
-                    'schema',
-                    'table_name',
-                ],
-            },
-            {
-                service: 'BigQuery' as const,
-                expectedFields: ['interval', 'name', 'model', 'json_config_file', 'dataset_id', 'table_id'],
-            },
-            {
-                service: 'Snowflake' as const,
-                expectedFields: [
-                    'interval',
-                    'name',
-                    'model',
-                    'account',
-                    'database',
-                    'warehouse',
-                    'user',
-                    'password',
-                    'schema',
-                    'table_name',
-                ],
+                fields: ['user', 'password', 'host', 'port', 'database', 'schema', 'table_name'],
             },
             {
                 service: 'Redshift' as const,
-                expectedFields: [
-                    'interval',
-                    'name',
-                    'model',
-                    'user',
-                    'password',
-                    'host',
-                    'port',
-                    'database',
-                    'schema',
-                    'table_name',
-                ],
+                fields: ['user', 'password', 'host', 'port', 'database', 'schema', 'table_name'],
             },
             {
-                service: 'HTTP' as const,
-                expectedFields: ['interval', 'name', 'model', 'url', 'token'],
+                service: 'Snowflake' as const,
+                fields: ['account', 'database', 'warehouse', 'user', 'password', 'schema', 'table_name'],
             },
+            { service: 'BigQuery' as const, fields: ['json_config_file', 'dataset_id', 'table_id'] },
+            { service: 'HTTP' as const, fields: ['url', 'token'] },
             {
                 service: 'Databricks' as const,
-                expectedFields: [
-                    'interval',
-                    'name',
-                    'model',
-                    'integration_id',
-                    'http_path',
-                    'catalog',
-                    'schema',
-                    'table_name',
-                ],
+                fields: ['integration_id', 'http_path', 'catalog', 'schema', 'table_name'],
             },
-            {
-                service: 'AzureBlob' as const,
-                expectedFields: ['interval', 'name', 'model', 'integration_id', 'container_name', 'file_format'],
-            },
-        ])('rejects empty form for $service', async ({ service, expectedFields }) => {
+            { service: 'AzureBlob' as const, fields: ['integration_id', 'container_name', 'file_format'] },
+        ])('rejects empty form for $service', async ({ service, fields }) => {
             await initLogic({ service, id: null })
 
             await expectLogic(logic, () => {
                 logic.actions.submitConfiguration()
             }).toDispatchActions(['submitConfiguration', 'submitConfigurationFailure'])
 
+            const defaults = getDefaultConfiguration(service)
             const errors = logic.values.configurationErrors
-            for (const field of expectedFields) {
-                expect(errors).toHaveProperty(field)
+            for (const field of [...GENERAL_REQUIRED_FIELDS, ...fields]) {
+                // Fields pre-filled by getDefaultConfiguration (name, model, file_format) shouldn't
+                // error; every other required field must surface a "required" message.
+                const expectedError = defaults[field] ? undefined : 'This field is required'
+                expect(errors[field]).toBe(expectedError)
             }
         })
     })
@@ -290,65 +438,121 @@ describe('batchExportConfigFormLogic', () => {
             await expectLogic(logic).toFinishAllListeners()
 
             const errors = logic.values.configurationErrors
-            if (error) {
-                expect(errors.bucket_name).toBe(error)
-            } else {
-                expect(errors.bucket_name).toBeUndefined()
-            }
+            expect(errors.bucket_name).toBe(error)
         })
     })
 
-    describe('successful create', () => {
-        it('sends correct payload and redirects on success', async () => {
-            await initLogic({ service: 'S3', id: null })
+    describe('AzureBlob container name validation', () => {
+        it.each([
+            {
+                container: 'My-Container',
+                error: 'Must be lowercase letters, numbers, and hyphens; start and end with letter or number',
+            },
+            { container: 'my--container', error: 'Cannot contain consecutive hyphens' },
+            { container: 'my-container', error: undefined },
+            { container: 'mycontainer1', error: undefined },
+        ])('container "$container" → $error', async ({ container, error }) => {
+            await initLogic({ service: 'AzureBlob', id: null })
 
             logic.actions.setConfigurationValues({
                 ...logic.values.configuration,
-                bucket_name: 'my-bucket',
-                region: 'us-east-1',
-                prefix: 'test/',
-                aws_access_key_id: 'AKIAIOSFODNN7EXAMPLE',
-                aws_secret_access_key: 'secret',
-                file_format: 'Parquet',
+                integration_id: 11,
+                container_name: container,
                 interval: 'hour',
-                name: 'Test S3 Export',
+                name: 'Test Export',
                 model: 'events',
             })
 
-            await expectLogic(logic, () => {
-                logic.actions.submitConfiguration()
-            })
-                .toDispatchActions(['submitConfiguration', 'updateBatchExportConfigSuccess'])
-                .toFinishAllListeners()
+            logic.actions.submitConfiguration()
+            await expectLogic(logic).toFinishAllListeners()
 
-            expect(router.values.location.pathname).toContain(urls.batchExport('new-export-id'))
-            expect(lastPostBody).toEqual({
-                paused: true,
-                name: 'Test S3 Export',
+            expect(logic.values.configurationErrors.container_name).toBe(error)
+        })
+    })
+
+    describe('Redshift bucket validation only runs in COPY mode', () => {
+        // Validates that Redshift's mode-conditional validation only kicks in for COPY mode.
+        // INSERT mode shouldn't validate the (irrelevant) bucket name field.
+        it.each([
+            { mode: 'INSERT', expected: undefined },
+            { mode: 'COPY', expected: 'Bucket name must be lowercase' },
+        ])('mode=$mode → bucket error: $expected', async ({ mode, expected }) => {
+            await initLogic({ service: 'Redshift', id: null })
+
+            logic.actions.setConfigurationValues({
+                ...logic.values.configuration,
+                user: 'rs-user',
+                password: 'rs-pass',
+                host: 'rs-host',
+                port: 5439,
+                database: 'rs-db',
+                schema: 'public',
+                table_name: 'events',
+                mode,
+                redshift_s3_bucket: 'INVALID-BUCKET',
+                redshift_s3_key_prefix: 'rs/',
+                redshift_s3_bucket_region_name: 'us-east-1',
+                redshift_iam_role: 'arn:aws:iam::123:role/rs',
                 interval: 'hour',
-                timezone: null,
-                offset_day: null,
-                offset_hour: null,
+                name: 'Test Export',
                 model: 'events',
-                destination: {
-                    type: 'S3',
-                    config: {
-                        file_format: 'Parquet',
-                        compression: 'zstd',
-                        bucket_name: 'my-bucket',
-                        region: 'us-east-1',
-                        prefix: 'test/',
-                        aws_access_key_id: 'AKIAIOSFODNN7EXAMPLE',
-                        aws_secret_access_key: 'secret',
-                    },
+            })
+
+            logic.actions.submitConfiguration()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.configurationErrors.redshift_s3_bucket).toBe(expected)
+        })
+    })
+
+    describe('BigQuery uploads parsed JSON config', () => {
+        // Selecting json_config_file reads it via FileReader, parses JSON, and lifts the
+        // service-account fields into the form. We stub FileReader to make the test hermetic.
+        let originalFileReader: any
+        let fileReaderResult: string
+        beforeEach(() => {
+            originalFileReader = (global as any).FileReader
+            ;(global as any).FileReader = jest.fn().mockImplementation(() => ({
+                readAsText() {
+                    setTimeout(() => this.onload({ target: { result: fileReaderResult } }), 0)
                 },
-            })
+            }))
+        })
+        afterEach(() => {
+            ;(global as any).FileReader = originalFileReader
+        })
+
+        it('parses uploaded JSON and writes service-account fields into the form', async () => {
+            const config = {
+                project_id: 'parsed-project',
+                private_key: 'parsed-key',
+                private_key_id: 'parsed-key-id',
+                client_email: 'parsed@iam.gserviceaccount.com',
+                token_uri: 'https://oauth2.googleapis.com/token',
+            }
+            fileReaderResult = JSON.stringify(config)
+            await initLogic({ service: 'BigQuery', id: null })
+
+            logic.actions.setConfigurationValue('json_config_file', [new Blob(['{}'], { type: 'application/json' })])
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.configuration).toEqual(expect.objectContaining(config))
+        })
+
+        it('sets a manual error when the uploaded JSON is invalid', async () => {
+            fileReaderResult = 'not json'
+            await initLogic({ service: 'BigQuery', id: null })
+
+            logic.actions.setConfigurationValue('json_config_file', [new Blob(['x'], { type: 'application/json' })])
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.configurationErrors.json_config_file).toBe('The config file is not valid')
         })
     })
 
     describe('successful update', () => {
-        it('sends correct payload on existing export', async () => {
-            await initLogic({ service: null, id: 'test-s3-id' })
+        it('sends changed field plus untouched fixture defaults', async () => {
+            await initLogic({ service: null, id: S3_BATCH_EXPORT.id })
 
             logic.actions.setConfigurationValues({
                 ...logic.values.configuration,
@@ -359,33 +563,12 @@ describe('batchExportConfigFormLogic', () => {
                 logic.actions.submitConfiguration()
             }).toDispatchActions(['submitConfiguration', 'updateBatchExportConfigSuccess'])
 
-            expect(lastPatchBody).toEqual({
-                paused: false,
-                name: 'S3 Export',
-                interval: 'hour',
-                timezone: null,
-                offset_day: null,
-                offset_hour: null,
-                model: 'events',
-                filters: [],
-                destination: {
-                    type: 'S3',
-                    config: {
-                        bucket_name: 'test-bucket',
-                        region: 'us-east-1',
-                        prefix: 'updated-prefix/',
-                        aws_access_key_id: 'AKIAIOSFODNN7EXAMPLE',
-                        aws_secret_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-                        exclude_events: [],
-                        include_events: [],
-                        compression: 'gzip',
-                        encryption: null,
-                        kms_key_id: null,
-                        endpoint_url: null,
-                        file_format: 'Parquet',
-                        max_file_size_mb: null,
-                        use_virtual_style_addressing: false,
-                    },
+            // Derived from the fixture so default changes don't break this test.
+            expect(lastPatchBody!.destination).toEqual({
+                type: 'S3',
+                config: {
+                    ...S3_BATCH_EXPORT.destination.config,
+                    prefix: 'updated-prefix/',
                 },
             })
         })
@@ -449,6 +632,281 @@ describe('batchExportConfigFormLogic', () => {
         ])('returns correct defaults for $service', ({ service, expected }) => {
             const config = getDefaultConfiguration(service)
             expect(config).toEqual(expect.objectContaining(expected))
+        })
+    })
+
+    // For each destination, fill in only the required fields and assert the exact create payload.
+    // Guards against destinations silently changing their default config or required-field set.
+    describe('create with required fields per destination', () => {
+        it.each([
+            {
+                name: 'S3',
+                service: 'S3' as const,
+                requiredValues: {
+                    bucket_name: 'my-bucket',
+                    region: 'us-east-1',
+                    prefix: 'test/',
+                    aws_access_key_id: 'AKIA',
+                    aws_secret_access_key: 'secret',
+                },
+                expectedDestination: {
+                    type: 'S3',
+                    config: {
+                        bucket_name: 'my-bucket',
+                        region: 'us-east-1',
+                        prefix: 'test/',
+                        aws_access_key_id: 'AKIA',
+                        aws_secret_access_key: 'secret',
+                        file_format: 'Parquet',
+                        compression: 'zstd',
+                    },
+                },
+            },
+            {
+                name: 'Postgres',
+                service: 'Postgres' as const,
+                requiredValues: {
+                    user: 'pg-user',
+                    password: 'pg-pass',
+                    host: 'pg-host',
+                    port: 5432,
+                    database: 'pg-db',
+                    schema: 'public',
+                    table_name: 'events',
+                },
+                expectedDestination: {
+                    type: 'Postgres',
+                    config: {
+                        user: 'pg-user',
+                        password: 'pg-pass',
+                        host: 'pg-host',
+                        port: 5432,
+                        database: 'pg-db',
+                        schema: 'public',
+                        table_name: 'events',
+                    },
+                },
+            },
+            {
+                name: 'Snowflake (password)',
+                service: 'Snowflake' as const,
+                requiredValues: {
+                    account: 'sf-account',
+                    database: 'sf-db',
+                    warehouse: 'sf-wh',
+                    user: 'sf-user',
+                    password: 'sf-pass',
+                    schema: 'public',
+                    table_name: 'events',
+                },
+                expectedDestination: {
+                    type: 'Snowflake',
+                    config: {
+                        account: 'sf-account',
+                        database: 'sf-db',
+                        warehouse: 'sf-wh',
+                        user: 'sf-user',
+                        password: 'sf-pass',
+                        authentication_type: 'password',
+                        schema: 'public',
+                        table_name: 'events',
+                    },
+                },
+            },
+            {
+                name: 'Redshift (default COPY + IAM)',
+                service: 'Redshift' as const,
+                requiredValues: {
+                    user: 'rs-user',
+                    password: 'rs-pass',
+                    host: 'rs-host',
+                    port: 5439,
+                    database: 'rs-db',
+                    schema: 'public',
+                    table_name: 'events',
+                    redshift_s3_bucket: 'rs-staging',
+                    redshift_s3_key_prefix: 'rs/copy/',
+                    redshift_s3_bucket_region_name: 'us-east-1',
+                    redshift_iam_role: 'arn:aws:iam::123:role/rs',
+                },
+                expectedDestination: {
+                    type: 'Redshift',
+                    config: {
+                        user: 'rs-user',
+                        password: 'rs-pass',
+                        host: 'rs-host',
+                        port: 5439,
+                        database: 'rs-db',
+                        schema: 'public',
+                        table_name: 'events',
+                        properties_data_type: 'SUPER',
+                        mode: 'COPY',
+                        copy_inputs: {
+                            s3_bucket: 'rs-staging',
+                            s3_key_prefix: 'rs/copy/',
+                            region_name: 'us-east-1',
+                            authorization: 'arn:aws:iam::123:role/rs',
+                        },
+                    },
+                },
+            },
+            {
+                name: 'HTTP',
+                service: 'HTTP' as const,
+                requiredValues: {
+                    url: 'https://us.i.posthog.com/batch/',
+                    token: 'phc_xxx',
+                },
+                expectedDestination: {
+                    type: 'HTTP',
+                    config: {
+                        url: 'https://us.i.posthog.com/batch/',
+                        token: 'phc_xxx',
+                    },
+                },
+            },
+            {
+                name: 'Databricks',
+                service: 'Databricks' as const,
+                requiredValues: {
+                    integration_id: 7,
+                    http_path: '/sql/1.0/warehouses/abc',
+                    catalog: 'workspace',
+                    schema: 'default',
+                    table_name: 'events',
+                },
+                expectedDestination: {
+                    type: 'Databricks',
+                    integration: 7,
+                    config: {
+                        http_path: '/sql/1.0/warehouses/abc',
+                        catalog: 'workspace',
+                        schema: 'default',
+                        table_name: 'events',
+                        use_variant_type: true,
+                    },
+                },
+            },
+            {
+                name: 'AzureBlob',
+                service: 'AzureBlob' as const,
+                requiredValues: {
+                    integration_id: 11,
+                    container_name: 'my-container',
+                },
+                expectedDestination: {
+                    type: 'AzureBlob',
+                    integration: 11,
+                    config: {
+                        container_name: 'my-container',
+                        file_format: 'Parquet',
+                        compression: 'zstd',
+                    },
+                },
+            },
+            {
+                // BigQuery's required-field set depends on BATCH_EXPORTS_BIGQUERY_INTEGRATION.
+                // With the flag off, json_config_file is required but stripped from the payload;
+                // we set parsed fields directly to bypass the file-reader side effect.
+                name: 'BigQuery (integration flag off)',
+                service: 'BigQuery' as const,
+                requiredValues: {
+                    json_config_file: ['placeholder'],
+                    project_id: 'p',
+                    private_key: 'pk',
+                    private_key_id: 'pki',
+                    client_email: 'ce',
+                    token_uri: 'tu',
+                    dataset_id: 'ds',
+                    table_id: 'events',
+                },
+                expectedDestination: {
+                    type: 'BigQuery',
+                    config: {
+                        project_id: 'p',
+                        private_key: 'pk',
+                        private_key_id: 'pki',
+                        client_email: 'ce',
+                        token_uri: 'tu',
+                        dataset_id: 'ds',
+                        table_id: 'events',
+                    },
+                },
+            },
+            {
+                name: 'BigQuery (integration flag on)',
+                service: 'BigQuery' as const,
+                featureFlags: { [FEATURE_FLAGS.BATCH_EXPORTS_BIGQUERY_INTEGRATION]: true } as Record<string, boolean>,
+                requiredValues: {
+                    integration_id: 5,
+                    dataset_id: 'ds',
+                    table_id: 'events',
+                },
+                expectedDestination: {
+                    type: 'BigQuery',
+                    integration: 5,
+                    config: {
+                        dataset_id: 'ds',
+                        table_id: 'events',
+                    },
+                },
+            },
+        ])(
+            'create $name sends expected payload',
+            async ({ service, requiredValues, expectedDestination, featureFlags }) => {
+                if (featureFlags) {
+                    featureFlagLogic.mount()
+                    featureFlagLogic.actions.setFeatureFlags(Object.keys(featureFlags), featureFlags)
+                }
+                await initLogic({ service, id: null })
+
+                logic.actions.setConfigurationValues({
+                    ...logic.values.configuration,
+                    interval: 'hour',
+                    name: `Test ${service} Export`,
+                    model: 'events',
+                    ...requiredValues,
+                })
+
+                await expectLogic(logic, () => {
+                    logic.actions.submitConfiguration()
+                })
+                    .toDispatchActions(['submitConfiguration', 'updateBatchExportConfigSuccess'])
+                    .toFinishAllListeners()
+
+                expect(lastPostBody).not.toBeNull()
+                expect(lastPostBody!.destination).toEqual(expectedDestination)
+                expect(router.values.location.pathname).toContain(urls.batchExport('new-export-id'))
+            }
+        )
+    })
+
+    describe('round-trip: load and save preserves destination config', () => {
+        it.each([
+            { name: 'S3', fixture: S3_BATCH_EXPORT },
+            { name: 'BigQuery', fixture: BIGQUERY_BATCH_EXPORT },
+            { name: 'Postgres', fixture: POSTGRES_BATCH_EXPORT },
+            { name: 'Snowflake (password)', fixture: SNOWFLAKE_PASSWORD_BATCH_EXPORT },
+            { name: 'Snowflake (keypair)', fixture: SNOWFLAKE_KEYPAIR_BATCH_EXPORT },
+            { name: 'Redshift (INSERT)', fixture: REDSHIFT_INSERT_BATCH_EXPORT },
+            { name: 'Redshift (COPY + IAM)', fixture: REDSHIFT_COPY_IAM_BATCH_EXPORT },
+            { name: 'Redshift (COPY + Credentials)', fixture: REDSHIFT_COPY_CREDENTIALS_BATCH_EXPORT },
+            { name: 'HTTP', fixture: HTTP_BATCH_EXPORT },
+            { name: 'Databricks', fixture: DATABRICKS_BATCH_EXPORT },
+            { name: 'AzureBlob', fixture: AZUREBLOB_BATCH_EXPORT },
+        ])('$name round-trips without modifying destination', async ({ fixture }) => {
+            await initLogic({ service: null, id: fixture.id })
+
+            // Submit immediately without changes — captures whether deserialize+serialize is symmetrical.
+            await expectLogic(logic, () => {
+                logic.actions.submitConfiguration()
+            })
+                .toDispatchActions(['submitConfiguration', 'updateBatchExportConfigSuccess'])
+                .toFinishAllListeners()
+
+            const body = patchBodiesById[fixture.id]
+            expect(body).not.toBeUndefined()
+            expect(body.destination).toEqual(fixture.destination)
         })
     })
 })


### PR DESCRIPTION
## Problem

We don't have tests for the frontend that cover all batch export destinations. We're planning a refactor of the frontend, so some regression tests would help here to ensure no behavioural changes are introduced.

## Changes

Add tests for the batch export edit form ahead of the frontend destination config refactor, so the same suite can prove behaviour is unchanged before and after.

## How did you test this code?

These are tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Authored with PostHog Code (Opus 4.7)
