### PR TITLE
feat(user_interviews): preview an invite from the topic page

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6046,6 +6046,18 @@ snapshots:
         hash: v1.k794b7964.5fd9cfd154dfac9e92c492b11d72f4b26f8f6c91b073d7b8c728ecbcb8f699e4.Y7xIgQfsOCcp9HiLZaExdWRFGE7WFst8c13z8uM8tME
     scenes-app-surveys-surveyresponsekeysreference--webhook--light:
         hash: v1.k794b7964.9b5c484a3a1bd7a09c266a1f164e3ed9eef3ffabbcd12253f0843b3f0b69a808.cc6Rai2vShlFJA_KypMbVcc1IIaVX0nTcZ29RPEEZjo
+    scenes-app-user-interviews-invite-preview-modal--emailable--dark:
+        hash: v1.k794b7964.0cd3e50dcd442e57712b0ebe06d6952c589a4c88c49fca26771c9e17bc07e6dc.iNYX9Up5MvnGHGT7ku7yMuFIJ0NnbSspOz6Ce0Kb2cU
+    scenes-app-user-interviews-invite-preview-modal--emailable--light:
+        hash: v1.k794b7964.1da4c067b795e56838c13c2b2e4cd8d29efd4fb198de90355a358510de470170.tJQeSqaVE518QuEjwwJ6kb7g3Xuche8IUFRHM-wiTNA
+    scenes-app-user-interviews-invite-preview-modal--loading--dark:
+        hash: v1.k794b7964.a458b0aa1d5356d554aafade8302946e0206750044af6531f40eba2e0ee002b7.coF7r1Pbx7buAdFsC3Z4CsVQO9UPoPtDXg9i0kbCbfY
+    scenes-app-user-interviews-invite-preview-modal--loading--light:
+        hash: v1.k794b7964.320ec527145a72ffe5f2c55a15f1b98c814b364dca4f76160d4ba6f4325d6c7b.u50iTSAbyyPjw768_H0H-R75dh0bLlaRYQ8cV8KxkvE
+    scenes-app-user-interviews-invite-preview-modal--no-email-address--dark:
+        hash: v1.k794b7964.5a67fc78bd8a1db181189f2098a0dc2bc448bc635285c7c59139ae9cbfb890ce.aSOWhTz0GF9Drb6_R4J0WOsKZZt64gbDI5YDjYr_8pg
+    scenes-app-user-interviews-invite-preview-modal--no-email-address--light:
+        hash: v1.k794b7964.2ba399f598933941cd57c856dca34de8a53a6cedd5fbba35ee2aa6c46c6031cf.rbs7K-0c710BvMt2zDW23glddQz51j9ONMgeCTrfRWs
     scenes-app-user-interviews-transcript-chat--assistant-and-interviewee--dark:
         hash: v1.k794b7964.148301407c715a271faf97ce39d47c60a01334938ad7bedadb4d39a5dbe30cad.D-ZO2XVMcasLXe5oB_ZEb-m3bdpIO8BQf5d5XC1u1-0
     scenes-app-user-interviews-transcript-chat--assistant-and-interviewee--light:

--- a/products/user_interviews/frontend/InvitePreviewModal.stories.tsx
+++ b/products/user_interviews/frontend/InvitePreviewModal.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import type { PreviewInviteResultApi } from './generated/api.schemas'
+import { InvitePreviewModal } from './UserInterview'
+
+const meta: Meta<typeof InvitePreviewModal> = {
+    title: 'Scenes-App/User Interviews/Invite Preview Modal',
+    component: InvitePreviewModal,
+    parameters: {
+        layout: 'fullscreen',
+        testOptions: {
+            waitForSelector: '.LemonModal',
+            waitForLoadersToDisappear: false,
+        },
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof InvitePreviewModal>
+
+const emailHtml = `<!DOCTYPE html>
+<html>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; color: #2d2d2d; max-width: 560px; margin: 0 auto; padding: 24px;">
+  <h1 style="font-size: 22px; margin-bottom: 24px;">Got 5 minutes to chat?</h1>
+  <p>Hey Alex,</p>
+  <p>We're researching <strong>creating insights with the MCP integration</strong> and your perspective would be really valuable. Got 5&ndash;10 minutes for a quick voice conversation?</p>
+  <p>It's a casual call with an AI interviewer &mdash; not a sales call, just research. You can do it whenever's convenient in the next few days.</p>
+  <p style="text-align: center; margin: 32px 0;">
+    <a href="#" target="_blank" style="background: #1d4aff; color: #ffffff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 600;">Start the interview</a>
+  </p>
+  <p style="font-size: 12px; color: #888;">Or paste this link into your browser: <a href="#">https://us.posthog.com/interview/preview</a></p>
+  <p>Thanks!<br />The PostHog team</p>
+</body>
+</html>`
+
+const emailablePreview: PreviewInviteResultApi = {
+    interviewee_identifier: 'alex@example.com',
+    user_name: 'Alex',
+    email: 'alex@example.com',
+    subject: 'Got 5 minutes to talk about creating insights with the MCP integration?',
+    html: emailHtml,
+    interview_url: 'https://us.posthog.com/interview/preview',
+    emailable: true,
+    is_preview_link: true,
+}
+
+export const Emailable: Story = {
+    args: {
+        isOpen: true,
+        onClose: () => {},
+        preview: emailablePreview,
+        loading: false,
+    },
+}
+
+export const Loading: Story = {
+    args: {
+        isOpen: true,
+        onClose: () => {},
+        preview: null,
+        loading: true,
+    },
+}
+
+export const NoEmailAddress: Story = {
+    args: {
+        isOpen: true,
+        onClose: () => {},
+        preview: {
+            ...emailablePreview,
+            interviewee_identifier: 'distinct_id_abc123',
+            user_name: 'distinct_id_abc123',
+            email: null,
+            emailable: false,
+        },
+        loading: false,
+    },
+}

--- a/products/user_interviews/frontend/UserInterview.tsx
+++ b/products/user_interviews/frontend/UserInterview.tsx
@@ -229,7 +229,7 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
     )
 }
 
-function InvitePreviewModal({
+export function InvitePreviewModal({
     isOpen,
     onClose,
     preview,

--- a/products/user_interviews/frontend/UserInterview.tsx
+++ b/products/user_interviews/frontend/UserInterview.tsx
@@ -7,9 +7,10 @@ import {
     IconClock,
     IconCopy,
     IconDownload,
+    IconEye,
     IconFlask,
 } from '@posthog/icons'
-import { LemonButton, LemonSkeleton, LemonTag, LemonWidget } from '@posthog/lemon-ui'
+import { LemonButton, LemonModal, LemonSkeleton, LemonTag, LemonWidget } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
 import { dayjs } from 'lib/dayjs'
@@ -21,7 +22,7 @@ import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 
-import type { TestInterviewLinkApi, UserInterviewTopicApi } from './generated/api.schemas'
+import type { PreviewInviteResultApi, TestInterviewLinkApi, UserInterviewTopicApi } from './generated/api.schemas'
 import { InterviewLinkCopyButton } from './InterviewLinkCopyButton'
 import { UserInterviewLogicProps, userInterviewLogic } from './userInterviewLogic'
 
@@ -57,8 +58,11 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
         linksCsvExporting,
         testLink,
         testLinkLoading,
+        previewInviteIdentifier,
+        invitePreview,
+        invitePreviewLoading,
     } = useValues(userInterviewLogic)
-    const { exportLinksCsv, loadTestLink } = useActions(userInterviewLogic)
+    const { exportLinksCsv, loadTestLink, openInvitePreview, closeInvitePreview } = useActions(userInterviewLogic)
 
     if (topicLoading && !topic) {
         return (
@@ -173,6 +177,8 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
                                         identifier={identifier}
                                         topicId={id}
                                         hasResponded={respondedIdentifiers.has(identifier)}
+                                        onPreview={() => openInvitePreview(identifier)}
+                                        previewLoading={previewInviteIdentifier === identifier && invitePreviewLoading}
                                     />
                                 ))
                             )}
@@ -212,7 +218,62 @@ export function UserInterview({ id }: UserInterviewLogicProps): JSX.Element {
                     )}
                 </div>
             </div>
+
+            <InvitePreviewModal
+                isOpen={previewInviteIdentifier !== null}
+                onClose={closeInvitePreview}
+                preview={invitePreview}
+                loading={invitePreviewLoading}
+            />
         </SceneContent>
+    )
+}
+
+function InvitePreviewModal({
+    isOpen,
+    onClose,
+    preview,
+    loading,
+}: {
+    isOpen: boolean
+    onClose: () => void
+    preview: PreviewInviteResultApi | null
+    loading: boolean
+}): JSX.Element {
+    return (
+        <LemonModal isOpen={isOpen} onClose={onClose} title="Invite email preview" width="90vw">
+            {loading && !preview ? (
+                <div className="space-y-3 h-[70vh]">
+                    <LemonSkeleton.Text className="h-4 w-[50%]" />
+                    <LemonSkeleton className="h-[60vh]" />
+                </div>
+            ) : preview ? (
+                <div className="flex flex-col gap-3">
+                    <div className="flex flex-col gap-1">
+                        <div className="text-xs font-semibold uppercase text-muted tracking-wide">Subject</div>
+                        <div className="text-sm font-medium">{preview.subject}</div>
+                        <div className="text-sm text-muted">
+                            To {preview.user_name}
+                            {preview.email ? ` <${preview.email}>` : ''}
+                        </div>
+                        <div className="flex items-center gap-2 flex-wrap">
+                            {!preview.emailable && <LemonTag type="warning">No email address — can't be sent</LemonTag>}
+                            {preview.is_preview_link && (
+                                <LemonTag type="default">Link is a placeholder until invites are sent</LemonTag>
+                            )}
+                        </div>
+                    </div>
+                    <iframe
+                        srcDoc={preview.html}
+                        sandbox=""
+                        title="Invite email preview"
+                        className="w-full h-[70vh] border rounded"
+                    />
+                </div>
+            ) : (
+                <div className="text-muted h-[70vh]">Couldn't load the preview. Try again.</div>
+            )}
+        </LemonModal>
     )
 }
 
@@ -361,10 +422,14 @@ function PersonRow({
     identifier,
     topicId,
     hasResponded,
+    onPreview,
+    previewLoading,
 }: {
     identifier: string
     topicId: string
     hasResponded: boolean
+    onPreview: () => void
+    previewLoading: boolean
 }): JSX.Element {
     return (
         <Link
@@ -377,6 +442,19 @@ function PersonRow({
                         <div className="font-medium text-sm">{identifier}</div>
                     </div>
                     <div className="flex items-center gap-2">
+                        <LemonButton
+                            type="tertiary"
+                            size="xsmall"
+                            icon={<IconEye />}
+                            loading={previewLoading}
+                            onClick={(e) => {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                onPreview()
+                            }}
+                            data-attr="user-interview-preview-invite"
+                            tooltip="Preview the invite email this person would receive"
+                        />
                         <InterviewLinkCopyButton identifier={identifier} topicId={topicId} />
                         {hasResponded ? (
                             <LemonTag type="success" icon={<IconCheck />}>

--- a/products/user_interviews/frontend/UserInterview.tsx
+++ b/products/user_interviews/frontend/UserInterview.tsx
@@ -242,7 +242,10 @@ function InvitePreviewModal({
 }): JSX.Element {
     return (
         <LemonModal isOpen={isOpen} onClose={onClose} title="Invite email preview" width="90vw">
-            {loading && !preview ? (
+            {/* Gate on `loading` alone (not `loading && !preview`): while a newly opened person's
+                preview loads, kea-loaders still holds the previous person's value, so keying off
+                `loading` shows the skeleton instead of the stale email. */}
+            {loading ? (
                 <div className="space-y-3 h-[70vh]">
                     <LemonSkeleton.Text className="h-4 w-[50%]" />
                     <LemonSkeleton className="h-[60vh]" />

--- a/products/user_interviews/frontend/userInterviewLogic.ts
+++ b/products/user_interviews/frontend/userInterviewLogic.ts
@@ -13,6 +13,7 @@ import {
     getUserInterviewTopicsLinksCsvCreateUrl,
     userInterviewTopicsGenerateLinksCreate,
     userInterviewTopicsIntervieweesList,
+    userInterviewTopicsPreviewInviteCreate,
     userInterviewTopicsRetrieve,
     userInterviewTopicsTestLinkRetrieve,
     userInterviewsList,
@@ -20,6 +21,7 @@ import {
 import type {
     IntervieweeContextApi,
     InterviewLinkApi,
+    PreviewInviteResultApi,
     TestInterviewLinkApi,
     UserInterviewApi,
     UserInterviewTopicApi,
@@ -94,10 +96,21 @@ export const userInterviewLogic = kea<userInterviewLogicType>([
                 return await userInterviewTopicsTestLinkRetrieve(projectId, props.id)
             },
         },
+        invitePreview: {
+            __default: null as PreviewInviteResultApi | null,
+            loadInvitePreview: async (identifier: string): Promise<PreviewInviteResultApi> => {
+                const projectId = String(teamLogic.values.currentTeamId)
+                return await userInterviewTopicsPreviewInviteCreate(projectId, props.id, {
+                    interviewee_identifier: identifier,
+                })
+            },
+        },
     })),
     actions({
         exportLinksCsv: true,
         exportLinksCsvDone: true,
+        openInvitePreview: (identifier: string) => ({ identifier }),
+        closeInvitePreview: true,
     }),
     reducers({
         linksLoadFailed: [
@@ -114,8 +127,18 @@ export const userInterviewLogic = kea<userInterviewLogicType>([
                 exportLinksCsvDone: () => false,
             },
         ],
+        previewInviteIdentifier: [
+            null as string | null,
+            {
+                openInvitePreview: (_, { identifier }) => identifier,
+                closeInvitePreview: () => null,
+            },
+        ],
     }),
     listeners(({ props, values, actions }) => ({
+        openInvitePreview: ({ identifier }) => {
+            actions.loadInvitePreview(identifier)
+        },
         exportLinksCsv: async () => {
             const projectId = String(teamLogic.values.currentTeamId)
             try {


### PR DESCRIPTION
## Problem

Part **4 of 6** of the stack splitting #61263 (stacked on #61283). Surface the preview endpoint in the web UI.

## Changes

- A per-row **Preview invite** button (`IconEye`, `data-attr` for a previewed→sent funnel) on the topic page's people list, double-submission-guarded via the loader's loading state.
- A `LemonModal` showing the rendered subject + recipient + the email HTML in a sandboxed `<iframe srcDoc … sandbox="">`, with hints when the link is a placeholder or the person isn't emailable.
- Preview action / loader / reducer wired into `userInterviewLogic` against the generated `userInterviewTopicsPreviewInviteCreate`.

Merges cleanly with #61239 (kept `orderedIdentifiers` ordering, added the preview props to `PersonRow`).

## How did you test this code?

I'm an agent (PostHog Code). Frontend-only; consumes the generated client from part 3. Local full-frontend `tsc` can't run here (kea-typegen artifacts aren't generated in this checkout — affects all products); CI runs typegen first. No backend codegen.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). Stacked on the preview-backend PR. Follows the EmailTemplater `srcDoc` + `sandbox=""` preview pattern. Requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*