### PR TITLE
fix(web-analytics): force sync flag load in eager precompute op

### DIFF
--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -282,9 +282,22 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
     return warmed, failed
 
 
-@dagster.op
+@dagster.op(required_resource_keys={"posthoganalytics"})
 def warm_eager_baseline_op(context: dagster.OpExecutionContext) -> dict[str, int]:
-    """Run the baseline tile matrix against every flag-enrolled team."""
+    """Run the baseline tile matrix against every flag-enrolled team.
+
+    Declaring the `posthoganalytics` resource ensures Dagster runs
+    `PostHogAnalyticsResource.create_resource` first, which sets
+    `posthoganalytics.personal_api_key` from `EnvVar("PERSONAL_API_KEY")`.
+    The op then forces a synchronous load of flag definitions — the
+    SDK's background poller runs on a 90s interval and would not fire
+    before this short-lived op subprocess exits.
+    """
+    try:
+        posthoganalytics.load_feature_flags()
+    except Exception:
+        context.log.exception("eager_baseline_warming_load_feature_flags_failed")
+
     team_ids, gate_reason, diagnostics = _resolve_eager_audience()
     diag_str = " ".join(f"{k}={v}" for k, v in diagnostics.items())
     context.log.info(

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -273,8 +273,7 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         assert result == {"teams": 0, "warmed": 0, "failed": 0, "skipped": 0}
         get_runner.assert_not_called()
 
-    @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
-    def test_forces_synchronous_flag_load_before_resolving_audience(self, get_runner, defs, load_flags, _is_cloud):
+    def test_forces_synchronous_flag_load_before_resolving_audience(self, defs, load_flags, _is_cloud):
         # The SDK's background poller runs on a 90s interval; this op
         # subprocess finishes in seconds, so we must force a sync load
         # or `feature_flag_definitions()` returns empty.
@@ -282,8 +281,7 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         warm_eager_baseline_op(self._op_context())
         load_flags.assert_called_once_with()
 
-    @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
-    def test_load_failure_does_not_abort_the_run(self, get_runner, defs, load_flags, _is_cloud):
+    def test_load_failure_does_not_abort_the_run(self, defs, load_flags, _is_cloud):
         # A flaky local-evaluation endpoint should not crash the op —
         # the run continues with whatever the SDK already has cached.
         load_flags.side_effect = RuntimeError("network blip")

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -209,10 +209,18 @@ class TestGetEagerTeamIds(APIBaseTest):
 
 
 @patch("products.web_analytics.dags.eager_web_analytics_precompute.is_cloud", return_value=True)
+@patch("products.web_analytics.dags.eager_web_analytics_precompute.posthoganalytics.load_feature_flags")
 @patch("products.web_analytics.dags.eager_web_analytics_precompute.posthoganalytics.feature_flag_definitions")
 class TestWarmEagerBaselineOp(APIBaseTest):
     """Integration-shaped tests for the op. Query runners are patched so
     no ClickHouse traffic is needed — we assert orchestration semantics."""
+
+    @staticmethod
+    def _op_context() -> dagster.OpExecutionContext:
+        # The op declares the `posthoganalytics` resource so Dagster can
+        # initialize `personal_api_key` before the body runs; supply a
+        # mock for direct invocation.
+        return dagster.build_op_context(resources={"posthoganalytics": Mock()})
 
     def _enroll_org(self, *, name: str) -> tuple[Team, str]:
         org = Organization.objects.create(name=name)
@@ -220,7 +228,9 @@ class TestWarmEagerBaselineOp(APIBaseTest):
 
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
-    def test_one_team_failure_does_not_poison_other_teams(self, get_runner, tag_queries_mock, defs, _is_cloud):
+    def test_one_team_failure_does_not_poison_other_teams(
+        self, get_runner, tag_queries_mock, defs, _load_flags, _is_cloud
+    ):
         t1, org_a = self._enroll_org(name="A")
         t2, org_b = self._enroll_org(name="B")
         defs.return_value = [_flag(groups=[_org_id_group(org_a), _org_id_group(org_b)])]
@@ -235,7 +245,7 @@ class TestWarmEagerBaselineOp(APIBaseTest):
 
         get_runner.side_effect = runner_factory
 
-        context = dagster.build_op_context()
+        context = self._op_context()
         result = warm_eager_baseline_op(context)
 
         assert result["teams"] == 2
@@ -256,12 +266,30 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         assert tag_queries_mock.call_count == _QUERIES_PER_TEAM * 2
 
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
-    def test_returns_zeroed_metadata_when_no_teams_enrolled(self, get_runner, defs, _is_cloud):
+    def test_returns_zeroed_metadata_when_no_teams_enrolled(self, get_runner, defs, _load_flags, _is_cloud):
         defs.return_value = []
-        context = dagster.build_op_context()
+        context = self._op_context()
         result = warm_eager_baseline_op(context)
         assert result == {"teams": 0, "warmed": 0, "failed": 0, "skipped": 0}
         get_runner.assert_not_called()
+
+    @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
+    def test_forces_synchronous_flag_load_before_resolving_audience(self, get_runner, defs, load_flags, _is_cloud):
+        # The SDK's background poller runs on a 90s interval; this op
+        # subprocess finishes in seconds, so we must force a sync load
+        # or `feature_flag_definitions()` returns empty.
+        defs.return_value = []
+        warm_eager_baseline_op(self._op_context())
+        load_flags.assert_called_once_with()
+
+    @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
+    def test_load_failure_does_not_abort_the_run(self, get_runner, defs, load_flags, _is_cloud):
+        # A flaky local-evaluation endpoint should not crash the op —
+        # the run continues with whatever the SDK already has cached.
+        load_flags.side_effect = RuntimeError("network blip")
+        defs.return_value = []
+        result = warm_eager_baseline_op(self._op_context())
+        assert result == {"teams": 0, "warmed": 0, "failed": 0, "skipped": 0}
 
 
 class TestWarmBaselineForTeam(APIBaseTest):


### PR DESCRIPTION
## Problem

After [#61234](https://github.com/PostHog/posthog/pull/61234) added gate-reason logging to the eager precompute warming job, the first production run surfaced the actual cause of every `teams=0` run: `gate_reason=flag_not_found flags_in_cache=0`. The Dagster subprocess running `warm_eager_baseline_op` never had a populated `posthoganalytics` SDK flag cache, so the audience could never resolve.

Two distinct issues caused this:

1. `warm_eager_baseline_op` didn't request the `posthoganalytics` resource, so `PostHogAnalyticsResource.create_resource` never ran and `posthoganalytics.personal_api_key` was never set from `EnvVar("PERSONAL_API_KEY")` in the op's subprocess. The companion `get_teams_for_warming_op` in `cache_warming.py` requests this resource for exactly the same reason.
2. Even with the key set, the SDK's local-evaluation poller runs on a 90s interval (`posthog/apps.py` sets `posthoganalytics.poll_interval = 90`) while each Dagster op subprocess finishes in ~2s. So `feature_flag_definitions()` would still see an empty cache.

## Changes

- Add `required_resource_keys={"posthoganalytics"}` to the `@dagster.op` decorator. This makes Dagster run `PostHogAnalyticsResource.create_resource` first, setting `personal_api_key` before the body executes. Using `required_resource_keys` rather than the typed-parameter pattern avoids shadowing the `posthoganalytics` module import already used inside the file.
- Call `posthoganalytics.load_feature_flags()` synchronously at the start of the op body — this hits `/api/feature_flag/local_evaluation/` immediately so the in-memory cache is populated before the audience resolver reads `feature_flag_definitions()`.
- Catch and log (do not re-raise) any exception from `load_feature_flags()` — a transient network blip should not abort the entire warming run; we fall through to whatever the SDK already has and the gate-reason log will still show the empty state.
- Test updates:
    - Patch `posthoganalytics.load_feature_flags` in `TestWarmEagerBaselineOp` so tests don't make real network calls.
    - Supply a `Mock()` for the `posthoganalytics` resource via `dagster.build_op_context(resources=...)` so direct-invocation tests satisfy the new resource requirement.
    - Add `test_forces_synchronous_flag_load_before_resolving_audience` pinning the new `load_feature_flags()` call.
    - Add `test_load_failure_does_not_abort_the_run` pinning the swallow-and-continue behavior.

No change to gate logic, audience semantics, or query payloads.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I ran locally:

- `hogli test products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py` → 27 passed (25 existing + 2 new).
- `ruff check` + `ruff format` clean on both modified files.

I did not exercise this against a live Dagster instance. Verification will land via the next scheduled run of `web_analytics_eager_baseline_warming_job` — the existing gate-reason output metadata will immediately reveal whether `flags_in_cache` becomes non-zero and whether `gate_reason` advances past `flag_not_found`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing surface change; skipping docs.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). The previous PR's gate-reason logging immediately surfaced the SDK-cache emptiness; this PR addresses it.

Design considerations:

- Considered the typed-parameter pattern (`posthoganalytics: PostHogAnalyticsResource`) used by `get_teams_for_warming_op` in `cache_warming.py` but it would shadow the module-level `import posthoganalytics`, which the audience resolver already calls into. `required_resource_keys` decouples the resource key from any local symbol.
- Considered relying on Django `AppConfig.ready()` to set `personal_api_key` since Dagster imports Django models. This is unreliable for short-lived subprocesses (timing varies by import order, and the SDK key was clearly not propagating in production based on `flags_in_cache=0`). Explicitly declaring the resource is the contract Dagster expects.
- Considered calling `posthoganalytics.feature_enabled(...)` directly instead of `load_feature_flags()` + `feature_flag_definitions()`. Rejected — the audience is org-IDs embedded in flag conditions, not a per-team flag evaluation, so we need the raw definitions.
- Swallowed `load_feature_flags()` exceptions deliberately. The op is hourly; one bad fetch should let subsequent runs recover rather than alerting on a transient blip. The gate-reason metadata already exposes the SDK-empty state when it happens.