### PR TITLE
feat(property-vals): count dropped values by reason in fan-out

### DIFF
--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 use crate::config::ExcludedPropertyKeys;
+use crate::metrics_consts::VALUES_DROPPED;
 use crate::types::{Event, GroupIdentify, PropertyType, PropertyValueMessage, TupleKey};
 
 pub const MAX_PROPERTY_KEY_LEN: usize = 400;
@@ -70,19 +71,31 @@ fn emit_from_blob(
 
     for (key, value) in obj {
         if value.is_null() {
+            metrics::counter!(VALUES_DROPPED, "reason" => "null_value").increment(1);
             continue;
         }
 
         if excluded.contains(key) {
+            metrics::counter!(VALUES_DROPPED, "reason" => "excluded_key").increment(1);
             continue;
         }
 
         let property_value = coerce_to_string(value);
 
-        if key.is_empty() || key.chars().count() > MAX_PROPERTY_KEY_LEN {
+        if key.is_empty() {
+            metrics::counter!(VALUES_DROPPED, "reason" => "empty_key").increment(1);
             continue;
         }
-        if property_value.is_empty() || property_value.chars().count() > MAX_PROPERTY_VALUE_LEN {
+        if key.chars().count() > MAX_PROPERTY_KEY_LEN {
+            metrics::counter!(VALUES_DROPPED, "reason" => "key_too_long").increment(1);
+            continue;
+        }
+        if property_value.is_empty() {
+            metrics::counter!(VALUES_DROPPED, "reason" => "empty_value").increment(1);
+            continue;
+        }
+        if property_value.chars().count() > MAX_PROPERTY_VALUE_LEN {
+            metrics::counter!(VALUES_DROPPED, "reason" => "value_too_long").increment(1);
             continue;
         }
 

--- a/rust/property-vals-rs/src/metrics_consts.rs
+++ b/rust/property-vals-rs/src/metrics_consts.rs
@@ -1,5 +1,6 @@
 pub const EVENTS_RECEIVED: &str = "property_vals_rs_events_received_total";
 pub const EVENTS_FILTERED: &str = "property_vals_rs_events_filtered_total";
+pub const VALUES_DROPPED: &str = "property_vals_rs_values_dropped_total";
 pub const TUPLES_AGGREGATED: &str = "property_vals_rs_tuples_aggregated_total";
 pub const FLUSH_TUPLES: &str = "property_vals_rs_flush_tuples";
 pub const FLUSH_TUPLE_COUNT: &str = "property_vals_rs_flush_tuple_count";


### PR DESCRIPTION
## Problem

The events and groups workers in property-vals-rs silently drop property values during fan-out for several reasons (null values, keys on the exclusion list, empty or over-length keys, and empty or over-length values), but none of these drops were instrumented. There was no way to see how many values are discarded or why, in particular how many exceed the 255-character cap that both the service and the storage materialized view enforce. That blind spot makes it hard to reason about value-autocomplete coverage or to notice a team sending a flood of over-length or excluded-key values.

## Changes

Adds a `property_vals_rs_values_dropped_total` counter, labelled by `reason`, incremented at each skip point in `emit_from_blob`:

- `null_value`
- `excluded_key`
- `empty_key`, `key_too_long`
- `empty_value`, `value_too_long`

The empty and over-length cases are split so length-based drops can be read on their own. Filtering behavior is unchanged; this is observability only. The label set is small and fixed and the counter only increments on the drop paths, so there is no meaningful hot-path cost.

A dashboard panel (`sum by (reason) (rate(property_vals_rs_values_dropped_total[$__rate_interval]))`) will be added to the property-vals-rs dashboard once this deploys and the metric is emitting.

## How did you test this code?

I am an agent (Claude Code) and did not do manual testing. Automated checks run locally:

- `cargo check -p property-vals-rs` (clean)
- `cargo clippy -p property-vals-rs --all-targets` (no new warnings)
- `cargo test -p property-vals-rs` (48 passed). The existing `fan_out` tests assert the output still obeys the key/value length caps, confirming the filtering behavior is unchanged by the refactor.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed; this is an internal observability metric.

## 🤖 Agent context

Authored with Claude Code. This came out of a question about whether we can quantify how many property values get dropped by the length cap. We found the drops in `emit_from_blob` were bare `continue`s with no metric, so the volume was invisible end to end: the storage-side materialized view applies the same 255-character filter, but the service drops first, so it cannot be measured downstream either.

Decisions: instrument at the skip sites with one `reason`-labelled counter rather than a separate metric per reason, and split the empty vs over-length conditions so length drops are distinguishable. Scoped to the events/groups fan-out only; the merger's `extract_tuple` empty-check was left uninstrumented since it is a rarely-hit backstop. The dashboard panel is deferred until the metric is live to avoid shipping an empty panel.
