### PR TITLE
fix(ci): add personhog to docker compose dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -163,6 +163,9 @@ services:
             CDP_REDIS_HOST: redis7
             # Encryption keys default is only set when NODE_ENV=dev, but the image uses production
             ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00'
+            # PersonHog is required for CDP — point at the local gRPC router
+            PERSONHOG_ADDR: 'personhog-router:50052'
+            PERSONHOG_ENABLED: 'true'
         depends_on:
             kafka:
                 condition: service_started
@@ -170,6 +173,8 @@ services:
                 condition: service_healthy
             db:
                 condition: service_healthy
+            personhog-router:
+                condition: service_started
         healthcheck:
             test: ['CMD', 'curl', '-f', 'http://localhost:6738/_ready']
             interval: 5s
@@ -537,6 +542,28 @@ services:
             - '2080:8080'
         environment:
             - AUTO_CREATE_SESSIONS=true
+
+    personhog-replica:
+        extends:
+            file: docker-compose.base.yml
+            service: personhog-replica
+        environment:
+            PRIMARY_DATABASE_URL: postgres://posthog:posthog@db:5432/${POSTHOG_PERSONS_DB_NAME:-posthog}
+        depends_on:
+            db:
+                condition: service_healthy
+        profiles:
+            - ingestion
+
+    personhog-router:
+        extends:
+            file: docker-compose.base.yml
+            service: personhog-router
+        depends_on:
+            personhog-replica:
+                condition: service_started
+        profiles:
+            - ingestion
 
     feature-flags:
         extends:


### PR DESCRIPTION

## Problem

Personhog service became required for CDP services to start up but wasn't included in the docker compose dev file.

## Changes

Add personhog router and replica to the docker compose dev file

Enable personhog and register the correct address for it in the cdp configuration section

## How did you test this code?

CI
