### PR TITLE
chore(property-vals): remove person and group property fan-out

### DIFF
--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -44,12 +44,6 @@ pub struct Config {
     #[envconfig(default = "60")]
     pub kafka_produce_timeout_secs: u64,
 
-    #[envconfig(default = "clickhouse_groups")]
-    pub groups_kafka_consumer_topic: String,
-
-    #[envconfig(default = "clickhouse-property-vals-rs-groups")]
-    pub groups_kafka_consumer_group: String,
-
     #[envconfig(default = "")]
     pub allowed_teams: TeamList,
 

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 use crate::config::ExcludedPropertyKeys;
 use crate::metrics_consts::VALUES_DROPPED;
-use crate::types::{Event, GroupIdentify, PropertyType, PropertyValueMessage, TupleKey};
+use crate::types::{Event, PropertyType, PropertyValueMessage, TupleKey};
 
 pub const MAX_PROPERTY_KEY_LEN: usize = 400;
 pub const MAX_PROPERTY_VALUE_LEN: usize = 255;
@@ -13,27 +13,7 @@ pub fn fan_out(event: &Event, excluded: &ExcludedPropertyKeys) -> Vec<(TupleKey,
     if let Some(raw) = &event.properties {
         emit_from_blob(event.team_id, PropertyType::Event, raw, excluded, &mut out);
     }
-    if let Some(raw) = &event.person_properties {
-        emit_from_blob(event.team_id, PropertyType::Person, raw, excluded, &mut out);
-    }
 
-    out
-}
-
-pub fn fan_out_group(
-    event: &GroupIdentify,
-    excluded: &ExcludedPropertyKeys,
-) -> Vec<(TupleKey, u64)> {
-    let mut out = Vec::new();
-    if let Some(raw) = &event.group_properties {
-        emit_from_blob(
-            event.team_id,
-            PropertyType::Group(event.group_type_index),
-            raw,
-            excluded,
-            &mut out,
-        );
-    }
     out
 }
 
@@ -128,15 +108,6 @@ mod tests {
         Event {
             team_id: 2,
             properties: Some(properties.to_string()),
-            person_properties: None,
-        }
-    }
-
-    fn group_identify(group_type_index: u8, properties: &str) -> GroupIdentify {
-        GroupIdentify {
-            team_id: 2,
-            group_type_index,
-            group_properties: Some(properties.to_string()),
         }
     }
 
@@ -166,19 +137,8 @@ mod tests {
         fn arb_event()(
             team_id: i64,
             properties in prop::option::of(arb_blob()),
-            person_properties in prop::option::of(arb_blob()),
         ) -> Event {
-            Event { team_id, properties, person_properties }
-        }
-    }
-
-    prop_compose! {
-        fn arb_group_identify()(
-            team_id: i64,
-            group_type_index: u8,
-            group_properties in prop::option::of(arb_blob()),
-        ) -> GroupIdentify {
-            GroupIdentify { team_id, group_type_index, group_properties }
+            Event { team_id, properties }
         }
     }
 
@@ -208,27 +168,8 @@ mod tests {
         }
 
         #[test]
-        fn fan_out_group_outputs_obey_caps_and_team(g in arb_group_identify()) {
-            for (t, n) in fan_out_group(&g, &none()) {
-                check_tuple_invariants(&t, n, g.team_id);
-            }
-        }
-
-        #[test]
         fn fan_out_is_pure(e in arb_event()) {
             prop_assert_eq!(fan_out(&e, &none()), fan_out(&e, &none()));
-        }
-
-        #[test]
-        fn fan_out_group_is_pure(g in arb_group_identify()) {
-            prop_assert_eq!(fan_out_group(&g, &none()), fan_out_group(&g, &none()));
-        }
-
-        #[test]
-        fn fan_out_group_property_type_matches_index(g in arb_group_identify()) {
-            for (t, _) in fan_out_group(&g, &none()) {
-                prop_assert_eq!(t.property_type, PropertyType::Group(g.group_type_index));
-            }
         }
     }
 
@@ -252,20 +193,6 @@ mod tests {
     fn empty_string_value_is_dropped() {
         let tuples = fan_out(&event(r#"{"blank":""}"#), &none());
         assert!(tuples.is_empty());
-    }
-
-    #[test]
-    fn person_properties_emit_person_type() {
-        let ev = Event {
-            team_id: 2,
-            properties: None,
-            person_properties: Some(r#"{"email":"foo@bar.com"}"#.to_string()),
-        };
-        let tuples = fan_out(&ev, &none());
-        assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].0.property_type, PropertyType::Person);
-        assert_eq!(tuples[0].0.property_key, "email");
-        assert_eq!(tuples[0].0.property_value, "foo@bar.com");
     }
 
     #[test]
@@ -295,38 +222,6 @@ mod tests {
     }
 
     #[test]
-    fn group_identify_index_0_emits_group_type() {
-        let tuples = fan_out_group(&group_identify(0, r#"{"plan":"enterprise"}"#), &none());
-        assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].0.property_type, PropertyType::Group(0));
-        assert_eq!(tuples[0].0.property_key, "plan");
-        assert_eq!(tuples[0].0.property_value, "enterprise");
-    }
-
-    #[test]
-    fn group_identify_emits_group_type_matching_index() {
-        let tuples = fan_out_group(&group_identify(4, r#"{"region":"us-east"}"#), &none());
-        assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].0.property_type, PropertyType::Group(4));
-    }
-
-    #[test]
-    fn group_identify_missing_properties_drops() {
-        let g = GroupIdentify {
-            team_id: 2,
-            group_type_index: 0,
-            group_properties: None,
-        };
-        assert!(fan_out_group(&g, &none()).is_empty());
-    }
-
-    #[test]
-    fn group_identify_unparseable_drops() {
-        let tuples = fan_out_group(&group_identify(0, "not valid json"), &none());
-        assert!(tuples.is_empty());
-    }
-
-    #[test]
     fn excluded_event_property_keys_are_skipped() {
         let blob =
             r#"{"$insert_id":"abc-123","$browser":"Chrome","distinct_id":"u1","$session_id":"s1"}"#;
@@ -335,34 +230,6 @@ mod tests {
         assert_eq!(tuples.len(), 1, "only $browser should survive exclusion");
         assert_eq!(tuples[0].0.property_key, "$browser");
         assert_eq!(tuples[0].0.property_value, "Chrome");
-    }
-
-    #[test]
-    fn excluded_person_property_keys_are_skipped() {
-        let ev = Event {
-            team_id: 2,
-            properties: None,
-            person_properties: Some(
-                r#"{"email":"a@b.com","$session_id":"s1","plan":"enterprise"}"#.to_string(),
-            ),
-        };
-        let tuples = fan_out(&ev, &excluded(&["$session_id"]));
-        assert_eq!(tuples.len(), 2);
-        let keys: Vec<&str> = tuples
-            .iter()
-            .map(|(t, _)| t.property_key.as_str())
-            .collect();
-        assert!(keys.contains(&"email"));
-        assert!(keys.contains(&"plan"));
-        assert!(!keys.contains(&"$session_id"));
-    }
-
-    #[test]
-    fn excluded_group_property_keys_are_skipped() {
-        let g = group_identify(0, r#"{"plan":"enterprise","internal_id":"g-42"}"#);
-        let tuples = fan_out_group(&g, &excluded(&["internal_id"]));
-        assert_eq!(tuples.len(), 1);
-        assert_eq!(tuples[0].0.property_key, "plan");
     }
 
     #[test]

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -6,9 +6,9 @@ use common_kafka::kafka_consumer::SingleTopicConsumer;
 use lifecycle::{ComponentOptions, Manager};
 use property_vals_rs::{
     config::Config,
-    fan_out::{extract_tuple, fan_out, fan_out_group},
+    fan_out::{extract_tuple, fan_out},
     producer::AggregatedProducer,
-    types::{Event, GroupIdentify, PropertyValueMessage},
+    types::{Event, PropertyValueMessage},
     worker::{worker_loop, ReductionConfig},
 };
 use serve_metrics::setup_metrics_routes;
@@ -59,13 +59,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_liveness_deadline(Duration::from_secs(60))
             .with_stall_threshold(3),
     );
-    let groups_handle = manager.register(
-        "groups-worker",
-        ComponentOptions::new()
-            .with_graceful_shutdown(Duration::from_secs(30))
-            .with_liveness_deadline(Duration::from_secs(60))
-            .with_stall_threshold(3),
-    );
     let merger_handle = manager.register(
         "merger-worker",
         ComponentOptions::new()
@@ -83,8 +76,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!(
         events_topic = %config.consumer.kafka_consumer_topic,
         events_consumer_group = %config.consumer.kafka_consumer_group,
-        groups_topic = %config.groups_kafka_consumer_topic,
-        groups_consumer_group = %config.groups_kafka_consumer_group,
         intermediate_topic = %config.intermediate_topic,
         merger_consumer_group = %config.merger_consumer_group,
         output_topic = %config.output_topic,
@@ -98,18 +89,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let events_producer = AggregatedProducer::new(
         &config.kafka,
         events_handle.clone(),
-        config.intermediate_topic.clone(),
-        produce_timeout,
-    )
-    .await?;
-
-    let mut groups_consumer_config = config.consumer.clone();
-    groups_consumer_config.kafka_consumer_topic = config.groups_kafka_consumer_topic.clone();
-    groups_consumer_config.kafka_consumer_group = config.groups_kafka_consumer_group.clone();
-    let groups_consumer = SingleTopicConsumer::new(config.kafka.clone(), groups_consumer_config)?;
-    let groups_producer = AggregatedProducer::new(
-        &config.kafka,
-        groups_handle.clone(),
         config.intermediate_topic.clone(),
         produce_timeout,
     )
@@ -131,10 +110,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Subscribed to topic: {}",
         config.consumer.kafka_consumer_topic
     );
-    info!(
-        "Subscribed to topic: {}",
-        config.groups_kafka_consumer_topic
-    );
     info!("Subscribed to topic: {}", config.intermediate_topic);
 
     let shared_config = Arc::new(config.clone());
@@ -142,7 +117,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let guard = manager.monitor_background();
 
     let excluded_events = shared_config.excluded_property_keys.clone();
-    let excluded_groups = shared_config.excluded_property_keys.clone();
 
     tokio::spawn(worker_loop::<Event, _, _>(
         shared_config.clone(),
@@ -151,15 +125,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         events_handle.clone(),
         move |e: &Event| fan_out(e, &excluded_events),
         "events",
-        ReductionConfig::default(),
-    ));
-    tokio::spawn(worker_loop::<GroupIdentify, _, _>(
-        shared_config.clone(),
-        groups_consumer,
-        groups_producer,
-        groups_handle.clone(),
-        move |g: &GroupIdentify| fan_out_group(g, &excluded_groups),
-        "groups",
         ReductionConfig::default(),
     ));
     tokio::spawn(worker_loop::<PropertyValueMessage, _, _>(
@@ -175,7 +140,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     ));
     drop(events_handle);
-    drop(groups_handle);
     drop(merger_handle);
 
     let app = Router::new()

--- a/rust/property-vals-rs/src/producer.rs
+++ b/rust/property-vals-rs/src/producer.rs
@@ -87,7 +87,7 @@ impl Producer for AggregatedProducer {
         // Full-tuple partition key. The same (team, type, key, value) tuple
         // from any pod always lands on the same partition, so the merger on
         // the consuming side can merge the per-pod duplicates that the
-        // events/groups workers emit across replicas.
+        // events worker emits across replicas.
         let send_fut = send_keyed_iter_to_kafka(
             &self.inner,
             &self.output_topic,

--- a/rust/property-vals-rs/src/types.rs
+++ b/rust/property-vals-rs/src/types.rs
@@ -11,25 +11,9 @@ pub struct Event {
 
     #[serde(default)]
     pub properties: Option<String>,
-    #[serde(default)]
-    pub person_properties: Option<String>,
 }
 
 impl IngestableEvent for Event {
-    fn team_id(&self) -> i64 {
-        self.team_id
-    }
-}
-
-#[derive(Debug, Clone, serde::Deserialize)]
-pub struct GroupIdentify {
-    pub team_id: i64,
-    pub group_type_index: u8,
-    #[serde(default)]
-    pub group_properties: Option<String>,
-}
-
-impl IngestableEvent for GroupIdentify {
     fn team_id(&self) -> i64 {
         self.team_id
     }
@@ -43,6 +27,9 @@ pub struct TupleKey {
     pub property_value: String,
 }
 
+// Only Event is produced now that person and group fan-out is gone. Person and
+// Group remain so the merger can still deserialize and drain in-flight
+// intermediate-topic messages produced before this rolled out.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub enum PropertyType {
     Event,


### PR DESCRIPTION
## Problem

The property-vals service builds a deduped catalog of property values so the taxonomic filter can autocomplete without scanning `events`. It writes to an `AggregatingMergeTree` with a 30-day TTL, fed from the event stream.

That model is a clean fit for event properties but not for person or group properties:

- Event property search is already time-bounded (the runner queries the last 7 days), so the catalog's 30-day TTL is a superset and the catalog can only ever return more than the old query.
- Person and group property search is unbounded over the `persons` and `groups` tables, the current state of every entity, with no time filter. A 30-day TTL structurally cannot match that: it drops values for any entity not seen in the window.

It is also a source mismatch. The catalog's person rows come from `person_properties` riding on events (person-on-events snapshots) and group rows from groupidentify, not from the canonical `persons`/`groups` tables. So even ignoring the TTL, this pipeline reads person/group values from the wrong place.

Person and group properties were a meaningful share of the catalog's write volume while never being a faithful replacement for their searches, so this scopes the catalog to event properties.

## Changes

- The events worker stops fanning out `person_properties`.
- The groups worker is removed entirely (its consumer, producer, handle, and the `clickhouse_groups` subscription).
- Removes the now-unused `GroupIdentify` type, the `person_properties` field on `Event`, and the `groups_kafka_consumer_topic` / `groups_kafka_consumer_group` config fields.
- Keeps `PropertyType::Person`/`Group` and the merger's pass-through so any in-flight intermediate-topic messages produced before rollout still deserialize and drain cleanly. Existing person/group rows in the table age out via the 30-day TTL; no ClickHouse change is needed.

Operational notes for the rollout:

- The `clickhouse-property-vals-rs-groups` consumer group stops consuming once deployed; its lag will grow harmlessly and the group can be deleted later.
- The chart still sets `GROUPS_KAFKA_CONSUMER_TOPIC` / `GROUPS_KAFKA_CONSUMER_GROUP`; the binary no longer reads them (envconfig ignores unknown vars), so they are harmless no-ops to clean up in a follow-up.

A proper person/group value catalog (per-entity argMax / ReplacingMergeTree, no TTL, sourced from person/group updates rather than events) is a separate effort, deliberately out of scope here.

## How did you test this code?

I am an agent (Claude Code). I did not do manual testing. I ran, on the `property-vals-rs` crate:

- `cargo check` — clean
- `cargo clippy` — clean
- `cargo test` — 38 passed, 0 failed

The retained tests cover the merger still deserializing and round-tripping Event/Person/Group wire messages (the drain path).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change.

## 🤖 Agent context

Authored with Claude Code (Read/Edit/Bash tooling) while investigating property-value search performance.

Key decision: the conversation started toward adding an `event_name` dimension to the catalog, but analysis showed 84% of event autocomplete queries are event-scoped, which raised the question of whether person/group belong in this table at all. They don't, the TTL plus event-stream source make the catalog a recency-bounded approximation of an unbounded, canonical-table search, so it can never be a correct replacement. Rather than carry that write load and an implicit wrong contract, this removes them and leaves a faithful person/group catalog as a separate design (argMax/per-entity, no TTL).

Removal was kept staged on purpose: stop producing person/group, but keep the merger able to drain in-flight messages and let the TTL clean up existing rows, so there is no abrupt data cutover.
