### PR TITLE
feat(oauth): log scope-ceiling rejections at /authorize

### DIFF
--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -29,6 +29,7 @@ from posthog.models.oauth import (
     OAuthRefreshToken,
 )
 from posthog.models.team.team import Team
+from posthog.scopes import UNPRIVILEGED_SCOPES
 
 
 def generate_rsa_key() -> str:
@@ -2287,10 +2288,19 @@ class TestOAuthAPI(APIBaseTest):
         assert location
         self.assertIn("error=invalid_scope", location)
 
-    def test_authorize_rejection_emits_ceiling_log(self):
-        self._set_ceiling("experiment:read")
+    @parameterized.expand(
+        [
+            # ceiling set, requested scope outside it (has_ceiling=True branch)
+            ("ceiling_set", ["experiment:read"], "experiment:write", ["experiment:write"], ["experiment:read"]),
+            # empty ceiling, privileged scope excluded by the broad default (has_ceiling=False branch)
+            ("empty_ceiling_privileged", [], "llm_gateway:read", ["llm_gateway:read"], sorted(UNPRIVILEGED_SCOPES)),
+        ]
+    )
+    def test_authorize_rejection_emits_ceiling_log(self, _name, ceiling, scope, expected_requested, expected_ceiling):
+        if ceiling:
+            self._set_ceiling(*ceiling)
         with patch("posthog.api.oauth.views.logger") as mock_logger:
-            response = self.client.get(f"{self.base_authorization_url}&scope=experiment:write")
+            response = self.client.get(f"{self.base_authorization_url}&scope={scope}")
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         rejection_calls = [
             call
@@ -2301,8 +2311,8 @@ class TestOAuthAPI(APIBaseTest):
         kwargs = rejection_calls[0].kwargs
         self.assertEqual(kwargs["client_id"], "test_confidential_client_id")
         self.assertEqual(kwargs["is_first_party"], self.confidential_application.is_first_party)
-        self.assertEqual(kwargs["requested"], ["experiment:write"])
-        self.assertEqual(kwargs["ceiling"], ["experiment:read"])
+        self.assertEqual(kwargs["requested"], expected_requested)
+        self.assertEqual(kwargs["ceiling"], expected_ceiling)
 
     def test_authorize_accepts_scope_within_app_ceiling(self):
         self._set_ceiling("experiment:read", "dashboard:read")

--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -2287,6 +2287,21 @@ class TestOAuthAPI(APIBaseTest):
         assert location
         self.assertIn("error=invalid_scope", location)
 
+    def test_authorize_rejection_emits_ceiling_log(self):
+        self._set_ceiling("experiment:read")
+        with patch("posthog.api.oauth.views.logger") as mock_logger:
+            response = self.client.get(f"{self.base_authorization_url}&scope=experiment:write")
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        rejection_calls = [
+            call for call in mock_logger.warning.call_args_list if call.args and call.args[0] == "oauth_scope_ceiling_rejected"
+        ]
+        self.assertEqual(len(rejection_calls), 1)
+        kwargs = rejection_calls[0].kwargs
+        self.assertEqual(kwargs["client_id"], "test_confidential_client_id")
+        self.assertEqual(kwargs["is_first_party"], self.confidential_application.is_first_party)
+        self.assertEqual(kwargs["requested"], ["experiment:write"])
+        self.assertEqual(kwargs["ceiling"], ["experiment:read"])
+
     def test_authorize_accepts_scope_within_app_ceiling(self):
         self._set_ceiling("experiment:read", "dashboard:read")
         response = self._authorize_post("experiment:read")

--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -2293,7 +2293,9 @@ class TestOAuthAPI(APIBaseTest):
             response = self.client.get(f"{self.base_authorization_url}&scope=experiment:write")
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         rejection_calls = [
-            call for call in mock_logger.warning.call_args_list if call.args and call.args[0] == "oauth_scope_ceiling_rejected"
+            call
+            for call in mock_logger.warning.call_args_list
+            if call.args and call.args[0] == "oauth_scope_ceiling_rejected"
         ]
         self.assertEqual(len(rejection_calls), 1)
         kwargs = rejection_calls[0].kwargs

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -394,8 +394,19 @@ class OAuthValidator(OAuth2Validator):
             return True
 
         if has_ceiling:
-            return "*" not in to_check and to_check.issubset(effective)
-        return to_check.issubset(UNPRIVILEGED_SCOPES | {"*"})
+            allowed = "*" not in to_check and to_check.issubset(effective)
+        else:
+            allowed = to_check.issubset(UNPRIVILEGED_SCOPES | {"*"})
+
+        if not allowed:
+            logger.warning(
+                "oauth_scope_ceiling_rejected",
+                client_id=client_id,
+                is_first_party=getattr(client, "is_first_party", False),
+                requested=sorted(to_check),
+                ceiling=sorted(effective),
+            )
+        return allowed
 
     def get_original_scopes(self, refresh_token, request, *args, **kwargs):
         """Cap refreshed scopes at the application's current ceiling.


### PR DESCRIPTION
## Problem

The per-app OAuth scope ceiling (#60477) enforces, at `/authorize`, that a client may only be granted scopes within its `OAuthApplication.scopes` set. When a request asks for a scope outside that ceiling, `OAuthValidator.validate_scopes` returns `False`, and oauthlib turns that into a 302 redirect carrying `error=invalid_scope`.

That reject path is **silent**: no `logger` call, no `capture_exception`, and a 302 is not a 4xx/5xx, so error-rate and APM dashboards miss it too. The failure mode this hides is a first-party app whose `scopes` ceiling is empty or only partially seeded. Its OAuth clients (for example the setup wizard, which requests `llm_gateway:read` among others) begin failing `/authorize` with `invalid_scope`, users can't complete login, and nothing server-side records which client requested which scope.

This is the observability gap behind a real regression: after the ceiling enforcement shipped, a first-party client's logins broke with `invalid_scope` and there was no server-side trace of the rejection. The only signals were the client's own exception telemetry (fragmented across install paths, unalerted) and users noticing.

## Changes

- `posthog/api/oauth/views.py`: in `validate_scopes`, emit a structured `logger.warning("oauth_scope_ceiling_rejected", ...)` on the reject branch, carrying `client_id`, `is_first_party`, the requested out-of-ceiling scopes, and the app's effective ceiling. The boolean resolution is byte-for-byte unchanged; this only adds a log side-effect on the existing `False` path.
- `posthog/api/oauth/test_views.py`: asserts the event fires once with the expected fields when a scope is rejected.

`is_first_party` is included so a downstream alert can page only on first-party rejections, which are near-zero baseline and almost always a misconfiguration (an unseeded or partially-seeded ceiling). Third-party clients over-asking is expected and logs at `is_first_party=false`.

## Follow-ups

- A log alert on `oauth_scope_ceiling_rejected` filtered to `is_first_party=true`, created once this deploys (the event has to exist before there's anything to alert on). That alert is what turns this from "users report it" into "we're paged at deploy time."
- Client-side telemetry enrichment + issue grouping for the wizard: https://github.com/PostHog/wizard/pull/501

## How did you test this code?

I'm an agent (Claude). Automated only:
- `test_authorize_rejection_emits_ceiling_log` patches the module logger and asserts a single `oauth_scope_ceiling_rejected` warning with the expected `client_id` / `is_first_party` / `requested` / `ceiling`. It ran green in the Django CI matrix.
- `ruff check` and `ruff format` clean on both files.
- I could not run the Django test harness locally in this environment; the backend suite (including the new test) ran in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

skip-inkeep-docs — no user-facing docs change.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8). Follow-up observability on the per-app scope ceiling (#60477): the reject path in `validate_scopes` was silent, so a misconfigured first-party ceiling produced `invalid_scope` with no server-side signal. Chose a single `logger.warning` on the existing `False` branch (structlog, matching the other `logger.warning` calls in this file) over `capture_exception`, since the rejection is a normal 302 redirect rather than a 4xx/5xx error path. Boolean resolution is unchanged; only the log was added.
