### PR TITLE
feat(user_interviews): preview an invite from the in-app Max agent

### DIFF
--- a/ee/hogai/core/agent_modes/presets/test/test_user_interview_preset.py
+++ b/ee/hogai/core/agent_modes/presets/test/test_user_interview_preset.py
@@ -32,7 +32,7 @@ class TestUserInterviewAgentToolkit(TestCase):
             tool_class.__name__ for tool_class in _make_toolkit(ReadOnlyUserInterviewAgentToolkit).tools
         ]
 
-        self.assertEqual(tool_class_names, ["AnalyzeUserInterviewsTool"])
+        self.assertEqual(tool_class_names, ["AnalyzeUserInterviewsTool", "PreviewUserInterviewInviteTool"])
 
     def test_toolkit_has_trajectory_examples(self):
         examples = UserInterviewAgentToolkit.POSITIVE_TODO_EXAMPLES

--- a/ee/hogai/core/agent_modes/presets/user_interview.py
+++ b/ee/hogai/core/agent_modes/presets/user_interview.py
@@ -84,9 +84,17 @@ class UserInterviewAgentToolkit(AgentToolkit):
 
     @property
     def tools(self) -> list[type["MaxTool"]]:
-        from products.user_interviews.backend.facade.api import AnalyzeUserInterviewsTool, CreateUserInterviewTopicTool
+        from products.user_interviews.backend.facade.api import (
+            AnalyzeUserInterviewsTool,
+            CreateUserInterviewTopicTool,
+            PreviewUserInterviewInviteTool,
+        )
 
-        tools: list[type[MaxTool]] = [CreateUserInterviewTopicTool, AnalyzeUserInterviewsTool]
+        tools: list[type[MaxTool]] = [
+            CreateUserInterviewTopicTool,
+            AnalyzeUserInterviewsTool,
+            PreviewUserInterviewInviteTool,
+        ]
         return tools
 
 
@@ -98,13 +106,16 @@ user_interview_agent = AgentModeDefinition(
 
 
 class ReadOnlyUserInterviewAgentToolkit(AgentToolkit):
-    """User interview toolkit for subagents — only includes AnalyzeUserInterviewsTool (read-only)."""
+    """User interview toolkit for subagents — only includes read-only tools."""
 
     @property
     def tools(self) -> list[type["MaxTool"]]:
-        from products.user_interviews.backend.facade.api import AnalyzeUserInterviewsTool
+        from products.user_interviews.backend.facade.api import (
+            AnalyzeUserInterviewsTool,
+            PreviewUserInterviewInviteTool,
+        )
 
-        return [AnalyzeUserInterviewsTool]
+        return [AnalyzeUserInterviewsTool, PreviewUserInterviewInviteTool]
 
 
 READ_ONLY_USER_INTERVIEW_MODE_DESCRIPTION = (

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3802,6 +3802,7 @@
                 "fix_hogql_query",
                 "analyze_user_interviews",
                 "create_user_interview_topic",
+                "preview_user_interview_invite",
                 "create_hog_transformation_function",
                 "create_hog_function_filters",
                 "create_hog_function_inputs",

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -455,6 +455,7 @@ export type AssistantTool =
     | 'fix_hogql_query'
     | 'analyze_user_interviews'
     | 'create_user_interview_topic'
+    | 'preview_user_interview_invite'
     | 'create_hog_transformation_function'
     | 'create_hog_function_filters'
     | 'create_hog_function_inputs'

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -589,7 +589,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
     preview_user_interview_invite: {
         name: 'Preview interview invite',
         description:
-            'Preview the invitation email a targeted interviewee would receive — subject and body — without sending',
+            'Preview interview invite — see the subject and body of the invitation email a targeted interviewee would receive, without sending',
         product: Scene.UserInterviews,
         flag: FEATURE_FLAGS.USER_INTERVIEWS,
         icon: iconForType('user_interview'),

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -586,6 +586,21 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
             return 'Setting up interview topic...'
         },
     },
+    preview_user_interview_invite: {
+        name: 'Preview interview invite',
+        description:
+            'Preview the invitation email a targeted interviewee would receive — subject and body — without sending',
+        product: Scene.UserInterviews,
+        flag: FEATURE_FLAGS.USER_INTERVIEWS,
+        icon: iconForType('user_interview'),
+        modes: [AgentMode.UserInterview],
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Previewed interview invite'
+            }
+            return 'Previewing interview invite...'
+        },
+    },
     create_hog_function_filters: {
         name: 'Set up function filters',
         description: 'Set up function filters for quick pipeline configuration',

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -749,6 +749,7 @@ class AssistantTool(StrEnum):
     FIX_HOGQL_QUERY = "fix_hogql_query"
     ANALYZE_USER_INTERVIEWS = "analyze_user_interviews"
     CREATE_USER_INTERVIEW_TOPIC = "create_user_interview_topic"
+    PREVIEW_USER_INTERVIEW_INVITE = "preview_user_interview_invite"
     CREATE_HOG_TRANSFORMATION_FUNCTION = "create_hog_transformation_function"
     CREATE_HOG_FUNCTION_FILTERS = "create_hog_function_filters"
     CREATE_HOG_FUNCTION_INPUTS = "create_hog_function_inputs"

--- a/products/user_interviews/backend/facade/api.py
+++ b/products/user_interviews/backend/facade/api.py
@@ -19,12 +19,17 @@ from uuid import UUID
 from products.user_interviews.backend import logic
 from products.user_interviews.backend.classification import derive_auto_classifications
 from products.user_interviews.backend.facade.contracts import IntervieweeIdentity
-from products.user_interviews.backend.max_tools import AnalyzeUserInterviewsTool, CreateUserInterviewTopicTool
+from products.user_interviews.backend.max_tools import (
+    AnalyzeUserInterviewsTool,
+    CreateUserInterviewTopicTool,
+    PreviewUserInterviewInviteTool,
+)
 
 __all__ = [
     "AnalyzeUserInterviewsTool",
     "CreateUserInterviewTopicTool",
     "IntervieweeIdentity",
+    "PreviewUserInterviewInviteTool",
     "derive_auto_classifications",
     "has_replied",
     "parse_interviewee_identifier",

--- a/products/user_interviews/backend/max_tools.py
+++ b/products/user_interviews/backend/max_tools.py
@@ -360,7 +360,7 @@ class PreviewUserInterviewInviteTool(MaxTool):
 
         try:
             topic = await UserInterviewTopic.objects.aget(team=self._team, id=topic_id)
-        except (UserInterviewTopic.DoesNotExist, ValueError):
+        except (UserInterviewTopic.DoesNotExist, DjangoValidationError, ValueError):
             return "No user interview topic found with that ID.", {
                 "error": "not_found",
                 "error_message": f"No user interview topic {topic_id} exists for this team.",

--- a/products/user_interviews/backend/max_tools.py
+++ b/products/user_interviews/backend/max_tools.py
@@ -379,17 +379,17 @@ class PreviewUserInterviewInviteTool(MaxTool):
             }
 
         emailable_note = (
-            "" if payload["emailable"] else " This interviewee has no email address, so they can't be emailed."
+            "" if payload["emailable"] else "\n\n(This interviewee has no email address, so they can't be emailed.)"
         )
-        link_note = (
-            " The link shown is an illustrative placeholder — a real per-recipient link is created when invites are sent."
-            if payload["is_preview_link"]
-            else ""
-        )
+        # Include the intro copy in the text result so the body can be proofread from the chat itself,
+        # not only via the artifact renderer. The greeting + interview-link button are fixed boilerplate.
+        body_preview = (topic.invite_message or "").strip() or "(default copy — no custom intro message set)"
         content = (
             f"Invite preview for **{payload['interviewee_identifier']}** "
             f"(greeting addressed to {payload['user_name']}):\n\n"
             f"**Subject:** {payload['subject']}\n\n"
-            f"The full rendered email is shown below.{emailable_note}{link_note}"
+            f"**Intro message:**\n{body_preview}\n\n"
+            f"A fixed greeting and an interview-link button are appended below this intro in the actual email "
+            f"(the link is minted per recipient when invites are sent).{emailable_note}"
         )
         return content, payload

--- a/products/user_interviews/backend/max_tools.py
+++ b/products/user_interviews/backend/max_tools.py
@@ -368,7 +368,6 @@ class PreviewUserInterviewInviteTool(MaxTool):
 
         payload = await sync_to_async(resolve_invite_preview)(
             topic=topic,
-            team=self._team,
             interviewee_identifier=interviewee_identifier,
         )
         if payload is None:

--- a/products/user_interviews/backend/max_tools.py
+++ b/products/user_interviews/backend/max_tools.py
@@ -4,6 +4,7 @@ from typing import Any
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 
+from asgiref.sync import sync_to_async
 from openai import OpenAI
 from pydantic import BaseModel, ConfigDict, Field
 from rest_framework.serializers import ValidationError as DRFValidationError
@@ -14,7 +15,7 @@ from posthog.scopes import APIScopeObject
 
 from ee.hogai.tool import MaxTool
 
-from .invite_email import validate_invite_message, validate_invite_subject
+from .invite_email import resolve_invite_preview, validate_invite_message, validate_invite_subject
 from .models import EmailWithDisplayNameValidator, UserInterview, UserInterviewTopic
 
 
@@ -317,3 +318,79 @@ class CreateUserInterviewTopicTool(MaxTool):
             "interviewee_distinct_id_count": len(distinct_ids),
             "question_count": len(questions),
         }
+
+
+class PreviewUserInterviewInviteArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    topic_id: str = Field(
+        description="The ID of the user interview topic to preview an invitation email for.",
+    )
+    interviewee_identifier: str = Field(
+        default="",
+        description=(
+            "Optional email address or PostHog distinct ID of a targeted interviewee to render the "
+            "preview for. Leave empty to preview for the first targeted interviewee on the topic."
+        ),
+    )
+
+
+class PreviewUserInterviewInviteTool(MaxTool):
+    name: str = "preview_user_interview_invite"
+    description: str = (
+        "Preview the invitation email a specific interviewee would receive for a user interview topic "
+        "— the personalized subject and body — without sending anything or creating any links."
+    )
+    context_prompt_template: str = (
+        "When the user wants to see, check, or proofread what the interview invitation email looks "
+        "like for a topic (or for a particular person), use `preview_user_interview_invite`."
+    )
+    args_schema: type[BaseModel] = PreviewUserInterviewInviteArgs
+
+    def get_required_resource_access(self) -> list[tuple[APIScopeObject, AccessControlLevel]]:
+        return [("user_interview", "viewer")]
+
+    async def _arun_impl(self, topic_id: str = "", interviewee_identifier: str = "") -> tuple[str, Any]:
+        topic_id = (topic_id or "").strip()
+        if not topic_id:
+            return "A topic_id is required to preview an invite.", {
+                "error": "validation_failed",
+                "error_message": "Provide the topic_id of the user interview topic to preview.",
+            }
+
+        try:
+            topic = await UserInterviewTopic.objects.aget(team=self._team, id=topic_id)
+        except (UserInterviewTopic.DoesNotExist, ValueError):
+            return "No user interview topic found with that ID.", {
+                "error": "not_found",
+                "error_message": f"No user interview topic {topic_id} exists for this team.",
+            }
+
+        payload = await sync_to_async(resolve_invite_preview)(
+            topic=topic,
+            team=self._team,
+            interviewee_identifier=interviewee_identifier,
+        )
+        if payload is None:
+            return "This topic has no interviewees to preview yet.", {
+                "error": "no_interviewees",
+                "error_message": (
+                    "Add interviewee_emails or interviewee_distinct_ids to the topic before previewing an invite."
+                ),
+            }
+
+        emailable_note = (
+            "" if payload["emailable"] else " This interviewee has no email address, so they can't be emailed."
+        )
+        link_note = (
+            " The link shown is an illustrative placeholder — a real per-recipient link is created when invites are sent."
+            if payload["is_preview_link"]
+            else ""
+        )
+        content = (
+            f"Invite preview for **{payload['interviewee_identifier']}** "
+            f"(greeting addressed to {payload['user_name']}):\n\n"
+            f"**Subject:** {payload['subject']}\n\n"
+            f"The full rendered email is shown below.{emailable_note}{link_note}"
+        )
+        return content, payload

--- a/products/user_interviews/backend/test_max_tools.py
+++ b/products/user_interviews/backend/test_max_tools.py
@@ -245,6 +245,7 @@ class TestPreviewUserInterviewInviteTool(BaseTest):
         [
             ("missing_topic_id", {"topic_id": "  "}, "validation_failed"),
             ("unknown_topic_id", {"topic_id": "01890000-0000-0000-0000-000000000000"}, "not_found"),
+            ("malformed_topic_id", {"topic_id": "not-a-uuid"}, "not_found"),
         ]
     )
     async def test_arun_impl_rejects_bad_topic(self, _name, kwargs, expected_error):

--- a/products/user_interviews/backend/test_max_tools.py
+++ b/products/user_interviews/backend/test_max_tools.py
@@ -220,6 +220,27 @@ class TestPreviewUserInterviewInviteTool(BaseTest):
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
+    async def test_arun_impl_previews_for_specific_identifier(self):
+        topic = await self._create_topic(
+            interviewee_emails=["Alex <alex@example.com>", "jordan@example.com"], interviewee_distinct_ids=[]
+        )
+        _content, artifact = await self._tool()._arun_impl(
+            topic_id=str(topic.id), interviewee_identifier="jordan@example.com"
+        )
+        assert artifact["interviewee_identifier"] == "jordan@example.com"
+        assert artifact["email"] == "jordan@example.com"
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_arun_impl_rejects_non_targeted_identifier(self):
+        topic = await self._create_topic()
+        _content, artifact = await self._tool()._arun_impl(
+            topic_id=str(topic.id), interviewee_identifier="not-targeted@example.com"
+        )
+        assert artifact["error"] == "no_interviewees"
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
     @parameterized.expand(
         [
             ("missing_topic_id", {"topic_id": "  "}, "validation_failed"),

--- a/products/user_interviews/backend/test_max_tools.py
+++ b/products/user_interviews/backend/test_max_tools.py
@@ -7,7 +7,7 @@ from parameterized import parameterized
 
 from products.user_interviews.backend.models import UserInterviewTopic
 
-from .max_tools import CreateUserInterviewTopicTool
+from .max_tools import CreateUserInterviewTopicTool, PreviewUserInterviewInviteTool
 
 
 class TestCreateUserInterviewTopicTool(BaseTest):
@@ -177,3 +177,62 @@ class TestCreateUserInterviewTopicTool(BaseTest):
         assert artifact["error"] == "validation_failed"
         assert "invite" in content.lower()
         assert not await sync_to_async(UserInterviewTopic.objects.filter(team=self.team).exists)()
+
+
+class TestPreviewUserInterviewInviteTool(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self._config: RunnableConfig = {"configurable": {"team": self.team, "user": self.user}}
+
+    def _tool(self) -> PreviewUserInterviewInviteTool:
+        return PreviewUserInterviewInviteTool(team=self.team, user=self.user, config=self._config)
+
+    async def _create_topic(self, **overrides) -> UserInterviewTopic:
+        defaults: dict = {
+            "team": self.team,
+            "created_by": self.user,
+            "topic": "Session replay adoption",
+            "interviewee_emails": ["Alex <alex@example.com>"],
+            "interviewee_distinct_ids": [],
+            "invite_subject": "Quick chat?",
+            "invite_message": "Hey, got a sec?",
+        }
+        defaults.update(overrides)
+        return await UserInterviewTopic.objects.acreate(**defaults)
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_arun_impl_previews_invite(self):
+        topic = await self._create_topic()
+        content, artifact = await self._tool()._arun_impl(topic_id=str(topic.id))
+        assert "Quick chat?" in content
+        assert artifact["subject"] == "Quick chat?"
+        assert artifact["emailable"] is True
+        assert "Hey, got a sec?" in artifact["html"]
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_arun_impl_distinct_id_only_is_not_emailable(self):
+        topic = await self._create_topic(interviewee_emails=[], interviewee_distinct_ids=["distinct-1"])
+        _content, artifact = await self._tool()._arun_impl(topic_id=str(topic.id))
+        assert artifact["emailable"] is False
+        assert artifact["email"] is None
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    @parameterized.expand(
+        [
+            ("missing_topic_id", {"topic_id": "  "}, "validation_failed"),
+            ("unknown_topic_id", {"topic_id": "01890000-0000-0000-0000-000000000000"}, "not_found"),
+        ]
+    )
+    async def test_arun_impl_rejects_bad_topic(self, _name, kwargs, expected_error):
+        _content, artifact = await self._tool()._arun_impl(**kwargs)
+        assert artifact["error"] == expected_error
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_arun_impl_no_interviewees(self):
+        topic = await self._create_topic(interviewee_emails=[], interviewee_distinct_ids=[])
+        _content, artifact = await self._tool()._arun_impl(topic_id=str(topic.id))
+        assert artifact["error"] == "no_interviewees"


### PR DESCRIPTION
## Problem

Part **6 of 6** (top of the stack) splitting #61263 (stacked on #61286). Let the in-app Max agent preview an invite too.

## Changes

- `PreviewUserInterviewInviteTool` (`preview_user_interview_invite`, read-only `user_interview` viewer access): renders an invite preview for a topic, returning the subject + body as content and the full payload as `ui_payload`.
- Wired through the product facade and both user-interview agent toolkits; registered in the `AssistantTool` schema (regenerated `posthog/schema.py`).

## How did you test this code?

I'm an agent (PostHog Code). `hogli test` on `test_max_tools.py` — 22 pass (incl. the preview tool: render, distinct-id not-emailable, bad/missing topic, no-interviewees). `pnpm schema:build` + `ruff` clean.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). Top of the 6-PR stack split out of #61263. Reuses `resolve_invite_preview` from the preview-backend PR. Requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*