### PR TITLE
feat(jwt): sign JWTs with dedicated key and support fallbacks

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1,7 +1,6 @@
 import re
 import json
 import math
-import hashlib
 import secrets
 from datetime import timedelta
 from functools import cached_property
@@ -31,7 +30,7 @@ from posthog.constants import AvailableFeature
 from posthog.decorators import disallow_if_impersonated
 from posthog.event_usage import report_user_action
 from posthog.geoip import get_geoip_properties
-from posthog.jwt import PosthogJwtAudience, encode_jwt
+from posthog.jwt import PosthogJwtAudience, encode_jwt, signing_key_fingerprint
 from posthog.models import ProductIntent, Team, TeamMarketingAnalyticsConfig, TeamRevenueAnalyticsConfig, User
 from posthog.models.activity_logging.activity_log import (
     ActivityLog,
@@ -551,13 +550,13 @@ LIVE_EVENTS_TOKEN_TTL_SECONDS = 24 * 60 * 60
 def _live_events_token_cache_key(team: Team, user_id: int | None) -> str:
     """Build the cache key for the live-events JWT.
 
-    Includes a short fingerprint of `settings.SECRET_KEY` so that rotating the
-    signing secret automatically partitions the cache namespace - cached tokens
-    signed with the old key become unreachable rather than served until TTL.
+    Includes a short fingerprint of `settings.JWT_SIGNING_KEY` so that rotating the
+    signing key automatically partitions the cache namespace - cached tokens signed
+    with the old key become unreachable rather than served until TTL.
     Hashing also defends the cache key against future api-token formats that
     might contain the `:` separator we use between components.
     """
-    signing_fingerprint = hashlib.sha256(settings.SECRET_KEY.encode()).hexdigest()[:16]
+    signing_fingerprint = signing_key_fingerprint(settings.JWT_SIGNING_KEY)
     return f"live_events_token:{signing_fingerprint}:{team.id}:{user_id}:{team.api_token}:{team.organization_id}"
 
 
@@ -567,8 +566,8 @@ def get_or_mint_live_events_token(team: Team, user_id: int | None) -> str:
     The JWT itself is valid for 7 days. The cache TTL is 24h, so any token returned
     from cache still has at least 6 days of remaining validity. The cache key includes
     every field that ends up in the claims so api-token rotations or organization
-    moves automatically force a fresh mint, plus a SECRET_KEY fingerprint so signing-
-    key rotation auto-partitions the cache namespace (no manual flush needed).
+    moves automatically force a fresh mint, plus a JWT_SIGNING_KEY fingerprint so
+    signing-key rotation auto-partitions the cache namespace (no manual flush needed).
     """
     cache_key = _live_events_token_cache_key(team, user_id)
     cached = get_safe_cache(cache_key)

--- a/posthog/api/test/test_id_jag.py
+++ b/posthog/api/test/test_id_jag.py
@@ -935,7 +935,7 @@ class TestIDJagAccessTokenAuthentication(APIBaseTest):
         `/api/projects/@current/`) get a default authenticator chain that
         includes `JwtAuthentication` ahead of other token-based backends.
 
-        `JwtAuthentication.decode_jwt` hard-codes HS256+SECRET_KEY and raises
+        `JwtAuthentication.decode_jwt` hard-codes HS256 + the JWT signing key and raises
         `AuthenticationFailed` (→ 401) on any non-`jwt.DecodeError` exception,
         including the `InvalidAlgorithmError` that fires for an RS256 ID-JAG
         access token. If `IDJagAccessTokenAuthentication` doesn't run first,

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -3483,17 +3483,17 @@ class TestGetOrMintLiveEventsToken(APIBaseTest):
         token_after = get_or_mint_live_events_token(self.team, second_user_id)
         assert token_before != token_after
 
-    def test_secret_key_rotation_partitions_the_cache_namespace(self) -> None:
-        # SECRET_KEY rotation must invalidate cached tokens automatically — otherwise
+    def test_signing_key_rotation_partitions_the_cache_namespace(self) -> None:
+        # JWT signing-key rotation must invalidate cached tokens automatically — otherwise
         # the livestream service would reject the cached old-key signatures for up
-        # to the cache TTL. We embed a fingerprint of SECRET_KEY in the cache key so
+        # to the cache TTL. We embed a fingerprint of JWT_SIGNING_KEY in the cache key so
         # the namespace partitions cleanly on rotation.
         from posthog.api.team import get_or_mint_live_events_token
 
-        token_old_secret = get_or_mint_live_events_token(self.team, self.user.id)
-        with override_settings(SECRET_KEY="completely-different-rotated-secret"):
-            token_new_secret = get_or_mint_live_events_token(self.team, self.user.id)
-        assert token_old_secret != token_new_secret
+        token_old_key = get_or_mint_live_events_token(self.team, self.user.id)
+        with override_settings(JWT_SIGNING_KEY="completely-different-rotated-secret"):
+            token_new_key = get_or_mint_live_events_token(self.team, self.user.id)
+        assert token_old_key != token_new_key
 
 
 # Sensitive Team/Project settings the frontend gates behind

--- a/posthog/jwt.py
+++ b/posthog/jwt.py
@@ -1,3 +1,4 @@
+import hashlib
 from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any
@@ -6,6 +7,8 @@ from django.conf import settings
 
 import jwt
 from cryptography.hazmat.primitives import serialization
+
+JWT_ALGORITHM = "HS256"
 
 
 class PosthogJwtAudience(Enum):
@@ -17,6 +20,18 @@ class PosthogJwtAudience(Enum):
     SHARING_PASSWORD_PROTECTED = "posthog:sharing_password_protected"
 
 
+def signing_key_fingerprint(key: str) -> str:
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+def _signing_key() -> str:
+    return settings.JWT_SIGNING_KEY
+
+
+def _verification_keys() -> list[str]:
+    return [_signing_key(), *settings.JWT_SIGNING_KEY_FALLBACKS]
+
+
 def encode_jwt(payload: dict, expiry_delta: timedelta, audience: PosthogJwtAudience) -> str:
     """
     Create a JWT ensuring that the correct audience and signing token is used
@@ -24,23 +39,26 @@ def encode_jwt(payload: dict, expiry_delta: timedelta, audience: PosthogJwtAudie
     if not isinstance(audience, PosthogJwtAudience):
         raise Exception("Audience must be in the list of PostHog-supported audiences")
 
-    encoded_jwt = jwt.encode(
+    return jwt.encode(
         {
             **payload,
             "exp": datetime.now(tz=UTC) + expiry_delta,
             "aud": audience.value,
         },
-        settings.SECRET_KEY,
-        algorithm="HS256",
+        _signing_key(),
+        algorithm=JWT_ALGORITHM,
     )
-
-    return encoded_jwt
 
 
 def decode_jwt(token: str, audience: PosthogJwtAudience) -> dict[str, Any]:
-    info = jwt.decode(token, settings.SECRET_KEY, audience=audience.value, algorithms=["HS256"])
+    last_error: jwt.InvalidSignatureError | None = None
+    for key in _verification_keys():
+        try:
+            return jwt.decode(token, key, audience=audience.value, algorithms=[JWT_ALGORITHM])
+        except jwt.InvalidSignatureError as error:
+            last_error = error
 
-    return info
+    raise last_error or jwt.InvalidSignatureError("Signature verification failed")
 
 
 def get_oidc_public_key() -> Any:

--- a/posthog/models/test/test_subscription_model.py
+++ b/posthog/models/test/test_subscription_model.py
@@ -29,7 +29,7 @@ from products.exports.backend.models.subscription import (
 from products.product_analytics.backend.models.insight import Insight
 
 
-@patch.object(settings, "SECRET_KEY", "not-so-secret")
+@patch.object(settings, "JWT_SIGNING_KEY", "not-so-secret")
 @freeze_time("2022-01-01")
 class TestSubscription(BaseTest):
     def _create_insight_subscription(self, **kwargs):

--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -70,11 +70,18 @@ SECRET_KEY_FALLBACKS: list[str] = get_list(os.getenv("SECRET_KEY_FALLBACKS", "")
 # Dedicated key for signing PostHog-issued JWTs (posthog.jwt), so JWT signing can move off
 # SECRET_KEY. Defaults to SECRET_KEY, so deployments keep working until they provision a
 # separate key; once set, add the old key to JWT_SIGNING_KEY_FALLBACKS so tokens already in
-# flight keep validating until they expire.
+# flight keep validating until they expire. An empty value coalesces back to SECRET_KEY —
+# signing with an empty key is never a valid intent.
 JWT_SIGNING_KEY: str = os.getenv("JWT_SIGNING_KEY", "") or SECRET_KEY
 # Previous JWT signing keys still trusted for verifying tokens in flight, newest first.
-# Defaults to SECRET_KEY_FALLBACKS so a SECRET_KEY rotation keeps covering JWTs by default.
-JWT_SIGNING_KEY_FALLBACKS: list[str] = get_list(os.getenv("JWT_SIGNING_KEY_FALLBACKS", "")) or SECRET_KEY_FALLBACKS
+# Defaults to SECRET_KEY_FALLBACKS only when *unset*; an explicit empty value (e.g.
+# JWT_SIGNING_KEY_FALLBACKS="") clears it, so operators can stop trusting old JWT keys
+# without disturbing SECRET_KEY_FALLBACKS (which Django also uses for session/CSRF rotation).
+JWT_SIGNING_KEY_FALLBACKS: list[str] = (
+    get_list(os.environ["JWT_SIGNING_KEY_FALLBACKS"])
+    if "JWT_SIGNING_KEY_FALLBACKS" in os.environ
+    else SECRET_KEY_FALLBACKS
+)
 
 
 if not DEBUG and not TEST and not STATIC_COLLECTION and SECRET_KEY == DEFAULT_SECRET_KEY:

--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -80,7 +80,7 @@ JWT_SIGNING_KEY: str = os.getenv("JWT_SIGNING_KEY", "") or SECRET_KEY
 JWT_SIGNING_KEY_FALLBACKS: list[str] = (
     get_list(os.environ["JWT_SIGNING_KEY_FALLBACKS"])
     if "JWT_SIGNING_KEY_FALLBACKS" in os.environ
-    else SECRET_KEY_FALLBACKS
+    else (SECRET_KEY_FALLBACKS if JWT_SIGNING_KEY == SECRET_KEY else [])
 )
 
 

--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -65,6 +65,17 @@ DEFAULT_SECRET_KEY = "<randomly generated secret key>"
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY: str = os.getenv("SECRET_KEY", DEFAULT_SECRET_KEY)
 
+SECRET_KEY_FALLBACKS: list[str] = get_list(os.getenv("SECRET_KEY_FALLBACKS", ""))
+
+# Dedicated key for signing PostHog-issued JWTs (posthog.jwt), so JWT signing can move off
+# SECRET_KEY. Defaults to SECRET_KEY, so deployments keep working until they provision a
+# separate key; once set, add the old key to JWT_SIGNING_KEY_FALLBACKS so tokens already in
+# flight keep validating until they expire.
+JWT_SIGNING_KEY: str = os.getenv("JWT_SIGNING_KEY", "") or SECRET_KEY
+# Previous JWT signing keys still trusted for verifying tokens in flight, newest first.
+# Defaults to SECRET_KEY_FALLBACKS so a SECRET_KEY rotation keeps covering JWTs by default.
+JWT_SIGNING_KEY_FALLBACKS: list[str] = get_list(os.getenv("JWT_SIGNING_KEY_FALLBACKS", "")) or SECRET_KEY_FALLBACKS
+
 
 if not DEBUG and not TEST and not STATIC_COLLECTION and SECRET_KEY == DEFAULT_SECRET_KEY:
     logger.critical(

--- a/posthog/test/test_jwt.py
+++ b/posthog/test/test_jwt.py
@@ -1,0 +1,124 @@
+from datetime import UTC, datetime, timedelta
+
+from django.conf import settings
+from django.test import SimpleTestCase, override_settings
+
+import jwt
+from parameterized import parameterized
+
+from posthog.jwt import PosthogJwtAudience, decode_jwt, encode_jwt, signing_key_fingerprint
+
+PRIMARY = "primary-signing-key"
+ROTATED = "rotated-new-signing-key"
+UNKNOWN = "never-configured-signing-key"
+AUD = PosthogJwtAudience.EXPORTED_ASSET
+
+
+def _raw_token(
+    key: str,
+    *,
+    audience: PosthogJwtAudience = AUD,
+    kid: str | None = None,
+    expiry: timedelta = timedelta(minutes=5),
+    claims: dict | None = None,
+) -> str:
+    payload = {**(claims or {}), "exp": datetime.now(tz=UTC) + expiry, "aud": audience.value}
+    headers = {"kid": kid} if kid is not None else None
+    return jwt.encode(payload, key, algorithm="HS256", headers=headers)
+
+
+@override_settings(JWT_SIGNING_KEY=PRIMARY, JWT_SIGNING_KEY_FALLBACKS=[])
+class TestJwt(SimpleTestCase):
+    def test_encode_does_not_tag_token_with_a_key_id(self):
+        # Tokens stay untagged so the header leaks nothing about which key signed them.
+        token = encode_jwt({"id": 7}, timedelta(minutes=5), AUD)
+        assert "kid" not in jwt.get_unverified_header(token)
+
+    @parameterized.expand(
+        [
+            ("no rotation", PRIMARY, []),
+            ("primary demoted to fallback after rotation", ROTATED, [PRIMARY]),
+        ]
+    )
+    def test_encoded_token_verifies_through_rotation(self, _name: str, signing_key: str, fallbacks: list[str]):
+        # Signed under the class-level PRIMARY key, then verified under the rotated settings.
+        token = encode_jwt({"id": 7}, timedelta(minutes=5), AUD)
+        with override_settings(JWT_SIGNING_KEY=signing_key, JWT_SIGNING_KEY_FALLBACKS=fallbacks):
+            assert decode_jwt(token, AUD)["id"] == 7
+
+    @parameterized.expand(
+        [
+            # name, active_signing_key, fallbacks, key_token_was_signed_with, expect_ok
+            ("current signing key", PRIMARY, [], PRIMARY, True),
+            ("fallback key after rotation", ROTATED, [PRIMARY], PRIMARY, True),
+            ("old key dropped from fallbacks", ROTATED, [], PRIMARY, False),
+            ("unknown key", PRIMARY, [], UNKNOWN, False),
+        ]
+    )
+    def test_decode_outcome_by_key_state(
+        self,
+        _name: str,
+        active_key: str,
+        fallbacks: list[str],
+        signing_key: str,
+        expect_ok: bool,
+    ):
+        token = _raw_token(signing_key, claims={"id": 7})
+        with override_settings(JWT_SIGNING_KEY=active_key, JWT_SIGNING_KEY_FALLBACKS=fallbacks):
+            if expect_ok:
+                assert decode_jwt(token, AUD)["id"] == 7
+            else:
+                with self.assertRaises(jwt.InvalidSignatureError):
+                    decode_jwt(token, AUD)
+
+    @parameterized.expand(
+        [
+            # A stray/forged kid must not influence verification — only the signature matters.
+            ("trusted signature, forged kid", PRIMARY, True),
+            ("untrusted signature, forged kid", UNKNOWN, False),
+        ]
+    )
+    def test_decode_ignores_stray_kid_header(self, _name: str, signing_key: str, expect_ok: bool):
+        token = _raw_token(signing_key, kid="some-forged-kid", claims={"id": 7})
+        if expect_ok:
+            assert decode_jwt(token, AUD)["id"] == 7
+        else:
+            with self.assertRaises(jwt.InvalidSignatureError):
+                decode_jwt(token, AUD)
+
+    @parameterized.expand(
+        [
+            ("expired", lambda: encode_jwt({"id": 7}, timedelta(seconds=-1), AUD), jwt.ExpiredSignatureError),
+            (
+                "wrong audience",
+                lambda: encode_jwt({"id": 7}, timedelta(minutes=5), PosthogJwtAudience.UNSUBSCRIBE),
+                jwt.InvalidAudienceError,
+            ),
+            ("malformed garbage", lambda: "not-a-jwt", jwt.DecodeError),
+            ("malformed empty", lambda: "", jwt.DecodeError),
+            ("malformed two segments", lambda: "a.b", jwt.DecodeError),
+            ("malformed bad base64", lambda: "a.b.c", jwt.DecodeError),
+        ]
+    )
+    def test_non_signature_errors_propagate(self, _name: str, token_factory, expected: type[Exception]):
+        # The multi-key loop only swallows InvalidSignatureError; every other failure surfaces as-is.
+        with self.assertRaises(expected):
+            decode_jwt(token_factory(), AUD)
+
+    @parameterized.expand([("audience value", AUD.value), ("none", None), ("int", 5)])
+    def test_encode_rejects_non_audience(self, _name: str, bad_audience):
+        with self.assertRaises(Exception):
+            encode_jwt({"id": 7}, timedelta(minutes=5), bad_audience)
+
+    def test_signing_key_fingerprint_is_stable_and_key_specific(self):
+        assert signing_key_fingerprint(PRIMARY) == signing_key_fingerprint(PRIMARY)
+        assert signing_key_fingerprint(PRIMARY) != signing_key_fingerprint(ROTATED)
+        assert len(signing_key_fingerprint(PRIMARY)) == 16
+
+
+class TestJwtSigningKeyDefaults(SimpleTestCase):
+    def test_signing_key_settings_default_to_secret_key(self):
+        # With no JWT_SIGNING_KEY* env set (the test environment), JWT signing transparently
+        # reuses SECRET_KEY and its fallbacks, so nothing breaks until a key is provisioned.
+        assert settings.JWT_SIGNING_KEY == settings.SECRET_KEY
+        assert settings.JWT_SIGNING_KEY_FALLBACKS == settings.SECRET_KEY_FALLBACKS

--- a/posthog/test/test_jwt.py
+++ b/posthog/test/test_jwt.py
@@ -105,6 +105,24 @@ class TestJwt(SimpleTestCase):
         with self.assertRaises(expected):
             decode_jwt(token_factory(), AUD)
 
+    @parameterized.expand(
+        [
+            ("expired", lambda: _raw_token(PRIMARY, expiry=timedelta(seconds=-1)), jwt.ExpiredSignatureError),
+            (
+                "wrong audience",
+                lambda: _raw_token(PRIMARY, audience=PosthogJwtAudience.UNSUBSCRIBE),
+                jwt.InvalidAudienceError,
+            ),
+        ]
+    )
+    @override_settings(JWT_SIGNING_KEY=ROTATED, JWT_SIGNING_KEY_FALLBACKS=[PRIMARY])
+    def test_claim_errors_from_fallback_key_are_not_masked(self, _name: str, token_factory, expected: type[Exception]):
+        # A token signed by the fallback key (PRIMARY) fails the InvalidSignatureError check against
+        # the active key (ROTATED) first; the loop must keep going and surface the claim error raised
+        # once PRIMARY matches the signature — not the earlier mismatch.
+        with self.assertRaises(expected):
+            decode_jwt(token_factory(), AUD)
+
     @parameterized.expand([("audience value", AUD.value), ("none", None), ("int", 5)])
     def test_encode_rejects_non_audience(self, _name: str, bad_audience):
         with self.assertRaises(Exception):


### PR DESCRIPTION
## Problem

Every PostHog-issued JWT is signed and verified with a single value: `SECRET_KEY`. That couples two unrelated concerns and leaves no safe rotation path:

- **`SECRET_KEY` can't be rotated without disruption.** The moment you change it, every in-flight token (exported assets live up to 30 days) fails verification, because there's only ever one accepted key.
- **JWT signing can't move off `SECRET_KEY`** onto its own key, even though it's a distinct secret with a different blast radius.

## Changes

- **`posthog/jwt.py` verifies against a list of keys, current signing key first.** `decode_jwt` tries each trusted key in order and only swallows `InvalidSignatureError` to advance — every other failure (expired, wrong audience, malformed) propagates from the key that actually matched. `encode_jwt` signs with the primary key. Tokens are deliberately left **untagged** (no `kid`): the header reveals nothing about which key signed them, and trying a handful of keys costs only microseconds.
- **New settings `JWT_SIGNING_KEY` / `JWT_SIGNING_KEY_FALLBACKS`** (in `settings/access.py`). `jwt.py` reads *only* these — it no longer references `SECRET_KEY` at all. The defaulting lives in settings: `JWT_SIGNING_KEY` defaults to `SECRET_KEY`, and `JWT_SIGNING_KEY_FALLBACKS` defaults to `SECRET_KEY_FALLBACKS`. **So behavior is identical until an operator opts in** — nothing changes by default.
- **`JWT_SIGNING_KEY_FALLBACKS` can be explicitly cleared.** It keys off env *presence*, not truthiness, so `JWT_SIGNING_KEY_FALLBACKS=""` stops trusting old JWT keys without disturbing `SECRET_KEY_FALLBACKS` (which Django also uses for its own session/CSRF rotation). The signing key keeps `… or SECRET_KEY` — an empty *signing* key is never a valid intent.
- **`posthog/api/team.py`** partitions the live-events token cache on `JWT_SIGNING_KEY` (the key that actually signs the token) instead of `SECRET_KEY`, so rotating the signing key invalidates cached tokens instead of serving now-unverifiable ones for the cache TTL.

**Rotation this enables (operator-facing):** set `JWT_SIGNING_KEY=<new>` and add the old key to `JWT_SIGNING_KEY_FALLBACKS`; new tokens sign with `<new>`, in-flight tokens verify via the fallback; drop the old key from the fallback list after the longest TTL (30-day exported assets) elapses.

## How did you test this code?

Automated tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No default behavior change. Two new optional env vars (`JWT_SIGNING_KEY`, `JWT_SIGNING_KEY_FALLBACKS`) exist for self-hosted key rotation; operator-facing rotation docs can follow separately.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8).