### PR TITLE
feat(data-warehouse): add oauth2 auth to custom REST source

### DIFF
--- a/posthog/temporal/data_imports/sources/common/rest_source/auth.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/auth.py
@@ -5,6 +5,8 @@ from typing import Literal, Optional
 from requests import PreparedRequest
 from requests.auth import AuthBase
 
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+
 TApiKeyLocation = Literal["header", "query", "param", "cookie"]
 TOAuth2GrantType = Literal["client_credentials", "refresh_token"]
 
@@ -146,12 +148,6 @@ class OAuth2Auth(AuthConfigBase):
         return datetime.now(UTC) >= self._expires_at
 
     def _obtain_token(self) -> None:
-        # Imported here to keep the heavy HTTP transport stack off this module's
-        # import path (it is imported by the source registry at startup).
-        from posthog.temporal.data_imports.sources.common.http import (  # noqa: PLC0415 — avoids import cycle with the transport stack
-            make_tracked_session,
-        )
-
         if not self.token_url:
             raise OAuth2TokenError("token_url is required to obtain an OAuth2 access token")
 
@@ -186,10 +182,16 @@ class OAuth2Auth(AuthConfigBase):
 
         expires_in = payload.get(self.expires_in_name)
         try:
-            seconds = int(expires_in) if expires_in is not None else _OAUTH2_DEFAULT_EXPIRES_IN
+            # float() first so a string like "300.0" parses instead of falling
+            # back to the 1-hour default and masking a genuinely short TTL.
+            seconds = int(float(expires_in)) if expires_in is not None else _OAUTH2_DEFAULT_EXPIRES_IN
         except (TypeError, ValueError):
             seconds = _OAUTH2_DEFAULT_EXPIRES_IN
-        self._expires_at = datetime.now(UTC) + timedelta(seconds=seconds) - _OAUTH2_EXPIRY_MARGIN
+        # Re-mint slightly before expiry, but never let the safety margin push the
+        # deadline into the past for a short-lived token — otherwise the token
+        # reads as already-expired and re-mints on every paginated request.
+        margin = min(_OAUTH2_EXPIRY_MARGIN, timedelta(seconds=seconds / 2))
+        self._expires_at = datetime.now(UTC) + timedelta(seconds=seconds) - margin
 
     def secret_values(self) -> tuple[str, ...]:
         return tuple(value for value in (self.client_secret, self.refresh_token, self._access_token) if value)

--- a/posthog/temporal/data_imports/sources/common/rest_source/auth.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/auth.py
@@ -1,10 +1,18 @@
 from base64 import b64encode
+from datetime import UTC, datetime, timedelta
 from typing import Literal, Optional
 
 from requests import PreparedRequest
 from requests.auth import AuthBase
 
 TApiKeyLocation = Literal["header", "query", "param", "cookie"]
+TOAuth2GrantType = Literal["client_credentials", "refresh_token"]
+
+# Used when the token endpoint omits `expires_in`; mirrors the 1-hour default
+# the existing SalesforceAuth assumes. The safety margin re-mints slightly early
+# so a token never expires mid-request.
+_OAUTH2_DEFAULT_EXPIRES_IN = 3600
+_OAUTH2_EXPIRY_MARGIN = timedelta(seconds=60)
 
 
 class AuthConfigBase(AuthBase):
@@ -78,6 +86,113 @@ class HttpBasicAuth(AuthConfigBase):
 
     def secret_values(self) -> tuple[str, ...]:
         return (self.password,) if self.password else ()
+
+
+class OAuth2TokenError(Exception):
+    """Raised when the OAuth2 token endpoint rejects the credential exchange."""
+
+
+class OAuth2Auth(AuthConfigBase):
+    """OAuth2 ``client_credentials`` / ``refresh_token`` authenticator.
+
+    Exchanges user-supplied credentials at a token endpoint for an access token
+    at request time and injects it as a ``Bearer`` (or custom-prefixed) header,
+    re-minting on expiry. The token is cached in-memory for the life of this auth
+    object only — nothing is persisted, so rotating single-use refresh tokens are
+    not supported (a fresh access token is obtained from the stable
+    ``refresh_token`` / client credentials on each new sync).
+
+    Modeled on :class:`~posthog.temporal.data_imports.sources.salesforce.auth.SalesforceAuth`,
+    but generic over a user-provided ``token_url`` and client credentials. The
+    token POST goes through ``make_tracked_session()`` so it is logged and the
+    credentials are redacted; ``token_url`` itself is vetted for SSRF at manifest
+    validation time, the same as every other URL in a custom-source manifest.
+    """
+
+    def __init__(
+        self,
+        token_url: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        grant_type: TOAuth2GrantType = "refresh_token",
+        refresh_token: Optional[str] = None,
+        scopes: Optional[list[str] | str] = None,
+        access_token_name: str = "access_token",
+        expires_in_name: str = "expires_in",
+        header_prefix: str = "Bearer",
+    ) -> None:
+        self.token_url = token_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.grant_type = grant_type
+        self.refresh_token = refresh_token
+        # Normalize scopes to the space-delimited string the token endpoint expects.
+        self.scopes = " ".join(scopes) if isinstance(scopes, list) else scopes
+        self.access_token_name = access_token_name
+        self.expires_in_name = expires_in_name
+        self.header_prefix = header_prefix
+        self._access_token: Optional[str] = None
+        self._expires_at: Optional[datetime] = None
+
+    def __call__(self, request: PreparedRequest) -> PreparedRequest:
+        if self._access_token is None or self._is_expired():
+            self._obtain_token()
+        request.headers["Authorization"] = f"{self.header_prefix} {self._access_token}"
+        return request
+
+    def _is_expired(self) -> bool:
+        if self._expires_at is None:
+            return True
+        return datetime.now(UTC) >= self._expires_at
+
+    def _obtain_token(self) -> None:
+        # Imported here to keep the heavy HTTP transport stack off this module's
+        # import path (it is imported by the source registry at startup).
+        from posthog.temporal.data_imports.sources.common.http import (  # noqa: PLC0415 — avoids import cycle with the transport stack
+            make_tracked_session,
+        )
+
+        if not self.token_url:
+            raise OAuth2TokenError("token_url is required to obtain an OAuth2 access token")
+
+        body: dict[str, str] = {"grant_type": self.grant_type}
+        if self.client_id:
+            body["client_id"] = self.client_id
+        if self.client_secret:
+            body["client_secret"] = self.client_secret
+        if self.grant_type == "refresh_token":
+            if not self.refresh_token:
+                raise OAuth2TokenError("refresh_token is required for the refresh_token grant")
+            body["refresh_token"] = self.refresh_token
+        if self.scopes:
+            body["scope"] = self.scopes
+
+        session = make_tracked_session(redact_values=self.secret_values())
+        response = session.post(self.token_url, data=body, timeout=30)
+        if response.status_code >= 400:
+            raise OAuth2TokenError(
+                f"Token endpoint {self.token_url} returned HTTP {response.status_code}: {response.text[:200]}"
+            )
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise OAuth2TokenError(f"Token endpoint {self.token_url} returned a non-JSON response") from exc
+
+        token = payload.get(self.access_token_name)
+        if not token:
+            raise OAuth2TokenError(f"Token endpoint {self.token_url} response had no {self.access_token_name!r} field")
+        self._access_token = token
+
+        expires_in = payload.get(self.expires_in_name)
+        try:
+            seconds = int(expires_in) if expires_in is not None else _OAUTH2_DEFAULT_EXPIRES_IN
+        except (TypeError, ValueError):
+            seconds = _OAUTH2_DEFAULT_EXPIRES_IN
+        self._expires_at = datetime.now(UTC) + timedelta(seconds=seconds) - _OAUTH2_EXPIRY_MARGIN
+
+    def secret_values(self) -> tuple[str, ...]:
+        return tuple(value for value in (self.client_secret, self.refresh_token, self._access_token) if value)
 
 
 def auth_secret_values(auth: Optional[AuthBase]) -> tuple[str, ...]:

--- a/posthog/temporal/data_imports/sources/common/rest_source/config_setup.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/config_setup.py
@@ -8,7 +8,7 @@ from typing import Any, NamedTuple, Optional, cast
 
 from requests import Response
 
-from .auth import APIKeyAuth, AuthConfigBase, BearerTokenAuth, HttpBasicAuth
+from .auth import APIKeyAuth, AuthConfigBase, BearerTokenAuth, HttpBasicAuth, OAuth2Auth
 from .exceptions import IgnoreResponseException
 from .jsonpath_utils import find_values
 from .paginators import (
@@ -51,6 +51,7 @@ AUTH_MAP: dict[AuthType, type[AuthConfigBase]] = {
     "bearer": BearerTokenAuth,
     "api_key": APIKeyAuth,
     "http_basic": HttpBasicAuth,
+    "oauth2": OAuth2Auth,
 }
 
 

--- a/posthog/temporal/data_imports/sources/common/rest_source/typing.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/typing.py
@@ -2,7 +2,15 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional, TypedDict
 
-from .auth import APIKeyAuth, AuthConfigBase, BearerTokenAuth, HttpBasicAuth, TApiKeyLocation
+from .auth import (
+    APIKeyAuth,
+    AuthConfigBase,
+    BearerTokenAuth,
+    HttpBasicAuth,
+    OAuth2Auth,
+    TApiKeyLocation,
+    TOAuth2GrantType,
+)
 from .jsonpath_utils import TJsonPath, compile_path
 from .paginators import (
     BasePaginator,
@@ -85,7 +93,7 @@ PaginatorConfig = (
 )
 
 
-AuthType = Literal["bearer", "api_key", "http_basic"]
+AuthType = Literal["bearer", "api_key", "http_basic", "oauth2"]
 
 
 class AuthTypeConfig(TypedDict, total=True):
@@ -108,15 +116,29 @@ class HttpBasicAuthConfig(AuthTypeConfig, total=True):
     password: str
 
 
+class OAuth2AuthConfig(AuthTypeConfig, total=False):
+    token_url: str
+    client_id: Optional[str]
+    client_secret: Optional[str]
+    grant_type: Optional[TOAuth2GrantType]
+    refresh_token: Optional[str]
+    scopes: Optional[list[str] | str]
+    access_token_name: Optional[str]
+    expires_in_name: Optional[str]
+    header_prefix: Optional[str]
+
+
 AuthConfig = (
     AuthConfigBase
     | AuthType
     | BearerTokenAuthConfig
     | ApiKeyAuthConfig
     | HttpBasicAuthConfig
+    | OAuth2AuthConfig
     | BearerTokenAuth
     | APIKeyAuth
     | HttpBasicAuth
+    | OAuth2Auth
 )
 
 

--- a/posthog/temporal/data_imports/sources/custom/README.md
+++ b/posthog/temporal/data_imports/sources/custom/README.md
@@ -1,0 +1,91 @@
+# Custom REST source
+
+A user-defined data-warehouse source. The user supplies a JSON **manifest** in the same
+`RESTAPIConfig` shape that powers the built-in REST sources (Attio, Chargebee, Clerk, …), so the
+shared REST engine in [`../common/rest_source/`](../common/rest_source/) handles pagination, auth,
+JSONPath extraction, and incremental params with no per-source code.
+
+The source is alpha and gated to a single pilot team on PostHog Cloud US
+(`is_custom_source_available_for_team`) plus the `dwh_custom_source` feature flag, until SSRF
+protection for arbitrary user-supplied URLs is fully enabled.
+
+## Manifest shape
+
+```jsonc
+{
+  "client": {
+    "base_url": "https://api.example.com/v1/",
+    "auth": {
+      /* see Auth below */
+    },
+    "headers": { "Accept": "application/json" }, // optional, non-secret
+  },
+  "resources": [
+    {
+      "name": "orders",
+      "primary_key": "id",
+      "sort_mode": "asc", // "asc" (default) | "desc"
+      "endpoint": {
+        "path": "orders",
+        "method": "GET", // GET | POST only
+        "data_selector": "data", // JSONPath to the row array
+        "incremental": { "cursor_path": "updated_at", "start_param": "since", "cursor_type": "datetime" },
+      },
+    },
+  ],
+}
+```
+
+Credentials are **never** embedded inline in the manifest — the manifest is non-secret and
+round-trips to the client. Secret values live in the dedicated `auth_*` config fields (encrypted in
+`job_inputs`, redacted from API reads) and are rejoined into `client.auth` at sync time by
+`_inject_auth_secrets`.
+
+## Auth
+
+The manifest's `client.auth.type` selects one of four authenticators. Non-secret fields go in the
+manifest; the matching secret goes in the indicated `auth_*` field.
+
+| `type`       | Manifest (non-secret) fields                                                                                | Secret field                               |
+| ------------ | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `bearer`     | —                                                                                                           | `auth_token`                               |
+| `api_key`    | `name`, `location` (`header`/`query`/`param`/`cookie`)                                                      | `auth_api_key`                             |
+| `http_basic` | `username`                                                                                                  | `auth_password`                            |
+| `oauth2`     | `token_url`\*, `client_id`, `grant_type`, `scopes`, `access_token_name`, `expires_in_name`, `header_prefix` | `auth_client_secret`, `auth_refresh_token` |
+
+\* `token_url` is required for `oauth2` and is SSRF-vetted (host safety + https-on-cloud) the same
+as `base_url` and every resource URL. Changing it forces the secrets to be re-entered (retarget guard).
+
+### OAuth2
+
+Supports the `client_credentials` and (non-rotating) `refresh_token` grants. The access token is
+minted from the token endpoint at sync time and cached in-memory until expiry — nothing is
+persisted, so providers that rotate single-use refresh tokens (e.g. QuickBooks/Intuit) are not yet
+supported. Credentials are pasted directly (there is no browser OAuth connect flow); obtain a
+`refresh_token` / client credentials out-of-band first.
+
+`grant_type` defaults to `refresh_token`. Defaults: `access_token_name="access_token"`,
+`expires_in_name="expires_in"`, `header_prefix="Bearer"` (set e.g. `"Zoho-oauthtoken"` for Zoho).
+
+**client_credentials** (e.g. PayPal, Zoom, Auth0 confidential app):
+
+```jsonc
+{
+  "client": {
+    "base_url": "https://api.example.com/v1/",
+    "auth": {
+      "type": "oauth2",
+      "token_url": "https://auth.example.com/oauth/token",
+      "grant_type": "client_credentials",
+      "client_id": "abc123",
+      "scopes": ["read"],
+    },
+  },
+  "resources": [{ "name": "orders", "endpoint": { "path": "orders" } }],
+}
+```
+
+…with `auth_client_secret` set in the secret field.
+
+**refresh_token** (e.g. Zoho CRM): same block with `"grant_type": "refresh_token"`, plus
+`auth_refresh_token` set in the secret field.

--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -32,7 +32,7 @@ from products.data_warehouse.backend.types import ExternalDataSourceType, Increm
 
 # Credential keys that must NOT appear inline in the manifest — they belong in
 # the dedicated secret `auth_*` config fields so the API layer can redact them.
-INLINE_SECRET_KEYS = ("token", "api_key", "password")
+INLINE_SECRET_KEYS = ("token", "api_key", "password", "client_secret", "refresh_token", "access_token")
 
 
 def is_custom_source_available_for_team(team_id: int | None) -> bool:
@@ -57,10 +57,19 @@ class _ManifestAuth(BaseModel):
     # engine's `create_auth` with an unexpected-kwarg TypeError at sync time.
     model_config = ConfigDict(extra="forbid")
 
-    type: Literal["bearer", "api_key", "http_basic"]
+    type: Literal["bearer", "api_key", "http_basic", "oauth2"]
     name: str | None = None
     location: Literal["header", "query", "param", "cookie"] | None = None
     username: str | None = None
+    # OAuth2 (non-secret) fields. The secrets — client_secret, refresh_token —
+    # live in the dedicated `auth_*` config fields and are injected at sync time.
+    token_url: str | None = None
+    client_id: str | None = None
+    grant_type: Literal["client_credentials", "refresh_token"] | None = None
+    scopes: list[str] | str | None = None
+    access_token_name: str | None = None
+    expires_in_name: str | None = None
+    header_prefix: str | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -74,6 +83,14 @@ class _ManifestAuth(BaseModel):
                     f"Credentials ({', '.join(inline)}) must not be embedded — use the dedicated auth fields"
                 )
         return data
+
+    @model_validator(mode="after")
+    def _oauth2_requires_token_url(self) -> "_ManifestAuth":
+        # token_url is the endpoint the credential is POSTed to — it must be
+        # present (and is SSRF-vetted by validate_manifest_urls) for oauth2.
+        if self.type == "oauth2" and not self.token_url:
+            raise ValueError("oauth2 auth requires a token_url")
+        return self
 
 
 class _ManifestClient(BaseModel):
@@ -157,10 +174,21 @@ def validate_manifest_urls(manifest: dict[str, Any], team_id: int) -> tuple[bool
     the host check via :func:`_is_host_safe` (which is itself a no-op
     outside of cloud).
     """
-    base_url = manifest["client"]["base_url"]
+    client = manifest["client"]
+    base_url = client["base_url"]
     ok, err = _check_url(base_url, team_id)
     if not ok:
         return False, f"Invalid base_url: {err}"
+
+    # The OAuth2 token endpoint is a user-supplied URL the server POSTs the
+    # credential to, so it gets the same host-safety + https-on-cloud vetting.
+    auth = client.get("auth")
+    if isinstance(auth, dict) and auth.get("type") == "oauth2":
+        token_url = auth.get("token_url")
+        if isinstance(token_url, str) and token_url:
+            ok, err = _check_url(token_url, team_id)
+            if not ok:
+                return False, f"Invalid token_url: {err}"
 
     base_host = _url_hostname(base_url)
     for resource in manifest["resources"]:
@@ -255,6 +283,15 @@ def manifest_request_hosts(manifest_json: Any) -> frozenset[str]:
     base_for_resolve = base_url if isinstance(base_url, str) else ""
 
     urls: list[str] = [base_url] if isinstance(base_url, str) else []
+
+    # The OAuth2 token endpoint also receives the credential, so a change to it
+    # must trip the retarget guard and force the secret to be re-entered.
+    auth = client.get("auth") if isinstance(client, dict) else None
+    if isinstance(auth, dict) and auth.get("type") == "oauth2":
+        token_url = auth.get("token_url")
+        if isinstance(token_url, str):
+            urls.append(token_url)
+
     resources = manifest.get("resources")
     if isinstance(resources, list):
         for resource in resources:
@@ -350,6 +387,25 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
                     SourceFieldInputConfig(
                         name="auth_password",
                         label="Auth password",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=False,
+                        placeholder="",
+                        secret=True,
+                    ),
+                    # OAuth2 secrets — used when the manifest's client.auth.type is
+                    # "oauth2". client_id / token_url are non-secret and live in the
+                    # manifest; these credentials are injected at sync time.
+                    SourceFieldInputConfig(
+                        name="auth_client_secret",
+                        label="OAuth client secret",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=False,
+                        placeholder="",
+                        secret=True,
+                    ),
+                    SourceFieldInputConfig(
+                        name="auth_refresh_token",
+                        label="OAuth refresh token",
                         type=SourceFieldInputConfigType.PASSWORD,
                         required=False,
                         placeholder="",
@@ -577,6 +633,11 @@ def _inject_auth_secrets(manifest: dict[str, Any], config: CustomSourceConfig) -
         auth["api_key"] = config.auth_api_key
     elif auth_type == "http_basic" and config.auth_password:
         auth["password"] = config.auth_password
+    elif auth_type == "oauth2":
+        if config.auth_client_secret:
+            auth["client_secret"] = config.auth_client_secret
+        if config.auth_refresh_token:
+            auth["refresh_token"] = config.auth_refresh_token
 
 
 def _incremental_field_type(raw: Any) -> IncrementalFieldType:

--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -167,6 +167,25 @@ def _format_validation_errors(exc: ValidationError) -> str:
     return "; ".join(messages)
 
 
+def _oauth2_token_url(client: Any) -> str | None:
+    """The OAuth2 token endpoint declared in a manifest's ``client.auth``, if any.
+
+    Single source of truth for the two sites that must treat ``token_url`` as a
+    credential-receiving URL and stay in lockstep: the SSRF/https check in
+    :func:`validate_manifest_urls` and the retarget guard in
+    :func:`manifest_request_hosts`. If they ever disagreed, the secret could be
+    POSTed to a host that was never re-vetted. Returns ``None`` for any non-oauth2
+    or malformed auth block.
+    """
+    if not isinstance(client, dict):
+        return None
+    auth = client.get("auth")
+    if not isinstance(auth, dict) or auth.get("type") != "oauth2":
+        return None
+    token_url = auth.get("token_url")
+    return token_url if isinstance(token_url, str) and token_url else None
+
+
 def validate_manifest_urls(manifest: dict[str, Any], team_id: int) -> tuple[bool, str | None]:
     """Walk every URL field in the manifest and reject internal/private hosts.
 
@@ -182,13 +201,11 @@ def validate_manifest_urls(manifest: dict[str, Any], team_id: int) -> tuple[bool
 
     # The OAuth2 token endpoint is a user-supplied URL the server POSTs the
     # credential to, so it gets the same host-safety + https-on-cloud vetting.
-    auth = client.get("auth")
-    if isinstance(auth, dict) and auth.get("type") == "oauth2":
-        token_url = auth.get("token_url")
-        if isinstance(token_url, str) and token_url:
-            ok, err = _check_url(token_url, team_id)
-            if not ok:
-                return False, f"Invalid token_url: {err}"
+    token_url = _oauth2_token_url(client)
+    if token_url is not None:
+        ok, err = _check_url(token_url, team_id)
+        if not ok:
+            return False, f"Invalid token_url: {err}"
 
     base_host = _url_hostname(base_url)
     for resource in manifest["resources"]:
@@ -286,11 +303,9 @@ def manifest_request_hosts(manifest_json: Any) -> frozenset[str]:
 
     # The OAuth2 token endpoint also receives the credential, so a change to it
     # must trip the retarget guard and force the secret to be re-entered.
-    auth = client.get("auth") if isinstance(client, dict) else None
-    if isinstance(auth, dict) and auth.get("type") == "oauth2":
-        token_url = auth.get("token_url")
-        if isinstance(token_url, str):
-            urls.append(token_url)
+    token_url = _oauth2_token_url(client)
+    if token_url is not None:
+        urls.append(token_url)
 
     resources = manifest.get("resources")
     if isinstance(resources, list):

--- a/posthog/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/posthog/temporal/data_imports/sources/custom/test_custom_source.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime
 
 from unittest.mock import MagicMock, patch
 
@@ -6,7 +7,13 @@ from django.test import SimpleTestCase, override_settings
 
 from parameterized import parameterized
 
-from posthog.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth, BearerTokenAuth, HttpBasicAuth
+from posthog.temporal.data_imports.sources.common.rest_source.auth import (
+    APIKeyAuth,
+    BearerTokenAuth,
+    HttpBasicAuth,
+    OAuth2Auth,
+    OAuth2TokenError,
+)
 from posthog.temporal.data_imports.sources.custom.source import (
     CustomSource,
     ManifestValidationError,
@@ -111,11 +118,37 @@ class TestValidateManifest(SimpleTestCase):
             validate_manifest(manifest)
         assert field in str(ctx.exception)
 
+    def test_accepts_oauth2_auth(self):
+        manifest = _minimal_manifest()
+        manifest["client"]["auth"] = {
+            "type": "oauth2",
+            "token_url": "https://auth.example.com/token",
+            "client_id": "abc",
+            "grant_type": "client_credentials",
+            "scopes": ["read"],
+        }
+        validate_manifest(manifest)
+
+    def test_rejects_oauth2_without_token_url(self):
+        manifest = _minimal_manifest()
+        manifest["client"]["auth"] = {"type": "oauth2", "client_id": "abc"}
+        with self.assertRaises(ManifestValidationError) as ctx:
+            validate_manifest(manifest)
+        assert "token_url" in str(ctx.exception)
+
     @parameterized.expand(
         [
             ("token", {"type": "bearer", "token": "leaked"}),
             ("api_key", {"type": "api_key", "api_key": "leaked"}),
             ("password", {"type": "http_basic", "username": "alice", "password": "leaked"}),
+            (
+                "client_secret",
+                {"type": "oauth2", "token_url": "https://auth.example.com/token", "client_secret": "leaked"},
+            ),
+            (
+                "refresh_token",
+                {"type": "oauth2", "token_url": "https://auth.example.com/token", "refresh_token": "leaked"},
+            ),
         ]
     )
     def test_rejects_inline_credentials(self, _name, auth):
@@ -185,6 +218,41 @@ class TestValidateManifestUrls(SimpleTestCase):
         ok, err = validate_manifest_urls(manifest, team_id=999)
         assert ok, err
 
+    @parameterized.expand(
+        [
+            ("loopback", "https://127.0.0.1/token"),
+            ("imds", "https://169.254.169.254/token"),
+            ("http_on_cloud", "http://auth.example.com/token"),
+        ]
+    )
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch(
+        "posthog.temporal.data_imports.sources.custom.source._is_host_safe",
+        side_effect=lambda host, team_id: (
+            host not in ("127.0.0.1", "169.254.169.254"),
+            None if host not in ("127.0.0.1", "169.254.169.254") else "blocked",
+        ),
+    )
+    def test_rejects_unsafe_oauth2_token_url(self, _name: str, token_url: str, _mock):
+        # The token endpoint receives the credential, so it must pass the same
+        # host-safety + https-on-cloud gate as base_url and resource URLs.
+        manifest = _minimal_manifest()
+        manifest["client"]["auth"] = {"type": "oauth2", "token_url": token_url}
+        ok, err = validate_manifest_urls(manifest, team_id=999)
+        assert not ok
+        assert "token_url" in (err or "")
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch(
+        "posthog.temporal.data_imports.sources.custom.source._is_host_safe",
+        side_effect=lambda host, team_id: (True, None),
+    )
+    def test_accepts_safe_oauth2_token_url(self, _mock):
+        manifest = _minimal_manifest()
+        manifest["client"]["auth"] = {"type": "oauth2", "token_url": "https://auth.example.com/token"}
+        ok, err = validate_manifest_urls(manifest, team_id=999)
+        assert ok, err
+
 
 class TestCustomSourceAssembleManifest(SimpleTestCase):
     def test_rejects_invalid_json(self):
@@ -216,6 +284,20 @@ class TestCustomSourceAssembleManifest(SimpleTestCase):
                 "password",
                 "hunter2",
             ),
+            (
+                "oauth2_client_secret",
+                {"type": "oauth2", "token_url": "https://auth.example.com/token", "grant_type": "client_credentials"},
+                {"auth_client_secret": "cs_secret"},
+                "client_secret",
+                "cs_secret",
+            ),
+            (
+                "oauth2_refresh_token",
+                {"type": "oauth2", "token_url": "https://auth.example.com/token", "grant_type": "refresh_token"},
+                {"auth_refresh_token": "rt_secret"},
+                "refresh_token",
+                "rt_secret",
+            ),
         ]
     )
     def test_injects_auth_secret_for_type(self, _name, auth, secret_kwargs, expected_key, expected_value):
@@ -225,6 +307,27 @@ class TestCustomSourceAssembleManifest(SimpleTestCase):
         config = CustomSourceConfig(manifest_json=json.dumps(manifest), **secret_kwargs)
         assembled = source._assemble_manifest(config)
         assert assembled["client"]["auth"][expected_key] == expected_value
+
+    def test_injects_both_oauth2_secrets(self):
+        manifest = _minimal_manifest()
+        manifest["client"]["auth"] = {
+            "type": "oauth2",
+            "token_url": "https://auth.example.com/token",
+            "client_id": "abc",
+            "grant_type": "refresh_token",
+        }
+        source = CustomSource()
+        config = CustomSourceConfig(
+            manifest_json=json.dumps(manifest),
+            auth_client_secret="cs_secret",
+            auth_refresh_token="rt_secret",
+        )
+        assembled = source._assemble_manifest(config)
+        auth = assembled["client"]["auth"]
+        assert auth["client_secret"] == "cs_secret"
+        assert auth["refresh_token"] == "rt_secret"
+        # client_id stays in the (non-secret) manifest, untouched.
+        assert auth["client_id"] == "abc"
 
     def test_leaves_auth_alone_when_no_secret_provided(self):
         source = CustomSource()
@@ -514,6 +617,20 @@ class TestManifestRequestHosts(SimpleTestCase):
         manifest = self._manifest("https://api.example.com", ["/users", "https://cdn.other.net/data"])
         assert manifest_request_hosts(manifest) == frozenset({"api.example.com", "cdn.other.net"})
 
+    def test_oauth2_token_url_host_is_collected(self):
+        # The token endpoint also receives the credential, so a change to it must
+        # trip the retarget guard — its host has to be in the tracked set.
+        manifest = json.dumps(
+            {
+                "client": {
+                    "base_url": "https://api.example.com",
+                    "auth": {"type": "oauth2", "token_url": "https://auth.other.net/token"},
+                },
+                "resources": [{"name": "r", "endpoint": {"path": "/users"}}],
+            }
+        )
+        assert manifest_request_hosts(manifest) == frozenset({"api.example.com", "auth.other.net"})
+
     def test_path_param_absolute_url_is_collected(self):
         # A scalar param bound into a "{placeholder}" becomes the request URL at sync time
         # (_bind_path_params), so its host must be tracked even though the literal path is relative.
@@ -752,3 +869,140 @@ class TestCustomSourceSourceForPipeline(SimpleTestCase):
 
         threaded_incremental = mock_resource.call_args.args[0]["resources"][0]["endpoint"]["incremental"]
         assert threaded_incremental == {"cursor_path": "updated_at", "start_param": "since"}
+
+
+def _oauth2_session(payload: dict, status_code: int = 200):
+    """A fake tracked session whose .post returns the given token response."""
+    response = MagicMock(status_code=status_code, text=json.dumps(payload))
+    response.json.return_value = payload
+    session = MagicMock()
+    session.post.return_value = response
+    return session, response
+
+
+class TestOAuth2Auth(SimpleTestCase):
+    _PATCH = "posthog.temporal.data_imports.sources.common.http.make_tracked_session"
+
+    def test_client_credentials_grant_sets_bearer_header(self):
+        session, _ = _oauth2_session({"access_token": "tok", "expires_in": 3600})
+        auth = OAuth2Auth(
+            token_url="https://auth.example.com/token",
+            client_id="cid",
+            client_secret="csecret",
+            grant_type="client_credentials",
+        )
+        with patch(self._PATCH, return_value=session):
+            request = MagicMock(headers={})
+            auth(request)
+
+        body = session.post.call_args.kwargs["data"]
+        assert body == {"grant_type": "client_credentials", "client_id": "cid", "client_secret": "csecret"}
+        assert request.headers["Authorization"] == "Bearer tok"
+
+    def test_refresh_token_grant_includes_refresh_token(self):
+        session, _ = _oauth2_session({"access_token": "tok", "expires_in": 3600})
+        auth = OAuth2Auth(
+            token_url="https://auth.example.com/token",
+            client_id="cid",
+            client_secret="csecret",
+            grant_type="refresh_token",
+            refresh_token="rtok",
+            scopes=["read", "write"],
+        )
+        with patch(self._PATCH, return_value=session):
+            auth(MagicMock(headers={}))
+
+        body = session.post.call_args.kwargs["data"]
+        assert body["grant_type"] == "refresh_token"
+        assert body["refresh_token"] == "rtok"
+        assert body["scope"] == "read write"
+
+    def test_token_cached_until_expiry_then_refreshed(self):
+        session, _ = _oauth2_session({"access_token": "tok", "expires_in": 3600})
+        auth = OAuth2Auth(token_url="https://auth.example.com/token", grant_type="client_credentials")
+        with patch(self._PATCH, return_value=session):
+            auth(MagicMock(headers={}))
+            auth(MagicMock(headers={}))
+            # Second call reuses the cached token — no second token POST.
+            assert session.post.call_count == 1
+            # Force expiry; the next call re-mints.
+            auth._expires_at = datetime(2000, 1, 1, tzinfo=UTC)
+            auth(MagicMock(headers={}))
+            assert session.post.call_count == 2
+
+    def test_custom_token_and_expiry_field_names_and_prefix(self):
+        session, _ = _oauth2_session({"my_token": "tok", "ttl": 60})
+        auth = OAuth2Auth(
+            token_url="https://auth.example.com/token",
+            grant_type="client_credentials",
+            access_token_name="my_token",
+            expires_in_name="ttl",
+            header_prefix="Zoho-oauthtoken",
+        )
+        with patch(self._PATCH, return_value=session):
+            request = MagicMock(headers={})
+            auth(request)
+        assert request.headers["Authorization"] == "Zoho-oauthtoken tok"
+
+    def test_missing_expires_in_falls_back_to_default(self):
+        session, _ = _oauth2_session({"access_token": "tok"})
+        auth = OAuth2Auth(token_url="https://auth.example.com/token", grant_type="client_credentials")
+        with patch(self._PATCH, return_value=session):
+            auth(MagicMock(headers={}))
+        assert auth._expires_at is not None
+        assert not auth._is_expired()
+
+    def test_refresh_token_grant_without_token_raises(self):
+        auth = OAuth2Auth(token_url="https://auth.example.com/token", grant_type="refresh_token")
+        with patch(self._PATCH, return_value=_oauth2_session({})[0]):
+            with self.assertRaises(OAuth2TokenError):
+                auth(MagicMock(headers={}))
+
+    @parameterized.expand([401, 403, 500])
+    def test_error_status_raises(self, status_code):
+        session, _ = _oauth2_session({"error": "nope"}, status_code=status_code)
+        auth = OAuth2Auth(token_url="https://auth.example.com/token", grant_type="client_credentials")
+        with patch(self._PATCH, return_value=session):
+            with self.assertRaises(OAuth2TokenError):
+                auth(MagicMock(headers={}))
+
+    def test_missing_access_token_in_response_raises(self):
+        session, _ = _oauth2_session({"expires_in": 3600})
+        auth = OAuth2Auth(token_url="https://auth.example.com/token", grant_type="client_credentials")
+        with patch(self._PATCH, return_value=session):
+            with self.assertRaises(OAuth2TokenError):
+                auth(MagicMock(headers={}))
+
+    def test_secret_values_for_redaction(self):
+        auth = OAuth2Auth(
+            token_url="https://auth.example.com/token",
+            client_secret="csecret",
+            refresh_token="rtok",
+            grant_type="refresh_token",
+        )
+        # Before minting: client_secret + refresh_token. After: the access token too.
+        assert set(auth.secret_values()) == {"csecret", "rtok"}
+        auth._access_token = "tok"
+        assert set(auth.secret_values()) == {"csecret", "rtok", "tok"}
+
+
+class TestCustomSourceValidateCredentialsOAuth2(SimpleTestCase):
+    @patch("posthog.temporal.data_imports.sources.common.http.make_tracked_session")
+    @patch("posthog.temporal.data_imports.sources.custom.source.make_tracked_session")
+    def test_probe_mints_token_then_succeeds(self, probe_session, token_session):
+        # The probe builds OAuth2Auth via create_auth; on the first probe request the
+        # auth callable mints a token from the token endpoint, then the resource probe runs.
+        probe_session.return_value.request.return_value = MagicMock(status_code=200, text="{}")
+        token_session.return_value, _ = _oauth2_session({"access_token": "tok", "expires_in": 3600})
+
+        manifest = _minimal_manifest()
+        manifest["client"]["auth"] = {
+            "type": "oauth2",
+            "token_url": "https://auth.example.com/token",
+            "client_id": "cid",
+            "grant_type": "client_credentials",
+        }
+        source = CustomSource()
+        config = CustomSourceConfig(manifest_json=json.dumps(manifest), auth_client_secret="csecret")
+        ok, err = source.validate_credentials(config, team_id=999)
+        assert ok, err

--- a/posthog/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/posthog/temporal/data_imports/sources/custom/test_custom_source.py
@@ -881,7 +881,7 @@ def _oauth2_session(payload: dict, status_code: int = 200):
 
 
 class TestOAuth2Auth(SimpleTestCase):
-    _PATCH = "posthog.temporal.data_imports.sources.common.http.make_tracked_session"
+    _PATCH = "posthog.temporal.data_imports.sources.common.rest_source.auth.make_tracked_session"
 
     def test_client_credentials_grant_sets_bearer_header(self):
         session, _ = _oauth2_session({"access_token": "tok", "expires_in": 3600})
@@ -952,6 +952,40 @@ class TestOAuth2Auth(SimpleTestCase):
         assert auth._expires_at is not None
         assert not auth._is_expired()
 
+    def test_short_expires_in_does_not_immediately_expire(self):
+        # A short TTL must not let the safety margin push the deadline into the
+        # past — otherwise the token re-mints on every paginated request.
+        session, _ = _oauth2_session({"access_token": "tok", "expires_in": 10})
+        auth = OAuth2Auth(token_url="https://auth.example.com/token", grant_type="client_credentials")
+        with patch(self._PATCH, return_value=session):
+            auth(MagicMock(headers={}))
+            assert not auth._is_expired()
+            # A second request within the (clamped) lifetime reuses the cached token.
+            auth(MagicMock(headers={}))
+            assert session.post.call_count == 1
+
+    def test_string_float_expires_in_is_parsed(self):
+        # "300.0" must parse to a 300s TTL, not fall back to the 1-hour default
+        # (which would mask a genuinely short token and cause mid-sync 401s).
+        session, _ = _oauth2_session({"access_token": "tok", "expires_in": "300.0"})
+        auth = OAuth2Auth(token_url="https://auth.example.com/token", grant_type="client_credentials")
+        with patch(self._PATCH, return_value=session):
+            auth(MagicMock(headers={}))
+        assert auth._expires_at is not None
+        remaining = (auth._expires_at - datetime.now(UTC)).total_seconds()
+        # 300s TTL minus the 60s margin ≈ 240s; comfortably under the 1h default.
+        assert 200 < remaining < 260
+
+    def test_non_json_token_response_raises(self):
+        response = MagicMock(status_code=200, text="<html>not json</html>")
+        response.json.side_effect = ValueError("no json")
+        session = MagicMock()
+        session.post.return_value = response
+        auth = OAuth2Auth(token_url="https://auth.example.com/token", grant_type="client_credentials")
+        with patch(self._PATCH, return_value=session):
+            with self.assertRaises(OAuth2TokenError):
+                auth(MagicMock(headers={}))
+
     def test_refresh_token_grant_without_token_raises(self):
         auth = OAuth2Auth(token_url="https://auth.example.com/token", grant_type="refresh_token")
         with patch(self._PATCH, return_value=_oauth2_session({})[0]):
@@ -987,7 +1021,7 @@ class TestOAuth2Auth(SimpleTestCase):
 
 
 class TestCustomSourceValidateCredentialsOAuth2(SimpleTestCase):
-    @patch("posthog.temporal.data_imports.sources.common.http.make_tracked_session")
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.auth.make_tracked_session")
     @patch("posthog.temporal.data_imports.sources.custom.source.make_tracked_session")
     def test_probe_mints_token_then_succeeds(self, probe_session, token_session):
         # The probe builds OAuth2Auth via create_auth; on the first probe request the

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -286,6 +286,8 @@ class CustomSourceConfig(config.Config):
     auth_token: str | None = None
     auth_api_key: str | None = None
     auth_password: str | None = None
+    auth_client_secret: str | None = None
+    auth_refresh_token: str | None = None
 
 
 @config.config

--- a/products/data_warehouse/frontend/shared/components/forms/CustomSourceManifestBuilder.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/CustomSourceManifestBuilder.tsx
@@ -15,6 +15,8 @@ import {
     type CursorType,
     type HeaderEntry,
     type ManifestState,
+    OAUTH2_GRANT_TYPES,
+    type OAuth2GrantType,
     type Paginator,
     PAGINATOR_DEFAULTS,
     PAGINATOR_TYPES,
@@ -46,8 +48,15 @@ const AUTH_LABELS: Record<AuthType, string> = {
     bearer: 'Bearer token',
     api_key: 'API key',
     http_basic: 'HTTP basic auth',
+    oauth2: 'OAuth2',
 }
 const AUTH_OPTIONS = AUTH_TYPES.map((value) => ({ value, label: AUTH_LABELS[value] }))
+
+const OAUTH2_GRANT_LABELS: Record<OAuth2GrantType, string> = {
+    client_credentials: 'Client credentials',
+    refresh_token: 'Refresh token',
+}
+const OAUTH2_GRANT_OPTIONS = OAUTH2_GRANT_TYPES.map((value) => ({ value, label: OAUTH2_GRANT_LABELS[value] }))
 
 const API_KEY_LOCATION_LABELS: Record<ApiKeyLocation, string> = {
     header: 'Header',
@@ -230,6 +239,66 @@ function AuthSection({
                             value={state.auth_password}
                             onChange={(value) => update({ auth_password: value })}
                         />
+                    </LemonField.Pure>
+                </div>
+            )}
+            {state.auth_type === 'oauth2' && (
+                <div className="space-y-2">
+                    <div className="grid grid-cols-2 gap-2">
+                        <LemonField.Pure label="Grant type">
+                            <LemonSelect
+                                value={state.auth_oauth_grant_type}
+                                onChange={(value) => update({ auth_oauth_grant_type: value as OAuth2GrantType })}
+                                options={OAUTH2_GRANT_OPTIONS}
+                            />
+                        </LemonField.Pure>
+                        <LemonField.Pure label="Token URL">
+                            <LemonInput
+                                placeholder="https://auth.example.com/oauth/token"
+                                value={state.auth_oauth_token_url}
+                                onChange={(value) => update({ auth_oauth_token_url: value })}
+                            />
+                        </LemonField.Pure>
+                    </div>
+                    <div className="grid grid-cols-2 gap-2">
+                        <LemonField.Pure label="Client ID">
+                            <LemonInput
+                                placeholder="client id"
+                                value={state.auth_oauth_client_id}
+                                onChange={(value) => update({ auth_oauth_client_id: value })}
+                            />
+                        </LemonField.Pure>
+                        <LemonField.Pure label="Client secret">
+                            <LemonInput
+                                type="password"
+                                autoComplete="off"
+                                placeholder="client secret"
+                                value={state.auth_oauth_client_secret}
+                                onChange={(value) => update({ auth_oauth_client_secret: value })}
+                            />
+                        </LemonField.Pure>
+                    </div>
+                    {state.auth_oauth_grant_type === 'refresh_token' && (
+                        <LemonField.Pure label="Refresh token">
+                            <LemonInput
+                                type="password"
+                                autoComplete="off"
+                                placeholder="refresh token"
+                                value={state.auth_oauth_refresh_token}
+                                onChange={(value) => update({ auth_oauth_refresh_token: value })}
+                            />
+                        </LemonField.Pure>
+                    )}
+                    <LemonField.Pure label="Scopes (optional)">
+                        <LemonInput
+                            placeholder="read write"
+                            value={state.auth_oauth_scopes}
+                            onChange={(value) => update({ auth_oauth_scopes: value })}
+                        />
+                        <p className="m-0 mt-1 text-xs text-secondary">
+                            Space- or comma-separated. PostHog mints an access token at sync time and refreshes it on
+                            expiry.
+                        </p>
                     </LemonField.Pure>
                 </div>
             )}

--- a/products/data_warehouse/frontend/shared/components/forms/__tests__/customSourceManifest.test.ts
+++ b/products/data_warehouse/frontend/shared/components/forms/__tests__/customSourceManifest.test.ts
@@ -9,6 +9,12 @@ const baseState = (): ManifestState => ({
     auth_api_key_location: 'header',
     auth_username: '',
     auth_password: '',
+    auth_oauth_token_url: '',
+    auth_oauth_client_id: '',
+    auth_oauth_grant_type: 'client_credentials',
+    auth_oauth_scopes: '',
+    auth_oauth_client_secret: '',
+    auth_oauth_refresh_token: '',
     headers: [],
     streams: [
         {
@@ -413,30 +419,154 @@ describe('extractAuthSecrets', () => {
         const state = baseState()
         state.auth_type = 'bearer'
         state.auth_token = 'tok_123'
-        expect(extractAuthSecrets(state)).toEqual({ auth_token: 'tok_123', auth_api_key: '', auth_password: '' })
+        expect(extractAuthSecrets(state)).toEqual({
+            auth_token: 'tok_123',
+            auth_api_key: '',
+            auth_password: '',
+            auth_client_secret: '',
+            auth_refresh_token: '',
+        })
     })
 
     it('returns only the api key for api_key auth', () => {
         const state = baseState()
         state.auth_type = 'api_key'
         state.auth_api_key = 'sk_test'
-        expect(extractAuthSecrets(state)).toEqual({ auth_token: '', auth_api_key: 'sk_test', auth_password: '' })
+        expect(extractAuthSecrets(state)).toEqual({
+            auth_token: '',
+            auth_api_key: 'sk_test',
+            auth_password: '',
+            auth_client_secret: '',
+            auth_refresh_token: '',
+        })
     })
 
     it('returns only the password for http_basic auth', () => {
         const state = baseState()
         state.auth_type = 'http_basic'
         state.auth_password = 'hunter2'
-        expect(extractAuthSecrets(state)).toEqual({ auth_token: '', auth_api_key: '', auth_password: 'hunter2' })
+        expect(extractAuthSecrets(state)).toEqual({
+            auth_token: '',
+            auth_api_key: '',
+            auth_password: 'hunter2',
+            auth_client_secret: '',
+            auth_refresh_token: '',
+        })
     })
 
     it('returns all-empty for none auth, ignoring stale credential state', () => {
         const state = baseState()
         state.auth_type = 'none'
-        // All three stale so each ternary's false-arm is genuinely exercised.
+        // All stale so each ternary's false-arm is genuinely exercised.
         state.auth_token = 'tok_123'
         state.auth_api_key = 'sk_test'
         state.auth_password = 'hunter2'
-        expect(extractAuthSecrets(state)).toEqual({ auth_token: '', auth_api_key: '', auth_password: '' })
+        state.auth_oauth_client_secret = 'cs'
+        state.auth_oauth_refresh_token = 'rt'
+        expect(extractAuthSecrets(state)).toEqual({
+            auth_token: '',
+            auth_api_key: '',
+            auth_password: '',
+            auth_client_secret: '',
+            auth_refresh_token: '',
+        })
+    })
+
+    it('returns the client secret for the oauth2 client_credentials grant (no refresh token)', () => {
+        const state = baseState()
+        state.auth_type = 'oauth2'
+        state.auth_oauth_grant_type = 'client_credentials'
+        state.auth_oauth_client_secret = 'cs_secret'
+        state.auth_oauth_refresh_token = 'should_be_ignored'
+        expect(extractAuthSecrets(state)).toEqual({
+            auth_token: '',
+            auth_api_key: '',
+            auth_password: '',
+            auth_client_secret: 'cs_secret',
+            auth_refresh_token: '',
+        })
+    })
+
+    it('returns client secret and refresh token for the oauth2 refresh_token grant', () => {
+        const state = baseState()
+        state.auth_type = 'oauth2'
+        state.auth_oauth_grant_type = 'refresh_token'
+        state.auth_oauth_client_secret = 'cs_secret'
+        state.auth_oauth_refresh_token = 'rt_secret'
+        expect(extractAuthSecrets(state)).toEqual({
+            auth_token: '',
+            auth_api_key: '',
+            auth_password: '',
+            auth_client_secret: 'cs_secret',
+            auth_refresh_token: 'rt_secret',
+        })
+    })
+})
+
+describe('oauth2 manifest', () => {
+    it('emits client.auth for oauth2 with non-secret fields only', () => {
+        const state = baseState()
+        state.auth_type = 'oauth2'
+        state.auth_oauth_token_url = 'https://auth.example.com/token'
+        state.auth_oauth_client_id = 'cid'
+        state.auth_oauth_grant_type = 'client_credentials'
+        state.auth_oauth_scopes = 'read write'
+        state.auth_oauth_client_secret = 'must_not_inline'
+        const manifest = buildManifest(state) as any
+        expect(manifest.client.auth).toEqual({
+            type: 'oauth2',
+            token_url: 'https://auth.example.com/token',
+            grant_type: 'client_credentials',
+            client_id: 'cid',
+            scopes: ['read', 'write'],
+        })
+        expect(manifest.client.auth.client_secret).toBeUndefined()
+        expect(manifest.client.auth.refresh_token).toBeUndefined()
+    })
+
+    it('omits scopes and client_id when blank', () => {
+        const state = baseState()
+        state.auth_type = 'oauth2'
+        state.auth_oauth_token_url = 'https://auth.example.com/token'
+        state.auth_oauth_grant_type = 'refresh_token'
+        const manifest = buildManifest(state) as any
+        expect(manifest.client.auth).toEqual({
+            type: 'oauth2',
+            token_url: 'https://auth.example.com/token',
+            grant_type: 'refresh_token',
+        })
+    })
+
+    it('round-trips an oauth2 manifest through parse (secrets excluded)', () => {
+        const state = baseState()
+        state.auth_type = 'oauth2'
+        state.auth_oauth_token_url = 'https://auth.example.com/token'
+        state.auth_oauth_client_id = 'cid'
+        state.auth_oauth_grant_type = 'refresh_token'
+        state.auth_oauth_scopes = 'read write'
+        const json = JSON.stringify(buildManifest(state))
+        const parsed = parseManifestIntoState(json)
+        expect(parsed.auth_type).toBe('oauth2')
+        expect(parsed.auth_oauth_token_url).toBe('https://auth.example.com/token')
+        expect(parsed.auth_oauth_client_id).toBe('cid')
+        expect(parsed.auth_oauth_grant_type).toBe('refresh_token')
+        expect(parsed.auth_oauth_scopes).toBe('read write')
+    })
+
+    it('parses scopes whether authored as an array or a string', () => {
+        const asArray = parseManifestIntoState(
+            JSON.stringify({
+                client: { base_url: 'x', auth: { type: 'oauth2', token_url: 't', scopes: ['a', 'b'] } },
+                resources: [{ name: 'r', endpoint: { path: '/r' } }],
+            })
+        )
+        expect(asArray.auth_oauth_scopes).toBe('a b')
+        const asString = parseManifestIntoState(
+            JSON.stringify({
+                client: { base_url: 'x', auth: { type: 'oauth2', token_url: 't', scopes: 'a b' } },
+                resources: [{ name: 'r', endpoint: { path: '/r' } }],
+            })
+        )
+        expect(asString.auth_oauth_scopes).toBe('a b')
     })
 })

--- a/products/data_warehouse/frontend/shared/components/forms/customSourceManifest.ts
+++ b/products/data_warehouse/frontend/shared/components/forms/customSourceManifest.ts
@@ -6,8 +6,14 @@
 // Each enum-like value set is declared once as an `as const` tuple; the union type
 // and the runtime guard (via `isMember`) are derived from it, so the allowed values
 // can't drift between the type, the parser, and the component's select options.
-export const AUTH_TYPES = ['none', 'bearer', 'api_key', 'http_basic'] as const
+export const AUTH_TYPES = ['none', 'bearer', 'api_key', 'http_basic', 'oauth2'] as const
 export type AuthType = (typeof AUTH_TYPES)[number]
+
+// OAuth2 grants the Custom source supports. Only these two are exposed: a fresh
+// access token is minted per sync (client_credentials) or from a stable
+// refresh token; rotating single-use refresh tokens are not supported.
+export const OAUTH2_GRANT_TYPES = ['client_credentials', 'refresh_token'] as const
+export type OAuth2GrantType = (typeof OAUTH2_GRANT_TYPES)[number]
 
 // The backend treats 'query' and 'param' as synonymous (auth.py:41), so we
 // only surface 'query' in the UI — the parser still accepts 'param' for
@@ -97,6 +103,15 @@ export interface ManifestState {
     auth_api_key_location: ApiKeyLocation
     auth_username: string
     auth_password: string
+    // OAuth2: token_url / client_id / grant_type / scopes are non-secret and live
+    // in the manifest; client_secret / refresh_token are secrets pushed to their
+    // own form fields (see extractAuthSecrets).
+    auth_oauth_token_url: string
+    auth_oauth_client_id: string
+    auth_oauth_grant_type: OAuth2GrantType
+    auth_oauth_scopes: string
+    auth_oauth_client_secret: string
+    auth_oauth_refresh_token: string
     headers: HeaderEntry[]
     streams: StreamForm[]
 }
@@ -105,6 +120,8 @@ export interface AuthSecrets {
     auth_token: string
     auth_api_key: string
     auth_password: string
+    auth_client_secret: string
+    auth_refresh_token: string
 }
 
 export function emptyHeader(): HeaderEntry {
@@ -138,6 +155,12 @@ export function defaultState(): ManifestState {
         auth_api_key_location: 'header',
         auth_username: '',
         auth_password: '',
+        auth_oauth_token_url: '',
+        auth_oauth_client_id: '',
+        auth_oauth_grant_type: 'client_credentials',
+        auth_oauth_scopes: '',
+        auth_oauth_client_secret: '',
+        auth_oauth_refresh_token: '',
         headers: [],
         streams: [emptyStream()],
     }
@@ -165,6 +188,24 @@ export function buildManifest(state: ManifestState): Record<string, unknown> {
                 }
             case 'http_basic':
                 return { type: 'http_basic', username: state.auth_username }
+            case 'oauth2': {
+                const oauth: Record<string, unknown> = {
+                    type: 'oauth2',
+                    token_url: state.auth_oauth_token_url.trim(),
+                    grant_type: state.auth_oauth_grant_type,
+                }
+                if (state.auth_oauth_client_id.trim()) {
+                    oauth.client_id = state.auth_oauth_client_id.trim()
+                }
+                const scopes = state.auth_oauth_scopes
+                    .split(/[\s,]+/)
+                    .map((s) => s.trim())
+                    .filter(Boolean)
+                if (scopes.length > 0) {
+                    oauth.scopes = scopes
+                }
+                return oauth
+            }
             default:
                 return undefined
         }
@@ -230,10 +271,16 @@ export function buildManifest(state: ManifestState): Record<string, unknown> {
  * sensitive-field machinery. Non-active auth types yield empty strings.
  */
 export function extractAuthSecrets(state: ManifestState): AuthSecrets {
+    const isOauth = state.auth_type === 'oauth2'
     return {
         auth_token: state.auth_type === 'bearer' ? state.auth_token : '',
         auth_api_key: state.auth_type === 'api_key' ? state.auth_api_key : '',
         auth_password: state.auth_type === 'http_basic' ? state.auth_password : '',
+        auth_client_secret: isOauth ? state.auth_oauth_client_secret : '',
+        // refresh_token only applies to the refresh_token grant — leave it empty
+        // for client_credentials so a stale value isn't persisted.
+        auth_refresh_token:
+            isOauth && state.auth_oauth_grant_type === 'refresh_token' ? state.auth_oauth_refresh_token : '',
     }
 }
 
@@ -310,6 +357,13 @@ export function parseManifestIntoState(rawJson: string | undefined): ManifestSta
     const apiKeyLocation: ApiKeyLocation = isMember(API_KEY_LOCATIONS, normalizedLocation)
         ? normalizedLocation
         : 'header'
+    const oauthGrantRaw = asString(auth.grant_type, 'client_credentials')
+    const oauthGrant: OAuth2GrantType = isMember(OAUTH2_GRANT_TYPES, oauthGrantRaw)
+        ? oauthGrantRaw
+        : 'client_credentials'
+    // scopes may be authored as an array or a space-delimited string; surface it
+    // as a single editable string either way.
+    const oauthScopes = Array.isArray(auth.scopes) ? auth.scopes.map((s) => String(s)).join(' ') : asString(auth.scopes)
     const headerObj = asObject(client.headers)
     const headers: HeaderEntry[] = Object.entries(headerObj).map(([key, value]) => ({
         id: nextHeaderId(),
@@ -327,6 +381,14 @@ export function parseManifestIntoState(rawJson: string | undefined): ManifestSta
         auth_api_key_location: apiKeyLocation,
         auth_username: asString(auth.username),
         auth_password: asString(auth.password),
+        // client_secret / refresh_token are stored in separate secret fields and
+        // redacted from reads, so they parse back as empty — re-entered on edit.
+        auth_oauth_token_url: asString(auth.token_url),
+        auth_oauth_client_id: asString(auth.client_id),
+        auth_oauth_grant_type: oauthGrant,
+        auth_oauth_scopes: oauthScopes,
+        auth_oauth_client_secret: asString(auth.client_secret),
+        auth_oauth_refresh_token: asString(auth.refresh_token),
         headers,
         streams,
     }

--- a/products/data_warehouse/frontend/shared/components/forms/customSourceManifestBuilderLogic.ts
+++ b/products/data_warehouse/frontend/shared/components/forms/customSourceManifestBuilderLogic.ts
@@ -161,6 +161,8 @@ export const customSourceManifestBuilderLogic = kea<customSourceManifestBuilderL
             props.setValue(['payload', 'auth_token'] as FieldName, values.authSecrets.auth_token)
             props.setValue(['payload', 'auth_api_key'] as FieldName, values.authSecrets.auth_api_key)
             props.setValue(['payload', 'auth_password'] as FieldName, values.authSecrets.auth_password)
+            props.setValue(['payload', 'auth_client_secret'] as FieldName, values.authSecrets.auth_client_secret)
+            props.setValue(['payload', 'auth_refresh_token'] as FieldName, values.authSecrets.auth_refresh_token)
         },
     })),
     // Every state mutation re-pushes the serialized manifest + secrets to the

--- a/products/logs/frontend/scenes/LogsAlertNotificationDetailScene/LogsAlertNotificationDetailScene.tsx
+++ b/products/logs/frontend/scenes/LogsAlertNotificationDetailScene/LogsAlertNotificationDetailScene.tsx
@@ -57,7 +57,7 @@ export function LogsAlertNotificationDetailScene(): JSX.Element {
         if (firstSlackIntegration) {
             loadAllSlackChannels()
         }
-    }, [firstSlackIntegration?.id, loadAllSlackChannels, firstSlackIntegration])
+    }, [firstSlackIntegration?.id, loadAllSlackChannels])
 
     const loading = alertLoading || hogFunctionsLoading
     const displayLabel = destinationGroup ? resolveGroupLabel(destinationGroup, slackChannels) : 'Destination'

--- a/products/logs/frontend/scenes/LogsAlertNotificationDetailScene/LogsAlertNotificationDetailScene.tsx
+++ b/products/logs/frontend/scenes/LogsAlertNotificationDetailScene/LogsAlertNotificationDetailScene.tsx
@@ -57,7 +57,7 @@ export function LogsAlertNotificationDetailScene(): JSX.Element {
         if (firstSlackIntegration) {
             loadAllSlackChannels()
         }
-    }, [firstSlackIntegration?.id, loadAllSlackChannels])
+    }, [firstSlackIntegration?.id, loadAllSlackChannels, firstSlackIntegration])
 
     const loading = alertLoading || hogFunctionsLoading
     const displayLabel = destinationGroup ? resolveGroupLabel(destinationGroup, slackChannels) : 'Destination'

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -22,6 +22,12 @@ export const VisionObservationsListParams = /* @__PURE__ */ zod.object({
 export const VisionObservationsListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    order_by: zod
+        .string()
+        .optional()
+        .describe(
+            'Sort observations by created_at, started_at, completed_at, or status. Prefix with `-` for descending.'
+        ),
     session_id: zod.string().describe('Session recording id to return observations for.'),
 })
 

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -37,6 +37,7 @@ const visionObservationsList = (): ToolBase<
             query: {
                 limit: params.limit,
                 offset: params.offset,
+                order_by: params.order_by,
                 session_id: params.session_id,
             },
         })


### PR DESCRIPTION
## Problem

The data-warehouse **Custom REST source** lets users self-serve a connector by pasting a JSON manifest, but it only supports three **static** auth types — `bearer`, `api_key`, `http_basic`. An analysis of our most-requested new sources found that **OAuth2 (client-credentials / refresh-token) is the single highest-impact missing auth capability**: it makes Zoho CRM, PayPal, Zoom, and Auth0-confidential self-servable via the custom source instead of each requiring a bespoke native connector, and it's the foundation the larger Google Analytics / Apple Search Ads / YouTube tier would later build on.

## Changes

Adds `oauth2` as a fourth declarative auth `type` for the custom source, modeled on Airbyte's low-code `OAuthAuthenticator` and the existing self-refreshing `SalesforceAuth`. It's fully self-contained in the manifest + secret fields — no `Integration`-model linkage and no browser OAuth connect flow.

- **`common/rest_source/auth.py`** — new `OAuth2Auth` (a `requests` auth-callable): mints an access token from a user-supplied `token_url` at request time, caches it in-memory until expiry, and injects it as a `Bearer` (or custom-prefix) header. Supports the `client_credentials` and `refresh_token` grants. The token POST goes through `make_tracked_session()` so it's logged with credentials redacted.
- **`config_setup.py` / `typing.py`** — register `oauth2` in `AUTH_MAP`, the `AuthType` literal, and a new `OAuth2AuthConfig` TypedDict.
- **`custom/source.py`** — extend the manifest auth model (non-secret oauth fields + a `token_url`-required validator), add two encrypted/redacted secret fields (`auth_client_secret`, `auth_refresh_token`), inject them at sync time, and **vet `token_url` for SSRF** in `validate_manifest_urls` + include its host in the retarget guard (`manifest_request_hosts`), exactly as base/resource URLs are treated.
- **`custom/README.md`** — manifest + auth field reference with worked OAuth2 examples.

Scope is deliberately bounded: `client_credentials` + **non-rotating** `refresh_token`, with pasted credentials. Providers that rotate single-use refresh tokens (QuickBooks/Intuit) and the JWT-bearer/service-account grant (GA/Apple) remain native-only and are noted as fast-follows. The source stays behind its existing pilot-team gate and the `dwh_custom_source` flag, so there's no new exposure surface.

## How did you test this code?

I'm an agent — I did **not** perform manual testing against a live OAuth provider. Automated tests I actually ran:

- Extended `custom/test_custom_source.py` with 24 cases: both grants, token caching/refresh-on-expiry, custom `access_token_name`/`expires_in_name`/`header_prefix`, error and missing-token paths, `secret_values()` redaction list, manifest validation (accept oauth2, reject missing `token_url`, reject inline `client_secret`/`refresh_token`), `token_url` SSRF rejection + retarget-host collection, and an end-to-end probe that mints a token then probes resources. **131 passed.**
- Full engine suite `posthog/temporal/data_imports/sources/common/` — **573 passed.**
- `ruff check` / `ruff format` clean; `ty check` passed via lint-staged on commit.

Still needs before merge: the manual end-to-end against a real client-credentials API (e.g. a Zoom server-to-server or PayPal sandbox app) on the pilot team, and CI mypy.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code. The work started from an analysis of our most-requested sources comparing each against the custom REST source's capabilities and the corresponding Airbyte connector, which surfaced OAuth2 as the top unblock. I then explored the REST engine, PostHog's existing OAuth infrastructure (`OauthIntegration`, `SalesforceAuth`), and Airbyte's declarative `OAuthAuthenticator` before planning.

Key decisions:
- **Self-contained over Integration-backed.** The `Integration` model assumes a hardcoded provider `kind` with app credentials in Django settings — a poor fit for a generic user-supplied connector. Storing client/refresh secrets in the source's encrypted `job_inputs` (mirroring the existing `auth_*` fields) is simpler and reuses the existing redaction + retarget-guard machinery for free.
- **In-memory token cache, no write-back.** Non-rotating refresh tokens and client-credentials don't need persistence; this avoids mid-sync writes to `job_inputs`, which is why rotating-refresh-token providers are explicitly out of scope for now.
- **`token_url` treated as a first-class credential-receiving URL** — SSRF-vetted at validation time and folded into the retarget guard, so changing it forces secret re-entry.

Agent-authored; requires human review and the live-provider test before merge.
