### PR TITLE
feat(user_interviews): show responded interviewees first on the topic page

### DIFF
--- a/products/user_interviews/frontend/UserInterview.tsx
+++ b/products/user_interviews/frontend/UserInterview.tsx
@@ -84,6 +84,10 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
     const pendingCount = totalTargeted - respondedCount
     const questionCount = topic.questions?.length || 0
     const allIdentifiers = [...(topic.interviewee_emails || []), ...(topic.interviewee_distinct_ids || [])]
+    // Responded interviewees first (grouped together), awaiting ones below — stable within each group.
+    const orderedIdentifiers = [...allIdentifiers].sort(
+        (a, b) => Number(respondedIdentifiers.has(b)) - Number(respondedIdentifiers.has(a))
+    )
 
     return (
         <SceneContent>
@@ -163,7 +167,7 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
                                     links.
                                 </div>
                             ) : (
-                                allIdentifiers.map((identifier) => (
+                                orderedIdentifiers.map((identifier) => (
                                     <PersonRow
                                         key={identifier}
                                         identifier={identifier}


### PR DESCRIPTION
## Problem

On a user-interview topic's People list, responded and awaiting interviewees were interleaved in targeting order, so you couldn't tell at a glance who had actually replied.

## Changes

Sort the topic's People list so interviewees who have responded appear first (grouped together), with awaiting ones below — a stable partition keyed on the existing `respondedIdentifiers` set. One-line, frontend-only.

Split out of #60808 (response classifications) so the two land independently.

## How did you test this code?

I'm an agent — no manual browser testing. The change is a pure stable sort over an existing `Set`; `respondedIdentifiers.has` is O(1). oxlint clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

Authored by PostHog Code. Extracted from the combined classifications PR (#60808) at the user's request to separate the ordering change from the tagging feature.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
