### PR TITLE
feat(provisioning): send email verification on agentic account creation

### DIFF
--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -65,6 +65,24 @@ class TestAccountRequests(ProvisioningTestBase):
         assert user.organization is not None
         assert user.team is not None
 
+    @patch("ee.api.agentic_provisioning.views.is_email_available", return_value=True)
+    @patch("ee.api.agentic_provisioning.views.is_email_verification_disabled", return_value=False)
+    @patch("ee.api.agentic_provisioning.views.EmailVerifier.create_token_and_send_email_verification")
+    def test_new_user_sends_email_verification(self, mock_send, _mock_disabled, _mock_available):
+        payload = self._account_request_payload()
+        res = self._post_signed("/api/agentic/provisioning/account_requests", data=payload)
+        assert res.status_code == 200
+        mock_send.assert_called_once()
+        assert mock_send.call_args.args[0].email == "newuser@example.com"
+
+    @patch("ee.api.agentic_provisioning.views.is_email_available", return_value=False)
+    @patch("ee.api.agentic_provisioning.views.EmailVerifier.create_token_and_send_email_verification")
+    def test_new_user_skips_email_verification_when_email_unavailable(self, mock_send, _mock_available):
+        payload = self._account_request_payload()
+        res = self._post_signed("/api/agentic/provisioning/account_requests", data=payload)
+        assert res.status_code == 200
+        mock_send.assert_not_called()
+
     def test_existing_user_returns_oauth_type_with_code(self):
         User.objects.create_and_join(
             organization=self.organization, email="existing@example.com", password="testpass", first_name="Existing"

--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -65,23 +65,31 @@ class TestAccountRequests(ProvisioningTestBase):
         assert user.organization is not None
         assert user.team is not None
 
-    @patch("ee.api.agentic_provisioning.views.is_email_available", return_value=True)
-    @patch("ee.api.agentic_provisioning.views.is_email_verification_disabled", return_value=False)
-    @patch("ee.api.agentic_provisioning.views.EmailVerifier.create_token_and_send_email_verification")
-    def test_new_user_sends_email_verification(self, mock_send, _mock_disabled, _mock_available):
-        payload = self._account_request_payload()
-        res = self._post_signed("/api/agentic/provisioning/account_requests", data=payload)
-        assert res.status_code == 200
-        mock_send.assert_called_once()
-        assert mock_send.call_args.args[0].email == "newuser@example.com"
-
-    @patch("ee.api.agentic_provisioning.views.is_email_available", return_value=False)
-    @patch("ee.api.agentic_provisioning.views.EmailVerifier.create_token_and_send_email_verification")
-    def test_new_user_skips_email_verification_when_email_unavailable(self, mock_send, _mock_available):
-        payload = self._account_request_payload()
-        res = self._post_signed("/api/agentic/provisioning/account_requests", data=payload)
-        assert res.status_code == 200
-        mock_send.assert_not_called()
+    @parameterized.expand(
+        [
+            ("email_unavailable", False, False, False),
+            ("verification_disabled", True, True, False),
+            ("email_available_and_enabled", True, False, True),
+        ]
+    )
+    def test_new_user_email_verification_branches(self, _name, email_available, verification_disabled, should_send):
+        with (
+            patch("ee.api.agentic_provisioning.views.is_email_available", return_value=email_available),
+            patch(
+                "ee.api.agentic_provisioning.views.is_email_verification_disabled",
+                return_value=verification_disabled,
+            ),
+            patch(
+                "ee.api.agentic_provisioning.views.EmailVerifier.create_token_and_send_email_verification"
+            ) as mock_send,
+        ):
+            res = self._post_signed("/api/agentic/provisioning/account_requests", data=self._account_request_payload())
+            assert res.status_code == 200
+            if should_send:
+                mock_send.assert_called_once()
+                assert mock_send.call_args.args[0].email == "newuser@example.com"
+            else:
+                mock_send.assert_not_called()
 
     def test_existing_user_returns_oauth_type_with_code(self):
         User.objects.create_and_join(

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -25,7 +25,7 @@ import requests
 import structlog
 import posthoganalytics
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.exceptions import APIException, AuthenticationFailed
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -742,6 +742,10 @@ def _handle_new_user(
     if is_email_available() and not user.is_email_verified and not is_email_verification_disabled(user):
         try:
             EmailVerifier.create_token_and_send_email_verification(user)
+        except APIException:
+            # Send failures are already captured inside EmailVerifier; swallow so a mail
+            # problem doesn't fail provisioning, and avoid a duplicate error report.
+            pass
         except Exception:
             capture_exception(additional_properties={"user_id": user.id, "step": "provisioning_email_verification"})
 

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -31,6 +31,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.authentication import password_reset_token_generator
+from posthog.api.email_verification import EmailVerifier, is_email_verification_disabled
+from posthog.email import is_email_available
 from posthog.exceptions_capture import capture_exception
 from posthog.models.integration import StripeIntegration
 from posthog.models.oauth import (
@@ -736,6 +738,12 @@ def _handle_new_user(
         send_provisioning_welcome.delay(user.id, reset_token, partner_label)
     except Exception:
         capture_exception(additional_properties={"user_id": user.id, "step": "provisioning_welcome_email"})
+
+    if is_email_available() and not user.is_email_verified and not is_email_verification_disabled(user):
+        try:
+            EmailVerifier.create_token_and_send_email_verification(user)
+        except Exception:
+            capture_exception(additional_properties={"user_id": user.id, "step": "provisioning_email_verification"})
 
     code = secrets.token_urlsafe(32)
     cache_key = f"{AUTH_CODE_CACHE_PREFIX}{code}"


### PR DESCRIPTION
## Problem

Accounts created via agentic/marketplace provisioning (e.g. the Vercel integration) are created **unverified** and never receive a verification email — yet the in-app banner still prompts the user to verify their address. The user is left with a verify prompt and no email behind it.

## Changes

In `_handle_new_user` (`ee/api/agentic_provisioning/views.py`), after the account is bootstrapped, send the email-verification email — the same trigger the normal signup path uses. Gated on email being available for the instance and verification not being disabled for the org, and wrapped so a mail failure can't fail the provisioning flow (which still returns the OAuth code).

This applies to all agentic-provisioned accounts (not just one partner), since the path is partner-agnostic.

**Deliberately does not auto-verify.** Marking provisioned accounts verified would be cleaner UX (no banner, no email), but the partner-supplied email isn't trusted as proof of ownership, so we keep real verification. (Social/SSO signup auto-verifies because the OAuth handshake proves ownership; marketplace provisioning doesn't give us that.)

## How did you test this code?

I'm an agent (Claude Code). Automated tests added to `test_account_requests.py`:

- `test_new_user_sends_email_verification` — asserts the verification send is triggered for a new provisioned user (email available, verification enabled).
- `test_new_user_skips_email_verification_when_email_unavailable` — asserts it's skipped when email isn't configured.

These exercise the new branch via the existing provisioning request flow. CI runs the full `TestAccountRequests` suite.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

Authored with Claude Code (Claude Opus 4.8). Split from a sibling frontend PR that fixes the banner's "Send verification email" CTA. The send-vs-auto-verify question was a deliberate product/security decision: auto-verify was considered and rejected because we don't trust the partner-supplied email as ownership proof. The two-emails outcome (existing "set your password" welcome + this verification email) is known and accepted. Requires human review.
