### PR TITLE
fix(slack-app): post org mismatch reply to thread instead of ephemeral

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -466,6 +466,7 @@ def resolve_slack_user(
                         f"Sorry, I couldn't find {slack_email} in the {organization_name} organization. "
                         f"Please make sure you're a member of that PostHog organization."
                     ),
+                    prefer_thread_message=True,
                 )
             return None
 

--- a/products/slack_app/backend/tests/test_resolve_slack_user.py
+++ b/products/slack_app/backend/tests/test_resolve_slack_user.py
@@ -64,8 +64,11 @@ class TestResolveSlackUser:
         result = resolve_slack_user(slack, self.integration, "U123", "C001", "1234.5678")
 
         assert result is None
-        call_text = mock_client.chat_postEphemeral.call_args.kwargs["text"]
-        assert "stranger@example.com" in call_text
+        mock_client.chat_postEphemeral.assert_not_called()
+        mock_client.chat_postMessage.assert_called_once()
+        call_kwargs = mock_client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["thread_ts"] == "1234.5678"
+        assert "stranger@example.com" in call_kwargs["text"]
 
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.UserPermissions")


### PR DESCRIPTION
## Problem

When a Slack user mentions the PostHog app but their Slack email doesn't match any member of the connected PostHog organization, we replied with an ephemeral message. Only the mentioning user could see it, which left other thread participants wondering why PostHog never responded.

## Changes

Switch the "couldn't find <email> in <org>" reply in `resolve_slack_user` to a regular thread message so it's visible to everyone in the thread, matching the existing behavior for the "no email in Slack profile" case.

## How did you test this code?

Agent-authored. I (the agent) only ran the automated test for this path:

- `products/slack_app/backend/tests/test_resolve_slack_user.py::TestResolveSlackUser::test_no_org_membership` — updated to assert `chat_postMessage` with `thread_ts` instead of `chat_postEphemeral`. Passes locally.

## Showcase

<img width="600" height="229" alt="Screenshot 2026-06-02 at 23 56 37" src="https://github.com/user-attachments/assets/920f4699-494c-4c52-9a44-97b2e277b44e" />


## 🤖 Agent context

Claude Code (Opus 4.7). One-line behavior change at `products/slack_app/backend/api.py:469` plus the matching test update. Considered making this configurable per feedback case but kept it minimal — the other org-not-found-shaped error (missing Slack email) already posts to thread, so this aligns the two paths.