### PR TITLE
fix(ci): restore ai_observability trigger for general-purpose temporal worker

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -356,7 +356,7 @@ jobs:
             - name: Check for changes that affect general purpose temporal worker
               id: check_changes_general_purpose_temporal_worker
               run: |
-                  if git diff --name-only HEAD^ HEAD | grep -qE '^products/exports/backend/temporal/subscriptions|^posthog/temporal/common|^posthog/temporal/session_recordings|^posthog/temporal/proxy_service|^posthog/temporal/llm_analytics|^posthog/temporal/product_analytics|^posthog/temporal/delete_persons|^posthog/temporal/ingestion_acceptance_test|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
+                  if git diff --name-only HEAD^ HEAD | grep -qE '^products/exports/backend/temporal/subscriptions|^posthog/temporal/common|^posthog/temporal/session_recordings|^posthog/temporal/proxy_service|^posthog/temporal/(ai_observability|llm_analytics)|^posthog/temporal/product_analytics|^posthog/temporal/delete_persons|^posthog/temporal/ingestion_acceptance_test|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
                       echo "changed=true" >> $GITHUB_OUTPUT
                   else
                       echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The general-purpose temporal worker's change-detection step in `container-images-cd.yml` decides whether a code change should rebuild and redeploy that worker. #60228 renamed the subscriptions module path on that same `grep -qE` line and, in the process, accidentally collapsed `^posthog/temporal/(ai_observability|llm_analytics)` down to `^posthog/temporal/llm_analytics` — dropping the `ai_observability` alternative.

The LLM analytics temporal workflows live under `posthog/temporal/ai_observability/` (that's where `start_temporal_worker.py` imports them from). So after #60228, a change touching only `posthog/temporal/ai_observability/**` no longer matched the filter and stopped triggering a rebuild/redeploy of the general-purpose temporal worker.

## Changes

Restore the dropped `ai_observability` alternative in the general-purpose temporal worker's change filter: `^posthog/temporal/llm_analytics` → `^posthog/temporal/(ai_observability|llm_analytics)`. One-token change, single line.

The subscriptions-path rename from #60228 is correct and left untouched. Other steps (e.g. the LLM analytics evals worker) already carry the full `(ai_observability|llm_analytics)` group and are unchanged.

## How did you test this code?

Authored by an agent. No automated tests added — this is a one-line CI workflow regex fix. Verified by inspection: the dropped alternative is restored, the `git diff` against master is exactly one line, and the subscriptions path and all other tokens on the line are unchanged. The regex still parses (balanced parens, valid alternation). Confirmed the general-purpose worker was the only step missing the group; the evals worker step already had it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact — CI workflow change only.

## 🤖 Agent context

Authored by Claude Code (Opus). The task was scoped to a single regression: #60228's subscriptions-path rename silently narrowed the general-purpose temporal worker's change filter, so changes under `posthog/temporal/ai_observability/**` stopped triggering its rebuild/redeploy.

Approach: searched the workflow for `posthog/temporal/llm_analytics` tokens not already inside an `(ai_observability|llm_analytics)` group, found exactly one (the general-purpose worker step), and restored the alternation there. Left the evals worker step alone since it already had the full group, and deliberately did not touch the subscriptions path rename. Kept the change to a single line to make the regression and the fix easy to verify.

Agent-authored — requires human review.
