### PR TITLE
feat(replay-vision): observation polish, always-on embeddings, tri-state monitor

### DIFF
--- a/products/replay_vision/README.md
+++ b/products/replay_vision/README.md
@@ -4,7 +4,7 @@ A sub-product of Session Replay. Users configure named **scanners** that PostHog
 
 ## Concepts
 
-**Scanner** — a configured probe scoped to a team. Carries a prompt, a scanner type (`monitor` / `classifier` / `scorer` / `summarizer`), a `RecordingsQuery` that selects matching sessions, and a sampling rate. Each enabled scanner has a Temporal schedule that fires every 5 minutes. Summarizers can opt into emitting per-facet embeddings via the `emits_embeddings` config flag.
+**Scanner** — a configured probe scoped to a team. Carries a prompt, a scanner type (`monitor` / `classifier` / `scorer` / `summarizer`), a `RecordingsQuery` that selects matching sessions, and a sampling rate. Each enabled scanner has a Temporal schedule that fires every 5 minutes. Summarizers always emit per-facet embeddings for downstream free-text search.
 
 **Observation** — one application of a scanner to a session. Created in `pending` when triggered (by the scanner's schedule or the `/observe/` action), transitions to `running` while `ApplyScannerWorkflow` executes, and lands in `succeeded` (with content emitted as a `$recording_observed` event) or `failed`. Each observation snapshots the full scanner state (`scanner_snapshot`) that produced it, so subsequent edits to the scanner don't retro-mutate history.
 

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -66,8 +66,8 @@ class ReplayScannerSerializer(serializers.ModelSerializer):
     )
     scanner_config = serializers.JSONField(
         help_text=(
-            "Type-specific configuration. All scanner types require `prompt`; classifiers add `tags`, "
-            "scorers add `scale`, summarizers add optional `length` and `emits_embeddings` flag."
+            "Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, "
+            "classifiers add `tags`, scorers add `scale`, summarizers add optional `length`."
         ),
     )
     query = extend_schema_field(RecordingsQuery)(  # type: ignore[arg-type, type-var]

--- a/products/replay_vision/backend/migrations/0011_backfill_monitor_verdict.py
+++ b/products/replay_vision/backend/migrations/0011_backfill_monitor_verdict.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+# Idempotent backfill: rewrites monitor observations' `verdict` from boolean to the literal
+# strings 'yes' / 'no' so the persisted output JSON matches the new MonitorOutput schema.
+# Replay vision is in closed beta with very low row counts, so a single UPDATE is fine.
+_BACKFILL_SQL = """
+UPDATE replay_vision_replayobservation
+SET scanner_result = jsonb_set(
+    scanner_result,
+    '{model_output,verdict}',
+    to_jsonb(CASE
+        WHEN (scanner_result->'model_output'->>'verdict')::boolean THEN 'yes'
+        ELSE 'no'
+    END)
+)
+WHERE scanner_snapshot->>'scanner_type' = 'monitor'
+  AND scanner_result IS NOT NULL
+  AND scanner_result->'model_output' ? 'verdict'
+  AND jsonb_typeof(scanner_result->'model_output'->'verdict') = 'boolean';
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("replay_vision", "0010_replayscanner_last_seen_session_id"),
+    ]
+
+    operations = [
+        migrations.RunSQL(sql=_BACKFILL_SQL, reverse_sql=migrations.RunSQL.noop),
+    ]

--- a/products/replay_vision/backend/migrations/0011_backfill_monitor_verdict.py
+++ b/products/replay_vision/backend/migrations/0011_backfill_monitor_verdict.py
@@ -1,8 +1,6 @@
 from django.db import migrations
 
-# Idempotent backfill: rewrites monitor observations' `verdict` from boolean to the literal
-# strings 'yes' / 'no' so the persisted output JSON matches the new MonitorOutput schema.
-# Replay vision is in closed beta with very low row counts, so a single UPDATE is fine.
+# Idempotent — the `jsonb_typeof = 'boolean'` guard makes a re-run a no-op.
 _BACKFILL_SQL = """
 UPDATE replay_vision_replayobservation
 SET scanner_result = jsonb_set(

--- a/products/replay_vision/backend/migrations/0011_backfill_monitor_verdict.py
+++ b/products/replay_vision/backend/migrations/0011_backfill_monitor_verdict.py
@@ -1,21 +1,23 @@
 from django.db import migrations
 
-# Idempotent — the `jsonb_typeof = 'boolean'` guard makes a re-run a no-op.
-_BACKFILL_SQL = """
-UPDATE replay_vision_replayobservation
-SET scanner_result = jsonb_set(
-    scanner_result,
-    '{model_output,verdict}',
-    to_jsonb(CASE
-        WHEN (scanner_result->'model_output'->>'verdict')::boolean THEN 'yes'
-        ELSE 'no'
-    END)
-)
-WHERE scanner_snapshot->>'scanner_type' = 'monitor'
-  AND scanner_result IS NOT NULL
-  AND scanner_result->'model_output' ? 'verdict'
-  AND jsonb_typeof(scanner_result->'model_output'->'verdict') = 'boolean';
-"""
+
+def backfill_monitor_verdict(apps, schema_editor):
+    # Idempotent — only rows whose `verdict` is still boolean are touched.
+    ReplayObservation = apps.get_model("replay_vision", "ReplayObservation")
+    qs = ReplayObservation.objects.filter(
+        scanner_snapshot__scanner_type="monitor",
+        scanner_result__isnull=False,
+    ).iterator(chunk_size=500)
+    for obs in qs:
+        model_output = obs.scanner_result.get("model_output") if obs.scanner_result else None
+        if not isinstance(model_output, dict):
+            continue
+        verdict = model_output.get("verdict")
+        if not isinstance(verdict, bool):
+            continue
+        model_output["verdict"] = "yes" if verdict else "no"
+        obs.scanner_result["model_output"] = model_output
+        obs.save(update_fields=["scanner_result"])
 
 
 class Migration(migrations.Migration):
@@ -24,5 +26,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL(sql=_BACKFILL_SQL, reverse_sql=migrations.RunSQL.noop),
+        migrations.RunPython(backfill_monitor_verdict, reverse_code=migrations.RunPython.noop),
     ]

--- a/products/replay_vision/backend/migrations/max_migration.txt
+++ b/products/replay_vision/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0010_replayscanner_last_seen_session_id
+0011_backfill_monitor_verdict

--- a/products/replay_vision/backend/temporal/activities/create_observation.py
+++ b/products/replay_vision/backend/temporal/activities/create_observation.py
@@ -19,10 +19,6 @@ from products.replay_vision.backend.temporal.types import (
 )
 
 
-def _emits_embeddings(scanner_config: dict) -> bool:
-    return bool(scanner_config.get("emits_embeddings", False))
-
-
 def _build_scanner_snapshot(scanner: ReplayScanner) -> dict[str, Any]:
     return ScannerSnapshot(
         name=scanner.name,
@@ -94,12 +90,10 @@ def create_observation_activity(inputs: CreateObservationInputs) -> CreateObserv
             observation_id=existing.id,
             was_created=False,
             scanner_type=existing_snapshot.scanner_type,
-            emits_embeddings=_emits_embeddings(existing_snapshot.scanner_config),
         )
 
     return CreateObservationOutput(
         observation_id=observation.id,
         was_created=True,
         scanner_type=scanner.scanner_type,
-        emits_embeddings=_emits_embeddings(scanner.scanner_config),
     )

--- a/products/replay_vision/backend/temporal/scanners/monitor.py
+++ b/products/replay_vision/backend/temporal/scanners/monitor.py
@@ -1,17 +1,24 @@
 """Monitor scanner: detects whether a specific condition occurred during the session."""
 
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field
 
 from products.replay_vision.backend.models.replay_scanner import ScannerType
 from products.replay_vision.backend.temporal.scanners.base import BaseScanner, BaseScannerOutput, Segment
 
+MonitorVerdict = Literal["yes", "no", "inconclusive"]
+
 
 class MonitorLlmResponse(BaseScannerOutput, frozen=True):
     """LLM-facing schema: the model decides these fields; `scanner_type` is stamped by the workflow in `finalize`."""
 
-    verdict: bool = Field(description="Did the condition described in the scanner intent occur during the session?")
+    verdict: MonitorVerdict = Field(
+        description=(
+            "Did the condition described in the scanner intent occur during the session? "
+            "`yes` if it did, `no` if it didn't, `inconclusive` only when the session genuinely does not provide enough signal to decide."
+        )
+    )
     reasoning: str = Field(
         description="One paragraph grounding the verdict in concrete moments from the video and events."
     )
@@ -29,7 +36,18 @@ class MonitorScanner(BaseScanner, frozen=True):
     prompt_template: ClassVar[str] = "monitor.jinja"
     citation_fields: ClassVar[tuple[str, ...]] = ("reasoning",)
     output_cls: ClassVar[type[BaseScannerOutput]] = MonitorOutput
+    allow_inconclusive: bool = False
 
     @property
     def llm_response_schema(self) -> type[BaseModel]:
         return MonitorLlmResponse
+
+    def prompt_context(self) -> dict[str, Any]:
+        return {"allow_inconclusive": self.allow_inconclusive}
+
+    def validate_semantics(self, output: BaseScannerOutput) -> str | None:
+        if isinstance(output, MonitorOutput) and output.verdict == "inconclusive" and not self.allow_inconclusive:
+            return (
+                "Verdict is `inconclusive` but this scanner does not allow inconclusive verdicts; choose `yes` or `no`."
+            )
+        return None

--- a/products/replay_vision/backend/temporal/scanners/prompts/monitor.jinja
+++ b/products/replay_vision/backend/temporal/scanners/prompts/monitor.jinja
@@ -2,6 +2,6 @@
 {% from "_macros.jinja" import cite_in %}
 {% block task %}Decide whether the following condition occurred during the session: {{ user_prompt }}
 
-Set `verdict` to true only if there is direct visual or event-level evidence; otherwise false. Use `reasoning` to ground your decision.
+{% if allow_inconclusive %}Set `verdict` to `yes` only if there is direct visual or event-level evidence the condition occurred, `no` if there is direct evidence it did not, and `inconclusive` only when the session genuinely does not provide enough signal to decide. Use `reasoning` to ground your decision.{% else %}Set `verdict` to `yes` only if there is direct visual or event-level evidence the condition occurred; otherwise `no`. Do not return `inconclusive`. Use `reasoning` to ground your decision.{% endif %}
 
 {{ cite_in('reasoning') }}{% endblock %}

--- a/products/replay_vision/backend/temporal/scanners/prompts/summarizer.jinja
+++ b/products/replay_vision/backend/temporal/scanners/prompts/summarizer.jinja
@@ -5,7 +5,6 @@
 `title` is at most ~80 characters and contains no event citations. `summary` should be {{ length_guidance }}.
 
 {{ cite_in('summary') }}
-{% if emits_embeddings %}
 
 Also produce facets that characterize this session for free-text search by future users:
 
@@ -15,4 +14,4 @@ Also produce facets that characterize this session for free-text search by futur
 - `keywords`: 5-15 distinctive lowercase terms — favor action verbs and specific feature names; skip generic terms ('user', 'session', 'navigation') and the product/team name.
 
 Do not include any event citations or `event_uuid` values inside `intent`, `outcome`, `friction_points`, or `keywords` — those are consumed by a vector-embedding pipeline and UUID tokens would be noise.
-{% endif %}{% endblock %}
+{% endblock %}

--- a/products/replay_vision/backend/temporal/scanners/summarizer.py
+++ b/products/replay_vision/backend/temporal/scanners/summarizer.py
@@ -56,7 +56,7 @@ class SummarizerLlmResponse(BaseScannerOutput, frozen=True):
 
 
 class SummarizerOutput(SummarizerLlmResponse, frozen=True):
-    """Persisted output: defaults keep older flag-off rows round-tripping cleanly."""
+    """Persisted output."""
 
     scanner_type: Literal[ScannerType.SUMMARIZER] = ScannerType.SUMMARIZER
     summary_segments: list[Segment] = Field(default_factory=list)

--- a/products/replay_vision/backend/temporal/scanners/summarizer.py
+++ b/products/replay_vision/backend/temporal/scanners/summarizer.py
@@ -1,4 +1,4 @@
-"""Summarizer scanner: produces a title and a text summary, optionally with facet embeddings."""
+"""Summarizer scanner: produces a title, a text summary, and facet fields used for embedding-backed free-text search."""
 
 from typing import Any, ClassVar, Literal
 
@@ -17,15 +17,10 @@ _LENGTH_GUIDANCE: dict[SummaryLength, str] = {
 
 
 class SummarizerLlmResponse(BaseScannerOutput, frozen=True):
-    """LLM-facing schema (title + summary). Used when `emits_embeddings=False` to keep the schema lean."""
+    """LLM-facing schema: title + summary + facet fields that get embedded for downstream free-text search."""
 
     title: str = Field(max_length=120, description="Short title for the session (~80 chars). Plain text, no quotes.")
     summary: str = Field(description="Body text whose length follows the scanner's configured length.")
-
-
-class SummarizerWithFacetsLlmResponse(SummarizerLlmResponse, frozen=True):
-    """Extended LLM-facing schema with embedding facets. Used when `emits_embeddings=True`."""
-
     intent: str = Field(
         description=(
             "One sentence describing what the user was trying to accomplish at the start of the session "
@@ -61,7 +56,7 @@ class SummarizerWithFacetsLlmResponse(SummarizerLlmResponse, frozen=True):
 
 
 class SummarizerOutput(SummarizerLlmResponse, frozen=True):
-    """Persisted output: facet fields default to empty so flag-off summarizers round-trip cleanly."""
+    """Persisted output: defaults keep older flag-off rows round-tripping cleanly."""
 
     scanner_type: Literal[ScannerType.SUMMARIZER] = ScannerType.SUMMARIZER
     summary_segments: list[Segment] = Field(default_factory=list)
@@ -81,14 +76,10 @@ class SummarizerScanner(BaseScanner, frozen=True):
     citation_fields: ClassVar[tuple[str, ...]] = ("summary",)
     output_cls: ClassVar[type[BaseScannerOutput]] = SummarizerOutput
     length: SummaryLength = "medium"
-    emits_embeddings: bool = False
 
     @property
     def llm_response_schema(self) -> type[BaseModel]:
-        return SummarizerWithFacetsLlmResponse if self.emits_embeddings else SummarizerLlmResponse
+        return SummarizerLlmResponse
 
     def prompt_context(self) -> dict[str, Any]:
-        return {
-            "length_guidance": _LENGTH_GUIDANCE[self.length],
-            "emits_embeddings": self.emits_embeddings,
-        }
+        return {"length_guidance": _LENGTH_GUIDANCE[self.length]}

--- a/products/replay_vision/backend/temporal/types.py
+++ b/products/replay_vision/backend/temporal/types.py
@@ -72,7 +72,6 @@ class CreateObservationOutput(BaseModel, frozen=True):
     observation_id: UUID | None
     was_created: bool
     scanner_type: ScannerType
-    emits_embeddings: bool = False
 
 
 class MarkObservationRunningInputs(BaseModel, frozen=True):

--- a/products/replay_vision/backend/temporal/workflow.py
+++ b/products/replay_vision/backend/temporal/workflow.py
@@ -186,9 +186,7 @@ class ApplyScannerWorkflow(PostHogWorkflow):
                 start_to_close_timeout=dt.timedelta(minutes=5),
                 retry_policy=_PROVIDER_CALL_RETRY,
             )
-            await self._apply_scanner_side_effects(
-                inputs, observation_id, call_output.model_output, create_result.emits_embeddings
-            )
+            await self._apply_scanner_side_effects(inputs, observation_id, call_output.model_output)
             await wf.execute_activity(
                 emit_observation_event_activity,
                 EmitObservationEventInputs(observation_id=observation_id, model_output=call_output.model_output),
@@ -299,10 +297,9 @@ class ApplyScannerWorkflow(PostHogWorkflow):
         inputs: ApplyScannerInputs,
         observation_id: UUID,
         model_output: object,
-        emits_embeddings: bool,
     ) -> None:
         """Dispatch scanner-type-specific side-effects after the LLM call; failure aborts the workflow."""
-        if isinstance(model_output, SummarizerOutput) and emits_embeddings and model_output.has_any_facet():
+        if isinstance(model_output, SummarizerOutput) and model_output.has_any_facet():
             await wf.execute_activity(
                 embed_summarizer_observation_activity,
                 EmbedSummarizerObservationInputs(

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -187,10 +187,10 @@ class TestReplayScannerViewSet(_VisionAPITestCase):
     @parameterized.expand(
         [
             ("monitor", ScannerType.MONITOR, {"prompt": "p"}),
+            ("monitor-allow-inconclusive", ScannerType.MONITOR, {"prompt": "p", "allow_inconclusive": True}),
             ("classifier", ScannerType.CLASSIFIER, {"prompt": "p", "tags": ["a", "b"]}),
             ("scorer", ScannerType.SCORER, {"prompt": "p", "scale": {"min": 0, "max": 10}}),
             ("summarizer", ScannerType.SUMMARIZER, {"prompt": "p"}),
-            ("summarizer-with-embeddings", ScannerType.SUMMARIZER, {"prompt": "p", "emits_embeddings": True}),
         ]
     )
     def test_create_accepts_valid_scanner_config_per_type(

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -458,7 +458,7 @@ class TestReplayObservationViewSet(_VisionAPITestCase):
             scanner_result={
                 "model_output": {
                     "scanner_type": "monitor",
-                    "verdict": True,
+                    "verdict": "yes",
                     "reasoning": "user completed checkout",
                     "confidence": 0.9,
                 },
@@ -469,7 +469,7 @@ class TestReplayObservationViewSet(_VisionAPITestCase):
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
         self.assertEqual(body["scanner_result"]["signals_count"], 0)
-        self.assertEqual(body["scanner_result"]["model_output"]["verdict"], True)
+        self.assertEqual(body["scanner_result"]["model_output"]["verdict"], "yes")
         self.assertEqual(body["scanner_result"]["model_output"]["confidence"], 0.9)
 
     @parameterized.expand(

--- a/products/replay_vision/backend/tests/test_scanners.py
+++ b/products/replay_vision/backend/tests/test_scanners.py
@@ -186,16 +186,18 @@ class TestMonitorScanner:
 
     def test_output_rejects_unknown_verdict_value(self) -> None:
         with pytest.raises(ValidationError):
-            MonitorOutput(verdict="maybe", reasoning="x", confidence=0.5)  # type: ignore[arg-type]
+            MonitorOutput.model_validate({"verdict": "maybe", "reasoning": "x", "confidence": 0.5})
 
     def test_validate_semantics_rejects_inconclusive_when_disallowed(self) -> None:
         scanner = scanner_from_db(_build_replay_scanner())
+        assert isinstance(scanner, MonitorScanner)
         assert scanner.allow_inconclusive is False
         out = MonitorOutput(verdict="inconclusive", reasoning="not sure", confidence=0.4)
         assert scanner.validate_semantics(out) is not None
 
     def test_validate_semantics_accepts_inconclusive_when_allowed(self) -> None:
         scanner = scanner_from_db(_build_replay_scanner(scanner_config={"prompt": "p", "allow_inconclusive": True}))
+        assert isinstance(scanner, MonitorScanner)
         assert scanner.allow_inconclusive is True
         out = MonitorOutput(verdict="inconclusive", reasoning="ambiguous", confidence=0.4)
         assert scanner.validate_semantics(out) is None
@@ -203,6 +205,8 @@ class TestMonitorScanner:
     def test_prompt_context_propagates_allow_inconclusive(self) -> None:
         on_scanner = scanner_from_db(_build_replay_scanner(scanner_config={"prompt": "p", "allow_inconclusive": True}))
         off_scanner = scanner_from_db(_build_replay_scanner())
+        assert isinstance(on_scanner, MonitorScanner)
+        assert isinstance(off_scanner, MonitorScanner)
         assert on_scanner.prompt_context()["allow_inconclusive"] is True
         assert off_scanner.prompt_context()["allow_inconclusive"] is False
 

--- a/products/replay_vision/backend/tests/test_scanners.py
+++ b/products/replay_vision/backend/tests/test_scanners.py
@@ -17,7 +17,6 @@ from products.replay_vision.backend.temporal.scanners import (
     SummarizerScanner,
     scanner_from_db,
 )
-from products.replay_vision.backend.temporal.scanners.summarizer import SummarizerWithFacetsLlmResponse
 from products.replay_vision.backend.temporal.types import EventTable
 
 
@@ -157,33 +156,55 @@ class TestMonitorScanner:
 
     def test_finalize_stamps_scanner_type_onto_llm_response(self) -> None:
         scanner = scanner_from_db(_build_replay_scanner())
-        llm_response = MonitorLlmResponse(verdict=True, reasoning="user clicked Export at 0:42", confidence=0.9)
+        llm_response = MonitorLlmResponse(verdict="yes", reasoning="user clicked Export at 0:42", confidence=0.9)
         finalized = scanner.finalize(llm_response)
         assert isinstance(finalized, MonitorOutput)
         assert finalized.scanner_type == ScannerType.MONITOR
-        assert finalized.verdict is True
+        assert finalized.verdict == "yes"
         assert finalized.reasoning == "user clicked Export at 0:42"
         assert finalized.confidence == 0.9
 
     def test_validate_semantics_passes_for_well_formed_output(self) -> None:
         scanner = scanner_from_db(_build_replay_scanner())
-        out = MonitorOutput(verdict=False, reasoning="no checkout button visible", confidence=0.8)
+        out = MonitorOutput(verdict="no", reasoning="no checkout button visible", confidence=0.8)
         assert scanner.validate_semantics(out) is None
 
     def test_output_round_trip_includes_confidence(self) -> None:
         out = MonitorOutput.model_validate_json(
-            '{"verdict": true, "reasoning": "user clicked Export at 0:42", "confidence": 0.85}'
+            '{"verdict": "yes", "reasoning": "user clicked Export at 0:42", "confidence": 0.85}'
         )
-        assert out.verdict is True
+        assert out.verdict == "yes"
         assert out.confidence == 0.85
 
     def test_output_rejects_confidence_out_of_range(self) -> None:
         with pytest.raises(ValidationError):
-            MonitorOutput(verdict=True, reasoning="x", confidence=1.5)
+            MonitorOutput(verdict="yes", reasoning="x", confidence=1.5)
 
     def test_output_rejects_invalid_shape(self) -> None:
         with pytest.raises(ValidationError):
             MonitorOutput.model_validate_json('{"verdict": "yes", "confidence": 1}')
+
+    def test_output_rejects_unknown_verdict_value(self) -> None:
+        with pytest.raises(ValidationError):
+            MonitorOutput(verdict="maybe", reasoning="x", confidence=0.5)  # type: ignore[arg-type]
+
+    def test_validate_semantics_rejects_inconclusive_when_disallowed(self) -> None:
+        scanner = scanner_from_db(_build_replay_scanner())
+        assert scanner.allow_inconclusive is False
+        out = MonitorOutput(verdict="inconclusive", reasoning="not sure", confidence=0.4)
+        assert scanner.validate_semantics(out) is not None
+
+    def test_validate_semantics_accepts_inconclusive_when_allowed(self) -> None:
+        scanner = scanner_from_db(_build_replay_scanner(scanner_config={"prompt": "p", "allow_inconclusive": True}))
+        assert scanner.allow_inconclusive is True
+        out = MonitorOutput(verdict="inconclusive", reasoning="ambiguous", confidence=0.4)
+        assert scanner.validate_semantics(out) is None
+
+    def test_prompt_context_propagates_allow_inconclusive(self) -> None:
+        on_scanner = scanner_from_db(_build_replay_scanner(scanner_config={"prompt": "p", "allow_inconclusive": True}))
+        off_scanner = scanner_from_db(_build_replay_scanner())
+        assert on_scanner.prompt_context()["allow_inconclusive"] is True
+        assert off_scanner.prompt_context()["allow_inconclusive"] is False
 
 
 class TestClassifierScanner:
@@ -493,21 +514,12 @@ class TestSummarizerScanner:
 
 
 class TestSummarizerScannerFacets:
-    def test_emits_embeddings_defaults_to_false(self) -> None:
+    def test_llm_response_schema_is_summarizer_response(self) -> None:
         scanner = scanner_from_db(
             _build_replay_scanner(scanner_type=ScannerType.SUMMARIZER, scanner_config={"prompt": "p"})
         )
         assert isinstance(scanner, SummarizerScanner)
-        assert scanner.emits_embeddings is False
-
-    def test_emits_embeddings_propagates_into_prompt_context(self) -> None:
-        scanner = scanner_from_db(
-            _build_replay_scanner(
-                scanner_type=ScannerType.SUMMARIZER,
-                scanner_config={"prompt": "p", "emits_embeddings": True},
-            )
-        )
-        assert scanner.prompt_context()["emits_embeddings"] is True
+        assert scanner.llm_response_schema is SummarizerLlmResponse
 
     def test_output_round_trip_carries_facets(self) -> None:
         out = SummarizerOutput(
@@ -529,27 +541,11 @@ class TestSummarizerScannerFacets:
         assert out.friction_points == []
         assert out.keywords == []
 
-    def test_llm_response_schema_branches_on_flag(self) -> None:
-        without_facets = scanner_from_db(
-            _build_replay_scanner(scanner_type=ScannerType.SUMMARIZER, scanner_config={"prompt": "p"})
-        )
-        with_facets = scanner_from_db(
-            _build_replay_scanner(
-                scanner_type=ScannerType.SUMMARIZER,
-                scanner_config={"prompt": "p", "emits_embeddings": True},
-            )
-        )
-        assert without_facets.llm_response_schema is SummarizerLlmResponse
-        assert with_facets.llm_response_schema is SummarizerWithFacetsLlmResponse
-
     def test_finalize_lowercases_keywords_and_friction_points(self) -> None:
         scanner = scanner_from_db(
-            _build_replay_scanner(
-                scanner_type=ScannerType.SUMMARIZER,
-                scanner_config={"prompt": "p", "emits_embeddings": True},
-            )
+            _build_replay_scanner(scanner_type=ScannerType.SUMMARIZER, scanner_config={"prompt": "p"})
         )
-        response = SummarizerWithFacetsLlmResponse(
+        response = SummarizerLlmResponse(
             title="Auth",
             summary="Tried to log in",
             intent="Authenticate",
@@ -578,7 +574,7 @@ class TestSummarizerOutputHasAnyFacet:
 
 class TestToEventProperties:
     def test_flattens_with_scanner_output_prefix(self) -> None:
-        out = MonitorOutput(verdict=True, reasoning="found it", confidence=0.9)
+        out = MonitorOutput(verdict="yes", reasoning="found it", confidence=0.9)
         props = out.to_event_properties()
         assert props == {
             "scanner_output_verdict": True,
@@ -589,7 +585,7 @@ class TestToEventProperties:
 
     def test_excludes_scanner_type_discriminator(self) -> None:
         # `scanner_type` lives at the top-level event property; flattening it would duplicate.
-        out = MonitorOutput(verdict=False, reasoning="nope", confidence=0.5)
+        out = MonitorOutput(verdict="no", reasoning="nope", confidence=0.5)
         props = out.to_event_properties()
         assert "scanner_output_scanner_type" not in props
         assert "scanner_type" not in props

--- a/products/replay_vision/backend/tests/test_scanners.py
+++ b/products/replay_vision/backend/tests/test_scanners.py
@@ -581,7 +581,7 @@ class TestToEventProperties:
         out = MonitorOutput(verdict="yes", reasoning="found it", confidence=0.9)
         props = out.to_event_properties()
         assert props == {
-            "scanner_output_verdict": True,
+            "scanner_output_verdict": "yes",
             "scanner_output_reasoning": "found it",
             "scanner_output_reasoning_segments": [],
             "scanner_output_confidence": 0.9,

--- a/products/replay_vision/backend/tests/test_temporal.py
+++ b/products/replay_vision/backend/tests/test_temporal.py
@@ -385,7 +385,7 @@ class TestObservationStateActivities:
     def test_mark_succeeded_stamps_lifecycle_metadata_and_persists_result(self) -> None:
         scanner = _make_scanner()
         observation = _make_observation(scanner, status=ObservationStatus.RUNNING, started_at=timezone.now())
-        result = ScannerResult(model_output=MonitorOutput(verdict=True, reasoning="ok", confidence=0.9))
+        result = ScannerResult(model_output=MonitorOutput(verdict="yes", reasoning="ok", confidence=0.9))
 
         mark_observation_succeeded_activity(
             MarkObservationSucceededInputs(
@@ -404,7 +404,7 @@ class TestObservationStateActivities:
         observation = _make_observation(
             scanner, status=ObservationStatus.FAILED, error_reason="prior", completed_at=timezone.now()
         )
-        result = ScannerResult(model_output=MonitorOutput(verdict=True, reasoning="late", confidence=0.9))
+        result = ScannerResult(model_output=MonitorOutput(verdict="yes", reasoning="late", confidence=0.9))
 
         mark_observation_succeeded_activity(
             MarkObservationSucceededInputs(
@@ -427,7 +427,7 @@ class TestObservationStateMetricsAndLogs:
     def test_mark_succeeded_increments_observations_counter_and_logs(self) -> None:
         scanner = _make_scanner()
         observation = _make_observation(scanner, status=ObservationStatus.RUNNING, started_at=timezone.now())
-        result = ScannerResult(model_output=MonitorOutput(verdict=True, reasoning="ok", confidence=0.8))
+        result = ScannerResult(model_output=MonitorOutput(verdict="yes", reasoning="ok", confidence=0.8))
         before = _counter_value("replay_vision_observations_total", status="succeeded", scanner_type="monitor")
 
         with capture_logs() as logs:
@@ -515,7 +515,7 @@ class TestObservationStateMetricsAndLogs:
     def test_activity_duration_histogram_records_success_observation(self) -> None:
         scanner = _make_scanner()
         observation = _make_observation(scanner, status=ObservationStatus.RUNNING, started_at=timezone.now())
-        result = ScannerResult(model_output=MonitorOutput(verdict=True, reasoning="ok", confidence=0.8))
+        result = ScannerResult(model_output=MonitorOutput(verdict="yes", reasoning="ok", confidence=0.8))
         labels = {"activity": "mark_observation_succeeded_activity", "status": "succeeded"}
         before = _counter_value("replay_vision_activity_duration_seconds_count", **labels)
 
@@ -589,7 +589,7 @@ class TestObservationStateMetricsAndLogs:
                     MarkObservationSucceededInputs(
                         observation_id=obs_id,
                         scanner_result=ScannerResult(
-                            model_output=MonitorOutput(verdict=True, reasoning="late", confidence=0.8)
+                            model_output=MonitorOutput(verdict="yes", reasoning="late", confidence=0.8)
                         ),
                         scanner_type=ScannerType.MONITOR,
                     )
@@ -637,7 +637,7 @@ class TestObservationStateMetricsAndLogs:
                     MarkObservationSucceededInputs(
                         observation_id=observation.id,
                         scanner_result=ScannerResult(
-                            model_output=MonitorOutput(verdict=True, reasoning="ok", confidence=0.8)
+                            model_output=MonitorOutput(verdict="yes", reasoning="ok", confidence=0.8)
                         ),
                         scanner_type=ScannerType.MONITOR,
                     )
@@ -1247,7 +1247,7 @@ async def _run_workflow(inputs: ApplyScannerInputs, mocks: _WorkflowMocks, workf
 @pytest.mark.asyncio
 async def test_apply_scanner_workflow_drives_full_success_pipeline() -> None:
     new_observation_id = uuid.uuid4()
-    model_output = MonitorOutput(verdict=True, reasoning="user exported", confidence=0.9)
+    model_output = MonitorOutput(verdict="yes", reasoning="user exported", confidence=0.9)
     mocks = _WorkflowMocks(
         activity_results={
             create_observation_activity: CreateObservationOutput(
@@ -1355,7 +1355,7 @@ async def test_apply_scanner_workflow_succeeds_even_when_cleanup_fails() -> None
                 file_uri="gemini://files/x", mime_type="video/mp4", gemini_file_name="files/x"
             ),
             call_scanner_provider_activity: ScannerCallOutput(
-                model_output=MonitorOutput(verdict=True, reasoning="ok", confidence=0.9),
+                model_output=MonitorOutput(verdict="yes", reasoning="ok", confidence=0.9),
             ),
         },
         activity_errors={cleanup_gemini_file_activity: RuntimeError("cleanup failed")},
@@ -1581,7 +1581,7 @@ async def test_emit_classifier_tags_raises_when_kafka_delivery_fails() -> None:
 
 
 @pytest.mark.asyncio
-async def test_apply_scanner_workflow_dispatches_summarizer_embedding_when_flag_and_facets_present() -> None:
+async def test_apply_scanner_workflow_dispatches_summarizer_embedding_when_facets_present() -> None:
     new_observation_id = uuid.uuid4()
     model_output = _summarizer_output_with_facets()
     mocks = _WorkflowMocks(
@@ -1590,7 +1590,6 @@ async def test_apply_scanner_workflow_dispatches_summarizer_embedding_when_flag_
                 observation_id=new_observation_id,
                 was_created=True,
                 scanner_type=ScannerType.SUMMARIZER,
-                emits_embeddings=True,
             ),
             ensure_session_asset_activity: EnsureSessionAssetOutput(asset_id=42),
             upload_video_to_gemini_activity: UploadedVideo(
@@ -1616,31 +1615,6 @@ async def test_apply_scanner_workflow_dispatches_summarizer_embedding_when_flag_
 
 
 @pytest.mark.asyncio
-async def test_apply_scanner_workflow_skips_summarizer_embedding_when_flag_off() -> None:
-    new_observation_id = uuid.uuid4()
-    mocks = _WorkflowMocks(
-        activity_results={
-            create_observation_activity: CreateObservationOutput(
-                observation_id=new_observation_id,
-                was_created=True,
-                scanner_type=ScannerType.SUMMARIZER,
-                emits_embeddings=False,
-            ),
-            ensure_session_asset_activity: EnsureSessionAssetOutput(asset_id=42),
-            upload_video_to_gemini_activity: UploadedVideo(
-                file_uri="gemini://files/x", mime_type="video/mp4", gemini_file_name="files/x"
-            ),
-            call_scanner_provider_activity: ScannerCallOutput(model_output=_summarizer_output_with_facets()),
-        },
-    )
-
-    await _run_workflow(_build_inputs(session_id="sess-noemb"), mocks)
-
-    called = {fn for fn, _ in mocks.activity_calls}
-    assert embed_summarizer_observation_activity not in called
-
-
-@pytest.mark.asyncio
 async def test_apply_scanner_workflow_skips_summarizer_embedding_when_no_facets() -> None:
     new_observation_id = uuid.uuid4()
     mocks = _WorkflowMocks(
@@ -1649,7 +1623,6 @@ async def test_apply_scanner_workflow_skips_summarizer_embedding_when_no_facets(
                 observation_id=new_observation_id,
                 was_created=True,
                 scanner_type=ScannerType.SUMMARIZER,
-                emits_embeddings=True,
             ),
             ensure_session_asset_activity: EnsureSessionAssetOutput(asset_id=42),
             upload_video_to_gemini_activity: UploadedVideo(
@@ -1698,7 +1671,7 @@ async def test_apply_scanner_workflow_dispatches_classifier_side_effect() -> Non
 @pytest.mark.asyncio
 async def test_apply_scanner_workflow_skips_side_effects_for_monitor() -> None:
     new_observation_id = uuid.uuid4()
-    model_output = MonitorOutput(verdict=True, reasoning="user exported", confidence=0.9)
+    model_output = MonitorOutput(verdict="yes", reasoning="user exported", confidence=0.9)
     mocks = _WorkflowMocks(
         activity_results={
             create_observation_activity: CreateObservationOutput(
@@ -1729,7 +1702,6 @@ async def test_apply_scanner_workflow_marks_failed_when_side_effect_raises() -> 
                 observation_id=new_observation_id,
                 was_created=True,
                 scanner_type=ScannerType.SUMMARIZER,
-                emits_embeddings=True,
             ),
             ensure_session_asset_activity: EnsureSessionAssetOutput(asset_id=42),
             upload_video_to_gemini_activity: UploadedVideo(
@@ -1902,7 +1874,9 @@ class TestExtractSegments:
 
 class TestResolveCitations:
     def test_populates_field_and_segments(self) -> None:
-        finalized = MonitorOutput(verdict=True, reasoning=f"User retried (event_uuid {_UUID_A}) twice.", confidence=0.9)
+        finalized = MonitorOutput(
+            verdict="yes", reasoning=f"User retried (event_uuid {_UUID_A}) twice.", confidence=0.9
+        )
         resolved = _resolve_citations(finalized, _monitor_scanner(), {_UUID_A: 1234})
         assert isinstance(resolved, MonitorOutput)
         assert resolved.reasoning == "User retried twice."
@@ -1920,7 +1894,7 @@ class TestResolveCitations:
         assert any(isinstance(s, ChipSegment) and s.uuid == _UUID_A for s in resolved.summary_segments)
 
     def test_no_citations_in_text_yields_single_text_segment(self) -> None:
-        finalized = MonitorOutput(verdict=True, reasoning="No citations here.", confidence=0.9)
+        finalized = MonitorOutput(verdict="yes", reasoning="No citations here.", confidence=0.9)
         resolved = _resolve_citations(finalized, _monitor_scanner(), {_UUID_A: 0})
         assert isinstance(resolved, MonitorOutput)
         assert resolved.reasoning == "No citations here."

--- a/products/replay_vision/frontend/components/ObservationCard.tsx
+++ b/products/replay_vision/frontend/components/ObservationCard.tsx
@@ -79,14 +79,14 @@ export function CitedText({
                 const label = colonDelimitedDuration(seconds, null)
                 if (onSeek) {
                     return (
-                        <Link key={i} onClick={() => onSeek(segment.timestamp_ms)}>
+                        <Link key={i} onClick={() => onSeek(segment.timestamp_ms)} className="ml-0.5">
                             <IconRewindPlay className="inline-block align-text-bottom mr-0.5" />
                             <span className="font-mono">{label}</span>
                         </Link>
                     )
                 }
                 return (
-                    <span key={i} className="text-muted font-mono">
+                    <span key={i} className="text-muted font-mono ml-0.5">
                         {label}
                     </span>
                 )
@@ -128,11 +128,21 @@ export function ObservationPrimaryOutput({
     const promptClass = 'text-xs text-muted'
 
     if (scannerType === 'monitor') {
-        const verdict = Boolean(result.verdict)
+        const verdict = result.verdict
+        const tagType =
+            verdict === 'yes'
+                ? 'success'
+                : verdict === 'no'
+                  ? 'default'
+                  : verdict === 'inconclusive'
+                    ? 'muted'
+                    : 'muted'
+        const tagLabel =
+            verdict === 'yes' ? 'Yes' : verdict === 'no' ? 'No' : verdict === 'inconclusive' ? 'Inconclusive' : '—'
         return (
             <div className="flex flex-col gap-1">
-                <LemonTag size="medium" type={verdict ? 'success' : 'default'} className="self-start">
-                    {verdict ? 'Yes' : 'No'}
+                <LemonTag size="medium" type={tagType} className="self-start">
+                    {tagLabel}
                 </LemonTag>
                 {prompt && <span className={promptClass}>{prompt}</span>}
             </div>
@@ -157,22 +167,26 @@ export function ObservationPrimaryOutput({
     if (scannerType === 'classifier') {
         const fixedTags = Array.isArray(result.tags) ? (result.tags as string[]) : []
         const freeformTags = Array.isArray(result.tags_freeform) ? (result.tags_freeform as string[]) : []
+        const configuredTags = Array.isArray(config.tags) ? (config.tags as string[]) : []
+        const chosen = new Set(fixedTags)
         const empty = fixedTags.length === 0 && freeformTags.length === 0
-        const renderFixed = (): JSX.Element[] =>
-            fixedTags.map((tag) => (
-                <LemonTag key={`fixed-${tag}`} size="medium" type="option" title="From the configured tag list">
-                    {tag}
-                </LemonTag>
-            ))
+        const renderVocab = (): JSX.Element[] =>
+            configuredTags.map((tag) => {
+                const isChosen = chosen.has(tag)
+                return (
+                    <LemonTag
+                        key={`fixed-${tag}`}
+                        size="medium"
+                        type={isChosen ? 'option' : 'default'}
+                        className={isChosen ? undefined : 'opacity-50 line-through'}
+                    >
+                        {tag}
+                    </LemonTag>
+                )
+            })
         const renderFreeform = (): JSX.Element[] =>
             freeformTags.map((tag) => (
-                <LemonTag
-                    key={`freeform-${tag}`}
-                    size="medium"
-                    type="default"
-                    icon={<IconSparkles />}
-                    title="Free-form tag from the model"
-                >
+                <LemonTag key={`freeform-${tag}`} size="medium" type="default" icon={<IconSparkles />}>
                     {tag}
                 </LemonTag>
             ))
@@ -184,7 +198,11 @@ export function ObservationPrimaryOutput({
                             <span className="text-muted text-sm">No tags</span>
                         ) : (
                             <>
-                                {renderFixed()}
+                                {fixedTags.map((tag) => (
+                                    <LemonTag key={`fixed-${tag}`} size="medium" type="option">
+                                        {tag}
+                                    </LemonTag>
+                                ))}
                                 {renderFreeform()}
                             </>
                         )}
@@ -193,7 +211,7 @@ export function ObservationPrimaryOutput({
                 </div>
             )
         }
-        if (empty) {
+        if (configuredTags.length === 0 && empty) {
             return (
                 <div className="flex flex-col gap-1">
                     <span className="text-muted text-sm">No tags</span>
@@ -203,23 +221,10 @@ export function ObservationPrimaryOutput({
         }
         return (
             <div className="flex flex-col gap-3">
-                {fixedTags.length > 0 && (
-                    <div className="flex flex-col gap-1.5">
-                        <div className="text-xs font-medium uppercase tracking-wide text-muted">Fixed</div>
-                        <p className="text-xs text-muted m-0">Tags from the scanner's configured list.</p>
-                        <div className="flex flex-wrap gap-1">{renderFixed()}</div>
-                    </div>
-                )}
-                {freeformTags.length > 0 && (
-                    <div className="flex flex-col gap-1.5">
-                        <div className="flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-muted">
-                            <IconSparkles className="text-sm" />
-                            <span>Freeform</span>
-                        </div>
-                        <p className="text-xs text-muted m-0">Emitted by the model outside the configured tags.</p>
-                        <div className="flex flex-wrap gap-1">{renderFreeform()}</div>
-                    </div>
-                )}
+                <div className="flex flex-wrap items-center gap-1">
+                    {renderVocab()}
+                    {renderFreeform()}
+                </div>
                 {prompt && <span className={promptClass}>{prompt}</span>}
             </div>
         )

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -244,7 +244,7 @@ export interface ReplayScannerApi {
   * `scorer` - Scorer
   * `summarizer` - Summarizer */
     scanner_type: ScannerTypeEnumApi
-    /** Type-specific configuration. All scanner types require `prompt`; classifiers add `tags`, scorers add `scale`, summarizers add optional `length` and `emits_embeddings` flag. */
+    /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
     scanner_config: unknown
     /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
     query?: unknown
@@ -302,7 +302,7 @@ export interface PatchedReplayScannerApi {
   * `scorer` - Scorer
   * `summarizer` - Summarizer */
     scanner_type?: ScannerTypeEnumApi
-    /** Type-specific configuration. All scanner types require `prompt`; classifiers add `tags`, scorers add `scale`, summarizers add optional `length` and `emits_embeddings` flag. */
+    /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
     scanner_config?: unknown
     /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
     query?: unknown

--- a/products/replay_vision/frontend/generated/api.zod.ts
+++ b/products/replay_vision/frontend/generated/api.zod.ts
@@ -34,7 +34,7 @@ export const VisionScannersCreateBody = /* @__PURE__ */ zod.object({
     scanner_config: zod
         .unknown()
         .describe(
-            'Type-specific configuration. All scanner types require `prompt`; classifiers add `tags`, scorers add `scale`, summarizers add optional `length` and `emits_embeddings` flag.'
+            'Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`.'
         ),
     query: zod
         .unknown()
@@ -101,7 +101,7 @@ export const VisionScannersPartialUpdateBody = /* @__PURE__ */ zod.object({
         .unknown()
         .optional()
         .describe(
-            'Type-specific configuration. All scanner types require `prompt`; classifiers add `tags`, scorers add `scale`, summarizers add optional `length` and `emits_embeddings` flag.'
+            'Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`.'
         ),
     query: zod
         .unknown()

--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -1,6 +1,8 @@
 import { useValues } from 'kea'
+import { useEffect, useState } from 'react'
 
-import { LemonTag, Link } from '@posthog/lemon-ui'
+import { IconCollapse, IconExpand, IconVideoCamera } from '@posthog/icons'
+import { LemonButton, LemonCard, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { dayjs } from 'lib/dayjs'
@@ -38,8 +40,32 @@ export const scene: SceneExport<ReplayObservationSceneLogicProps> = {
     productKey: ProductKey.REPLAY_VISION,
 }
 
+/** Subscribes to the player's data and fires `seekToTime` the moment metadata is available. */
+function AutoSeekToTime({
+    playerKey,
+    sessionRecordingId,
+    ms,
+    trigger,
+}: {
+    playerKey: string
+    sessionRecordingId: string
+    ms: number
+    trigger: number
+}): null {
+    const { sessionPlayerData } = useValues(sessionRecordingPlayerLogic({ playerKey, sessionRecordingId }))
+    useEffect(() => {
+        if (sessionPlayerData?.start && sessionPlayerData?.end) {
+            sessionRecordingPlayerLogic.findMounted({ playerKey, sessionRecordingId })?.actions.seekToTime(ms)
+        }
+        // `trigger` lets a repeat click on the same citation re-fire the seek.
+    }, [sessionPlayerData?.start, sessionPlayerData?.end, ms, trigger, playerKey, sessionRecordingId])
+    return null
+}
+
 export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): JSX.Element {
     const { observationId } = useValues(replayObservationSceneLogic)
+    const [recordingExpanded, setRecordingExpanded] = useState(true)
+    const [pendingSeek, setPendingSeek] = useState<{ ms: number; trigger: number } | null>(null)
 
     const observationLogic = replayObservationLogic({ id: observationId, tabId })
     useAttachedLogic(observationLogic, replayObservationSceneLogic)
@@ -77,6 +103,20 @@ export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): J
     const prompt = typeof snapshotConfig.prompt === 'string' ? snapshotConfig.prompt : null
     const summarizerLength =
         scannerType === 'summarizer' && typeof snapshotConfig.length === 'string' ? snapshotConfig.length : null
+    const classifierVocab =
+        scannerType === 'classifier' && Array.isArray(snapshotConfig.tags)
+            ? (snapshotConfig.tags as unknown[]).filter((t): t is string => typeof t === 'string')
+            : null
+    const classifierMultiLabel = scannerType === 'classifier' ? snapshotConfig.multi_label === true : null
+    const monitorAllowInconclusive = scannerType === 'monitor' ? snapshotConfig.allow_inconclusive === true : null
+    const classifierAllowFreeform = scannerType === 'classifier' ? snapshotConfig.allow_freeform_tags === true : null
+    const scorerScale =
+        scannerType === 'scorer' && snapshotConfig.scale && typeof snapshotConfig.scale === 'object'
+            ? (snapshotConfig.scale as { min?: unknown; max?: unknown; label?: unknown })
+            : null
+    const scorerMin = scorerScale && typeof scorerScale.min === 'number' ? scorerScale.min : null
+    const scorerMax = scorerScale && typeof scorerScale.max === 'number' ? scorerScale.max : null
+    const scorerLabel = scorerScale && typeof scorerScale.label === 'string' ? scorerScale.label : null
     const durationMs =
         observation.started_at && observation.completed_at
             ? dayjs(observation.completed_at).diff(observation.started_at)
@@ -91,31 +131,23 @@ export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): J
             : null
 
     const seekEmbeddedPlayer = (ms: number): void => {
-        sessionRecordingPlayerLogic
-            .findMounted({
-                playerKey: `vision-observation-${observation.id}`,
-                sessionRecordingId: observation.session_id,
-            })
-            ?.actions.seekToTime(ms)
+        if (!recordingExpanded) {
+            setRecordingExpanded(true)
+        }
+        setPendingSeek({ ms, trigger: Date.now() })
     }
 
     return (
         <SceneContent>
             <SceneTitleSection
                 name={scannerName}
-                description={`Observation on session ${observation.session_id}`}
+                description={`Observation of session ${observation.session_id}`}
                 resourceType={{ type: 'replay_vision' }}
             />
 
             <div className={scannerType === 'summarizer' ? '' : 'grid grid-cols-1 lg:grid-cols-2 gap-4'}>
                 <section className="border rounded p-4 bg-surface-primary space-y-3">
-                    <div className="flex items-center justify-between gap-2">
-                        <div className="flex items-center gap-2">
-                            <span className="text-sm font-medium uppercase tracking-wide text-muted">Result</span>
-                            {scannerType && <LemonTag type="option">{scannerTypeLabel(scannerType)}</LemonTag>}
-                        </div>
-                        <ObservationStatusTag status={observation.status} />
-                    </div>
+                    <div className="text-sm font-medium">Result</div>
 
                     {observation.status === 'failed' && observation.error_reason && (
                         <FailureDetail errorReason={observation.error_reason} />
@@ -126,15 +158,32 @@ export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): J
                     )}
 
                     {observation.status === 'succeeded' && snapshot && result && (
-                        <div className="flex flex-col gap-2">
-                            {prompt && scannerType !== 'summarizer' && (
-                                <p className="text-sm text-default m-0 leading-snug">{prompt}</p>
+                        <div className="flex flex-col gap-3">
+                            {scannerType && (
+                                <div className="flex flex-col gap-1">
+                                    <div className="text-xs text-muted">Type</div>
+                                    <LemonTag type="option" className="self-start">
+                                        {scannerTypeLabel(scannerType)}
+                                    </LemonTag>
+                                </div>
                             )}
-                            <ObservationPrimaryOutput
-                                observation={observation}
-                                showPrompt={false}
-                                onSeek={seekEmbeddedPlayer}
-                            />
+                            {prompt && scannerType !== 'summarizer' && (
+                                <div className="flex flex-col gap-1">
+                                    <div className="text-xs text-muted">Prompt</div>
+                                    <p className="text-sm text-default m-0 leading-snug">{prompt}</p>
+                                </div>
+                            )}
+                            <div className="flex flex-col gap-1">
+                                {scannerType === 'classifier' && <div className="text-xs text-muted">Tags</div>}
+                                {scannerType === 'summarizer' && <div className="text-xs text-muted">Summary</div>}
+                                {scannerType === 'monitor' && <div className="text-xs text-muted">Verdict</div>}
+                                {scannerType === 'scorer' && <div className="text-xs text-muted">Score</div>}
+                                <ObservationPrimaryOutput
+                                    observation={observation}
+                                    showPrompt={false}
+                                    onSeek={seekEmbeddedPlayer}
+                                />
+                            </div>
                         </div>
                     )}
 
@@ -159,82 +208,200 @@ export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): J
                 )}
             </div>
 
-            <section className="border rounded p-4 bg-surface-primary">
-                <div className="text-sm font-medium mb-3">Run details</div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-3 text-sm">
-                    <div>
-                        <div className="text-xs text-muted mb-0.5">Triggered by</div>
-                        {observation.triggered_by === 'on_demand' && observation.triggered_by_user ? (
-                            <ProfilePicture
-                                user={{
-                                    first_name: observation.triggered_by_user.first_name,
-                                    last_name: observation.triggered_by_user.last_name,
-                                    email: observation.triggered_by_user.email,
-                                }}
-                                size="sm"
-                                showName
-                            />
-                        ) : (
-                            <span>{triggerLabel}</span>
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                <LemonCard className="p-4" hoverEffect={false}>
+                    <div className="text-sm font-medium mb-3">Observation details</div>
+                    <div className="flex flex-col gap-3 text-sm">
+                        <div>
+                            <div className="text-xs text-muted mb-0.5">Status</div>
+                            <ObservationStatusTag status={observation.status} />
+                        </div>
+                        {result && typeof result.confidence === 'number' && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Confidence</div>
+                                <ObservationConfidence result={result} />
+                            </div>
+                        )}
+                        <div>
+                            <div className="text-xs text-muted mb-0.5">Triggered by</div>
+                            {observation.triggered_by === 'on_demand' && observation.triggered_by_user ? (
+                                <ProfilePicture
+                                    user={{
+                                        first_name: observation.triggered_by_user.first_name,
+                                        last_name: observation.triggered_by_user.last_name,
+                                        email: observation.triggered_by_user.email,
+                                    }}
+                                    size="sm"
+                                    showName
+                                />
+                            ) : (
+                                <span>{triggerLabel}</span>
+                            )}
+                        </div>
+                        <div>
+                            <div className="text-xs text-muted mb-0.5">Session</div>
+                            <Link to={urls.sessionProfile(observation.session_id)}>{observation.session_id}</Link>
+                        </div>
+                    </div>
+                </LemonCard>
+
+                <LemonCard className="p-4" hoverEffect={false}>
+                    <div className="text-sm font-medium mb-3">Lifecycle</div>
+                    <div className="flex flex-col gap-3 text-sm">
+                        <div>
+                            <div className="text-xs text-muted mb-0.5">Created at</div>
+                            <TZLabel time={observation.created_at} />
+                        </div>
+                        {observation.started_at && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Started at</div>
+                                <TZLabel time={observation.started_at} />
+                            </div>
+                        )}
+                        {observation.completed_at && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Completed at</div>
+                                <TZLabel time={observation.completed_at} />
+                            </div>
+                        )}
+                        {durationLabel && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Duration</div>
+                                <span>{durationLabel}</span>
+                            </div>
                         )}
                     </div>
-                    <div>
-                        <div className="text-xs text-muted mb-0.5">Run at</div>
-                        <TZLabel time={observation.created_at} />
-                    </div>
-                    {durationLabel && (
-                        <div>
-                            <div className="text-xs text-muted mb-0.5">Duration</div>
-                            <span>{durationLabel}</span>
-                        </div>
-                    )}
-                    {result && typeof result.confidence === 'number' && (
-                        <div>
-                            <div className="text-xs text-muted mb-0.5">Confidence</div>
-                            <ObservationConfidence result={result} />
-                        </div>
-                    )}
-                    {snapshot?.model && (
-                        <div>
-                            <div className="text-xs text-muted mb-0.5">Model</div>
-                            <span>{modelLabel(snapshot.model)}</span>
-                        </div>
-                    )}
-                    {typeof snapshot?.scanner_version === 'number' && (
-                        <div>
-                            <div className="text-xs text-muted mb-0.5">Scanner version</div>
-                            <span>v{snapshot.scanner_version}</span>
-                        </div>
-                    )}
-                    {summarizerLength && (
-                        <div>
-                            <div className="text-xs text-muted mb-0.5">Summary length</div>
-                            <span className="capitalize">{summarizerLength}</span>
-                        </div>
-                    )}
-                    {snapshot?.emits_signals && (
-                        <div>
-                            <div className="text-xs text-muted mb-0.5">Signals</div>
-                            <span>Emitted ({observation.scanner_result?.signals_count ?? 0})</span>
-                        </div>
-                    )}
-                </div>
-            </section>
+                </LemonCard>
 
-            <section className="border rounded bg-surface-primary overflow-hidden">
-                <div className="p-4 pb-2 text-sm font-medium">Recording</div>
-                <div className="aspect-video max-h-[80vh] min-h-[480px]">
-                    <SessionRecordingPlayer
-                        sessionRecordingId={observation.session_id}
-                        playerKey={`vision-observation-${observation.id}`}
-                        mode={SessionRecordingPlayerMode.Standard}
-                        autoPlay={false}
-                        noMeta
-                        noBorder
-                        withSidebar={false}
+                <LemonCard className="p-4" hoverEffect={false}>
+                    <div className="text-sm font-medium mb-3">Configuration</div>
+                    <div className="flex flex-col gap-3 text-sm">
+                        {snapshot?.model && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Model</div>
+                                <span>{modelLabel(snapshot.model)}</span>
+                            </div>
+                        )}
+                        {summarizerLength && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Summary length</div>
+                                <span className="capitalize">{summarizerLength}</span>
+                            </div>
+                        )}
+                        {classifierVocab && classifierVocab.length > 0 && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Vocabulary</div>
+                                <div className="flex flex-wrap gap-1">
+                                    {classifierVocab.map((tag) => (
+                                        <LemonTag key={tag} type="default" size="small">
+                                            {tag}
+                                        </LemonTag>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+                        {monitorAllowInconclusive !== null && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Allow inconclusive verdicts</div>
+                                <LemonTag
+                                    type={monitorAllowInconclusive ? 'success' : 'muted'}
+                                    size="small"
+                                    className="self-start"
+                                >
+                                    {monitorAllowInconclusive ? 'Enabled' : 'Disabled'}
+                                </LemonTag>
+                            </div>
+                        )}
+                        {classifierMultiLabel !== null && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Multi-label</div>
+                                <LemonTag
+                                    type={classifierMultiLabel ? 'success' : 'muted'}
+                                    size="small"
+                                    className="self-start"
+                                >
+                                    {classifierMultiLabel ? 'Enabled' : 'Disabled'}
+                                </LemonTag>
+                            </div>
+                        )}
+                        {classifierAllowFreeform !== null && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Freeform tags</div>
+                                <LemonTag
+                                    type={classifierAllowFreeform ? 'success' : 'muted'}
+                                    size="small"
+                                    className="self-start"
+                                >
+                                    {classifierAllowFreeform ? 'Enabled' : 'Disabled'}
+                                </LemonTag>
+                            </div>
+                        )}
+                        {scorerMin !== null && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Scale minimum</div>
+                                <span>{scorerMin}</span>
+                            </div>
+                        )}
+                        {scorerMax !== null && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Scale maximum</div>
+                                <span>{scorerMax}</span>
+                            </div>
+                        )}
+                        {scorerLabel && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Score label</div>
+                                <span>{scorerLabel}</span>
+                            </div>
+                        )}
+                        {snapshot?.emits_signals && (
+                            <div>
+                                <div className="text-xs text-muted mb-0.5">Signals</div>
+                                <span>Emitted ({observation.scanner_result?.signals_count ?? 0})</span>
+                            </div>
+                        )}
+                    </div>
+                </LemonCard>
+            </div>
+
+            <LemonCard className="overflow-hidden p-0" hoverEffect={false}>
+                <div
+                    className="flex items-center gap-2 bg-surface-primary p-3 cursor-pointer hover:bg-surface-secondary"
+                    onClick={() => setRecordingExpanded(!recordingExpanded)}
+                >
+                    <LemonButton
+                        icon={recordingExpanded ? <IconCollapse /> : <IconExpand />}
+                        size="small"
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            setRecordingExpanded(!recordingExpanded)
+                        }}
                     />
+                    <IconVideoCamera className="text-muted-alt" />
+                    <h3 className="text-lg font-semibold m-0">Recording</h3>
                 </div>
-            </section>
+                {recordingExpanded && (
+                    <div className="border-t border-border h-[480px]">
+                        <SessionRecordingPlayer
+                            sessionRecordingId={observation.session_id}
+                            playerKey={`vision-observation-${observation.id}`}
+                            mode={SessionRecordingPlayerMode.Standard}
+                            autoPlay={false}
+                            noMeta
+                            noBorder
+                            withSidebar
+                        />
+                        {pendingSeek && (
+                            <AutoSeekToTime
+                                playerKey={`vision-observation-${observation.id}`}
+                                sessionRecordingId={observation.session_id}
+                                ms={pendingSeek.ms}
+                                trigger={pendingSeek.trigger}
+                            />
+                        )}
+                    </div>
+                )}
+            </LemonCard>
         </SceneContent>
     )
 }

--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -40,7 +40,6 @@ export const scene: SceneExport<ReplayObservationSceneLogicProps> = {
     productKey: ProductKey.REPLAY_VISION,
 }
 
-/** Subscribes to the player's data and fires `seekToTime` once per `trigger` increment after metadata is available. */
 function AutoSeekToTime({
     playerKey,
     sessionRecordingId,
@@ -52,11 +51,11 @@ function AutoSeekToTime({
     ms: number
     trigger: number
 }): null {
-    // `sessionPlayerData.start`/`.end` are fresh Dayjs objects on every snapshot batch — compare epochs so deps stay stable.
     const { sessionPlayerData } = useValues(sessionRecordingPlayerLogic({ playerKey, sessionRecordingId }))
+    // `start`/`end` are fresh Dayjs objects on every snapshot batch; compare epochs so deps stay stable.
     const startMs = sessionPlayerData?.start?.valueOf() ?? null
     const endMs = sessionPlayerData?.end?.valueOf() ?? null
-    // Latch per-trigger so a repeat click re-fires but snapshot-batch arrivals don't re-seek and fight playback.
+    // Latch per-trigger so snapshot-batch arrivals don't re-seek and fight playback.
     const seekedForTrigger = useRef<number | null>(null)
     useEffect(() => {
         if (seekedForTrigger.current === trigger || startMs == null || endMs == null) {

--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -1,5 +1,5 @@
 import { useValues } from 'kea'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { IconCollapse, IconExpand, IconVideoCamera } from '@posthog/icons'
 import { LemonButton, LemonCard, LemonTag, Link } from '@posthog/lemon-ui'
@@ -40,7 +40,7 @@ export const scene: SceneExport<ReplayObservationSceneLogicProps> = {
     productKey: ProductKey.REPLAY_VISION,
 }
 
-/** Subscribes to the player's data and fires `seekToTime` the moment metadata is available. */
+/** Subscribes to the player's data and fires `seekToTime` once per `trigger` increment after metadata is available. */
 function AutoSeekToTime({
     playerKey,
     sessionRecordingId,
@@ -52,13 +52,19 @@ function AutoSeekToTime({
     ms: number
     trigger: number
 }): null {
+    // `sessionPlayerData.start`/`.end` are fresh Dayjs objects on every snapshot batch — compare epochs so deps stay stable.
     const { sessionPlayerData } = useValues(sessionRecordingPlayerLogic({ playerKey, sessionRecordingId }))
+    const startMs = sessionPlayerData?.start?.valueOf() ?? null
+    const endMs = sessionPlayerData?.end?.valueOf() ?? null
+    // Latch per-trigger so a repeat click re-fires but snapshot-batch arrivals don't re-seek and fight playback.
+    const seekedForTrigger = useRef<number | null>(null)
     useEffect(() => {
-        if (sessionPlayerData?.start && sessionPlayerData?.end) {
-            sessionRecordingPlayerLogic.findMounted({ playerKey, sessionRecordingId })?.actions.seekToTime(ms)
+        if (seekedForTrigger.current === trigger || startMs == null || endMs == null) {
+            return
         }
-        // `trigger` lets a repeat click on the same citation re-fire the seek.
-    }, [sessionPlayerData?.start, sessionPlayerData?.end, ms, trigger, playerKey, sessionRecordingId])
+        sessionRecordingPlayerLogic.findMounted({ playerKey, sessionRecordingId })?.actions.seekToTime(ms)
+        seekedForTrigger.current = trigger
+    }, [startMs, endMs, ms, trigger, playerKey, sessionRecordingId])
     return null
 }
 

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerInsightsChart.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerInsightsChart.tsx
@@ -51,7 +51,7 @@ function buildQuery(
                             type: PropertyFilterType.Event,
                             key: 'scanner_output_verdict',
                             operator: PropertyOperator.Exact,
-                            value: 'true',
+                            value: 'yes',
                         },
                     ],
                 },

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
@@ -35,6 +35,7 @@ const TRIGGERED_BY_OPTIONS: { value: ObservationTriggeredByValue; label: string 
 const VERDICT_OPTIONS: { value: ObservationVerdictValue; label: string }[] = [
     { value: 'yes', label: 'Yes' },
     { value: 'no', label: 'No' },
+    { value: 'inconclusive', label: 'Inconclusive' },
 ]
 
 // Nulls (no model output) sort last regardless of direction.

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -33,17 +33,19 @@ function OverviewPanel({
 
 function MonitorOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element | null {
     const { monitorStats } = useValues(replayScannerLogic({ id: scannerId, tabId }))
-    const { yesTotal, noTotal } = monitorStats
-    const total = yesTotal + noTotal
+    const { yesTotal, noTotal, inconclusiveTotal } = monitorStats
+    const total = yesTotal + noTotal + inconclusiveTotal
     if (total === 0) {
         return null
     }
     const yesPct = Math.round((yesTotal / total) * 100)
+    const noPct = Math.round((noTotal / total) * 100)
+    const inconclusivePct = Math.max(0, 100 - yesPct - noPct)
 
     return (
         <OverviewPanel title="Verdict mix" subtitle={`${total} verdict${total === 1 ? '' : 's'}`}>
             <LemonProgress percent={yesPct} />
-            <div className="flex items-center gap-4 text-sm">
+            <div className="flex flex-wrap items-center gap-4 text-sm">
                 <span className="flex items-center gap-2">
                     <LemonTag type="success">Yes</LemonTag>
                     <span className="tabular-nums">
@@ -53,9 +55,17 @@ function MonitorOverview({ scannerId, tabId }: { scannerId: string; tabId: strin
                 <span className="flex items-center gap-2">
                     <LemonTag type="default">No</LemonTag>
                     <span className="tabular-nums">
-                        {noTotal} ({100 - yesPct}%)
+                        {noTotal} ({noPct}%)
                     </span>
                 </span>
+                {inconclusiveTotal > 0 && (
+                    <span className="flex items-center gap-2">
+                        <LemonTag type="muted">Inconclusive</LemonTag>
+                        <span className="tabular-nums">
+                            {inconclusiveTotal} ({inconclusivePct}%)
+                        </span>
+                    </span>
+                )}
             </div>
         </OverviewPanel>
     )

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTypeConfigEditor.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTypeConfigEditor.tsx
@@ -33,28 +33,34 @@ export function ScannerTypeConfigEditor({ scannerId, tabId }: { scannerId: strin
                 <Field name="scanner_config.length" label="Summary length">
                     <LemonSegmentedButton options={SUMMARIZER_LENGTH_OPTIONS} />
                 </Field>
-                <Field name="scanner_config.emits_embeddings">
-                    {({ value, onChange }) => (
-                        <LemonSwitch
-                            label="Emit embeddings to enable free-text search"
-                            checked={!!value}
-                            onChange={onChange}
-                            bordered
-                        />
-                    )}
-                </Field>
             </div>
         )
     }
 
     if (scanner.scanner_type === 'monitor') {
         return (
-            <Field name="scanner_config.prompt" label="Prompt">
-                <LemonTextArea
-                    placeholder="Did the user encounter a payment failure? Answer yes or no with a one-sentence reason."
-                    minRows={6}
-                />
-            </Field>
+            <div className="space-y-4">
+                <Field name="scanner_config.prompt" label="Prompt">
+                    <LemonTextArea
+                        placeholder="Did the user encounter a payment failure? Answer yes or no with a one-sentence reason."
+                        minRows={6}
+                    />
+                </Field>
+                <Field name="scanner_config.allow_inconclusive">
+                    {({ value, onChange }) => (
+                        <div className="flex items-center gap-2">
+                            <LemonSwitch checked={!!value} onChange={onChange} />
+                            <div>
+                                <div className="text-sm font-medium">Allow inconclusive verdicts</div>
+                                <div className="text-xs text-muted">
+                                    Lets the model return `inconclusive` when the session genuinely doesn't provide
+                                    enough signal to decide. Otherwise the verdict must be `yes` or `no`.
+                                </div>
+                            </div>
+                        </div>
+                    )}
+                </Field>
+            </div>
         )
     }
 

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -56,7 +56,7 @@ describe('replayScannerLogic', () => {
     describe('setScannerType', () => {
         it.each([
             { type: 'monitor' as const, expectedConfig: { prompt: '' } },
-            { type: 'summarizer' as const, expectedConfig: { prompt: '', length: 'medium', emits_embeddings: false } },
+            { type: 'summarizer' as const, expectedConfig: { prompt: '', length: 'medium' } },
             { type: 'classifier' as const, expectedConfig: { prompt: '', tags: [], multi_label: true } },
             { type: 'scorer' as const, expectedConfig: { prompt: '', scale: { min: 0, max: 10 } } },
         ])(
@@ -72,7 +72,7 @@ describe('replayScannerLogic', () => {
             logic.actions.setScannerValues({ scanner_config: { prompt: 'Was there a refund?' } })
             await expectLogic(logic, () => logic.actions.setScannerType('summarizer')).toMatchValues({
                 scanner: expect.objectContaining({
-                    scanner_config: { prompt: '', length: 'medium', emits_embeddings: false },
+                    scanner_config: { prompt: '', length: 'medium' },
                 }),
             })
         })

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -40,7 +40,7 @@ export interface ReplayScannerLogicProps {
 
 export type ObservationStatusValue = ReplayObservationApi['status']
 export type ObservationTriggeredByValue = ReplayObservationApi['triggered_by']
-export type ObservationVerdictValue = 'yes' | 'no'
+export type ObservationVerdictValue = 'yes' | 'no' | 'inconclusive'
 
 function quantile(sorted: number[], q: number): number {
     if (sorted.length === 1) {
@@ -59,7 +59,7 @@ function currentTemplateKey(): string | null {
 
 function defaultConfigForType(scannerType: ScannerType): ScannerConfig {
     if (scannerType === 'summarizer') {
-        return { prompt: '', length: 'medium', emits_embeddings: false }
+        return { prompt: '', length: 'medium' }
     }
     if (scannerType === 'classifier') {
         return { prompt: '', tags: [], multi_label: true }
@@ -280,7 +280,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     }
                     if (verdictFilter.length > 0) {
                         const verdict = readVerdict(o)
-                        if (verdict === null || !verdictFilter.includes(verdict ? 'yes' : 'no')) {
+                        if (verdict === null || !verdictFilter.includes(verdict)) {
                             return false
                         }
                     }
@@ -370,18 +370,23 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
         ],
         monitorStats: [
             (s) => [s.succeededObservations],
-            (observations: ReplayObservationApi[]): { yesTotal: number; noTotal: number } => {
+            (
+                observations: ReplayObservationApi[]
+            ): { yesTotal: number; noTotal: number; inconclusiveTotal: number } => {
                 let yesTotal = 0
                 let noTotal = 0
+                let inconclusiveTotal = 0
                 for (const obs of observations) {
                     const v = readVerdict(obs)
-                    if (v === true) {
+                    if (v === 'yes') {
                         yesTotal += 1
-                    } else if (v === false) {
+                    } else if (v === 'no') {
                         noTotal += 1
+                    } else if (v === 'inconclusive') {
+                        inconclusiveTotal += 1
                     }
                 }
-                return { yesTotal, noTotal }
+                return { yesTotal, noTotal, inconclusiveTotal }
             },
         ],
         classifierTagStats: [

--- a/products/replay_vision/frontend/replay_scanners/scannerTemplates.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerTemplates.ts
@@ -72,7 +72,6 @@ export const defaultScannerTemplates: readonly ScannerTemplate[] = [
         scanner_config: {
             prompt: 'Summarize what the user did in this session. Mention the main pages they visited, the primary actions they took, and any notable moments (errors, confusion, completed flows). Be concrete and avoid speculation.',
             length: 'medium',
-            emits_embeddings: false,
         },
     },
     {

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -139,12 +139,12 @@ export const ALL_EDITOR_TABS: EditorTab[] = ['observations', 'configuration']
 
 export interface MonitorScannerConfig {
     prompt: string
+    allow_inconclusive?: boolean
 }
 
 export interface SummarizerScannerConfig {
     prompt: string
     length: 'short' | 'medium' | 'long'
-    emits_embeddings: boolean
 }
 
 export interface ClassifierScannerConfig {

--- a/products/replay_vision/frontend/utils/observation.ts
+++ b/products/replay_vision/frontend/utils/observation.ts
@@ -10,9 +10,11 @@ export function readScore(obs: ReplayObservationApi): number | null {
     return typeof raw === 'number' ? raw : null
 }
 
-export function readVerdict(obs: ReplayObservationApi): boolean | null {
+export type MonitorVerdict = 'yes' | 'no' | 'inconclusive'
+
+export function readVerdict(obs: ReplayObservationApi): MonitorVerdict | null {
     const raw = readModelOutput(obs)?.verdict
-    return typeof raw === 'boolean' ? raw : null
+    return raw === 'yes' || raw === 'no' || raw === 'inconclusive' ? raw : null
 }
 
 function readStringArray(value: unknown): string[] {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -24087,7 +24087,7 @@ export namespace Schemas {
       * `scorer` - Scorer
       * `summarizer` - Summarizer */
       scanner_type: ScannerTypeEnum;
-      /** Type-specific configuration. All scanner types require `prompt`; classifiers add `tags`, scorers add `scale`, summarizers add optional `length` and `emits_embeddings` flag. */
+      /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
       scanner_config: unknown;
       /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
       query?: unknown;
@@ -30487,7 +30487,7 @@ export namespace Schemas {
       * `scorer` - Scorer
       * `summarizer` - Summarizer */
       scanner_type?: ScannerTypeEnum;
-      /** Type-specific configuration. All scanner types require `prompt`; classifiers add `tags`, scorers add `scale`, summarizers add optional `length` and `emits_embeddings` flag. */
+      /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
       scanner_config?: unknown;
       /** Persisted `RecordingsQuery` shape used to pick candidate sessions. `date_from`/`date_to` are stripped on save — the schedule controls time, not the user. */
       query?: unknown;

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -112,7 +112,7 @@ export const VisionScannersCreateBody = /* @__PURE__ */ zod.object({
     scanner_config: zod
         .unknown()
         .describe(
-            'Type-specific configuration. All scanner types require `prompt`; classifiers add `tags`, scorers add `scale`, summarizers add optional `length` and `emits_embeddings` flag.'
+            'Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`.'
         ),
     query: zod
         .unknown()
@@ -200,7 +200,7 @@ export const VisionScannersPartialUpdateBody = /* @__PURE__ */ zod.object({
         .unknown()
         .optional()
         .describe(
-            'Type-specific configuration. All scanner types require `prompt`; classifiers add `tags`, scorers add `scale`, summarizers add optional `length` and `emits_embeddings` flag.'
+            'Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`.'
         ),
     query: zod
         .unknown()


### PR DESCRIPTION
## Problem

Polish pass on Replay vision: observation detail page was hard to scan, summarizer carried an `emits_embeddings` flag nobody ever wanted off, and monitor verdicts were forced into a hard yes/no even when the session genuinely didn't say.

## Changes

- **Observation detail page**: per-type result label (Tags / Summary / Verdict / Score), metadata split into three side-by-side cards (Observation details / Lifecycle / Configuration), classifier vocab shown with unchosen tags struck through, session link, embedded recording mirrors the Session Profile pattern (collapsible `LemonCard` with native player background). Citation chips auto-expand the section and seek the player.
- **Summarizer**: drops `emits_embeddings` config flag — facets are always emitted now.
- **Monitor**: verdict is tri-state (`yes` / `no` / `inconclusive`) gated by a new `allow_inconclusive` config flag. Includes idempotent backfill migration `0011_backfill_monitor_verdict` that rewrites legacy boolean verdicts to strings.

## How did you test this code?

Agent-authored. Automated only: `hogli test products/replay_vision/backend/tests/` (monitor + summarizer suites green), `hogli build:openapi` + `kea-typegen write` both clean, migration applied locally and re-run confirmed no-op. Hand-tested the observation detail page in browser against newly triggered observations across all four scanner types.

## Publish to changelog?

no

## 🤖 Agent context

Tool: Claude Code. Bundles three changes from the same iteration session because the observation-detail work surfaced both scanner-config simplifications. For the monitor backfill, chose the explicit string literal shape (with a one-shot `jsonb_set` migration) over `bool | None` because the row count is tiny.