### PR TITLE
fix(flags): quietly handle missing self team in flag provider

### DIFF
--- a/products/feature_flags/backend/sdk_cache_provider.py
+++ b/products/feature_flags/backend/sdk_cache_provider.py
@@ -61,9 +61,7 @@ class HyperCacheFlagProvider:
             logger.debug("hypercache_flag_provider_import_pending", team_id=self._team_id)
             return None
         except ObjectDoesNotExist:
-            # The configured self-team (POSTHOG_SELF_TEAM_ID, default 2) doesn't exist in
-            # this instance — expected on local/self-hosted. Fall back to the SDK's API
-            # fetch quietly instead of logging a traceback on every poll.
+            # Fall back to the SDK's API
             logger.debug("hypercache_flag_provider_team_missing", team_id=self._team_id)
             return None
         except Exception:

--- a/products/feature_flags/backend/sdk_cache_provider.py
+++ b/products/feature_flags/backend/sdk_cache_provider.py
@@ -61,7 +61,8 @@ class HyperCacheFlagProvider:
             logger.debug("hypercache_flag_provider_import_pending", team_id=self._team_id)
             return None
         except ObjectDoesNotExist:
-            # Fall back to the SDK's API
+            # Self-hosted/local instances often lack the configured self team
+            # (POSTHOG_SELF_TEAM_ID, default 2). Returning None lets the SDK fall back to its API fetch.
             logger.debug("hypercache_flag_provider_team_missing", team_id=self._team_id)
             return None
         except Exception:

--- a/products/feature_flags/backend/sdk_cache_provider.py
+++ b/products/feature_flags/backend/sdk_cache_provider.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
+from django.core.exceptions import ObjectDoesNotExist
+
 import structlog
 from posthoganalytics.flag_definition_cache import FlagDefinitionCacheData
 
@@ -57,6 +59,12 @@ class HyperCacheFlagProvider:
             # circular import chain through cohort.util that resolves once
             # all modules finish loading. The SDK's next poll cycle will retry.
             logger.debug("hypercache_flag_provider_import_pending", team_id=self._team_id)
+            return None
+        except ObjectDoesNotExist:
+            # The configured self-team (POSTHOG_SELF_TEAM_ID, default 2) doesn't exist in
+            # this instance — expected on local/self-hosted. Fall back to the SDK's API
+            # fetch quietly instead of logging a traceback on every poll.
+            logger.debug("hypercache_flag_provider_team_missing", team_id=self._team_id)
             return None
         except Exception:
             logger.exception("hypercache_flag_provider_read_error", team_id=self._team_id)

--- a/products/feature_flags/backend/test/test_sdk_cache_provider.py
+++ b/products/feature_flags/backend/test/test_sdk_cache_provider.py
@@ -5,6 +5,8 @@ from django.test import SimpleTestCase
 from parameterized import parameterized
 from posthoganalytics.client import Client
 
+from posthog.models import Team
+
 from products.feature_flags.backend.sdk_cache_provider import HyperCacheFlagProvider
 
 
@@ -70,6 +72,20 @@ class TestHyperCacheFlagProvider(SimpleTestCase):
     )
     def test_get_flag_definitions_returns_none_on_circular_import(self, _mock):
         assert self.provider.get_flag_definitions() is None
+
+    @patch("products.feature_flags.backend.sdk_cache_provider.logger")
+    @patch("products.feature_flags.backend.local_evaluation.flag_definitions_hypercache")
+    def test_get_flag_definitions_returns_none_on_missing_team(self, mock_hypercache, mock_logger):
+        # The self team (POSTHOG_SELF_TEAM_ID, default 2) is absent on most local/self-hosted instances.
+        # Team.DoesNotExist subclasses ObjectDoesNotExist, so it must be caught and logged at debug, not error.
+        self.provider._hypercache = None
+        mock_hypercache.get_from_cache.side_effect = Team.DoesNotExist("Team matching query does not exist.")
+
+        result = self.provider.get_flag_definitions()
+
+        assert result is None
+        mock_logger.debug.assert_called_once_with("hypercache_flag_provider_team_missing", team_id=2)
+        mock_logger.exception.assert_not_called()
 
     @patch("products.feature_flags.backend.local_evaluation.flag_definitions_hypercache")
     def test_caches_hypercache_reference(self, mock_hypercache):


### PR DESCRIPTION
## Problem

Running a management command locally logged `hypercache_flag_provider_read_error` at error level with a full traceback. The SDK flag provider reads definitions for `POSTHOG_SELF_TEAM_ID`, which defaults to 2. That team exists on Cloud but not on most local or self hosted instances, so a cold cache read called `Team.objects.get(id=2)` and raised `Team.DoesNotExist`. The broad `except Exception` then logged the full traceback on every poll.

The failure was harmless: the provider returned None and the SDK fell back to its API fetch, so this was only log noise. It surfaced in management commands because they run with DEBUG false, which enables posthoganalytics. The local dev server sets DEBUG to 1 and never hit it.

## Changes

`products/feature_flags/backend/sdk_cache_provider.py` now catches `ObjectDoesNotExist` before the broad `except Exception`. A missing self team logs at debug as `hypercache_flag_provider_team_missing` and returns None, so the SDK still falls back to its API fetch. Any other failure still logs `hypercache_flag_provider_read_error` at error level.

`ObjectDoesNotExist` is the parent of `Team.DoesNotExist`, so the fix needs no model import and adds no circular import risk. The default team id stays 2, which is correct on Cloud and overridable with `POSTHOG_SELF_TEAM_ID`.

## How did you test this code?

I reproduced the error by running a management command with DEBUG unset against a cold cache. Raising `Team.DoesNotExist` through the provider now returns None and logs at debug instead of error, while any other exception still logs at error.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change.
