### PR TITLE
fix(auth): unverified-email banner CTA not sending verification email

### DIFF
--- a/frontend/src/layout/navigation/projectNoticeLogic.test.ts
+++ b/frontend/src/layout/navigation/projectNoticeLogic.test.ts
@@ -2,6 +2,8 @@ import { MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { expectLogic } from 'kea-test-utils'
 
+import { verifyEmailLogic } from 'scenes/authentication/signup/verify-email/verifyEmailLogic'
+
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { AppContext } from '~/types'
@@ -61,6 +63,36 @@ describe('projectNoticeLogic', () => {
             logic.mount()
 
             await expectLogic(logic).toDispatchActions(['loadRecords'])
+
+            logic.unmount()
+        })
+    })
+
+    describe('unverified email banner CTA', () => {
+        beforeEach(() => {
+            useMocks({
+                get: {
+                    '/api/organizations/@current/proxy_records': [200, { results: [] }],
+                },
+                post: {
+                    '/api/users/request_email_verification/': [200, { success: true }],
+                },
+            })
+            initKeaTests()
+        })
+
+        it('mounts verifyEmailLogic so the CTA reaches its request loader', async () => {
+            const logic = projectNoticeLogic()
+            logic.mount()
+
+            // The banner renders on every scene, but verifyEmailLogic is otherwise only mounted on the
+            // verify-email scene — without this connection the CTA action dispatches into an unmounted
+            // logic and silently no-ops.
+            expect(verifyEmailLogic.isMounted()).toBe(true)
+
+            await expectLogic(verifyEmailLogic, () => {
+                verifyEmailLogic.actions.requestVerificationLink('test-uuid')
+            }).toDispatchActions(['requestVerificationLink', 'requestVerificationLinkSuccess'])
 
             logic.unmount()
         })

--- a/frontend/src/layout/navigation/projectNoticeLogic.tsx
+++ b/frontend/src/layout/navigation/projectNoticeLogic.tsx
@@ -116,7 +116,14 @@ export const projectNoticeLogic = kea<projectNoticeLogicType>([
     path(['layout', 'navigation', 'projectNoticeLogic']),
     connect(() => ({
         values: [membersLogic, ['memberCount'], organizationLogic, ['currentOrganizationId']],
-        actions: [eventUsageLogic, ['reportProjectNoticeDismissed', 'reportProjectNoticeShown']],
+        actions: [
+            eventUsageLogic,
+            ['reportProjectNoticeDismissed', 'reportProjectNoticeShown'],
+            // Mount verifyEmailLogic so the "Send verification email" banner CTA's loader fires.
+            // The banner renders on every scene, but verifyEmailLogic is otherwise only mounted on the verify-email scene.
+            verifyEmailLogic,
+            ['requestVerificationLink'],
+        ],
     })),
     actions({
         dismissProjectNotice: (dismissKey: string | null) => ({ dismissKey }),


### PR DESCRIPTION
## Problem

The "Please verify your email address" banner has a **Send verification email** CTA. Clicking it did nothing — no request, no toast, no feedback — for any unverified user on any scene other than the verify-email page. Users had no working way to re-trigger their verification email from the in-app prompt.

## Changes

The banner (`projectNoticeLogic`) dispatched `verifyEmailLogic.actions.requestVerificationLink(...)`, but `verifyEmailLogic` is only mounted on the verify-email scene. The banner renders globally, so on every other scene the action was dispatched into an **unmounted** logic and its loader (the actual `POST /api/users/request_email_verification/`) never ran. kea `autoMount` is off, so this was a silent no-op. The sibling `inviteLogic` CTA works only because `GlobalModals` mounts it globally.

Fix: `connect` `verifyEmailLogic`'s `requestVerificationLink` action into `projectNoticeLogic`, so the logic mounts as a dependency wherever the banner renders and the loader fires.

## How did you test this code?

I'm an agent (Claude Code). Tests I actually ran:

- **Automated (jest):** added a regression test in `projectNoticeLogic.test.ts` asserting that mounting `projectNoticeLogic` also mounts `verifyEmailLogic` and that the CTA action reaches its request loader. Confirmed **red → green**: it fails without the `connect` (`verifyEmailLogic.isMounted()` is `false`) and passes with it.
- **Manual (live app, sandbox):** drove the real UI in a browser as an unverified user. Before the fix, clicking the CTA produced no network request and no toast. With the fix applied, the same click fires `POST /api/users/request_email_verification/` → `200` and shows the success toast.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

Authored with Claude Code (Claude Opus 4.8). The bug was traced statically (banner → `verifyEmailLogic` loader → mount sites → `autoMount` off), then confirmed two ways: a red→green kea logic test and a live before/after in a running sandbox. Considered alternatives — mounting `verifyEmailLogic` globally or duplicating the request in `userLogic` — and chose `connect` because it reuses the existing loader and is the standard kea way to express the mount dependency. Generated kea types (`projectNoticeLogicType`) regenerate cleanly; those files are gitignored. Requires human review.
