### PR TITLE
fix(experiments): stabilize flaky experiment-lifecycle wizard test

### DIFF
--- a/playwright/e2e/experiments/experiment-lifecycle.spec.ts
+++ b/playwright/e2e/experiments/experiment-lifecycle.spec.ts
@@ -68,9 +68,17 @@ test.describe('Experiment lifecycle', () => {
                 await page.goto('/experiments/new')
                 await expect(page.getByRole('heading', { name: 'New experiment' })).toBeVisible()
 
-                // About step
+                // About step. Typing into the name/flag-key fields schedules a debounced
+                // feature-flag-key validation request (used to detect key collisions). The
+                // final "Save as draft" handler silently rejects the save while this
+                // validation is still in flight, so wait for it to resolve here — otherwise
+                // the save is dropped and the redirect never happens.
+                const flagKeyValidated = page.waitForResponse(
+                    (resp) => resp.url().includes('/feature_flags/') && resp.url().includes(`search=${FLAG_KEY}`)
+                )
                 await page.getByTestId('experiment-wizard-name').fill(experimentName)
                 await page.getByTestId('experiment-wizard-flag-key').fill(FLAG_KEY)
+                await flagKeyValidated
                 await page.getByRole('button', { name: 'Continue' }).click()
 
                 // Variants step — wait for stepper to confirm transition
@@ -88,13 +96,11 @@ test.describe('Experiment lifecycle', () => {
                 await expect(page.locator('[aria-current="step"]', { hasText: 'Analytics' })).toBeVisible()
                 await expect(page.getByText('How to measure impact?')).toBeVisible()
 
-                // This click occasionally doesn't produce a navigation. Possible causes:
-                // the click not reaching React's event handler after the step transition,
-                // or the backend response being slow. Retry until navigation confirms success.
-                await expect(async () => {
-                    await page.getByRole('button', { name: 'Save as draft' }).click()
-                    await page.waitForURL(/\/experiments\/\d+$/, { timeout: 5000 })
-                }).toPass({ timeout: 30000 })
+                // Flag-key validation settled on the About step, so the save handler won't
+                // reject this click. Click once and wait for the redirect to the saved
+                // experiment — re-clicking risks a double submission.
+                await page.getByRole('button', { name: 'Save as draft' }).click()
+                await page.waitForURL(/\/experiments\/\d+$/, { timeout: 30000 })
                 await expect(page.getByTestId('launch-experiment')).toBeVisible()
 
                 // Verify the custom split is preserved


### PR DESCRIPTION
## Problem

`experiment-lifecycle.spec.ts` → "create experiment via wizard, add metrics, and launch" was flaky in CI. It timed out at the wizard's final step, where `page.waitForURL(/\/experiments\/\d+$/)` never resolved after clicking **Save as draft**. The flake showed up across unrelated branches that don't touch experiment code, and failed all Playwright retries within a job while passing on re-run — the hallmark of a load-dependent timing race rather than a real regression.

Root cause: the feature-flag-key field runs a **debounced (300ms) async validation** (`/feature_flags/?search=...`) to detect key collisions. The `saveExperiment` handler **silently rejects the save while that validation is in flight**:

```ts
if (values.featureFlagKeyValidationLoading) {
    lemonToast.error('Please wait for validation to complete')
    actions.saveExperimentFailure()
    return // no navigation → waitForURL never resolves
}
```

Under CI load the validation request is slow, so when the test reached **Save as draft** the validation was often still pending — the click was dropped (toast, no redirect). The existing `.toPass({ timeout: 30000 })` re-click loop only sometimes recovered, and re-clicking a submit button additionally risks double submission.

## Changes

- Wait for the feature-flag-key validation request to resolve on the **About** step (set up `waitForResponse` before filling the fields so the debounced request can't be missed) before advancing through the wizard.
- Click **Save as draft** once and wait for the redirect, replacing the fragile `.toPass` re-click loop.

No production code changed — this is a test-stability fix.

## How did you test this code?

I'm an agent (PostHog Code). I did **not** run the Playwright suite live — the local E2E environment isn't running in this workspace, so I could not execute `--repeat-each 10`. Static checks I did run:

- `oxfmt --check` on the spec file — passes.

The fix is grounded in tracing the wizard logic (`experimentWizardLogic` → `createExperimentLogic.saveExperiment`, `variantsPanelLogic` validation loader, and `AboutStep`'s debounced validation). Please let CI run the Playwright job to confirm stability.

## 🤖 Agent context

Authored by PostHog Code (Claude) from a Slack thread about this flaky test. Investigation path: read the failing spec, traced the "Save as draft" navigation through `createExperimentLogic` (navigation is driven by `experimentSceneLogic.setSceneState` → `tabAwareActionToUrl`), and found the `featureFlagKeyValidationLoading` early-return in the save handler. Confirmed the validation is debounced and triggered by typing into the name/flag-key fields in `AboutStep`, which is why the race is load-sensitive.

Considered fixes: (a) keep the `toPass` loop but wait for validation inside it — rejected, re-clicking risks double submission; (b) change product code to await validation in the save handler — rejected as out of scope for a test flake and riskier. Chose to synchronize the test on the validation request and click once.

Requires human review; not validated end-to-end by the agent.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
