### PR TITLE
fix(onboarding): dismiss product intro banner immediately on close

### DIFF
--- a/frontend/src/lib/components/ProductIntroduction/ProductIntroduction.tsx
+++ b/frontend/src/lib/components/ProductIntroduction/ProductIntroduction.tsx
@@ -83,14 +83,17 @@ export const ProductIntroduction = ({
     mcpSurfaceKey,
 }: ProductIntroductionProps): JSX.Element | null => {
     const { updateHasSeenProductIntroFor } = useActions(userLogic)
-    const { user } = useValues(userLogic)
+    const { user, seenProductIntrosOptimistic } = useValues(userLogic)
 
     if (!user) {
         return null
     }
 
-    if (!isEmpty && (!productKey || user.has_seen_product_intro_for?.[productKey])) {
-        // Hide if its not an empty list but the user has seen it before
+    if (
+        !isEmpty &&
+        (!productKey || user.has_seen_product_intro_for?.[productKey] || seenProductIntrosOptimistic[productKey])
+    ) {
+        // Hide if its not an empty list but the user has seen it before (or just dismissed it this session)
         return null
     }
 

--- a/frontend/src/scenes/userLogic.test.ts
+++ b/frontend/src/scenes/userLogic.test.ts
@@ -96,6 +96,33 @@ describe('userLogic', () => {
         })
     })
 
+    describe('product intro dismissal', () => {
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it('seenProductIntrosOptimistic records the dismissal immediately, before the PATCH resolves', async () => {
+            // Never-resolving PATCH so we assert the optimistic state, not the round-trip result
+            jest.spyOn(api, 'update').mockImplementation(async () => await new Promise(() => undefined))
+
+            await expectLogic(userLogic, () => {
+                userLogic.actions.updateHasSeenProductIntroFor('replay_vision' as any)
+            }).toMatchValues({
+                seenProductIntrosOptimistic: { replay_vision: true },
+            })
+        })
+
+        it('passing value=false records the negative state optimistically', async () => {
+            jest.spyOn(api, 'update').mockImplementation(async () => await new Promise(() => undefined))
+
+            await expectLogic(userLogic, () => {
+                userLogic.actions.updateHasSeenProductIntroFor('replay_vision' as any, false)
+            }).toMatchValues({
+                seenProductIntrosOptimistic: { replay_vision: false },
+            })
+        })
+    })
+
     describe('realtime notification preferences', () => {
         let updateUserSpy: jest.SpyInstance
 

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -255,6 +255,14 @@ export const userLogic = kea<userLogicType>([
                 credentialReviewDismissed: () => true,
             },
         ],
+        // Optimistic mirror of `user.has_seen_product_intro_for`, so a dismissal hides the
+        // banner immediately instead of waiting for the PATCH + loadUser round-trip.
+        seenProductIntrosOptimistic: [
+            {} as Record<string, boolean>,
+            {
+                updateHasSeenProductIntroFor: (state, { productKey, value }) => ({ ...state, [productKey]: value }),
+            },
+        ],
     }),
     listeners(({ actions, values, cache }) => ({
         logout: ({ preserveLocation }) => {


### PR DESCRIPTION
## Problem

The `ProductIntroduction` "Welcome to …" banner's X (dismiss) button felt broken — clicking it didn't visibly dismiss the banner. The dismiss handler fires a `PATCH /api/users/@me/` to set `has_seen_product_intro_for[productKey]`, then re-fetches the user via `loadUser`, but there was **no optimistic update**: the banner only re-evaluated its visibility once that full network round-trip resolved. Any latency or hiccup in the round-trip left the banner sitting on screen, reading as "the X doesn't work."

This is in the shared component, so it affected every product's intro banner — surfaced via Replay vision's welcome banner.

The backend was fine: `has_seen_product_intro_for` is a plain writable `JSONField` with no validation, and `replay_vision` is accepted and round-trips correctly. The gap was purely the missing client-side optimism.

## Changes

- Add a `seenProductIntrosOptimistic` reducer to `userLogic` (keyed by product key), mirroring the existing `optimisticThemeMode` pattern. It records the dismissal the instant `updateHasSeenProductIntroFor` fires.
- `ProductIntroduction` now hides as soon as **either** the persisted `has_seen_product_intro_for[productKey]` **or** the optimistic flag is set, so the X dismisses the banner immediately.
- Persistence is unchanged — the existing PATCH still writes the flag so the dismissal sticks across reloads.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I actually ran:

- `hogli test frontend/src/scenes/userLogic.test.ts` — 10/10 pass, including two new cases asserting `seenProductIntrosOptimistic` is set immediately (before the PATCH resolves), for both `value=true` and `value=false`.
- `pnpm --filter=@posthog/frontend typescript:check` — passes (0 errors).
- `pnpm --filter=@posthog/frontend format` — clean.

I did **not** click through the banner in a running app; a human should verify the X dismisses instantly and stays dismissed after reload.

## 🤖 Agent context

Investigated via a code trace of the dismiss flow (component → `userLogic.updateHasSeenProductIntroFor` → `PATCH /api/users/@me/` → backend `UserSerializer`). Ruled out a backend rejection of the `replay_vision` product key (field is unvalidated and round-trips fine) and the `isEmpty` guard (the Replay vision scene renders the persistent welcome variant, not the empty-state variant). Root cause was the absent optimistic update; fix follows the existing `optimisticThemeMode` precedent in the same logic rather than introducing component-local state.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
