### PR TITLE
fix(notebooks): don't show error toast when JSON file selection is cancelled

### DIFF
--- a/frontend/src/scenes/notebooks/NotebookCanvasScene.tsx
+++ b/frontend/src/scenes/notebooks/NotebookCanvasScene.tsx
@@ -61,8 +61,11 @@ export function NotebookCanvas(): JSX.Element {
                                             contentType: 'application/json',
                                             multiple: false,
                                         })
-                                            .then((files) => getTextFromFile(files[0]))
-                                            .then((text) => {
+                                            .then(async (files) => {
+                                                if (!files.length) {
+                                                    return
+                                                }
+                                                const text = await getTextFromFile(files[0])
                                                 const data = JSON.parse(text)
                                                 if (data.type !== 'doc') {
                                                     throw new Error('Not a notebook')

--- a/frontend/src/scenes/notebooks/NotebooksScene.tsx
+++ b/frontend/src/scenes/notebooks/NotebooksScene.tsx
@@ -44,8 +44,11 @@ export function NotebooksScene(): JSX.Element {
                                             contentType: 'application/json',
                                             multiple: false,
                                         })
-                                            .then((files) => getTextFromFile(files[0]))
-                                            .then((text) => {
+                                            .then(async (files) => {
+                                                if (!files.length) {
+                                                    return
+                                                }
+                                                const text = await getTextFromFile(files[0])
                                                 const data = JSON.parse(text)
                                                 if (data.type !== 'doc') {
                                                     throw new Error('Not a notebook')


### PR DESCRIPTION
## Problem

In Notebooks, clicking the three-dot menu → **Load from JSON** opens the native file picker. If the user closes/cancels the picker without choosing a file, an error toast appears:

> Failed to execute 'readAsText' on 'FileReader': parameter 1 is not of type 'Blob'.

The error should only appear when an actually-invalid (non-notebook) JSON file is selected, not every time the picker is dismissed.

## Changes

`selectFiles` resolves with an empty array when the user cancels the native picker. The `Load from JSON` handlers then called `getTextFromFile(files[0])` with `undefined`, which `FileReader.readAsText` rejects — surfacing the misleading toast.

Both handlers (`NotebooksScene.tsx` and `NotebookCanvasScene.tsx`) now guard against an empty selection and return early when no file was chosen, so the error path is reserved for genuinely invalid files.

## How did you test this code?

I'm an agent. I made the code change but did not run manual or automated tests for this fix. The change is a small guard clause; reviewers should verify by opening the Notebooks "Load from JSON" menu, cancelling the file picker (no toast expected), and separately selecting a non-notebook JSON file (error toast still expected).

## 🤖 Agent context

Authored by PostHog Code (Claude). Traced the toast to `selectFiles` resolving `[]` on cancel while the chained `.then` unconditionally passed `files[0]` to `getTextFromFile`. Restructured both Notebook "Load from JSON" handlers to bail out early on an empty selection rather than changing `getTextFromFile`/`selectFiles`, keeping the shared utilities untouched and the fix local to the two call sites.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*