### PR TITLE
feat(replay-vision): expose quota, estimate, observation MCP tools

### DIFF
--- a/products/replay_vision/mcp/tools.yaml
+++ b/products/replay_vision/mcp/tools.yaml
@@ -11,13 +11,59 @@ ui_apps: {}
 tools:
     vision-observations-list:
         operation: vision_observations_list
-        enabled: false
+        enabled: true
+        scopes:
+            - replay_scanner:read
+            - session_recording:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List a session's replay vision observations
+        description: >
+            List every replay vision observation recorded for a single session, across all scanners the caller can read.
+            This is the "what has Replay Vision found about this session?" lookup — pair it with the session-recording
+            MCP tools or the investigating-replay skill while investigating a recording. The `session_id` query
+            parameter is REQUIRED; without it the request is rejected. Each result includes the scanner that produced
+            it, the observation `status` (pending/running/succeeded/failed/ineligible), the `error_reason` for terminal
+            non-success statuses, and the `scanner_result` (LLM output) on success. To list observations for one
+            specific scanner over time instead, use `vision-scanners-observations-list`.
+        feature_flag: replay-vision
     vision-observations-retrieve:
         operation: vision_observations_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - replay_scanner:read
+            - session_recording:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get a session's replay vision observation
+        description: >
+            Get a single replay vision observation by ID, scoped to the scanners the caller can read. Returns the full
+            `scanner_snapshot` (the scanner's configuration at run time) and `scanner_result` (the LLM output, with any
+            event citations). Use `vision-observations-list` to find observation IDs for a session first.
+        feature_flag: replay-vision
     vision-quota-retrieve:
         operation: environment_vision_quota_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - replay_scanner:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get replay vision quota
+        description: >
+            Get the organization's monthly Replay Vision observation budget. Returns `monthly_quota`, `usage_this_month`
+            (in-flight + succeeded observations counted against it), `remaining`, `exhausted`, and the
+            `period_start`/`period_end` of the current calendar-month window. Check `remaining`/`exhausted` before
+            creating a scanner or calling `vision-scanners-scan-session` — observations requested over quota are
+            silently skipped until the next period. Pair with `vision-scanners-estimate-create` to size a new scanner
+            against the remaining budget.
+        feature_flag: replay-vision
     vision-scanners-create:
         operation: vision_scanners_create
         enabled: true
@@ -37,7 +83,11 @@ tools:
             `emits_embeddings`. `query` is a `RecordingsQuery` shape that defines which sessions the scanner watches —
             `date_from` and `date_to` are ignored (the schedule controls time). `sampling_rate` is a 0..1 random
             downsample applied after the query matches (default 1.0). `model` chooses the LLM. Names must be unique
-            within the team.
+            within the team. Before creating a broad scanner (a permissive `query` and/or high `sampling_rate`), first
+            call `vision-scanners-estimate-create` to project its monthly observation volume and `vision-quota-retrieve`
+            to check the org's remaining budget — an enabled scanner sweeps matching recordings every 5 minutes, and
+            creation itself does not check quota, so a too-broad scanner can exhaust the monthly budget on its first
+            sweeps.
         exclude_params:
             - id
             - scanner_version
@@ -65,7 +115,23 @@ tools:
         feature_flag: replay-vision
     vision-scanners-estimate-create:
         operation: vision_scanners_estimate_create
-        enabled: false
+        enabled: true
+        scopes:
+            - replay_scanner:read
+            - session_recording:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Estimate replay vision scanner volume
+        description: >
+            Preview how many observations a proposed scanner would generate before saving it. Send a `query`
+            (`RecordingsQuery` shape; `date_from`/`date_to` are ignored — the estimate uses a fixed 30-day lookback) and
+            an optional `sampling_rate`. Returns `matched_sessions_in_window`, the `window_days` it was measured over,
+            and `estimated_observations_per_month`. Enabled scanners sweep every 5 minutes, so a broad query can exhaust
+            the monthly quota quickly — run this and compare against `vision-quota-retrieve` before
+            `vision-scanners-create`.
+        feature_flag: replay-vision
     vision-scanners-get:
         operation: vision_scanners_retrieve
         enabled: true
@@ -132,9 +198,12 @@ tools:
         title: List scanner observations
         description: >
             List the observations recorded by a single scanner. Each observation is one scan of one session and includes
-            its `status` (pending/running/succeeded/failed), `triggered_by` (`schedule` or `on_demand`), `workflow_id`,
-            the `scanner_result` (the LLM output validated against the scanner's response schema for that scanner_type),
-            and the `session_id` of the recording it analysed. Use this to inspect what a scanner has found over time.
+            its `status` (pending/running/succeeded/failed/ineligible), `error_reason` (set on terminal non-success
+            statuses, e.g. `too_short`/`no_recording` for ineligible or `provider_rejected`/`validation_failed` for
+            failed — useful for triaging why a scan produced no result), `triggered_by` (`schedule` or `on_demand`),
+            `workflow_id`, the `scanner_result` (the LLM output validated against the scanner's response schema for that
+            scanner_type), and the `session_id` of the recording it analysed. Use this to inspect what a scanner has
+            found over time; to see every scanner's observations for one session, use `vision-observations-list`.
         feature_flag: replay-vision
     vision-scanners-partial-update:
         operation: vision_scanners_partial_update
@@ -156,7 +225,8 @@ tools:
             `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes —
             rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an
             investigation: pick a scanner that matches the question you want answered, and point it at the session
-            you're examining.
+            you're examining. A scanner can observe a given session only once — re-triggering it on a session that
+            already has an observation (even a failed or ineligible one) is a no-op and will not produce a fresh scan.
         requires_ai_consent: true
         feature_flag: replay-vision
     vision-scanners-update:
@@ -175,7 +245,9 @@ tools:
             toggle `enabled` to pause/resume scanning, adjust `sampling_rate`, tweak the `scanner_config` prompt or
             tags, or refine the `query` to watch a different slice of sessions. `scanner_type` is locked after creation
             — to change it, delete and recreate. Editing any config field bumps `scanner_version`; existing observations
-            keep a snapshot of the previous config for reproducibility.
+            keep a snapshot of the previous config for reproducibility. If you widen the `query` or raise
+            `sampling_rate`, re-check projected volume with `vision-scanners-estimate-create` and remaining budget with
+            `vision-quota-retrieve` first — the scanner resumes sweeping every 5 minutes at the new, broader scope.
         exclude_params:
             - id
             - scanner_version

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5399,8 +5399,53 @@
             "readOnlyHint": false
         }
     },
+    "vision-observations-list": {
+        "description": "List every replay vision observation recorded for a single session, across all scanners the caller can read. This is the \"what has Replay Vision found about this session?\" lookup — pair it with the session-recording MCP tools or the investigating-replay skill while investigating a recording. The `session_id` query parameter is REQUIRED; without it the request is rejected. Each result includes the scanner that produced it, the observation `status` (pending/running/succeeded/failed/ineligible), the `error_reason` for terminal non-success statuses, and the `scanner_result` (LLM output) on success. To list observations for one specific scanner over time instead, use `vision-scanners-observations-list`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "List a session's replay vision observations",
+        "title": "List a session's replay vision observations",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-observations-retrieve": {
+        "description": "Get a single replay vision observation by ID, scoped to the scanners the caller can read. Returns the full `scanner_snapshot` (the scanner's configuration at run time) and `scanner_result` (the LLM output, with any event citations). Use `vision-observations-list` to find observation IDs for a session first.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get a session's replay vision observation",
+        "title": "Get a session's replay vision observation",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-quota-retrieve": {
+        "description": "Get the organization's monthly Replay Vision observation budget. Returns `monthly_quota`, `usage_this_month` (in-flight + succeeded observations counted against it), `remaining`, `exhausted`, and the `period_start`/`period_end` of the current calendar-month window. Check `remaining`/`exhausted` before creating a scanner or calling `vision-scanners-scan-session` — observations requested over quota are silently skipped until the next period. Pair with `vision-scanners-estimate-create` to size a new scanner against the remaining budget.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get replay vision quota",
+        "title": "Get replay vision quota",
+        "required_scopes": ["replay_scanner:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
     "vision-scanners-create": {
-        "description": "Create a replay vision scanner. Pick a `scanner_type` — `monitor` (open-ended observations), `classifier` (assign a tag from a fixed label set), `scorer` (numeric rubric), or `summarizer` (free-text summary with optional facet embeddings via `emits_embeddings`) — and fill `scanner_config` to match: all types need a `prompt`; classifiers also need `tags`; scorers also need `scale`; summarizers optionally set `length` and `emits_embeddings`. `query` is a `RecordingsQuery` shape that defines which sessions the scanner watches — `date_from` and `date_to` are ignored (the schedule controls time). `sampling_rate` is a 0..1 random downsample applied after the query matches (default 1.0). `model` chooses the LLM. Names must be unique within the team.",
+        "description": "Create a replay vision scanner. Pick a `scanner_type` — `monitor` (open-ended observations), `classifier` (assign a tag from a fixed label set), `scorer` (numeric rubric), or `summarizer` (free-text summary with optional facet embeddings via `emits_embeddings`) — and fill `scanner_config` to match: all types need a `prompt`; classifiers also need `tags`; scorers also need `scale`; summarizers optionally set `length` and `emits_embeddings`. `query` is a `RecordingsQuery` shape that defines which sessions the scanner watches — `date_from` and `date_to` are ignored (the schedule controls time). `sampling_rate` is a 0..1 random downsample applied after the query matches (default 1.0). `model` chooses the LLM. Names must be unique within the team. Before creating a broad scanner (a permissive `query` and/or high `sampling_rate`), first call `vision-scanners-estimate-create` to project its monthly observation volume and `vision-quota-retrieve` to check the org's remaining budget — an enabled scanner sweeps matching recordings every 5 minutes, and creation itself does not check quota, so a too-broad scanner can exhaust the monthly budget on its first sweeps.",
         "category": "Replay vision",
         "feature": "replay_vision",
         "summary": "Create replay vision scanner",
@@ -5427,6 +5472,21 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-estimate-create": {
+        "description": "Preview how many observations a proposed scanner would generate before saving it. Send a `query` (`RecordingsQuery` shape; `date_from`/`date_to` are ignored — the estimate uses a fixed 30-day lookback) and an optional `sampling_rate`. Returns `matched_sessions_in_window`, the `window_days` it was measured over, and `estimated_observations_per_month`. Enabled scanners sweep every 5 minutes, so a broad query can exhaust the monthly quota quickly — run this and compare against `vision-quota-retrieve` before `vision-scanners-create`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Estimate replay vision scanner volume",
+        "title": "Estimate replay vision scanner volume",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         },
         "feature_flag": "replay-vision"
     },
@@ -5476,7 +5536,7 @@
         "feature_flag": "replay-vision"
     },
     "vision-scanners-observations-list": {
-        "description": "List the observations recorded by a single scanner. Each observation is one scan of one session and includes its `status` (pending/running/succeeded/failed), `triggered_by` (`schedule` or `on_demand`), `workflow_id`, the `scanner_result` (the LLM output validated against the scanner's response schema for that scanner_type), and the `session_id` of the recording it analysed. Use this to inspect what a scanner has found over time.",
+        "description": "List the observations recorded by a single scanner. Each observation is one scan of one session and includes its `status` (pending/running/succeeded/failed/ineligible), `error_reason` (set on terminal non-success statuses, e.g. `too_short`/`no_recording` for ineligible or `provider_rejected`/`validation_failed` for failed — useful for triaging why a scan produced no result), `triggered_by` (`schedule` or `on_demand`), `workflow_id`, the `scanner_result` (the LLM output validated against the scanner's response schema for that scanner_type), and the `session_id` of the recording it analysed. Use this to inspect what a scanner has found over time; to see every scanner's observations for one session, use `vision-observations-list`.",
         "category": "Replay vision",
         "feature": "replay_vision",
         "summary": "List scanner observations",
@@ -5491,7 +5551,7 @@
         "feature_flag": "replay-vision"
     },
     "vision-scanners-scan-session": {
-        "description": "Trigger a scanner against a specific session immediately, bypassing the sampling rate and any scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an investigation: pick a scanner that matches the question you want answered, and point it at the session you're examining.",
+        "description": "Trigger a scanner against a specific session immediately, bypassing the sampling rate and any scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an investigation: pick a scanner that matches the question you want answered, and point it at the session you're examining. A scanner can observe a given session only once — re-triggering it on a session that already has an observation (even a failed or ineligible one) is a no-op and will not produce a fresh scan.",
         "category": "Replay vision",
         "feature": "replay_vision",
         "summary": "Run scanner against a session now",
@@ -5507,7 +5567,7 @@
         "feature_flag": "replay-vision"
     },
     "vision-scanners-update": {
-        "description": "Partially update a replay vision scanner by ID. Send only the fields you want to change. Common changes: toggle `enabled` to pause/resume scanning, adjust `sampling_rate`, tweak the `scanner_config` prompt or tags, or refine the `query` to watch a different slice of sessions. `scanner_type` is locked after creation — to change it, delete and recreate. Editing any config field bumps `scanner_version`; existing observations keep a snapshot of the previous config for reproducibility.",
+        "description": "Partially update a replay vision scanner by ID. Send only the fields you want to change. Common changes: toggle `enabled` to pause/resume scanning, adjust `sampling_rate`, tweak the `scanner_config` prompt or tags, or refine the `query` to watch a different slice of sessions. `scanner_type` is locked after creation — to change it, delete and recreate. Editing any config field bumps `scanner_version`; existing observations keep a snapshot of the previous config for reproducibility. If you widen the `query` or raise `sampling_rate`, re-check projected volume with `vision-scanners-estimate-create` and remaining budget with `vision-quota-retrieve` first — the scanner resumes sweeping every 5 minutes at the new, broader scope.",
         "category": "Replay vision",
         "feature": "replay_vision",
         "summary": "Update replay vision scanner",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5754,8 +5754,53 @@
             "readOnlyHint": false
         }
     },
+    "vision-observations-list": {
+        "description": "List every replay vision observation recorded for a single session, across all scanners the caller can read. This is the \"what has Replay Vision found about this session?\" lookup — pair it with the session-recording MCP tools or the investigating-replay skill while investigating a recording. The `session_id` query parameter is REQUIRED; without it the request is rejected. Each result includes the scanner that produced it, the observation `status` (pending/running/succeeded/failed/ineligible), the `error_reason` for terminal non-success statuses, and the `scanner_result` (LLM output) on success. To list observations for one specific scanner over time instead, use `vision-scanners-observations-list`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "List a session's replay vision observations",
+        "title": "List a session's replay vision observations",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-observations-retrieve": {
+        "description": "Get a single replay vision observation by ID, scoped to the scanners the caller can read. Returns the full `scanner_snapshot` (the scanner's configuration at run time) and `scanner_result` (the LLM output, with any event citations). Use `vision-observations-list` to find observation IDs for a session first.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get a session's replay vision observation",
+        "title": "Get a session's replay vision observation",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-quota-retrieve": {
+        "description": "Get the organization's monthly Replay Vision observation budget. Returns `monthly_quota`, `usage_this_month` (in-flight + succeeded observations counted against it), `remaining`, `exhausted`, and the `period_start`/`period_end` of the current calendar-month window. Check `remaining`/`exhausted` before creating a scanner or calling `vision-scanners-scan-session` — observations requested over quota are silently skipped until the next period. Pair with `vision-scanners-estimate-create` to size a new scanner against the remaining budget.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get replay vision quota",
+        "title": "Get replay vision quota",
+        "required_scopes": ["replay_scanner:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
     "vision-scanners-create": {
-        "description": "Create a replay vision scanner. Pick a `scanner_type` — `monitor` (open-ended observations), `classifier` (assign a tag from a fixed label set), `scorer` (numeric rubric), or `summarizer` (free-text summary with optional facet embeddings via `emits_embeddings`) — and fill `scanner_config` to match: all types need a `prompt`; classifiers also need `tags`; scorers also need `scale`; summarizers optionally set `length` and `emits_embeddings`. `query` is a `RecordingsQuery` shape that defines which sessions the scanner watches — `date_from` and `date_to` are ignored (the schedule controls time). `sampling_rate` is a 0..1 random downsample applied after the query matches (default 1.0). `model` chooses the LLM. Names must be unique within the team.",
+        "description": "Create a replay vision scanner. Pick a `scanner_type` — `monitor` (open-ended observations), `classifier` (assign a tag from a fixed label set), `scorer` (numeric rubric), or `summarizer` (free-text summary with optional facet embeddings via `emits_embeddings`) — and fill `scanner_config` to match: all types need a `prompt`; classifiers also need `tags`; scorers also need `scale`; summarizers optionally set `length` and `emits_embeddings`. `query` is a `RecordingsQuery` shape that defines which sessions the scanner watches — `date_from` and `date_to` are ignored (the schedule controls time). `sampling_rate` is a 0..1 random downsample applied after the query matches (default 1.0). `model` chooses the LLM. Names must be unique within the team. Before creating a broad scanner (a permissive `query` and/or high `sampling_rate`), first call `vision-scanners-estimate-create` to project its monthly observation volume and `vision-quota-retrieve` to check the org's remaining budget — an enabled scanner sweeps matching recordings every 5 minutes, and creation itself does not check quota, so a too-broad scanner can exhaust the monthly budget on its first sweeps.",
         "category": "Replay vision",
         "feature": "replay_vision",
         "summary": "Create replay vision scanner",
@@ -5782,6 +5827,21 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-scanners-estimate-create": {
+        "description": "Preview how many observations a proposed scanner would generate before saving it. Send a `query` (`RecordingsQuery` shape; `date_from`/`date_to` are ignored — the estimate uses a fixed 30-day lookback) and an optional `sampling_rate`. Returns `matched_sessions_in_window`, the `window_days` it was measured over, and `estimated_observations_per_month`. Enabled scanners sweep every 5 minutes, so a broad query can exhaust the monthly quota quickly — run this and compare against `vision-quota-retrieve` before `vision-scanners-create`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Estimate replay vision scanner volume",
+        "title": "Estimate replay vision scanner volume",
+        "required_scopes": ["replay_scanner:read", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         },
         "feature_flag": "replay-vision"
     },
@@ -5831,7 +5891,7 @@
         "feature_flag": "replay-vision"
     },
     "vision-scanners-observations-list": {
-        "description": "List the observations recorded by a single scanner. Each observation is one scan of one session and includes its `status` (pending/running/succeeded/failed), `triggered_by` (`schedule` or `on_demand`), `workflow_id`, the `scanner_result` (the LLM output validated against the scanner's response schema for that scanner_type), and the `session_id` of the recording it analysed. Use this to inspect what a scanner has found over time.",
+        "description": "List the observations recorded by a single scanner. Each observation is one scan of one session and includes its `status` (pending/running/succeeded/failed/ineligible), `error_reason` (set on terminal non-success statuses, e.g. `too_short`/`no_recording` for ineligible or `provider_rejected`/`validation_failed` for failed — useful for triaging why a scan produced no result), `triggered_by` (`schedule` or `on_demand`), `workflow_id`, the `scanner_result` (the LLM output validated against the scanner's response schema for that scanner_type), and the `session_id` of the recording it analysed. Use this to inspect what a scanner has found over time; to see every scanner's observations for one session, use `vision-observations-list`.",
         "category": "Replay vision",
         "feature": "replay_vision",
         "summary": "List scanner observations",
@@ -5846,7 +5906,7 @@
         "feature_flag": "replay-vision"
     },
     "vision-scanners-scan-session": {
-        "description": "Trigger a scanner against a specific session immediately, bypassing the sampling rate and any scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an investigation: pick a scanner that matches the question you want answered, and point it at the session you're examining.",
+        "description": "Trigger a scanner against a specific session immediately, bypassing the sampling rate and any scheduled sweep. Returns 202 with a `workflow_id`; the resulting observation appears under `vision-scanners-observations-list` once the Temporal workflow finishes (typically several minutes — rasterising the recording into video and calling the LLM is slow). Useful for ad-hoc scanning during an investigation: pick a scanner that matches the question you want answered, and point it at the session you're examining. A scanner can observe a given session only once — re-triggering it on a session that already has an observation (even a failed or ineligible one) is a no-op and will not produce a fresh scan.",
         "category": "Replay vision",
         "feature": "replay_vision",
         "summary": "Run scanner against a session now",
@@ -5862,7 +5922,7 @@
         "feature_flag": "replay-vision"
     },
     "vision-scanners-update": {
-        "description": "Partially update a replay vision scanner by ID. Send only the fields you want to change. Common changes: toggle `enabled` to pause/resume scanning, adjust `sampling_rate`, tweak the `scanner_config` prompt or tags, or refine the `query` to watch a different slice of sessions. `scanner_type` is locked after creation — to change it, delete and recreate. Editing any config field bumps `scanner_version`; existing observations keep a snapshot of the previous config for reproducibility.",
+        "description": "Partially update a replay vision scanner by ID. Send only the fields you want to change. Common changes: toggle `enabled` to pause/resume scanning, adjust `sampling_rate`, tweak the `scanner_config` prompt or tags, or refine the `query` to watch a different slice of sessions. `scanner_type` is locked after creation — to change it, delete and recreate. Editing any config field bumps `scanner_version`; existing observations keep a snapshot of the previous config for reproducibility. If you widen the `query` or raise `sampling_rate`, re-check projected volume with `vision-scanners-estimate-create` and remaining budget with `vision-quota-retrieve` first — the scanner resumes sweeping every 5 minutes at the new, broader scope.",
         "category": "Replay vision",
         "feature": "replay_vision",
         "summary": "Update replay vision scanner",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -43784,10 +43784,6 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
-     */
-    order_by?: string;
-    /**
      * Session recording id to return observations for.
      */
     session_id: string;
@@ -43812,8 +43808,17 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
+
+    * `name` - Name
+    * `-name` - Name (descending)
+    * `created_at` - Created at
+    * `-created_at` - Created at (descending)
+    * `updated_at` - Updated at
+    * `-updated_at` - Updated at (descending)
+    * `scanner_type` - Scanner type
+    * `-scanner_type` - Scanner type (descending)
      */
-    order_by?: string;
+    order_by?: string[];
     /**
      * Filter by scanner type (monitor, classifier, scorer, summarizer).
 
@@ -43846,8 +43851,17 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
+
+    * `created_at` - Created at
+    * `-created_at` - Created at (descending)
+    * `started_at` - Started at
+    * `-started_at` - Started at (descending)
+    * `completed_at` - Completed at
+    * `-completed_at` - Completed at (descending)
+    * `status` - Status
+    * `-status` - Status (descending)
      */
-    order_by?: string;
+    order_by?: string[];
     /**
      * Filter to observations of a specific session recording.
      */
@@ -49844,10 +49858,6 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
-     */
-    order_by?: string;
-    /**
      * Session recording id to return observations for.
      */
     session_id: string;
@@ -49872,8 +49882,17 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
+
+    * `name` - Name
+    * `-name` - Name (descending)
+    * `created_at` - Created at
+    * `-created_at` - Created at (descending)
+    * `updated_at` - Updated at
+    * `-updated_at` - Updated at (descending)
+    * `scanner_type` - Scanner type
+    * `-scanner_type` - Scanner type (descending)
      */
-    order_by?: string;
+    order_by?: string[];
     /**
      * Filter by scanner type (monitor, classifier, scorer, summarizer).
 
@@ -49906,8 +49925,17 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
+
+    * `created_at` - Created at
+    * `-created_at` - Created at (descending)
+    * `started_at` - Started at
+    * `-started_at` - Started at (descending)
+    * `completed_at` - Completed at
+    * `-completed_at` - Completed at (descending)
+    * `status` - Status
+    * `-status` - Status (descending)
      */
-    order_by?: string;
+    order_by?: string[];
     /**
      * Filter to observations of a specific session recording.
      */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -43784,6 +43784,10 @@ export namespace Schemas {
      */
     offset?: number;
     /**
+     * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
+     */
+    order_by?: string;
+    /**
      * Session recording id to return observations for.
      */
     session_id: string;
@@ -43808,17 +43812,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
-
-    * `name` - Name
-    * `-name` - Name (descending)
-    * `created_at` - Created at
-    * `-created_at` - Created at (descending)
-    * `updated_at` - Updated at
-    * `-updated_at` - Updated at (descending)
-    * `scanner_type` - Scanner type
-    * `-scanner_type` - Scanner type (descending)
      */
-    order_by?: string[];
+    order_by?: string;
     /**
      * Filter by scanner type (monitor, classifier, scorer, summarizer).
 
@@ -43851,17 +43846,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
-
-    * `created_at` - Created at
-    * `-created_at` - Created at (descending)
-    * `started_at` - Started at
-    * `-started_at` - Started at (descending)
-    * `completed_at` - Completed at
-    * `-completed_at` - Completed at (descending)
-    * `status` - Status
-    * `-status` - Status (descending)
      */
-    order_by?: string[];
+    order_by?: string;
     /**
      * Filter to observations of a specific session recording.
      */
@@ -49858,6 +49844,10 @@ export namespace Schemas {
      */
     offset?: number;
     /**
+     * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
+     */
+    order_by?: string;
+    /**
      * Session recording id to return observations for.
      */
     session_id: string;
@@ -49882,17 +49872,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
-
-    * `name` - Name
-    * `-name` - Name (descending)
-    * `created_at` - Created at
-    * `-created_at` - Created at (descending)
-    * `updated_at` - Updated at
-    * `-updated_at` - Updated at (descending)
-    * `scanner_type` - Scanner type
-    * `-scanner_type` - Scanner type (descending)
      */
-    order_by?: string[];
+    order_by?: string;
     /**
      * Filter by scanner type (monitor, classifier, scorer, summarizer).
 
@@ -49925,17 +49906,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.
-
-    * `created_at` - Created at
-    * `-created_at` - Created at (descending)
-    * `started_at` - Started at
-    * `-started_at` - Started at (descending)
-    * `completed_at` - Completed at
-    * `-completed_at` - Completed at (descending)
-    * `status` - Status
-    * `-status` - Status (descending)
      */
-    order_by?: string[];
+    order_by?: string;
     /**
      * Filter to observations of a specific session recording.
      */

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -3,10 +3,53 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 8 enabled ops
+ * PostHog API - MCP 12 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
+
+/**
+ * Read-only access to a session's observations across every scanner the caller can read, for the replay-page dock.
+ */
+export const VisionObservationsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const VisionObservationsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    order_by: zod
+        .string()
+        .optional()
+        .describe(
+            'Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.'
+        ),
+    session_id: zod.string().describe('Session recording id to return observations for.'),
+})
+
+/**
+ * Read-only access to a session's observations across every scanner the caller can read, for the replay-page dock.
+ */
+export const VisionObservationsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this replay observation.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const EnvironmentVisionQuotaRetrieveParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
 
 /**
  * CRUD for Replay Vision scanners.
@@ -25,11 +68,9 @@ export const VisionScannersListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     order_by: zod
-        .array(zod.string())
+        .string()
         .optional()
-        .describe(
-            'Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.\n\n* `name` - Name\n* `-name` - Name (descending)\n* `created_at` - Created at\n* `-created_at` - Created at (descending)\n* `updated_at` - Updated at\n* `-updated_at` - Updated at (descending)\n* `scanner_type` - Scanner type\n* `-scanner_type` - Scanner type (descending)'
-        ),
+        .describe('Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.'),
     scanner_type: zod
         .enum(['classifier', 'monitor', 'scorer', 'summarizer'])
         .optional()
@@ -250,10 +291,10 @@ export const VisionScannersObservationsListQueryParams = /* @__PURE__ */ zod.obj
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     order_by: zod
-        .array(zod.string())
+        .string()
         .optional()
         .describe(
-            'Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.\n\n* `created_at` - Created at\n* `-created_at` - Created at (descending)\n* `started_at` - Started at\n* `-started_at` - Started at (descending)\n* `completed_at` - Completed at\n* `-completed_at` - Completed at (descending)\n* `status` - Status\n* `-status` - Status (descending)'
+            'Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.'
         ),
     session_id: zod.string().optional().describe('Filter to observations of a specific session recording.'),
     status: zod
@@ -282,3 +323,35 @@ export const VisionScannersObservationsRetrieveParams = /* @__PURE__ */ zod.obje
         ),
     scanner_id: zod.string(),
 })
+
+/**
+ * Estimate the observation volume a proposed scanner would generate, for the pre-save cost preview.
+ */
+export const VisionScannersEstimateCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const visionScannersEstimateCreateBodySamplingRateDefault = 1
+export const visionScannersEstimateCreateBodySamplingRateMin = 0
+export const visionScannersEstimateCreateBodySamplingRateMax = 1
+
+export const VisionScannersEstimateCreateBody = /* @__PURE__ */ zod
+    .object({
+        query: zod
+            .unknown()
+            .optional()
+            .describe(
+                'Proposed `RecordingsQuery` for the candidate filter. `date_from`/`date_to` are ignored — the estimate always uses a fixed 30-day lookback. Omit to estimate against all recordings.'
+            ),
+        sampling_rate: zod
+            .number()
+            .min(visionScannersEstimateCreateBodySamplingRateMin)
+            .max(visionScannersEstimateCreateBodySamplingRateMax)
+            .default(visionScannersEstimateCreateBodySamplingRateDefault)
+            .describe('0..1 downsample applied to matched sessions. Defaults to 1.0 (no downsampling).'),
+    })
+    .describe('Body of POST /vision/scanners/estimate/ — a proposed, unsaved scanner config.')

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -22,12 +22,6 @@ export const VisionObservationsListParams = /* @__PURE__ */ zod.object({
 export const VisionObservationsListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
-    order_by: zod
-        .string()
-        .optional()
-        .describe(
-            'Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.'
-        ),
     session_id: zod.string().describe('Session recording id to return observations for.'),
 })
 
@@ -68,9 +62,11 @@ export const VisionScannersListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     order_by: zod
-        .string()
+        .array(zod.string())
         .optional()
-        .describe('Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.'),
+        .describe(
+            'Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.\n\n* `name` - Name\n* `-name` - Name (descending)\n* `created_at` - Created at\n* `-created_at` - Created at (descending)\n* `updated_at` - Updated at\n* `-updated_at` - Updated at (descending)\n* `scanner_type` - Scanner type\n* `-scanner_type` - Scanner type (descending)'
+        ),
     scanner_type: zod
         .enum(['classifier', 'monitor', 'scorer', 'summarizer'])
         .optional()
@@ -291,10 +287,10 @@ export const VisionScannersObservationsListQueryParams = /* @__PURE__ */ zod.obj
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     order_by: zod
-        .string()
+        .array(zod.string())
         .optional()
         .describe(
-            'Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.'
+            'Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.\n\n* `created_at` - Created at\n* `-created_at` - Created at (descending)\n* `started_at` - Started at\n* `-started_at` - Started at (descending)\n* `completed_at` - Completed at\n* `-completed_at` - Completed at (descending)\n* `status` - Status\n* `-status` - Status (descending)'
         ),
     session_id: zod.string().optional().describe('Filter to observations of a specific session recording.'),
     status: zod

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -3,8 +3,11 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
+    VisionObservationsListQueryParams,
+    VisionObservationsRetrieveParams,
     VisionScannersCreateBody,
     VisionScannersDestroyParams,
+    VisionScannersEstimateCreateBody,
     VisionScannersListQueryParams,
     VisionScannersObservationsListParams,
     VisionScannersObservationsListQueryParams,
@@ -17,6 +20,64 @@ import {
 } from '@/generated/replay_vision/api'
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const VisionObservationsListSchema = VisionObservationsListQueryParams
+
+const visionObservationsList = (): ToolBase<
+    typeof VisionObservationsListSchema,
+    WithPostHogUrl<Schemas.PaginatedReplayObservationList>
+> => ({
+    name: 'vision-observations-list',
+    schema: VisionObservationsListSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionObservationsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedReplayObservationList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/observations/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+                order_by: params.order_by,
+                session_id: params.session_id,
+            },
+        })
+        return await withPostHogUrl(context, result, '/replay-vision')
+    },
+})
+
+const VisionObservationsRetrieveSchema = VisionObservationsRetrieveParams.omit({ project_id: true })
+
+const visionObservationsRetrieve = (): ToolBase<
+    typeof VisionObservationsRetrieveSchema,
+    Schemas.ReplayObservation
+> => ({
+    name: 'vision-observations-retrieve',
+    schema: VisionObservationsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionObservationsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ReplayObservation>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/observations/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const VisionQuotaRetrieveSchema = z.object({})
+
+const visionQuotaRetrieve = (): ToolBase<typeof VisionQuotaRetrieveSchema, Schemas.VisionQuota> => ({
+    name: 'vision-quota-retrieve',
+    schema: VisionQuotaRetrieveSchema,
+    // eslint-disable-next-line no-unused-vars
+    handler: async (context: Context, params: z.infer<typeof VisionQuotaRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.VisionQuota>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/quota/`,
+        })
+        return result
+    },
+})
 
 const VisionScannersCreateSchema = VisionScannersCreateBody
 
@@ -75,6 +136,32 @@ const visionScannersDelete = (): ToolBase<typeof VisionScannersDeleteSchema, unk
         const result = await context.api.request<unknown>({
             method: 'DELETE',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/scanners/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const VisionScannersEstimateCreateSchema = VisionScannersEstimateCreateBody
+
+const visionScannersEstimateCreate = (): ToolBase<
+    typeof VisionScannersEstimateCreateSchema,
+    Schemas.EstimateResponse
+> => ({
+    name: 'vision-scanners-estimate-create',
+    schema: VisionScannersEstimateCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionScannersEstimateCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.query !== undefined) {
+            body['query'] = params.query
+        }
+        if (params.sampling_rate !== undefined) {
+            body['sampling_rate'] = params.sampling_rate
+        }
+        const result = await context.api.request<Schemas.EstimateResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/scanners/estimate/`,
+            body,
         })
         return result
     },
@@ -239,8 +326,12 @@ const visionScannersUpdate = (): ToolBase<typeof VisionScannersUpdateSchema, Sch
 })
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'vision-observations-list': visionObservationsList,
+    'vision-observations-retrieve': visionObservationsRetrieve,
+    'vision-quota-retrieve': visionQuotaRetrieve,
     'vision-scanners-create': visionScannersCreate,
     'vision-scanners-delete': visionScannersDelete,
+    'vision-scanners-estimate-create': visionScannersEstimateCreate,
     'vision-scanners-get': visionScannersGet,
     'vision-scanners-list': visionScannersList,
     'vision-scanners-observations-get': visionScannersObservationsGet,

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -37,7 +37,6 @@ const visionObservationsList = (): ToolBase<
             query: {
                 limit: params.limit,
                 offset: params.offset,
-                order_by: params.order_by,
                 session_id: params.session_id,
             },
         })


### PR DESCRIPTION
## Problem

The Replay Vision MCP surface exposed full scanner CRUD and per-scanner observation reads, but left three useful endpoints scaffolded-but-disabled. The practical gaps for an agent driving scanners:

- No way to check the org's monthly observation quota before creating a scanner or triggering a scan — over-quota observations are silently skipped.
- No way to preview how many sessions a proposed scanner would match before saving. Since enabled scanners sweep every 5 minutes, a too-broad query can burn the monthly budget fast.
- No way to answer "what has Replay Vision found about *this* session?" across all scanners — only per-scanner listing existed.

## Changes

Enables three already-scaffolded tools (the backends already exist and are permission-gated; this is config + codegen, with no backend change) and tightens two descriptions:

| Tool | What it adds |
|---|---|
| `vision-quota-retrieve` | Org monthly observation budget: `monthly_quota`, `usage_this_month`, `remaining`, `exhausted`, period bounds. |
| `vision-scanners-estimate-create` | Pre-save matched-session volume preview for a proposed `query` + `sampling_rate`. Read-only count query (no AI consent). |
| `vision-observations-list` / `-retrieve` | Cross-scanner, per-session observation lookups (`session_id` required). |

Description fixes:

- `vision-scanners-observations-list` now documents the `ineligible` status and the structured `error_reason` field (for triaging why a scan produced no result).
- `vision-scanners-scan-session` now notes that re-scanning a session that already has an observation (incl. failed/ineligible) is a no-op due to the `UNIQUE (scanner_id, session_id)` constraint.

All enabled tools remain gated behind the `replay-vision` feature flag (default `enable` behavior, fail-closed), and the backends additionally return 404 when the flag is off.

## How did you test this code?

I'm an agent (PostHog Code). Live testing was not possible because the deployed MCP server runs `master` and does not yet have these tools enabled — the backend endpoints already exist and are flag-gated, so they become exercisable once this ships. Automated checks run locally:

- `scaffold-yaml --sync-all` — replay_vision in sync (12 ops, no changes)
- Regenerated `generate-orval-schemas` → `generate-mcp-types` → `generate-tools`
- `lint-tool-names` — pass
- `typecheck` (`tsc --noEmit`) — clean
- Confirmed `session_id` is required on the generated list schema and the generated-file diff is fully replay_vision-scoped (no unrelated product drift)

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). This started as an audit of the Replay Vision MCP tools; the audit surfaced the three disabled high-value endpoints and the description drift, and the human chose to enable all three plus apply the doc fixes. Only `products/replay_vision/mcp/tools.yaml` was hand-edited — the rest are regenerated artifacts. Estimate was intentionally left without `requires_ai_consent` since it runs a plain count query rather than invoking an LLM. Requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
