### PR TITLE
fix(insights): thin out overlapping horizontal bar category labels

### DIFF
--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.test.ts
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.test.ts
@@ -1,0 +1,45 @@
+import { computeVisibleYLabels } from './AxisLabels'
+
+describe('computeVisibleYLabels', () => {
+    const labels = ['a', 'b', 'c', 'd', 'e']
+
+    it('keeps every label when rows have room', () => {
+        // 40px apart — far more than the ~16px a 12px label needs.
+        const yScale = (label: string): number => labels.indexOf(label) * 40
+        const visible = computeVisibleYLabels(labels, yScale)
+        expect(visible.map((v) => v.text)).toEqual(labels)
+    })
+
+    it('thins out labels when bands are compressed', () => {
+        // 6px apart — labels would overlap, so only a spaced-out subset survives.
+        const yScale = (label: string): number => labels.indexOf(label) * 6
+        const visible = computeVisibleYLabels(labels, yScale)
+        expect(visible.length).toBeLessThan(labels.length)
+        // The first label is always anchored, and kept labels never overlap.
+        expect(visible[0].text).toBe('a')
+        for (let i = 1; i < visible.length; i++) {
+            expect(visible[i].y - visible[i - 1].y).toBeGreaterThanOrEqual(12)
+        }
+    })
+
+    it('drops labels the formatter nulls out (band-shared breakdown rows)', () => {
+        const yScale = (label: string): number => labels.indexOf(label) * 40
+        const formatter = (value: string): string | null => (value === 'c' ? null : value)
+        const visible = computeVisibleYLabels(labels, yScale, formatter)
+        expect(visible.map((v) => v.text)).toEqual(['a', 'b', 'd', 'e'])
+    })
+
+    it('skips labels with no finite coordinate', () => {
+        const yScale = (label: string): number | undefined => (label === 'b' ? undefined : labels.indexOf(label) * 40)
+        const visible = computeVisibleYLabels(labels, yScale)
+        expect(visible.map((v) => v.text)).toEqual(['a', 'c', 'd', 'e'])
+    })
+
+    it('orders by coordinate before thinning so out-of-order labels still pack correctly', () => {
+        const coords: Record<string, number> = { a: 100, b: 0, c: 50, d: 25, e: 75 }
+        const yScale = (label: string): number => coords[label]
+        const visible = computeVisibleYLabels(labels, yScale)
+        const ys = visible.map((v) => v.y)
+        expect(ys).toEqual([...ys].sort((x, y) => x - y))
+    })
+})

--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
@@ -65,6 +65,50 @@ export function computeVisibleXLabels(
     return visible
 }
 
+// Category tick labels are a fixed ~12px tall (see TICK_STYLE_BASE.fontSize); require this much
+// center-to-center spacing so stacked rows stay legible. The vertical x-axis uses LABEL_PADDING
+// for the same purpose on width — this is its band-axis analogue for horizontal charts.
+const Y_LABEL_LINE_HEIGHT = 12
+const Y_LABEL_PADDING = 4
+
+/** Horizontal-orientation analogue of `computeVisibleXLabels`: returns the subset of category
+ *  (band) labels that fit down the y-axis without overlapping. When the plot is tall enough every
+ *  label clears the previous one and all are kept; when bands are compressed (e.g. a small
+ *  dashboard tile with many breakdowns) it thins them out evenly instead of stacking them into an
+ *  unreadable band. Label height is constant, so no per-label text measurement is needed. */
+export function computeVisibleYLabels(
+    labels: string[],
+    yScale: (label: string) => number | undefined,
+    formatter?: (value: string, index: number) => string | null
+): { index: number; text: string; y: number }[] {
+    const candidates: { index: number; text: string; y: number }[] = []
+    for (let i = 0; i < labels.length; i++) {
+        const text = formatter ? formatter(labels[i], i) : labels[i]
+        if (text === null) {
+            continue
+        }
+        const y = yScale(labels[i])
+        if (y == null || !isFinite(y)) {
+            continue
+        }
+        candidates.push({ index: i, text, y })
+    }
+
+    // Greedy from the top: keep a label only when it clears the last kept label's bottom edge plus
+    // padding, so the rendered set never overlaps regardless of how many bands are packed in.
+    candidates.sort((a, b) => a.y - b.y)
+    const visible: { index: number; text: string; y: number }[] = []
+    let lastBottomEdge = -Infinity
+    const halfHeight = Y_LABEL_LINE_HEIGHT / 2
+    for (const candidate of candidates) {
+        if (candidate.y - halfHeight >= lastBottomEdge + Y_LABEL_PADDING) {
+            visible.push(candidate)
+            lastBottomEdge = candidate.y + halfHeight
+        }
+    }
+    return visible
+}
+
 const TICK_STYLE_BASE: React.CSSProperties = {
     position: 'absolute',
     fontSize: 12,
@@ -164,36 +208,32 @@ export function AxisLabels({
         [hideXAxis, labels, scales.x, xTickFormatter, orientation]
     )
 
+    // In horizontal mode `scales.y` holds value→x-pixel and the label→y-pixel function lives on
+    // `scales.x` (or `labelToCoord` if explicitly overridden). Thin out overlapping category labels.
+    const visibleYLabels = useMemo(
+        () =>
+            hideYAxis || orientation !== 'horizontal'
+                ? []
+                : computeVisibleYLabels(labels, labelToCoord ?? scales.x, xTickFormatter),
+        [hideYAxis, orientation, labels, labelToCoord, scales.x, xTickFormatter]
+    )
+
     const rightFormatter = yRightTickFormatter ?? yTickFormatter
 
     if (orientation === 'horizontal') {
-        // In horizontal mode `scales.y` holds value→x-pixel and the label→y-pixel function lives
-        // on `scales.x` (or `labelToCoord` if explicitly overridden).
-        const labelToY = labelToCoord ?? scales.x
         return (
             <>
-                {!hideYAxis &&
-                    labels.map((labelText, i) => {
-                        const text = xTickFormatter ? xTickFormatter(labelText, i) : labelText
-                        if (text === null) {
-                            return null
-                        }
-                        const y = labelToY(labelText)
-                        if (y == null || !isFinite(y)) {
-                            return null
-                        }
-                        return (
-                            <YTickLabel
-                                key={`y-cat-${i}`}
-                                y={y}
-                                side="left"
-                                box={dimensions}
-                                text={text}
-                                color={axisColor}
-                                dataAttr="hog-chart-axis-tick-y"
-                            />
-                        )
-                    })}
+                {visibleYLabels.map(({ index, text, y }) => (
+                    <YTickLabel
+                        key={`y-cat-${index}`}
+                        y={y}
+                        side="left"
+                        box={dimensions}
+                        text={text}
+                        color={axisColor}
+                        dataAttr="hog-chart-axis-tick-y"
+                    />
+                ))}
                 {!hideXAxis &&
                     yTicks.map((tick: number) => {
                         const x = scales.y(tick)

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
@@ -453,3 +453,91 @@ const PERCENT_STACK_BREAKDOWN_INSIGHT = {
 export const PercentStackBreakdown: Story = {
     render: () => renderTrendsBarChart(PERCENT_STACK_BREAKDOWN_INSIGHT),
 }
+
+// Many breakdown values in a constrained dashboard-card-sized viz area: the category labels must
+// thin out instead of stacking into an unreadable overlapping band.
+const MANY_BREAKDOWN_VALUES = Array.from({ length: 40 }, (_, i) => `Category ${String(i + 1).padStart(2, '0')}`)
+
+const MANY_BREAKDOWN_INSIGHT = {
+    id: 203,
+    short_id: 'barValueMany',
+    name: 'Pageviews by category',
+    derived_name: 'Pageview count',
+    filters: {},
+    last_refresh: '2023-07-11T12:00:00Z',
+    refreshing: false,
+    saved: true,
+    is_sample: false,
+    description: 'Pageviews broken down by category',
+    tags: [],
+    favorited: false,
+    created_at: '2023-07-11T12:00:00Z',
+    updated_at: '2023-07-11T12:00:00Z',
+    last_modified_at: '2023-07-11T12:00:00Z',
+    dashboards: [],
+    dashboard_tiles: [],
+    result: MANY_BREAKDOWN_VALUES.map((value, i) => ({
+        action: ACTION,
+        label: value,
+        count: 0,
+        // Long-tailed: a couple of huge values, then a rapid decay to near-zero.
+        aggregated_value: Math.round(22000 / (i + 1)),
+        data: [],
+        labels: [],
+        days: [],
+        breakdown_value: value,
+        filter: {
+            date_from: '2023-07-04T00:00:00Z',
+            date_to: '2023-07-10T23:59:59Z',
+            display: 'ActionsBarValue',
+            insight: 'TRENDS',
+            interval: 'day',
+        },
+    })),
+    query: {
+        kind: 'InsightVizNode',
+        source: {
+            dateRange: { date_from: 'all' },
+            filterTestAccounts: false,
+            interval: 'day',
+            kind: 'TrendsQuery',
+            series: [{ event: '$pageview', kind: 'EventsNode', math: 'total', name: '$pageview' }],
+            trendsFilter: { display: 'ActionsBarValue' },
+            breakdownFilter: { breakdown: 'category', breakdown_type: 'event' },
+            version: 2,
+        },
+        full: true,
+    },
+}
+
+function renderInDashboardCard(insightFixture: any): JSX.Element {
+    const [dashboardItemId] = useState(() => `TrendsBarChartStory.${uniqueNode++}` as InsightShortId)
+    const cachedInsight = { ...insightFixture, short_id: dashboardItemId }
+    const insightProps: InsightLogicProps = { dashboardItemId, doNotLoad: true, cachedInsight }
+    const dataNodeLogicProps: DataNodeLogicProps = {
+        query: cachedInsight.query.source,
+        key: insightVizDataNodeKey(insightProps),
+        cachedResults: getCachedResults(cachedInsight, cachedInsight.query.source),
+        doNotLoad: true,
+    }
+    return (
+        <BindLogic logic={insightLogic} props={insightProps}>
+            <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
+                {/* Mimic the dashboard InsightCard: fixed 30rem card, header, then an
+                    overflow:auto viz area — the same constraints the real card imposes. */}
+                {/* eslint-disable-next-line react/forbid-dom-props */}
+                <div style={{ height: '30rem', width: 460, display: 'flex', flexDirection: 'column' }}>
+                    {/* eslint-disable-next-line react/forbid-dom-props */}
+                    <div style={{ height: 56, flexShrink: 0 }} />
+                    <div className="InsightCard__viz">
+                        <TrendsBarChart />
+                    </div>
+                </div>
+            </BindLogic>
+        </BindLogic>
+    )
+}
+
+export const DashboardManyBreakdowns: Story = {
+    render: () => renderInDashboardCard(MANY_BREAKDOWN_INSIGHT),
+}


### PR DESCRIPTION
## Problem

Horizontal bar charts in hog-charts (trends "value" bar charts, `ActionsBarValue`) rendered every category label with no overlap avoidance. When a breakdown has many values and the chart is squeezed into a small dashboard tile, the bands compress to a few pixels each and all the labels stack into an unreadable overlapping band. The vertical axis already thins labels via `computeVisibleXLabels`; the horizontal branch never had the equivalent.

## Changes

- Add `computeVisibleYLabels` to `AxisLabels.tsx` — the band-axis analogue of `computeVisibleXLabels`. Greedy top-to-bottom: keep a label only when it clears the previous kept label's bottom edge plus padding. Label height is constant, so no per-label text measurement is needed.
- Horizontal-orientation `AxisLabels` now renders this thinned subset instead of mapping every label. It's a no-op when rows have room (tall chart / scrolled card → all labels kept) and thins them out only when bands are compressed.
- Add a `DashboardManyBreakdowns` story rendering an `ActionsBarValue` insight with 40 synthetic breakdown values inside a dashboard-card-sized (`overflow:auto`, fixed-height) viz area, so the visual-regression snapshot covers this case.
- Add `AxisLabels.test.ts` unit tests for `computeVisibleYLabels`.

## How did you test this code?

I'm an agent. I ran the new unit tests (`AxisLabels.test.ts`, 5 cases, all passing) and per-file type-checked `AxisLabels.tsx` (clean). I could not screenshot the new story locally — the local Storybook iframe is broken by a pre-existing dependency mismatch (`@storybook/theming@8` pulling `storybook/internal/theming` while the CLI is `7.6.21`), which breaks every story, not just this one. The added story exists so CI's visual-regression job produces the snapshot; please eyeball it on the snapshot or on a real dashboard.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Investigated a report that a horizontal trends insight on a dashboard rendered all its category labels overlapping. Traced the path to the flag-gated hog-charts `TrendsBarChart` (aggregated `ActionsBarValue` → horizontal `BarChart`), and found the horizontal `AxisLabels` branch maps every label while the vertical branch already thins overlapping ones.

There's an existing `minBandSize`/`wrapperMinHeight` mechanism intended to grow the chart and let the card scroll, but on dashboards the tile stays compressed. Rather than depend on that, the chosen fix thins labels directly, which is correct either way: a no-op when there's room, thinning when there isn't. Whether dashboards *should* grow-and-scroll vs fit-and-thin is left as a separate question for the reviewer.