### PR TITLE
fix(propdefs): stop writing $feature/* rows to posthog_eventproperty

### DIFF
--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -71,6 +71,13 @@ pub const SKIP_PROPERTIES: [&str; 9] = [
     "$groups",
 ];
 
+// Property key prefixes that should NOT generate posthog_eventproperty rows.
+// Feature flags are appended as $feature/<key> on nearly every event by posthog-js,
+// so the (event_name × flag_key) cross product dominates eventproperty cardinality
+// without providing useful per-event scoping (flags are global). The corresponding
+// PropertyDefinition rows ARE still written so flags remain discoverable.
+pub const SKIP_EVENT_PROPERTY_PREFIXES: [&str; 2] = ["$feature/", "$feature_enrollment/"];
+
 const DATETIME_PROPERTY_NAME_KEYWORDS: [&str; 7] = [
     "time",
     "timestamp",
@@ -344,12 +351,23 @@ impl Event {
             // person, group, and session properties have no meaningful event association
             // and no read path consumes those rows.
             if parent_type == PropertyParentType::Event {
-                updates.push(Update::EventProperty(EventProperty {
-                    team_id: self.team_id,
-                    project_id: self.project_id,
-                    event: sanitize_string(&self.event),
-                    property: sanitize_string(key),
-                }));
+                if SKIP_EVENT_PROPERTY_PREFIXES
+                    .iter()
+                    .any(|prefix| key.starts_with(prefix))
+                {
+                    metrics::counter!(
+                        UPDATES_SKIPPED,
+                        &[("reason", "feature_flag_event_property")]
+                    )
+                    .increment(1);
+                } else {
+                    updates.push(Update::EventProperty(EventProperty {
+                        team_id: self.team_id,
+                        project_id: self.project_id,
+                        event: sanitize_string(&self.event),
+                        property: sanitize_string(key),
+                    }));
+                }
             }
 
             let property_type = detect_property_type(key, value);

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -76,6 +76,8 @@ pub const SKIP_PROPERTIES: [&str; 9] = [
 // so the (event_name × flag_key) cross product dominates eventproperty cardinality
 // without providing useful per-event scoping (flags are global). The corresponding
 // PropertyDefinition rows ARE still written so flags remain discoverable.
+// $feature_enrollment/ is usually a person property; it's included defensively for the
+// rare cases it arrives as a top-level event property, and carries little cardinality weight.
 pub const SKIP_EVENT_PROPERTY_PREFIXES: [&str; 2] = ["$feature/", "$feature_enrollment/"];
 
 const DATETIME_PROPERTY_NAME_KEYWORDS: [&str; 7] = [

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -2,7 +2,8 @@ use chrono::Utc;
 use property_defs_rs::types::{
     detect_property_type, get_floored_last_seen, Event, PropertyValueType, Update,
 };
-use serde_json::{json, Number, Value};
+use rstest::rstest;
+use serde_json::{json, Map, Number, Value};
 
 #[test]
 fn test_date_flooring() {
@@ -635,4 +636,60 @@ fn test_plain_event_properties_still_emitted() {
     );
     assert!(event_property_keys.contains(&"page"));
     assert!(event_property_keys.contains(&"referrer"));
+}
+
+#[rstest]
+#[case("$feature/", "$feature/my-flag")]
+#[case("$feature_enrollment/", "$feature_enrollment/enrolled-flag")]
+fn test_feature_flag_properties_skip_event_property_but_keep_property_definition(
+    #[case] prefix: &str,
+    #[case] flagged_key: &str,
+) {
+    let mut props_map = Map::new();
+    props_map.insert("page".to_string(), json!("/home"));
+    props_map.insert("$active_feature_flags".to_string(), json!(["my-flag"]));
+    props_map.insert(flagged_key.to_string(), json!(true));
+
+    let event = Event {
+        team_id: 1,
+        project_id: 1,
+        event: "$pageview".to_string(),
+        properties: Some(Value::Object(props_map).to_string()),
+    };
+
+    let updates = event.into_updates(1000);
+
+    let event_property_keys: Vec<&str> = updates
+        .iter()
+        .filter_map(|u| match u {
+            Update::EventProperty(ep) => Some(ep.property.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !event_property_keys.iter().any(|k| k.starts_with(prefix)),
+        "{prefix}* must not appear in EventProperty: {event_property_keys:?}"
+    );
+
+    assert!(
+        event_property_keys.contains(&"page"),
+        "expected EventProperty for 'page': {event_property_keys:?}"
+    );
+    assert!(
+        event_property_keys.contains(&"$active_feature_flags"),
+        "expected EventProperty for '$active_feature_flags': {event_property_keys:?}"
+    );
+
+    let prop_def_names: Vec<&str> = updates
+        .iter()
+        .filter_map(|u| match u {
+            Update::Property(pd) => Some(pd.name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        prop_def_names.contains(&flagged_key),
+        "expected PropertyDefinition for '{flagged_key}': {prop_def_names:?}"
+    );
 }


### PR DESCRIPTION
## Problem

`posthog-js` emits active flags as `$feature/<key>` properties on nearly every event. The `(event_name x flag_key)` cross product dominates `posthog_eventproperty` cardinality — 86% of distinct rows for the heaviest EU tenant — saturating the `eventprops` cache at 100% fill and causing ~2k evictions/sec in prod-eu.

## Changes

- **Write skip** ([types.rs L73-L80](https://github.com/PostHog/posthog/blob/eli.r/propdefs-skip-feature-flag-eventproperty-writes/rust/property-defs-rs/src/types.rs#L73-L80)): Added `SKIP_EVENT_PROPERTY_PREFIXES` for `$feature/` and `$feature_enrollment/`. In `get_props_from_object` ([L354-L365](https://github.com/PostHog/posthog/blob/eli.r/propdefs-skip-feature-flag-eventproperty-writes/rust/property-defs-rs/src/types.rs#L354-L365)), skip the `Update::EventProperty` push for matching keys while still pushing `Update::Property` so flags remain discoverable in `posthog_propertydefinition`.
- **Observability**: emits `prop_defs_skipped_updates{reason="feature_flag_event_property"}` counter.
- **Rollback**: pure write-path filter. Reverting the binary resumes writing; `ON CONFLICT DO NOTHING` means no dedup damage.

**Safety**: all read paths for feature flags filter on `posthog_propertydefinition.name LIKE '$feature/%'` ([Django](https://github.com/PostHog/posthog/blob/master/posthog/taxonomy/property_definition_api.py#L201), [Rust](https://github.com/PostHog/posthog/blob/master/rust/property-defs-rs/src/api/v1/query.rs#L461)), not on `posthog_eventproperty`. The one read path that would break (scoped feature-flag picker INNER JOIN) is fixed in the prerequisite PR (#61259).

**Depends on**: #61259 must land first.

## How did you test this code?

Added `test_feature_flag_properties_skip_event_property_but_keep_property_definition` to `tests/types.rs` — asserts `$feature/*` and `$feature_enrollment/*` keys produce `PropertyDefinition` but NOT `EventProperty` updates, while regular keys still produce both. All 18 Rust tests pass (`SQLX_OFFLINE=true cargo test --test types`).

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Eli planned, Claude coded. 