### PR TITLE
feat(replay-vision): snappier scanner toggle and color-coded type column

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { IconCopy, IconPencil, IconPlus, IconSearch, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonSwitch, LemonTable, LemonTag, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonSwitch, LemonTable, LemonTag, LemonTagType, Link } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { XRayHog } from 'lib/components/hedgehogs'
@@ -21,12 +21,26 @@ import { AccessControlLevel, AccessControlResourceType } from '~/types'
 import { FilterPill } from '../components/FilterPill'
 import { VisionQuotaMeter } from './components/VisionQuotaMeter'
 import { replayScannersLogic } from './replayScannersLogic'
-import { ENABLED_OPTIONS, EnabledFilter, SCANNER_TYPE_OPTIONS, ScannerType, ReplayScanner } from './types'
+import {
+    ENABLED_OPTIONS,
+    EnabledFilter,
+    SCANNER_TYPE_OPTIONS,
+    ScannerType,
+    ReplayScanner,
+    scannerTypeLabel,
+} from './types'
 
 const TYPE_OPTIONS: { value: ScannerType; label: string }[] = SCANNER_TYPE_OPTIONS.map(({ value, label }) => ({
     value,
     label,
 }))
+
+const SCANNER_TYPE_TAG_TYPE: Record<ScannerType, LemonTagType> = {
+    monitor: 'primary',
+    classifier: 'completion',
+    scorer: 'warning',
+    summarizer: 'success',
+}
 
 export const scene: SceneExport = {
     component: ReplayScannersScene,
@@ -35,8 +49,16 @@ export const scene: SceneExport = {
 }
 
 export function ReplayScannersScene(): JSX.Element {
-    const { filteredScanners, scanners, scannersLoading, search, enabledFilter, scannerTypeFilter, hasActiveFilters } =
-        useValues(replayScannersLogic)
+    const {
+        filteredScanners,
+        scanners,
+        scannersLoading,
+        togglingIds,
+        search,
+        enabledFilter,
+        scannerTypeFilter,
+        hasActiveFilters,
+    } = useValues(replayScannersLogic)
     const {
         loadScanners,
         deleteScanner,
@@ -75,10 +97,11 @@ export function ReplayScannersScene(): JSX.Element {
                         <LemonSwitch
                             checked={scanner.enabled}
                             onChange={() => toggleScannerEnabled(scanner.id)}
+                            disabled={togglingIds.includes(scanner.id)}
                             size="small"
                         />
                     </AccessControlAction>
-                    <span className={scanner.enabled ? 'text-success' : 'text-muted'}>
+                    <span className={`inline-block min-w-[4.5rem] ${scanner.enabled ? 'text-success' : 'text-muted'}`}>
                         {scanner.enabled ? 'Enabled' : 'Disabled'}
                     </span>
                 </div>
@@ -88,7 +111,11 @@ export function ReplayScannersScene(): JSX.Element {
         {
             title: 'Type',
             key: 'scanner_type',
-            render: (_, scanner) => <LemonTag type="option">{scanner.scanner_type}</LemonTag>,
+            render: (_, scanner) => (
+                <LemonTag type={SCANNER_TYPE_TAG_TYPE[scanner.scanner_type]}>
+                    {scannerTypeLabel(scanner.scanner_type)}
+                </LemonTag>
+            ),
             sorter: (a, b) => a.scanner_type.localeCompare(b.scanner_type),
         },
         {

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
@@ -51,6 +51,9 @@ describe('replayScannersLogic', () => {
                 '/api/projects/:team/vision/scanners/': { results: [] },
                 '/api/projects/:team/vision/quota/': () => [404, {}],
             },
+            patch: {
+                '/api/projects/:team/vision/scanners/:id/': () => [200, {}],
+            },
         })
         initKeaTests()
         logic = replayScannersLogic({ tabId: 'test' })
@@ -123,12 +126,24 @@ describe('replayScannersLogic', () => {
         })
     })
 
-    it('toggleScannerEnabledSuccess flips the scanner row', async () => {
+    it('toggleScannerEnabled optimistically flips the row and marks it in-flight', async () => {
         await expectLogic(logic, () => {
             logic.actions.loadScannersSuccess(scanners)
-            logic.actions.toggleScannerEnabledSuccess('a')
+            logic.actions.toggleScannerEnabled('a')
         }).toMatchValues({
             scanners: expect.arrayContaining([expect.objectContaining({ id: 'a', enabled: false })]),
+            togglingIds: ['a'],
+        })
+    })
+
+    it('revertScannerEnabled flips the row back and clears the in-flight id', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadScannersSuccess(scanners)
+            logic.actions.toggleScannerEnabled('a')
+            logic.actions.revertScannerEnabled('a')
+        }).toMatchValues({
+            scanners: expect.arrayContaining([expect.objectContaining({ id: 'a', enabled: true })]),
+            togglingIds: [],
         })
     })
 })

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
@@ -62,7 +62,8 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
         duplicateScanner: (id: string) => ({ id }),
         duplicateScannerSuccess: (scanner: ReplayScanner) => ({ scanner }),
         toggleScannerEnabled: (id: string) => ({ id }),
-        toggleScannerEnabledSuccess: (id: string) => ({ id }),
+        toggleScannerEnabledDone: (id: string) => ({ id }),
+        revertScannerEnabled: (id: string) => ({ id }),
         setSearch: (search: string) => ({ search }),
         setEnabledFilter: (values: EnabledFilter[]) => ({ values }),
         setScannerTypeFilter: (scannerTypes: ScannerType[]) => ({ scannerTypes }),
@@ -76,8 +77,18 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
                 loadScannersSuccess: (_, { scanners }) => scanners,
                 deleteScannerSuccess: (state, { id }) => state.filter((l) => l.id !== id),
                 duplicateScannerSuccess: (state, { scanner }) => [...state, scanner],
-                toggleScannerEnabledSuccess: (state, { id }) =>
+                toggleScannerEnabled: (state, { id }) =>
                     state.map((l) => (l.id === id ? { ...l, enabled: !l.enabled } : l)),
+                revertScannerEnabled: (state, { id }) =>
+                    state.map((l) => (l.id === id ? { ...l, enabled: !l.enabled } : l)),
+            },
+        ],
+        togglingIds: [
+            [] as string[],
+            {
+                toggleScannerEnabled: (state, { id }) => [...state, id],
+                toggleScannerEnabledDone: (state, { id }) => state.filter((i) => i !== id),
+                revertScannerEnabled: (state, { id }) => state.filter((i) => i !== id),
             },
         ],
         scannersLoading: [
@@ -191,19 +202,22 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
         },
 
         toggleScannerEnabled: async ({ id }) => {
+            // The reducer has already flipped `enabled` optimistically, so this reflects the new target state.
             const scanner = values.scanners.find((l) => l.id === id)
             if (!scanner) {
                 return
             }
             const teamId = teamLogic.values.currentTeamId
             if (!teamId) {
+                actions.revertScannerEnabled(id)
                 return
             }
             try {
-                await visionScannersPartialUpdate(String(teamId), id, { enabled: !scanner.enabled })
-                actions.toggleScannerEnabledSuccess(id)
+                await visionScannersPartialUpdate(String(teamId), id, { enabled: scanner.enabled })
+                actions.toggleScannerEnabledDone(id)
             } catch (error) {
-                lemonToast.error(`Failed to ${scanner.enabled ? 'disable' : 'enable'} scanner: ${String(error)}`)
+                lemonToast.error(`Failed to ${scanner.enabled ? 'enable' : 'disable'} scanner: ${String(error)}`)
+                actions.revertScannerEnabled(id)
             }
         },
     })),


### PR DESCRIPTION
## Problem

On the Replay vision scanners list, toggling a scanner's enable/disable switch felt laggy: the switch only flipped after the API round-trip completed, and once the status label changed between "Enabled" and "Disabled" (different text widths) the auto-sized table column re-flowed and visibly shifted. Separately, the Type column rendered every scanner type as the same orange tag, so types were hard to tell apart at a glance.

## Changes

- **Optimistic toggle.** The `enabled` state now flips immediately in the reducer, so the switch responds instantly. The API call runs in the background; on failure the row reverts and an error toast is shown.
- **Double-submit guard.** A per-row in-flight set (`togglingIds`) disables the individual switch while its request is pending — matching the existing pattern in `logsAlertNotificationDetailSceneLogic` and `featureFlagsLogic`.
- **No layout shift.** The status label sits in a fixed-width container so the column no longer resizes when the text swaps between "Enabled" and "Disabled".
- **Color-coded Type column.** Each scanner type maps to a distinct `LemonTag` colour (monitor → primary, classifier → completion, scorer → warning, summarizer → success) and uses the capitalised label via the existing `scannerTypeLabel` helper.

## How did you test this code?

I'm an agent. I did not perform manual browser testing. I updated and ran the existing kea logic test suite (`replayScannersLogic.test.ts`) — 11/11 pass — including two new cases covering the optimistic flip + in-flight tracking and the revert-on-failure path. Formatting ran via lint-staged on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude). The reviewer asked to make the toggle snappier (no lag, no column shift) and to color-code the scanner type column.

Key decisions:
- Chose an optimistic update + revert over waiting on the server response, since the lag was the main complaint. Paired it with a `togglingIds` in-flight guard after confirming this is an established PostHog idiom (array form in `logsAlertNotificationDetailSceneLogic`, map form in `featureFlagsLogic`) rather than inventing one — the lazier no-guard approach in some list logics has a known double-submit bug.
- Traced the column shift to the variable-width status label resizing an auto-sized table column; fixed with a fixed-width label container rather than hardcoding column widths.
- Type colours were mapped to distinct existing `LemonTagType` values for visual separation; labels now use the shared `scannerTypeLabel` helper for sentence-case display.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
