### PR TITLE
fix(insights): tidy funnel steps bar chart layout

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2081,13 +2081,13 @@ snapshots:
     insights-funnelpropertycorrelationtable--default--light:
         hash: v1.k794b7964.46127dfa894a9b46a595c1b48b9bd8996a2851ce5ae04e70c4f1ee43d2d818ec.dddj8FIYUsb6XDaYbe4eQ_k4bJ5NY2kvo6m3KFS3Vwg
     insights-funnelstepsbarchart--breakdown--dark:
-        hash: v1.k794b7964.94617507a1b49bddbd663dc4498d6189977c559aab97b8190621e070230bc8b2.NMRs4pet51Wc-J6xIGjyQcv_VCAKl4ZZtr6RfYLaqUk
+        hash: v1.k794b7964.63df19cde8f7f89c150d30193c048bce1e870840d46faeae19f7ce870c6e3dc4.g7tolr-QiuWK37B5sTScwyOtBOqQPWzo8xeolSJTyqw
     insights-funnelstepsbarchart--breakdown--light:
-        hash: v1.k794b7964.11a6150cd4d624ea803386b5295c61efe16cc0564548d7b035fb2605c6a8930b._GcZUhCuEWqr9LTrGqjFS6wjt5SKR9eJXTtK2ADXih4
+        hash: v1.k794b7964.1756a0ad7f62391063419d1e06b8ec5b96363ebc190bf06b456ef42a5cb54e90.REPttMoN0bjSw-5bby2FH2RrgfM0tQQKDPCkoj00T8g
     insights-funnelstepsbarchart--default--dark:
-        hash: v1.k794b7964.4f5c0e9fb7907950d12c5ae90aef213eac07353a1e45102e4c5ec646413bcd40.2srh4MBJkGURgf-ZfiOmmEnkyVi1RvpRG-GW23QyykE
+        hash: v1.k794b7964.343d6f9338ccca79f5fdc4d89743ddde0653472078edce3a14e94033f3e473e7.FLZZ7r2xhSL6EzdbtcwCJy7BIoaylsYWs_NmAQOsjFg
     insights-funnelstepsbarchart--default--light:
-        hash: v1.k794b7964.07679a2d2baaff185b71e5040a6e40e3c43cc38dd07b2277271e3b4950e648a6.I5hkW4tlRFnOGapBnuZ0-uJReW-Svbr9IBAU5a9JzRw
+        hash: v1.k794b7964.86e53149def5039ee2e1e0722ad6aa5edd77d0a52c53ee915ab1d63742f580ef.-tCw9bfxPaUe6lDvT1LDuZBq0WImmDMKx5dce8Qg1f4
     insights-insightstable--aggregation--dark:
         hash: v1.k794b7964.7ca9378b33815143119b6263ad32770289133ce2faa21251189b505821d7d846.NXyGQGn0JrsrEWfzXtZTntAvvx5CSTKBLXWWdzgkCI8
     insights-insightstable--aggregation--light:

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -19,7 +19,7 @@ import { buildFunnelStepsBarData, type FunnelStepsBarSeriesMeta } from './funnel
 
 const STEP_WIDTH_PX = 240
 const BAND_PADDING = 0.04
-const STEP_BAR_WIDTH_PX = STEP_WIDTH_PX * (1 - BAND_PADDING)
+const STEP_BAND_WIDTH_PX = STEP_WIDTH_PX * (1 - BAND_PADDING)
 
 const baseChartConfig: BarChartConfig = {
     barLayout: 'grouped',
@@ -134,7 +134,7 @@ export function FunnelStepsBarChart({
                                 className={`flex min-w-0 flex-1 ${stepIndex === 0 ? 'justify-start' : 'justify-center'}`}
                             >
                                 {/* eslint-disable-next-line react/forbid-dom-props */}
-                                <div className="min-w-0 overflow-hidden" style={{ width: STEP_BAR_WIDTH_PX }}>
+                                <div className="min-w-0 overflow-hidden" style={{ width: STEP_BAND_WIDTH_PX }}>
                                     <StepLegend
                                         step={step}
                                         stepIndex={stepIndex}

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -17,18 +17,24 @@ import { ChartParams, type FunnelStepWithConversionMetrics } from '~/types'
 import { FunnelStepsBarTooltip } from './FunnelStepsBarTooltip'
 import { buildFunnelStepsBarData, type FunnelStepsBarSeriesMeta } from './funnelStepsBarTransforms'
 
-// Per-step width — caps bars and legend column width together so few-step funnels don't
-// stretch across the whole chart with huge gaps. Gridlines still span the full width.
-const STEP_WIDTH_PX = 320
+const STEP_WIDTH_PX = 240
+const BAND_PADDING = 0.04
+const STEP_BAR_WIDTH_PX = STEP_WIDTH_PX * (1 - BAND_PADDING)
 
 const baseChartConfig: BarChartConfig = {
     barLayout: 'grouped',
     showGrid: true,
-    bars: { cornerRadius: 10, track: true, shadow: true },
+    bars: {
+        cornerRadius: 10,
+        track: true,
+        shadow: { color: 'rgba(0,0,0,0.15)', blur: 6, offsetY: -2 },
+        bandPadding: BAND_PADDING,
+    },
     animateHover: true,
     hideXAxis: true,
     yTickFormatter: (value) => `${Math.round(value)}%`,
     tooltip: { placement: 'top' },
+    margins: { left: DEFAULT_MARGINS.left },
 }
 
 const handleChartError = (error: Error, info: ErrorInfo): void => {
@@ -69,10 +75,7 @@ export function FunnelStepsBarChart({
     const groupTypeLabel = aggregationLabel(querySource?.aggregation_group_type_index).plural
     const showTime = steps.some((step) => step.average_conversion_time != null)
     const barsWidth = steps.length * STEP_WIDTH_PX
-    const chartConfig = useMemo<BarChartConfig>(
-        () => ({ ...baseChartConfig, bars: { ...baseChartConfig.bars, maxBandRange: barsWidth } }),
-        [barsWidth]
-    )
+    const chartWidth = DEFAULT_MARGINS.left + barsWidth + DEFAULT_MARGINS.right
 
     const onPointClick = useCallback(
         (clickData: PointClickData<FunnelStepsBarSeriesMeta>): void => {
@@ -107,31 +110,39 @@ export function FunnelStepsBarChart({
     return (
         <div className="flex w-full flex-1 flex-col overflow-x-auto" data-attr="funnel-steps-bar-chart">
             <div className="flex flex-1 flex-col">
-                <div className="flex min-h-[150px] flex-1">
+                {/* eslint-disable-next-line react/forbid-dom-props */}
+                <div className="flex min-h-[150px] flex-1" style={{ width: chartWidth }}>
                     <BarChart<FunnelStepsBarSeriesMeta>
                         series={series}
                         labels={labels}
                         theme={theme}
-                        config={chartConfig}
+                        config={baseChartConfig}
                         tooltip={renderTooltip}
                         onPointClick={showPersonsModal ? onPointClick : undefined}
                         onError={handleChartError}
                     />
                 </div>
-                {/* Legend padding matches the chart's left margin and bars-width so
-                    legend columns align with the bars above. */}
                 {/* eslint-disable-next-line react/forbid-dom-props */}
-                <div className="flex" style={{ paddingLeft: DEFAULT_MARGINS.left }}>
-                    <div className="flex" style={{ width: barsWidth }}>
+                <div
+                    className="flex shrink-0"
+                    style={{ paddingLeft: DEFAULT_MARGINS.left, paddingRight: DEFAULT_MARGINS.right }}
+                >
+                    <div className="flex shrink-0" style={{ width: barsWidth }}>
                         {steps.map((step, stepIndex) => (
-                            <div key={stepIndex} className="min-w-0 flex-1 overflow-hidden">
-                                <StepLegend
-                                    step={step}
-                                    stepIndex={stepIndex}
-                                    showTime={showTime}
-                                    showPersonsModal={showPersonsModal}
-                                    inCardView={inCardView}
-                                />
+                            <div
+                                key={stepIndex}
+                                className={`flex min-w-0 flex-1 ${stepIndex === 0 ? 'justify-start' : 'justify-center'}`}
+                            >
+                                {/* eslint-disable-next-line react/forbid-dom-props */}
+                                <div className="min-w-0 overflow-hidden" style={{ width: STEP_BAR_WIDTH_PX }}>
+                                    <StepLegend
+                                        step={step}
+                                        stepIndex={stepIndex}
+                                        showTime={showTime}
+                                        showPersonsModal={showPersonsModal}
+                                        inCardView={inCardView}
+                                    />
+                                </div>
                             </div>
                         ))}
                     </div>


### PR DESCRIPTION
## Problem

The new funnel steps bar chart had a few visual rough edges before going live: the bar drop shadow was heavy, wide funnels (5+ steps) squished the bars to fit the viewport while the legend below overflowed and scrolled — so the bars and their legend sections didn't line up — and each step column was wide enough that bars looked fat and legend sections had a lot of empty space, limiting how many steps fit on screen.

## Changes

- Reduce the bar drop shadow (lighter color, smaller blur and offset).
- Size the chart container to the full per-step width and pin its left margin so wide funnels scroll horizontally in lockstep with the legend instead of compressing.
- Keep the legend's fixed-width row from being shrunk by flexbox (`shrink-0`) so it holds its width and scrolls with the chart.
- Center each legend section under its bar; left-align the first one so it anchors to the plot's left edge.
- Tighten per-step column width (320 → 240) and band padding so bars are thinner, legend white space shrinks, and more steps fit on screen.

No changes outside `FunnelStepsBarChart.tsx`.

## How did you test this code?

I'm an agent. This is a frontend layout change with no direct unit tests; the existing Storybook story (`FunnelStepsBarChart.stories.tsx`) feeds visual-regression snapshots which will cover the rendered result. I have **not** manually verified it in a browser — the layout was iterated against screenshots shared during the session, but the final per-step width should be confirmed visually (in particular that the longest legend line doesn't wrap at 240px).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Iterated the layout against screenshots the author shared at each step.

Notable decisions:
- An earlier attempt added a `bandAlign: 'center' | 'start'` option to the shared `hog-charts` `BarChart` to left-align bars under a left-aligned legend. The author flagged this as avoidable API growth, so it was reverted entirely — the lib is untouched. Instead, bars use the default centered layout and each legend section is centered under its bar (robust because a centered bar's center always equals its column center, regardless of series count).
- Root cause of the squish/misalignment was that the chart container sits in a column flex parent (explicit width preserved → scrolls) while the legend's width div sat in a row flex parent (default `flex-shrink` collapsed it to the viewport). Fixed with `shrink-0` on the legend.