### PR TITLE
fix(caching): share query_cache RedisCluster client process-wide

### DIFF
--- a/posthog/caching/redis_cluster_connection_factory.py
+++ b/posthog/caching/redis_cluster_connection_factory.py
@@ -38,11 +38,9 @@ class RedisClusterConnectionFactory(ConnectionFactory):
     instances, so discovery runs once per process and the post-fork prewarm
     populates the same client the request threads read.
 
-    A RedisCluster holds open sockets, so it must not cross a fork: a client
-    discovered before fork (e.g. by a pre-fork prewarm) would be inherited by
-    every worker, sharing the same file descriptors across processes. connect()
-    guards against this by binding the cache to the pid that filled it and
-    rediscovering after a fork.
+    A RedisCluster holds open sockets, so it must not cross a fork; connect()
+    binds the cache to the pid that filled it and rediscovers in a forked worker
+    (see _reset_if_forked) so workers never share inherited file descriptors.
 
     This relies on the client being long-lived, so CLOSE_CONNECTION is
     unsupported on this alias and rejected in __init__: django_redis closes
@@ -71,16 +69,23 @@ class RedisClusterConnectionFactory(ConnectionFactory):
         client = self._cluster_clients.get(url) if self._owner_pid == pid else None
         if client is None:
             with self._lock:
-                if self._owner_pid != pid:
-                    # Crossed a fork: the inherited clients hold the parent's
-                    # sockets. Drop them and rediscover in this process.
-                    self._cluster_clients.clear()
-                    RedisClusterConnectionFactory._owner_pid = pid
+                self._reset_if_forked(pid)
                 client = self._cluster_clients.get(url)
                 if client is None:
                     client = self._discover_cluster(url)
                     self._cluster_clients[url] = client
         return client
+
+    def _reset_if_forked(self, pid: int) -> None:
+        # A client discovered before a fork holds the parent's sockets, so a
+        # forked worker drops the inherited cache and rediscovers its own. Caller
+        # must hold _lock.
+        if self._owner_pid == pid:
+            return
+        if self._owner_pid is not None:
+            logger.info("redis_cluster_rediscovering_after_fork", previous_pid=self._owner_pid, pid=pid)
+        self._cluster_clients.clear()
+        RedisClusterConnectionFactory._owner_pid = pid
 
     @tracer.start_as_current_span("redis_cluster.discovery")
     def _discover_cluster(self, url: str) -> RedisCluster:

--- a/posthog/caching/redis_cluster_connection_factory.py
+++ b/posthog/caching/redis_cluster_connection_factory.py
@@ -54,9 +54,11 @@ class RedisClusterConnectionFactory(ConnectionFactory):
 
     @tracer.start_as_current_span("redis_cluster.discovery")
     def _discover_cluster(self, url: str) -> RedisCluster:
-        # socket_keepalive keeps the long-lived pooled connections healthy across
-        # idle periods, so an LB/NAT idle-timeout can't silently drop them and
-        # force a reconnect (and fresh discovery) mid-request.
+        # socket_keepalive enables TCP keepalive on the long-lived pooled
+        # connections -- best-effort protection against an idle LB/NAT silently
+        # dropping them and forcing a reconnect (and fresh discovery) mid-request.
+        # With OS-default keepalive timing this isn't a hard guarantee; tune
+        # socket_keepalive_options below the real idle timeout if drops persist.
         return RedisCluster.from_url(url, socket_keepalive=True)
 
     def disconnect(self, connection) -> None:

--- a/posthog/caching/redis_cluster_connection_factory.py
+++ b/posthog/caching/redis_cluster_connection_factory.py
@@ -1,7 +1,9 @@
+import os
 import threading
 
 from django.conf import settings
 from django.core.cache import caches
+from django.core.exceptions import ImproperlyConfigured
 
 import structlog
 from django_redis.pool import ConnectionFactory
@@ -36,20 +38,44 @@ class RedisClusterConnectionFactory(ConnectionFactory):
     instances, so discovery runs once per process and the post-fork prewarm
     populates the same client the request threads read.
 
-    This relies on the client being long-lived: do not enable CLOSE_CONNECTION
-    on the query_cache alias. django_redis closes connections per request when
-    it is set, which would tear down and rediscover the shared client on every
-    request -- the exact per-request discovery this class exists to avoid.
+    A RedisCluster holds open sockets, so it must not cross a fork: a client
+    discovered before fork (e.g. by a pre-fork prewarm) would be inherited by
+    every worker, sharing the same file descriptors across processes. connect()
+    guards against this by binding the cache to the pid that filled it and
+    rediscovering after a fork.
+
+    This relies on the client being long-lived, so CLOSE_CONNECTION is
+    unsupported on this alias and rejected in __init__: django_redis closes
+    connections per request when it is set, which would tear down and rediscover
+    the shared client on every request -- the exact per-request discovery this
+    class exists to avoid.
     """
 
     # Class scope (process-global), not per-instance -- see the class docstring.
     _cluster_clients: dict[str, RedisCluster] = {}
     _lock = threading.Lock()
+    _owner_pid: int | None = None
+
+    def __init__(self, options: dict) -> None:
+        super().__init__(options)
+        close_connection = options.get("CLOSE_CONNECTION", getattr(settings, "DJANGO_REDIS_CLOSE_CONNECTION", False))
+        if close_connection:
+            raise ImproperlyConfigured(
+                "CLOSE_CONNECTION is not supported on a RedisClusterConnectionFactory alias: "
+                "the cluster client is shared process-wide and long-lived, so closing it per "
+                "request would force topology rediscovery on every request."
+            )
 
     def connect(self, url: str) -> RedisCluster:
-        client = self._cluster_clients.get(url)
+        pid = os.getpid()
+        client = self._cluster_clients.get(url) if self._owner_pid == pid else None
         if client is None:
             with self._lock:
+                if self._owner_pid != pid:
+                    # Crossed a fork: the inherited clients hold the parent's
+                    # sockets. Drop them and rediscover in this process.
+                    self._cluster_clients.clear()
+                    RedisClusterConnectionFactory._owner_pid = pid
                 client = self._cluster_clients.get(url)
                 if client is None:
                     client = self._discover_cluster(url)
@@ -70,11 +96,11 @@ def prewarm_query_cache_cluster() -> None:
     """Force RedisCluster topology discovery during worker warmup.
 
     Discovery (COMMAND + CLUSTER SLOTS) otherwise happens lazily on the worker's
-    first cacheable query, putting it on a user's query critical path. Issuing a
-    trivial read here moves it earlier: to module import under WSGI, and to a
-    background thread spawned from the post-fork init hook under ASGI (so it never
-    blocks the event loop). Safe to call when the query_cache alias is not
-    configured — it is a no-op then.
+    first cacheable query, putting it on a user's query critical path. Both
+    wsgi.py and asgi.py call this (via the background helper) from a first-request
+    post-fork hook, so discovery runs in the worker process and is warm before the
+    first real query. Safe to call when the query_cache alias is not configured —
+    it is a no-op then.
     """
     if QUERY_CACHE_ALIAS not in settings.CACHES:
         return
@@ -87,11 +113,13 @@ def prewarm_query_cache_cluster() -> None:
 def prewarm_query_cache_cluster_in_background() -> threading.Thread:
     """Run prewarm_query_cache_cluster() on a daemon thread.
 
-    Callers on an event loop (the ASGI post-fork hook) must not run the blocking
-    cluster discovery inline. prewarm_query_cache_cluster swallows and logs its
-    own failures, so the thread cannot raise into the interpreter; daemon=True
-    keeps a still-running warmup from delaying shutdown. Start this only after
-    fork — never at module import on a server that forks workers.
+    The first-request post-fork hooks (wsgi.py and asgi.py) use this so the
+    blocking cluster discovery never runs inline -- it would block the ASGI event
+    loop, and needlessly delay the first WSGI request. prewarm_query_cache_cluster
+    swallows and logs its own failures, so the thread cannot raise into the
+    interpreter; daemon=True keeps a still-running warmup from delaying shutdown.
+    Start this only after fork — never at module import on a server that forks
+    workers.
     """
     thread = threading.Thread(
         target=prewarm_query_cache_cluster,

--- a/posthog/caching/redis_cluster_connection_factory.py
+++ b/posthog/caching/redis_cluster_connection_factory.py
@@ -78,10 +78,9 @@ class RedisClusterConnectionFactory(ConnectionFactory):
 
     @classmethod
     def _reset_if_forked(cls, pid: int) -> None:
-        # A client discovered before a fork holds the parent's sockets, so a
-        # forked worker drops the inherited cache and rediscovers its own. A
-        # classmethod so the writes land on the class (process-global) with no
-        # `self` in scope to shadow them onto an instance. Caller must hold _lock.
+        # A classmethod so the cache/owner-pid writes land on the class
+        # (process-global) with no `self` in scope to shadow them onto an
+        # instance. Caller must hold _lock.
         if cls._owner_pid == pid:
             return
         if cls._owner_pid is not None:

--- a/posthog/caching/redis_cluster_connection_factory.py
+++ b/posthog/caching/redis_cluster_connection_factory.py
@@ -37,8 +37,7 @@ class RedisClusterConnectionFactory(ConnectionFactory):
     populates the same client the request threads read.
     """
 
-    # Process-global cache of discovered cluster clients, keyed by URL. Must not
-    # be per-instance -- see the class docstring.
+    # Class scope (process-global), not per-instance -- see the class docstring.
     _cluster_clients: dict[str, RedisCluster] = {}
     _lock = threading.Lock()
 
@@ -61,7 +60,7 @@ class RedisClusterConnectionFactory(ConnectionFactory):
         # socket_keepalive_options below the real idle timeout if drops persist.
         return RedisCluster.from_url(url, socket_keepalive=True)
 
-    def disconnect(self, connection) -> None:
+    def disconnect(self, connection: RedisCluster) -> None:
         # The client is process-global, so evict it before closing -- otherwise
         # the cache would keep handing out a closed client. A no-op in the default
         # config (CLOSE_CONNECTION is unset, so django_redis never calls this per

--- a/posthog/caching/redis_cluster_connection_factory.py
+++ b/posthog/caching/redis_cluster_connection_factory.py
@@ -35,6 +35,11 @@ class RedisClusterConnectionFactory(ConnectionFactory):
     request thread would re-run discovery. Class-level state is shared across all
     instances, so discovery runs once per process and the post-fork prewarm
     populates the same client the request threads read.
+
+    This relies on the client being long-lived: do not enable CLOSE_CONNECTION
+    on the query_cache alias. django_redis closes connections per request when
+    it is set, which would tear down and rediscover the shared client on every
+    request -- the exact per-request discovery this class exists to avoid.
     """
 
     # Class scope (process-global), not per-instance -- see the class docstring.
@@ -59,18 +64,6 @@ class RedisClusterConnectionFactory(ConnectionFactory):
         # With OS-default keepalive timing this isn't a hard guarantee; tune
         # socket_keepalive_options below the real idle timeout if drops persist.
         return RedisCluster.from_url(url, socket_keepalive=True)
-
-    def disconnect(self, connection: RedisCluster) -> None:
-        # The client is process-global, so evict it before closing -- otherwise
-        # the cache would keep handing out a closed client. A no-op in the default
-        # config (CLOSE_CONNECTION is unset, so django_redis never calls this per
-        # request), but keeps the shared cache consistent if it is ever enabled.
-        with self._lock:
-            for url, client in list(self._cluster_clients.items()):
-                if client is connection:
-                    del self._cluster_clients[url]
-                    break
-        connection.close()
 
 
 def prewarm_query_cache_cluster() -> None:

--- a/posthog/caching/redis_cluster_connection_factory.py
+++ b/posthog/caching/redis_cluster_connection_factory.py
@@ -76,18 +76,18 @@ class RedisClusterConnectionFactory(ConnectionFactory):
                     self._cluster_clients[url] = client
         return client
 
-    def _reset_if_forked(self, pid: int) -> None:
+    @classmethod
+    def _reset_if_forked(cls, pid: int) -> None:
         # A client discovered before a fork holds the parent's sockets, so a
-        # forked worker drops the inherited cache and rediscovers its own. Caller
-        # must hold _lock.
-        if self._owner_pid == pid:
+        # forked worker drops the inherited cache and rediscovers its own. A
+        # classmethod so the writes land on the class (process-global) with no
+        # `self` in scope to shadow them onto an instance. Caller must hold _lock.
+        if cls._owner_pid == pid:
             return
-        if self._owner_pid is not None:
-            logger.info("redis_cluster_rediscovering_after_fork", previous_pid=self._owner_pid, pid=pid)
-        self._cluster_clients.clear()
-        # Assign on the class, never self: a `self._owner_pid = ...` write would
-        # create a per-instance attribute that shadows the process-global one.
-        RedisClusterConnectionFactory._owner_pid = pid
+        if cls._owner_pid is not None:
+            logger.info("redis_cluster_rediscovering_after_fork", previous_pid=cls._owner_pid, pid=pid)
+        cls._cluster_clients.clear()
+        cls._owner_pid = pid
 
     @tracer.start_as_current_span("redis_cluster.discovery")
     def _discover_cluster(self, url: str) -> RedisCluster:

--- a/posthog/caching/redis_cluster_connection_factory.py
+++ b/posthog/caching/redis_cluster_connection_factory.py
@@ -27,25 +27,48 @@ class RedisClusterConnectionFactory(ConnectionFactory):
     discovery. We wrap that construction in a "redis_cluster.discovery" span so
     its place in a trace is visible: nested under a request span means discovery
     is on a user's critical path; a parentless span means it ran during warmup.
+
+    Discovered clients are cached at class scope (process-global), mirroring
+    django_redis's ConnectionFactory._pools. Django builds a new cache client --
+    and therefore a new factory instance -- per request, and `caches` is
+    thread-local, so per-instance state would be discarded constantly and every
+    request thread would re-run discovery. Class-level state is shared across all
+    instances, so discovery runs once per process and the post-fork prewarm
+    populates the same client the request threads read.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._cluster_clients: dict[str, RedisCluster] = {}
-        self._lock = threading.Lock()
+    # Process-global cache of discovered cluster clients, keyed by URL. Must not
+    # be per-instance -- see the class docstring.
+    _cluster_clients: dict[str, RedisCluster] = {}
+    _lock = threading.Lock()
 
     def connect(self, url: str) -> RedisCluster:
-        if url not in self._cluster_clients:
+        client = self._cluster_clients.get(url)
+        if client is None:
             with self._lock:
-                if url not in self._cluster_clients:
-                    self._cluster_clients[url] = self._discover_cluster(url)
-        return self._cluster_clients[url]
+                client = self._cluster_clients.get(url)
+                if client is None:
+                    client = self._discover_cluster(url)
+                    self._cluster_clients[url] = client
+        return client
 
     @tracer.start_as_current_span("redis_cluster.discovery")
     def _discover_cluster(self, url: str) -> RedisCluster:
-        return RedisCluster.from_url(url)
+        # socket_keepalive keeps the long-lived pooled connections healthy across
+        # idle periods, so an LB/NAT idle-timeout can't silently drop them and
+        # force a reconnect (and fresh discovery) mid-request.
+        return RedisCluster.from_url(url, socket_keepalive=True)
 
     def disconnect(self, connection) -> None:
+        # The client is process-global, so evict it before closing -- otherwise
+        # the cache would keep handing out a closed client. A no-op in the default
+        # config (CLOSE_CONNECTION is unset, so django_redis never calls this per
+        # request), but keeps the shared cache consistent if it is ever enabled.
+        with self._lock:
+            for url, client in list(self._cluster_clients.items()):
+                if client is connection:
+                    del self._cluster_clients[url]
+                    break
         connection.close()
 
 

--- a/posthog/caching/redis_cluster_connection_factory.py
+++ b/posthog/caching/redis_cluster_connection_factory.py
@@ -38,9 +38,9 @@ class RedisClusterConnectionFactory(ConnectionFactory):
     instances, so discovery runs once per process and the post-fork prewarm
     populates the same client the request threads read.
 
-    A RedisCluster holds open sockets, so it must not cross a fork; connect()
-    binds the cache to the pid that filled it and rediscovers in a forked worker
-    (see _reset_if_forked) so workers never share inherited file descriptors.
+    A RedisCluster holds open sockets, so the cache is pid-bound and rediscovered
+    after a fork (see _reset_if_forked) -- workers must never share inherited file
+    descriptors.
 
     This relies on the client being long-lived, so CLOSE_CONNECTION is
     unsupported on this alias and rejected in __init__: django_redis closes
@@ -85,6 +85,8 @@ class RedisClusterConnectionFactory(ConnectionFactory):
         if self._owner_pid is not None:
             logger.info("redis_cluster_rediscovering_after_fork", previous_pid=self._owner_pid, pid=pid)
         self._cluster_clients.clear()
+        # Assign on the class, never self: a `self._owner_pid = ...` write would
+        # create a per-instance attribute that shadows the process-global one.
         RedisClusterConnectionFactory._owner_pid = pid
 
     @tracer.start_as_current_span("redis_cluster.discovery")

--- a/posthog/caching/test/test_redis_cluster_connection_factory.py
+++ b/posthog/caching/test/test_redis_cluster_connection_factory.py
@@ -1,3 +1,4 @@
+import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
@@ -124,6 +125,20 @@ class TestRedisClusterConnectionFactory(TestCase):
 
         assert enters_after_warmup == 1
         assert counting_lock.enter_count == 1
+
+    @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")
+    def test_owner_pid_is_recorded_on_the_class_not_the_instance(self, from_url: MagicMock) -> None:
+        # The fork guard only works if _owner_pid is process-global. If it were
+        # ever written through `self` it would shadow onto the instance, every
+        # fresh per-request factory would look unforked, and discovery would run
+        # per request again. Pin it to the class.
+        from_url.return_value = MagicMock()
+        factory = self._factory()
+
+        factory.connect("redis://node-a:6379")
+
+        assert RedisClusterConnectionFactory._owner_pid == os.getpid()
+        assert "_owner_pid" not in factory.__dict__
 
     @patch("posthog.caching.redis_cluster_connection_factory.os.getpid")
     @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")

--- a/posthog/caching/test/test_redis_cluster_connection_factory.py
+++ b/posthog/caching/test/test_redis_cluster_connection_factory.py
@@ -1,3 +1,5 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
@@ -71,6 +73,63 @@ class TestRedisClusterConnectionFactory(TestCase):
         first.close.assert_called_once_with()
         assert second is not first
         assert from_url.call_count == 2
+
+    @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")
+    def test_concurrent_connect_discovers_once_and_returns_one_shared_client(self, from_url: MagicMock) -> None:
+        # A thundering herd of request threads must not each run discovery: the
+        # double-checked lock means exactly one construction even when every
+        # thread races into connect() at the same instant.
+        sentinel = MagicMock()
+        from_url.return_value = sentinel
+
+        thread_count = 16
+        start = threading.Barrier(thread_count)
+        results: list[object] = []
+        results_lock = threading.Lock()
+
+        def worker() -> None:
+            factory = self._factory()  # a fresh per-thread factory, as Django builds per request
+            start.wait()
+            client = factory.connect("redis://node-a:6379")
+            with results_lock:
+                results.append(client)
+
+        with ThreadPoolExecutor(max_workers=thread_count) as pool:
+            for future in [pool.submit(worker) for _ in range(thread_count)]:
+                future.result()
+
+        assert from_url.call_count == 1
+        assert results == [sentinel] * thread_count
+
+    @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")
+    def test_cache_hit_never_acquires_the_global_lock(self, from_url: MagicMock) -> None:
+        # The lock guards construction only. If it leaked onto the cache-hit path
+        # it would serialize every query-cache access process-wide and block the
+        # server under load, so assert the warm path takes it zero times.
+        from_url.return_value = MagicMock()
+
+        class CountingLock:
+            def __init__(self) -> None:
+                self._lock = threading.Lock()
+                self.enter_count = 0
+
+            def __enter__(self) -> None:
+                self.enter_count += 1
+                self._lock.acquire()
+
+            def __exit__(self, *args: object) -> None:
+                self._lock.release()
+
+        counting_lock = CountingLock()
+        with patch.object(RedisClusterConnectionFactory, "_lock", counting_lock):
+            factory = self._factory()
+            factory.connect("redis://node-a:6379")  # cold: one construction → one acquire
+            enters_after_warmup = counting_lock.enter_count
+            for _ in range(50):
+                factory.connect("redis://node-a:6379")  # warm: must not touch the lock
+
+        assert enters_after_warmup == 1
+        assert counting_lock.enter_count == 1
 
 
 class TestPrewarmQueryCacheCluster(TestCase):

--- a/posthog/caching/test/test_redis_cluster_connection_factory.py
+++ b/posthog/caching/test/test_redis_cluster_connection_factory.py
@@ -63,20 +63,6 @@ class TestRedisClusterConnectionFactory(TestCase):
         from_url.assert_called_once_with("redis://node-a:6379", socket_keepalive=True)
 
     @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")
-    def test_disconnect_evicts_client_so_next_connect_rediscovers(self, from_url: MagicMock) -> None:
-        clients = [MagicMock(name="client-a"), MagicMock(name="client-b")]
-        from_url.side_effect = clients
-        factory = self._factory()
-
-        first = factory.connect("redis://node-a:6379")
-        factory.disconnect(first)
-        second = factory.connect("redis://node-a:6379")
-
-        clients[0].close.assert_called_once_with()
-        assert second is not first
-        assert from_url.call_count == 2
-
-    @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")
     def test_concurrent_connect_discovers_once_and_returns_one_shared_client(self, from_url: MagicMock) -> None:
         # A thundering herd of request threads must not each run discovery: the
         # double-checked lock means exactly one construction even when every

--- a/posthog/caching/test/test_redis_cluster_connection_factory.py
+++ b/posthog/caching/test/test_redis_cluster_connection_factory.py
@@ -127,11 +127,11 @@ class TestRedisClusterConnectionFactory(TestCase):
         assert counting_lock.enter_count == 1
 
     @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")
-    def test_owner_pid_is_recorded_on_the_class_not_the_instance(self, from_url: MagicMock) -> None:
-        # The fork guard only works if _owner_pid is process-global. If it were
-        # ever written through `self` it would shadow onto the instance, every
-        # fresh per-request factory would look unforked, and discovery would run
-        # per request again. Pin it to the class.
+    def test_shared_state_lives_on_the_class_not_the_instance(self, from_url: MagicMock) -> None:
+        # The fork guard only works if _owner_pid and the client cache are
+        # process-global. If either were ever written through `self` it would
+        # shadow onto the instance, every fresh per-request factory would look
+        # unforked, and discovery would run per request again. Pin them to the class.
         from_url.return_value = MagicMock()
         factory = self._factory()
 
@@ -139,6 +139,7 @@ class TestRedisClusterConnectionFactory(TestCase):
 
         assert RedisClusterConnectionFactory._owner_pid == os.getpid()
         assert "_owner_pid" not in factory.__dict__
+        assert "_cluster_clients" not in factory.__dict__
 
     @patch("posthog.caching.redis_cluster_connection_factory.os.getpid")
     @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")

--- a/posthog/caching/test/test_redis_cluster_connection_factory.py
+++ b/posthog/caching/test/test_redis_cluster_connection_factory.py
@@ -1,5 +1,6 @@
 import threading
 from concurrent.futures import ThreadPoolExecutor
+
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase

--- a/posthog/caching/test/test_redis_cluster_connection_factory.py
+++ b/posthog/caching/test/test_redis_cluster_connection_factory.py
@@ -11,6 +11,14 @@ from posthog.caching.redis_cluster_connection_factory import (
 
 
 class TestRedisClusterConnectionFactory(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        RedisClusterConnectionFactory._cluster_clients.clear()
+
+    def tearDown(self) -> None:
+        RedisClusterConnectionFactory._cluster_clients.clear()
+        super().tearDown()
+
     def _factory(self) -> RedisClusterConnectionFactory:
         return RedisClusterConnectionFactory(options={})
 
@@ -25,17 +33,43 @@ class TestRedisClusterConnectionFactory(TestCase):
 
         assert first is sentinel
         assert second is sentinel
-        from_url.assert_called_once_with("redis://node-a:6379")
+        from_url.assert_called_once_with("redis://node-a:6379", socket_keepalive=True)
 
     @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")
     def test_connect_constructs_one_client_per_distinct_url(self, from_url: MagicMock) -> None:
         factory = self._factory()
-        from_url.side_effect = lambda url: MagicMock(name=url)
+        from_url.side_effect = lambda url, **kwargs: MagicMock(name=url)
 
         factory.connect("redis://node-a:6379")
         factory.connect("redis://node-b:6379")
         factory.connect("redis://node-a:6379")
 
+        assert from_url.call_count == 2
+
+    @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")
+    def test_discovered_client_is_shared_across_factory_instances(self, from_url: MagicMock) -> None:
+        sentinel = MagicMock()
+        from_url.return_value = sentinel
+
+        # Django builds a fresh factory per request/thread; discovery must still
+        # happen only once because the cache is process-global, not per-instance.
+        first = self._factory().connect("redis://node-a:6379")
+        second = self._factory().connect("redis://node-a:6379")
+
+        assert first is second is sentinel
+        from_url.assert_called_once_with("redis://node-a:6379", socket_keepalive=True)
+
+    @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")
+    def test_disconnect_evicts_client_so_next_connect_rediscovers(self, from_url: MagicMock) -> None:
+        from_url.side_effect = lambda url, **kwargs: MagicMock(name=url)
+        factory = self._factory()
+
+        first = factory.connect("redis://node-a:6379")
+        factory.disconnect(first)
+        second = factory.connect("redis://node-a:6379")
+
+        first.close.assert_called_once_with()
+        assert second is not first
         assert from_url.call_count == 2
 
 

--- a/posthog/caching/test/test_redis_cluster_connection_factory.py
+++ b/posthog/caching/test/test_redis_cluster_connection_factory.py
@@ -1,9 +1,13 @@
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
 from unittest.mock import MagicMock, patch
 
+from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
+
+from parameterized import parameterized
 
 from posthog.caching.redis_cluster_connection_factory import (
     QUERY_CACHE_ALIAS,
@@ -17,9 +21,11 @@ class TestRedisClusterConnectionFactory(TestCase):
     def setUp(self) -> None:
         super().setUp()
         RedisClusterConnectionFactory._cluster_clients.clear()
+        RedisClusterConnectionFactory._owner_pid = None
 
     def tearDown(self) -> None:
         RedisClusterConnectionFactory._cluster_clients.clear()
+        RedisClusterConnectionFactory._owner_pid = None
         super().tearDown()
 
     def _factory(self) -> RedisClusterConnectionFactory:
@@ -118,6 +124,32 @@ class TestRedisClusterConnectionFactory(TestCase):
 
         assert enters_after_warmup == 1
         assert counting_lock.enter_count == 1
+
+    @patch("posthog.caching.redis_cluster_connection_factory.os.getpid")
+    @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")
+    def test_connect_rediscovers_after_a_fork(self, from_url: MagicMock, getpid: MagicMock) -> None:
+        # A client discovered pre-fork holds the parent's sockets; once getpid()
+        # changes (the worker is a forked child) connect() must drop the inherited
+        # cache and rediscover so workers never share file descriptors.
+        from_url.side_effect = lambda url, **kwargs: MagicMock(name=url)
+        getpid.return_value = 1000
+        parent_client = self._factory().connect("redis://node-a:6379")
+
+        getpid.return_value = 2000  # forked worker
+        child_client = self._factory().connect("redis://node-a:6379")
+
+        assert child_client is not parent_client
+        assert from_url.call_count == 2
+
+    @parameterized.expand(
+        [
+            ("alias_option", {"CLOSE_CONNECTION": True}, {}),
+            ("global_setting", {}, {"DJANGO_REDIS_CLOSE_CONNECTION": True}),
+        ]
+    )
+    def test_init_rejects_close_connection(self, _name: str, options: dict, settings_overrides: dict) -> None:
+        with self.settings(**settings_overrides), pytest.raises(ImproperlyConfigured):
+            RedisClusterConnectionFactory(options=options)
 
 
 class TestPrewarmQueryCacheCluster(TestCase):

--- a/posthog/caching/test/test_redis_cluster_connection_factory.py
+++ b/posthog/caching/test/test_redis_cluster_connection_factory.py
@@ -64,14 +64,15 @@ class TestRedisClusterConnectionFactory(TestCase):
 
     @patch("posthog.caching.redis_cluster_connection_factory.RedisCluster.from_url")
     def test_disconnect_evicts_client_so_next_connect_rediscovers(self, from_url: MagicMock) -> None:
-        from_url.side_effect = lambda url, **kwargs: MagicMock(name=url)
+        clients = [MagicMock(name="client-a"), MagicMock(name="client-b")]
+        from_url.side_effect = clients
         factory = self._factory()
 
         first = factory.connect("redis://node-a:6379")
         factory.disconnect(first)
         second = factory.connect("redis://node-a:6379")
 
-        first.close.assert_called_once_with()
+        clients[0].close.assert_called_once_with()
         assert second is not first
         assert from_url.call_count == 2
 

--- a/posthog/wsgi.py
+++ b/posthog/wsgi.py
@@ -25,8 +25,14 @@ _django_application = get_wsgi_application()
 # Nginx Unit forks workers from a prototype process that imported this module, so
 # the query_cache RedisCluster must be discovered post-fork: a client built here at
 # import time would be inherited -- sockets and all -- by every worker. Defer the
-# prewarm to the first request so discovery runs in the worker. Mirrors asgi.py's
-# _ensure_post_fork_init; the factory also pid-guards the cache as a backstop.
+# prewarm to the first request so discovery runs in the worker; the factory also
+# pid-guards the cache as a backstop. (start_continuous_profiling/initialize_otel
+# above still run pre-fork here, unlike asgi.py which defers them -- that is a
+# separate, pre-existing concern, not addressed by this change.)
+#
+# Best-effort once-guard: a concurrent first-request race may spawn a couple of
+# redundant prewarm threads, which is harmless -- prewarm is idempotent and the
+# factory dedups discovery under its own lock -- so it intentionally takes no lock.
 _prewarmed = False
 
 

--- a/posthog/wsgi.py
+++ b/posthog/wsgi.py
@@ -11,7 +11,7 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-from posthog.caching.redis_cluster_connection_factory import prewarm_query_cache_cluster
+from posthog.caching.redis_cluster_connection_factory import prewarm_query_cache_cluster_in_background
 from posthog.continuous_profiling import start_continuous_profiling
 from posthog.otel_instrumentation import initialize_otel
 
@@ -20,5 +20,19 @@ os.environ.setdefault("SERVER_GATEWAY_INTERFACE", "WSGI")
 
 start_continuous_profiling()
 initialize_otel()
-application = get_wsgi_application()
-prewarm_query_cache_cluster()
+_django_application = get_wsgi_application()
+
+# Nginx Unit forks workers from a prototype process that imported this module, so
+# the query_cache RedisCluster must be discovered post-fork: a client built here at
+# import time would be inherited -- sockets and all -- by every worker. Defer the
+# prewarm to the first request so discovery runs in the worker. Mirrors asgi.py's
+# _ensure_post_fork_init; the factory also pid-guards the cache as a backstop.
+_prewarmed = False
+
+
+def application(environ, start_response):
+    global _prewarmed
+    if not _prewarmed:
+        prewarm_query_cache_cluster_in_background()
+        _prewarmed = True
+    return _django_application(environ, start_response)


### PR DESCRIPTION
## Problem

PR #60912 added a post-fork prewarm for the `query_cache` `RedisCluster` so its topology discovery (`COMMAND` + `CLUSTER SLOTS`, ~100 ms) would happen during worker warmup instead of on a user's query critical path. APM shows it isn't helping: discovery is still on the critical path, and day-over-day `COMMAND`/`CLUSTER SLOTS` volume and latency are unchanged.

The `redis_cluster.discovery` span made the cause visible. In the call-tree for `posthog-query-django`, ~88% of discovery spans are children of `process_query_model`, starting at offset ≈0 — on the request path — while only ~12% are the parentless prewarm spans. Discovery runs ~7× per worker lifetime, not once.

Root cause: the factory cached discovered clients in an **instance-level** dict. Django builds a new cache client — and therefore a new `RedisClusterConnectionFactory` — per request, and `django.core.cache.caches` is thread-local, so the cache was discarded constantly and every request thread re-ran discovery. The prewarm warms one thread's factory that no request thread ever reads. This is exactly the gotcha django_redis documents on its base `ConnectionFactory._pools`, which is class-level for this reason.

### Is this a bug, or intentional?

A bug, and a long-standing one. The instance-level dict has been there since the factory was first introduced in #47936 (the dedicated-cluster migration, 2026-02-19); #60912 never touched it. Nothing in the code or that PR indicates per-instance scoping was deliberate — and the lock-guarded double-checked memoization shows the author intended construct-once-and-reuse, just scoped to the wrong lifetime. Because of that scoping the client was rebuilt per request-thread from day one, so the cache never did what it was written to do. This change makes the existing intent actually take effect; it does not remove a deliberate behaviour. (It also means #60912's prewarm rested on a per-process-discovery assumption that never held.)

## Changes

- Hoist `_cluster_clients` and its lock to **class scope** (process-global), mirroring `ConnectionFactory._pools`. Discovery now runs once per process and the prewarm populates the same client the request threads read. A shared, long-lived `RedisCluster` is the intended usage — its per-node pools are thread-safe.
- Set `socket_keepalive=True` on the now long-lived client as best-effort protection against an idle LB/NAT silently dropping pooled connections and forcing a reconnect (and fresh discovery) mid-request. With OS-default keepalive timing this isn't a hard guarantee — `socket_keepalive_options` would need tuning below the real idle timeout if drops are observed.
- Document on the class that `CLOSE_CONNECTION` must stay unset for the query_cache alias: django_redis closes connections per request when it's set, which would tear down and rediscover the shared client every request — the exact per-request discovery this fix removes.

Expected effect: `redis_cluster.discovery` moves from ~88% nested-in-query to ~100% parentless (warmup), and `process_query_model` sheds the ~104 ms `COMMAND`+`CLUSTER SLOTS` it pays per cold thread today.

## How did you test this code?

Extended `posthog/caching/test/test_redis_cluster_connection_factory.py` (all passing locally):

- existing tests updated for the `socket_keepalive=True` kwarg and to reset the now-shared class cache between tests;
- `test_discovered_client_is_shared_across_factory_instances` — two distinct factory instances trigger discovery only once (guards the regression);
- `test_concurrent_connect_discovers_once_and_returns_one_shared_client` — a 16-thread thundering herd runs discovery exactly once and every thread gets the same client;
- `test_cache_hit_never_acquires_the_global_lock` — the warm path takes the lock zero times, so a hot cache can't serialize query-cache access process-wide.

No manual testing against a real Redis cluster.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude). Started from an APM investigation into why #60912's prewarm wasn't reducing Redis discovery overhead. Using the `apm-spans-tree` / `apm-spans-aggregate` MCP tools, established that discovery runs ~once per request thread (not once per process), with `redis_cluster.discovery` spans nested under `process_query_model` rather than parentless. Traced that to the instance-level client cache interacting with thread-local `caches`, and confirmed via file history that the instance dict predates #60912 — it was introduced with the factory in #47936 and was never functioning as a process-wide cache.

Chose the minimal structural fix — class-level cache matching `ConnectionFactory._pools` — over a separate module-level singleton, since it's the idiomatic django_redis pattern and keeps everything on the factory. Added `socket_keepalive` because it only makes sense once the client is genuinely long-lived. An earlier revision also overrode `disconnect()` to evict-and-close the shared client; that was dropped after tracing that `connection_factory.disconnect` is only reachable via `DefaultClient.close()` → `do_close_clients()`, which django_redis gates behind `CLOSE_CONNECTION` (unset here) — so it was dead code, and under `CLOSE_CONNECTION=true` it would have re-broken the fix by rediscovering per request.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
