### PR TITLE
feat(logs): allow multiple distinct_id attribute keys with COALESCE matching

### DIFF
--- a/frontend/src/scenes/persons/PersonLogsTab.tsx
+++ b/frontend/src/scenes/persons/PersonLogsTab.tsx
@@ -51,7 +51,7 @@ export function PersonLogsTab({ person }: { person: PersonType }): JSX.Element {
                 <LemonButton
                     size="xsmall"
                     icon={<IconGear />}
-                    tooltip="Change the log attribute used to pivot logs onto a person"
+                    tooltip="Change the log attribute used to link logs to a person"
                     to={urls.settings('environment-logs', 'logs-distinct-id-attribute-key')}
                 />
             </p>

--- a/frontend/src/scenes/persons/PersonLogsTab.tsx
+++ b/frontend/src/scenes/persons/PersonLogsTab.tsx
@@ -1,59 +1,68 @@
+import equal from 'fast-deep-equal'
 import { useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { IconGear } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { Link } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
 
 import { FilterLogicalOperator, LogPropertyFilter, PersonType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer/LogsViewer'
-import { DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY, logsConfigLogic } from 'products/logs/frontend/logsConfigLogic'
+import { DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS, logsConfigLogic } from 'products/logs/frontend/logsConfigLogic'
 
 // Renders the Logs tab on the person profile. Mounted only when the tab is active
 // (LemonTabs renders just the active tab's content), so `logsConfigLogic` only fetches
-// the team's `logs_distinct_id_attribute_key` on demand rather than on every team load.
-// While the config loads, falls back to the default key — accurate for the vast majority
-// of teams; non-default teams briefly see the wrong filter then resolve to the override.
+// the team's `logs_distinct_id_attribute_keys` on demand rather than on every team load.
+// While the config loads, falls back to the default key list — accurate for the vast
+// majority of teams; non-default teams briefly see the wrong filter then resolve to the
+// override.
 export function PersonLogsTab({ person }: { person: PersonType }): JSX.Element {
     const { logsConfig } = useValues(logsConfigLogic)
-    const distinctIdAttributeKey = logsConfig?.logs_distinct_id_attribute_key ?? DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY
-    const isCustomizedKey = distinctIdAttributeKey !== DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY
+    const distinctIdAttributeKeys =
+        logsConfig?.logs_distinct_id_attribute_keys ?? DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS
+    const isCustomized = !equal(distinctIdAttributeKeys, DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS)
 
     const pinnedFilters = useMemo(
         () => ({
             type: FilterLogicalOperator.And,
             values: [
                 {
-                    key: distinctIdAttributeKey,
+                    // `key` is the first configured attribute — kept populated so any
+                    // generic property-filter consumer (chip renderer, taxonomic picker,
+                    // saved-view serialization) sees a valid single-key filter. The
+                    // `keys` array is the priority-ordered fallback list that the backend
+                    // compiles to `coalesce(attributes[k1__str], attributes[k2__str], …)`.
+                    key: distinctIdAttributeKeys[0],
+                    keys: distinctIdAttributeKeys,
                     type: PropertyFilterType.LogAttribute,
                     operator: PropertyOperator.Exact,
                     value: person.distinct_ids,
                 } as LogPropertyFilter,
             ],
         }),
-        [distinctIdAttributeKey, person.distinct_ids]
+        [distinctIdAttributeKeys, person.distinct_ids]
     )
+
+    const settingsUrl = urls.settings('environment-logs', 'logs-distinct-id-attribute-key')
 
     return (
         <div className="flex flex-col h-[calc(100vh-16rem)] min-h-[25rem]">
-            <p className="text-muted text-xs mb-2 flex items-center gap-1 flex-wrap">
-                <span>
-                    Scoped to this person via the <code>{distinctIdAttributeKey}</code> log attribute.
-                    {isCustomizedKey && (
-                        <>
-                            {' '}
-                            Customised from default <code>{DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY}</code>.
-                        </>
-                    )}
-                </span>
-                <LemonButton
-                    size="xsmall"
-                    icon={<IconGear />}
-                    tooltip="Change the log attribute used to link logs to a person"
-                    to={urls.settings('environment-logs', 'logs-distinct-id-attribute-key')}
-                />
+            <p className="text-muted text-xs mb-2">
+                Scoped to this person via the{' '}
+                {distinctIdAttributeKeys.map((key, i) => (
+                    <span key={key}>
+                        {i > 0 && ', '}
+                        <code>{key}</code>
+                    </span>
+                ))}{' '}
+                log {distinctIdAttributeKeys.length === 1 ? 'attribute' : 'attributes (priority order)'}.{' '}
+                {isCustomized && (
+                    <>
+                        Customised from default <code>{DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS[0]}</code>.{' '}
+                    </>
+                )}
+                <Link to={settingsUrl}>Link logs to a person →</Link>
             </p>
             <LogsViewer
                 id={`person-${person.uuid ?? person.id}`}

--- a/frontend/src/scenes/persons/PersonLogsTab.tsx
+++ b/frontend/src/scenes/persons/PersonLogsTab.tsx
@@ -1,6 +1,11 @@
 import { useValues } from 'kea'
 import { useMemo } from 'react'
 
+import { IconGear } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
 import { FilterLogicalOperator, LogPropertyFilter, PersonType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer/LogsViewer'
@@ -33,14 +38,22 @@ export function PersonLogsTab({ person }: { person: PersonType }): JSX.Element {
 
     return (
         <div className="flex flex-col h-[calc(100vh-16rem)] min-h-[25rem]">
-            <p className="text-muted text-xs mb-2">
-                Scoped to this person via the <code>{distinctIdAttributeKey}</code> log attribute.
-                {isCustomizedKey && (
-                    <>
-                        {' '}
-                        Customised from default <code>{DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY}</code>.
-                    </>
-                )}
+            <p className="text-muted text-xs mb-2 flex items-center gap-1 flex-wrap">
+                <span>
+                    Scoped to this person via the <code>{distinctIdAttributeKey}</code> log attribute.
+                    {isCustomizedKey && (
+                        <>
+                            {' '}
+                            Customised from default <code>{DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY}</code>.
+                        </>
+                    )}
+                </span>
+                <LemonButton
+                    size="xsmall"
+                    icon={<IconGear />}
+                    tooltip="Change the log attribute used to pivot logs onto a person"
+                    to={urls.settings('environment-logs', 'logs-distinct-id-attribute-key')}
+                />
             </p>
             <LogsViewer
                 id={`person-${person.uuid ?? person.id}`}

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -719,10 +719,16 @@ export const SETTINGS_MAP: SettingSection[] = [
             {
                 id: 'logs-distinct-id-attribute-key',
                 title: 'Person pivot attribute',
-                description:
-                    "Which OTel log attribute we match against a person's distinct_ids to surface logs on their person profile. " +
-                    'Defaults to `posthogDistinctId` — the key the JavaScript and React Native SDKs auto-attach. ' +
-                    'Override only if your pipeline emits the person identifier under a different key.',
+                description: (
+                    <>
+                        Which OTel log attribute we match against a person&apos;s distinct_ids to surface logs on their
+                        person profile. Defaults to <code>posthogDistinctId</code> — the key the JavaScript and React
+                        Native SDKs auto-attach. Override only if your pipeline emits the person identifier under a
+                        different key.
+                    </>
+                ),
+                searchDescription:
+                    "Which OTel log attribute we match against a person's distinct_ids to surface logs on their person profile. Defaults to posthogDistinctId — the key the JavaScript and React Native SDKs auto-attach. Override only if your pipeline emits the person identifier under a different key.",
                 component: <LogsDistinctIdAttributeKey />,
                 flag: 'LOGS_SETTINGS',
                 keywords: ['log', 'person', 'distinct', 'attribute', 'pivot', 'profile', 'link'],

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -95,6 +95,7 @@ import {
     LogsPiiScrubSettings,
     LogsRetentionSettings,
 } from './environment/LogsCaptureSettings'
+import { LogsDistinctIdAttributeKey } from './environment/LogsDistinctIdAttributeKey'
 import { ManagedReverseProxy } from './environment/ManagedReverseProxy'
 import { MarketingAnalyticsSettingsWrapper } from './environment/MarketingAnalyticsSettingsWrapper'
 import MCPServerSettings from './environment/MCPServerSettings'
@@ -714,6 +715,17 @@ export const SETTINGS_MAP: SettingSection[] = [
                 component: <LogsPiiScrubSettings />,
                 flag: 'LOGS_SETTINGS_PII_SCRUB',
                 keywords: ['pii', 'privacy', 'gdpr', 'redact', 'mask', 'scrub', 'sensitive'],
+            },
+            {
+                id: 'logs-distinct-id-attribute-key',
+                title: 'Person pivot attribute',
+                description:
+                    "Which OTel log attribute we match against a person's distinct_ids to surface logs on their person profile. " +
+                    'Defaults to `posthogDistinctId` — the key the JavaScript and React Native SDKs auto-attach. ' +
+                    'Override only if your pipeline emits the person identifier under a different key.',
+                component: <LogsDistinctIdAttributeKey />,
+                flag: 'LOGS_SETTINGS',
+                keywords: ['log', 'person', 'distinct', 'attribute', 'pivot', 'profile', 'link'],
             },
             {
                 id: 'logs-retention',

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -718,17 +718,17 @@ export const SETTINGS_MAP: SettingSection[] = [
             },
             {
                 id: 'logs-distinct-id-attribute-key',
-                title: 'Person pivot attribute',
+                title: 'Link to person',
                 description: (
                     <>
-                        Which OTel log attribute we match against a person&apos;s distinct_ids to surface logs on their
-                        person profile. Defaults to <code>posthogDistinctId</code> — the key the JavaScript and React
-                        Native SDKs auto-attach. Override only if your pipeline emits the person identifier under a
-                        different key.
+                        The log attribute PostHog reads to identify which person a log belongs to. Matched against the
+                        person&apos;s distinct IDs to surface logs on their profile. Defaults to{' '}
+                        <code>posthogDistinctId</code> — the key the JavaScript and React Native SDKs auto-attach.
+                        Override only if your backend pipeline emits the person identifier under a different key.
                     </>
                 ),
                 searchDescription:
-                    "Which OTel log attribute we match against a person's distinct_ids to surface logs on their person profile. Defaults to posthogDistinctId — the key the JavaScript and React Native SDKs auto-attach. Override only if your pipeline emits the person identifier under a different key.",
+                    "The log attribute PostHog reads to identify which person a log belongs to. Matched against the person's distinct IDs to surface logs on their profile. Defaults to posthogDistinctId — the key the JavaScript and React Native SDKs auto-attach. Override only if your backend pipeline emits the person identifier under a different key.",
                 component: <LogsDistinctIdAttributeKey />,
                 flag: 'LOGS_SETTINGS',
                 keywords: ['log', 'person', 'distinct', 'attribute', 'pivot', 'profile', 'link'],

--- a/frontend/src/scenes/settings/environment/LogsDistinctIdAttributeKey.tsx
+++ b/frontend/src/scenes/settings/environment/LogsDistinctIdAttributeKey.tsx
@@ -1,0 +1,59 @@
+import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
+
+import { LemonButton, LemonInput } from '@posthog/lemon-ui'
+
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+
+import { DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY, logsConfigLogic } from 'products/logs/frontend/logsConfigLogic'
+
+export function LogsDistinctIdAttributeKey(): JSX.Element {
+    const { logsConfig, logsConfigLoading } = useValues(logsConfigLogic)
+    const { updateLogsConfig } = useActions(logsConfigLogic)
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
+
+    const [value, setValue] = useState<string>('')
+
+    useEffect(() => {
+        if (logsConfig) {
+            setValue(logsConfig.logs_distinct_id_attribute_key)
+        }
+    }, [logsConfig])
+
+    if (!logsConfig && logsConfigLoading) {
+        return <LemonSkeleton className="w-1/2 h-4" />
+    }
+
+    const trimmed = value.trim()
+    const isDirty = trimmed !== (logsConfig?.logs_distinct_id_attribute_key ?? '')
+    const isEmpty = trimmed.length === 0
+
+    return (
+        <div className="deprecated-space-y-4">
+            <LemonInput
+                value={value}
+                onChange={setValue}
+                placeholder={DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY}
+                maxLength={200}
+                disabledReason={restrictedReason}
+                className="max-w-md"
+            />
+            <LemonButton
+                type="primary"
+                onClick={() => updateLogsConfig({ logs_distinct_id_attribute_key: trimmed })}
+                disabledReason={
+                    restrictedReason ||
+                    (isEmpty ? 'Attribute key is required' : !isDirty ? 'No changes to save' : undefined)
+                }
+                loading={logsConfigLoading}
+            >
+                Save
+            </LemonButton>
+        </div>
+    )
+}

--- a/frontend/src/scenes/settings/environment/LogsDistinctIdAttributeKey.tsx
+++ b/frontend/src/scenes/settings/environment/LogsDistinctIdAttributeKey.tsx
@@ -1,6 +1,6 @@
 import equal from 'fast-deep-equal'
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
@@ -9,7 +9,11 @@ import { TeamMembershipLevel } from 'lib/constants'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 
-import { DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS, logsConfigLogic } from 'products/logs/frontend/logsConfigLogic'
+import {
+    DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS,
+    SUGGESTED_DISTINCT_ID_ATTRIBUTE_KEYS,
+    logsConfigLogic,
+} from 'products/logs/frontend/logsConfigLogic'
 
 const MAX_KEY_LENGTH = 200
 
@@ -29,7 +33,7 @@ function cleanKeys(input: string[]): string[] {
 }
 
 export function LogsDistinctIdAttributeKey(): JSX.Element {
-    const { logsConfig, logsConfigLoading } = useValues(logsConfigLogic)
+    const { logsConfig, logsConfigLoading, attributeKeyOptions } = useValues(logsConfigLogic)
     const { updateLogsConfig } = useActions(logsConfigLogic)
     const restrictedReason = useRestrictedArea({
         scope: RestrictionScope.Project,
@@ -43,6 +47,21 @@ export function LogsDistinctIdAttributeKey(): JSX.Element {
             setValue(logsConfig.logs_distinct_id_attribute_keys)
         }
     }, [logsConfig])
+
+    // Build the autocomplete option list: ingested attribute keys (from the team's actual logs
+    // in the past 30 days) merged with the canonical PostHog-link conventions, deduped, with
+    // the suggested keys floated to the top so they're discoverable on a fresh team.
+    const options = useMemo(() => {
+        const seen = new Set<string>()
+        const ordered: string[] = []
+        for (const key of [...SUGGESTED_DISTINCT_ID_ATTRIBUTE_KEYS, ...attributeKeyOptions]) {
+            if (!seen.has(key)) {
+                seen.add(key)
+                ordered.push(key)
+            }
+        }
+        return ordered.map((key) => ({ key, label: key }))
+    }, [attributeKeyOptions])
 
     if (!logsConfig && logsConfigLoading) {
         return <LemonSkeleton className="w-1/2 h-4" />
@@ -63,15 +82,15 @@ export function LogsDistinctIdAttributeKey(): JSX.Element {
                 value={value}
                 onChange={setValue}
                 placeholder={DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS[0]}
-                options={[]}
+                options={options}
                 disabled={!!restrictedReason}
             />
             <p className="text-muted text-xs mt-1">
                 {restrictedReason ?? (
                     <>
-                        Order is priority — for each log, the first configured key found on that row is used as the
-                        person identifier (priority-ordered fallback via SQL <code>coalesce</code>). Drag to reorder,
-                        press Enter or paste a comma-separated list to add multiple at once.
+                        Type to search attribute keys present in your logs, or paste a custom key — both are accepted.
+                        Order is priority: for each log, the first configured key found on that row is used as the
+                        person identifier (priority-ordered fallback via SQL <code>coalesce</code>). Drag to reorder.
                     </>
                 )}
             </p>

--- a/frontend/src/scenes/settings/environment/LogsDistinctIdAttributeKey.tsx
+++ b/frontend/src/scenes/settings/environment/LogsDistinctIdAttributeKey.tsx
@@ -1,13 +1,32 @@
+import equal from 'fast-deep-equal'
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
-import { LemonButton, LemonInput } from '@posthog/lemon-ui'
+import { LemonButton } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TeamMembershipLevel } from 'lib/constants'
+import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 
-import { DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY, logsConfigLogic } from 'products/logs/frontend/logsConfigLogic'
+import { DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS, logsConfigLogic } from 'products/logs/frontend/logsConfigLogic'
+
+const MAX_KEY_LENGTH = 200
+
+function cleanKeys(input: string[]): string[] {
+    // Trim each entry, drop empties, dedupe while preserving order.
+    const seen = new Set<string>()
+    const cleaned: string[] = []
+    for (const raw of input) {
+        const trimmed = raw.trim()
+        if (!trimmed || seen.has(trimmed)) {
+            continue
+        }
+        seen.add(trimmed)
+        cleaned.push(trimmed)
+    }
+    return cleaned
+}
 
 export function LogsDistinctIdAttributeKey(): JSX.Element {
     const { logsConfig, logsConfigLoading } = useValues(logsConfigLogic)
@@ -17,11 +36,11 @@ export function LogsDistinctIdAttributeKey(): JSX.Element {
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
 
-    const [value, setValue] = useState<string>('')
+    const [value, setValue] = useState<string[]>([])
 
     useEffect(() => {
         if (logsConfig) {
-            setValue(logsConfig.logs_distinct_id_attribute_key)
+            setValue(logsConfig.logs_distinct_id_attribute_keys)
         }
     }, [logsConfig])
 
@@ -29,26 +48,45 @@ export function LogsDistinctIdAttributeKey(): JSX.Element {
         return <LemonSkeleton className="w-1/2 h-4" />
     }
 
-    const trimmed = value.trim()
-    const isDirty = trimmed !== (logsConfig?.logs_distinct_id_attribute_key ?? '')
-    const isEmpty = trimmed.length === 0
+    const cleaned = cleanKeys(value)
+    const existing = logsConfig?.logs_distinct_id_attribute_keys ?? []
+    const isDirty = !equal(cleaned, existing)
+    const isEmpty = cleaned.length === 0
+    const hasOverlongKey = cleaned.some((k) => k.length > MAX_KEY_LENGTH)
 
     return (
-        <div className="deprecated-space-y-4">
-            <LemonInput
+        <div className="deprecated-space-y-4 max-w-md">
+            <LemonInputSelect
+                mode="multiple"
+                allowCustomValues
+                sortable
                 value={value}
                 onChange={setValue}
-                placeholder={DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY}
-                maxLength={200}
-                disabledReason={restrictedReason}
-                className="max-w-md"
+                placeholder={DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS[0]}
+                options={[]}
+                disabled={!!restrictedReason}
             />
+            <p className="text-muted text-xs mt-1">
+                {restrictedReason ?? (
+                    <>
+                        Order is priority — for each log, the first configured key found on that row is used as the
+                        person identifier (priority-ordered fallback via SQL <code>coalesce</code>). Drag to reorder,
+                        press Enter or paste a comma-separated list to add multiple at once.
+                    </>
+                )}
+            </p>
             <LemonButton
                 type="primary"
-                onClick={() => updateLogsConfig({ logs_distinct_id_attribute_key: trimmed })}
+                onClick={() => updateLogsConfig({ logs_distinct_id_attribute_keys: cleaned })}
                 disabledReason={
                     restrictedReason ||
-                    (isEmpty ? 'Attribute key is required' : !isDirty ? 'No changes to save' : undefined)
+                    (isEmpty
+                        ? 'At least one attribute key is required'
+                        : hasOverlongKey
+                          ? `Each key must be no longer than ${MAX_KEY_LENGTH} characters`
+                          : !isDirty
+                            ? 'No changes to save'
+                            : undefined)
                 }
                 loading={logsConfigLoading}
             >

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -171,6 +171,7 @@ export type SettingId =
     | 'js-snippet-version'
     | 'logs'
     | 'logs-alerting'
+    | 'logs-distinct-id-attribute-key'
     | 'logs-drop-rules'
     | 'logs-json-parse'
     | 'logs-pii-scrub'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1139,6 +1139,14 @@ export type LogPropertyFilterType =
 export interface LogPropertyFilter extends BasePropertyFilter {
     type: LogPropertyFilterType
     operator: PropertyOperator
+    /**
+     * Optional priority-ordered list of attribute keys. When set, the matcher reads
+     * `coalesce(attributes[keys[0]], attributes[keys[1]], …)` against `value` instead of
+     * `attributes[key]`. Used by the person profile Logs tab to scope by any of the
+     * team's configured `logs_distinct_id_attribute_keys`. When unset, falls back to
+     * the single `key`.
+     */
+    keys?: string[]
 }
 
 export type SpanPropertyFilterType =

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -101,21 +101,41 @@ tracer = trace.get_tracer(__name__)
 
 
 class TeamLogsConfigSerializer(serializers.ModelSerializer):
-    logs_distinct_id_attribute_key = serializers.CharField(
-        max_length=200,
+    logs_distinct_id_attribute_keys = serializers.ListField(
+        child=serializers.CharField(max_length=200),
+        min_length=1,
+        max_length=10,
         help_text=(
-            "Log attribute key whose value should match a person's distinct_id. "
-            "Used by the person profile Logs tab and the `query-logs` MCP tool. "
-            "Defaults to 'posthogDistinctId' — the convention documented at "
-            "https://posthog.com/docs/logs/link-session-replay and the key the "
-            "posthog-js / posthog-react-native SDKs auto-attach. Override only if "
-            "your pipeline emits a different attribute."
+            "Ordered list of log attributes used to identify which person a log "
+            "belongs to. For each log row, the first configured key found on that "
+            "row is matched against the person's distinct_ids (priority-ordered "
+            "fallback via SQL COALESCE). Used by the person profile Logs tab and "
+            "the `query-logs` MCP tool. Defaults to ['posthogDistinctId'] — the "
+            "key the posthog-js / posthog-react-native SDKs auto-attach; the "
+            "convention is documented at https://posthog.com/docs/logs/link-person. "
+            "Override only if your pipeline emits the person identifier under a "
+            "different key."
         ),
     )
 
     class Meta:
         model = TeamLogsConfig
-        fields = ["logs_distinct_id_attribute_key"]
+        fields = ["logs_distinct_id_attribute_keys"]
+
+    def validate_logs_distinct_id_attribute_keys(self, value: list[str]) -> list[str]:
+        # Trim and dedupe while preserving order. Reject empty strings (caught by
+        # CharField if blank, but explicit here for clarity in the API response).
+        seen: set[str] = set()
+        cleaned: list[str] = []
+        for key in value:
+            stripped = key.strip()
+            if not stripped:
+                raise serializers.ValidationError("Attribute keys cannot be empty or whitespace-only.")
+            if stripped in seen:
+                continue
+            seen.add(stripped)
+            cleaned.append(stripped)
+        return cleaned
 
 
 def handle_logs_config(request: request.Request, team: Team) -> response.Response:

--- a/posthog/api/test/test_team_logs_config.py
+++ b/posthog/api/test/test_team_logs_config.py
@@ -23,42 +23,91 @@ class TestTeamLogsConfig(APIBaseTest):
         return f"/{prefix}/{self.team.id}/logs_config/"
 
     @parameterized.expand(URL_PREFIXES)
-    def test_get_returns_default_attribute_key(self, _name: str, prefix: str):
+    def test_get_returns_default_attribute_keys(self, _name: str, prefix: str):
         response = self.client.get(self._url(prefix))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {"logs_distinct_id_attribute_key": "posthogDistinctId"})
+        self.assertEqual(response.json(), {"logs_distinct_id_attribute_keys": ["posthogDistinctId"]})
 
     @parameterized.expand(URL_PREFIXES)
-    def test_patch_updates_attribute_key(self, _name: str, prefix: str):
+    def test_patch_updates_attribute_keys(self, _name: str, prefix: str):
         response = self.client.patch(
             self._url(prefix),
-            {"logs_distinct_id_attribute_key": "user.id"},
+            {"logs_distinct_id_attribute_keys": ["user.id", "posthogDistinctId"]},
             format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {"logs_distinct_id_attribute_key": "user.id"})
+        self.assertEqual(response.json(), {"logs_distinct_id_attribute_keys": ["user.id", "posthogDistinctId"]})
 
         config = get_or_create_team_extension(self.team, TeamLogsConfig)
-        self.assertEqual(config.logs_distinct_id_attribute_key, "user.id")
+        self.assertEqual(config.logs_distinct_id_attribute_keys, ["user.id", "posthogDistinctId"])
 
     @parameterized.expand(URL_PREFIXES)
     def test_patch_persists_across_requests(self, _name: str, prefix: str):
         self.client.patch(
             self._url(prefix),
-            {"logs_distinct_id_attribute_key": "posthog.distinct_id"},
+            {"logs_distinct_id_attribute_keys": ["posthog.distinct_id"]},
             format="json",
         )
 
         response = self.client.get(self._url(prefix))
-        self.assertEqual(response.json(), {"logs_distinct_id_attribute_key": "posthog.distinct_id"})
+        self.assertEqual(response.json(), {"logs_distinct_id_attribute_keys": ["posthog.distinct_id"]})
+
+    @parameterized.expand(URL_PREFIXES)
+    def test_patch_preserves_order(self, _name: str, prefix: str):
+        # Order matters — it's the priority order for COALESCE matching.
+        response = self.client.patch(
+            self._url(prefix),
+            {"logs_distinct_id_attribute_keys": ["c", "a", "b"]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"logs_distinct_id_attribute_keys": ["c", "a", "b"]})
+
+    @parameterized.expand(URL_PREFIXES)
+    def test_patch_dedupes_preserving_order(self, _name: str, prefix: str):
+        response = self.client.patch(
+            self._url(prefix),
+            {"logs_distinct_id_attribute_keys": ["a", "b", "a", "c", "b"]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"logs_distinct_id_attribute_keys": ["a", "b", "c"]})
+
+    @parameterized.expand(URL_PREFIXES)
+    def test_patch_trims_whitespace(self, _name: str, prefix: str):
+        response = self.client.patch(
+            self._url(prefix),
+            {"logs_distinct_id_attribute_keys": ["  user.id  ", "posthogDistinctId"]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"logs_distinct_id_attribute_keys": ["user.id", "posthogDistinctId"]})
+
+    @parameterized.expand(URL_PREFIXES)
+    def test_patch_rejects_empty_list(self, _name: str, prefix: str):
+        response = self.client.patch(
+            self._url(prefix),
+            {"logs_distinct_id_attribute_keys": []},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @parameterized.expand(URL_PREFIXES)
+    def test_patch_rejects_blank_entry(self, _name: str, prefix: str):
+        response = self.client.patch(
+            self._url(prefix),
+            {"logs_distinct_id_attribute_keys": ["posthogDistinctId", "   "]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @parameterized.expand(URL_PREFIXES)
     def test_patch_rejects_key_over_max_length(self, _name: str, prefix: str):
         response = self.client.patch(
             self._url(prefix),
-            {"logs_distinct_id_attribute_key": "x" * 201},
+            {"logs_distinct_id_attribute_keys": ["x" * 201]},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -70,11 +119,11 @@ class TestTeamLogsConfig(APIBaseTest):
 
         response = self.client.patch(
             self._url(prefix),
-            {"logs_distinct_id_attribute_key": "user.id"},
+            {"logs_distinct_id_attribute_keys": ["user.id"]},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {"logs_distinct_id_attribute_key": "user.id"})
+        self.assertEqual(response.json(), {"logs_distinct_id_attribute_keys": ["user.id"]})
 
     @parameterized.expand(URL_PREFIXES)
     def test_config_is_scoped_per_environment(self, _name: str, prefix: str):
@@ -88,14 +137,14 @@ class TestTeamLogsConfig(APIBaseTest):
 
         self.client.patch(
             self._url(prefix),
-            {"logs_distinct_id_attribute_key": "user.id"},
+            {"logs_distinct_id_attribute_keys": ["user.id"]},
             format="json",
         )
 
         sibling_response = self.client.get(f"/{prefix}/{sibling.id}/logs_config/")
         self.assertEqual(
             sibling_response.json(),
-            {"logs_distinct_id_attribute_key": "posthogDistinctId"},
+            {"logs_distinct_id_attribute_keys": ["posthogDistinctId"]},
         )
 
     def test_project_and_environment_share_same_config(self):
@@ -104,8 +153,8 @@ class TestTeamLogsConfig(APIBaseTest):
         # same env-scoped TeamLogsConfig keyed by team_id.
         self.client.patch(
             f"/api/projects/{self.team.id}/logs_config/",
-            {"logs_distinct_id_attribute_key": "user.id"},
+            {"logs_distinct_id_attribute_keys": ["user.id"]},
             format="json",
         )
         env_response = self.client.get(f"/api/environments/{self.team.id}/logs_config/")
-        self.assertEqual(env_response.json(), {"logs_distinct_id_attribute_key": "user.id"})
+        self.assertEqual(env_response.json(), {"logs_distinct_id_attribute_keys": ["user.id"]})

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7788,6 +7788,14 @@ class LogPropertyFilter(BaseModel):
         extra="forbid",
     )
     key: str
+    keys: list[str] | None = None
+    """
+    Optional priority-ordered list of attribute keys. When set, the matcher reads
+    `coalesce(attributes[keys[0]], attributes[keys[1]], …)` against `value` instead of
+    `attributes[key]`. Used by the person profile Logs tab to scope by any of the
+    team's configured `logs_distinct_id_attribute_keys`. When unset, falls back to
+    the single `key`.
+    """
     label: str | None = None
     operator: PropertyOperator
     type: LogPropertyFilterType

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -180,6 +180,52 @@ def _get_property_type(value) -> str:
     return "str"
 
 
+def _multikey_log_attribute_to_expr(filter: LogPropertyFilter) -> ast.Expr:
+    """Compile a `LogPropertyFilter` whose `keys` field is set to a HogQL expression
+    matching `coalesce(attributes[k1__suffix], attributes[k2__suffix], ...) <op> value`.
+
+    Priority-ordered fallback: on each log row, the first non-null configured key's value
+    is matched against `value`. Used by the person profile Logs tab to scope by any of
+    the team's configured `logs_distinct_id_attribute_keys` without needing the runner
+    to grow nested OR-group support.
+
+    Supports `Exact` and `IsNot` operators — sufficient for the pivot use case. Extend
+    here when new operators are needed.
+    """
+    assert filter.keys, "multikey filter must have non-empty keys list"
+
+    # Detect the per-type attribute map suffix the same way the single-key path does.
+    # Distinct_id values are strings, so the `__str` map is the default.
+    type_suffix = "str"
+    if isinstance(filter.value, list) and filter.value:
+        detected = {_get_property_type(v) for v in filter.value}
+        if len(detected) == 1:
+            type_suffix = detected.pop()
+    elif filter.value is not None and not isinstance(filter.value, list):
+        type_suffix = _get_property_type(filter.value)
+
+    coalesce_args: list[ast.Expr] = [ast.Field(chain=["attributes", f"{key}__{type_suffix}"]) for key in filter.keys]
+    attr_expr: ast.Expr = ast.Call(name="coalesce", args=coalesce_args) if len(coalesce_args) > 1 else coalesce_args[0]
+
+    if isinstance(filter.value, list):
+        values_tuple = ast.Tuple(exprs=[ast.Constant(value=str(v)) for v in filter.value])
+        op = ast.CompareOperationOp.NotIn if filter.operator == PropertyOperator.IS_NOT else ast.CompareOperationOp.In
+        return ast.CompareOperation(op=op, left=attr_expr, right=values_tuple)
+
+    if filter.value is None:
+        # Treat as IS_SET / IS_NOT_SET — log row matches if any configured key has a non-null value.
+        return ast.CompareOperation(
+            op=ast.CompareOperationOp.NotEq
+            if filter.operator == PropertyOperator.IS_NOT
+            else ast.CompareOperationOp.Eq,
+            left=attr_expr,
+            right=ast.Constant(value=None),
+        )
+
+    op = ast.CompareOperationOp.NotEq if filter.operator == PropertyOperator.IS_NOT else ast.CompareOperationOp.Eq
+    return ast.CompareOperation(op=op, left=attr_expr, right=ast.Constant(value=str(filter.value)))
+
+
 class LogsFilterBuilder:
     """Builds HogQL WHERE clause AST from LogsQuery filter fields.
 
@@ -195,6 +241,11 @@ class LogsFilterBuilder:
         self.resource_attribute_negative_filters: list[LogPropertyFilter] = []
         self.log_filters: list[LogPropertyFilter] = []
         self.attribute_filters: list[LogPropertyFilter] = []
+        # Multikey log-attribute filters (e.g. person-profile pivot scoped by a list of
+        # `logs_distinct_id_attribute_keys`). Compiled to a COALESCE-based HogQL expr
+        # directly — bypasses the universal property_to_expr pipeline because the latter
+        # is single-key-only.
+        self.multikey_attribute_filters: list[LogPropertyFilter] = []
         if self.query.filterGroup and len(self.query.filterGroup.values) > 0:
             for property_group in self.query.filterGroup.values:
                 self.resource_attribute_filters = cast(
@@ -230,6 +281,13 @@ class LogsFilterBuilder:
             for property_filter in self.query.filterGroup.values[0].values:
                 # we only do the type mapping for log attributes
                 if property_filter.type != LogPropertyFilterType.LOG_ATTRIBUTE:
+                    continue
+
+                # Multi-key filters (priority-ordered COALESCE) are compiled separately —
+                # property_to_expr is single-key-only, so we bypass the type-suffix rewrite
+                # here and let `where()` call `_multikey_log_attribute_to_expr` instead.
+                if isinstance(property_filter, LogPropertyFilter) and property_filter.keys:
+                    self.multikey_attribute_filters.append(property_filter)
                     continue
 
                 if isinstance(property_filter, LogPropertyFilter) and property_filter.value:
@@ -286,6 +344,13 @@ class LogsFilterBuilder:
 
             if self.attribute_filters:
                 exprs.append(property_to_expr(self.attribute_filters, team=self.team))
+
+            # Multi-key log-attribute pivots (e.g. person-profile scope across a list of
+            # configured `logs_distinct_id_attribute_keys`). Each compiles to a single
+            # COALESCE-based comparison; multiple multi-key filters in the same group
+            # are ANDed alongside the rest.
+            for multikey_filter in self.multikey_attribute_filters:
+                exprs.append(_multikey_log_attribute_to_expr(multikey_filter))
 
             if self.log_filters:
                 for log_filter in self.log_filters:

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -182,48 +182,70 @@ def _get_property_type(value) -> str:
 
 def _multikey_log_attribute_to_expr(filter: LogPropertyFilter) -> ast.Expr:
     """Compile a `LogPropertyFilter` whose `keys` field is set to a HogQL expression
-    matching `coalesce(attributes[k1__suffix], attributes[k2__suffix], ...) <op> value`.
+    matching the configured keys against `value` across the per-type attribute maps.
 
     Priority-ordered fallback: on each log row, the first non-null configured key's value
-    is matched against `value`. Used by the person profile Logs tab to scope by any of
-    the team's configured `logs_distinct_id_attribute_keys` without needing the runner
+    is matched (via SQL `coalesce`). Used by the person profile Logs tab to scope by any
+    of the team's configured `logs_distinct_id_attribute_keys` without needing the runner
     to grow nested OR-group support.
+
+    Person distinct_ids are strings, but a log may emit the same identifier as a number
+    (`5`, `5.0`) rather than a string (`"5"`). Every emitted value lands in the `__str`
+    attribute map, and additionally in the `__float` map when it parses as a number
+    (`__float` ⊆ `__str`). To link regardless of how the value was emitted, we match BOTH
+    maps and OR the results: a person whose distinct_id is "5" links to a log whose
+    `posthogDistinctId` is `"5"`, `5`, `5.0`, or `"05"`. This permissiveness — including the
+    `"5"`/`"05"` numeric collision — is deliberately scoped to the pivot; the general
+    single-key log filter keeps strict per-type routing.
 
     Supports `Exact` and `IsNot` operators — sufficient for the pivot use case. Extend
     here when new operators are needed.
     """
     assert filter.keys, "multikey filter must have non-empty keys list"
 
-    # Detect the per-type attribute map suffix the same way the single-key path does.
-    # Distinct_id values are strings, so the `__str` map is the default.
-    type_suffix = "str"
-    if isinstance(filter.value, list) and filter.value:
-        detected = {_get_property_type(v) for v in filter.value}
-        if len(detected) == 1:
-            type_suffix = detected.pop()
-    elif filter.value is not None and not isinstance(filter.value, list):
-        type_suffix = _get_property_type(filter.value)
+    is_negative = filter.operator == PropertyOperator.IS_NOT
 
-    coalesce_args: list[ast.Expr] = [ast.Field(chain=["attributes", f"{key}__{type_suffix}"]) for key in filter.keys]
-    attr_expr: ast.Expr = ast.Call(name="coalesce", args=coalesce_args) if len(coalesce_args) > 1 else coalesce_args[0]
+    def coalesce(suffix: str) -> ast.Expr:
+        # Mirrors the single-key path's `attributes[key__suffix]` field-access shape, which
+        # the query layer rewrites onto the matching `attributes_map_<suffix>` column.
+        args: list[ast.Expr] = [ast.Field(chain=["attributes", f"{key}__{suffix}"]) for key in filter.keys]
+        return ast.Call(name="coalesce", args=args) if len(args) > 1 else args[0]
 
-    if isinstance(filter.value, list):
-        values_tuple = ast.Tuple(exprs=[ast.Constant(value=str(v)) for v in filter.value])
-        op = ast.CompareOperationOp.NotIn if filter.operator == PropertyOperator.IS_NOT else ast.CompareOperationOp.In
-        return ast.CompareOperation(op=op, left=attr_expr, right=values_tuple)
-
+    # IS_SET / IS_NOT_SET — value omitted. A key present in `__float` is also present in
+    # `__str` (float ⊆ str), so the str map alone answers "is any configured key set".
     if filter.value is None:
-        # Treat as IS_SET / IS_NOT_SET — log row matches if any configured key has a non-null value.
         return ast.CompareOperation(
-            op=ast.CompareOperationOp.NotEq
-            if filter.operator == PropertyOperator.IS_NOT
-            else ast.CompareOperationOp.Eq,
-            left=attr_expr,
+            op=ast.CompareOperationOp.NotEq if is_negative else ast.CompareOperationOp.Eq,
+            left=coalesce("str"),
             right=ast.Constant(value=None),
         )
 
-    op = ast.CompareOperationOp.NotEq if filter.operator == PropertyOperator.IS_NOT else ast.CompareOperationOp.Eq
-    return ast.CompareOperation(op=op, left=attr_expr, right=ast.Constant(value=str(filter.value)))
+    is_list = isinstance(filter.value, list)
+    values = filter.value if is_list else [filter.value]
+    numeric_values: list[float] = []
+    for v in values:
+        try:
+            numeric_values.append(float(v))
+        except (TypeError, ValueError):
+            pass
+
+    def compare(suffix: str, consts: list[ast.Expr]) -> ast.CompareOperation:
+        if is_list:
+            op = ast.CompareOperationOp.NotIn if is_negative else ast.CompareOperationOp.In
+            return ast.CompareOperation(op=op, left=coalesce(suffix), right=ast.Tuple(exprs=consts))
+        op = ast.CompareOperationOp.NotEq if is_negative else ast.CompareOperationOp.Eq
+        return ast.CompareOperation(op=op, left=coalesce(suffix), right=consts[0])
+
+    str_clause = compare("str", [ast.Constant(value=str(v)) for v in values])
+
+    # No numeric-parseable values (e.g. UUID distinct_ids) — the str map is sufficient.
+    if not numeric_values:
+        return str_clause
+
+    float_clause = compare("float", [ast.Constant(value=n) for n in numeric_values])
+
+    # Positive: value is in the str map OR the float map. Negative (De Morgan): in NEITHER.
+    return ast.And(exprs=[str_clause, float_clause]) if is_negative else ast.Or(exprs=[str_clause, float_clause])
 
 
 class LogsFilterBuilder:

--- a/products/logs/backend/migrations/0015_teamlogsconfig_attribute_keys.py
+++ b/products/logs/backend/migrations/0015_teamlogsconfig_attribute_keys.py
@@ -1,0 +1,43 @@
+from django.contrib.postgres.fields import ArrayField
+from django.db import migrations, models
+
+
+def backfill_singular_to_array(apps, schema_editor):
+    """Carry each row's existing `logs_distinct_id_attribute_key` (singular) into
+    `logs_distinct_id_attribute_keys` (a single-element list)."""
+    Cfg = apps.get_model("logs", "TeamLogsConfig")
+    for cfg in Cfg.objects.all():
+        existing = cfg.logs_distinct_id_attribute_key or "posthogDistinctId"
+        cfg.logs_distinct_id_attribute_keys = [existing]
+        cfg.save(update_fields=["logs_distinct_id_attribute_keys"])
+
+
+def rollback_array_to_singular(apps, schema_editor):
+    Cfg = apps.get_model("logs", "TeamLogsConfig")
+    for cfg in Cfg.objects.all():
+        keys = cfg.logs_distinct_id_attribute_keys or ["posthogDistinctId"]
+        cfg.logs_distinct_id_attribute_key = keys[0]
+        cfg.save(update_fields=["logs_distinct_id_attribute_key"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("logs", "0014_teamlogsconfig"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="teamlogsconfig",
+            name="logs_distinct_id_attribute_keys",
+            field=ArrayField(
+                base_field=models.CharField(max_length=200),
+                default=list,
+                size=None,
+            ),
+        ),
+        migrations.RunPython(backfill_singular_to_array, rollback_array_to_singular, elidable=True),
+        migrations.RemoveField(
+            model_name="teamlogsconfig",
+            name="logs_distinct_id_attribute_key",
+        ),
+    ]

--- a/products/logs/backend/migrations/max_migration.txt
+++ b/products/logs/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0014_teamlogsconfig
+0015_teamlogsconfig_attribute_keys

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -4,6 +4,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
+from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
 
@@ -22,7 +23,12 @@ logger = logging.getLogger(__name__)
 # posthog-js / posthog-react-native SDKs auto-attach `posthogDistinctId` to every log
 # they emit, and the docs instruct OTel-emitting backends to set the same key. Customers
 # whose pipeline uses a different key can override via the `logs_config` endpoint.
-DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY = "posthogDistinctId"
+DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS: list[str] = ["posthogDistinctId"]
+
+
+def _default_logs_distinct_id_attribute_keys() -> list[str]:
+    # Returns a fresh list so the model default isn't shared across rows.
+    return list(DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS)
 
 
 class TeamLogsConfig(models.Model):
@@ -33,13 +39,14 @@ class TeamLogsConfig(models.Model):
     # access to. Mirrors the `TeamExperimentsConfig` precedent.
     team = models.OneToOneField("posthog.Team", on_delete=models.CASCADE, primary_key=True)
 
-    # Log attribute key whose value matches a PostHog person's distinct_id. Used by the
+    # Ordered list of log attribute keys used to identify which person a log belongs to.
+    # For each log row, the first configured key found on that row is matched against the
+    # person's distinct_ids (priority-ordered fallback via SQL COALESCE). Used by the
     # person profile Logs tab and the `query-logs` MCP tool to filter logs to a single
     # user without needing per-team prompt engineering.
-    logs_distinct_id_attribute_key = models.CharField(
-        max_length=200,
-        default=DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY,
-        db_default=DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY,
+    logs_distinct_id_attribute_keys = ArrayField(
+        models.CharField(max_length=200),
+        default=_default_logs_distinct_id_attribute_keys,
     )
 
 

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -82,6 +82,76 @@ class TestAttributeFilters(APIBaseTest):
         # this optimization was premature and needs more thought, and probably has very little benefit anyway
         self.assertNotIn("in(resource_fingerprint", query_str)
 
+    def test_log_attribute_multikey_filter_emits_coalesce(self):
+        """A `LogPropertyFilter` with `keys` set compiles to a `coalesce()`-based HogQL
+        expression spanning every key, with the type suffix applied per key.
+
+        Calls the helper directly (rather than the full runner → executor → parser pipeline)
+        to keep the test scoped to the compile-time behavior we own here.
+        """
+        from posthog.hogql import ast as hogql_ast
+
+        from products.logs.backend.logs_query_runner import _multikey_log_attribute_to_expr
+
+        filter = LogPropertyFilter(
+            key="posthogDistinctId",
+            keys=["posthogDistinctId", "user.id"],
+            operator=PropertyOperator.EXACT,
+            type=LogPropertyFilterType.LOG_ATTRIBUTE,
+            value=["abc-123", "def-456"],
+        )
+
+        expr = _multikey_log_attribute_to_expr(filter)
+
+        # Compare-op IN over a coalesce() call with one Field per configured key.
+        self.assertIsInstance(expr, hogql_ast.CompareOperation)
+        self.assertEqual(expr.op, hogql_ast.CompareOperationOp.In)  # type: ignore[union-attr]
+        coalesce = expr.left  # type: ignore[union-attr]
+        self.assertIsInstance(coalesce, hogql_ast.Call)
+        self.assertEqual(coalesce.name, "coalesce")  # type: ignore[union-attr]
+        self.assertEqual(len(coalesce.args), 2)  # type: ignore[union-attr]
+        self.assertEqual(coalesce.args[0].chain, ["attributes", "posthogDistinctId__str"])  # type: ignore[union-attr]
+        self.assertEqual(coalesce.args[1].chain, ["attributes", "user.id__str"])  # type: ignore[union-attr]
+
+    def test_log_attribute_multikey_filter_single_key_skips_coalesce(self):
+        """When `keys` has a single entry, the compiled expression is a plain attribute
+        lookup (no `coalesce()` wrapper) — keeps the SQL tidy on the default-config path."""
+        from posthog.hogql import ast as hogql_ast
+
+        from products.logs.backend.logs_query_runner import _multikey_log_attribute_to_expr
+
+        filter = LogPropertyFilter(
+            key="posthogDistinctId",
+            keys=["posthogDistinctId"],
+            operator=PropertyOperator.EXACT,
+            type=LogPropertyFilterType.LOG_ATTRIBUTE,
+            value=["solo-id"],
+        )
+
+        expr = _multikey_log_attribute_to_expr(filter)
+        self.assertIsInstance(expr, hogql_ast.CompareOperation)
+        # Single key: the left side is a Field directly, no coalesce() wrapper.
+        self.assertIsInstance(expr.left, hogql_ast.Field)  # type: ignore[union-attr]
+        self.assertEqual(expr.left.chain, ["attributes", "posthogDistinctId__str"])  # type: ignore[union-attr]
+
+    def test_log_attribute_multikey_filter_is_not_uses_not_in(self):
+        """`IsNot` operator produces NotIn on the coalesce expression."""
+        from posthog.hogql import ast as hogql_ast
+
+        from products.logs.backend.logs_query_runner import _multikey_log_attribute_to_expr
+
+        filter = LogPropertyFilter(
+            key="posthogDistinctId",
+            keys=["posthogDistinctId", "user.id"],
+            operator=PropertyOperator.IS_NOT,
+            type=LogPropertyFilterType.LOG_ATTRIBUTE,
+            value=["alice", "bob"],
+        )
+
+        expr = _multikey_log_attribute_to_expr(filter)
+        self.assertIsInstance(expr, hogql_ast.CompareOperation)
+        self.assertEqual(expr.op, hogql_ast.CompareOperationOp.NotIn)  # type: ignore[union-attr]
+
     def test_resource_attribute_filters(self):
         """Test that resource attribute filters are properly handled"""
         query = LogsQuery(

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -23,6 +23,7 @@ from posthog.hogql.query import HogQLQueryExecutor
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
+from posthog.models.utils import UUIDT
 
 from products.logs.backend.logs_query_runner import LogsQueryRunner
 
@@ -151,6 +152,60 @@ class TestAttributeFilters(APIBaseTest):
         expr = _multikey_log_attribute_to_expr(filter)
         self.assertIsInstance(expr, hogql_ast.CompareOperation)
         self.assertEqual(expr.op, hogql_ast.CompareOperationOp.NotIn)  # type: ignore[union-attr]
+
+    def test_log_attribute_multikey_filter_numeric_value_matches_str_or_float(self):
+        """A distinct_id that parses as a number must link whether the log emitted it as a
+        string ("5"), an int (5), a float (5.0), or zero-padded ("05"). The compiled
+        expression ORs a str-map match (exact) with a float-map match (numeric-equal); the
+        float clause only carries the numeric-parseable values.
+        """
+        from posthog.hogql import ast as hogql_ast
+
+        from products.logs.backend.logs_query_runner import _multikey_log_attribute_to_expr
+
+        filter = LogPropertyFilter(
+            key="posthogDistinctId",
+            keys=["posthogDistinctId", "user.id"],
+            operator=PropertyOperator.EXACT,
+            type=LogPropertyFilterType.LOG_ATTRIBUTE,
+            value=["5", "abc-uuid"],
+        )
+
+        expr = _multikey_log_attribute_to_expr(filter)
+
+        self.assertIsInstance(expr, hogql_ast.Or)
+        str_clause, float_clause = expr.exprs  # type: ignore[union-attr]
+
+        # str clause: coalesce over the __str maps, IN every value as a string.
+        self.assertEqual(str_clause.op, hogql_ast.CompareOperationOp.In)
+        self.assertEqual(str_clause.left.args[0].chain, ["attributes", "posthogDistinctId__str"])
+        self.assertEqual([c.value for c in str_clause.right.exprs], ["5", "abc-uuid"])
+
+        # float clause: coalesce over the __float maps, IN only the numeric-parseable values.
+        self.assertEqual(float_clause.op, hogql_ast.CompareOperationOp.In)
+        self.assertEqual(float_clause.left.args[0].chain, ["attributes", "posthogDistinctId__float"])
+        self.assertEqual([c.value for c in float_clause.right.exprs], [5.0])
+
+    def test_log_attribute_multikey_filter_is_not_numeric_uses_and_of_not_in(self):
+        """`IsNot` with numeric values negates the positive match (De Morgan): the value must
+        be absent from BOTH the str and float maps, so the clauses are ANDed."""
+        from posthog.hogql import ast as hogql_ast
+
+        from products.logs.backend.logs_query_runner import _multikey_log_attribute_to_expr
+
+        filter = LogPropertyFilter(
+            key="posthogDistinctId",
+            keys=["posthogDistinctId", "user.id"],
+            operator=PropertyOperator.IS_NOT,
+            type=LogPropertyFilterType.LOG_ATTRIBUTE,
+            value=["5", "abc-uuid"],
+        )
+
+        expr = _multikey_log_attribute_to_expr(filter)
+
+        self.assertIsInstance(expr, hogql_ast.And)
+        for clause in expr.exprs:  # type: ignore[union-attr]
+            self.assertEqual(clause.op, hogql_ast.CompareOperationOp.NotIn)
 
     def test_resource_attribute_filters(self):
         """Test that resource attribute filters are properly handled"""
@@ -1004,3 +1059,70 @@ class TestLogsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         }
         response = self._make_logs_api_request(query_params)
         self.assertGreater(len(response["results"]), 0)
+
+
+class TestMultikeyPivotNumericLinking(ClickhouseTestMixin, APIBaseTest):
+    """End-to-end proof that the person-profile pivot links a numeric distinct_id to logs
+    regardless of how the identifier was emitted. Reproduces the Circleback scenario — a
+    person whose distinct_id is numeric ("5") — and asserts the str-OR-float pivot match
+    links the string, int, float, and zero-padded forms while excluding non-matches.
+
+    Inserts only `attributes_map_str`; the logs table materializes `attributes_map_float`
+    from it via `toFloat64OrNull`, exactly as production does (float ⊆ str). So "05" lands
+    in __str as "05" and in __float as 5.0 — the case the pre-fix str-only routing dropped.
+    """
+
+    def _insert_pivot_log(self, body: str, posthog_distinct_id: str) -> None:
+        row = {
+            "uuid": str(UUIDT()),
+            "team_id": self.team.id,
+            "timestamp": "2025-12-16 10:00:00.000000",
+            "observed_timestamp": "2025-12-16 10:00:00.000000",
+            "body": body,
+            "severity_text": "info",
+            "severity_number": 9,
+            "service_name": "pivot-test",
+            "attributes_map_str": {"posthogDistinctId__str": posthog_distinct_id},
+        }
+        sync_execute(f"INSERT INTO logs FORMAT JSONEachRow\n{json.dumps(row)}\n")
+
+    def _bodies_for_pivot(self, distinct_ids: list[str]) -> set[str]:
+        query_params = {
+            "dateRange": {"date_from": "2025-12-16 09:00:00", "date_to": "2025-12-16 11:00:00"},
+            "limit": 100,
+            "filterGroup": {
+                "type": "AND",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "key": "posthogDistinctId",
+                                "keys": ["posthogDistinctId"],
+                                "operator": "exact",
+                                "type": "log_attribute",
+                                "value": distinct_ids,
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/logs/query", data={"query": query_params})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return {r["body"] for r in response.json()["results"]}
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_numeric_distinct_id_links_across_emitted_forms(self):
+        self._insert_pivot_log("string-5", "5")  # str-exact match
+        self._insert_pivot_log("zero-padded", "05")  # float-only match (5.0); pre-fix this was dropped
+        self._insert_pivot_log("decimal", "5.0")  # float-only match (5.0); pre-fix this was dropped
+        self._insert_pivot_log("uuid", "abc-uuid")  # str-exact match (the person's other distinct_id)
+        self._insert_pivot_log("other-numeric", "6")  # must NOT match — different number
+        self._insert_pivot_log("other-string", "nope")  # must NOT match — non-numeric, not a distinct_id
+
+        # Person has a numeric distinct_id AND a uuid — the realistic mixed case where the
+        # pre-fix str-only routing matched only the exact "5" and the uuid, dropping "05"/"5.0".
+        matched = self._bodies_for_pivot(["5", "abc-uuid"])
+
+        self.assertEqual(matched, {"string-5", "zero-padded", "decimal", "uuid"})

--- a/products/logs/frontend/logsConfigLogic.ts
+++ b/products/logs/frontend/logsConfigLogic.ts
@@ -27,6 +27,10 @@ export const logsConfigLogic = kea<logsConfigLogicType>([
                     // nosemgrep: prefer-codegen-api
                     return await api.get(`api/projects/${values.currentTeamId}/logs_config/`)
                 },
+                updateLogsConfig: async (patch: Partial<LogsConfig>): Promise<LogsConfig> => {
+                    // nosemgrep: prefer-codegen-api
+                    return await api.update(`api/projects/${values.currentTeamId}/logs_config/`, patch)
+                },
             },
         ],
     })),

--- a/products/logs/frontend/logsConfigLogic.ts
+++ b/products/logs/frontend/logsConfigLogic.ts
@@ -6,14 +6,14 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import type { logsConfigLogicType } from './logsConfigLogicType'
 
-// Mirrors the backend default in products/logs/backend/models.py — the convention
-// documented at https://posthog.com/docs/logs/link-session-replay. Used as the
-// pre-load fallback in `PersonLogsTab` so the initial pinned filter matches the
-// SDK convention before `logs_config` resolves.
-export const DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY = 'posthogDistinctId'
+// Mirrors the backend default in products/logs/backend/models.py. Used as the pre-load
+// fallback in `PersonLogsTab` so the initial pinned filter matches the SDK convention
+// (the JS / React Native SDKs auto-attach `posthogDistinctId` to every log) before
+// `logs_config` resolves.
+export const DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS = ['posthogDistinctId']
 
 export interface LogsConfig {
-    logs_distinct_id_attribute_key: string
+    logs_distinct_id_attribute_keys: string[]
 }
 
 export const logsConfigLogic = kea<logsConfigLogicType>([

--- a/products/logs/frontend/logsConfigLogic.ts
+++ b/products/logs/frontend/logsConfigLogic.ts
@@ -1,7 +1,9 @@
 import { afterMount, connect, kea, path } from 'kea'
 import { loaders } from 'kea-loaders'
+import { combineUrl } from 'kea-router'
 
 import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
 import { teamLogic } from 'scenes/teamLogic'
 
 import type { logsConfigLogicType } from './logsConfigLogicType'
@@ -12,8 +14,29 @@ import type { logsConfigLogicType } from './logsConfigLogicType'
 // `logs_config` resolves.
 export const DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS = ['posthogDistinctId']
 
+// Common identifier attribute keys we know teams use across the OTel ecosystem. Surfaced
+// in the settings picker even when the team hasn't ingested any logs under them yet —
+// they're the canonical PostHog-link conventions plus the OTel-spec equivalents the
+// Logs viewer's defensive matcher already understands (see products/logs/frontend/utils.tsx
+// `DISTINCT_ID_KEYS`). Picking one of these in the settings UI matches what a freshly
+// integrated backend will emit.
+export const SUGGESTED_DISTINCT_ID_ATTRIBUTE_KEYS = [
+    'posthogDistinctId',
+    'posthog.distinct_id',
+    'posthog_distinct_id',
+    'distinct_id',
+    'distinctId',
+    'user.id',
+    'userId',
+    'user_id',
+]
+
 export interface LogsConfig {
     logs_distinct_id_attribute_keys: string[]
+}
+
+interface AttributeOption {
+    name: string
 }
 
 export const logsConfigLogic = kea<logsConfigLogicType>([
@@ -33,8 +56,39 @@ export const logsConfigLogic = kea<logsConfigLogicType>([
                 },
             },
         ],
+        // Recent log + resource attribute keys the team's pipeline has actually emitted,
+        // used to populate the "Link to person" settings picker with autocomplete options.
+        // Falls back to the static `SUGGESTED_DISTINCT_ID_ATTRIBUTE_KEYS` list on error so
+        // teams configuring before any logs land still get sensible suggestions.
+        attributeKeyOptions: [
+            [] as string[],
+            {
+                loadAttributeKeyOptions: async (): Promise<string[]> => {
+                    const dateRange = JSON.stringify({
+                        date_from: dayjs().subtract(30, 'day').toISOString(),
+                        date_to: dayjs().toISOString(),
+                    })
+                    const fetchType = async (attribute_type: 'log' | 'resource'): Promise<string[]> => {
+                        try {
+                            const url = combineUrl(`api/projects/${values.currentTeamId}/logs/attributes`, {
+                                attribute_type,
+                                dateRange,
+                            }).url
+                            // nosemgrep: prefer-codegen-api
+                            const response: { results: AttributeOption[] } = await api.get(url)
+                            return response.results.map((r) => r.name)
+                        } catch {
+                            return []
+                        }
+                    }
+                    const [logs, resource] = await Promise.all([fetchType('log'), fetchType('resource')])
+                    return Array.from(new Set([...logs, ...resource]))
+                },
+            },
+        ],
     })),
     afterMount(({ actions }) => {
         actions.loadLogsConfig()
+        actions.loadAttributeKeyOptions()
     }),
 ])


### PR DESCRIPTION
## Problem

`TeamLogsConfig` links logs to a person by matching one log attribute against the person's distinct IDs. A single attribute, matched one way, doesn't cover how real pipelines actually emit the identifier:

- **Different keys per service.** The PostHog JS / React Native SDKs auto-attach `posthogDistinctId` (camelCase); OTel-emitting backends often use `posthog.distinct_id` (dotted snake), `user.id`, or a plain `distinct_id`. With a single configured key, a team loses linkage on every log emitted under another key.
- **Different value shapes for the same id.** A person's `distinct_id` is always a string (e.g. `"5"`), but a backend may emit that identifier as a JSON number (`5`, `5.0`) or a zero-padded string (`"05"`). Logs are stored in per-type attribute maps — every value lands in the `__str` map, and additionally in the `__float` map when it parses as a number. Matching only `__str` exact means a numeric distinct_id silently fails to link whenever the emitted form differs textually (`"05"`/`"5.0"` ≠ `"5"`), even though they're the same identifier.

## Changes

Two things, both keeping the person-profile pinned filter as a single condition ANDed with user filters — **no nested OR-group support in the query runner**:

1. **Multiple keys, priority-ordered fallback.** Configure an ordered list of attribute keys; for any log row the first present key is matched, compiled as a single SQL `COALESCE(...)`.
2. **Type-agnostic value matching for the pivot.** The pivot matches a distinct_id against **both** maps: `coalesce(attrs[k__str], …) IN <ids>` **OR** `coalesce(attrs[k__float], …) IN <numeric ids>`. A person whose `distinct_id` is `"5"` now links to logs emitting `"5"`, `5`, `5.0`, or `"05"`.

### Backend
- `products/logs/backend/models.py` + `migrations/0015_*`: `logs_distinct_id_attribute_key: CharField` → `logs_distinct_id_attribute_keys: ArrayField(CharField(max_length=200), default=lambda: ["posthogDistinctId"])`. Migration mirrors `posthog/migrations/0032_team_multiple_app_urls.py` — add → backfill (RunPython, `elidable=True`) → remove.
- `posthog/api/team.py`: serializer becomes `ListField(child=CharField)`, `min_length=1`, `max_length=10`. Validates non-blank entries, dedupes preserving order, trims whitespace.
- `posthog/schema.py` + `frontend/src/types.ts`: new optional `keys: list[str]` on `LogPropertyFilter` (alternative to `key`).
- `products/logs/backend/logs_query_runner.py`: `_multikey_log_attribute_to_expr` compiles a `keys`-bearing filter. When any distinct_id parses as a number it emits `coalesce(…__str) IN <all ids> OR coalesce(…__float) IN <numeric ids>`; UUID-only ids skip the float clause and stay a single str comparison. `IsNot` negates via De Morgan (`AND` of two `NOT IN`); `IS_SET`/`IS_NOT_SET` use the str map (`__float` ⊆ `__str`). Single compile-site change in the LogAttribute branch — `property_to_expr` and the nested-group walk are untouched.

This permissiveness — including the `"5"` / `"05"` numeric collision — is **deliberately scoped to the pivot** via the `keys` signal. The general single-key log filter is untouched and keeps its existing per-type routing.

### Frontend
- `products/logs/frontend/logsConfigLogic.ts`: plural shape + `DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS = ['posthogDistinctId']`.
- `frontend/src/scenes/settings/environment/LogsDistinctIdAttributeKey.tsx`: swap `LemonInput` for `LemonInputSelect` (`mode="multiple"`, `allowCustomValues`, `sortable`). Drag-to-reorder, comma-paste to add multiple. Save validates ≥1 entry, ≤200 chars per entry, dedupes/trims. Admin gating unchanged. Helper text explains priority order.
- `frontend/src/scenes/persons/PersonLogsTab.tsx`: pinned filter carries the `keys` array. Scope hint renders all configured keys with a prominent inline "Link logs to a person →" link to the settings page (replaces the previous discreet gear icon).

### Tests
- `posthog/api/test/test_team_logs_config.py`: 23 parametrized tests, plural shape — empty/blank/over-length/duplicate/whitespace input, order preservation, dual-route parity, env isolation.
- `products/logs/backend/test/test_logs_query_runner.py`: builder-level tests assert `_multikey_log_attribute_to_expr` produces a `coalesce(...)` `Call` of per-key `__str` `Field`s for non-numeric ids, and an `Or(str_clause, float_clause)` (with the float clause carrying only the numeric values) when an id parses as a number. New ClickHouse-backed `TestMultikeyPivotNumericLinking` inserts only `attributes_map_str` and lets the table materialize `attributes_map_float` exactly as production does, proving a person `["5", <uuid>]` links the `"5"`, `"05"`, `"5.0"`, and uuid logs while excluding `"6"` / non-numeric strings.

## How did you test this code?

I'm an agent (PostHog Code). The user reviewed and approved the design: COALESCE-over-OR for multi-key, and "also match numeric-equal (str OR float)" scoped to the pivot for the value-shape fix. Automated tests I ran on this branch:

- `pytest posthog/api/test/test_team_logs_config.py` — **23/23 passing**.
- `pytest products/logs/backend/test/test_logs_query_runner.py` — **40/40 passing** (full file, including the new ClickHouse-backed numeric-linking test).
- **Teeth check:** with the runner fix stashed, `TestMultikeyPivotNumericLinking` fails — pre-fix it drops the `"05"` and `"5.0"` logs, the exact format variants str-exact misses — confirming the test exercises the real behavior change.

Frontend changes are covered by CI (`typescript:check`).

## Notes for reviewers

- Builds on **#61301** (the admin-gated settings UI), now merged — this branch needs a rebase onto current master to pick it up.
- Priority/COALESCE semantics: a log carrying both `posthogDistinctId = X` (not a distinct_id) AND `user.id = Y` (a distinct_id) does NOT link — the first present key's value wins per row. A single log emits one identifier under one key in practice, so this is rare; documented in the docs follow-up.
- True OR-across-keys was considered and rejected — it needs nested OR-group support in the query runner, a much larger change for marginal gain.
- The str-OR-float pivot match is intentionally permissive: a numeric distinct_id will also match other numerically-equal but textually-different log values (e.g. person `"5"` matches a log's `"05"`). This is acceptable for the person-scoping pivot; it is **not** applied to general user-typed log filters.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Follow-up docs PR in `PostHog/posthog.com` will update:
- `contents/docs/logs/link-person.mdx` — "Customizing the attribute key" becomes "Customizing the attribute keys"; add a multi-key worked example, explain priority/COALESCE semantics, and note that numeric identifiers link regardless of whether the log emitted them as a string or a number.
- `contents/docs/logs/troubleshooting.mdx` — mention the priority-fallback edge case (a log with a non-matching first-key value won't link even if a later key would have; suggest reordering).

## 🤖 Agent context

PostHog Code. Two design decisions, both steered by the user:

- **Multi-key matching:** the first draft proposed true OR semantics with nested OR-group recursion in the query runner; the user pushed back on the complexity ("AND is okay"), so the revised design uses COALESCE/priority and keeps the pinned filter a single ANDed condition.
- **Value-shape matching:** prompted by a user-shared log screenshot showing numeric distinct_ids that weren't linking. We established that the per-type maps mean `__float` ⊆ `__str`, so the gap is textual format variants (`"05"`, `"5.0"`), not cross-type routing. The user chose maximally permissive str-OR-float matching, scoped to the pivot only; the general single-key filter is intentionally left unchanged.

Agent-authored; requires human review before merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
