### PR TITLE
chore(batch-exports): remove rolled-out BigQuery integration flag

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4163,9 +4163,9 @@ snapshots:
     scenes-app-batchexports--backfills-with-estimates--light:
         hash: v1.k794b7964.ff65cb40f7e2201d018187cdbdea18316db0fc4a1d5d1f6354596c3a2f7134b6.Ty5F34_U08a4Xcj4XEr-mFtt7CP_4ulGFFaalXtYxBA
     scenes-app-batchexports--existing-big-query-export--dark:
-        hash: v1.k794b7964.5a2fda343405a843236153a192ab22ba3613ea7590464b97ef24b5a272295c63.4KGbOMQI5P3ksqvsVFv38LBg09rCKAgaV4F719Wxcio
+        hash: v1.k794b7964.c497a11d9bc7c4197179439db96463e5007de1c68fe3b23eed386ffd71698ca7.PWzPAn_tQGmm4DFgQetKTfnqo8X9qrVGNqDB9X13lrA
     scenes-app-batchexports--existing-big-query-export--light:
-        hash: v1.k794b7964.30ec356919af3213fec83a0baa49302ba25d138c61ed6f99138f21ef8faed8f3.cFiXEzU4Uiho9Y5yS_Sf7w55yFuWnrhKRX39enFIEig
+        hash: v1.k794b7964.e32682b42312ab15395bbf6f953dda6a8be6297bf2beee8a6307f4c469a3275a.ZDpnCTUn_ulIPUSvIrci2MAbwiQAIFzaEYceiNefQgQ
     scenes-app-batchexports--history-empty--dark:
         hash: v1.k794b7964.8c7742c97909864ee30c99ffdca41bb7f5487f5db9c71ae2b1e52ec6c5006621.4khsoQSxtDBQZwDnS8Hi6zEQskbCnpsNY0RqxoD2OPg
     scenes-app-batchexports--history-empty--light:
@@ -4187,13 +4187,9 @@ snapshots:
     scenes-app-batchexports--new-azure-blob-export--light:
         hash: v1.k794b7964.2f4fa15b571bd753e50ecc95371b3312d2ae007f94c60d23242ba50be982667c.8AmhbsCHMfm--TPjY0Iv3SS4xSIYXjGgAs1hEn6eudE
     scenes-app-batchexports--new-big-query-export--dark:
-        hash: v1.k794b7964.46c1bbbfd1614c8e98ed13cf8158a6c06e13db9d6b7998ac9993f18f226fabca.1lULOvQgq6-NHwB6ywiUHZlQanVlslaBGlx_YuuXH9s
+        hash: v1.k794b7964.b0017a9704d860ae6dbefea6e35ad51210bcd9b0d1b9e880b40bff062ef0313e.Meevy2ppWpbV6N50Q-EXk7n3F55mpI_kBGxmJif-RG8
     scenes-app-batchexports--new-big-query-export--light:
-        hash: v1.k794b7964.a7f74ef88efd16339eb283b55c2522f1cb5f12f7b8712d6daa86cce126406892.jV4L5DRuUxqr-uKjYNPeyNTrBNqzH_LmFca8lhKanaY
-    scenes-app-batchexports--new-big-query-export-with-integration--dark:
-        hash: v1.k794b7964.b0017a9704d860ae6dbefea6e35ad51210bcd9b0d1b9e880b40bff062ef0313e.4ZitrIL91s40q-7PAttfTwKJR6m7_7AuVnJ3tdjCrm8
-    scenes-app-batchexports--new-big-query-export-with-integration--light:
-        hash: v1.k794b7964.d74e0bf9deea6e90d2f919bcf36fd70546c91c7aef5fc6068ca8ec5ac8e5212e.pL2_3mN2nQvLGMs44hBLwFItesrAIlMK_NTNB-umOfE
+        hash: v1.k794b7964.d74e0bf9deea6e90d2f919bcf36fd70546c91c7aef5fc6068ca8ec5ac8e5212e.C8YO5nra2nSU2_FE6DYg--0rrHu0uYAR0OeevJTuPBk
     scenes-app-batchexports--new-databricks-export--dark:
         hash: v1.k794b7964.d54b3f7c4845b3c5f945b45689f5917c9bcde6a4ac4f72bf40d161f10d4f55fd.93WWAtDciTnt8SaNbW7U0AbnWuGyrb3Y3ZE3AvW6NVI
     scenes-app-batchexports--new-databricks-export--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -240,7 +240,6 @@ export const FEATURE_FLAGS = {
     APPROVALS: 'approvals', // owner: @yasen-posthog #team-platform-features
     AVERAGE_PAGE_VIEW_COLUMN: 'average-page-view-column', // owner: @jordanm-posthog #team-web-analytics
     BACKFILL_WORKFLOWS_DESTINATION: 'backfill-workflows-destination', // owner: #team-batch-exports
-    BATCH_EXPORTS_BIGQUERY_INTEGRATION: 'batch-exports-bigquery-integration', // owner: @tomasfarias #team-batch-exports
     BING_ADS_SOURCE: 'bing-ads-source', // owner: @jabahamondes #team-web-analytics
     CDP_ACTIVITY_LOG_NOTIFICATIONS: 'cdp-activity-log-notifications', // owner: #team-workflows-cdp
     CDP_DWH_TABLE_SOURCE: 'cdp-dwh-table-source', // owner: #team-workflows-cdp

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -1,4 +1,3 @@
-import { useValues } from 'kea'
 import React from 'react'
 
 import { IconInfo } from '@posthog/icons'
@@ -7,16 +6,13 @@ import {
     LemonCheckbox,
     LemonInput,
     LemonSelect,
-    LemonFileInput,
     LemonTextArea,
     Link,
     Tooltip,
 } from '@posthog/lemon-ui'
 
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { BatchExportConfigurationForm } from './types'
 
@@ -97,9 +93,6 @@ export function BatchExportsEditFields({
     batchExportConfigForm: BatchExportConfigurationForm
     configurationChanged: boolean
 }): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-    const bigQueryIntegrationEnabled = featureFlags[FEATURE_FLAGS.BATCH_EXPORTS_BIGQUERY_INTEGRATION]
-
     return (
         <div className="flex flex-col gap-y-4 max-w-200">
             {batchExportConfigForm.destination === 'S3' ? (
@@ -664,21 +657,15 @@ export function BatchExportsEditFields({
                 </>
             ) : batchExportConfigForm.destination === 'BigQuery' ? (
                 <>
-                    {bigQueryIntegrationEnabled ? (
-                        <LemonField name="integration_id" label="Integration">
-                            {({ value, onChange }) => (
-                                <IntegrationChoice
-                                    integration="google-cloud-service-account"
-                                    value={value}
-                                    onChange={onChange}
-                                />
-                            )}
-                        </LemonField>
-                    ) : (
-                        <LemonField name="json_config_file" label="Google Cloud JSON key file">
-                            <LemonFileInput accept=".json" multiple={false} />
-                        </LemonField>
-                    )}
+                    <LemonField name="integration_id" label="Integration">
+                        {({ value, onChange }) => (
+                            <IntegrationChoice
+                                integration="google-cloud-service-account"
+                                value={value}
+                                onChange={onChange}
+                            />
+                        )}
+                    </LemonField>
 
                     <LemonField name="table_id" label="Table ID">
                         <LemonInput placeholder="events" />

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.stories.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { App } from 'scenes/App'
 import { urls } from 'scenes/urls'
 
@@ -89,18 +88,9 @@ export const NewAzureBlobExport: Story = {
     },
 }
 
-// BigQuery has two variants gated on BATCH_EXPORTS_BIGQUERY_INTEGRATION: the JSON key-file
-// upload (flag off) and the IntegrationChoice picker (flag on).
 export const NewBigQueryExport: Story = {
     parameters: {
         pageUrl: urls.batchExportNew('bigquery'),
-    },
-}
-
-export const NewBigQueryExportWithIntegration: Story = {
-    parameters: {
-        pageUrl: urls.batchExportNew('bigquery'),
-        featureFlags: [FEATURE_FLAGS.BATCH_EXPORTS_BIGQUERY_INTEGRATION],
     },
 }
 

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
@@ -1,8 +1,6 @@
 import { router } from 'kea-router'
 import { expectLogic, partial } from 'kea-test-utils'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -60,36 +58,18 @@ const S3_BATCH_EXPORT = fixture('test-s3-id', 'S3 Export', {
     },
 })
 
+// BigQuery exports are integration-backed: the config carries `integration` and the
+// credentials live on the integration, not in the config.
 const BIGQUERY_BATCH_EXPORT = fixture('test-bq-id', 'BigQuery Export', {
     type: 'BigQuery',
+    integration: 7,
     config: {
-        project_id: 'test_project',
-        private_key: 'test-key',
-        private_key_id: 'key-id',
-        client_email: 'test@test.iam.gserviceaccount.com',
-        token_uri: 'https://oauth2.googleapis.com/token',
         dataset_id: 'test_dataset',
         table_id: 'events',
         exclude_events: [],
         include_events: [],
         use_json_type: false,
     },
-})
-
-// Integration-backed BigQuery: carries `integration` and omits the service-account fields,
-// so its wire shape differs from the legacy JSON-key-file variant above.
-const BIGQUERY_INTEGRATION_BATCH_EXPORT = fixture('test-bq-integration-id', 'BigQuery Integration Export', {
-    type: 'BigQuery',
-    integration: 7,
-    // Integration-backed config legitimately omits the service-account fields that
-    // BatchExportServiceBigQuery['config'] declares, so the cast keeps the fixture honest.
-    config: {
-        dataset_id: 'test_dataset',
-        table_id: 'events',
-        exclude_events: [],
-        include_events: [],
-        use_json_type: false,
-    } as any,
 })
 
 const POSTGRES_BATCH_EXPORT = fixture('fixture-postgres', 'Postgres Export', {
@@ -269,7 +249,6 @@ const AZUREBLOB_BATCH_EXPORT = fixture('fixture-azureblob', 'Azure Blob Export',
 const ALL_BATCH_EXPORTS: BatchExportConfiguration[] = [
     S3_BATCH_EXPORT,
     BIGQUERY_BATCH_EXPORT,
-    BIGQUERY_INTEGRATION_BATCH_EXPORT,
     POSTGRES_BATCH_EXPORT,
     SNOWFLAKE_PASSWORD_BATCH_EXPORT,
     SNOWFLAKE_KEYPAIR_BATCH_EXPORT,
@@ -402,7 +381,7 @@ describe('batchExportConfigFormLogic', () => {
                 service: 'Snowflake' as const,
                 fields: ['account', 'database', 'warehouse', 'user', 'password', 'schema', 'table_name'],
             },
-            { service: 'BigQuery' as const, fields: ['json_config_file', 'dataset_id', 'table_id'] },
+            { service: 'BigQuery' as const, fields: ['integration_id', 'dataset_id', 'table_id'] },
             { service: 'HTTP' as const, fields: ['url', 'token'] },
             {
                 service: 'Databricks' as const,
@@ -519,51 +498,6 @@ describe('batchExportConfigFormLogic', () => {
             await expectLogic(logic).toFinishAllListeners()
 
             expect(logic.values.configurationErrors.redshift_s3_bucket).toBe(expected)
-        })
-    })
-
-    describe('BigQuery uploads parsed JSON config', () => {
-        // Selecting json_config_file reads it via FileReader, parses JSON, and lifts the
-        // service-account fields into the form. We stub FileReader to make the test hermetic.
-        let originalFileReader: any
-        let fileReaderResult: string
-        beforeEach(() => {
-            originalFileReader = (global as any).FileReader
-            ;(global as any).FileReader = jest.fn().mockImplementation(() => ({
-                readAsText() {
-                    setTimeout(() => this.onload({ target: { result: fileReaderResult } }), 0)
-                },
-            }))
-        })
-        afterEach(() => {
-            ;(global as any).FileReader = originalFileReader
-        })
-
-        it('parses uploaded JSON and writes service-account fields into the form', async () => {
-            const config = {
-                project_id: 'parsed-project',
-                private_key: 'parsed-key',
-                private_key_id: 'parsed-key-id',
-                client_email: 'parsed@iam.gserviceaccount.com',
-                token_uri: 'https://oauth2.googleapis.com/token',
-            }
-            fileReaderResult = JSON.stringify(config)
-            await initLogic({ service: 'BigQuery', id: null })
-
-            logic.actions.setConfigurationValue('json_config_file', [new Blob(['{}'], { type: 'application/json' })])
-            await expectLogic(logic).toFinishAllListeners()
-
-            expect(logic.values.configuration).toEqual(expect.objectContaining(config))
-        })
-
-        it('sets a manual error when the uploaded JSON is invalid', async () => {
-            fileReaderResult = 'not json'
-            await initLogic({ service: 'BigQuery', id: null })
-
-            logic.actions.setConfigurationValue('json_config_file', [new Blob(['x'], { type: 'application/json' })])
-            await expectLogic(logic).toFinishAllListeners()
-
-            expect(logic.values.configurationErrors.json_config_file).toBe('The config file is not valid')
         })
     })
 
@@ -822,38 +756,8 @@ describe('batchExportConfigFormLogic', () => {
                 },
             },
             {
-                // BigQuery's required-field set depends on BATCH_EXPORTS_BIGQUERY_INTEGRATION.
-                // With the flag off, json_config_file is required but stripped from the payload;
-                // we set parsed fields directly to bypass the file-reader side effect.
-                name: 'BigQuery (integration flag off)',
+                name: 'BigQuery',
                 service: 'BigQuery' as const,
-                requiredValues: {
-                    json_config_file: ['placeholder'],
-                    project_id: 'p',
-                    private_key: 'pk',
-                    private_key_id: 'pki',
-                    client_email: 'ce',
-                    token_uri: 'tu',
-                    dataset_id: 'ds',
-                    table_id: 'events',
-                },
-                expectedDestination: {
-                    type: 'BigQuery',
-                    config: {
-                        project_id: 'p',
-                        private_key: 'pk',
-                        private_key_id: 'pki',
-                        client_email: 'ce',
-                        token_uri: 'tu',
-                        dataset_id: 'ds',
-                        table_id: 'events',
-                    },
-                },
-            },
-            {
-                name: 'BigQuery (integration flag on)',
-                service: 'BigQuery' as const,
-                featureFlags: { [FEATURE_FLAGS.BATCH_EXPORTS_BIGQUERY_INTEGRATION]: true } as Record<string, boolean>,
                 requiredValues: {
                     integration_id: 5,
                     dataset_id: 'ds',
@@ -868,41 +772,33 @@ describe('batchExportConfigFormLogic', () => {
                     },
                 },
             },
-        ])(
-            'create $name sends expected payload',
-            async ({ service, requiredValues, expectedDestination, featureFlags }) => {
-                if (featureFlags) {
-                    featureFlagLogic.mount()
-                    featureFlagLogic.actions.setFeatureFlags(Object.keys(featureFlags), featureFlags)
-                }
-                await initLogic({ service, id: null })
+        ])('create $name sends expected payload', async ({ service, requiredValues, expectedDestination }) => {
+            await initLogic({ service, id: null })
 
-                logic.actions.setConfigurationValues({
-                    ...logic.values.configuration,
-                    interval: 'hour',
-                    name: `Test ${service} Export`,
-                    model: 'events',
-                    ...requiredValues,
-                })
+            logic.actions.setConfigurationValues({
+                ...logic.values.configuration,
+                interval: 'hour',
+                name: `Test ${service} Export`,
+                model: 'events',
+                ...requiredValues,
+            })
 
-                await expectLogic(logic, () => {
-                    logic.actions.submitConfiguration()
-                })
-                    .toDispatchActions(['submitConfiguration', 'updateBatchExportConfigSuccess'])
-                    .toFinishAllListeners()
+            await expectLogic(logic, () => {
+                logic.actions.submitConfiguration()
+            })
+                .toDispatchActions(['submitConfiguration', 'updateBatchExportConfigSuccess'])
+                .toFinishAllListeners()
 
-                expect(lastPostBody).not.toBeNull()
-                expect(lastPostBody!.destination).toEqual(expectedDestination)
-                expect(router.values.location.pathname).toContain(urls.batchExport('new-export-id'))
-            }
-        )
+            expect(lastPostBody).not.toBeNull()
+            expect(lastPostBody!.destination).toEqual(expectedDestination)
+            expect(router.values.location.pathname).toContain(urls.batchExport('new-export-id'))
+        })
     })
 
     describe('round-trip: load and save preserves destination config', () => {
         it.each([
             { name: 'S3', fixture: S3_BATCH_EXPORT },
             { name: 'BigQuery', fixture: BIGQUERY_BATCH_EXPORT },
-            { name: 'BigQuery (integration)', fixture: BIGQUERY_INTEGRATION_BATCH_EXPORT },
             { name: 'Postgres', fixture: POSTGRES_BATCH_EXPORT },
             { name: 'Snowflake (password)', fixture: SNOWFLAKE_PASSWORD_BATCH_EXPORT },
             { name: 'Snowflake (keypair)', fixture: SNOWFLAKE_KEYPAIR_BATCH_EXPORT },

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
@@ -6,8 +6,6 @@ import { beforeUnload, router } from 'kea-router'
 import { LemonDialog, lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { addProductIntent } from 'lib/utils/product-intents'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -650,8 +648,6 @@ export const batchExportConfigFormLogic = kea<batchExportConfigFormLogicType>([
         values: [
             teamLogic,
             ['timezone as teamTimezone', 'weekStartDay as teamWeekStartDay'],
-            featureFlagLogic,
-            ['featureFlags'],
             batchExportDataLogic({ id: props.id }),
             ['batchExportConfig', 'batchExportConfigLoading'],
         ],
@@ -722,7 +718,6 @@ export const batchExportConfigFormLogic = kea<batchExportConfigFormLogicType>([
                         end_at,
                         model,
                         filters,
-                        json_config_file,
                         integration_id,
                         // Redshift COPY configuration
                         mode,
@@ -894,8 +889,8 @@ export const batchExportConfigFormLogic = kea<batchExportConfigFormLogicType>([
                 !!service && ['Postgres', 'Redshift', 'Snowflake', 'Databricks', 'BigQuery'].includes(service),
         ],
         requiredFields: [
-            (s) => [s.service, s.isNew, s.configuration, s.featureFlags],
-            (service, isNew, config, featureFlags): string[] => {
+            (s) => [s.service, s.isNew, s.configuration],
+            (service, isNew, config): string[] => {
                 const generalRequiredFields = ['interval', 'name', 'model']
                 if (service === 'Postgres') {
                     return [
@@ -930,17 +925,7 @@ export const batchExportConfigFormLogic = kea<batchExportConfigFormLogicType>([
                         ...(isNew ? ['file_format'] : []),
                     ]
                 } else if (service === 'BigQuery') {
-                    return [
-                        ...generalRequiredFields,
-                        ...(isNew && !featureFlags[FEATURE_FLAGS.BATCH_EXPORTS_BIGQUERY_INTEGRATION]
-                            ? ['json_config_file']
-                            : []),
-                        ...(isNew && featureFlags[FEATURE_FLAGS.BATCH_EXPORTS_BIGQUERY_INTEGRATION]
-                            ? ['integration_id']
-                            : []),
-                        'dataset_id',
-                        'table_id',
-                    ]
+                    return [...generalRequiredFields, ...(isNew ? ['integration_id'] : []), 'dataset_id', 'table_id']
                 } else if (service === 'HTTP') {
                     return [...generalRequiredFields, 'url', 'token']
                 } else if (service === 'Snowflake') {
@@ -984,7 +969,6 @@ export const batchExportConfigFormLogic = kea<batchExportConfigFormLogicType>([
                 end_at,
                 model,
                 filters,
-                json_config_file,
                 integration_id,
                 // Redshift COPY configuration
                 mode,
@@ -1131,33 +1115,9 @@ export const batchExportConfigFormLogic = kea<batchExportConfigFormLogicType>([
             }
             actions.setRunningStep(null)
         },
-        setConfigurationValue: async ({ name, value }) => {
+        setConfigurationValue: ({ name, value }) => {
             const fieldName = Array.isArray(name) ? name[0] : name
-            if (fieldName === 'json_config_file' && value) {
-                try {
-                    const loadedFile: string = await new Promise((resolve, reject) => {
-                        const filereader = new FileReader()
-                        filereader.onload = (e) => resolve(e.target?.result as string)
-                        filereader.onerror = (e) => reject(e)
-                        filereader.readAsText(value[0])
-                    })
-                    const jsonConfig = JSON.parse(loadedFile)
-                    const { json_config_file, ...remainingConfig } = values.configuration
-
-                    actions.setConfigurationValues({
-                        ...remainingConfig,
-                        project_id: jsonConfig.project_id,
-                        private_key: jsonConfig.private_key,
-                        private_key_id: jsonConfig.private_key_id,
-                        client_email: jsonConfig.client_email,
-                        token_uri: jsonConfig.token_uri,
-                    })
-                } catch {
-                    actions.setConfigurationManualErrors({
-                        json_config_file: 'The config file is not valid',
-                    })
-                }
-            } else if (fieldName === 'interval') {
+            if (fieldName === 'interval') {
                 // if changing to day or week, set the timezone to the team's timezone if not already set
                 if (value === 'day' || value === 'week') {
                     // if we didn't have a timezone set before, set it to the team's timezone

--- a/frontend/src/scenes/data-pipelines/batch-exports/types.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/types.ts
@@ -29,5 +29,4 @@ export type BatchExportConfigurationForm = Omit<
         destination: 'S3' | 'Snowflake' | 'Postgres' | 'BigQuery' | 'Redshift' | 'Databricks' | 'HTTP' | 'AzureBlob'
         start_at: Dayjs | null
         end_at: Dayjs | null
-        json_config_file?: File[] | null
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6113,11 +6113,6 @@ export type BatchExportServiceBigQuery = {
     type: 'BigQuery'
     integration?: number
     config: {
-        project_id: string
-        private_key: string
-        private_key_id: string
-        client_email: string
-        token_uri: string
         dataset_id: string
         table_id: string
         exclude_events: string[]


### PR DESCRIPTION
## Problem

`BATCH_EXPORTS_BIGQUERY_INTEGRATION` is fully rolled out, so the old service-account JSON key-file upload path for BigQuery batch exports is dead code. This removes the flag and that legacy path, leaving the integration picker as the only way to configure a BigQuery export.

## Changes

- Delete the `BATCH_EXPORTS_BIGQUERY_INTEGRATION` constant.
- BigQuery edit form always renders the integration picker; the JSON key-file upload (`LemonFileInput` + the `FileReader` handler that parsed the service-account JSON) is removed.
- `json_config_file` is dropped as a form field, and BigQuery's required fields become `integration_id` (when new) + `dataset_id` + `table_id`.
- Stories collapse to a single BigQuery new-export story.


## How did you test this code?

Ran the existing `batchExportConfigFormLogic` jest suite against this branch

## Docs update

No docs change needed.

## 🤖 Agent context

Authored with PostHog Code

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*