### PR TITLE
fix(workflows): start hogflow subscription matcher consumer at latest offset

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-hogflow-subscription-matcher.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-hogflow-subscription-matcher.consumer.ts
@@ -5,7 +5,7 @@ import { Counter, Histogram } from 'prom-client'
 import { instrumentFn, instrumented } from '~/common/tracing/tracing-utils'
 
 import { KAFKA_EVENTS_JSON } from '../../config/kafka-topics'
-import { KafkaConsumerInterface, createKafkaConsumer } from '../../kafka/consumer'
+import { KafkaConsumerInterface, RdKafkaConsumerConfig, createKafkaConsumer } from '../../kafka/consumer'
 import { HogFlow, HogFlowAction } from '../../schema/hogflow'
 import { HealthCheckResult, PluginsServerConfig, RawClickHouseEvent } from '../../types'
 import { parseJSON } from '../../utils/json-parse'
@@ -79,10 +79,16 @@ export class CdpHogflowSubscriptionMatcherConsumer<
 
     constructor(config: TConfig, deps: CdpConsumerBaseDeps) {
         super(config, deps)
-        this.kafkaConsumer = createKafkaConsumer({
-            groupId: 'cdp-hogflow-subscription-matcher-consumer',
-            topic: KAFKA_EVENTS_JSON,
-        })
+        // A waker only needs events that arrive after a job parks, never history, so start at the
+        // head: auto.offset.reset=latest makes a fresh consumer group begin at the tip instead of
+        // replaying the clickhouse_events_json backlog (unconsumable at prod volume).
+        this.kafkaConsumer = createKafkaConsumer(
+            {
+                groupId: 'cdp-hogflow-subscription-matcher-consumer',
+                topic: KAFKA_EVENTS_JSON,
+            },
+            { ['auto.offset.reset' as keyof RdKafkaConsumerConfig]: 'latest' as never }
+        )
 
         // The matcher does nothing but read/write cyclotron_jobs, so a missing connection
         // string means it would silently consume the event stream and wake nothing. Fail


### PR DESCRIPTION
## Problem

The hogflow subscription matcher consumes `clickhouse_events_json` to wake parked `wait_until_condition` jobs. Its Kafka consumer group inherited the default `auto.offset.reset=earliest`. For a real-time waker — which only cares about events that arrive *after* a job parks, never history — a brand-new consumer group starting at the earliest offset has to replay the entire topic backlog before it reaches current events. At production volume that backlog is effectively unconsumable, so the matcher would never catch up to the head and would wake nothing.

This must land before the matcher is enabled in production: the first deploy there creates a fresh consumer group, and with `earliest` it would start at the beginning of the full firehose.

## Changes

- Start the subscription matcher's consumer at `latest` instead of `earliest`, using the existing rdkafka override argument on `createKafkaConsumer`. Scoped to this one consumer — every other consumer keeps `earliest`.
- Consumer group name is unchanged; a fresh group (new deploy, or after an offset reset) now begins at the tip.

## How did you test this code?

I'm an agent (Claude Code). I ran `tsc --noEmit` (passes) and `prettier --check` on the changed file (passes). No new automated tests — this is a one-line consumer-config behaviour change; correctness rests on rdkafka config precedence (the override is applied after the hardcoded default). Functional behaviour will be confirmed by deploying to a non-production environment and watching the consumer-group lag stay near the head.

## 🤖 Agent context

Agent-assisted. Root cause investigation found a brand-new consumer group on a high-volume topic starting at `earliest`, replaying the whole backlog and never reaching the head — so parked workflows were never woken. Options considered: (a) renaming the group to force a fresh start, (b) a charts/env override (`KAFKA_CONSUMER_AUTO_OFFSET_RESET`), and (c) an in-code rdkafka override. Chose (c) at `latest` and kept the group name: it's the minimal, consumer-scoped fix and is the semantically correct default for a real-time waker. Reviewer note: a real-time matcher only needs events after a job parks, so skipping history on a fresh group loses nothing.
