### PR TITLE
feat(property-vals): aggregate property values per event behind flags

### DIFF
--- a/rust/property-vals-rs/src/aggregator.rs
+++ b/rust/property-vals-rs/src/aggregator.rs
@@ -48,6 +48,7 @@ mod tests {
             property_type: PropertyType::Event,
             property_key: key.to_string(),
             property_value: value.to_string(),
+            event_name: String::new(),
         }
     }
 
@@ -65,8 +66,9 @@ mod tests {
             property_type in arb_property_type(),
             property_key in "[a-c]{1,3}",
             property_value in "[x-z]{1,3}",
+            event_name in "[a-b]{0,2}",
         ) -> TupleKey {
-            TupleKey { team_id, property_type, property_key, property_value }
+            TupleKey { team_id, property_type, property_key, property_value, event_name }
         }
     }
 

--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -41,6 +41,12 @@ pub struct Config {
     #[envconfig(default = "255")]
     pub max_property_value_len: usize,
 
+    #[envconfig(default = "false")]
+    pub aggregate_by_event_name: bool,
+
+    #[envconfig(default = "false")]
+    pub emit_event_name: bool,
+
     #[envconfig(default = "0")]
     pub merger_seen_cache_capacity: usize,
 

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -6,18 +6,30 @@ use crate::types::{Event, GroupIdentify, PropertyType, PropertyValueMessage, Tup
 
 pub const MAX_PROPERTY_KEY_LEN: usize = 400;
 pub const MAX_PROPERTY_VALUE_LEN: usize = 255;
+pub const MAX_EVENT_NAME_LEN: usize = 200;
 
 pub fn fan_out(
     event: &Event,
     excluded: &ExcludedPropertyKeys,
     max_property_value_len: usize,
+    aggregate_by_event_name: bool,
 ) -> Vec<(TupleKey, u64)> {
     let mut out = Vec::new();
 
     if let Some(raw) = &event.properties {
+        let event_name = if aggregate_by_event_name {
+            event
+                .event
+                .as_deref()
+                .filter(|e| e.chars().count() <= MAX_EVENT_NAME_LEN)
+                .unwrap_or("")
+        } else {
+            ""
+        };
         emit_from_blob(
             event.team_id,
             PropertyType::Event,
+            event_name,
             raw,
             excluded,
             max_property_value_len,
@@ -25,9 +37,11 @@ pub fn fan_out(
         );
     }
     if let Some(raw) = &event.person_properties {
+        // Person values are not scoped by event, so they carry no event name.
         emit_from_blob(
             event.team_id,
             PropertyType::Person,
+            "",
             raw,
             excluded,
             max_property_value_len,
@@ -48,6 +62,7 @@ pub fn fan_out_group(
         emit_from_blob(
             event.team_id,
             PropertyType::Group(event.group_type_index),
+            "",
             raw,
             excluded,
             max_property_value_len,
@@ -67,6 +82,7 @@ pub fn extract_tuple(msg: &PropertyValueMessage) -> Vec<(TupleKey, u64)> {
             property_type: msg.property_type,
             property_key: msg.property_key.clone(),
             property_value: msg.property_value.clone(),
+            event_name: msg.event_name.clone(),
         },
         msg.property_count,
     )]
@@ -75,6 +91,7 @@ pub fn extract_tuple(msg: &PropertyValueMessage) -> Vec<(TupleKey, u64)> {
 fn emit_from_blob(
     team_id: i64,
     property_type: PropertyType,
+    event_name: &str,
     raw: &str,
     excluded: &ExcludedPropertyKeys,
     max_property_value_len: usize,
@@ -126,6 +143,7 @@ fn emit_from_blob(
                 property_type,
                 property_key: key.clone(),
                 property_value,
+                event_name: event_name.to_string(),
             },
             1,
         ));
@@ -148,6 +166,7 @@ mod tests {
     fn event(properties: &str) -> Event {
         Event {
             team_id: 2,
+            event: None,
             properties: Some(properties.to_string()),
             person_properties: None,
         }
@@ -186,10 +205,11 @@ mod tests {
     prop_compose! {
         fn arb_event()(
             team_id: i64,
+            event in prop::option::of(arb_property_string()),
             properties in prop::option::of(arb_blob()),
             person_properties in prop::option::of(arb_blob()),
         ) -> Event {
-            Event { team_id, properties, person_properties }
+            Event { team_id, event, properties, person_properties }
         }
     }
 
@@ -223,7 +243,7 @@ mod tests {
     proptest! {
         #[test]
         fn fan_out_outputs_obey_caps_and_team(e in arb_event()) {
-            for (t, n) in fan_out(&e, &none(), MAX_PROPERTY_VALUE_LEN) {
+            for (t, n) in fan_out(&e, &none(), MAX_PROPERTY_VALUE_LEN, false) {
                 check_tuple_invariants(&t, n, e.team_id);
             }
         }
@@ -237,7 +257,10 @@ mod tests {
 
         #[test]
         fn fan_out_is_pure(e in arb_event()) {
-            prop_assert_eq!(fan_out(&e, &none(), MAX_PROPERTY_VALUE_LEN), fan_out(&e, &none(), MAX_PROPERTY_VALUE_LEN));
+            prop_assert_eq!(
+                fan_out(&e, &none(), MAX_PROPERTY_VALUE_LEN, true),
+                fan_out(&e, &none(), MAX_PROPERTY_VALUE_LEN, true)
+            );
         }
 
         #[test]
@@ -251,6 +274,26 @@ mod tests {
                 prop_assert_eq!(t.property_type, PropertyType::Group(g.group_type_index));
             }
         }
+
+        #[test]
+        fn stamped_event_tuples_carry_source_event_name(name in "[a-z]{1,20}", blob in arb_blob()) {
+            let e = Event {
+                team_id: 2,
+                event: Some(name.clone()),
+                properties: Some(blob),
+                person_properties: None,
+            };
+            for (t, _) in fan_out(&e, &none(), MAX_PROPERTY_VALUE_LEN, true) {
+                prop_assert_eq!(&t.event_name, &name);
+            }
+        }
+
+        #[test]
+        fn unstamped_tuples_have_empty_event_name(e in arb_event()) {
+            for (t, _) in fan_out(&e, &none(), MAX_PROPERTY_VALUE_LEN, false) {
+                prop_assert!(t.event_name.is_empty());
+            }
+        }
     }
 
     #[test]
@@ -259,6 +302,7 @@ mod tests {
             &event(r#"{"$browser":"Chrome"}"#),
             &none(),
             MAX_PROPERTY_VALUE_LEN,
+            false,
         );
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].0.property_type, PropertyType::Event);
@@ -268,18 +312,66 @@ mod tests {
     }
 
     #[test]
+    fn stamping_uses_source_event_name_for_event_type_only() {
+        let ev = Event {
+            team_id: 2,
+            event: Some("$pageview".to_string()),
+            properties: Some(r#"{"$browser":"Chrome"}"#.to_string()),
+            person_properties: Some(r#"{"email":"a@b.com"}"#.to_string()),
+        };
+        let tuples = fan_out(&ev, &none(), MAX_PROPERTY_VALUE_LEN, true);
+        let event_tuple = tuples
+            .iter()
+            .find(|(t, _)| t.property_type == PropertyType::Event)
+            .unwrap();
+        assert_eq!(event_tuple.0.event_name, "$pageview");
+        let person_tuple = tuples
+            .iter()
+            .find(|(t, _)| t.property_type == PropertyType::Person)
+            .unwrap();
+        assert_eq!(
+            person_tuple.0.event_name, "",
+            "person values are not event-scoped"
+        );
+    }
+
+    #[test]
+    fn oversized_event_name_is_not_stamped() {
+        let long_name = "a".repeat(MAX_EVENT_NAME_LEN + 1);
+        let ev = Event {
+            team_id: 2,
+            event: Some(long_name),
+            properties: Some(r#"{"$browser":"Chrome"}"#.to_string()),
+            person_properties: None,
+        };
+        let tuples = fan_out(&ev, &none(), MAX_PROPERTY_VALUE_LEN, true);
+        assert_eq!(tuples.len(), 1);
+        assert_eq!(
+            tuples[0].0.event_name, "",
+            "oversized event name is dropped"
+        );
+        assert_eq!(tuples[0].0.property_value, "Chrome");
+    }
+
+    #[test]
     fn json_null_value_is_dropped() {
         let tuples = fan_out(
             &event(r#"{"nullable_field":null}"#),
             &none(),
             MAX_PROPERTY_VALUE_LEN,
+            false,
         );
         assert!(tuples.is_empty());
     }
 
     #[test]
     fn empty_string_value_is_dropped() {
-        let tuples = fan_out(&event(r#"{"blank":""}"#), &none(), MAX_PROPERTY_VALUE_LEN);
+        let tuples = fan_out(
+            &event(r#"{"blank":""}"#),
+            &none(),
+            MAX_PROPERTY_VALUE_LEN,
+            false,
+        );
         assert!(tuples.is_empty());
     }
 
@@ -287,10 +379,11 @@ mod tests {
     fn person_properties_emit_person_type() {
         let ev = Event {
             team_id: 2,
+            event: None,
             properties: None,
             person_properties: Some(r#"{"email":"foo@bar.com"}"#.to_string()),
         };
-        let tuples = fan_out(&ev, &none(), MAX_PROPERTY_VALUE_LEN);
+        let tuples = fan_out(&ev, &none(), MAX_PROPERTY_VALUE_LEN, false);
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].0.property_type, PropertyType::Person);
         assert_eq!(tuples[0].0.property_key, "email");
@@ -303,6 +396,7 @@ mod tests {
             &event(r#"{"a_bool":true}"#),
             &none(),
             MAX_PROPERTY_VALUE_LEN,
+            false,
         );
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].0.property_value, "true");
@@ -314,6 +408,7 @@ mod tests {
             &event(r#"{"a_number":42}"#),
             &none(),
             MAX_PROPERTY_VALUE_LEN,
+            false,
         );
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].0.property_value, "42");
@@ -321,13 +416,18 @@ mod tests {
 
     #[test]
     fn unparseable_blob_emits_nothing() {
-        let tuples = fan_out(&event(r#"not valid json"#), &none(), MAX_PROPERTY_VALUE_LEN);
+        let tuples = fan_out(
+            &event(r#"not valid json"#),
+            &none(),
+            MAX_PROPERTY_VALUE_LEN,
+            false,
+        );
         assert!(tuples.is_empty());
     }
 
     #[test]
     fn empty_object_emits_nothing() {
-        let tuples = fan_out(&event("{}"), &none(), MAX_PROPERTY_VALUE_LEN);
+        let tuples = fan_out(&event("{}"), &none(), MAX_PROPERTY_VALUE_LEN, false);
         assert!(tuples.is_empty());
     }
 
@@ -380,7 +480,7 @@ mod tests {
         let blob =
             r#"{"$insert_id":"abc-123","$browser":"Chrome","distinct_id":"u1","$session_id":"s1"}"#;
         let exclusions = excluded(&["$insert_id", "distinct_id", "$session_id"]);
-        let tuples = fan_out(&event(blob), &exclusions, MAX_PROPERTY_VALUE_LEN);
+        let tuples = fan_out(&event(blob), &exclusions, MAX_PROPERTY_VALUE_LEN, false);
         assert_eq!(tuples.len(), 1, "only $browser should survive exclusion");
         assert_eq!(tuples[0].0.property_key, "$browser");
         assert_eq!(tuples[0].0.property_value, "Chrome");
@@ -390,12 +490,18 @@ mod tests {
     fn excluded_person_property_keys_are_skipped() {
         let ev = Event {
             team_id: 2,
+            event: None,
             properties: None,
             person_properties: Some(
                 r#"{"email":"a@b.com","$session_id":"s1","plan":"enterprise"}"#.to_string(),
             ),
         };
-        let tuples = fan_out(&ev, &excluded(&["$session_id"]), MAX_PROPERTY_VALUE_LEN);
+        let tuples = fan_out(
+            &ev,
+            &excluded(&["$session_id"]),
+            MAX_PROPERTY_VALUE_LEN,
+            false,
+        );
         assert_eq!(tuples.len(), 2);
         let keys: Vec<&str> = tuples
             .iter()
@@ -417,9 +523,9 @@ mod tests {
     #[test]
     fn empty_exclusion_list_is_a_noop() {
         let blob = r#"{"$browser":"Chrome","email":"a@b.com"}"#;
-        let with_default = fan_out(&event(blob), &none(), MAX_PROPERTY_VALUE_LEN);
+        let with_default = fan_out(&event(blob), &none(), MAX_PROPERTY_VALUE_LEN, false);
         let parsed_empty: ExcludedPropertyKeys = "".parse().unwrap();
-        let with_parsed_empty = fan_out(&event(blob), &parsed_empty, MAX_PROPERTY_VALUE_LEN);
+        let with_parsed_empty = fan_out(&event(blob), &parsed_empty, MAX_PROPERTY_VALUE_LEN, false);
         assert_eq!(with_default.len(), 2);
         assert_eq!(with_default, with_parsed_empty);
     }
@@ -437,7 +543,16 @@ mod tests {
             property_key: key.to_string(),
             property_value: value.to_string(),
             property_count: count,
+            event_name: String::new(),
         }
+    }
+
+    #[test]
+    fn extract_tuple_carries_event_name_from_message() {
+        let mut msg = pv_message(2, PropertyType::Event, "$browser", "Chrome", 1);
+        msg.event_name = "$pageview".to_string();
+        let out = extract_tuple(&msg);
+        assert_eq!(out[0].0.event_name, "$pageview");
     }
 
     #[test]
@@ -491,6 +606,7 @@ mod tests {
                 property_key: "$browser",
                 property_value: "Chrome",
                 property_count: 99,
+                event_name: "$pageview",
             };
             let serialized = serde_json::to_string(&outgoing).unwrap();
             assert!(
@@ -503,6 +619,27 @@ mod tests {
             assert_eq!(parsed.property_key, "$browser");
             assert_eq!(parsed.property_value, "Chrome");
             assert_eq!(parsed.property_count, 99);
+            assert_eq!(parsed.event_name, "$pageview");
         }
+    }
+
+    #[test]
+    fn empty_event_name_is_omitted_from_wire_format() {
+        use crate::producer::Outgoing;
+        let outgoing = Outgoing {
+            team_id: 2,
+            property_type: PropertyType::Event,
+            property_key: "$browser",
+            property_value: "Chrome",
+            property_count: 1,
+            event_name: "",
+        };
+        let serialized = serde_json::to_string(&outgoing).unwrap();
+        assert!(
+            !serialized.contains("event_name"),
+            "empty event_name must be omitted so flag-off messages match the old format: {serialized}"
+        );
+        let parsed: PropertyValueMessage = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed.event_name, "");
     }
 }

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -100,6 +100,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         events_handle.clone(),
         config.intermediate_topic.clone(),
         produce_timeout,
+        true,
     )
     .await?;
 
@@ -112,6 +113,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         groups_handle.clone(),
         config.intermediate_topic.clone(),
         produce_timeout,
+        true,
     )
     .await?;
 
@@ -124,6 +126,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         merger_handle.clone(),
         config.output_topic.clone(),
         produce_timeout,
+        config.emit_event_name,
     )
     .await?;
 
@@ -144,13 +147,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let excluded_events = shared_config.excluded_property_keys.clone();
     let excluded_groups = shared_config.excluded_property_keys.clone();
     let max_property_value_len = shared_config.max_property_value_len;
+    let aggregate_by_event_name = shared_config.aggregate_by_event_name;
 
     tokio::spawn(worker_loop::<Event, _, _>(
         shared_config.clone(),
         events_consumer,
         events_producer,
         events_handle.clone(),
-        move |e: &Event| fan_out(e, &excluded_events, max_property_value_len),
+        move |e: &Event| {
+            fan_out(
+                e,
+                &excluded_events,
+                max_property_value_len,
+                aggregate_by_event_name,
+            )
+        },
         "events",
         ReductionConfig::default(),
     ));

--- a/rust/property-vals-rs/src/producer.rs
+++ b/rust/property-vals-rs/src/producer.rs
@@ -12,6 +12,10 @@ use tracing::warn;
 
 use crate::types::{PropertyType, TupleKey};
 
+fn str_is_empty(s: &&str) -> bool {
+    s.is_empty()
+}
+
 #[derive(serde::Serialize)]
 pub(crate) struct Outgoing<'a> {
     pub team_id: i64,
@@ -19,6 +23,11 @@ pub(crate) struct Outgoing<'a> {
     pub property_key: &'a str,
     pub property_value: &'a str,
     pub property_count: u64,
+    // Omitted when empty so flag-off (and person/group) messages are identical
+    // to before this field existed, letting the service ship ahead of the
+    // ClickHouse column that reads it.
+    #[serde(skip_serializing_if = "str_is_empty")]
+    pub event_name: &'a str,
 }
 
 #[derive(Debug, Error)]
@@ -44,6 +53,7 @@ pub struct AggregatedProducer {
     inner: FutureProducer<KafkaContext>,
     output_topic: String,
     produce_timeout: Duration,
+    serialize_event_name: bool,
 }
 
 impl AggregatedProducer {
@@ -52,6 +62,7 @@ impl AggregatedProducer {
         liveness: L,
         output_topic: String,
         produce_timeout: Duration,
+        serialize_event_name: bool,
     ) -> Result<Self, KafkaError>
     where
         L: common_liveness::SyncLivenessReporter + Clone + 'static,
@@ -61,6 +72,7 @@ impl AggregatedProducer {
             inner,
             output_topic,
             produce_timeout,
+            serialize_event_name,
         })
     }
 }
@@ -81,6 +93,11 @@ impl Producer for AggregatedProducer {
                 property_key: &tuple.property_key,
                 property_value: &tuple.property_value,
                 property_count: *count,
+                event_name: if self.serialize_event_name {
+                    &tuple.event_name
+                } else {
+                    ""
+                },
             })
             .collect();
 

--- a/rust/property-vals-rs/src/types.rs
+++ b/rust/property-vals-rs/src/types.rs
@@ -10,6 +10,8 @@ pub struct Event {
     pub team_id: i64,
 
     #[serde(default)]
+    pub event: Option<String>,
+    #[serde(default)]
     pub properties: Option<String>,
     #[serde(default)]
     pub person_properties: Option<String>,
@@ -41,6 +43,10 @@ pub struct TupleKey {
     pub property_type: PropertyType,
     pub property_key: String,
     pub property_value: String,
+    // Source event name for event-type values, used to scope value lookups to a
+    // specific event. Empty for person/group (not event-scoped) and for event
+    // values until STAMP_EVENT_NAME is enabled.
+    pub event_name: String,
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
@@ -95,6 +101,8 @@ pub struct PropertyValueMessage {
     pub property_key: String,
     pub property_value: String,
     pub property_count: u64,
+    #[serde(default)]
+    pub event_name: String,
 }
 
 impl IngestableEvent for PropertyValueMessage {

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -173,20 +173,23 @@ pub(crate) async fn flush<P: Producer>(
     }
 }
 
-/// Cap each (team, type, key) to its `k` highest-count values, dropping the
-/// rest. Keys with `<= k` distinct values are untouched, so low-cardinality
+/// Cap each (team, type, key, event) to its `k` highest-count values, dropping
+/// the rest. Keys with `<= k` distinct values are untouched, so low-cardinality
 /// keys keep everything; only high-cardinality keys lose their long tail.
+type CapGroup = (i64, PropertyType, String, String);
+
 fn cap_top_k(
     snapshot: Vec<(TupleKey, u64)>,
     k: usize,
     worker: &'static str,
 ) -> Vec<(TupleKey, u64)> {
-    let mut by_key: HashMap<(i64, PropertyType, String), Vec<(TupleKey, u64)>> = HashMap::new();
+    let mut by_key: HashMap<CapGroup, Vec<(TupleKey, u64)>> = HashMap::new();
     for entry in snapshot {
         let group = (
             entry.0.team_id,
             entry.0.property_type,
             entry.0.property_key.clone(),
+            entry.0.event_name.clone(),
         );
         by_key.entry(group).or_default().push(entry);
     }
@@ -279,6 +282,7 @@ mod tests {
             property_type: PropertyType::Event,
             property_key: key.to_string(),
             property_value: value.to_string(),
+            event_name: String::new(),
         }
     }
 
@@ -642,8 +646,9 @@ mod tests {
             property_type in arb_property_type(),
             property_key in "[a-c]{1,2}",
             property_value in "[x-z]{1,2}",
+            event_name in "[a-b]{0,2}",
         ) -> TupleKey {
-            TupleKey { team_id, property_type, property_key, property_value }
+            TupleKey { team_id, property_type, property_key, property_value, event_name }
         }
     }
 


### PR DESCRIPTION
## Problem

We want property-value autocomplete to be scopable to a specific event (filtering "events where event = X and property = Y"). For that, the value catalog needs to know which event each value appeared on. This is the service half of that change: it threads the source event name through the aggregation pipeline so a later ClickHouse column can support per-event value lookups.

It is gated and ships dark, so it is safe to land and deploy ahead of the ClickHouse side.

## Changes

- The events worker stamps the source event name onto event-type values. Person and group values are never event-scoped (group properties are not even on the event stream), so they stay empty.
- `event_name` becomes part of the in-memory aggregation key, the merger's emit-once seen cache, and the top-K cap, so event values aggregate and cap per `(event, key)` rather than per `key`.
- Two independent flags, both default off:
  - `AGGREGATE_BY_EVENT_NAME` controls whether the event name enters the aggregation key. On, event values fragment per event (this is what drives the write amplification). Off, event values carry an empty name like person/group.
  - `EMIT_EVENT_NAME` controls whether the merger writes the `event_name` field on the output topic. The field is omitted when empty (`serde(skip_serializing_if)`), so with this off the messages to `clickhouse_property_values` are byte-identical to the pre-`event_name` format.

Splitting the two flags lets us exercise the write-amplification behavior before the ClickHouse column exists. Turn `AGGREGATE_BY_EVENT_NAME` on with `EMIT_EVENT_NAME` off to produce the same fragmented record count (and the same write throughput) the finished feature will, while the wire stays in the old format so the current ClickHouse kafka table keeps consuming it unchanged. Once the ClickHouse column is live, turn `EMIT_EVENT_NAME` on too.

Rollout order: deploy the ClickHouse PR, deploy this service with both flags off, optionally flip `AGGREGATE_BY_EVENT_NAME` alone to load-test throughput, then flip `EMIT_EVENT_NAME` on.

One thing to weigh: aggregating per event lowers the collapse ratio, so write throughput to ClickHouse rises (roughly 2-6x at the flush cadence depending on a team's event diversity). Lengthening `FLUSH_INTERVAL_SECS` is the lever if that is too much.

## How did you test this code?

I am an agent (Claude Code). No manual testing. On the `property-vals-rs` crate: `cargo fmt`, `cargo clippy`, and `cargo test` (54 passed). New tests cover:

- event values get the source event name when aggregation is on; person values stay empty in the same event
- all values are empty when aggregation is off
- oversized event names (over 200 chars) are not stamped, so the values still land unscoped
- the wire field is omitted when empty (so the message matches the pre-`event_name` format) and round-trips back to empty
- the merger carries `event_name` through from the intermediate message

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change.

## 🤖 Agent context

Authored with Claude Code (Read/Edit/Bash) while working through property-value search performance.

Decisions: the two flags (`AGGREGATE_BY_EVENT_NAME`, `EMIT_EVENT_NAME`) are split so the per-event aggregation grain, and its write amplification, can be exercised on production before the consuming ClickHouse column exists, which decouples the two deploys. The output field is omitted when empty so flag-off messages stay byte-identical to the old format. Person and group are intentionally left unscoped because their values are not event-specific (groups are not on the event stream at all). The aggregation key, merger seen cache, and top-K cap all key on `event_name` so the per-event grain is consistent end to end. The ~2-6x write amplification was measured and is called out as a rollout consideration, not a blocker, since it only bites once aggregation is on.

Stacked on the value-length base PR: https://github.com/PostHog/posthog/pull/61325
