### PR TITLE
fix(llma): stabilize AI observability preference storage

### DIFF
--- a/products/ai_observability/frontend/aiObservabilityLogic.test.ts
+++ b/products/ai_observability/frontend/aiObservabilityLogic.test.ts
@@ -9,7 +9,11 @@ import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { sceneLogic } from '../../../frontend/src/scenes/sceneLogic'
 import { aiObservabilitySharedLogic } from './aiObservabilitySharedLogic'
+import { DisplayOption, aiObservabilityTraceLogic } from './aiObservabilityTraceLogic'
+import { aiObservabilityDashboardLogic } from './tabs/aiObservabilityDashboardLogic'
+import { aiObservabilityGenerationsLogic } from './tabs/aiObservabilityGenerationsLogic'
 import { aiObservabilitySessionsViewLogic } from './tabs/aiObservabilitySessionsViewLogic'
+import { aiObservabilityTracesTabLogic } from './tabs/aiObservabilityTracesTabLogic'
 
 type RedirectParams = Record<string, string>
 
@@ -394,5 +398,79 @@ describe('aiObservabilitySessionsViewLogic', () => {
                 fullTraces: {},
             })
         })
+    })
+})
+
+describe('AI observability persisted preferences', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        window.localStorage.clear()
+    })
+
+    it('keeps generation column preferences stable across tab ids', () => {
+        const columns = ['uuid', 'timestamp']
+        const firstLogic = aiObservabilityGenerationsLogic({ tabId: 'first-tab' })
+        firstLogic.mount()
+        firstLogic.actions.setGenerationsColumns(columns)
+        firstLogic.unmount()
+
+        const secondLogic = aiObservabilityGenerationsLogic({ tabId: 'second-tab' })
+        secondLogic.mount()
+
+        expect(secondLogic.values.generationsColumns).toEqual(columns)
+
+        secondLogic.unmount()
+    })
+
+    it('keeps traces table preferences stable across tab ids', () => {
+        const firstLogic = aiObservabilityTracesTabLogic({ tabId: 'first-tab' })
+        firstLogic.mount()
+        firstLogic.actions.setShowInputOutputColumns(false)
+        firstLogic.unmount()
+
+        const secondLogic = aiObservabilityTracesTabLogic({ tabId: 'second-tab' })
+        secondLogic.mount()
+
+        expect(secondLogic.values.showInputOutputColumns).toBe(false)
+
+        secondLogic.unmount()
+    })
+
+    it('keeps selected dashboard stable across tab ids', () => {
+        const firstLogic = aiObservabilityDashboardLogic({ tabId: 'first-tab' })
+        firstLogic.mount()
+        firstLogic.actions.loadLLMDashboardsSuccess([{ id: 42, name: 'AI dashboard', description: '' }])
+        firstLogic.unmount()
+
+        const secondLogic = aiObservabilityDashboardLogic({ tabId: 'second-tab' })
+        secondLogic.mount()
+
+        expect(secondLogic.values.selectedDashboardId).toBe(42)
+
+        secondLogic.unmount()
+    })
+
+    it('keeps trace display preferences stable across tab ids', () => {
+        const firstLogic = aiObservabilityTraceLogic({ tabId: 'first-tab' })
+        firstLogic.mount()
+        firstLogic.actions.setIsRenderingMarkdown(false)
+        firstLogic.actions.setIsRenderingXml(true)
+        firstLogic.actions.setDisplayOption(DisplayOption.TextView)
+        firstLogic.actions.setTraceReviewPanelExpanded(true)
+        firstLogic.unmount()
+
+        const secondLogic = aiObservabilityTraceLogic({ tabId: 'second-tab' })
+        secondLogic.mount()
+
+        expect(secondLogic.values.isRenderingMarkdown).toBe(false)
+        expect(secondLogic.values.isRenderingXml).toBe(true)
+        expect(secondLogic.values.displayOption).toBe(DisplayOption.TextView)
+        expect(secondLogic.values.isTraceReviewPanelExpanded).toBe(true)
+
+        secondLogic.unmount()
     })
 })

--- a/products/ai_observability/frontend/aiObservabilityLogic.test.ts
+++ b/products/ai_observability/frontend/aiObservabilityLogic.test.ts
@@ -1,3 +1,5 @@
+import { MOCK_TEAM_ID } from 'lib/api.mock'
+
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
@@ -472,5 +474,19 @@ describe('AI observability persisted preferences', () => {
         expect(secondLogic.values.isTraceReviewPanelExpanded).toBe(true)
 
         secondLogic.unmount()
+    })
+
+    it('scopes explicit storage keys to the current team', () => {
+        const logic = aiObservabilityTraceLogic({ tabId: 'team-scoped-tab' })
+        logic.mount()
+        logic.actions.setIsRenderingMarkdown(false)
+
+        const storageKey = `${MOCK_TEAM_ID}__ai_observability.trace.isRenderingMarkdown`
+        expect(window.localStorage[storageKey]).toBe('false')
+        expect(
+            Object.getOwnPropertyNames(window.localStorage).filter((key) => key.endsWith('trace.isRenderingMarkdown'))
+        ).toEqual([storageKey])
+
+        logic.unmount()
     })
 })

--- a/products/ai_observability/frontend/aiObservabilityTraceLogic.ts
+++ b/products/ai_observability/frontend/aiObservabilityTraceLogic.ts
@@ -31,7 +31,7 @@ import { ActivityScope, AnyPropertyFilter, Breadcrumb, InsightLogicProps } from 
 
 import { aiObservabilitySharedLogic } from './aiObservabilitySharedLogic'
 import type { aiObservabilityTraceLogicType } from './aiObservabilityTraceLogicType'
-import { aiObservabilityPreferenceStorage } from './preferenceStorage'
+import { buildAiObservabilityStorageConfig } from './preferenceStorage'
 
 export enum DisplayOption {
     ExpandAll = 'expand_all',
@@ -122,7 +122,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         loadNeighbors: (traceId: string, timestamp: string) => ({ traceId, timestamp }),
     }),
 
-    reducers({
+    reducers(() => ({
         traceId: ['' as string, { setTraceId: (_, { traceId }) => traceId }],
         eventId: [null as string | null, { setEventId: (_, { eventId }) => eventId }],
         highlightMessageIndex: [
@@ -170,7 +170,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         searchQuery: ['' as string, { setSearchQuery: (_, { searchQuery }) => String(searchQuery || '') }],
         isRenderingMarkdown: [
             true as boolean,
-            { ...aiObservabilityPreferenceStorage, storageKey: 'trace.isRenderingMarkdown' },
+            buildAiObservabilityStorageConfig('trace.isRenderingMarkdown'),
             {
                 setIsRenderingMarkdown: (_, { isRenderingMarkdown }) => isRenderingMarkdown,
                 toggleMarkdownRendering: (state) => !state,
@@ -178,7 +178,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         ],
         isRenderingXml: [
             false as boolean,
-            { ...aiObservabilityPreferenceStorage, storageKey: 'trace.isRenderingXml' },
+            buildAiObservabilityStorageConfig('trace.isRenderingXml'),
             {
                 setIsRenderingXml: (_, { isRenderingXml }) => isRenderingXml,
                 toggleXmlRendering: (state) => !state,
@@ -225,7 +225,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         ],
         displayOption: [
             DisplayOption.CollapseExceptOutputAndLastInput as DisplayOption,
-            { ...aiObservabilityPreferenceStorage, storageKey: 'trace.displayOption' },
+            buildAiObservabilityStorageConfig('trace.displayOption'),
             {
                 setDisplayOption: (_, { displayOption }) => displayOption,
                 handleTextViewFallback: () => DisplayOption.ExpandAll,
@@ -233,7 +233,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         ],
         eventTypeExpandedMap: [
             {} as Record<string, boolean>,
-            { ...aiObservabilityPreferenceStorage, storageKey: 'trace.eventTypeExpandedMap' },
+            buildAiObservabilityStorageConfig('trace.eventTypeExpandedMap'),
             {
                 toggleEventTypeExpanded: (state, { eventType }) => ({
                     ...state,
@@ -243,12 +243,12 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         ],
         isTraceReviewPanelExpanded: [
             false as boolean,
-            { ...aiObservabilityPreferenceStorage, storageKey: 'trace.isTraceReviewPanelExpanded' },
+            buildAiObservabilityStorageConfig('trace.isTraceReviewPanelExpanded'),
             {
                 setTraceReviewPanelExpanded: (_, { isExpanded }) => isExpanded,
             },
         ],
-    }),
+    })),
 
     loaders(({ values }) => ({
         commentCount: [

--- a/products/ai_observability/frontend/aiObservabilityTraceLogic.ts
+++ b/products/ai_observability/frontend/aiObservabilityTraceLogic.ts
@@ -31,9 +31,7 @@ import { ActivityScope, AnyPropertyFilter, Breadcrumb, InsightLogicProps } from 
 
 import { aiObservabilitySharedLogic } from './aiObservabilitySharedLogic'
 import type { aiObservabilityTraceLogicType } from './aiObservabilityTraceLogicType'
-
-const teamId = window.POSTHOG_APP_CONTEXT?.current_team?.id
-const persistConfig = { persist: true, prefix: `${teamId}__` }
+import { aiObservabilityPreferenceStorage } from './preferenceStorage'
 
 export enum DisplayOption {
     ExpandAll = 'expand_all',
@@ -172,7 +170,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         searchQuery: ['' as string, { setSearchQuery: (_, { searchQuery }) => String(searchQuery || '') }],
         isRenderingMarkdown: [
             true as boolean,
-            persistConfig,
+            { ...aiObservabilityPreferenceStorage, storageKey: 'trace.isRenderingMarkdown' },
             {
                 setIsRenderingMarkdown: (_, { isRenderingMarkdown }) => isRenderingMarkdown,
                 toggleMarkdownRendering: (state) => !state,
@@ -180,7 +178,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         ],
         isRenderingXml: [
             false as boolean,
-            persistConfig,
+            { ...aiObservabilityPreferenceStorage, storageKey: 'trace.isRenderingXml' },
             {
                 setIsRenderingXml: (_, { isRenderingXml }) => isRenderingXml,
                 toggleXmlRendering: (state) => !state,
@@ -227,7 +225,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         ],
         displayOption: [
             DisplayOption.CollapseExceptOutputAndLastInput as DisplayOption,
-            persistConfig,
+            { ...aiObservabilityPreferenceStorage, storageKey: 'trace.displayOption' },
             {
                 setDisplayOption: (_, { displayOption }) => displayOption,
                 handleTextViewFallback: () => DisplayOption.ExpandAll,
@@ -235,7 +233,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         ],
         eventTypeExpandedMap: [
             {} as Record<string, boolean>,
-            persistConfig,
+            { ...aiObservabilityPreferenceStorage, storageKey: 'trace.eventTypeExpandedMap' },
             {
                 toggleEventTypeExpanded: (state, { eventType }) => ({
                     ...state,
@@ -245,7 +243,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         ],
         isTraceReviewPanelExpanded: [
             false as boolean,
-            persistConfig,
+            { ...aiObservabilityPreferenceStorage, storageKey: 'trace.isTraceReviewPanelExpanded' },
             {
                 setTraceReviewPanelExpanded: (_, { isExpanded }) => isExpanded,
             },

--- a/products/ai_observability/frontend/preferenceStorage.ts
+++ b/products/ai_observability/frontend/preferenceStorage.ts
@@ -1,0 +1,7 @@
+const teamId = window.POSTHOG_APP_CONTEXT?.current_team?.id
+const teamPrefix = teamId ? `${teamId}__` : ''
+
+export const aiObservabilityPreferenceStorage = {
+    persist: true,
+    prefix: `${teamPrefix}ai_observability`,
+} as const

--- a/products/ai_observability/frontend/preferenceStorage.ts
+++ b/products/ai_observability/frontend/preferenceStorage.ts
@@ -1,7 +1,16 @@
-const teamId = window.POSTHOG_APP_CONTEXT?.current_team?.id
-const teamPrefix = teamId ? `${teamId}__` : ''
+import { getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
 
-export const aiObservabilityPreferenceStorage = {
-    persist: true,
-    prefix: `${teamPrefix}ai_observability`,
-} as const
+interface AIObservabilityPreferenceStorageConfig {
+    persist: true
+    storageKey: string
+}
+
+export function buildAiObservabilityStorageConfig(storageKey: string): AIObservabilityPreferenceStorageConfig {
+    const teamId = getCurrentTeamIdOrNone()
+    const teamPrefix = teamId ? `${teamId}__` : ''
+
+    return {
+        persist: true,
+        storageKey: `${teamPrefix}ai_observability.${storageKey}`,
+    }
+}

--- a/products/ai_observability/frontend/tabs/aiObservabilityDashboardLogic.ts
+++ b/products/ai_observability/frontend/tabs/aiObservabilityDashboardLogic.ts
@@ -21,7 +21,7 @@ import {
 } from '~/types'
 
 import { aiObservabilitySharedLogic } from '../aiObservabilitySharedLogic'
-import { aiObservabilityPreferenceStorage } from '../preferenceStorage'
+import { buildAiObservabilityStorageConfig } from '../preferenceStorage'
 import type { aiObservabilityDashboardLogicType } from './aiObservabilityDashboardLogicType'
 
 export interface AIObservabilityDashboardLogicProps {
@@ -69,7 +69,7 @@ export const aiObservabilityDashboardLogic = kea<aiObservabilityDashboardLogicTy
         loadLLMDashboards: true,
     }),
 
-    reducers({
+    reducers(() => ({
         refreshStatus: [
             {} as Record<string, { loading?: boolean; timer?: Date }>,
             {
@@ -90,7 +90,7 @@ export const aiObservabilityDashboardLogic = kea<aiObservabilityDashboardLogicTy
 
         selectedDashboardId: [
             null as number | null,
-            { ...aiObservabilityPreferenceStorage, storageKey: 'dashboard.selectedDashboardId' },
+            buildAiObservabilityStorageConfig('dashboard.selectedDashboardId'),
             {
                 loadLLMDashboardsSuccess: (state, { availableDashboards }) => {
                     // If no dashboards available, clear selection
@@ -108,7 +108,7 @@ export const aiObservabilityDashboardLogic = kea<aiObservabilityDashboardLogicTy
                 },
             },
         ],
-    }),
+    })),
 
     loaders(() => ({
         availableDashboards: [

--- a/products/ai_observability/frontend/tabs/aiObservabilityDashboardLogic.ts
+++ b/products/ai_observability/frontend/tabs/aiObservabilityDashboardLogic.ts
@@ -21,6 +21,7 @@ import {
 } from '~/types'
 
 import { aiObservabilitySharedLogic } from '../aiObservabilitySharedLogic'
+import { aiObservabilityPreferenceStorage } from '../preferenceStorage'
 import type { aiObservabilityDashboardLogicType } from './aiObservabilityDashboardLogicType'
 
 export interface AIObservabilityDashboardLogicProps {
@@ -89,7 +90,7 @@ export const aiObservabilityDashboardLogic = kea<aiObservabilityDashboardLogicTy
 
         selectedDashboardId: [
             null as number | null,
-            { persist: true, prefix: 'llma_' },
+            { ...aiObservabilityPreferenceStorage, storageKey: 'dashboard.selectedDashboardId' },
             {
                 loadLLMDashboardsSuccess: (state, { availableDashboards }) => {
                     // If no dashboards available, clear selection

--- a/products/ai_observability/frontend/tabs/aiObservabilityGenerationsLogic.ts
+++ b/products/ai_observability/frontend/tabs/aiObservabilityGenerationsLogic.ts
@@ -9,7 +9,7 @@ import { groupsModel } from '~/models/groupsModel'
 import { DataTableNode, LLMTrace, NodeKind, TraceQuery } from '~/queries/schema/schema-general'
 
 import { SortDirection, SortState, aiObservabilitySharedLogic } from '../aiObservabilitySharedLogic'
-import { aiObservabilityPreferenceStorage } from '../preferenceStorage'
+import { buildAiObservabilityStorageConfig } from '../preferenceStorage'
 import type { aiObservabilityGenerationsLogicType } from './aiObservabilityGenerationsLogicType'
 
 export interface AIObservabilityGenerationsLogicProps {
@@ -62,7 +62,7 @@ export const aiObservabilityGenerationsLogic = kea<aiObservabilityGenerationsLog
         clearExpandedGenerations: true,
     }),
 
-    reducers({
+    reducers(() => ({
         generationsQueryOverride: [
             null as DataTableNode | null,
             {
@@ -72,7 +72,7 @@ export const aiObservabilityGenerationsLogic = kea<aiObservabilityGenerationsLog
 
         generationsColumns: [
             null as string[] | null,
-            { ...aiObservabilityPreferenceStorage, storageKey: 'generations.columns' },
+            buildAiObservabilityStorageConfig('generations.columns'),
             {
                 setGenerationsColumns: (_, { columns }) => columns,
             },
@@ -121,7 +121,7 @@ export const aiObservabilityGenerationsLogic = kea<aiObservabilityGenerationsLog
                 applyUrlState: () => ({}),
             },
         ],
-    }),
+    })),
 
     listeners(({ actions, values }) => ({
         toggleGenerationExpanded: async ({ uuid, traceId }) => {

--- a/products/ai_observability/frontend/tabs/aiObservabilityGenerationsLogic.ts
+++ b/products/ai_observability/frontend/tabs/aiObservabilityGenerationsLogic.ts
@@ -9,6 +9,7 @@ import { groupsModel } from '~/models/groupsModel'
 import { DataTableNode, LLMTrace, NodeKind, TraceQuery } from '~/queries/schema/schema-general'
 
 import { SortDirection, SortState, aiObservabilitySharedLogic } from '../aiObservabilitySharedLogic'
+import { aiObservabilityPreferenceStorage } from '../preferenceStorage'
 import type { aiObservabilityGenerationsLogicType } from './aiObservabilityGenerationsLogicType'
 
 export interface AIObservabilityGenerationsLogicProps {
@@ -71,7 +72,7 @@ export const aiObservabilityGenerationsLogic = kea<aiObservabilityGenerationsLog
 
         generationsColumns: [
             null as string[] | null,
-            { persist: true },
+            { ...aiObservabilityPreferenceStorage, storageKey: 'generations.columns' },
             {
                 setGenerationsColumns: (_, { columns }) => columns,
             },

--- a/products/ai_observability/frontend/tabs/aiObservabilityTracesTabLogic.ts
+++ b/products/ai_observability/frontend/tabs/aiObservabilityTracesTabLogic.ts
@@ -9,6 +9,7 @@ import { groupsModel } from '~/models/groupsModel'
 import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
 
 import { aiObservabilitySharedLogic } from '../aiObservabilitySharedLogic'
+import { aiObservabilityPreferenceStorage } from '../preferenceStorage'
 import { LLM_TRACES_PAGE_SIZE } from '../utils'
 import type { aiObservabilityTracesTabLogicType } from './aiObservabilityTracesTabLogicType'
 
@@ -57,14 +58,14 @@ export const aiObservabilityTracesTabLogic = kea<aiObservabilityTracesTabLogicTy
         ],
         showInputOutputColumns: [
             true as boolean,
-            { persist: true },
+            { ...aiObservabilityPreferenceStorage, storageKey: 'traces.showInputOutputColumns' },
             {
                 setShowInputOutputColumns: (_, { show }) => show,
             },
         ],
         showSentimentColumn: [
             true as boolean,
-            { persist: true },
+            { ...aiObservabilityPreferenceStorage, storageKey: 'traces.showSentimentColumn' },
             {
                 setShowSentimentColumn: (_, { show }) => show,
             },

--- a/products/ai_observability/frontend/tabs/aiObservabilityTracesTabLogic.ts
+++ b/products/ai_observability/frontend/tabs/aiObservabilityTracesTabLogic.ts
@@ -9,7 +9,7 @@ import { groupsModel } from '~/models/groupsModel'
 import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
 
 import { aiObservabilitySharedLogic } from '../aiObservabilitySharedLogic'
-import { aiObservabilityPreferenceStorage } from '../preferenceStorage'
+import { buildAiObservabilityStorageConfig } from '../preferenceStorage'
 import { LLM_TRACES_PAGE_SIZE } from '../utils'
 import type { aiObservabilityTracesTabLogicType } from './aiObservabilityTracesTabLogicType'
 
@@ -49,7 +49,7 @@ export const aiObservabilityTracesTabLogic = kea<aiObservabilityTracesTabLogicTy
         setShowSentimentColumn: (show: boolean) => ({ show }),
     }),
 
-    reducers({
+    reducers(() => ({
         tracesQueryOverride: [
             null as DataTableNode | null,
             {
@@ -58,19 +58,19 @@ export const aiObservabilityTracesTabLogic = kea<aiObservabilityTracesTabLogicTy
         ],
         showInputOutputColumns: [
             true as boolean,
-            { ...aiObservabilityPreferenceStorage, storageKey: 'traces.showInputOutputColumns' },
+            buildAiObservabilityStorageConfig('traces.showInputOutputColumns'),
             {
                 setShowInputOutputColumns: (_, { show }) => show,
             },
         ],
         showSentimentColumn: [
             true as boolean,
-            { ...aiObservabilityPreferenceStorage, storageKey: 'traces.showSentimentColumn' },
+            buildAiObservabilityStorageConfig('traces.showSentimentColumn'),
             {
                 setShowSentimentColumn: (_, { show }) => show,
             },
         ],
-    }),
+    })),
 
     selectors({
         tracesQuery: [


### PR DESCRIPTION
## Problem

AI observability stores several UI preferences in Kea localStorage reducers. Some of those logics are keyed by `tabId`, which is now a fresh page-load identifier, so saved preferences can be missed after refreshes.

## Changes

- Add a shared AI observability preference storage namespace scoped by team.
- Use explicit storage keys for generation columns, trace table columns, dashboard selection, and trace display options.
- Add tests that mount the logics with different `tabId`s and verify persisted preferences survive.
- No screenshots; this changes preference persistence behavior only.

## How did you test this code?

Automated tests covering AI observability persisted preferences.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update; this is frontend preference storage behavior only.

## 🤖 Agent context

Codex prepared this PR. The main decision was to keep the existing tab-aware scene pattern, but decouple persisted AI observability preferences from random page-load `tabId`s by giving the reducers explicit stable storage keys.

The generation columns reducer now uses the same namespace as the other AI observability preferences with no legacy fallback.