### PR TITLE
feat(replay): gate trigger group editing to project admins

### DIFF
--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupCard.tsx
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupCard.tsx
@@ -1,6 +1,8 @@
 import { IconFilter, IconTrash, IconPencil } from '@posthog/icons'
 import { LemonButton, LemonTag, LemonSnack, Tooltip } from '@posthog/lemon-ui'
 
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { IconSubArrowRight } from 'lib/lemon-ui/icons'
 
 import { EventTriggerConfig, SessionRecordingTriggerGroup } from '~/lib/components/IngestionControls/types'
@@ -107,6 +109,11 @@ function ConditionRow({
 export function TriggerGroupCard({ group, onEdit, onDelete }: TriggerGroupCardProps): JSX.Element {
     const { id, name, sampleRate, minDurationMs, conditions } = group
 
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
+
     // Format display name
     const displayName = name || `Trigger group ${id.slice(0, 8)}`
 
@@ -153,7 +160,13 @@ export function TriggerGroupCard({ group, onEdit, onDelete }: TriggerGroupCardPr
                 </div>
                 <div className="flex items-center gap-4">
                     <div className="flex gap-2">
-                        <LemonButton size="small" icon={<IconPencil />} onClick={onEdit} data-attr="trigger-group-edit">
+                        <LemonButton
+                            size="small"
+                            icon={<IconPencil />}
+                            onClick={onEdit}
+                            disabledReason={restrictedReason}
+                            data-attr="trigger-group-edit"
+                        >
                             Edit
                         </LemonButton>
                         <LemonButton
@@ -161,7 +174,7 @@ export function TriggerGroupCard({ group, onEdit, onDelete }: TriggerGroupCardPr
                             icon={<IconTrash />}
                             status="danger"
                             onClick={onDelete ? () => onDelete(id) : undefined}
-                            disabledReason={!onDelete ? 'Delete not yet implemented' : undefined}
+                            disabledReason={restrictedReason ?? (!onDelete ? 'Delete not yet implemented' : undefined)}
                             data-attr="trigger-group-delete"
                         >
                             Delete

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
@@ -16,8 +16,9 @@ import {
 import { FlagSelector } from 'lib/components/FlagSelector'
 import { EventTriggerSelect } from 'lib/components/IngestionControls/triggers/EventTrigger'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { SESSION_REPLAY_MINIMUM_DURATION_OPTIONS } from 'lib/constants'
+import { SESSION_REPLAY_MINIMUM_DURATION_OPTIONS, TeamMembershipLevel } from 'lib/constants'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { TRIGGER_GROUPS_MIN_SDK_VERSION } from 'scenes/settings/environment/ReplayTriggers'
@@ -95,6 +96,11 @@ export function TriggerGroupsEditor(): JSX.Element {
         confirmCreateFromLegacy,
     } = useActions(replayTriggersV2Logic)
 
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
+
     const handleDeleteTriggerGroup = (id: string): void => {
         if (triggerGroups.length === 1) {
             setDeleteModalGroupId(id)
@@ -134,6 +140,7 @@ export function TriggerGroupsEditor(): JSX.Element {
                                 type="secondary"
                                 size="small"
                                 onClick={showCreateFromLegacyModal}
+                                disabledReason={restrictedReason}
                                 data-attr="trigger-group-migrate-from-legacy"
                             >
                                 Migrate from legacy recording conditions
@@ -144,6 +151,7 @@ export function TriggerGroupsEditor(): JSX.Element {
                             icon={<IconPlus />}
                             size="small"
                             onClick={() => setIsAddingGroup(true)}
+                            disabledReason={restrictedReason}
                             data-attr="trigger-group-add"
                         >
                             Add


### PR DESCRIPTION
## Problem

In session replay settings, the legacy ("V1") recording-condition controls (URLs, events, sampling, min-duration, feature flag, match-type) are gated to project admins and up — non-admins see them disabled with an explanatory tooltip. The newer "Trigger groups" (V2) UI did not enforce this, so any user who could view the settings page could create, edit, delete, or migrate trigger groups even though they could not touch the legacy equivalents.

## Changes

Apply the same project-admin gating to the V2 trigger-group editing entry points, so V1 and V2 behave identically with respect to access control. Reuses the existing `useRestrictedArea` hook (`scope: Project`, `minimumAccessLevel: Admin`), which reads `currentTeam.effective_membership_level` and therefore respects whatever project-level membership rules apply.

- `TriggerGroupsEditor.tsx`: gate the **Add** and **Migrate from legacy recording conditions** buttons.
- `TriggerGroupCard.tsx`: gate the per-card **Edit** and **Delete** actions (Delete merges the restriction reason with its existing reason).

Matching V1 precisely, the inline `GroupForm` buttons are not separately gated — the form is only reachable through the already-gated Add/Edit entry points, exactly as the legacy `UrlConfigForm` save is left ungated.

Non-admins now see all four controls disabled with the same tooltip ("This area is restricted to project admins and up. Your level is member.") as the legacy controls directly below.

## How did you test this code?

I'm an agent. Automated checks I actually ran locally: `pnpm --filter=@posthog/frontend format` (0 errors) and `tsc --noEmit` (exit 0, 0 errors). I did not perform manual UI testing — the admin-vs-member tooltip behavior should be verified by a human reviewer, though it mirrors the established legacy-control pattern exactly.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.8). The change repeats an existing, well-established gating idiom rather than introducing new access-control logic: the legacy trigger controls already call `useRestrictedArea({ scope: RestrictionScope.Project, minimumAccessLevel: TeamMembershipLevel.Admin })` per control, and this PR applies the identical call to the V2 entry points. Decision: gate only the entry points (Add/Migrate/Edit/Delete) rather than every inner form control, since the form is unreachable without passing through a gated button — this matches how V1 leaves its inner form save ungated.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*