### PR TITLE
chore: reassign product owners after team split

### DIFF
--- a/products/mcp_analytics/product.yaml
+++ b/products/mcp_analytics/product.yaml
@@ -1,3 +1,3 @@
 name: MCP analytics
 owners:
-    - team-posthog-ai
+    - team-signals

--- a/products/mcp_store/product.yaml
+++ b/products/mcp_store/product.yaml
@@ -1,3 +1,3 @@
 name: MCP servers
 owners:
-    - team-posthog-ai
+    - team-signals

--- a/products/posthog_ai/product.yaml
+++ b/products/posthog_ai/product.yaml
@@ -1,3 +1,3 @@
 name: PostHog AI
 owners:
-    - team-posthog-ai
+    - team-signals

--- a/products/slack_app/product.yaml
+++ b/products/slack_app/product.yaml
@@ -1,3 +1,3 @@
 name: Slack app
 owners:
-    - team-posthog-ai
+    - team-signals

--- a/products/tasks/product.yaml
+++ b/products/tasks/product.yaml
@@ -1,3 +1,3 @@
 name: Tasks
 owners:
-    - team-posthog-ai
+    - team-posthog-code


### PR DESCRIPTION
## Problem

[PostHog/posthog.com#17202](https://github.com/PostHog/posthog.com/pull/17202) updates feature ownership to reflect a team change: `posthog-ai` is being split into `signals` and `posthog-code`. The `products/*/product.yaml` `owners:` fields in this repo (which drive automatic reviewer assignment via `.github/scripts/assign-reviewers.js`) still point at the retired `team-posthog-ai`, so PRs touching these products would be routed to the wrong team.

## Changes

Reassign every `product.yaml` still owned by `team-posthog-ai`:

| Product | Old owner | New owner | Source |
|---|---|---|---|
| `slack_app` | `team-posthog-ai` | `team-signals` | "Slack app" → signals |
| `mcp_store` | `team-posthog-ai` | `team-signals` | "MCP server" → signals |
| `posthog_ai` | `team-posthog-ai` | `team-signals` | "PostHog AI platform" → signals |
| `tasks` | `team-posthog-ai` | `team-posthog-code` | "Background agents" → "Cloud agents" → posthog-code |
| `mcp_analytics` | `team-posthog-ai` | `team-signals` | Not a posthog.com feature; grouped with the other MCP product since its owner team is retired |

After this change no `product.yaml` references `team-posthog-ai`.

## How did you test this code?

I'm an agent (PostHog Code). No automated tests were run locally. The repo's owner-lint (`hogli product:lint:owners`, gated on `products/*/product.yaml` changes) validates the new owner slugs against PostHog org teams in CI — `team-signals` is already used by `signals`/`tracing`, and `team-posthog-code` will be validated there.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact — this only changes reviewer-routing metadata.

## 🤖 Agent context

Authored by PostHog Code at Josh Snyder's request, following Julian's note to adjust the `product.yaml`s to the right GitHub teams after the posthog.com feature-ownership PR.

The mapping was derived from the diff of PostHog/posthog.com#17202 (`src/hooks/useFeatureOwnership.tsx`), translating each posthog.com owner slug to the repo's `team-<slug>` convention. `mcp_analytics` was the one judgement call: it has no matching posthog.com feature, but since `team-posthog-ai` is being fully retired it can't stay, so it was grouped with the other MCP product under `team-signals`. Flag if it should instead go to `team-posthog-code` or elsewhere.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*