### PR TITLE
fix(error-tracking): preserve symbol upload retries

### DIFF
--- a/products/error_tracking/backend/api/symbol_sets.py
+++ b/products/error_tracking/backend/api/symbol_sets.py
@@ -32,6 +32,32 @@ JS_DATA_TYPE_SOURCE_AND_MAP = 2
 PRESIGNED_MULTIPLE_UPLOAD_TIMEOUT = 60 * 5
 
 
+def _extract_failure_code(error_codes: object) -> str | None:
+    if isinstance(error_codes, str):
+        return error_codes
+
+    if isinstance(error_codes, list):
+        for error_code in error_codes:
+            failure_code = _extract_failure_code(error_code)
+            if failure_code:
+                return failure_code
+
+    if isinstance(error_codes, dict):
+        for error_code in error_codes.values():
+            failure_code = _extract_failure_code(error_code)
+            if failure_code:
+                return failure_code
+
+    return None
+
+
+def _get_failure_code(exception: Exception) -> str | None:
+    if isinstance(exception, ValidationError):
+        return _extract_failure_code(exception.get_codes())
+
+    return None
+
+
 class ErrorTrackingSymbolSetSerializer(serializers.ModelSerializer):
     id = serializers.UUIDField(read_only=True, help_text="Unique symbol set ID.")
     ref = serializers.CharField(read_only=True, help_text="Reference used to match stack frames to this symbol set.")
@@ -490,17 +516,17 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
 
         file_count = len(content_hashes)
         symbol_set_ids = set(content_hashes.keys())
-        symbol_sets = list(ErrorTrackingSymbolSet.objects.filter(team=self.team, id__in=symbol_set_ids))
-        found_symbol_set_ids = {str(symbol_set.id) for symbol_set in symbol_sets}
-        missing_symbol_set_ids = symbol_set_ids - found_symbol_set_ids
-        if missing_symbol_set_ids:
-            raise ValidationError(
-                code="symbol_set_not_found",
-                detail=f"Unknown symbol set IDs: {', '.join(sorted(missing_symbol_set_ids))}",
-            )
-
         total_file_size = 0
         try:
+            symbol_sets = list(ErrorTrackingSymbolSet.objects.filter(team=self.team, id__in=symbol_set_ids))
+            found_symbol_set_ids = {str(symbol_set.id) for symbol_set in symbol_sets}
+            missing_symbol_set_ids = symbol_set_ids - found_symbol_set_ids
+            if missing_symbol_set_ids:
+                raise ValidationError(
+                    code="symbol_set_not_found",
+                    detail=f"Unknown symbol set IDs: {', '.join(sorted(missing_symbol_set_ids))}",
+                )
+
             for symbol_set in symbol_sets:
                 s3_upload = None
                 if symbol_set.storage_ptr:
@@ -535,6 +561,7 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
                     "success": False,
                     "file_count": file_count,
                     "failure_reason": type(e).__name__,
+                    "failure_code": _get_failure_code(e),
                 },
                 groups=groups(self.team.organization, self.team),
             )

--- a/products/error_tracking/backend/api/symbol_sets.py
+++ b/products/error_tracking/backend/api/symbol_sets.py
@@ -489,8 +489,15 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
             )
 
         file_count = len(content_hashes)
-        symbol_set_ids = content_hashes.keys()
-        symbol_sets = ErrorTrackingSymbolSet.objects.filter(team=self.team, id__in=symbol_set_ids)
+        symbol_set_ids = set(content_hashes.keys())
+        symbol_sets = list(ErrorTrackingSymbolSet.objects.filter(team=self.team, id__in=symbol_set_ids))
+        found_symbol_set_ids = {str(symbol_set.id) for symbol_set in symbol_sets}
+        missing_symbol_set_ids = symbol_set_ids - found_symbol_set_ids
+        if missing_symbol_set_ids:
+            raise ValidationError(
+                code="symbol_set_not_found",
+                detail=f"Unknown symbol set IDs: {', '.join(sorted(missing_symbol_set_ids))}",
+            )
 
         total_file_size = 0
         try:
@@ -521,14 +528,6 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
                 symbol_set.content_hash = content_hash
             ErrorTrackingSymbolSet.objects.bulk_update(symbol_sets, ["content_hash"])
         except Exception as e:
-            for id in content_hashes.keys():
-                # Try to clean up the symbol sets preemptively if the upload fails
-                try:
-                    symbol_set = ErrorTrackingSymbolSet.objects.all().filter(id=id, team=self.team).get()
-                    symbol_set.delete()
-                except Exception:
-                    pass
-
             posthoganalytics.capture(
                 "error_tracking_symbol_set_uploaded",
                 properties={

--- a/products/error_tracking/backend/api/test/test_error_tracking_api.py
+++ b/products/error_tracking/backend/api/test/test_error_tracking_api.py
@@ -942,7 +942,8 @@ class TestErrorTracking(APIBaseTest):
         assert ErrorTrackingSymbolSet.objects.get(id=symbol_set_one.id).content_hash == "hash_one"
         assert ErrorTrackingSymbolSet.objects.get(id=symbol_set_two.id).content_hash == "hash_two"
 
-    def test_bulk_finish_upload_rejects_unknown_symbol_set_ids(self) -> None:
+    @patch("products.error_tracking.backend.api.symbol_sets.posthoganalytics.capture")
+    def test_bulk_finish_upload_rejects_unknown_symbol_set_ids(self, patched_capture: Mock) -> None:
         response = self.client.post(
             f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_finish_upload",
             data={"content_hashes": {str(uuid7()): "hash"}},
@@ -951,10 +952,19 @@ class TestErrorTracking(APIBaseTest):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["code"] == "symbol_set_not_found"
+        assert patched_capture.call_args.args[0] == "error_tracking_symbol_set_uploaded"
+        assert patched_capture.call_args.kwargs["properties"] == {
+            "file_size": 0,
+            "success": False,
+            "file_count": 1,
+            "failure_reason": "ValidationError",
+            "failure_code": "symbol_set_not_found",
+        }
 
+    @patch("products.error_tracking.backend.api.symbol_sets.posthoganalytics.capture")
     @patch("posthog.storage.object_storage.head_object")
     def test_bulk_finish_upload_preserves_pending_symbol_set_when_file_is_not_found(
-        self, patched_object_storage
+        self, patched_object_storage, patched_capture: Mock
     ) -> None:
         symbol_set = ErrorTrackingSymbolSet.objects.create(team=self.team, ref=str(uuid7()), storage_ptr="file/name")
         request_data = {"content_hashes": {str(symbol_set.id): "hash"}}
@@ -969,6 +979,15 @@ class TestErrorTracking(APIBaseTest):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["code"] == "file_not_found"
+        failure_call = patched_capture.call_args_list[0]
+        assert failure_call.args[0] == "error_tracking_symbol_set_uploaded"
+        assert failure_call.kwargs["properties"] == {
+            "file_size": 0,
+            "success": False,
+            "file_count": 1,
+            "failure_reason": "ValidationError",
+            "failure_code": "file_not_found",
+        }
 
         symbol_set.refresh_from_db()
         assert symbol_set.content_hash is None

--- a/products/error_tracking/backend/api/test/test_error_tracking_api.py
+++ b/products/error_tracking/backend/api/test/test_error_tracking_api.py
@@ -942,6 +942,47 @@ class TestErrorTracking(APIBaseTest):
         assert ErrorTrackingSymbolSet.objects.get(id=symbol_set_one.id).content_hash == "hash_one"
         assert ErrorTrackingSymbolSet.objects.get(id=symbol_set_two.id).content_hash == "hash_two"
 
+    def test_bulk_finish_upload_rejects_unknown_symbol_set_ids(self) -> None:
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_finish_upload",
+            data={"content_hashes": {str(uuid7()): "hash"}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["code"] == "symbol_set_not_found"
+
+    @patch("posthog.storage.object_storage.head_object")
+    def test_bulk_finish_upload_preserves_pending_symbol_set_when_file_is_not_found(
+        self, patched_object_storage
+    ) -> None:
+        symbol_set = ErrorTrackingSymbolSet.objects.create(team=self.team, ref=str(uuid7()), storage_ptr="file/name")
+        request_data = {"content_hashes": {str(symbol_set.id): "hash"}}
+
+        patched_object_storage.side_effect = [None, {"ContentLength": 1000}]
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_finish_upload",
+            data=request_data,
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["code"] == "file_not_found"
+
+        symbol_set.refresh_from_db()
+        assert symbol_set.content_hash is None
+
+        retry_response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_finish_upload",
+            data=request_data,
+            format="json",
+        )
+
+        assert retry_response.status_code == status.HTTP_201_CREATED
+        symbol_set.refresh_from_db()
+        assert symbol_set.content_hash == "hash"
+
     def _assert_logs_the_activity(self, error_tracking_issue_id: int, expected: list[dict]) -> None:
         activity_response = self._get_error_tracking_issue_activity(error_tracking_issue_id)
         activity: list[dict] = activity_response["results"]


### PR DESCRIPTION
## Problem

Hermes source map uploads can fail during bulk finish when object storage does not yet have the uploaded file. The server currently deletes the pending symbol set during that failure path. If the CLI retries the same finish request, the now-missing symbol set can make the retry appear successful without persisting a content hash, leaving frames unresolved.

## Changes

- Reject bulk finish requests that reference unknown symbol set IDs.
- Preserve pending symbol sets when object storage reports the uploaded file is missing, so retries and reruns can recover.
- Keep the existing explicit cleanup for oversized uploaded files.

## Tests

- `uv run pytest products/error_tracking/backend/api/test/test_error_tracking_api.py::TestErrorTracking::test_bulk_finish_upload_rejects_unknown_symbol_set_ids products/error_tracking/backend/api/test/test_error_tracking_api.py::TestErrorTracking::test_bulk_finish_upload_preserves_pending_symbol_set_when_file_is_not_found`
- `uv run pytest products/error_tracking/backend/api/test/test_error_tracking_api.py::TestErrorTracking -k symbol_set`
