### PR TITLE
fix(recording-rasterizer): drop --no-sandbox from chrome launch

### DIFF
--- a/nodejs/src/session-replay/recording-rasterizer/capture/browser-pool.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/capture/browser-pool.ts
@@ -8,7 +8,6 @@ import { RasterizationMetrics } from '../metrics'
 const log = createLogger()
 
 const LAUNCH_ARGS = [
-    '--no-sandbox',
     '--disable-dev-shm-usage',
     '--mute-audio',
     ...(process.env.CHROME_HOST_RESOLVER_RULES


### PR DESCRIPTION
## Problem

The session-replay recording rasterizer launched its capture browser with `--no-sandbox`, which disables Chrome's process sandbox. This worker renders untrusted session-replay DOM, so the sandbox is a meaningful isolation boundary — running without it means a renderer compromise has nothing between it and the worker process. The flag was originally needed because the runtime container couldn't support the sandbox; that infrastructure has since been put in place and rolled out, so the flag is no longer required.

## Changes

- Remove `--no-sandbox` from the Chrome launch args in `nodejs/src/session-replay/recording-rasterizer/capture/browser-pool.ts`, re-enabling the process sandbox.

The other launch args are unchanged: `--disable-dev-shm-usage` stays (it relocates Chrome's shared-memory scratch files off the small default `/dev/shm` — a reliability flag, not a security boundary), and `--disable-web-security` remains gated behind the `disableBrowserSecurity` config flag.

## How did you test this code?

I'm an agent (Claude Code). This is a one-line removal of a launch arg; there is no unit test that asserts on the browser launch args, and I did not exercise an in-container browser launch myself. The runtime's sandbox support was implemented and rolled out separately by the author, so sandbox-enabled launch is validated in the deployed environment rather than in this change. The lint-staged `format:nodejs` hook ran on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Agent-authored with Claude Code, at the author's direction. The author confirmed the container now supports the Chrome sandbox and asked to drop the flag.

Decisions along the way:
- Verified nothing else references the launch args (only `browser-pool.ts` uses `LAUNCH_ARGS`), so the removal is isolated and breaks no tests.
- Assessed `--disable-dev-shm-usage` on request and left it in place — it's a reliability workaround for the 64 MB default `/dev/shm`, not a security boundary like `--no-sandbox`.
- Tools used: Read, Edit, Grep/Bash, git.

Requires human review — not for self-merge.
