### PR TITLE
fix(mcp): strip default:null on untyped Any fields too

### DIFF
--- a/services/mcp/scripts/generate-orval-schemas.mjs
+++ b/services/mcp/scripts/generate-orval-schemas.mjs
@@ -80,6 +80,8 @@ function parseToolDefinition(filePath) {
  * - `type: ['string', 'null']` (OpenAPI 3.1 / JSON Schema)
  * - `anyOf: [{ type: 'string' }, { type: 'null' }]` (OpenAPI 3.1 / JSON Schema)
  * - `oneOf: [{ type: 'string' }, { type: 'null' }]` (OpenAPI 3.1 / JSON Schema)
+ * - Untyped `typing.Any` — Pydantic emits a bare `{}` (no type, no $ref, no
+ *   variants, no enum, no properties) which accepts every value including null.
  */
 function schemaAllowsNull(schema) {
     if (!schema || typeof schema !== 'object') {
@@ -96,6 +98,10 @@ function schemaAllowsNull(schema) {
         if (Array.isArray(variants) && variants.some(schemaAllowsNull)) {
             return true
         }
+    }
+    const constrained = ['type', 'anyOf', 'oneOf', '$ref', 'enum', 'const', 'properties']
+    if (constrained.every((key) => !(key in schema))) {
+        return true
     }
     return false
 }

--- a/services/mcp/src/generated/cohorts/api.ts
+++ b/services/mcp/src/generated/cohorts/api.ts
@@ -34,9 +34,7 @@ export const cohortsCreateBodyNameMax = 400
 export const cohortsCreateBodyDescriptionMax = 1000
 
 export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneNegationDefault = false
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemOneEventFiltersOneItemTwoValueDefault = null
 export const cohortsCreateBodyFiltersOnePropertiesValuesItemTwoNegationDefault = false
-export const cohortsCreateBodyFiltersOnePropertiesValuesItemThreeValueDefault = null
 export const cohortsCreateBodyFiltersOnePropertiesValuesItemThreeNegationDefault = false
 export const cohortsCreateBodyCreateStaticPersonIdsDefault = []
 
@@ -85,11 +83,7 @@ export const CohortsCreateBody = /* @__PURE__ */ zod.object({
                                                     zod.object({
                                                         type: zod.literal('hogql'),
                                                         key: zod.string(),
-                                                        value: zod
-                                                            .unknown()
-                                                            .default(
-                                                                cohortsCreateBodyFiltersOnePropertiesValuesItemOneEventFiltersOneItemTwoValueDefault
-                                                            ),
+                                                        value: zod.unknown().optional(),
                                                     }),
                                                 ])
                                             ),
@@ -117,9 +111,7 @@ export const CohortsCreateBody = /* @__PURE__ */ zod.object({
                                     type: zod.literal('person'),
                                     key: zod.string(),
                                     operator: zod.union([zod.string(), zod.null()]).optional(),
-                                    value: zod
-                                        .unknown()
-                                        .default(cohortsCreateBodyFiltersOnePropertiesValuesItemThreeValueDefault),
+                                    value: zod.unknown().optional(),
                                     negation: zod
                                         .boolean()
                                         .default(cohortsCreateBodyFiltersOnePropertiesValuesItemThreeNegationDefault),
@@ -178,9 +170,7 @@ export const cohortsPartialUpdateBodyNameMax = 400
 export const cohortsPartialUpdateBodyDescriptionMax = 1000
 
 export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneNegationDefault = false
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneEventFiltersOneItemTwoValueDefault = null
 export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemTwoNegationDefault = false
-export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeValueDefault = null
 export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeNegationDefault = false
 
 export const CohortsPartialUpdateBody = /* @__PURE__ */ zod.object({
@@ -231,11 +221,7 @@ export const CohortsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                     zod.object({
                                                         type: zod.literal('hogql'),
                                                         key: zod.string(),
-                                                        value: zod
-                                                            .unknown()
-                                                            .default(
-                                                                cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemOneEventFiltersOneItemTwoValueDefault
-                                                            ),
+                                                        value: zod.unknown().optional(),
                                                     }),
                                                 ])
                                             ),
@@ -265,11 +251,7 @@ export const CohortsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                     type: zod.literal('person'),
                                     key: zod.string(),
                                     operator: zod.union([zod.string(), zod.null()]).optional(),
-                                    value: zod
-                                        .unknown()
-                                        .default(
-                                            cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeValueDefault
-                                        ),
+                                    value: zod.unknown().optional(),
                                     negation: zod
                                         .boolean()
                                         .default(

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-create.json
@@ -107,9 +107,7 @@
                                                                                     "const": "hogql",
                                                                                     "type": "string"
                                                                                 },
-                                                                                "value": {
-                                                                                    "default": null
-                                                                                }
+                                                                                "value": {}
                                                                             },
                                                                             "required": ["type", "key"],
                                                                             "type": "object"
@@ -380,9 +378,7 @@
                                                         "const": "person",
                                                         "type": "string"
                                                     },
-                                                    "value": {
-                                                        "default": null
-                                                    }
+                                                    "value": {}
                                                 },
                                                 "required": ["type", "key"],
                                                 "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-partial-update.json
@@ -110,9 +110,7 @@
                                                                                     "const": "hogql",
                                                                                     "type": "string"
                                                                                 },
-                                                                                "value": {
-                                                                                    "default": null
-                                                                                }
+                                                                                "value": {}
                                                                             },
                                                                             "required": ["type", "key"],
                                                                             "type": "object"
@@ -383,9 +381,7 @@
                                                         "const": "person",
                                                         "type": "string"
                                                     },
-                                                    "value": {
-                                                        "default": null
-                                                    }
+                                                    "value": {}
                                                 },
                                                 "required": ["type", "key"],
                                                 "type": "object"


### PR DESCRIPTION
## Problem

Follow-up to #61072. Marcel's `schemaAllowsNull` matches every explicit nullability shape (`nullable: true`, `type: 'null'`, `type: [..., 'null']`, `anyOf`/`oneOf` with a null variant), but Pydantic emits `typing.Any` fields as bare `{}` with a `default: null` and no type info at all. Those slip past the check, Orval still emits `.default(null)` on the resulting `zod.unknown()`, and `safeParse({})` injects `null` for every omitted Any-typed field — same bug class as #61072, different shape.

Spotted in `services/mcp/src/generated/cohorts/api.ts`: 4 leftover `.default(null)` cases on `value` fields of the HogQL property filter and the person property filter inside cohort criteria.

## Changes

- Extend `schemaAllowsNull` to also return `true` when the schema has none of `type`, `anyOf`, `oneOf`, `$ref`, `enum`, `const`, `properties`. A schema without any of those constrains nothing — it accepts every value including null by definition, so `default: null` is redundant and stripping it just flips "omitted ⇒ injected null" back to "omitted ⇒ omitted", matching the PATCH semantics #61072 already established.
- Regenerate `services/mcp/src/generated/cohorts/api.ts` and the two cohort snapshots that flip.

## How did you test this code?

- Marcel's regression test (`tests/unit/experiments-metric-null-injection.test.ts`) still green
- `tests/unit/tool-schema-snapshots.test.ts` green, 2 cohort snapshots updated, no other tool snapshot moved
- `rg "Default = null|\.default\(null\)" services/mcp/src/generated/` returns 0
- Did not run manual testing — agent-authored

## 🤖 Agent context

Authored by Claude (Opus 4.7) during review of #61072. Surfaced the gap by grepping leftover `.default(null)` patterns in generated zod after that PR's regen, traced the cohort case back to `HogQLFilter.value: typing.Any` in the spec, and confirmed `schemaAllowsNull` returned `false` for the bare `{default: null, title: '…'}` shape. Stacks on #61072 — branch off `mcp/fix-tool-mode-null-injection`. Once #61072 merges this rebases cleanly onto master.
