### PR TITLE
fix(agents): stop one bad live spec from breaking the cron sweep

### DIFF
--- a/products/agent_stack/backend/spec_schema.py
+++ b/products/agent_stack/backend/spec_schema.py
@@ -90,13 +90,30 @@ _AGENT_SPEC_JSON_SCHEMA_RAW: dict[str, Any] = {
                         "type": "object",
                         "properties": {
                             "type": {"type": "string", "const": "cron"},
+                            # Mirror of the node cron config (services/agent-shared
+                            # spec.ts, added by the cron scheduler PR #61028). The
+                            # upstream Django mirror lagged at {schedule, timezone};
+                            # synced here so cron-triggered agents validate.
                             "config": {
                                 "type": "object",
                                 "properties": {
-                                    "schedule": {"type": "string"},
+                                    "name": {"type": "string", "minLength": 1},
+                                    "schedule": {"type": "string", "minLength": 1},
                                     "timezone": {"default": "UTC", "type": "string"},
+                                    "prompt": {"type": "string", "minLength": 1, "maxLength": 4096},
+                                    "external_key": {"type": "string"},
+                                    "catch_up": {
+                                        "enum": ["all", "most_recent", "skip"],
+                                        "default": "most_recent",
+                                    },
+                                    "max_catch_up_age_seconds": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 604800,
+                                        "default": 3600,
+                                    },
                                 },
-                                "required": ["schedule", "timezone"],
+                                "required": ["name", "schedule", "prompt"],
                                 "additionalProperties": False,
                             },
                         },

--- a/products/agent_stack/backend/test_spec_schema.py
+++ b/products/agent_stack/backend/test_spec_schema.py
@@ -68,7 +68,9 @@ def _with_auth(spec: dict) -> dict:
             "cron_omits_timezone",
             {
                 "model": "x",
-                "triggers": [{"type": "cron", "config": {"schedule": "0 * * * *"}}],
+                "triggers": [
+                    {"type": "cron", "config": {"name": "hourly", "schedule": "0 * * * *", "prompt": "run it"}}
+                ],
             },
         ),
         (
@@ -150,6 +152,20 @@ def test_validate_spec_accepts_valid_payloads(name: str, spec: dict) -> None:
         (
             "cron_missing_schedule",
             {"model": "x", "triggers": [{"type": "cron", "config": {"timezone": "UTC"}}]},
+            "triggers.0",
+        ),
+        # The exact drift that poisoned the cron sweep: a cron trigger without
+        # the now-required `prompt` (or `name`). The node schema rejects these
+        # at freeze; the Django mirror must reject them at write so a poisoned
+        # spec never reaches the DB in the first place.
+        (
+            "cron_missing_prompt",
+            {"model": "x", "triggers": [{"type": "cron", "config": {"name": "sweep", "schedule": "0 9 * * *"}}]},
+            "triggers.0",
+        ),
+        (
+            "cron_missing_name",
+            {"model": "x", "triggers": [{"type": "cron", "config": {"schedule": "0 9 * * *", "prompt": "go"}}]},
             "triggers.0",
         ),
     ],

--- a/products/agent_stack/frontend/generated/api.schemas.ts
+++ b/products/agent_stack/frontend/generated/api.schemas.ts
@@ -168,8 +168,23 @@ export type AgentRevisionApiSpecTriggersItem =
     | {
           type: 'cron'
           config: {
+              /** @minLength 1 */
+              name: string
+              /** @minLength 1 */
               schedule: string
-              timezone: string
+              timezone?: string
+              /**
+               * @minLength 1
+               * @maxLength 4096
+               */
+              prompt: string
+              external_key?: string
+              catch_up?: 'all' | 'most_recent' | 'skip'
+              /**
+               * @minimum 1
+               * @maximum 604800
+               */
+              max_catch_up_age_seconds?: number
           }
       }
     | {
@@ -347,8 +362,23 @@ export type PatchedAgentRevisionApiSpecTriggersItem =
     | {
           type: 'cron'
           config: {
+              /** @minLength 1 */
+              name: string
+              /** @minLength 1 */
               schedule: string
-              timezone: string
+              timezone?: string
+              /**
+               * @minLength 1
+               * @maxLength 4096
+               */
+              prompt: string
+              external_key?: string
+              catch_up?: 'all' | 'most_recent' | 'skip'
+              /**
+               * @minimum 1
+               * @maximum 604800
+               */
+              max_catch_up_age_seconds?: number
           }
       }
     | {

--- a/products/agent_stack/frontend/generated/api.zod.ts
+++ b/products/agent_stack/frontend/generated/api.zod.ts
@@ -99,7 +99,14 @@ URLs (nested under an application):
  */
 export const agentApplicationsRevisionsCreateBodyBundleUriDefault = ``
 export const agentApplicationsRevisionsCreateBodySpecTriggersItemOneConfigMentionOnlyDefault = false
+
 export const agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigTimezoneDefault = `UTC`
+export const agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigPromptMax = 4096
+
+export const agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigCatchUpDefault = `most_recent`
+export const agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsDefault = 3600
+export const agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsMax = 604800
+
 export const agentApplicationsRevisionsCreateBodySpecTriggersItemFourConfigRequireAuthDefault = true
 export const agentApplicationsRevisionsCreateBodySpecTriggersItemFiveConfigDefault = {}
 export const agentApplicationsRevisionsCreateBodySpecTriggersDefault = []
@@ -170,11 +177,31 @@ export const AgentApplicationsRevisionsCreateBody = /* @__PURE__ */ zod.object({
                         zod.object({
                             type: zod.literal('cron'),
                             config: zod.object({
-                                schedule: zod.string(),
+                                name: zod.string().min(1),
+                                schedule: zod.string().min(1),
                                 timezone: zod
                                     .string()
                                     .default(
                                         agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigTimezoneDefault
+                                    ),
+                                prompt: zod
+                                    .string()
+                                    .min(1)
+                                    .max(agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigPromptMax),
+                                external_key: zod.string().optional(),
+                                catch_up: zod
+                                    .enum(['all', 'most_recent', 'skip'])
+                                    .default(
+                                        agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigCatchUpDefault
+                                    ),
+                                max_catch_up_age_seconds: zod
+                                    .number()
+                                    .min(1)
+                                    .max(
+                                        agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsMax
+                                    )
+                                    .default(
+                                        agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsDefault
                                     ),
                             }),
                         }),
@@ -337,7 +364,14 @@ ready/live the spec is frozen — change requires a new revision.
  */
 export const agentApplicationsRevisionsUpdateBodyBundleUriDefault = ``
 export const agentApplicationsRevisionsUpdateBodySpecTriggersItemOneConfigMentionOnlyDefault = false
+
 export const agentApplicationsRevisionsUpdateBodySpecTriggersItemThreeConfigTimezoneDefault = `UTC`
+export const agentApplicationsRevisionsUpdateBodySpecTriggersItemThreeConfigPromptMax = 4096
+
+export const agentApplicationsRevisionsUpdateBodySpecTriggersItemThreeConfigCatchUpDefault = `most_recent`
+export const agentApplicationsRevisionsUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsDefault = 3600
+export const agentApplicationsRevisionsUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsMax = 604800
+
 export const agentApplicationsRevisionsUpdateBodySpecTriggersItemFourConfigRequireAuthDefault = true
 export const agentApplicationsRevisionsUpdateBodySpecTriggersItemFiveConfigDefault = {}
 export const agentApplicationsRevisionsUpdateBodySpecTriggersDefault = []
@@ -408,11 +442,31 @@ export const AgentApplicationsRevisionsUpdateBody = /* @__PURE__ */ zod.object({
                         zod.object({
                             type: zod.literal('cron'),
                             config: zod.object({
-                                schedule: zod.string(),
+                                name: zod.string().min(1),
+                                schedule: zod.string().min(1),
                                 timezone: zod
                                     .string()
                                     .default(
                                         agentApplicationsRevisionsUpdateBodySpecTriggersItemThreeConfigTimezoneDefault
+                                    ),
+                                prompt: zod
+                                    .string()
+                                    .min(1)
+                                    .max(agentApplicationsRevisionsUpdateBodySpecTriggersItemThreeConfigPromptMax),
+                                external_key: zod.string().optional(),
+                                catch_up: zod
+                                    .enum(['all', 'most_recent', 'skip'])
+                                    .default(
+                                        agentApplicationsRevisionsUpdateBodySpecTriggersItemThreeConfigCatchUpDefault
+                                    ),
+                                max_catch_up_age_seconds: zod
+                                    .number()
+                                    .min(1)
+                                    .max(
+                                        agentApplicationsRevisionsUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsMax
+                                    )
+                                    .default(
+                                        agentApplicationsRevisionsUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsDefault
                                     ),
                             }),
                         }),
@@ -598,7 +652,14 @@ URLs (nested under an application):
  */
 export const agentApplicationsRevisionsPartialUpdateBodyBundleUriDefault = ``
 export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemOneConfigMentionOnlyDefault = false
+
 export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigTimezoneDefault = `UTC`
+export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigPromptMax = 4096
+
+export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigCatchUpDefault = `most_recent`
+export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsDefault = 3600
+export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsMax = 604800
+
 export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemFourConfigRequireAuthDefault = true
 export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemFiveConfigDefault = {}
 export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersDefault = []
@@ -669,11 +730,33 @@ export const AgentApplicationsRevisionsPartialUpdateBody = /* @__PURE__ */ zod.o
                         zod.object({
                             type: zod.literal('cron'),
                             config: zod.object({
-                                schedule: zod.string(),
+                                name: zod.string().min(1),
+                                schedule: zod.string().min(1),
                                 timezone: zod
                                     .string()
                                     .default(
                                         agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigTimezoneDefault
+                                    ),
+                                prompt: zod
+                                    .string()
+                                    .min(1)
+                                    .max(
+                                        agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigPromptMax
+                                    ),
+                                external_key: zod.string().optional(),
+                                catch_up: zod
+                                    .enum(['all', 'most_recent', 'skip'])
+                                    .default(
+                                        agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigCatchUpDefault
+                                    ),
+                                max_catch_up_age_seconds: zod
+                                    .number()
+                                    .min(1)
+                                    .max(
+                                        agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsMax
+                                    )
+                                    .default(
+                                        agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsDefault
                                     ),
                             }),
                         }),

--- a/services/agent-shared/src/persistence/pg-impls.test.ts
+++ b/services/agent-shared/src/persistence/pg-impls.test.ts
@@ -111,6 +111,52 @@ maybeDescribe('Postgres impls (real PG)', () => {
         await expect(store.updateSpec(rev.id, AgentSpecSchema.parse({ model: 'y' }))).rejects.toThrow(/not a draft/)
     })
 
+    it('listLiveCronRevisions skips a live spec that no longer parses (schema drift) instead of throwing', async () => {
+        if (!reachable) {
+            return
+        }
+        const store = new PgRevisionStore(pool)
+
+        // A healthy live cron agent.
+        const good = await store.createApplication({ team_id: 1, slug: 'good-cron', name: 'Good', description: '' })
+        const goodRev = await store.createRevision({
+            application_id: good.id,
+            parent_revision_id: null,
+            created_by_id: null,
+            bundle_uri: 's3://x/',
+            spec: AgentSpecSchema.parse({
+                model: 'x',
+                triggers: [{ type: 'cron', config: { name: 'sweep', schedule: '0 * * * *', prompt: 'go' } }],
+            }),
+        })
+        await store.setRevisionState(goodRev.id, 'live')
+        await store.setLiveRevision(good.id, goodRev.id)
+
+        // A live agent whose stored spec drifted out of schema: a cron trigger
+        // frozen before `prompt` was required. Create it valid, then corrupt
+        // the jsonb directly to simulate a schema tightening after it went live.
+        const bad = await store.createApplication({ team_id: 1, slug: 'bad-cron', name: 'Bad', description: '' })
+        const badRev = await store.createRevision({
+            application_id: bad.id,
+            parent_revision_id: null,
+            created_by_id: null,
+            bundle_uri: 's3://x/',
+            spec: AgentSpecSchema.parse({ model: 'x' }),
+        })
+        await pool.query(`UPDATE agent_revision SET spec = $2::jsonb WHERE id = $1`, [
+            badRev.id,
+            JSON.stringify({ triggers: [{ type: 'cron', config: { schedule: '0 9 * * *', timezone: 'UTC' } }] }),
+        ])
+        await store.setRevisionState(badRev.id, 'live')
+        await store.setLiveRevision(bad.id, badRev.id)
+
+        // The poisoned row must not take down the whole fleet read.
+        const live = await store.listLiveCronRevisions()
+        const ids = live.map((r) => r.id)
+        expect(ids).toContain(goodRev.id)
+        expect(ids).not.toContain(badRev.id)
+    })
+
     it('PgSessionQueue enqueue/claim with SKIP LOCKED across concurrent claimers', async () => {
         if (!reachable) {
             return

--- a/services/agent-shared/src/persistence/pg-revision-store.test.ts
+++ b/services/agent-shared/src/persistence/pg-revision-store.test.ts
@@ -18,21 +18,36 @@ const baseRow = {
 }
 
 describe('safeRowToRev', () => {
-    it('parses a valid spec row into a revision', () => {
-        const rev = safeRowToRev({ ...baseRow, spec: { model: 'claude-sonnet-4-6' } })
-        expect(rev).not.toBeNull()
-        expect(rev!.id).toBe(baseRow.id)
-        expect(rev!.spec.model).toBe('claude-sonnet-4-6')
+    // Schema drift is tolerated: a valid spec parses; a cron trigger frozen
+    // before `prompt`/`name` were required is rejected by the current schema
+    // and skipped (null), never thrown.
+    it.each<[string, unknown, boolean]>([
+        ['valid spec', { model: 'claude-sonnet-4-6' }, false],
+        [
+            'cron trigger missing the now-required prompt',
+            { triggers: [{ type: 'cron', config: { name: 'sweep', schedule: '0 9 * * *', timezone: 'UTC' } }] },
+            true,
+        ],
+        [
+            'cron trigger missing name',
+            { triggers: [{ type: 'cron', config: { schedule: '0 9 * * *', prompt: 'go' } }] },
+            true,
+        ],
+    ])('%s → null=%s', (_label, spec, expectNull) => {
+        const rev = safeRowToRev({ ...baseRow, spec })
+        if (expectNull) {
+            expect(rev).toBeNull()
+        } else {
+            expect(rev).not.toBeNull()
+            expect(rev!.id).toBe(baseRow.id)
+        }
     })
 
-    it('returns null (does not throw) for a drifted spec — cron trigger missing the now-required prompt', () => {
-        // The exact shape that poisoned the fleet: a cron trigger frozen before
-        // `prompt` was required, so the current schema rejects it.
-        const rev = safeRowToRev({
-            ...baseRow,
-            spec: { triggers: [{ type: 'cron', config: { name: 'sweep', schedule: '0 9 * * *', timezone: 'UTC' } }] },
-        })
-        expect(rev).toBeNull()
+    it('re-throws a non-schema error (real bug) instead of swallowing the row', () => {
+        // A genuine bug in rowToRev — not schema drift — must surface loudly, not
+        // be logged as spec_unparseable and dropped. A null created_at throws a
+        // TypeError on .toISOString(), which is not a ZodError.
+        expect(() => safeRowToRev({ ...baseRow, created_at: null as unknown as Date, spec: { model: 'x' } })).toThrow()
     })
 
     it('a mixed batch keeps the good rows and drops the bad ones', () => {

--- a/services/agent-shared/src/persistence/pg-revision-store.test.ts
+++ b/services/agent-shared/src/persistence/pg-revision-store.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure unit tests for the resilient row parsing that keeps one drifted live
+ * spec from poisoning a whole bulk read (the regression that silently stopped
+ * the cron sweep fleet-wide). No Postgres — `safeRowToRev` is a pure function.
+ */
+
+import { safeRowToRev } from './pg-revision-store'
+
+const baseRow = {
+    id: '019e8990-0000-7000-8000-000000000001',
+    application_id: '019e8990-0000-7000-8000-0000000000aa',
+    parent_revision_id: null,
+    created_by_id: null,
+    created_at: new Date('2026-06-02T00:00:00.000Z'),
+    state: 'live',
+    bundle_uri: 's3://x/',
+    bundle_sha256: null,
+}
+
+describe('safeRowToRev', () => {
+    it('parses a valid spec row into a revision', () => {
+        const rev = safeRowToRev({ ...baseRow, spec: { model: 'claude-sonnet-4-6' } })
+        expect(rev).not.toBeNull()
+        expect(rev!.id).toBe(baseRow.id)
+        expect(rev!.spec.model).toBe('claude-sonnet-4-6')
+    })
+
+    it('returns null (does not throw) for a drifted spec — cron trigger missing the now-required prompt', () => {
+        // The exact shape that poisoned the fleet: a cron trigger frozen before
+        // `prompt` was required, so the current schema rejects it.
+        const rev = safeRowToRev({
+            ...baseRow,
+            spec: { triggers: [{ type: 'cron', config: { name: 'sweep', schedule: '0 9 * * *', timezone: 'UTC' } }] },
+        })
+        expect(rev).toBeNull()
+    })
+
+    it('a mixed batch keeps the good rows and drops the bad ones', () => {
+        const rows = [
+            { ...baseRow, id: 'a', spec: { model: 'x' } },
+            {
+                ...baseRow,
+                id: 'b',
+                spec: { triggers: [{ type: 'cron', config: { name: 'n', schedule: '* * * * *' } }] },
+            },
+            { ...baseRow, id: 'c', spec: { model: 'y' } },
+        ]
+        const kept = rows.map(safeRowToRev).filter((r): r is NonNullable<typeof r> => r !== null)
+        expect(kept.map((r) => r.id)).toEqual(['a', 'c'])
+    })
+})

--- a/services/agent-shared/src/persistence/pg-revision-store.ts
+++ b/services/agent-shared/src/persistence/pg-revision-store.ts
@@ -5,6 +5,7 @@
 
 import type { Pool } from 'pg'
 import { v4 as uuidv4 } from 'uuid'
+import { ZodError } from 'zod'
 
 import { createLogger } from '../runtime/logger'
 import { AgentApplication, AgentRevision, AgentSpec, AgentSpecSchema, RevisionState } from '../spec/spec'
@@ -243,16 +244,23 @@ function rowToRev(row: RevisionRow): AgentRevision {
  * (`getRevision`) deliberately stay strict so a direct fetch surfaces the real
  * error; this tolerant variant is for the bulk/fleet reads where one bad row
  * must not take out the rest. Exported for unit testing.
+ *
+ * Only `ZodError` (schema drift) is tolerated — any other throw (a real bug in
+ * `rowToRev`, e.g. a null `created_at`) re-raises so it surfaces loudly rather
+ * than silently dropping rows across every fleet read.
  */
 export function safeRowToRev(row: RevisionRow): AgentRevision | null {
     try {
         return rowToRev(row)
     } catch (err) {
+        if (!(err instanceof ZodError)) {
+            throw err
+        }
         log.warn(
             {
                 revision_id: row.id,
                 application_id: row.application_id,
-                err: (err as Error).message,
+                err: err.message,
             },
             'agent.revision.spec_unparseable'
         )

--- a/services/agent-shared/src/persistence/pg-revision-store.ts
+++ b/services/agent-shared/src/persistence/pg-revision-store.ts
@@ -6,8 +6,11 @@
 import type { Pool } from 'pg'
 import { v4 as uuidv4 } from 'uuid'
 
+import { createLogger } from '../runtime/logger'
 import { AgentApplication, AgentRevision, AgentSpec, AgentSpecSchema, RevisionState } from '../spec/spec'
 import { NewApplication, NewRevision, RevisionStore } from './revision-store'
+
+const log = createLogger('pg-revision-store')
 
 export class PgRevisionStore implements RevisionStore {
     constructor(private readonly pool: Pool) {}
@@ -78,7 +81,7 @@ export class PgRevisionStore implements RevisionStore {
              ORDER BY created_at ASC`,
             [applicationId]
         )
-        return r.rows.map(rowToRev)
+        return parseRowsResilient(r.rows)
     }
 
     async listRevisionsByIdPrefix(applicationId: string, idPrefix: string): Promise<AgentRevision[]> {
@@ -100,7 +103,7 @@ export class PgRevisionStore implements RevisionStore {
                AND replace(lower(id::text), '-', '') LIKE $2 || '%'`,
             [applicationId, needle]
         )
-        return r.rows.map(rowToRev)
+        return parseRowsResilient(r.rows)
     }
 
     async createRevision(input: NewRevision): Promise<AgentRevision> {
@@ -174,7 +177,12 @@ export class PgRevisionStore implements RevisionStore {
              JOIN agent_application a ON a.live_revision_id = r.id
              WHERE a.archived = false`
         )
-        const revs = r.rows.map(rowToRev)
+        // Resilient parse is load-bearing here: this runs every janitor tick
+        // across the WHOLE fleet, so a single live spec that no longer parses
+        // (e.g. a field the schema later made required) must not throw and
+        // abort the entire cron sweep — one poisoned spec would silently stop
+        // every agent's cron. `parseRowsResilient` skips + logs the bad row.
+        const revs = parseRowsResilient(r.rows)
         return revs.filter((rev) => rev.spec.triggers.some((t) => t.type === 'cron'))
     }
 }
@@ -201,7 +209,7 @@ function rowToApp(row: {
     }
 }
 
-function rowToRev(row: {
+type RevisionRow = {
     id: string
     application_id: string
     parent_revision_id: string | null
@@ -211,7 +219,9 @@ function rowToRev(row: {
     bundle_uri: string
     bundle_sha256: string | null
     spec: unknown
-}): AgentRevision {
+}
+
+function rowToRev(row: RevisionRow): AgentRevision {
     return {
         id: row.id,
         application_id: row.application_id,
@@ -223,4 +233,41 @@ function rowToRev(row: {
         bundle_sha256: row.bundle_sha256,
         spec: AgentSpecSchema.parse(row.spec ?? {}),
     }
+}
+
+/**
+ * Parse a revision row, returning `null` instead of throwing when its stored
+ * spec no longer satisfies `AgentSpecSchema`. The only way a live row reaches
+ * an unparseable state is schema drift — a field the spec schema later made
+ * stricter than it was when the revision was frozen. Single-revision reads
+ * (`getRevision`) deliberately stay strict so a direct fetch surfaces the real
+ * error; this tolerant variant is for the bulk/fleet reads where one bad row
+ * must not take out the rest. Exported for unit testing.
+ */
+export function safeRowToRev(row: RevisionRow): AgentRevision | null {
+    try {
+        return rowToRev(row)
+    } catch (err) {
+        log.warn(
+            {
+                revision_id: row.id,
+                application_id: row.application_id,
+                err: (err as Error).message,
+            },
+            'agent.revision.spec_unparseable'
+        )
+        return null
+    }
+}
+
+/** Map rows through `safeRowToRev`, dropping (and logging) any that fail to parse. */
+function parseRowsResilient(rows: RevisionRow[]): AgentRevision[] {
+    const out: AgentRevision[] = []
+    for (const row of rows) {
+        const rev = safeRowToRev(row)
+        if (rev) {
+            out.push(rev)
+        }
+    }
+    return out
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7648,8 +7648,23 @@ export namespace Schemas {
     } | {
       type: 'cron';
       config: {
+      /** @minLength 1 */
+      name: string;
+      /** @minLength 1 */
       schedule: string;
-      timezone: string;
+      timezone?: string;
+      /**
+         * @minLength 1
+         * @maxLength 4096
+         */
+      prompt: string;
+      external_key?: string;
+      catch_up?: 'all' | 'most_recent' | 'skip';
+      /**
+         * @minimum 1
+         * @maximum 604800
+         */
+      max_catch_up_age_seconds?: number;
     };
     } | {
       type: 'chat';
@@ -28356,8 +28371,23 @@ export namespace Schemas {
     } | {
       type: 'cron';
       config: {
+      /** @minLength 1 */
+      name: string;
+      /** @minLength 1 */
       schedule: string;
-      timezone: string;
+      timezone?: string;
+      /**
+         * @minLength 1
+         * @maxLength 4096
+         */
+      prompt: string;
+      external_key?: string;
+      catch_up?: 'all' | 'most_recent' | 'skip';
+      /**
+         * @minimum 1
+         * @maximum 604800
+         */
+      max_catch_up_age_seconds?: number;
     };
     } | {
       type: 'chat';

--- a/services/mcp/src/generated/agent_stack/api.ts
+++ b/services/mcp/src/generated/agent_stack/api.ts
@@ -151,7 +151,14 @@ export const AgentApplicationsRevisionsCreateParams = /* @__PURE__ */ zod.object
 
 export const agentApplicationsRevisionsCreateBodyBundleUriDefault = ``
 export const agentApplicationsRevisionsCreateBodySpecTriggersItemOneConfigMentionOnlyDefault = false
+
 export const agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigTimezoneDefault = `UTC`
+export const agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigPromptMax = 4096
+
+export const agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigCatchUpDefault = `most_recent`
+export const agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsDefault = 3600
+export const agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsMax = 604800
+
 export const agentApplicationsRevisionsCreateBodySpecTriggersItemFourConfigRequireAuthDefault = true
 export const agentApplicationsRevisionsCreateBodySpecTriggersItemFiveConfigDefault = {}
 export const agentApplicationsRevisionsCreateBodySpecTriggersDefault = []
@@ -222,11 +229,31 @@ export const AgentApplicationsRevisionsCreateBody = /* @__PURE__ */ zod.object({
                         zod.object({
                             type: zod.literal('cron'),
                             config: zod.object({
-                                schedule: zod.string(),
+                                name: zod.string().min(1),
+                                schedule: zod.string().min(1),
                                 timezone: zod
                                     .string()
                                     .default(
                                         agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigTimezoneDefault
+                                    ),
+                                prompt: zod
+                                    .string()
+                                    .min(1)
+                                    .max(agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigPromptMax),
+                                external_key: zod.string().optional(),
+                                catch_up: zod
+                                    .enum(['all', 'most_recent', 'skip'])
+                                    .default(
+                                        agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigCatchUpDefault
+                                    ),
+                                max_catch_up_age_seconds: zod
+                                    .number()
+                                    .min(1)
+                                    .max(
+                                        agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsMax
+                                    )
+                                    .default(
+                                        agentApplicationsRevisionsCreateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsDefault
                                     ),
                             }),
                         }),
@@ -458,7 +485,14 @@ export const AgentApplicationsRevisionsPartialUpdateParams = /* @__PURE__ */ zod
 })
 
 export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemOneConfigMentionOnlyDefault = false
+
 export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigTimezoneDefault = `UTC`
+export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigPromptMax = 4096
+
+export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigCatchUpDefault = `most_recent`
+export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsDefault = 3600
+export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsMax = 604800
+
 export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemFourConfigRequireAuthDefault = true
 export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemFiveConfigDefault = {}
 export const agentApplicationsRevisionsPartialUpdateBodySpecTriggersDefault = []
@@ -529,11 +563,33 @@ export const AgentApplicationsRevisionsPartialUpdateBody = /* @__PURE__ */ zod.o
                         zod.object({
                             type: zod.literal('cron'),
                             config: zod.object({
-                                schedule: zod.string(),
+                                name: zod.string().min(1),
+                                schedule: zod.string().min(1),
                                 timezone: zod
                                     .string()
                                     .default(
                                         agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigTimezoneDefault
+                                    ),
+                                prompt: zod
+                                    .string()
+                                    .min(1)
+                                    .max(
+                                        agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigPromptMax
+                                    ),
+                                external_key: zod.string().optional(),
+                                catch_up: zod
+                                    .enum(['all', 'most_recent', 'skip'])
+                                    .default(
+                                        agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigCatchUpDefault
+                                    ),
+                                max_catch_up_age_seconds: zod
+                                    .number()
+                                    .min(1)
+                                    .max(
+                                        agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsMax
+                                    )
+                                    .default(
+                                        agentApplicationsRevisionsPartialUpdateBodySpecTriggersItemThreeConfigMaxCatchUpAgeSecondsDefault
                                     ),
                             }),
                         }),


### PR DESCRIPTION
## Problem

A single live revision whose stored spec no longer parses against `AgentSpecSchema` threw inside `listLiveCronRevisions`, which aborts the entire janitor cron tick. Because that read is fleet-wide and runs every sweep, **one poisoned spec silently stops every agent's cron across the whole instance** — no error surfaced beyond an opaque per-tick failure log.

This is reachable through ordinary **schema drift**: a cron trigger frozen while it was valid (e.g. before `prompt` became a required field) becomes unparseable the moment the schema tightens, even though nothing about that agent changed.

A second, related gap: PR #61028 synced the node (zod) cron schema but not the Django JSON-Schema mirror used at write time. The mirror still only permitted `{schedule, timezone}`, so a cron config *missing* `prompt` passed Django but failed zod at freeze, while a *valid* cron config (with `prompt`) was rejected outright by `additionalProperties: false`. Net effect: cron agents couldn't actually be authored through the API on this branch.

## Changes

- **Runtime resilience** (`pg-revision-store.ts`): the bulk/fleet reads (`listRevisions`, `listRevisionsByIdPrefix`, `listLiveCronRevisions`) now parse each row through `safeRowToRev`, which skips and logs (`agent.revision.spec_unparseable`, with `revision_id` + `application_id` + the zod error) any row that fails to parse instead of throwing the whole batch. Single-revision `getRevision` stays strict so a direct fetch still surfaces the real error.
- **Schema sync** (`spec_schema.py`): the Django cron config JSON-Schema mirror now matches the node zod schema (`name`, `schedule`, `prompt`, `timezone`, `external_key`, `catch_up`, `max_catch_up_age_seconds`; `required: [name, schedule, prompt]`). A missing-`prompt` cron is now rejected cleanly at write (400, mirroring zod) instead of being stored and later failing freeze, and valid cron agents can be authored again.

Resilience is the durable fix (it handles future drift on already-live rows); the schema sync closes the write-time door so new poisoned specs don't get created in the first place.

## How did you test this code?

I'm an agent; these are the automated tests I actually ran (all green locally):

- `pg-revision-store.test.ts` (new, pure unit): `safeRowToRev` parses a valid row, returns `null` (no throw) for a cron trigger missing `prompt`, and a mixed batch keeps the good rows and drops the bad.
- `pg-impls.test.ts` (new case, real Postgres against `agent_runtime_queue_test`): seeds a healthy live cron agent and a second live agent whose stored spec is corrupted to a pre-`prompt` cron, then asserts `listLiveCronRevisions` returns the good revision and skips the poisoned one without throwing. Full persistence suite (23 tests) passes with no regressions.
- `test_spec_schema.py` (Django write gate): updated the `cron_omits_timezone` accept-case to the new required shape and added rejections for cron configs missing `prompt` and missing `name`. 17 passed.
- `tsc --noEmit` clean for `@posthog/agent-shared`.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Danilo's direction. Root cause was found by reproducing `listLiveCronRevisions()` against a live DB and tracing the throw to a demo agent's cron trigger that predated the required-`prompt` change.

Scope decision worth noting: an earlier plan included a "validate-on-promote" gate as a fourth item. While tracing the gates I found the freeze path already re-validates via zod-on-read, so a promote-time gate would have been redundant — the genuinely missing piece was the **Django mirror sync** (zod and the mirror had drifted apart in #61028). #4 was redirected accordingly. The unrelated immediate-unblock (archiving the stale demo agent that triggered the investigation) is intentionally **not** part of this PR — this change makes the fleet immune to such drift regardless.
