### PR TITLE
feat(agents): deterministic tabular memory for agents

### DIFF
--- a/products/agent_stack/backend/api.py
+++ b/products/agent_stack/backend/api.py
@@ -1973,6 +1973,12 @@ class AgentMemoryViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         )
         if app is None:
             raise NotFound("Application not found")
+        # This is a plain ViewSet, so it bypasses the mixin's get_object() and
+        # the object-level RBAC it runs. Enforce per-application access control
+        # explicitly (mirrors TeamAndOrgViewSetMixin.get_object) — otherwise a
+        # user with team access but no access to THIS application could read its
+        # memory files / tables by guessing the slug or UUID.
+        self.check_object_permissions(self.request, app)
         return app
 
     def _log_memory_change(

--- a/products/agent_stack/backend/api.py
+++ b/products/agent_stack/backend/api.py
@@ -2064,13 +2064,14 @@ class AgentMemoryViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     def table_rows(self, request: Request, name: str | None = None, **kwargs) -> Response:
         application = self._get_application()
         limit_raw = request.query_params.get("limit")
+        limit: int | None = None
+        if limit_raw:
+            try:
+                limit = int(limit_raw)
+            except ValueError:
+                raise ValidationError("limit must be an integer")
         try:
-            payload = _janitor().read_table(
-                int(self.team_id),
-                str(application.id),
-                str(name),
-                limit=int(limit_raw) if limit_raw else None,
-            )
+            payload = _janitor().read_table(int(self.team_id), str(application.id), str(name), limit=limit)
         except JanitorClientError as e:
             raise JanitorUpstreamError(e) from e
         return Response(payload)

--- a/products/agent_stack/backend/api.py
+++ b/products/agent_stack/backend/api.py
@@ -1844,6 +1844,37 @@ _MEMORY_FILE_RESPONSE = inline_serializer(
     },
 )
 
+_AGENT_TABLES_LIST_RESPONSE = inline_serializer(
+    name="AgentTablesListResponse",
+    fields={
+        "count": drf_serializers.IntegerField(help_text="Number of tables."),
+        "tables": drf_serializers.ListField(
+            child=inline_serializer(
+                name="AgentTableHeader",
+                fields={
+                    "name": drf_serializers.CharField(help_text="Table name."),
+                    "size": drf_serializers.IntegerField(help_text="Object size in bytes."),
+                },
+            ),
+            help_text="Tabular-reference tables for this agent (the @posthog/table-* JSONL tables).",
+        ),
+    },
+)
+
+_AGENT_TABLE_ROWS_RESPONSE = inline_serializer(
+    name="AgentTableRowsResponse",
+    fields={
+        "name": drf_serializers.CharField(),
+        "total": drf_serializers.IntegerField(help_text="Total rows in the table."),
+        "returned": drf_serializers.IntegerField(help_text="Rows in this response (capped by limit)."),
+        "limit": drf_serializers.IntegerField(),
+        "rows": drf_serializers.ListField(
+            child=drf_serializers.DictField(),
+            help_text="The rows (arbitrary JSON objects).",
+        ),
+    },
+)
+
 _MEMORY_TREE_RESPONSE = inline_serializer(
     name="AgentMemoryTreeResponse",
     fields={
@@ -1929,7 +1960,7 @@ class AgentMemoryViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     """
 
     scope_object = "agent_application"  # share the parent's scope
-    scope_object_read_actions = ["list_files", "tree", "get_file", "search"]
+    scope_object_read_actions = ["list_files", "tree", "get_file", "search", "tables", "table_rows"]
     scope_object_write_actions = ["create_file", "update_file", "delete_file"]
     # The parent URL kwarg is `application_id`; we override resolution to
     # accept slug-or-UUID via _resolve_application.
@@ -1994,6 +2025,51 @@ class AgentMemoryViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                 int(self.team_id),
                 str(application.id),
                 prefix=request.query_params.get("prefix") or None,
+            )
+        except JanitorClientError as e:
+            raise JanitorUpstreamError(e) from e
+        return Response(payload)
+
+    @extend_schema(
+        operation_id="agent_memory_list_tables",
+        request=None,
+        responses=OpenApiResponse(response=_AGENT_TABLES_LIST_RESPONSE),
+        description="List the agent's tabular-reference tables (the @posthog/table-* JSONL tables): name + byte size.",
+    )
+    @action(detail=False, methods=["get"], url_path="tables")
+    def tables(self, request: Request, **kwargs) -> Response:
+        application = self._get_application()
+        try:
+            payload = _janitor().list_tables(int(self.team_id), str(application.id))
+        except JanitorClientError as e:
+            raise JanitorUpstreamError(e) from e
+        return Response(payload)
+
+    @extend_schema(
+        operation_id="agent_memory_read_table",
+        parameters=[
+            OpenApiParameter(
+                "limit",
+                OpenApiTypes.INT,
+                OpenApiParameter.QUERY,
+                required=False,
+                description="Max rows to return (default 500, max 5000).",
+            ),
+        ],
+        request=None,
+        responses=OpenApiResponse(response=_AGENT_TABLE_ROWS_RESPONSE),
+        description="Read rows from one tabular-reference table (capped via ?limit).",
+    )
+    @action(detail=False, methods=["get"], url_path="tables/(?P<name>[^/]+)")
+    def table_rows(self, request: Request, name: str | None = None, **kwargs) -> Response:
+        application = self._get_application()
+        limit_raw = request.query_params.get("limit")
+        try:
+            payload = _janitor().read_table(
+                int(self.team_id),
+                str(application.id),
+                str(name),
+                limit=int(limit_raw) if limit_raw else None,
             )
         except JanitorClientError as e:
             raise JanitorUpstreamError(e) from e

--- a/products/agent_stack/backend/janitor_client.py
+++ b/products/agent_stack/backend/janitor_client.py
@@ -252,6 +252,17 @@ class JanitorClient:
     def get_memory_tree(self, team_id: int, application_id: str) -> dict:
         return self._call("GET", f"/memory/team/{team_id}/agent/{application_id}/tree")
 
+    # Tabular reference (the @posthog/table-* tools' JSONL tables) — read-only,
+    # surfaced in the console's memory tab alongside the markdown files.
+    def list_tables(self, team_id: int, application_id: str) -> dict:
+        return self._call("GET", f"/tables/team/{team_id}/agent/{application_id}")
+
+    def read_table(self, team_id: int, application_id: str, name: str, *, limit: int | None = None) -> dict:
+        params: dict[str, Any] = {}
+        if limit:
+            params["limit"] = limit
+        return self._call("GET", f"/tables/team/{team_id}/agent/{application_id}/{name}", params=params)
+
     def read_memory_file(self, team_id: int, application_id: str, path: str) -> dict:
         # The janitor uses the URL tail (Express `:path(.*)`) for the file path,
         # so `incidents/db.md` becomes `/files/incidents/db.md`. We don't

--- a/products/agent_stack/backend/test_memory_authz.py
+++ b/products/agent_stack/backend/test_memory_authz.py
@@ -1,0 +1,50 @@
+"""
+Object-level access control on the agent memory / table endpoints.
+
+`AgentMemoryViewSet` is a plain `ViewSet`, so it resolves the application via
+its own `_get_application()` rather than the mixin's `get_object()`. That
+helper must still run `check_object_permissions`, or a user with team access
+but no access to a specific application could read its memory files / tables
+by guessing the slug or UUID. These tests pin the team-scoping boundary and
+that the authorized path is not over-blocked by the added check.
+"""
+
+from __future__ import annotations
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+from posthog.models import Organization, Team
+
+from .models import AgentApplication
+
+
+class TestMemoryViewSetAuthz(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.application = AgentApplication.objects.create(
+            team=self.team, slug="memo-agent", name="Memo agent", description=""
+        )
+        self.tables_url = f"/api/projects/{self.team.id}/agent_applications/{self.application.id}/memory/tables/"
+
+    @patch("products.agent_stack.backend.api._janitor")
+    def test_authorized_member_can_list_tables(self, mock_janitor: MagicMock) -> None:
+        # The added object-permission check must not over-block or crash the
+        # normal path: a team member resolves the app and proxies to the janitor.
+        mock_janitor.return_value.list_tables.return_value = {"tables": []}
+        res = self.client.get(self.tables_url)
+        self.assertEqual(res.status_code, 200, res.content)
+        mock_janitor.return_value.list_tables.assert_called_once()
+
+    @patch("products.agent_stack.backend.api._janitor")
+    def test_application_from_another_team_is_not_readable(self, mock_janitor: MagicMock) -> None:
+        # An application owned by a different team must not be reachable through
+        # this team's URL — resolution is team-scoped, so the janitor is never
+        # called and no rows leak across the tenant boundary.
+        other_org = Organization.objects.create(name="other-org")
+        other_team = Team.objects.create(organization=other_org, name="other-team")
+        foreign = AgentApplication.objects.create(team=other_team, slug="foreign", name="Foreign", description="")
+        url = f"/api/projects/{self.team.id}/agent_applications/{foreign.id}/memory/tables/"
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 404, res.content)
+        mock_janitor.return_value.list_tables.assert_not_called()

--- a/products/agent_stack/frontend/generated/api.schemas.ts
+++ b/products/agent_stack/frontend/generated/api.schemas.ts
@@ -113,6 +113,33 @@ export interface AgentMemorySearchResponseApi {
     results: AgentMemorySearchResultApi[]
 }
 
+export interface AgentTableHeaderApi {
+    /** Table name. */
+    name: string
+    /** Object size in bytes. */
+    size: number
+}
+
+export interface AgentTablesListResponseApi {
+    /** Number of tables. */
+    count: number
+    /** Tabular-reference tables for this agent (the @posthog/table-* JSONL tables). */
+    tables: AgentTableHeaderApi[]
+}
+
+export type AgentTableRowsResponseApiRowsItem = { [key: string]: unknown }
+
+export interface AgentTableRowsResponseApi {
+    name: string
+    /** Total rows in the table. */
+    total: number
+    /** Rows in this response (capped by limit). */
+    returned: number
+    limit: number
+    /** The rows (arbitrary JSON objects). */
+    rows: AgentTableRowsResponseApiRowsItem[]
+}
+
 /**
  * Folder tree rooted at the agent's memory prefix. Each node is {name, type: 'folder'|'file', path?, description?, tags?, children?}.
  */
@@ -1627,6 +1654,13 @@ export type AgentMemorySearchParams = {
      * Search cue — plain natural language is fine.
      */
     q: string
+}
+
+export type AgentMemoryReadTableParams = {
+    /**
+     * Max rows to return (default 500, max 5000).
+     */
+    limit?: number
 }
 
 export type AgentApplicationsRevisionsListParams = {

--- a/products/agent_stack/frontend/generated/api.ts
+++ b/products/agent_stack/frontend/generated/api.ts
@@ -43,6 +43,7 @@ import type {
     AgentMemoryGetFileParams,
     AgentMemoryListFilesParams,
     AgentMemoryListResponseApi,
+    AgentMemoryReadTableParams,
     AgentMemorySearchParams,
     AgentMemorySearchResponseApi,
     AgentMemoryTreeResponseApi,
@@ -57,6 +58,8 @@ import type {
     AgentSkillTemplatesListParams,
     AgentSkillTemplatesNameRetrieveParams,
     AgentSkillTemplatesNameUsagesListParams,
+    AgentTableRowsResponseApi,
+    AgentTablesListResponseApi,
     CloneFromRequestApi,
     CustomToolTemplateCreateApi,
     CustomToolTemplateDetailApi,
@@ -368,6 +371,61 @@ export const agentMemorySearch = async (
     options?: RequestInit
 ): Promise<AgentMemorySearchResponseApi> => {
     return apiMutator<AgentMemorySearchResponseApi>(getAgentMemorySearchUrl(projectId, applicationId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getAgentMemoryListTablesUrl = (projectId: string, applicationId: string) => {
+    return `/api/projects/${projectId}/agent_applications/${applicationId}/memory/tables/`
+}
+
+/**
+ * List the agent's tabular-reference tables (the @posthog/table-* JSONL tables): name + byte size.
+ */
+export const agentMemoryListTables = async (
+    projectId: string,
+    applicationId: string,
+    options?: RequestInit
+): Promise<AgentTablesListResponseApi> => {
+    return apiMutator<AgentTablesListResponseApi>(getAgentMemoryListTablesUrl(projectId, applicationId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getAgentMemoryReadTableUrl = (
+    projectId: string,
+    applicationId: string,
+    name: string,
+    params?: AgentMemoryReadTableParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/agent_applications/${applicationId}/memory/tables/${name}/?${stringifiedParams}`
+        : `/api/projects/${projectId}/agent_applications/${applicationId}/memory/tables/${name}/`
+}
+
+/**
+ * Read rows from one tabular-reference table (capped via ?limit).
+ */
+export const agentMemoryReadTable = async (
+    projectId: string,
+    applicationId: string,
+    name: string,
+    params?: AgentMemoryReadTableParams,
+    options?: RequestInit
+): Promise<AgentTableRowsResponseApi> => {
+    return apiMutator<AgentTableRowsResponseApi>(getAgentMemoryReadTableUrl(projectId, applicationId, name, params), {
         ...options,
         method: 'GET',
     })

--- a/services/agent-console/app/agents-list-client.tsx
+++ b/services/agent-console/app/agents-list-client.tsx
@@ -38,19 +38,29 @@ export function AgentsListClient(): React.ReactElement {
     useSetDockPage({ kind: 'agent-list' })
     useSetDockConciergeAgent({ slug: 'agent-concierge' })
 
-    const agents = useResource(() => listAgents(teamId), [teamId])
+    // Poll the fleet dashboard — this is the "what's happening right now"
+    // surface, so it refreshes on a short interval (visibility-aware, so a
+    // backgrounded tab goes quiet and catches up on focus).
+    const POLL_MS = 10_000
+    const agents = useResource(() => listAgents(teamId), [teamId], { pollMs: POLL_MS })
     // Fleet endpoints are Phase C — tolerate 404 so the agents list still
     // renders against bare Django.
-    const fleet = useResource(() => tolerateMissing(getFleetStats(teamId), EMPTY_FLEET_STATS), [teamId])
+    const fleet = useResource(() => tolerateMissing(getFleetStats(teamId), EMPTY_FLEET_STATS), [teamId], {
+        pollMs: POLL_MS,
+    })
     // The fleet live-sessions endpoint returns `application_id` only —
     // we have to enrich each row with the agent's slug + name so the
     // LiveNowPanel can render and navigate. Sequence on agents so the
     // lookup is ready when the mapper runs.
-    const live = useResource(async (): Promise<ChatSession[]> => {
-        const agentList = await listAgents(teamId)
-        const agentsById = new Map(agentList.map((a) => [a.id, { id: a.id, name: a.name, slug: a.slug }]))
-        return tolerateMissing(listLiveSessions(teamId, agentsById), [])
-    }, [teamId])
+    const live = useResource(
+        async (): Promise<ChatSession[]> => {
+            const agentList = await listAgents(teamId)
+            const agentsById = new Map(agentList.map((a) => [a.id, { id: a.id, name: a.name, slug: a.slug }]))
+            return tolerateMissing(listLiveSessions(teamId, agentsById), [])
+        },
+        [teamId],
+        { pollMs: POLL_MS }
+    )
 
     const error = agents.error ?? fleet.error ?? live.error
 

--- a/services/agent-console/app/agents/[slug]/memory/memory-client.tsx
+++ b/services/agent-console/app/agents/[slug]/memory/memory-client.tsx
@@ -1,34 +1,13 @@
 'use client'
 
-import { useState } from 'react'
-
 import { useAgent } from '@/components/agent-context'
 import { MemoryClassic } from '@/components/MemoryClassic'
-import { MemoryTables } from '@/components/MemoryTables'
-
-type Pane = 'files' | 'tables'
 
 export function MemorySegment(): React.ReactElement {
     const agent = useAgent()
-    const [pane, setPane] = useState<Pane>('files')
     return (
-        <div className="flex h-full flex-col px-6 pb-6 pt-4">
-            <div className="mb-3 flex w-fit overflow-hidden rounded border border-border text-xs">
-                {(['files', 'tables'] as const).map((p) => (
-                    <button
-                        key={p}
-                        type="button"
-                        onClick={() => setPane(p)}
-                        aria-pressed={pane === p}
-                        className={`px-3 py-1 capitalize ${pane === p ? 'bg-muted font-medium' : 'hover:bg-accent'}`}
-                    >
-                        {p}
-                    </button>
-                ))}
-            </div>
-            <div className="min-h-0 flex-1">
-                {pane === 'files' ? <MemoryClassic slug={agent.slug} /> : <MemoryTables slug={agent.slug} />}
-            </div>
+        <div className="h-full px-6 pb-6 pt-4">
+            <MemoryClassic slug={agent.slug} />
         </div>
     )
 }

--- a/services/agent-console/app/agents/[slug]/memory/memory-client.tsx
+++ b/services/agent-console/app/agents/[slug]/memory/memory-client.tsx
@@ -1,13 +1,34 @@
 'use client'
 
+import { useState } from 'react'
+
 import { useAgent } from '@/components/agent-context'
 import { MemoryClassic } from '@/components/MemoryClassic'
+import { MemoryTables } from '@/components/MemoryTables'
+
+type Pane = 'files' | 'tables'
 
 export function MemorySegment(): React.ReactElement {
     const agent = useAgent()
+    const [pane, setPane] = useState<Pane>('files')
     return (
-        <div className="h-full px-6 pb-6 pt-4">
-            <MemoryClassic slug={agent.slug} />
+        <div className="flex h-full flex-col px-6 pb-6 pt-4">
+            <div className="mb-3 flex w-fit overflow-hidden rounded border border-border text-xs">
+                {(['files', 'tables'] as const).map((p) => (
+                    <button
+                        key={p}
+                        type="button"
+                        onClick={() => setPane(p)}
+                        aria-pressed={pane === p}
+                        className={`px-3 py-1 capitalize ${pane === p ? 'bg-muted font-medium' : 'hover:bg-accent'}`}
+                    >
+                        {p}
+                    </button>
+                ))}
+            </div>
+            <div className="min-h-0 flex-1">
+                {pane === 'files' ? <MemoryClassic slug={agent.slug} /> : <MemoryTables slug={agent.slug} />}
+            </div>
         </div>
     )
 }

--- a/services/agent-console/app/agents/[slug]/overview-client.tsx
+++ b/services/agent-console/app/agents/[slug]/overview-client.tsx
@@ -21,14 +21,19 @@ export function OverviewSegment(): React.ReactElement {
     useSetDockPage({ kind: 'agent', agent: { id: agent.id, name: agent.name, slug: agent.slug } })
 
     // Stats + sessions: best-effort. Janitor 404 / 502 leaves the panel
-    // with zeros + an empty list rather than failing the segment.
-    const stats = useResource(() => getAgentStats(teamId, agent.slug).catch(() => null), [teamId, agent.slug])
+    // with zeros + an empty list rather than failing the segment. Both
+    // poll on a short interval — this is a live monitoring surface.
+    const POLL_MS = 10_000
+    const stats = useResource(() => getAgentStats(teamId, agent.slug).catch(() => null), [teamId, agent.slug], {
+        pollMs: POLL_MS,
+    })
     const sessions = useResource(
         () =>
             listSessionsForAgent(teamId, agent.slug, { id: agent.id, name: agent.name, slug: agent.slug }).catch(
                 () => [] as ChatSession[]
             ),
-        [teamId, agent.slug, agent.id]
+        [teamId, agent.slug, agent.id],
+        { pollMs: POLL_MS }
     )
 
     const liveRevision = revisions.find((r) => r.id === agent.live_revision) ?? null

--- a/services/agent-console/app/agents/[slug]/sessions/sessions-client.tsx
+++ b/services/agent-console/app/agents/[slug]/sessions/sessions-client.tsx
@@ -33,12 +33,18 @@ export function SessionsSegment(): React.ReactElement {
             : { kind: 'agent-sessions', agent: { id: agent.id, name: agent.name, slug: agent.slug } }
     )
 
+    // Sessions and their logs change while an agent is running, so these
+    // reads poll on a short interval (visibility-aware — quiet in a
+    // background tab, catches up on focus).
+    const POLL_MS = 10_000
+
     const sessions = useResource(
         () =>
             listSessionsForAgent(teamId, agent.slug, { id: agent.id, name: agent.name, slug: agent.slug }).catch(
                 () => [] as ChatSession[]
             ),
-        [teamId, agent.slug, agent.id]
+        [teamId, agent.slug, agent.id],
+        { pollMs: POLL_MS }
     )
 
     const selectedSession = useResource(
@@ -50,7 +56,8 @@ export function SessionsSegment(): React.ReactElement {
                       slug: agent.slug,
                   }).catch(() => null)
                 : Promise.resolve(null),
-        [teamId, agent.slug, selectedSessionId, agent.id]
+        [teamId, agent.slug, selectedSessionId, agent.id],
+        { pollMs: POLL_MS }
     )
 
     const selectedLogs = useResource(
@@ -58,7 +65,8 @@ export function SessionsSegment(): React.ReactElement {
             selectedSessionId
                 ? listLogsForSession(teamId, agent.slug, selectedSessionId).catch(() => [] as LogEntry[])
                 : Promise.resolve([] as LogEntry[]),
-        [teamId, agent.slug, selectedSessionId]
+        [teamId, agent.slug, selectedSessionId],
+        { pollMs: POLL_MS }
     )
 
     const select = useCallback(

--- a/services/agent-console/src/components/MemoryClassic.tsx
+++ b/services/agent-console/src/components/MemoryClassic.tsx
@@ -12,7 +12,7 @@
 
 'use client'
 
-import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
+import { PencilIcon, PlusIcon, Table2Icon, Trash2Icon } from 'lucide-react'
 import { useCallback, useState } from 'react'
 
 import { Markdown } from '@posthog/agent-chat'
@@ -22,6 +22,7 @@ import {
     createMemoryFile,
     deleteMemoryFile,
     getMemoryTree,
+    listTables,
     readMemoryFile,
     searchMemoryApi,
     updateMemoryFile,
@@ -31,9 +32,13 @@ import {
 import { useResource } from '@/lib/useResource'
 
 import { FileExplorer, type FileExplorerSearchResult, type FileTreeNode } from './FileExplorer'
+import { TableView } from './MemoryTables'
 import { RefreshIndicator } from './RefreshIndicator'
 
 const NEW_FILE_SENTINEL = '__new__'
+// Selecting a tabular-reference table uses this synthetic path in the shared
+// tree; the right pane renders <TableView> instead of the file reader.
+const TABLE_PREFIX = 'table:'
 
 type ViewMode = 'rendered' | 'raw'
 
@@ -58,16 +63,26 @@ export function MemoryClassic({ slug }: MemoryClassicProps): React.ReactElement 
     const [draft, setDraft] = useState<DraftState | null>(null)
 
     const tree = useResource(() => getMemoryTree(teamId, slug), [teamId, slug])
+    const tables = useResource(() => listTables(teamId, slug), [teamId, slug])
     const search = useResource(
         () => (query.trim() ? searchMemoryApi(teamId, slug, query.trim()) : Promise.resolve(null)),
         [teamId, slug, query]
     )
 
+    // A table is selected when the path carries the table prefix — the right
+    // pane shows its rows instead of a file.
+    const selectedTable = selectedPath?.startsWith(TABLE_PREFIX) ? selectedPath.slice(TABLE_PREFIX.length) : null
+
     // Active file is what the reader pane should fetch. The "__new__"
-    // sentinel + the draft state together drive editor mode.
+    // sentinel + the draft state together drive editor mode; a selected table
+    // is not a file.
     const isEditingExisting = !!draft && !draft.isNew
     const activeFilePath =
-        draft?.isNew || selectedPath === NEW_FILE_SENTINEL ? null : isEditingExisting ? null : selectedPath
+        selectedTable || draft?.isNew || selectedPath === NEW_FILE_SENTINEL
+            ? null
+            : isEditingExisting
+              ? null
+              : selectedPath
 
     const file = useResource(
         () => (activeFilePath ? readMemoryFile(teamId, slug, activeFilePath) : Promise.resolve(null)),
@@ -139,7 +154,27 @@ export function MemoryClassic({ slug }: MemoryClassicProps): React.ReactElement 
         [teamId, slug, selectedPath, tree]
     )
 
-    const treeRoot: FileTreeNode | null = tree.data?.root ? toFileTreeNode(tree.data.root) : null
+    // The shared sidebar tree = memory files/folders, plus a "Tables" group at
+    // the end whose leaves are the agent's tabular-reference tables.
+    const memoryRoot = tree.data?.root ? toFileTreeNode(tree.data.root) : null
+    const tableNodes: FileTreeNode[] = (tables.data?.tables ?? []).map((t) => ({
+        type: 'file',
+        name: t.name,
+        path: `${TABLE_PREFIX}${t.name}`,
+        icon: <Table2Icon className="h-3.5 w-3.5 text-muted-foreground" />,
+    }))
+    const treeRoot: FileTreeNode | null =
+        memoryRoot || tableNodes.length
+            ? {
+                  type: 'folder',
+                  name: memoryRoot?.name ?? 'memory',
+                  path: memoryRoot?.path,
+                  children: [
+                      ...(memoryRoot?.children ?? []),
+                      ...(tableNodes.length ? [{ type: 'folder' as const, name: 'Tables', children: tableNodes }] : []),
+                  ],
+              }
+            : null
     const searchResults: FileExplorerSearchResult[] | null = query.trim()
         ? (search.data?.results ?? []).map((r) => ({
               path: r.path,
@@ -180,6 +215,8 @@ export function MemoryClassic({ slug }: MemoryClassicProps): React.ReactElement 
         >
             {draft ? (
                 <MemoryEditor initial={draft} onSave={saveDraft} onCancel={cancelDraft} />
+            ) : selectedTable ? (
+                <TableView slug={slug} name={selectedTable} />
             ) : selectedPath && selectedPath !== NEW_FILE_SENTINEL ? (
                 <MemoryReader
                     file={file.data}

--- a/services/agent-console/src/components/MemoryTables.tsx
+++ b/services/agent-console/src/components/MemoryTables.tsx
@@ -1,0 +1,147 @@
+/**
+ * `<MemoryTables>` — read-only viewer for the agent's tabular-reference
+ * tables (the `@posthog/table-*` JSONL tables: seen-sets, archive logs, etc.).
+ * Sits behind the Files|Tables toggle in the memory tab. Table list on the
+ * left; the selected table's rows render as a grid on the right.
+ */
+
+'use client'
+
+import { useState } from 'react'
+
+import { useSessionTeamId } from '@/components/session-context'
+import { listTables, readTable } from '@/lib/apiClient'
+import { useResource } from '@/lib/useResource'
+
+import { RefreshIndicator } from './RefreshIndicator'
+
+function fmtBytes(n: number): string {
+    if (n < 1024) {
+        return `${n} B`
+    }
+    if (n < 1024 * 1024) {
+        return `${(n / 1024).toFixed(1)} KB`
+    }
+    return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function cell(v: unknown): string {
+    if (v === null || v === undefined) {
+        return ''
+    }
+    if (typeof v === 'object') {
+        return JSON.stringify(v)
+    }
+    return String(v)
+}
+
+export function MemoryTables({ slug }: { slug: string }): React.ReactElement {
+    const teamId = useSessionTeamId()!
+    const [selected, setSelected] = useState<string | null>(null)
+
+    const tables = useResource(() => listTables(teamId, slug), [teamId, slug], { pollMs: 10000 })
+    const rows = useResource(
+        () => (selected ? readTable(teamId, slug, selected, { limit: 500 }) : Promise.resolve(null)),
+        [teamId, slug, selected],
+        { pollMs: selected ? 10000 : undefined }
+    )
+
+    const list = tables.data?.tables ?? []
+    // Column union across the returned rows — tables are schema-light.
+    const data = rows.data
+    const columns = data ? Array.from(new Set(data.rows.flatMap((r) => Object.keys(r)))) : []
+
+    return (
+        <div className="grid h-full grid-cols-[minmax(200px,260px)_minmax(0,1fr)] divide-x divide-border">
+            <aside className="flex min-h-0 flex-col overflow-y-auto">
+                <div className="flex items-center justify-between border-b border-border px-3 py-2">
+                    <span className="text-[0.625rem] uppercase tracking-wide text-muted-foreground">Tables</span>
+                    <RefreshIndicator resource={tables} intervalMs={0} />
+                </div>
+                {tables.loading && !tables.data ? (
+                    <div className="p-3 text-xs text-muted-foreground">Loading…</div>
+                ) : list.length === 0 ? (
+                    <div className="p-3 text-xs text-muted-foreground">
+                        No tables yet. The agent creates them on first `table-append`.
+                    </div>
+                ) : (
+                    <ul className="py-1">
+                        {list.map((t) => (
+                            <li key={t.name}>
+                                <button
+                                    type="button"
+                                    onClick={() => setSelected(t.name)}
+                                    className={`flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent ${
+                                        selected === t.name ? 'bg-muted font-medium' : ''
+                                    }`}
+                                >
+                                    <code className="truncate font-mono">{t.name}</code>
+                                    <span className="shrink-0 text-[0.625rem] text-muted-foreground">
+                                        {fmtBytes(t.size)}
+                                    </span>
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </aside>
+
+            <main className="min-h-0 overflow-auto">
+                {!selected ? (
+                    <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+                        Pick a table to view its rows.
+                    </div>
+                ) : rows.loading && !rows.data ? (
+                    <div className="p-6 text-sm text-muted-foreground">Loading…</div>
+                ) : rows.error ? (
+                    <div className="p-6 text-sm text-destructive-foreground">Failed to load: {rows.error.message}</div>
+                ) : data ? (
+                    <div className="flex h-full flex-col">
+                        <header className="flex items-center justify-between gap-3 border-b border-border bg-muted/10 px-3 py-2">
+                            <code className="text-[0.8125rem] font-mono">{data.name}</code>
+                            <span className="text-xs text-muted-foreground">
+                                {data.returned} of {data.total} rows
+                                {data.total > data.returned ? ` (showing first ${data.limit})` : ''}
+                            </span>
+                        </header>
+                        <div className="min-h-0 flex-1 overflow-auto">
+                            {data.rows.length === 0 ? (
+                                <div className="p-6 text-sm text-muted-foreground">Table is empty.</div>
+                            ) : (
+                                <table className="w-full border-collapse text-[0.75rem]">
+                                    <thead className="sticky top-0 bg-muted/40">
+                                        <tr>
+                                            {columns.map((c) => (
+                                                <th
+                                                    key={c}
+                                                    className="border-b border-border px-2 py-1 text-left font-mono font-medium"
+                                                >
+                                                    {c}
+                                                </th>
+                                            ))}
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {data.rows.map((r, i) => (
+                                            <tr key={i} className="even:bg-muted/10">
+                                                {columns.map((c) => (
+                                                    <td
+                                                        key={c}
+                                                        className="max-w-[28rem] truncate border-b border-border/50 px-2 py-1 font-mono"
+                                                        title={cell(r[c])}
+                                                    >
+                                                        {cell(r[c])}
+                                                    </td>
+                                                ))}
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            )}
+                        </div>
+                    </div>
+                ) : null}
+            </main>
+        </div>
+    )
+}

--- a/services/agent-console/src/components/MemoryTables.tsx
+++ b/services/agent-console/src/components/MemoryTables.tsx
@@ -1,29 +1,17 @@
 /**
- * `<MemoryTables>` — read-only viewer for the agent's tabular-reference
- * tables (the `@posthog/table-*` JSONL tables: seen-sets, archive logs, etc.).
- * Sits behind the Files|Tables toggle in the memory tab. Table list on the
- * left; the selected table's rows render as a grid on the right.
+ * `<TableView>` — read-only right-pane grid for one tabular-reference table
+ * (the `@posthog/table-*` JSONL tables). The table list itself lives in the
+ * memory file/folder tree (see `MemoryClassic`); this renders the rows of the
+ * selected table.
  */
 
 'use client'
 
-import { useState } from 'react'
-
 import { useSessionTeamId } from '@/components/session-context'
-import { listTables, readTable } from '@/lib/apiClient'
+import { readTable } from '@/lib/apiClient'
 import { useResource } from '@/lib/useResource'
 
 import { RefreshIndicator } from './RefreshIndicator'
-
-function fmtBytes(n: number): string {
-    if (n < 1024) {
-        return `${n} B`
-    }
-    if (n < 1024 * 1024) {
-        return `${(n / 1024).toFixed(1)} KB`
-    }
-    return `${(n / (1024 * 1024)).toFixed(1)} MB`
-}
 
 function cell(v: unknown): string {
     if (v === null || v === undefined) {
@@ -35,113 +23,71 @@ function cell(v: unknown): string {
     return String(v)
 }
 
-export function MemoryTables({ slug }: { slug: string }): React.ReactElement {
+export function TableView({ slug, name }: { slug: string; name: string }): React.ReactElement {
     const teamId = useSessionTeamId()!
-    const [selected, setSelected] = useState<string | null>(null)
+    const rows = useResource(() => readTable(teamId, slug, name, { limit: 500 }), [teamId, slug, name], {
+        pollMs: 10000,
+    })
 
-    const tables = useResource(() => listTables(teamId, slug), [teamId, slug], { pollMs: 10000 })
-    const rows = useResource(
-        () => (selected ? readTable(teamId, slug, selected, { limit: 500 }) : Promise.resolve(null)),
-        [teamId, slug, selected],
-        { pollMs: selected ? 10000 : undefined }
-    )
-
-    const list = tables.data?.tables ?? []
-    // Column union across the returned rows — tables are schema-light.
+    if (rows.loading && !rows.data) {
+        return <div className="p-6 text-sm text-muted-foreground">Loading…</div>
+    }
+    if (rows.error) {
+        return <div className="p-6 text-sm text-destructive-foreground">Failed to load: {rows.error.message}</div>
+    }
     const data = rows.data
-    const columns = data ? Array.from(new Set(data.rows.flatMap((r) => Object.keys(r)))) : []
+    if (!data) {
+        return <div className="p-6 text-sm text-muted-foreground">No data.</div>
+    }
+    const columns = Array.from(new Set(data.rows.flatMap((r) => Object.keys(r))))
 
     return (
-        <div className="grid h-full grid-cols-[minmax(200px,260px)_minmax(0,1fr)] divide-x divide-border">
-            <aside className="flex min-h-0 flex-col overflow-y-auto">
-                <div className="flex items-center justify-between border-b border-border px-3 py-2">
-                    <span className="text-[0.625rem] uppercase tracking-wide text-muted-foreground">Tables</span>
-                    <RefreshIndicator resource={tables} intervalMs={0} />
+        <div className="flex h-full flex-col">
+            <header className="flex items-center justify-between gap-3 border-b border-border bg-muted/10 px-3 py-2">
+                <code className="text-[0.8125rem] font-mono">{name}</code>
+                <div className="flex items-center gap-2">
+                    <span className="text-xs text-muted-foreground">
+                        {data.returned} of {data.total} rows
+                        {data.total > data.returned ? ` (first ${data.limit})` : ''}
+                    </span>
+                    <RefreshIndicator resource={rows} intervalMs={0} />
                 </div>
-                {tables.loading && !tables.data ? (
-                    <div className="p-3 text-xs text-muted-foreground">Loading…</div>
-                ) : list.length === 0 ? (
-                    <div className="p-3 text-xs text-muted-foreground">
-                        No tables yet. The agent creates them on first `table-append`.
-                    </div>
+            </header>
+            <div className="min-h-0 flex-1 overflow-auto">
+                {data.rows.length === 0 ? (
+                    <div className="p-6 text-sm text-muted-foreground">Table is empty.</div>
                 ) : (
-                    <ul className="py-1">
-                        {list.map((t) => (
-                            <li key={t.name}>
-                                <button
-                                    type="button"
-                                    onClick={() => setSelected(t.name)}
-                                    className={`flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent ${
-                                        selected === t.name ? 'bg-muted font-medium' : ''
-                                    }`}
-                                >
-                                    <code className="truncate font-mono">{t.name}</code>
-                                    <span className="shrink-0 text-[0.625rem] text-muted-foreground">
-                                        {fmtBytes(t.size)}
-                                    </span>
-                                </button>
-                            </li>
-                        ))}
-                    </ul>
+                    <table className="w-full border-collapse text-[0.75rem]">
+                        <thead className="sticky top-0 bg-muted/40">
+                            <tr>
+                                {columns.map((c) => (
+                                    <th
+                                        key={c}
+                                        className="border-b border-border px-2 py-1 text-left font-mono font-medium"
+                                    >
+                                        {c}
+                                    </th>
+                                ))}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {data.rows.map((r, i) => (
+                                <tr key={i} className="even:bg-muted/10">
+                                    {columns.map((c) => (
+                                        <td
+                                            key={c}
+                                            className="max-w-[28rem] truncate border-b border-border/50 px-2 py-1 font-mono"
+                                            title={cell(r[c])}
+                                        >
+                                            {cell(r[c])}
+                                        </td>
+                                    ))}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 )}
-            </aside>
-
-            <main className="min-h-0 overflow-auto">
-                {!selected ? (
-                    <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
-                        Pick a table to view its rows.
-                    </div>
-                ) : rows.loading && !rows.data ? (
-                    <div className="p-6 text-sm text-muted-foreground">Loading…</div>
-                ) : rows.error ? (
-                    <div className="p-6 text-sm text-destructive-foreground">Failed to load: {rows.error.message}</div>
-                ) : data ? (
-                    <div className="flex h-full flex-col">
-                        <header className="flex items-center justify-between gap-3 border-b border-border bg-muted/10 px-3 py-2">
-                            <code className="text-[0.8125rem] font-mono">{data.name}</code>
-                            <span className="text-xs text-muted-foreground">
-                                {data.returned} of {data.total} rows
-                                {data.total > data.returned ? ` (showing first ${data.limit})` : ''}
-                            </span>
-                        </header>
-                        <div className="min-h-0 flex-1 overflow-auto">
-                            {data.rows.length === 0 ? (
-                                <div className="p-6 text-sm text-muted-foreground">Table is empty.</div>
-                            ) : (
-                                <table className="w-full border-collapse text-[0.75rem]">
-                                    <thead className="sticky top-0 bg-muted/40">
-                                        <tr>
-                                            {columns.map((c) => (
-                                                <th
-                                                    key={c}
-                                                    className="border-b border-border px-2 py-1 text-left font-mono font-medium"
-                                                >
-                                                    {c}
-                                                </th>
-                                            ))}
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {data.rows.map((r, i) => (
-                                            <tr key={i} className="even:bg-muted/10">
-                                                {columns.map((c) => (
-                                                    <td
-                                                        key={c}
-                                                        className="max-w-[28rem] truncate border-b border-border/50 px-2 py-1 font-mono"
-                                                        title={cell(r[c])}
-                                                    >
-                                                        {cell(r[c])}
-                                                    </td>
-                                                ))}
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </table>
-                            )}
-                        </div>
-                    </div>
-                ) : null}
-            </main>
+            </div>
         </div>
     )
 }

--- a/services/agent-console/src/lib/apiClient.ts
+++ b/services/agent-console/src/lib/apiClient.ts
@@ -926,6 +926,35 @@ export async function readMemoryFile(teamId: number, slug: string, path: string)
     return getJson(memoryUrl(teamId, slug, `/files/by_path/?path=${encodeURIComponent(path)}`))
 }
 
+/* ── Tabular reference (the @posthog/table-* JSONL tables) ─────────── */
+
+export interface AgentTableHeader {
+    name: string
+    size: number
+}
+
+export interface AgentTableRows {
+    name: string
+    total: number
+    returned: number
+    limit: number
+    rows: Record<string, unknown>[]
+}
+
+export async function listTables(teamId: number, slug: string): Promise<{ count: number; tables: AgentTableHeader[] }> {
+    return getJson(memoryUrl(teamId, slug, `/tables/`))
+}
+
+export async function readTable(
+    teamId: number,
+    slug: string,
+    name: string,
+    opts: { limit?: number } = {}
+): Promise<AgentTableRows> {
+    const qs = opts.limit ? `?limit=${opts.limit}` : ''
+    return getJson(memoryUrl(teamId, slug, `/tables/${encodeURIComponent(name)}/${qs}`))
+}
+
 export async function searchMemoryApi(
     teamId: number,
     slug: string,

--- a/services/agent-console/src/lib/useResource.ts
+++ b/services/agent-console/src/lib/useResource.ts
@@ -32,7 +32,24 @@ export interface ResourceState<T> {
     lastFetchedAt: number | null
 }
 
-export function useResource<T>(factory: () => Promise<T>, deps: unknown[] = []): ResourceState<T> {
+export interface UseResourceOptions {
+    /**
+     * If set, refetch every `pollMs` milliseconds while the tab is
+     * visible. Ticks are skipped while `document.hidden` (background
+     * tab), and one catch-up reload fires on `visibilitychange` back to
+     * visible — so a backgrounded view shows fresh data the moment it's
+     * looked at again without hammering the API while hidden. Leave
+     * unset for one-shot reads (the default).
+     */
+    pollMs?: number
+}
+
+export function useResource<T>(
+    factory: () => Promise<T>,
+    deps: unknown[] = [],
+    options: UseResourceOptions = {}
+): ResourceState<T> {
+    const { pollMs } = options
     const reloadKey = useReloadKey()
     const [data, setData] = useState<T | null>(null)
     const [error, setError] = useState<Error | null>(null)
@@ -83,6 +100,31 @@ export function useResource<T>(factory: () => Promise<T>, deps: unknown[] = []):
     }, [...deps, reloadKey, manualReloadKey])
 
     const reload = useCallback(() => setManualReloadKey((k) => k + 1), [])
+
+    // Visibility-aware polling. The interval only fires `reload` when the
+    // tab is foreground; switching back to a visible tab triggers one
+    // immediate catch-up so stale background data refreshes on focus.
+    useEffect(() => {
+        if (!pollMs) {
+            return
+        }
+        const tick = (): void => {
+            if (!document.hidden) {
+                reload()
+            }
+        }
+        const onVisible = (): void => {
+            if (!document.hidden) {
+                reload()
+            }
+        }
+        const id = setInterval(tick, pollMs)
+        document.addEventListener('visibilitychange', onVisible)
+        return () => {
+            clearInterval(id)
+            document.removeEventListener('visibilitychange', onVisible)
+        }
+    }, [pollMs, reload])
 
     return { data, error, loading, reload, lastFetchedAt }
 }

--- a/services/agent-janitor/src/api/tables.ts
+++ b/services/agent-janitor/src/api/tables.ts
@@ -13,13 +13,15 @@
 import { Express, Request, Response } from 'express'
 import { z } from 'zod'
 
-import { Logger, TabularStore } from '@posthog/agent-shared'
+import { Logger, TableNameError, TabularStore } from '@posthog/agent-shared'
 
 import { asyncHandler } from '../http-utils'
 
+// application_id is interpolated into the S3 key (the tenancy boundary), so
+// require the UUID shape Django forwards — a non-empty string isn't enough.
 const ScopeParams = z.object({
     team_id: z.coerce.number().int().positive('missing_team_id'),
-    application_id: z.string().min(1, 'missing_application_id'),
+    application_id: z.string().uuid('application_id must be a UUID'),
 })
 
 const RowsQuery = z.object({ limit: z.coerce.number().int().min(1).max(5000).default(500) })
@@ -44,8 +46,9 @@ export function mountTableRoutes(app: Express, opts: MountTableRoutesOpts): void
     }
     function onError(res: Response, err: unknown): void {
         const message = (err as Error).message ?? 'tabular_error'
-        if (/invalid table name/i.test(message)) {
-            res.status(400).json({ error: 'invalid_table', message })
+        // Bad table name (typed) or a Zod params/query failure → 400.
+        if (err instanceof TableNameError || (err as { name?: string })?.name === 'ZodError') {
+            res.status(400).json({ error: 'invalid_request', message })
             return
         }
         opts.log.error({ err: message, stack: (err as Error).stack }, 'tables.unhandled')
@@ -78,8 +81,8 @@ export function mountTableRoutes(app: Express, opts: MountTableRoutesOpts): void
             try {
                 const { limit } = RowsQuery.parse(req.query)
                 const name = z.string().min(1).parse(req.params.name)
-                const rows = await store.query(scope(req), name, { limit })
-                const total = await store.count(scope(req), name)
+                // queryPage = rows + total from a single object read.
+                const { rows, total } = await store.queryPage(scope(req), name, { limit })
                 res.json({ name, total, returned: rows.length, limit, rows })
             } catch (err) {
                 onError(res, err)

--- a/services/agent-janitor/src/api/tables.ts
+++ b/services/agent-janitor/src/api/tables.ts
@@ -1,0 +1,89 @@
+/**
+ * Read-only HTTP surface for the agent's tabular reference (the JSONL tables
+ * the `@posthog/table-*` tools write). Lets the console's memory tab show
+ * structured state (seen-sets, archive logs) alongside the markdown memory
+ * files. Same S3-backed `TabularStore` the runner tools use.
+ *
+ * Routes scoped at `/tables/team/:team_id/agent/:application_id/...` — the
+ * caller maps slug → application_id before forwarding, same as memory.
+ *   GET  /tables/team/:t/agent/:a/            list table names + sizes
+ *   GET  /tables/team/:t/agent/:a/:name       rows (capped via ?limit, default 500)
+ */
+
+import { Express, Request, Response } from 'express'
+import { z } from 'zod'
+
+import { Logger, TabularStore } from '@posthog/agent-shared'
+
+import { asyncHandler } from '../http-utils'
+
+const ScopeParams = z.object({
+    team_id: z.coerce.number().int().positive('missing_team_id'),
+    application_id: z.string().min(1, 'missing_application_id'),
+})
+
+const RowsQuery = z.object({ limit: z.coerce.number().int().min(1).max(5000).default(500) })
+
+export interface MountTableRoutesOpts {
+    /** When omitted, every /tables/* route returns 503. */
+    tabularStore?: TabularStore
+    log: Logger
+}
+
+export function mountTableRoutes(app: Express, opts: MountTableRoutesOpts): void {
+    function scope(req: Request): { teamId: number; applicationId: string } {
+        const { team_id, application_id } = ScopeParams.parse(req.params)
+        return { teamId: team_id, applicationId: application_id }
+    }
+    function need(res: Response): TabularStore | null {
+        if (!opts.tabularStore) {
+            res.status(503).json({ error: 'tabular_store_not_configured' })
+            return null
+        }
+        return opts.tabularStore
+    }
+    function onError(res: Response, err: unknown): void {
+        const message = (err as Error).message ?? 'tabular_error'
+        if (/invalid table name/i.test(message)) {
+            res.status(400).json({ error: 'invalid_table', message })
+            return
+        }
+        opts.log.error({ err: message, stack: (err as Error).stack }, 'tables.unhandled')
+        res.status(500).json({ error: 'tabular_error', message })
+    }
+
+    app.get(
+        '/tables/team/:team_id/agent/:application_id',
+        asyncHandler(async (req: Request, res: Response) => {
+            const store = need(res)
+            if (!store) {
+                return
+            }
+            try {
+                const tables = await store.listTables(scope(req))
+                res.json({ count: tables.length, tables })
+            } catch (err) {
+                onError(res, err)
+            }
+        })
+    )
+
+    app.get(
+        '/tables/team/:team_id/agent/:application_id/:name',
+        asyncHandler(async (req: Request, res: Response) => {
+            const store = need(res)
+            if (!store) {
+                return
+            }
+            try {
+                const { limit } = RowsQuery.parse(req.query)
+                const name = z.string().min(1).parse(req.params.name)
+                const rows = await store.query(scope(req), name, { limit })
+                const total = await store.count(scope(req), name)
+                res.json({ name, total, returned: rows.length, limit, rows })
+            } catch (err) {
+                onError(res, err)
+            }
+        })
+    )
+}

--- a/services/agent-janitor/src/index.ts
+++ b/services/agent-janitor/src/index.ts
@@ -29,7 +29,9 @@ import {
     PgRevisionStore,
     PgSessionQueue,
     S3BundleStore,
+    S3JsonlTabularStore,
     S3MemoryStore,
+    TabularStore,
 } from '@posthog/agent-shared'
 
 import { loadAgentJanitorConfig } from './config'
@@ -102,6 +104,9 @@ async function main(): Promise<void> {
     // /memory/* endpoints (503), keeping local dev that hasn't wired
     // MinIO bootable.
     let memoryStore: MemoryStore | undefined
+    // Tabular store shares the memory S3 client + bucket (agent_tables prefix);
+    // serves the console Tables view via /tables/* routes.
+    let tabularStore: TabularStore | undefined
     if (config.memoryS3Bucket && config.memoryS3Endpoint) {
         const s3 = new S3Client({
             endpoint: config.memoryS3Endpoint,
@@ -120,6 +125,7 @@ async function main(): Promise<void> {
             bucket: config.memoryS3Bucket,
             bucketPrefix: config.memoryS3Prefix,
         })
+        tabularStore = new S3JsonlTabularStore({ client: s3, bucket: config.memoryS3Bucket, bucketPrefix: 'agent_tables' })
         log.info(
             { bucket: config.memoryS3Bucket, endpoint: config.memoryS3Endpoint, prefix: config.memoryS3Prefix },
             'memory.s3.enabled'
@@ -134,6 +140,7 @@ async function main(): Promise<void> {
         revisions,
         bundles,
         memoryStore,
+        tabularStore,
         internalSecret: config.internalSecret,
     })
     app.listen(config.port, () => {

--- a/services/agent-janitor/src/server.ts
+++ b/services/agent-janitor/src/server.ts
@@ -56,12 +56,14 @@ import {
     FRAMEWORK_PROMPT_VERSION,
     lastAssistantTextPreview,
     MemoryStore,
+    TabularStore,
     RevisionStore,
     SessionQueue,
 } from '@posthog/agent-shared'
 import { listNativeTools } from '@posthog/agent-tools'
 
 import { mountMemoryRoutes } from './api/memory'
+import { mountTableRoutes } from './api/tables'
 import { buildApprovalDecidedMarker } from './approval-marker'
 import { fireCronManually } from './cron-tick'
 import { asyncHandler, errorHandler } from './http-utils'
@@ -89,6 +91,8 @@ export interface JanitorServerOpts {
      * `InMemoryMemoryStore` directly.
      */
     memoryStore?: MemoryStore
+    /** Read-only tabular store for the console Tables view. */
+    tabularStore?: TabularStore
     internalSecret?: string
 }
 
@@ -902,6 +906,7 @@ export function buildJanitorApp(opts: JanitorServerOpts): Express {
     // pattern applies when they get extracted: one file per logical group,
     // each exporting `mount*Routes(app, opts, log)` called here.
     mountMemoryRoutes(app, { memoryStore: opts.memoryStore, log })
+    mountTableRoutes(app, { tabularStore: opts.tabularStore, log })
 
     // Last in the chain. Catches anything the route handlers threw (via
     // asyncHandler), translates ZodError → 400, everything else → 500.

--- a/services/agent-runner/src/index.ts
+++ b/services/agent-runner/src/index.ts
@@ -33,6 +33,8 @@ import {
     installProcessHandlers,
     KafkaLogSink,
     MemoryStore,
+    S3JsonlTabularStore,
+    TabularStore,
     NoopAnalyticsSink,
     NoopSessionEventBus,
     PgCredentialBroker,
@@ -182,6 +184,9 @@ async function main(): Promise<void> {
     // `memory_store_unavailable` to the model) when the bucket isn't
     // configured — dev/CI without object storage still boots cleanly.
     let memoryStore: MemoryStore | undefined
+    // Tabular reference store - shares the memory S3 client + bucket (agent_tables
+    // prefix); same enable condition as memory.
+    let tabularStore: TabularStore | undefined
     if (config.memoryS3Bucket && config.memoryS3Endpoint) {
         const s3 = new S3Client({
             endpoint: config.memoryS3Endpoint,
@@ -200,6 +205,7 @@ async function main(): Promise<void> {
             bucket: config.memoryS3Bucket,
             bucketPrefix: config.memoryS3Prefix,
         })
+        tabularStore = new S3JsonlTabularStore({ client: s3, bucket: config.memoryS3Bucket, bucketPrefix: 'agent_tables' })
         log.info(
             { bucket: config.memoryS3Bucket, endpoint: config.memoryS3Endpoint, prefix: config.memoryS3Prefix },
             'memory.s3.enabled'
@@ -290,6 +296,7 @@ async function main(): Promise<void> {
         analytics,
         maxConcurrency: config.maxConcurrency,
         memoryStore,
+        tabularStore,
         isAskerInApproverScope,
         agentMcpResolver,
     })

--- a/services/agent-runner/src/loop/build-agent-tools.ts
+++ b/services/agent-runner/src/loop/build-agent-tools.ts
@@ -35,6 +35,7 @@ import {
     CredentialBroker,
     IntegrationCredentials,
     MemoryStore,
+    TabularStore,
     Sandbox,
     ToolContext,
 } from '@posthog/agent-shared'
@@ -106,6 +107,8 @@ export interface AgentToolDeps {
      * `memory_store_unavailable` to the model.
      */
     memoryStore?: MemoryStore
+    /** Deterministic tabular store for @posthog/table-* tools. */
+    tabularStore?: TabularStore
     /**
      * Dispatcher for `kind: "client"` tools. The driver wires this up
      * over the session event bus: `execute` publishes a
@@ -409,6 +412,7 @@ function buildToolContext(deps: AgentToolDeps): ToolContext {
             }
         },
         memoryStore: deps.memoryStore,
+        tabularStore: deps.tabularStore,
         credentials: credentialBroker
             ? {
                   resolve: (target) => credentialBroker.resolve(sessionId, target),

--- a/services/agent-runner/src/loop/driver.ts
+++ b/services/agent-runner/src/loop/driver.ts
@@ -61,6 +61,7 @@ import {
     LogLevel,
     LogSink,
     MemoryStore,
+    TabularStore,
     NoopAnalyticsSink,
     NoopLogSink,
     NoopSessionEventBus,
@@ -134,6 +135,8 @@ export interface RunSessionDeps {
      * `AGENT_MEMORY_S3_*` config.
      */
     memoryStore?: MemoryStore
+    /** Deterministic tabular store for @posthog/table-* tools. */
+    tabularStore?: TabularStore
     /**
      * Per-session static HTTP headers stamped on every outbound model call.
      * On the ai-gateway path this carries `X-PostHog-Distinct-Id` +
@@ -281,6 +284,7 @@ export async function runSession(rev: AgentRevision, session: AgentSession, deps
             bundle: deps.bundle,
             log,
             memoryStore: deps.memoryStore,
+            tabularStore: deps.tabularStore,
             dispatchClientTool,
             credentialBroker: deps.credentialBroker,
             mcpClients: deps.mcpClients,

--- a/services/agent-runner/src/workers/worker.ts
+++ b/services/agent-runner/src/workers/worker.ts
@@ -32,6 +32,7 @@ import {
     GatewayClient,
     LogSink,
     MemoryStore,
+    TabularStore,
     RevisionStore,
     SandboxInstanceStore,
     SandboxPool,
@@ -147,6 +148,8 @@ export interface WorkerDeps {
      * AGENT_MEMORY_S3_* config; unset disables memory tools.
      */
     memoryStore?: MemoryStore
+    /** Deterministic tabular store for `@posthog/table-*` tools; same S3 config as memory. */
+    tabularStore?: TabularStore
     /**
      * Per-session credential broker, populated by ingress at /run + /send.
      * The runner passes this through to `runSession` → tool deps →
@@ -391,6 +394,7 @@ export class Worker {
                 approvals: this.deps.approvals,
                 buildApprovalUrl: this.deps.buildApprovalUrl,
                 memoryStore: this.deps.memoryStore,
+                tabularStore: this.deps.tabularStore,
                 credentialBroker: this.deps.credentialBroker,
                 isAskerInApproverScope: this.deps.isAskerInApproverScope,
                 mcpClients: openedMcpClients,

--- a/services/agent-shared/src/memory/index.ts
+++ b/services/agent-shared/src/memory/index.ts
@@ -7,3 +7,7 @@ export * from './store'
 export * from './s3-store'
 export * from './search'
 export * from './test-helpers'
+// Tabular reference — deterministic structured state (seen-sets, append logs,
+// simple queries), JSONL-in-S3 behind a swappable interface.
+export * from './tabular-store'
+export * from './s3-tabular-store'

--- a/services/agent-shared/src/memory/s3-tabular-store.test.ts
+++ b/services/agent-shared/src/memory/s3-tabular-store.test.ts
@@ -1,0 +1,132 @@
+/**
+ * S3JsonlTabularStore — exercised against real MinIO (no skip-if-unreachable;
+ * bring up object storage first, same convention as the memory store tests).
+ *
+ * The concurrency block is load-bearing: it proves the ETag optimistic-
+ * concurrency actually prevents lost updates on the deployed backend. If the
+ * backend silently ignored `If-Match`/`If-None-Match`, the racing-append test
+ * would drop rows and fail — so this is the canary for that whole guarantee.
+ *
+ * A separate pure block covers the predicate/cmp logic without MinIO.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import { S3JsonlTabularStore } from './s3-tabular-store'
+import { MemoryScope } from './store'
+import { buildTestS3Client, newTestPrefix, TEST_S3_BUCKET, wipeTestPrefix } from './test-helpers'
+import { applyQuery, MAX_TABLE_BYTES, matchRow, parseJsonl, TableTooLargeError } from './tabular-store'
+
+const SCOPE: MemoryScope = { teamId: 1, applicationId: '019e8990-0000-7000-8000-000000000001' }
+
+describe('tabular predicate + query (pure, no S3)', () => {
+    it('parseJsonl drops blank + corrupt lines, keeps object rows', () => {
+        const rows = parseJsonl('{"a":1}\n\n  \nnot json\n[1,2]\n{"b":2}\n')
+        expect(rows).toEqual([{ a: 1 }, { b: 2 }])
+    })
+
+    it('numeric range works even when one side is a string-stored number', () => {
+        const rows = [{ ts: 9 }, { ts: 10 }, { ts: '11' }, { ts: 'x' }]
+        // The cmp bug would make {gt:9} miss 10/"11" via lexicographic "10"<"9".
+        expect(applyQuery(rows, { where: { ts: { gt: 9 } } })).toEqual([{ ts: 10 }, { ts: '11' }])
+        expect(applyQuery(rows, { where: { ts: { gte: '10' } } })).toEqual([{ ts: 10 }, { ts: '11' }])
+    })
+
+    it('order_by sorts numerically when values coerce to numbers', () => {
+        const rows = [{ n: 2 }, { n: 10 }, { n: 1 }]
+        expect(applyQuery(rows, { order_by: 'n' }).map((r) => r.n)).toEqual([1, 2, 10])
+        expect(applyQuery(rows, { order_by: 'n', desc: true }).map((r) => r.n)).toEqual([10, 2, 1])
+    })
+
+    it('eq / in / projection / limit', () => {
+        const rows = [
+            { id: 'a', kind: 'x' },
+            { id: 'b', kind: 'y' },
+            { id: 'c', kind: 'x' },
+        ]
+        expect(applyQuery(rows, { where: { kind: 'x' }, columns: ['id'] })).toEqual([{ id: 'a' }, { id: 'c' }])
+        expect(applyQuery(rows, { where: { id: { in: ['b', 'c'] } } }).map((r) => r.id)).toEqual(['b', 'c'])
+        expect(applyQuery(rows, { limit: 2 })).toHaveLength(2)
+    })
+
+    it('matchRow ANDs conditions; false/null/0 compare by value', () => {
+        expect(matchRow({ a: false, b: 0 }, { a: false, b: 0 })).toBe(true)
+        expect(matchRow({ a: false }, { a: true })).toBe(false)
+        expect(matchRow({ a: null }, { a: null })).toBe(true)
+    })
+})
+
+describe('S3JsonlTabularStore (real S3 / MinIO)', () => {
+    let prefix: string
+    const client = buildTestS3Client()
+    // Generous retry budget so the high-contention concurrency test resolves.
+    const store = new S3JsonlTabularStore({ client, bucket: TEST_S3_BUCKET, bucketPrefix: '', maxRetries: 30 })
+
+    beforeAll(() => {
+        prefix = newTestPrefix('agent_tables_test')
+        // Re-root the store at a unique prefix so suites don't collide.
+        ;(store as unknown as { bucketPrefix: string }).bucketPrefix = prefix
+    })
+    afterEach(async () => {
+        await wipeTestPrefix(client, prefix)
+    })
+    afterAll(() => {
+        client.destroy()
+    })
+
+    it('membership partitions known vs new (incl. falsey keys)', async () => {
+        await store.append(SCOPE, 'seen', [{ id: 'a' }, { id: 'b' }, { id: 0 }, { id: false }])
+        const m = await store.membership(SCOPE, 'seen', 'id', ['a', 'x', 0, false, true])
+        expect(new Set(m.known)).toEqual(new Set(['a', 0, false]))
+        expect(new Set(m.new)).toEqual(new Set(['x', true]))
+        // empty table → everything new
+        expect((await store.membership(SCOPE, 'fresh', 'id', ['z'])).new).toEqual(['z'])
+    })
+
+    it('append dedupes on a key; rows missing the key always append', async () => {
+        let r = await store.append(SCOPE, 't', [{ id: 'a' }, { id: 'b' }, { id: 'a' }], { dedupeOn: 'id' })
+        expect(r).toEqual({ appended: 2, skipped: 1 }) // within-batch dup skipped
+        r = await store.append(SCOPE, 't', [{ id: 'a' }, { id: 'c' }, { other: 1 }], { dedupeOn: 'id' })
+        expect(r).toEqual({ appended: 2, skipped: 1 }) // 'a' skipped; keyless row appended
+        expect(await store.count(SCOPE, 't')).toBe(4)
+    })
+
+    it('query / count / delete / truncate round-trip', async () => {
+        await store.append(SCOPE, 'log', [
+            { id: 'm1', reason: 'ci', ts: 100 },
+            { id: 'm2', reason: 'promo', ts: 200 },
+            { id: 'm3', reason: 'ci', ts: 300 },
+        ])
+        const page = await store.queryPage(SCOPE, 'log', { where: { reason: 'ci' }, order_by: 'ts', desc: true })
+        expect(page.total).toBe(3)
+        expect(page.rows.map((r) => r.id)).toEqual(['m3', 'm1'])
+        expect(await store.count(SCOPE, 'log', { ts: { gte: 200 } })).toBe(2)
+        expect(await store.delete(SCOPE, 'log', { reason: 'ci' })).toEqual({ deleted: 2 })
+        expect(await store.count(SCOPE, 'log')).toBe(1)
+        await store.truncate(SCOPE, 'log')
+        expect(await store.count(SCOPE, 'log')).toBe(0)
+        // truncate of a non-existent table is a no-op
+        await expect(store.truncate(SCOPE, 'nope')).resolves.toBeUndefined()
+    })
+
+    it('CONCURRENCY: racing appends do not lose updates (ETag canary)', async () => {
+        // Seed one row so every concurrent append goes through the If-Match
+        // (update) path, not just If-None-Match (create).
+        await store.append(SCOPE, 'race', [{ id: 'seed' }])
+        const N = 10
+        await Promise.all(
+            Array.from({ length: N }, (_, i) => store.append(SCOPE, 'race', [{ id: `r${i}` }], { dedupeOn: 'id' }))
+        )
+        // If If-Match were ignored, later writers would clobber earlier ones and
+        // the count would be < N+1. It must be exactly N+1.
+        expect(await store.count(SCOPE, 'race')).toBe(N + 1)
+        const ids = (await store.query(SCOPE, 'race')).map((r) => r.id)
+        expect(new Set(ids)).toEqual(new Set(['seed', ...Array.from({ length: N }, (_, i) => `r${i}`)]))
+    })
+
+    it('append past the size ceiling throws TableTooLargeError', async () => {
+        const big = 'x'.repeat(50_000)
+        const rows = Array.from({ length: Math.ceil(MAX_TABLE_BYTES / 50_000) + 2 }, (_, i) => ({ i, big }))
+        await expect(store.append(SCOPE, 'huge', rows)).rejects.toBeInstanceOf(TableTooLargeError)
+    })
+})

--- a/services/agent-shared/src/memory/s3-tabular-store.ts
+++ b/services/agent-shared/src/memory/s3-tabular-store.ts
@@ -1,0 +1,219 @@
+/**
+ * S3-backed JSONL TabularStore. One object per table; whole-object
+ * read-modify-write with ETag optimistic concurrency (mutating ops retry on a
+ * 412 so concurrent firings can't lose-update). Talks to real S3 or MinIO.
+ */
+
+import {
+    DeleteObjectCommand,
+    GetObjectCommand,
+    ListObjectsV2Command,
+    PutObjectCommand,
+    S3Client,
+} from '@aws-sdk/client-s3'
+import { Readable } from 'node:stream'
+
+import { MemoryScope } from './store'
+import {
+    applyQuery,
+    matchRow,
+    parseJsonl,
+    serializeJsonl,
+    TabularConflictError,
+    tableKeyFor,
+    tablesPrefixFor,
+    TableRow,
+    TableScalar,
+    TabularStore,
+    TableQuery,
+} from './tabular-store'
+
+export interface S3TabularStoreOpts {
+    client: S3Client
+    bucket: string
+    /** Bucket-level prefix, default `agent_tables`. */
+    bucketPrefix?: string
+    /** Optimistic-concurrency retry attempts on conditional-write conflict. */
+    maxRetries?: number
+}
+
+export class S3JsonlTabularStore implements TabularStore {
+    private readonly client: S3Client
+    private readonly bucket: string
+    private readonly bucketPrefix: string
+    private readonly maxRetries: number
+
+    constructor(opts: S3TabularStoreOpts) {
+        this.client = opts.client
+        this.bucket = opts.bucket
+        this.bucketPrefix = opts.bucketPrefix ?? 'agent_tables'
+        this.maxRetries = opts.maxRetries ?? 5
+    }
+
+    async listTables(scope: MemoryScope): Promise<{ name: string; size: number }[]> {
+        const prefix = tablesPrefixFor(scope, this.bucketPrefix)
+        const out: { name: string; size: number }[] = []
+        let token: string | undefined
+        do {
+            const res = await this.client.send(
+                new ListObjectsV2Command({ Bucket: this.bucket, Prefix: prefix, ContinuationToken: token })
+            )
+            for (const obj of res.Contents ?? []) {
+                if (obj.Key?.endsWith('.jsonl')) {
+                    out.push({ name: obj.Key.slice(prefix.length, -'.jsonl'.length), size: obj.Size ?? 0 })
+                }
+            }
+            token = res.IsTruncated ? res.NextContinuationToken : undefined
+        } while (token)
+        out.sort((a, b) => a.name.localeCompare(b.name))
+        return out
+    }
+
+    async membership(
+        scope: MemoryScope,
+        table: string,
+        keyColumn: string,
+        values: TableScalar[]
+    ): Promise<{ known: TableScalar[]; new: TableScalar[] }> {
+        const { rows } = await this.readRows(scope, table)
+        const present = new Set(rows.map((r) => r[keyColumn] as TableScalar))
+        const known: TableScalar[] = []
+        const fresh: TableScalar[] = []
+        for (const v of values) {
+            ;(present.has(v) ? known : fresh).push(v)
+        }
+        return { known, new: fresh }
+    }
+
+    async append(
+        scope: MemoryScope,
+        table: string,
+        rowsToAdd: TableRow[],
+        opts: { dedupeOn?: string } = {}
+    ): Promise<{ appended: number; skipped: number }> {
+        return this.mutate(scope, table, (rows) => {
+            let appended = 0
+            let skipped = 0
+            const seen = opts.dedupeOn ? new Set(rows.map((r) => r[opts.dedupeOn!])) : null
+            for (const row of rowsToAdd) {
+                if (seen && row[opts.dedupeOn!] !== undefined && seen.has(row[opts.dedupeOn!])) {
+                    skipped++
+                    continue
+                }
+                rows.push(row)
+                if (seen) {
+                    seen.add(row[opts.dedupeOn!])
+                }
+                appended++
+            }
+            return { rows, result: { appended, skipped } }
+        })
+    }
+
+    async query(scope: MemoryScope, table: string, q: TableQuery = {}): Promise<TableRow[]> {
+        const { rows } = await this.readRows(scope, table)
+        return applyQuery(rows, q)
+    }
+
+    async count(scope: MemoryScope, table: string, where?: TableQuery['where']): Promise<number> {
+        const { rows } = await this.readRows(scope, table)
+        return rows.filter((r) => matchRow(r, where)).length
+    }
+
+    async delete(scope: MemoryScope, table: string, where: TableQuery['where']): Promise<{ deleted: number }> {
+        return this.mutate(scope, table, (rows) => {
+            const kept = rows.filter((r) => !matchRow(r, where))
+            return { rows: kept, result: { deleted: rows.length - kept.length } }
+        })
+    }
+
+    async truncate(scope: MemoryScope, table: string): Promise<void> {
+        const Key = tableKeyFor(scope, table, this.bucketPrefix)
+        try {
+            await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key }))
+        } catch (err) {
+            if (!isNotFound(err)) {
+                throw err
+            }
+        }
+    }
+
+    // --- internals ---------------------------------------------------------
+
+    private async readRows(scope: MemoryScope, table: string): Promise<{ rows: TableRow[]; etag?: string }> {
+        const Key = tableKeyFor(scope, table, this.bucketPrefix)
+        try {
+            const res = await this.client.send(new GetObjectCommand({ Bucket: this.bucket, Key }))
+            return { rows: parseJsonl(await streamToString(res.Body)), etag: res.ETag }
+        } catch (err) {
+            if (isNotFound(err)) {
+                return { rows: [], etag: undefined } // table doesn't exist yet
+            }
+            throw err
+        }
+    }
+
+    /** Read-modify-write with ETag optimistic concurrency + bounded retry. */
+    private async mutate<R>(
+        scope: MemoryScope,
+        table: string,
+        fn: (rows: TableRow[]) => { rows: TableRow[]; result: R }
+    ): Promise<R> {
+        const Key = tableKeyFor(scope, table, this.bucketPrefix)
+        for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+            const { rows, etag } = await this.readRows(scope, table)
+            const { rows: nextRows, result } = fn(rows)
+            try {
+                await this.client.send(
+                    new PutObjectCommand({
+                        Bucket: this.bucket,
+                        Key,
+                        Body: serializeJsonl(nextRows),
+                        ContentType: 'application/x-ndjson; charset=utf-8',
+                        // Optimistic concurrency: only write if the object is
+                        // unchanged since we read it (or still absent on create).
+                        ...(etag ? { IfMatch: etag } : { IfNoneMatch: '*' }),
+                    })
+                )
+                return result
+            } catch (err) {
+                if (isPreconditionFailed(err) && attempt < this.maxRetries) {
+                    continue // someone else wrote; re-read and re-apply
+                }
+                if (isPreconditionFailed(err)) {
+                    throw new TabularConflictError(table)
+                }
+                throw err
+            }
+        }
+        throw new TabularConflictError(table)
+    }
+}
+
+async function streamToString(body: unknown): Promise<string> {
+    if (!body) {
+        return ''
+    }
+    if (body instanceof Readable) {
+        const chunks: Buffer[] = []
+        for await (const chunk of body) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+        }
+        return Buffer.concat(chunks).toString('utf-8')
+    }
+    const maybe = body as { transformToString?: () => Promise<string> }
+    if (typeof maybe.transformToString === 'function') {
+        return maybe.transformToString()
+    }
+    throw new Error('S3JsonlTabularStore: unsupported response body type')
+}
+
+function isNotFound(err: unknown): boolean {
+    const e = err as { name?: string; $metadata?: { httpStatusCode?: number } }
+    return e?.name === 'NoSuchKey' || e?.name === 'NotFound' || e?.$metadata?.httpStatusCode === 404
+}
+
+function isPreconditionFailed(err: unknown): boolean {
+    const e = err as { name?: string; $metadata?: { httpStatusCode?: number } }
+    return e?.name === 'PreconditionFailed' || e?.$metadata?.httpStatusCode === 412
+}

--- a/services/agent-shared/src/memory/s3-tabular-store.ts
+++ b/services/agent-shared/src/memory/s3-tabular-store.ts
@@ -26,6 +26,8 @@ import {
     TableScalar,
     TabularStore,
     TableQuery,
+    MAX_TABLE_BYTES,
+    TableTooLargeError,
 } from './tabular-store'
 
 export interface S3TabularStoreOpts {
@@ -107,12 +109,21 @@ export class S3JsonlTabularStore implements TabularStore {
                 appended++
             }
             return { rows, result: { appended, skipped } }
-        })
+        }, { checkCeiling: true })
     }
 
     async query(scope: MemoryScope, table: string, q: TableQuery = {}): Promise<TableRow[]> {
         const { rows } = await this.readRows(scope, table)
         return applyQuery(rows, q)
+    }
+
+    async queryPage(
+        scope: MemoryScope,
+        table: string,
+        q: TableQuery = {}
+    ): Promise<{ rows: TableRow[]; total: number }> {
+        const { rows } = await this.readRows(scope, table)
+        return { rows: applyQuery(rows, q), total: rows.length }
     }
 
     async count(scope: MemoryScope, table: string, where?: TableQuery['where']): Promise<number> {
@@ -157,18 +168,25 @@ export class S3JsonlTabularStore implements TabularStore {
     private async mutate<R>(
         scope: MemoryScope,
         table: string,
-        fn: (rows: TableRow[]) => { rows: TableRow[]; result: R }
+        fn: (rows: TableRow[]) => { rows: TableRow[]; result: R },
+        opts: { checkCeiling?: boolean } = {}
     ): Promise<R> {
         const Key = tableKeyFor(scope, table, this.bucketPrefix)
         for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
             const { rows, etag } = await this.readRows(scope, table)
             const { rows: nextRows, result } = fn(rows)
+            const body = serializeJsonl(nextRows)
+            // Ceiling enforced only on growth paths (append) so a delete can
+            // always shrink an over-size table back down.
+            if (opts.checkCeiling && Buffer.byteLength(body) > MAX_TABLE_BYTES) {
+                throw new TableTooLargeError(table)
+            }
             try {
                 await this.client.send(
                     new PutObjectCommand({
                         Bucket: this.bucket,
                         Key,
-                        Body: serializeJsonl(nextRows),
+                        Body: body,
                         ContentType: 'application/x-ndjson; charset=utf-8',
                         // Optimistic concurrency: only write if the object is
                         // unchanged since we read it (or still absent on create).
@@ -177,15 +195,14 @@ export class S3JsonlTabularStore implements TabularStore {
                 )
                 return result
             } catch (err) {
-                if (isPreconditionFailed(err) && attempt < this.maxRetries) {
-                    continue // someone else wrote; re-read and re-apply
+                // A real error aborts immediately; a precondition failure means
+                // someone else wrote — fall through and retry (re-read, re-apply).
+                if (!isPreconditionFailed(err)) {
+                    throw err
                 }
-                if (isPreconditionFailed(err)) {
-                    throw new TabularConflictError(table)
-                }
-                throw err
             }
         }
+        // Exhausted all retries while still conflicting.
         throw new TabularConflictError(table)
     }
 }

--- a/services/agent-shared/src/memory/tabular-store.ts
+++ b/services/agent-shared/src/memory/tabular-store.ts
@@ -1,0 +1,193 @@
+/**
+ * TabularStore — deterministic structured state for agents, as a sibling to
+ * the prose MemoryStore. Where memory is "the model reads/writes markdown",
+ * tables are "the model sends keys/filters and gets back computed results" —
+ * the bytes never round-trip through inference. Membership tests, append-only
+ * logs, dedup, and simple lookups (seen-sets, archive logs, etc.) live here.
+ *
+ * Storage: one JSONL object per table at
+ *   <bucketPrefix>/team/<team_id>/agent/<application_slug>/tables/<name>.jsonl
+ * Rows are JSON objects. The determinism lives in THIS code (Node), not in S3
+ * and not in the model: each op GETs the whole object, computes in-process, and
+ * conditionally PUTs back. S3 is a blob store, so whole-object read-modify-write
+ * is the access pattern — fine at realistic sizes (thousands of rows = tens of
+ * KB). If a table ever outgrows in-process scans, swap a `PgTabularStore` behind
+ * this same interface; nothing above it changes.
+ *
+ * Concurrency: mutating ops use S3 ETag conditional writes (If-Match /
+ * If-None-Match) with bounded retry, so racing cron firings can't lose-update.
+ * Where the backend ignores conditionals it degrades to last-write-wins.
+ */
+
+import { MemoryScope } from './store'
+
+export type TableScalar = string | number | boolean | null
+export type TableRow = Record<string, unknown>
+
+/** A column predicate. A bare scalar is shorthand for `{ eq: <scalar> }`. */
+export interface TablePredicate {
+    eq?: TableScalar
+    in?: TableScalar[]
+    gt?: number | string
+    gte?: number | string
+    lt?: number | string
+    lte?: number | string
+}
+
+export interface TableQuery {
+    /** Column → scalar (equality) or predicate. All conditions AND together. */
+    where?: Record<string, TableScalar | TablePredicate>
+    /** Project only these columns (omit ⇒ whole row). */
+    columns?: string[]
+    /** Sort by this column before limiting. */
+    order_by?: string
+    /** Descending order (default ascending). */
+    desc?: boolean
+    /** Cap the number of rows returned. */
+    limit?: number
+}
+
+export interface TabularStore {
+    /** List the tables that exist for this scope (cheap — names + byte size, no row GET). */
+    listTables(scope: MemoryScope): Promise<{ name: string; size: number }[]>
+    /**
+     * Partition `values` into those already present in `keyColumn` and those
+     * not. The seen-set workhorse: send N candidate ids, get back only the new
+     * ones — O(1) model context regardless of table size.
+     */
+    membership(
+        scope: MemoryScope,
+        table: string,
+        keyColumn: string,
+        values: TableScalar[]
+    ): Promise<{ known: TableScalar[]; new: TableScalar[] }>
+    /** Append rows. With `dedupeOn`, rows whose key already exists are skipped. */
+    append(
+        scope: MemoryScope,
+        table: string,
+        rows: TableRow[],
+        opts?: { dedupeOn?: string }
+    ): Promise<{ appended: number; skipped: number }>
+    /** Filter + project + order + limit. Simple predicates only. */
+    query(scope: MemoryScope, table: string, q?: TableQuery): Promise<TableRow[]>
+    /** Count rows matching `where` (or all rows). */
+    count(scope: MemoryScope, table: string, where?: TableQuery['where']): Promise<number>
+    /** Delete rows matching `where`. Returns how many were removed. */
+    delete(scope: MemoryScope, table: string, where: TableQuery['where']): Promise<{ deleted: number }>
+    /** Remove the whole table object. */
+    truncate(scope: MemoryScope, table: string): Promise<void>
+}
+
+const TABLE_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/
+
+export function validateTableName(name: string): string {
+    if (!TABLE_NAME_RE.test(name) || name.length > 128) {
+        throw new Error(`invalid table name "${name}" — must match ${TABLE_NAME_RE} (≤128 chars)`)
+    }
+    return name
+}
+
+export function tableKeyFor(scope: MemoryScope, name: string, bucketPrefix: string): string {
+    return `${tablesPrefixFor(scope, bucketPrefix)}${validateTableName(name)}.jsonl`
+}
+
+export function tablesPrefixFor(scope: MemoryScope, bucketPrefix: string): string {
+    const trimmed = bucketPrefix.replace(/^\/+|\/+$/g, '')
+    return `${trimmed}/team/${scope.teamId}/agent/${scope.applicationId}/tables/`
+}
+
+/** Parse JSONL into rows, skipping blank/corrupt lines (graceful degradation). */
+export function parseJsonl(raw: string): TableRow[] {
+    const rows: TableRow[] = []
+    for (const line of raw.split('\n')) {
+        const t = line.trim()
+        if (!t) {
+            continue
+        }
+        try {
+            const v = JSON.parse(t)
+            if (v && typeof v === 'object' && !Array.isArray(v)) {
+                rows.push(v as TableRow)
+            }
+        } catch {
+            // drop a corrupt line rather than failing the whole table
+        }
+    }
+    return rows
+}
+
+export function serializeJsonl(rows: TableRow[]): string {
+    return rows.map((r) => JSON.stringify(r)).join('\n') + (rows.length ? '\n' : '')
+}
+
+function cmp(a: unknown, b: number | string): number {
+    if (typeof a === 'number' && typeof b === 'number') {
+        return a - b
+    }
+    return String(a).localeCompare(String(b))
+}
+
+/** Evaluate one column condition against a row value. */
+function matchPredicate(value: unknown, cond: TableScalar | TablePredicate): boolean {
+    if (cond === null || typeof cond !== 'object') {
+        return value === cond
+    }
+    if ('eq' in cond && value !== cond.eq) {
+        return false
+    }
+    if (cond.in && !cond.in.includes(value as TableScalar)) {
+        return false
+    }
+    if (cond.gt !== undefined && !(cmp(value, cond.gt) > 0)) {
+        return false
+    }
+    if (cond.gte !== undefined && !(cmp(value, cond.gte) >= 0)) {
+        return false
+    }
+    if (cond.lt !== undefined && !(cmp(value, cond.lt) < 0)) {
+        return false
+    }
+    if (cond.lte !== undefined && !(cmp(value, cond.lte) <= 0)) {
+        return false
+    }
+    return true
+}
+
+export function matchRow(row: TableRow, where?: TableQuery['where']): boolean {
+    if (!where) {
+        return true
+    }
+    for (const [col, cond] of Object.entries(where)) {
+        if (!matchPredicate(row[col], cond)) {
+            return false
+        }
+    }
+    return true
+}
+
+/** Apply where/columns/order/limit to an in-memory row set (shared by impls). */
+export function applyQuery(rows: TableRow[], q: TableQuery = {}): TableRow[] {
+    let out = rows.filter((r) => matchRow(r, q.where))
+    if (q.order_by) {
+        const col = q.order_by
+        out = [...out].sort((a, b) => cmp(a[col], b[col] as number | string))
+        if (q.desc) {
+            out.reverse()
+        }
+    }
+    if (q.limit !== undefined) {
+        out = out.slice(0, q.limit)
+    }
+    if (q.columns) {
+        const cols = q.columns
+        out = out.map((r) => Object.fromEntries(cols.map((c) => [c, r[c]])))
+    }
+    return out
+}
+
+export class TabularConflictError extends Error {
+    constructor(public readonly table: string) {
+        super(`tabular write conflict on "${table}" after retries`)
+        this.name = 'TabularConflictError'
+    }
+}

--- a/services/agent-shared/src/memory/tabular-store.ts
+++ b/services/agent-shared/src/memory/tabular-store.ts
@@ -61,7 +61,11 @@ export interface TabularStore {
         keyColumn: string,
         values: TableScalar[]
     ): Promise<{ known: TableScalar[]; new: TableScalar[] }>
-    /** Append rows. With `dedupeOn`, rows whose key already exists are skipped. */
+    /**
+     * Append rows. With `dedupeOn`, rows whose key already exists in the table
+     * (or earlier in this same batch) are skipped. Rows missing the `dedupeOn`
+     * column can't be deduped and are always appended (counted in `appended`).
+     */
     append(
         scope: MemoryScope,
         table: string,
@@ -70,6 +74,11 @@ export interface TabularStore {
     ): Promise<{ appended: number; skipped: number }>
     /** Filter + project + order + limit. Simple predicates only. */
     query(scope: MemoryScope, table: string, q?: TableQuery): Promise<TableRow[]>
+    /**
+     * Like `query`, but also returns the table's total row count from the SAME
+     * read — one GET instead of query()+count(). For paged views ("N of M").
+     */
+    queryPage(scope: MemoryScope, table: string, q?: TableQuery): Promise<{ rows: TableRow[]; total: number }>
     /** Count rows matching `where` (or all rows). */
     count(scope: MemoryScope, table: string, where?: TableQuery['where']): Promise<number>
     /** Delete rows matching `where`. Returns how many were removed. */
@@ -80,9 +89,33 @@ export interface TabularStore {
 
 const TABLE_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/
 
+/**
+ * Per-table object ceiling. Whole-object read-modify-write is O(size) per op,
+ * so an unbounded table degrades to quadratic over a session — cap it (mirrors
+ * the memory store's per-file ceiling). Past this, the table should move to a
+ * real DB backend behind the same interface.
+ */
+export const MAX_TABLE_BYTES = 5 * 1024 * 1024
+
+/** Thrown by `validateTableName` on a bad name → callers map to 400. */
+export class TableNameError extends Error {
+    constructor(public readonly table: string) {
+        super(`invalid table name "${table}" — must match ${TABLE_NAME_RE} (≤128 chars)`)
+        this.name = 'TableNameError'
+    }
+}
+
+/** Thrown when an append would push a table past `MAX_TABLE_BYTES`. */
+export class TableTooLargeError extends Error {
+    constructor(public readonly table: string) {
+        super(`table "${table}" would exceed ${MAX_TABLE_BYTES} bytes — move it to a DB-backed store`)
+        this.name = 'TableTooLargeError'
+    }
+}
+
 export function validateTableName(name: string): string {
     if (!TABLE_NAME_RE.test(name) || name.length > 128) {
-        throw new Error(`invalid table name "${name}" — must match ${TABLE_NAME_RE} (≤128 chars)`)
+        throw new TableNameError(name)
     }
     return name
 }
@@ -120,14 +153,53 @@ export function serializeJsonl(rows: TableRow[]): string {
     return rows.map((r) => JSON.stringify(r)).join('\n') + (rows.length ? '\n' : '')
 }
 
-function cmp(a: unknown, b: number | string): number {
-    if (typeof a === 'number' && typeof b === 'number') {
-        return a - b
+/** Parse to a finite number, or null if it isn't numeric. */
+function toNum(v: unknown): number | null {
+    if (typeof v === 'number') {
+        return Number.isFinite(v) ? v : null
+    }
+    if (typeof v === 'string' && v.trim() !== '') {
+        const n = Number(v)
+        return Number.isFinite(n) ? n : null
+    }
+    return null
+}
+
+/**
+ * Order two values for SORTING (`order_by`). Compares numerically when both
+ * coerce to finite numbers, else lexicographically. Total order, never null —
+ * sorting can't drop rows.
+ */
+function cmp(a: unknown, b: unknown): number {
+    const na = toNum(a)
+    const nb = toNum(b)
+    if (na !== null && nb !== null) {
+        return na - nb
     }
     return String(a).localeCompare(String(b))
 }
 
-/** Evaluate one column condition against a row value. */
+/**
+ * Compare a row value against a range PREDICATE bound. Returns the sign, or
+ * `null` when the two aren't comparable — a numeric bound (incl. a numeric
+ * string like `"10"`) only compares against numeric values, so `{ gt: 9 }`
+ * matches `10`/`"11"` but NOT `"x"`; a non-numeric string bound compares
+ * lexicographically. `null` means "doesn't satisfy the predicate".
+ */
+function rangeCmp(value: unknown, bound: number | string): number | null {
+    const nb = toNum(bound)
+    if (nb !== null) {
+        const nv = toNum(value)
+        return nv === null ? null : nv - nb
+    }
+    return String(value).localeCompare(String(bound))
+}
+
+/**
+ * Evaluate one column condition against a row value. Predicates operate on
+ * scalars: `in` uses value equality (objects won't match), range ops compare
+ * via `cmp` (numeric when both sides are numeric, else lexicographic).
+ */
 function matchPredicate(value: unknown, cond: TableScalar | TablePredicate): boolean {
     if (cond === null || typeof cond !== 'object') {
         return value === cond
@@ -138,17 +210,20 @@ function matchPredicate(value: unknown, cond: TableScalar | TablePredicate): boo
     if (cond.in && !cond.in.includes(value as TableScalar)) {
         return false
     }
-    if (cond.gt !== undefined && !(cmp(value, cond.gt) > 0)) {
-        return false
-    }
-    if (cond.gte !== undefined && !(cmp(value, cond.gte) >= 0)) {
-        return false
-    }
-    if (cond.lt !== undefined && !(cmp(value, cond.lt) < 0)) {
-        return false
-    }
-    if (cond.lte !== undefined && !(cmp(value, cond.lte) <= 0)) {
-        return false
+    const ranges: [number | string | undefined, (c: number) => boolean][] = [
+        [cond.gt, (c) => c > 0],
+        [cond.gte, (c) => c >= 0],
+        [cond.lt, (c) => c < 0],
+        [cond.lte, (c) => c <= 0],
+    ]
+    for (const [bound, ok] of ranges) {
+        if (bound === undefined) {
+            continue
+        }
+        const c = rangeCmp(value, bound)
+        if (c === null || !ok(c)) {
+            return false
+        }
     }
     return true
 }
@@ -170,7 +245,7 @@ export function applyQuery(rows: TableRow[], q: TableQuery = {}): TableRow[] {
     let out = rows.filter((r) => matchRow(r, q.where))
     if (q.order_by) {
         const col = q.order_by
-        out = [...out].sort((a, b) => cmp(a[col], b[col] as number | string))
+        out = [...out].sort((a, b) => cmp(a[col], b[col]))
         if (q.desc) {
             out.reverse()
         }

--- a/services/agent-shared/src/spec/tool.ts
+++ b/services/agent-shared/src/spec/tool.ts
@@ -18,6 +18,7 @@
 import { Static, TSchema, Type } from 'typebox'
 
 import type { MemoryStore } from '../memory/store'
+import type { TabularStore } from '../memory/tabular-store'
 import type { Credential } from '../runtime/credential-broker'
 
 export type { Static, TSchema }
@@ -69,6 +70,13 @@ export interface ToolContext {
      * `InMemoryMemoryStore` directly.
      */
     memoryStore?: MemoryStore
+    /**
+     * Deterministic tabular store (seen-sets, append logs, simple queries),
+     * scoped to (teamId, applicationId). Optional — when absent the
+     * `@posthog/table-*` tools surface 'tabular_store_unavailable'. Wired in
+     * the runner from the same S3 config as memory (agent_tables prefix).
+     */
+    tabularStore?: TabularStore
     /**
      * Resolve a per-session credential by target name. Set by ingress at
      * /run + /send (see `CredentialBroker`); returns null when the broker

--- a/services/agent-tests/src/examples/agent-concierge/agent.md
+++ b/services/agent-tests/src/examples/agent-concierge/agent.md
@@ -207,6 +207,26 @@ lossy read-rewrite of a growing list). Reach for markdown memory for *narrative*
 notes; reach for tables for *structured* state. The console's memory tab
 surfaces these tables read-only under a Tables view.
 
+**Wiring it into an agent you author.** Two steps when you create or edit an
+agent (via the agent-applications revision + bundle tools):
+
+1. Add the tools it needs to `spec.tools[]` as native refs:
+   ```json
+   { "kind": "native", "id": "@posthog/table-membership" },
+   { "kind": "native", "id": "@posthog/table-append" },
+   { "kind": "native", "id": "@posthog/table-query" }
+   ```
+2. Teach the pattern in its `agent.md` / a skill. The three that recur:
+   - **Skip-set (don't reprocess):** list candidates → `table-membership(table, key_column, ids)` → act only on `.new` → `table-append(table, rows, dedupe_on: key_column)` to record what was handled.
+   - **Append-log + digest:** `table-append` one row per event (`{ id, reason, ts, date }`); later `table-query(table, where: { date })` to summarize. Add a `date`/`ts` column up front so the digest filter is cheap.
+   - **Dedupe before a side effect:** before sending/escalating, `table-membership(table, "id", [id])` — if it's in `.known`, skip; else do it and `table-append`.
+
+Guidance to pass on: tables are created on first append (no setup); names are
+lowercase / digits / `_` / `-`; reads are capped (`limit`, default 500) so don't
+expect a full dump; keep one table to one purpose (a `seen` set, an
+`archive_log`) rather than overloading columns; and on a write that returns
+`code: "conflict"`, retry — it's an optimistic-concurrency miss, not a hard error.
+
 ### The client tools
 
 These run in the connecting client, not on the runner. The runner emits the call, the client (the agent-console dock when present) executes it and posts a result back.

--- a/services/agent-tests/src/examples/agent-concierge/agent.md
+++ b/services/agent-tests/src/examples/agent-concierge/agent.md
@@ -184,6 +184,29 @@ before archiving. Writes go through the same approval gate as agent
 mutations — `archive-create` and `files-destroy` require explicit
 user consent.
 
+### Tabular reference — deterministic structured state for agents
+
+When you help someone design an agent that needs to remember a *set* or keep a
+*log* — "skip messages I've already processed", "dedupe alerts", "append an
+audit row each run", "look up a value by key" — point them at the
+`@posthog/table-*` native tools instead of cramming it into markdown memory.
+They give an agent deterministic structured state in S3-backed JSONL tables,
+manipulated by tool (never by re-reading a list into the model's context):
+
+| Tool                                  | Use it for                                                                  |
+| ------------------------------------- | --------------------------------------------------------------------------- |
+| `@posthog/table-membership`           | partition ids into already-seen vs new — the seen-set / skip-set workhorse  |
+| `@posthog/table-append`               | append rows (optional `dedupe_on` a key column)                             |
+| `@posthog/table-query`                | filter (`eq` / `in` / range) + project + order + limit                      |
+| `@posthog/table-count`                | count rows matching a filter                                                |
+| `@posthog/table-delete` / `-truncate` | remove matching rows / reset a table                                        |
+
+The win over prose memory: membership + append are O(1) on the model's context
+regardless of table size, and the bytes never round-trip through inference (no
+lossy read-rewrite of a growing list). Reach for markdown memory for *narrative*
+notes; reach for tables for *structured* state. The console's memory tab
+surfaces these tables read-only under a Tables view.
+
 ### The client tools
 
 These run in the connecting client, not on the runner. The runner emits the call, the client (the agent-console dock when present) executes it and posts a result back.

--- a/services/agent-tools/src/registry.ts
+++ b/services/agent-tools/src/registry.ts
@@ -22,6 +22,14 @@ import {
 } from './tools/memory'
 import { endSessionTool, endTurnTool, emitEventTool } from './tools/meta'
 import {
+    tableAppendV1,
+    tableCountV1,
+    tableDeleteV1,
+    tableMembershipV1,
+    tableQueryV1,
+    tableTruncateV1,
+} from './tools/table'
+import {
     posthogAgentApplicationsListV1,
     posthogAgentApplicationsRetrieveV1,
     posthogAgentApplicationsRevisionsFileV1,
@@ -75,6 +83,12 @@ export const ALL_TOOLS: NativeTool[] = [
     memoryWriteV1,
     memoryUpdateV1,
     memoryDeleteV1,
+    tableMembershipV1,
+    tableAppendV1,
+    tableQueryV1,
+    tableCountV1,
+    tableDeleteV1,
+    tableTruncateV1,
 ]
 
 const BY_ID = new Map<string, NativeTool>(ALL_TOOLS.map((t) => [t.id, t]))

--- a/services/agent-tools/src/tools/table.ts
+++ b/services/agent-tools/src/tools/table.ts
@@ -15,7 +15,14 @@
  *   { in: [...] } | { gt|gte|lt|lte: <number|string> }   (conditions AND together)
  */
 
-import { defineNativeTool, type TableQuery, type TabularStore, type ToolContext, Type } from '@posthog/agent-shared'
+import {
+    defineNativeTool,
+    TabularConflictError,
+    type TableQuery,
+    type TabularStore,
+    type ToolContext,
+    Type,
+} from '@posthog/agent-shared'
 
 // The TypeBox `where` schema infers as Record<string, unknown>; the store
 // evaluates each condition structurally at runtime (scalar or predicate), so we
@@ -25,12 +32,15 @@ type Where = TableQuery['where']
 const RESULT = Type.Object({
     ok: Type.Boolean(),
     error: Type.Optional(Type.String()),
+    /** Machine-readable failure class so the model can branch (e.g. retry on
+     *  `conflict`, give up on `unavailable`/`error`). */
+    code: Type.Optional(Type.String()),
     data: Type.Optional(Type.Unknown()),
 })
 
-type Result<T> = { ok: true; data: T } | { ok: false; error: string }
+type Result<T> = { ok: true; data: T } | { ok: false; error: string; code: string }
 const ok = <T>(data: T): Result<T> => ({ ok: true, data })
-const err = (error: string): Result<never> => ({ ok: false, error })
+const err = (error: string, code = 'error'): Result<never> => ({ ok: false, error, code })
 
 function scope(ctx: ToolContext): { teamId: number; applicationId: string } {
     return { teamId: ctx.teamId, applicationId: ctx.applicationId }
@@ -43,6 +53,10 @@ function storeOrError(ctx: ToolContext): TabularStore | { error: string } {
 }
 function asError(thrown: unknown): string {
     return (thrown as Error)?.message ?? 'unknown_error'
+}
+/** Classify a thrown store error for the result `code`. */
+function asCode(thrown: unknown): string {
+    return thrown instanceof TabularConflictError ? 'conflict' : 'error'
 }
 
 const TABLE = Type.String({ description: 'Table name (lowercase, digits, _ or -). Created on first append.' })
@@ -66,13 +80,13 @@ export const tableMembershipV1 = defineNativeTool({
     async run(args, ctx) {
         const s = storeOrError(ctx)
         if ('error' in s) {
-            return err(s.error)
+            return err(s.error, 'unavailable')
         }
         try {
             const res = await s.membership(scope(ctx), args.table, args.key_column, args.values)
             return ok(res)
         } catch (e) {
-            return err(asError(e))
+            return err(asError(e), asCode(e))
         }
     },
 })
@@ -91,13 +105,13 @@ export const tableAppendV1 = defineNativeTool({
     async run(args, ctx) {
         const s = storeOrError(ctx)
         if ('error' in s) {
-            return err(s.error)
+            return err(s.error, 'unavailable')
         }
         try {
             const res = await s.append(scope(ctx), args.table, args.rows, { dedupeOn: args.dedupe_on })
             return ok(res)
         } catch (e) {
-            return err(asError(e))
+            return err(asError(e), asCode(e))
         }
     },
 })
@@ -119,7 +133,7 @@ export const tableQueryV1 = defineNativeTool({
     async run(args, ctx) {
         const s = storeOrError(ctx)
         if ('error' in s) {
-            return err(s.error)
+            return err(s.error, 'unavailable')
         }
         try {
             const rows = await s.query(scope(ctx), args.table, {
@@ -131,7 +145,7 @@ export const tableQueryV1 = defineNativeTool({
             })
             return ok({ count: rows.length, rows })
         } catch (e) {
-            return err(asError(e))
+            return err(asError(e), asCode(e))
         }
     },
 })
@@ -145,12 +159,12 @@ export const tableCountV1 = defineNativeTool({
     async run(args, ctx) {
         const s = storeOrError(ctx)
         if ('error' in s) {
-            return err(s.error)
+            return err(s.error, 'unavailable')
         }
         try {
             return ok({ count: await s.count(scope(ctx), args.table, args.where as Where) })
         } catch (e) {
-            return err(asError(e))
+            return err(asError(e), asCode(e))
         }
     },
 })
@@ -164,12 +178,12 @@ export const tableDeleteV1 = defineNativeTool({
     async run(args, ctx) {
         const s = storeOrError(ctx)
         if ('error' in s) {
-            return err(s.error)
+            return err(s.error, 'unavailable')
         }
         try {
             return ok(await s.delete(scope(ctx), args.table, args.where as Where))
         } catch (e) {
-            return err(asError(e))
+            return err(asError(e), asCode(e))
         }
     },
 })
@@ -183,13 +197,13 @@ export const tableTruncateV1 = defineNativeTool({
     async run(args, ctx) {
         const s = storeOrError(ctx)
         if ('error' in s) {
-            return err(s.error)
+            return err(s.error, 'unavailable')
         }
         try {
             await s.truncate(scope(ctx), args.table)
             return ok({ truncated: args.table })
         } catch (e) {
-            return err(asError(e))
+            return err(asError(e), asCode(e))
         }
     },
 })

--- a/services/agent-tools/src/tools/table.ts
+++ b/services/agent-tools/src/tools/table.ts
@@ -1,0 +1,195 @@
+/**
+ * Tabular reference tools — deterministic structured state for agents, backed
+ * by the S3 JSONL TabularStore (sibling to the prose memory tools). The model
+ * sends keys/filters and gets back computed results; the table bytes never
+ * round-trip through inference. Scoped per (team_id, application_id).
+ *
+ *   table-membership — partition ids into known vs new (the seen-set workhorse)
+ *   table-append     — append rows (optional dedupe on a key column)
+ *   table-query      — filter + project + order + limit (simple predicates)
+ *   table-count      — count rows matching a filter
+ *   table-delete     — delete rows matching a filter
+ *   table-truncate   — drop a whole table
+ *
+ * `where` is a map of column → value (equality) or a predicate object:
+ *   { in: [...] } | { gt|gte|lt|lte: <number|string> }   (conditions AND together)
+ */
+
+import { defineNativeTool, type TableQuery, type TabularStore, type ToolContext, Type } from '@posthog/agent-shared'
+
+// The TypeBox `where` schema infers as Record<string, unknown>; the store
+// evaluates each condition structurally at runtime (scalar or predicate), so we
+// cast at the tool boundary.
+type Where = TableQuery['where']
+
+const RESULT = Type.Object({
+    ok: Type.Boolean(),
+    error: Type.Optional(Type.String()),
+    data: Type.Optional(Type.Unknown()),
+})
+
+type Result<T> = { ok: true; data: T } | { ok: false; error: string }
+const ok = <T>(data: T): Result<T> => ({ ok: true, data })
+const err = (error: string): Result<never> => ({ ok: false, error })
+
+function scope(ctx: ToolContext): { teamId: number; applicationId: string } {
+    return { teamId: ctx.teamId, applicationId: ctx.applicationId }
+}
+function storeOrError(ctx: ToolContext): TabularStore | { error: string } {
+    if (!ctx.tabularStore) {
+        return { error: 'tabular_store_unavailable' }
+    }
+    return ctx.tabularStore
+}
+function asError(thrown: unknown): string {
+    return (thrown as Error)?.message ?? 'unknown_error'
+}
+
+const TABLE = Type.String({ description: 'Table name (lowercase, digits, _ or -). Created on first append.' })
+const SCALAR = Type.Union([Type.String(), Type.Number(), Type.Boolean(), Type.Null()])
+const WHERE = Type.Record(Type.String(), Type.Unknown(), {
+    description:
+        'Filter map: column → value (equality), or a predicate object {in:[...]}, {gte:x}, {lte:x}, {gt:x}, {lt:x}. Conditions AND together.',
+})
+
+export const tableMembershipV1 = defineNativeTool({
+    id: '@posthog/table-membership',
+    description:
+        'Partition `values` into those already present in `key_column` of the table and those not yet seen. The deterministic seen-set check: pass a batch of ids, get back only the `new` ones to process. Cheap regardless of table size; the table contents never enter your context.',
+    args: Type.Object({
+        table: TABLE,
+        key_column: Type.String({ description: 'The column holding the identifier to test membership against.' }),
+        values: Type.Array(SCALAR, { description: 'Candidate values to test.' }),
+    }),
+    returns: RESULT,
+    cost_hint: 'cheap',
+    async run(args, ctx) {
+        const s = storeOrError(ctx)
+        if ('error' in s) {
+            return err(s.error)
+        }
+        try {
+            const res = await s.membership(scope(ctx), args.table, args.key_column, args.values)
+            return ok(res)
+        } catch (e) {
+            return err(asError(e))
+        }
+    },
+})
+
+export const tableAppendV1 = defineNativeTool({
+    id: '@posthog/table-append',
+    description:
+        'Append rows (JSON objects) to a table, creating it if needed. With `dedupe_on`, rows whose value in that column already exists are skipped (returns counts). Use for seen-sets and append-only logs.',
+    args: Type.Object({
+        table: TABLE,
+        rows: Type.Array(Type.Record(Type.String(), Type.Unknown()), { description: 'Rows to append.' }),
+        dedupe_on: Type.Optional(Type.String({ description: 'Column to dedupe on; skip rows whose key already exists.' })),
+    }),
+    returns: RESULT,
+    cost_hint: 'cheap',
+    async run(args, ctx) {
+        const s = storeOrError(ctx)
+        if ('error' in s) {
+            return err(s.error)
+        }
+        try {
+            const res = await s.append(scope(ctx), args.table, args.rows, { dedupeOn: args.dedupe_on })
+            return ok(res)
+        } catch (e) {
+            return err(asError(e))
+        }
+    },
+})
+
+export const tableQueryV1 = defineNativeTool({
+    id: '@posthog/table-query',
+    description:
+        'Read rows from a table, filtered by `where`, optionally projected to `columns`, ordered, and limited. Returns the matching rows.',
+    args: Type.Object({
+        table: TABLE,
+        where: Type.Optional(WHERE),
+        columns: Type.Optional(Type.Array(Type.String(), { description: 'Project only these columns.' })),
+        order_by: Type.Optional(Type.String({ description: 'Sort by this column.' })),
+        desc: Type.Optional(Type.Boolean({ description: 'Descending order.' })),
+        limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+    }),
+    returns: RESULT,
+    cost_hint: 'cheap',
+    async run(args, ctx) {
+        const s = storeOrError(ctx)
+        if ('error' in s) {
+            return err(s.error)
+        }
+        try {
+            const rows = await s.query(scope(ctx), args.table, {
+                where: args.where as Where,
+                columns: args.columns,
+                order_by: args.order_by,
+                desc: args.desc,
+                limit: args.limit,
+            })
+            return ok({ count: rows.length, rows })
+        } catch (e) {
+            return err(asError(e))
+        }
+    },
+})
+
+export const tableCountV1 = defineNativeTool({
+    id: '@posthog/table-count',
+    description: 'Count rows in a table matching `where` (or all rows if omitted).',
+    args: Type.Object({ table: TABLE, where: Type.Optional(WHERE) }),
+    returns: RESULT,
+    cost_hint: 'cheap',
+    async run(args, ctx) {
+        const s = storeOrError(ctx)
+        if ('error' in s) {
+            return err(s.error)
+        }
+        try {
+            return ok({ count: await s.count(scope(ctx), args.table, args.where as Where) })
+        } catch (e) {
+            return err(asError(e))
+        }
+    },
+})
+
+export const tableDeleteV1 = defineNativeTool({
+    id: '@posthog/table-delete',
+    description: 'Delete rows from a table matching `where` (required). Returns how many were removed.',
+    args: Type.Object({ table: TABLE, where: WHERE }),
+    returns: RESULT,
+    cost_hint: 'cheap',
+    async run(args, ctx) {
+        const s = storeOrError(ctx)
+        if ('error' in s) {
+            return err(s.error)
+        }
+        try {
+            return ok(await s.delete(scope(ctx), args.table, args.where as Where))
+        } catch (e) {
+            return err(asError(e))
+        }
+    },
+})
+
+export const tableTruncateV1 = defineNativeTool({
+    id: '@posthog/table-truncate',
+    description: 'Remove an entire table (all rows). Use to reset state.',
+    args: Type.Object({ table: TABLE }),
+    returns: RESULT,
+    cost_hint: 'cheap',
+    async run(args, ctx) {
+        const s = storeOrError(ctx)
+        if ('error' in s) {
+            return err(s.error)
+        }
+        try {
+            await s.truncate(scope(ctx), args.table)
+            return ok({ truncated: args.table })
+        } catch (e) {
+            return err(asError(e))
+        }
+    },
+})

--- a/services/mcp/definitions/agent_stack.yaml
+++ b/services/mcp/definitions/agent_stack.yaml
@@ -608,6 +608,12 @@ tools:
     agent-memory-list-files:
         operation: agent_memory_list_files
         enabled: false
+    agent-memory-list-tables:
+        operation: agent_memory_list_tables
+        enabled: false
+    agent-memory-read-table:
+        operation: agent_memory_read_table
+        enabled: false
     agent-memory-search:
         operation: agent_memory_search
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7875,6 +7875,33 @@ export namespace Schemas {
       resolved_natives: string[];
     }
 
+    export interface AgentTableHeader {
+      /** Table name. */
+      name: string;
+      /** Object size in bytes. */
+      size: number;
+    }
+
+    export type AgentTableRowsResponseRowsItem = { [key: string]: unknown };
+
+    export interface AgentTableRowsResponse {
+      name: string;
+      /** Total rows in the table. */
+      total: number;
+      /** Rows in this response (capped by limit). */
+      returned: number;
+      limit: number;
+      /** The rows (arbitrary JSON objects). */
+      rows: AgentTableRowsResponseRowsItem[];
+    }
+
+    export interface AgentTablesListResponse {
+      /** Number of tables. */
+      count: number;
+      /** Tabular-reference tables for this agent (the @posthog/table-* JSONL tables). */
+      tables: AgentTableHeader[];
+    }
+
     export interface AggregatedSpanRow {
       avg_duration_nano: number;
       count: number;
@@ -46857,6 +46884,13 @@ export namespace Schemas {
      * Search cue — plain natural language is fine.
      */
     q: string;
+    };
+
+    export type AgentMemoryReadTableParams = {
+    /**
+     * Max rows to return (default 500, max 5000).
+     */
+    limit?: number;
     };
 
     export type AgentApplicationsRevisionsListParams = {


### PR DESCRIPTION
## Problem

Agents that need to remember a *set* or keep a *log* — skip already-seen items, dedupe, append audit rows, look up by key — currently have to cram that into markdown memory. That means the model reads a growing list into context and rewrites it every run: token-heavy, lossy, non-deterministic, and it doesn't scale.

## Changes

- **`TabularStore`** (`agent-shared`): deterministic structured state behind a swappable interface — `membership` / `append` / `query` / `count` / `delete` / `truncate`. `S3JsonlTabularStore` stores one JSONL object per table with ETag optimistic-concurrency writes. The determinism lives in tool code, not inference — the table bytes never enter the model's context. (Postgres is the upgrade path behind the same interface if a table outgrows in-process scans; chosen over SQLite-in-S3, which gains nothing in a blob store and adds binary-corruption / native-dep cost.)
- **`@posthog/table-*` native tools** wired through `ToolContext` like `memoryStore` (same S3 config, `agent_tables` prefix).
- **Console Tables view**: read-only `GET …/memory/tables[/<name>]` (Django → janitor), surfaced under a **Files | Tables** toggle in the memory tab.
- **Visibility-aware console polling**: `useResource({ pollMs })` — skips hidden tabs, catches up on focus — on the fleet / overview / sessions reads.
- The concierge `agent.md` now recommends tables for structured state when helping design agents.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Automated checks actually run: `tsc --noEmit` clean on `agent-shared` / `agent-tools` / `agent-janitor` (the two remaining typecheck errors are pre-existing and not in changed files — upstream `worker.test.ts` debt, and a worktree-only `@posthog/quill` link gap). I functionally exercised `S3JsonlTabularStore` against local MinIO (membership, append-with-dedupe, filtered/ordered/range queries, count) and confirmed the console → Django → janitor Tables path end-to-end.

No `table.test.ts` is committed yet — owed as a follow-up (MinIO-backed, mirroring `memory.test.ts`).

## 🤖 Agent context

Authored by Claude Code (Opus 4.8); no shareable session link. Key decisions: JSONL-in-S3 over SQLite (S3 is a blob store, not a block device — SQLite's indexed-query advantage never activates when you GET/PUT the whole object anyway, while it adds corruption-on-partial-write and a native dep), with Postgres as the real escape hatch behind the same `TabularStore` interface. Assembled on a clean `ass-dylan` worktree to isolate this feature from unrelated local WIP. Requires a human author + review.
