### PR TITLE
feat(mcp): render paths results in the query-results UI app

### DIFF
--- a/services/mcp/src/ui-apps/components/Component.tsx
+++ b/services/mcp/src/ui-apps/components/Component.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, Empty, EmptyDescription, EmptyHeader, EmptyMedia } f
 
 import { FunnelVisualizer } from './FunnelVisualizer'
 import { LifecycleVisualizer } from './LifecycleVisualizer'
+import { PathsVisualizer } from './PathsVisualizer'
 import { RetentionVisualizer } from './RetentionVisualizer'
 import { TableVisualizer } from './TableVisualizer'
 import { TrendsVisualizer } from './TrendsVisualizer'
@@ -14,13 +15,15 @@ import type {
     HogQLResult,
     LifecycleQuery,
     LifecycleResult,
+    PathsQuery,
+    PathsResult,
     RetentionQuery,
     RetentionResult,
     TrendsQuery,
     TrendsResult,
 } from './types'
 
-type VisualizationType = 'trends' | 'funnel' | 'lifecycle' | 'retention' | 'table'
+type VisualizationType = 'trends' | 'funnel' | 'lifecycle' | 'retention' | 'paths' | 'table'
 
 /**
  * Lifecycle results share the trends shape but each item carries a `status` field
@@ -108,6 +111,24 @@ function isRetentionResult(results: unknown): results is RetentionResult {
 }
 
 /**
+ * Paths results are an array of edges, each with string `source`/`target` node keys
+ * (`<stepIndex>_<value>`) and a numeric `value` (user count).
+ */
+function isPathsResult(results: unknown): results is PathsResult {
+    if (!Array.isArray(results) || results.length === 0) {
+        return false
+    }
+    const first = results[0] as Record<string, unknown>
+    return (
+        typeof first === 'object' &&
+        first !== null &&
+        typeof first.source === 'string' &&
+        typeof first.target === 'string' &&
+        typeof first.value === 'number'
+    )
+}
+
+/**
  * Check if results look like HogQLResult (object with columns and results arrays).
  */
 function isHogQLResult(results: unknown): results is HogQLResult {
@@ -143,6 +164,10 @@ function inferVisualizationType(data: unknown): VisualizationType | null {
     if (isLifecycleResult(results)) {
         return 'lifecycle'
     }
+    // Paths must come before trends/funnel — its edge rows match neither, but keep it explicit.
+    if (isPathsResult(results)) {
+        return 'paths'
+    }
     if (isTrendsResult(results)) {
         return 'trends'
     }
@@ -164,6 +189,9 @@ function inferVisualizationType(data: unknown): VisualizationType | null {
     if (query?.kind === 'RetentionQuery') {
         return 'retention'
     }
+    if (query?.kind === 'PathsQuery') {
+        return 'paths'
+    }
     if (query?.kind === 'HogQLQuery') {
         return 'table'
     }
@@ -173,8 +201,8 @@ function inferVisualizationType(data: unknown): VisualizationType | null {
 
 /** Data payload from MCP tools */
 interface DataPayload {
-    query?: TrendsQuery | FunnelsQuery | LifecycleQuery | RetentionQuery | Record<string, unknown>
-    results: TrendsResult | FunnelResult | LifecycleResult | RetentionResult | HogQLResult
+    query?: TrendsQuery | FunnelsQuery | LifecycleQuery | RetentionQuery | PathsQuery | Record<string, unknown>
+    results: TrendsResult | FunnelResult | LifecycleResult | RetentionResult | PathsResult | HogQLResult
     _posthogUrl?: string
 }
 
@@ -234,6 +262,9 @@ export function Component({ data }: ComponentProps): ReactElement {
                     />
                 )
 
+            case 'paths':
+                return <PathsVisualizer query={payload.query as PathsQuery} results={payload.results as PathsResult} />
+
             case 'table':
                 return <TableVisualizer results={payload.results as HogQLResult} />
 
@@ -252,6 +283,8 @@ export function Component({ data }: ComponentProps): ReactElement {
                 return 'Lifecycle'
             case 'retention':
                 return 'Retention'
+            case 'paths':
+                return 'Paths'
             case 'table':
                 return 'Query results'
             default:

--- a/services/mcp/src/ui-apps/components/Component.tsx
+++ b/services/mcp/src/ui-apps/components/Component.tsx
@@ -263,7 +263,7 @@ export function Component({ data }: ComponentProps): ReactElement {
                 )
 
             case 'paths':
-                return <PathsVisualizer query={payload.query as PathsQuery} results={payload.results as PathsResult} />
+                return <PathsVisualizer results={payload.results as PathsResult} />
 
             case 'table':
                 return <TableVisualizer results={payload.results as HogQLResult} />

--- a/services/mcp/src/ui-apps/components/PathsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/PathsVisualizer.tsx
@@ -1,0 +1,68 @@
+import type { ReactElement } from 'react'
+
+import { emptyStateIllustration } from '@posthog/mcp-ui'
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@posthog/quill'
+
+import { DataTable } from './charts'
+import type { PathsVisualizerProps } from './types'
+import { formatDuration, formatNumber } from './utils'
+
+/** Node keys are `<stepIndex>_<value>`; split into the step number and the path/value. */
+function parseNode(key: string): { step: number; path: string } {
+    const sep = key.indexOf('_')
+    if (sep === -1) {
+        return { step: 0, path: key }
+    }
+    const step = Number.parseInt(key.slice(0, sep), 10)
+    return { step: Number.isNaN(step) ? 0 : step, path: key.slice(sep + 1) }
+}
+
+export function PathsVisualizer({ results }: PathsVisualizerProps): ReactElement {
+    const edges = Array.isArray(results) ? results : []
+
+    if (edges.length === 0) {
+        return (
+            <Empty>
+                <EmptyHeader>
+                    <EmptyMedia>{emptyStateIllustration('generic')}</EmptyMedia>
+                    <EmptyDescription>No path data available</EmptyDescription>
+                </EmptyHeader>
+            </Empty>
+        )
+    }
+
+    // Each row is an edge between two nodes; sort by user count so the busiest paths lead.
+    const sorted = [...edges].sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
+
+    const columns = ['Step', 'From', 'To', 'Users', 'Avg. time']
+    const rows: unknown[][] = sorted.map((edge) => {
+        const from = parseNode(edge.source)
+        const to = parseNode(edge.target)
+        return [
+            `${from.step} → ${to.step}`,
+            from.path,
+            to.path,
+            edge.value ?? 0,
+            edge.average_conversion_time != null ? formatDuration(edge.average_conversion_time) : '-',
+        ]
+    })
+
+    const topUsers = sorted[0]?.value ?? 0
+
+    return (
+        <div>
+            <DataTable columns={columns} rows={rows} />
+
+            <div className="mt-4 rounded-md bg-muted/50 p-3 text-sm text-muted-foreground">
+                <strong className="text-foreground">{formatNumber(edges.length)}</strong> path transition
+                {edges.length === 1 ? '' : 's'}
+                {topUsers > 0 && (
+                    <>
+                        {' '}
+                        · busiest carries <strong className="text-foreground">{formatNumber(topUsers)}</strong> users
+                    </>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/services/mcp/src/ui-apps/components/types.ts
+++ b/services/mcp/src/ui-apps/components/types.ts
@@ -145,6 +145,29 @@ export interface RetentionResultItem {
 
 export type RetentionResult = RetentionResultItem[]
 
+export interface PathsQuery {
+    kind: 'PathsQuery'
+    pathsFilter?: {
+        includeEventTypes?: string[]
+        startPoint?: string
+        endPoint?: string
+    }
+}
+
+/**
+ * A single edge in a paths result. `source`/`target` are node keys of the form
+ * `<stepIndex>_<value>` (e.g. `2_https://example.com/pricing`); `value` is the user
+ * count on the edge; `average_conversion_time` is in milliseconds.
+ */
+export interface PathsResultItem {
+    source: string
+    target: string
+    value: number
+    average_conversion_time?: number
+}
+
+export type PathsResult = PathsResultItem[]
+
 // ============================================================================
 // Tool result payloads
 // The visualization type is inferred from the data structure, not a discriminator
@@ -201,4 +224,9 @@ export interface TableVisualizerProps {
 export interface RetentionVisualizerProps {
     query: RetentionQuery | undefined
     results: RetentionResult
+}
+
+export interface PathsVisualizerProps {
+    query: PathsQuery | undefined
+    results: PathsResult
 }

--- a/services/mcp/src/ui-apps/components/types.ts
+++ b/services/mcp/src/ui-apps/components/types.ts
@@ -227,6 +227,5 @@ export interface RetentionVisualizerProps {
 }
 
 export interface PathsVisualizerProps {
-    query: PathsQuery | undefined
     results: PathsResult
 }

--- a/services/mcp/src/ui-apps/components/utils.ts
+++ b/services/mcp/src/ui-apps/components/utils.ts
@@ -22,6 +22,22 @@ export function formatPercent(value: number): string {
     return `${(value * 100).toFixed(1)}%`
 }
 
+/** Format a duration given in milliseconds as the two most-significant units (e.g. `1d 3h`, `34m 43s`). */
+export function formatDuration(ms: number): string {
+    if (!isFinite(ms) || ms <= 0) {
+        return '0s'
+    }
+    const totalSeconds = Math.round(ms / 1000)
+    const units: Array<[number, string]> = [
+        [Math.floor(totalSeconds / 86400), 'd'],
+        [Math.floor((totalSeconds % 86400) / 3600), 'h'],
+        [Math.floor((totalSeconds % 3600) / 60), 'm'],
+        [totalSeconds % 60, 's'],
+    ]
+    const parts = units.filter(([value]) => value > 0).map(([value, unit]) => `${value}${unit}`)
+    return parts.slice(0, 2).join(' ') || '0s'
+}
+
 // Only format strings that look like ISO dates — `new Date(...)` is permissive enough that
 // labels like "Day 1" silently parse to Jan 1 2001, mangling pre-formatted axis labels.
 const ISO_DATE_PREFIX = /^\d{4}-\d{2}-\d{2}/


### PR DESCRIPTION
## Problem

Paths query results had no visualization in the `query-results` MCP UI app — they fell through to the "this visualization type isn't supported" state, leaving the agent/user with only the raw text table.

## Changes

Add a `PathsVisualizer` to the `query-results` app. It renders the paths edge list as a table:

- Parses the `<stepIndex>_<value>` node keys into a **step transition** (`1 → 2`) and the path.
- Sorts edges by user count, formats `average_conversion_time` (ms) as `1d 3h` / `34m 43s` via a new `formatDuration` util.
- Footer summary: `N path transitions · busiest carries X users`.

Wired into the `Component` dispatch by both result-shape detection (`source`/`target`/`value` guard) and the `PathsQuery` kind fallback, matching the existing visualizers. No YAML/generated changes — `query-results` is an existing custom app.

It's a structured table, not a Sankey graph — the UI-app chart kit has no flow primitive and chart visualizers are owned separately.

<img width="773" height="1064" alt="Screenshot 2026-06-03 at 11 41 12" src="https://github.com/user-attachments/assets/b668ff6e-cd65-45f8-b6bb-8e52aa11925d" />


## How did you test this code?

Agent-authored. Ran `pnpm typecheck` (pass) and built the UI apps locally. Verified end-to-end against a local instance: the paths query (hedgebox demo data) now renders the Paths table in the connected MCP client instead of the unsupported-state card.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Follow-up to the `query-paths-actors` tool (already merged). Kept scope to the visualizer; a dev-only asset cache-bust explored during testing was dropped from this change.
