### PR TITLE
feat(mcp-analytics): use hog-charts Metric for overview KPI tiles

### DIFF
--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -6,7 +6,7 @@ import { LemonSkeleton, Link } from '@posthog/lemon-ui'
 
 import { buildTheme } from 'lib/charts/utils/theme'
 import { type ChartTheme, Metric } from 'lib/hog-charts'
-import { humanFriendlyDuration, humanFriendlyNumber } from 'lib/utils'
+import { humanFriendlyDuration, humanFriendlyLargeNumber } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -56,7 +56,7 @@ function formatNumber(n: number): string {
     if (!isFinite(n)) {
         return '—'
     }
-    return humanFriendlyNumber(Math.round(n))
+    return humanFriendlyLargeNumber(n)
 }
 
 function formatPercent(n: number): string {

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -42,21 +42,14 @@ export function HarnessPill({ category, title }: { category: string; title?: str
     )
 }
 
-type TileColor = 'blue' | 'red' | 'green'
-
 interface TileSpec {
     label: string
     metric: KPIMetric
     href: string
     format: (n: number) => string
-    color: TileColor
+    /** Sparkline color, picked from the shared data-viz palette (theme.colors). */
+    color: string
     loading: boolean
-}
-
-const COLOR_STROKE: Record<TileColor, string> = {
-    blue: '#185FA5',
-    red: '#A32D2D',
-    green: '#0F6E56',
 }
 
 function formatNumber(n: number): string {
@@ -106,7 +99,7 @@ function KPITile({ tile, theme }: { tile: TileSpec; theme: ChartTheme }): JSX.El
                     value={metric.value}
                     data={hasSparkline ? metric.sparkline : undefined}
                     theme={theme}
-                    color={COLOR_STROKE[tile.color]}
+                    color={tile.color}
                     goodDirection={metric.goodDirection}
                     formatValue={tile.format}
                     subtitle={hasComparison ? `vs. ${tile.format(metric.previousValue)} prior` : undefined}
@@ -141,7 +134,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
             metric: kpis.sessions,
             href: urls.mcpAnalyticsSessions(),
             format: formatNumber,
-            color: 'blue',
+            color: theme.colors[0], // --data-color-1 (blue)
             loading: kpisLoading,
         },
         {
@@ -149,7 +142,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
             metric: kpis.toolCalls,
             href: urls.mcpAnalyticsToolQuality(),
             format: formatNumber,
-            color: 'blue',
+            color: theme.colors[0], // --data-color-1 (blue)
             loading: kpisLoading,
         },
         {
@@ -157,7 +150,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
             metric: kpis.errorRatePct,
             href: urls.mcpAnalyticsSessions(),
             format: formatPercent,
-            color: 'red',
+            color: theme.colors[4], // --data-color-5 (red)
             loading: kpisLoading,
         },
         {
@@ -165,7 +158,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
             metric: kpis.p95LatencyMs,
             href: urls.mcpAnalyticsToolQuality(),
             format: formatMs,
-            color: 'blue',
+            color: theme.colors[0], // --data-color-1 (blue)
             loading: kpisLoading,
         },
         {
@@ -173,7 +166,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
             metric: intentClusterCount,
             href: urls.mcpAnalyticsIntentClustering(),
             format: formatNumber,
-            color: 'green',
+            color: theme.colors[6], // --data-color-7 (green)
             loading: false,
         },
     ]

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -110,7 +110,7 @@ function KPITile({ tile, theme }: { tile: TileSpec; theme: ChartTheme }): JSX.El
                     goodDirection={metric.goodDirection}
                     formatValue={tile.format}
                     subtitle={hasComparison ? `vs. ${tile.format(metric.previousValue)} prior` : undefined}
-                    sparklineHeight={40}
+                    sparklineHeight={50}
                     sparklineClassName="mt-3 -mx-3.5 -mb-3"
                 />
             )}

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -1,10 +1,15 @@
 import { useValues } from 'kea'
+import { useMemo } from 'react'
 
 import { IconBolt } from '@posthog/icons'
 import { LemonSkeleton, Link } from '@posthog/lemon-ui'
 
+import { buildTheme } from 'lib/charts/utils/theme'
+import { type ChartTheme, Metric } from 'lib/hog-charts'
 import { humanFriendlyDuration, humanFriendlyNumber } from 'lib/utils'
 import { urls } from 'scenes/urls'
+
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import claudeLogo from './harness-logos/claude.svg'
 import cursorLogo from './harness-logos/cursor.svg'
@@ -78,65 +83,37 @@ function formatMs(n: number): string {
     return humanFriendlyDuration(n / 1000, { secondsPrecision: 1 })
 }
 
-function Sparkline({ values, stroke }: { values: number[]; stroke: string }): JSX.Element {
-    const width = 60
-    const height = 18
-    if (values.length === 0) {
-        return <svg width={width} height={height} aria-hidden />
-    }
-    const max = Math.max(...values, 1)
-    const min = Math.min(...values, 0)
-    const range = max - min || 1
-    const stepX = values.length > 1 ? width / (values.length - 1) : width
-    const points = values
-        .map((v, i) => {
-            const x = i * stepX
-            const y = height - ((v - min) / range) * height
-            return `${x.toFixed(1)},${y.toFixed(1)}`
-        })
-        .join(' ')
-    return (
-        <svg width={width} height={height} aria-hidden>
-            <polyline fill="none" stroke={stroke} strokeWidth="1.2" points={points} />
-        </svg>
-    )
-}
+function KPITile({ tile, theme }: { tile: TileSpec; theme: ChartTheme }): JSX.Element {
+    const { metric } = tile
+    const hasSparkline = metric.sparkline.length > 0
+    const hasComparison = metric.deltaPct !== null
 
-function DeltaPill({ metric }: { metric: KPIMetric }): JSX.Element {
-    if (metric.deltaPct === null) {
-        return <span className="text-[11px] font-medium text-secondary">—</span>
-    }
-    const rounded = Math.round(metric.deltaPct)
-    if (rounded === 0) {
-        return <span className="text-[11px] font-medium text-secondary">0%</span>
-    }
-    const isUp = rounded > 0
-    const isGood = isUp ? metric.goodDirection === 'up' : metric.goodDirection === 'down'
-    const colorClass = isGood ? 'text-success' : 'text-danger'
-    const arrow = isUp ? '↑' : '↓'
-    return (
-        <span className={`text-[11px] font-medium ${colorClass}`}>
-            {arrow} {Math.abs(rounded)}%
-        </span>
-    )
-}
-
-function KPITile({ tile }: { tile: TileSpec }): JSX.Element {
     return (
         <Link
             to={tile.href}
-            className="flex flex-col gap-1 rounded-md bg-surface-secondary px-3.5 py-3 transition-colors hover:bg-surface-tertiary"
+            subtle
+            className="flex flex-col rounded-lg border border-primary bg-surface-primary px-3.5 py-3 shadow-sm transition-all hover:border-secondary hover:shadow-md"
         >
-            <div className="text-[11px] text-secondary">{tile.label}</div>
             {tile.loading ? (
-                <LemonSkeleton className="h-5 w-16" />
+                <div className="flex flex-col gap-2">
+                    <LemonSkeleton className="h-3 w-16" />
+                    <LemonSkeleton className="h-7 w-20" />
+                </div>
             ) : (
-                <div className="text-xl font-medium leading-tight">{tile.format(tile.metric.value)}</div>
+                <Metric
+                    className="text-primary"
+                    title={tile.label}
+                    value={metric.value}
+                    data={hasSparkline ? metric.sparkline : undefined}
+                    theme={theme}
+                    color={COLOR_STROKE[tile.color]}
+                    goodDirection={metric.goodDirection}
+                    formatValue={tile.format}
+                    subtitle={hasComparison ? `vs. ${tile.format(metric.previousValue)} prior` : undefined}
+                    sparklineHeight={40}
+                    sparklineClassName="mt-3 -mx-3.5 -mb-3"
+                />
             )}
-            <div className="mt-1 flex items-center justify-between">
-                <Sparkline values={tile.metric.sparkline} stroke={COLOR_STROKE[tile.color]} />
-                <DeltaPill metric={tile.metric} />
-            </div>
         </Link>
     )
 }
@@ -154,6 +131,9 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
         harnessRows,
         harnessRawRowsLoading,
     } = useValues(mcpDashboardOverviewLogic)
+    const { isDarkModeOn } = useValues(themeLogic)
+
+    const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
 
     const tiles: TileSpec[] = [
         {
@@ -204,7 +184,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
             <Block kicker="Health" question="Is the MCP healthy right now?">
                 <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
                     {tiles.map((tile) => (
-                        <KPITile key={tile.label} tile={tile} />
+                        <KPITile key={tile.label} tile={tile} theme={theme} />
                     ))}
                 </div>
             </Block>


### PR DESCRIPTION
## Problem

Want to use hog-charts Metric component not custom one

## Changes
now looks like:
<img width="1284" height="501" alt="Screenshot 2026-06-02 at 19 07 05" src="https://github.com/user-attachments/assets/4e000fd4-55b6-4cf5-9f33-44259fd9a11c" />
<img width="1295" height="494" alt="Screenshot 2026-06-02 at 19 06 43" src="https://github.com/user-attachments/assets/6574e6d9-2ad9-4066-bdc1-adb4812a4c3b" />


## How did you test this code?

locally, claude seeded a loads of mcp mock data and got these displaying

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8).

Key decisions:
- The target ("the metric/sparkline component") was clarified through conversation to be the MCP analytics overview KPI tiles (not web analytics, which has a similar pattern).
- Dropped the fixed `change` prop so the pill tracks the hovered sparkline point — `Metric` only computes a hover-responsive delta when `change` is omitted.
- Pinned the tile text color because the `Link` wrapper colors descendant text with the product accent (`var(--color-accent)`), which surfaced as a yellow headline (and yellow-on-hover) under the LLM-analytics product theme.
- Matched the tile chrome to the existing `Card` blocks for visual consistency.

The subtitle still shows the fixed "vs. X prior" period comparison; making it react to the hovered point would require threading per-day labels through `KPIMetric` (sparkline is currently `number[]`), left out of scope.