### PR TITLE
fix(insights): fit horizontal bar charts to dashboard tiles

### DIFF
--- a/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/BarChart/BarChart.tsx
@@ -169,14 +169,17 @@ function BarChartInner<Meta = unknown>({
         maxBandRange,
         bandPadding,
         minBandSize,
+        fitToHeight = false,
         valueDomain,
         roundStackEnds = false,
     } = config?.bars ?? {}
     const isHorizontal = axisOrientation === 'horizontal'
 
     const resolvedMinBandSize = minBandSize ?? (isHorizontal ? HORIZONTAL_MIN_BAND_SIZE_DEFAULT : 0)
+    // Fit-to-height drops overflow rows instead of growing the container, so it never sets a
+    // wrapper floor — the chart fills whatever height the tile gives it.
     const wrapperMinHeight = useMemo(() => {
-        if (!isHorizontal || resolvedMinBandSize <= 0) {
+        if (!isHorizontal || fitToHeight || resolvedMinBandSize <= 0) {
             return undefined
         }
         const uniqueBands = new Set(labels).size
@@ -184,7 +187,7 @@ function BarChartInner<Meta = unknown>({
             return undefined
         }
         return uniqueBands * resolvedMinBandSize + HORIZONTAL_CHART_MARGIN_PX
-    }, [isHorizontal, resolvedMinBandSize, labels])
+    }, [isHorizontal, fitToHeight, resolvedMinBandSize, labels])
 
     const stackedData = useMemo((): Map<string, StackedBand> | undefined => {
         if (barLayout === 'percent') {
@@ -256,6 +259,8 @@ function BarChartInner<Meta = unknown>({
                 stackedSeries,
                 maxBandRange,
                 bandPadding,
+                fitToHeight,
+                minBandSize: resolvedMinBandSize,
                 valueDomain,
             })
 
@@ -315,6 +320,8 @@ function BarChartInner<Meta = unknown>({
             divergingStack,
             maxBandRange,
             bandPadding,
+            fitToHeight,
+            resolvedMinBandSize,
             valueDomain,
         ]
     )

--- a/frontend/src/lib/hog-charts/core/scales.test.ts
+++ b/frontend/src/lib/hog-charts/core/scales.test.ts
@@ -6,6 +6,7 @@ import {
     computeDivergingStackData,
     computePercentStackData,
     computeStackData,
+    createBarScales,
     createScales,
     createXScale,
     createYScale,
@@ -699,6 +700,54 @@ describe('hog-charts scales', () => {
             const resolve = buildSegmentResolveValue(computePercentStackData([a, b], ['x', 'y']))!
             expect(resolve(a, 1)).toBeCloseTo(20 / 35, 5)
             expect(resolve(b, 1)).toBeCloseTo(15 / 35, 5)
+        })
+    })
+
+    describe('createBarScales — horizontal fitToHeight', () => {
+        // plotHeight 100 / minBandSize 24 => 4 rows fit.
+        const shortDims = { ...dimensions, plotTop: 0, plotHeight: 100 }
+        const labels = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
+        const series = [makeSeries({ key: 's', data: labels.map((_, i) => 10 - i) })]
+
+        it('caps the band domain to the rows that fit at minBandSize, keeping the leading rows', () => {
+            const { band } = createBarScales(series, labels, shortDims, {
+                axisOrientation: 'horizontal',
+                fitToHeight: true,
+                minBandSize: 24,
+            })
+            expect(band.domain()).toEqual(['a', 'b', 'c', 'd'])
+            expect(band.bandwidth()).toBeGreaterThanOrEqual(20)
+        })
+
+        it('keeps every row when they all fit', () => {
+            const { band } = createBarScales(
+                series.map((s) => ({ ...s, data: [1, 2, 3] })),
+                ['a', 'b', 'c'],
+                shortDims,
+                {
+                    axisOrientation: 'horizontal',
+                    fitToHeight: true,
+                    minBandSize: 24,
+                }
+            )
+            expect(band.domain()).toEqual(['a', 'b', 'c'])
+        })
+
+        it('does not cap when fitToHeight is off (grow-to-fit-all behavior)', () => {
+            const { band } = createBarScales(series, labels, shortDims, {
+                axisOrientation: 'horizontal',
+                minBandSize: 24,
+            })
+            expect(band.domain()).toEqual(labels)
+        })
+
+        it('ignores fitToHeight for vertical charts', () => {
+            const { band } = createBarScales(series, labels, shortDims, {
+                axisOrientation: 'vertical',
+                fitToHeight: true,
+                minBandSize: 24,
+            })
+            expect(band.domain()).toEqual(labels)
         })
     })
 })

--- a/frontend/src/lib/hog-charts/core/scales.ts
+++ b/frontend/src/lib/hog-charts/core/scales.ts
@@ -387,6 +387,11 @@ export function createBarScales(
         stackedSeries?: Series[]
         /** Cap on the band-axis range in px — clusters bars at the start of the plot when set. */
         maxBandRange?: number
+        /** Horizontal fit-to-height mode: drop the rows that can't fit at `minBandSize` so bands
+         *  never crush below it and the plot fills the height it's given. Requires `minBandSize`. */
+        fitToHeight?: boolean
+        /** Minimum px per row — only consulted to compute the `fitToHeight` row cap. */
+        minBandSize?: number
         /** Fixed `[min, max]` or `{ include }` extra values the value axis must cover. */
         valueDomain?: ValueDomain
     } = {}
@@ -399,6 +404,8 @@ export function createBarScales(
         groupPadding = 0.1,
         stackedSeries,
         maxBandRange,
+        fitToHeight,
+        minBandSize,
         valueDomain,
     } = options
 
@@ -408,9 +415,20 @@ export function createBarScales(
     const bandAxisStart = isHorizontal ? dimensions.plotTop : dimensions.plotLeft
     const bandAxisExtent = isHorizontal ? dimensions.plotHeight : dimensions.plotWidth
     const cappedExtent = maxBandRange != null ? Math.min(bandAxisExtent, maxBandRange) : bandAxisExtent
+
+    // Fit-to-height: only keep the rows that fit at `minBandSize`. Labels arrive value-sorted, so
+    // slicing keeps the leading rows. Bars/labels/grid all resolve through `band(label)`, so a
+    // dropped label resolves to `undefined` and is skipped everywhere — no extra plumbing needed.
+    let domainLabels = labels
+    if (isHorizontal && fitToHeight && minBandSize && minBandSize > 0) {
+        const maxBands = Math.max(1, Math.floor(cappedExtent / minBandSize))
+        if (labels.length > maxBands) {
+            domainLabels = labels.slice(0, maxBands)
+        }
+    }
     const band = d3
         .scaleBand<string>()
-        .domain(labels)
+        .domain(domainLabels)
         .range([bandAxisStart, bandAxisStart + cappedExtent])
         .paddingInner(bandPadding)
         .paddingOuter(bandPadding / 2)

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -245,6 +245,11 @@ export interface BarsConfig {
      *  an unreadable strip, the chart expands its container height so each row has at least this
      *  much vertical space (label height + breathing room). Defaults to `24`. Pass `0` to opt out. */
     minBandSize?: number
+    /** Horizontal bar charts only — fit the chart to the height it's given instead of expanding the
+     *  container (the {@link minBandSize} default behavior). Rows that don't fit at `minBandSize` are
+     *  dropped, keeping the leading (value-sorted) rows, so bands never crush below `minBandSize` and
+     *  the container never grows or scrolls. Use inside fixed-height tiles such as dashboard cards. */
+    fitToHeight?: boolean
     /** Value-axis domain control — omit for data-derived auto-scaling. See {@link ValueDomain}. */
     valueDomain?: ValueDomain
     /** Stacked layouts only — round both *outer* ends of the whole stack so it reads as one pill,

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -77,7 +77,7 @@ const handleChartError = makeChartErrorHandler('trends-bar-chart')
 
 export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChartProps): JSX.Element | null {
     const theme = useMemo(() => buildTheme(), [])
-    const { insightProps, insight } = useValues(insightLogic)
+    const { insightProps, insight, isInDashboardContext } = useValues(insightLogic)
 
     const {
         indexedResults,
@@ -247,6 +247,9 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
             xTickFormatter,
             xAxisLabel: trendsFilter?.xAxisLabel,
             yAxisLabel: trendsFilter?.yAxisLabel,
+            // On a dashboard the tile is a fixed height: fit the rows that fit instead of growing
+            // the tile and scrolling. On the full insight page, keep the grow-to-fit-all behavior.
+            bars: { fitToHeight: isInDashboardContext },
         }
     }, [
         yAxisScaleType,
@@ -255,6 +258,7 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
         trendsFilter?.yAxisLabel,
         displayLabels,
         labels,
+        isInDashboardContext,
     ])
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal


### PR DESCRIPTION
## Problem

Aggregated horizontal bar charts (trends "total value" bars, `ActionsBarValue`) grew their container to give every row `minBandSize` px and scrolled. On a fixed-height dashboard tile that doesn't grow, the rows crammed in and the category labels overlapped into an unreadable band on first paint — then, once the tile's nested-flex layout settled and the chart re-measured, it corrected itself. So the bug showed up as a flash of overlapping labels on tile load.

## Changes

- Add a `fitToHeight` option to `BarsConfig`. When set (horizontal only), the chart fits the height it's given instead of expanding the container.
- In `createBarScales`, fit mode caps the band-scale domain to the rows that fit at `minBandSize` (`floor(plotHeight / minBandSize)`), keeping the leading (value-sorted) rows. Bars, labels and gridlines all resolve through `band(label)`, so a dropped label resolves to `undefined` and is skipped everywhere — no extra plumbing.
- `BarChart` skips the wrapper `minHeight` growth in fit mode and threads `minBandSize`/`fitToHeight` into the scales.
- `TrendsBarChart` turns on `fitToHeight` only when `insightLogic`'s `isInDashboardContext` is true, so dashboard tiles fit while the full insight page keeps the grow-to-fit-all (scroll) behavior.
- Because the row cap is derived from the measured height, it also removes the load flash: there's no compressed intermediate paint to correct.

## How did you test this code?

I'm an agent. Automated: added `createBarScales` fit-to-height unit tests and ran the hog-charts BarChart/scales and TrendsBarChart suites (175+ tests green); per-file type-checked the changed files. Manual: built a real dashboard tile (`$pageview` by Current URL, 51 values) in the local app and confirmed via DOM measurement that the tile no longer scrolls, the canvas fits the tile (~394px, not the old ~1294px), and ~14 rows render at ≥24px spacing with no overlap. The full insight page still shows all 51 rows.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Started from a report that a horizontal trends insight overlapped its labels on a dashboard. Initial attempt thinned overlapping labels in `AxisLabels`, but live inspection showed the steady state was already fine (the chart grows to ~1294px with all labels at 24px) — the overlap was a transient flash while the constrained tile settled. After confirming the desired dashboard behavior is fit-the-tile (not grow-and-scroll), the fix moved to capping the band scale by available height, which fixes both the overlap and the flash and supersedes the earlier label-thinning PR (#61236).