### PR TITLE
chore(llm-gateway): mark signals product as non-billable

### DIFF
--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -143,7 +143,7 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allowed_application_ids=None,
         allowed_models=None,  # any model — the signals pipeline picks models per stage (haiku, sonnet, ...)
         allow_api_keys=True,
-        billable=True,
+        billable=False,
     ),
     "subscriptions": ProductConfig(
         allowed_application_ids=None,


### PR DESCRIPTION
## Problem

The `signals` product in the LLM gateway was configured with `billable=True`, which tags its `$ai_generation` events with `$ai_billable=true`. The usage reporter (`posthog/tasks/usage_report.py`) then rolls those generations into the customer team's signals credit bucket. We want signals usage to no longer be billed this way.

## Changes

Set `billable=False` for the `signals` `ProductConfig` in `services/llm-gateway/src/llm_gateway/products/config.py`. This matches the default and means signals generations are emitted with `$ai_billable=false` and are excluded from the credit roll-up.

## How did you test this code?

I'm an agent. I did not run anything manually. I reviewed the existing gateway test suite and confirmed no test asserts `signals` is billable:

- `tests/callbacks/test_posthog.py` parametrizes billable assertions only over `slack_app`/`slack_app_routing` (expected billable) and `posthog_code`/`background_agents`/`wizard`/`llm_gateway` (expected non-billable). `signals` is not in either list.
- The `signals` cases in `test_posthog.py` only exercise `team_id` attribution and do not assert `$ai_billable`.
- `tests/test_product_config.py` `signals` cases only assert model/auth access, not billing.

So the existing tests remain valid without changes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) via PostHog Code. The request was to mark the signals product as non-billable in the gateway. The flag lives in the `posthog/posthog` `llm-gateway` service rather than the `ai-gateway` Go repo; located it by searching for the `billable` product attribute and flipped the single `signals` `ProductConfig` value from `True` to `False`, then verified no tests encode the old behavior.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
