### PR TITLE
fix(data-warehouse): correct stripe subscription discount expand encoding

### DIFF
--- a/posthog/temporal/data_imports/sources/stripe/stripe.py
+++ b/posthog/temporal/data_imports/sources/stripe/stripe.py
@@ -71,15 +71,21 @@ def _call_stripe(method: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     """Invoke a Stripe SDK list method and rewrite any StripeError it raises with a cleaned
     message — primarily collapsing the long asterisk run from redacted restricted keys.
 
-    Re-raises the same exception class (so framework-level non-retryable error matching on
+    Re-raises the same exception instance (so framework-level non-retryable error matching on
     `"PermissionError"` etc. continues to work) but with a shorter, frontend-friendly message
     that still preserves the actionable detail Stripe surfaces (which scope is missing).
+
+    The message is mutated in place rather than reconstructed: StripeError subclasses have
+    differing constructor signatures (e.g. InvalidRequestError requires a positional `param`),
+    so `type(e)(message=...)` would itself raise a TypeError and mask the original error.
     """
     try:
         return method(*args, **kwargs)
     except stripe_lib.StripeError as e:
-        cleaned = _clean_stripe_error_message(str(e))
-        raise type(e)(message=cleaned) from e
+        cleaned = _clean_stripe_error_message(e._message or "")
+        e._message = cleaned
+        e.args = (cleaned,)
+        raise
 
 
 def _stripe_base_addresses() -> BaseAddresses:
@@ -146,7 +152,10 @@ def _build_resources(
                 "status": "all",
                 # Expand discount objects so coupon details (amount_off, percent_off, duration) are inline.
                 # Without expansion Stripe returns only discount IDs, which prevents revenue projection.
-                "expand[]": ["data.discounts", "data.items.data.discounts"],
+                # Key must be "expand" (not "expand[]") for a list value: the SDK encodes it as
+                # expand[0]=…&expand[1]=…, whereas "expand[]" + a list yields expand[][0]=… (doubled
+                # brackets), which Stripe rejects with "Invalid string: {...}".
+                "expand": ["data.discounts", "data.items.data.discounts"],
             },
         ),
         CREDIT_NOTE_RESOURCE_NAME: StripeResource(method=client.credit_notes.list),

--- a/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
+++ b/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
@@ -25,6 +25,7 @@ from posthog.temporal.data_imports.sources.stripe.stripe import (
     StripeResumeConfig,
     StripeValidationError,
     _build_resources,
+    _call_stripe,
     _clean_stripe_error_message,
     check_endpoint_permissions,
     get_rows,
@@ -310,7 +311,10 @@ def test_subscription_list_uses_expand_for_discounts():
     mock_client.subscriptions.list.assert_called_once()
     call_params = mock_client.subscriptions.list.call_args.kwargs["params"]
     assert call_params["status"] == "all"
-    assert call_params["expand[]"] == ["data.discounts", "data.items.data.discounts"]
+    # Key must be "expand" (not "expand[]"): a list under "expand[]" encodes to expand[][0]=…
+    # (doubled brackets) which Stripe rejects. See _build_resources for the full explanation.
+    assert call_params["expand"] == ["data.discounts", "data.items.data.discounts"]
+    assert "expand[]" not in call_params
 
 
 @pytest.mark.parametrize("endpoint", WEBHOOK_ONLY_ENDPOINTS)
@@ -559,6 +563,71 @@ def test_clean_stripe_error_message_passthrough_when_no_redaction():
     """No redacted run in the message → return unchanged."""
     msg = "Request req_xxx: Some non-permission error without redaction."
     assert _clean_stripe_error_message(msg) == msg
+
+
+def test_subscription_expand_encodes_as_array_not_object():
+    """End-to-end encoding regression: the discount expand must reach Stripe as
+    expand[0]=…&expand[1]=… (a real array), not expand[][0]=… which Stripe parses as an
+    array-of-one-object and rejects with "Invalid string: {...}". The mock-based test above
+    can't catch this because it intercepts above the SDK's query-string encoding."""
+    captured: dict[str, str] = {}
+
+    class RecordingHTTPClient:
+        name = "recording"
+
+        def request_with_retries(self, method, url, headers, post_data=None, **kwargs):
+            captured["url"] = url
+            body = '{"object":"list","data":[],"has_more":false,"url":"/v1/subscriptions"}'
+            return body, 200, {"request-id": "req_test"}
+
+        def request_stream_with_retries(self, *args, **kwargs):
+            raise NotImplementedError
+
+        def close(self):
+            pass
+
+    client = stripe_lib.StripeClient("sk_test_x", http_client=RecordingHTTPClient())
+    resources = _build_resources(client)
+    subscription = resources[SUBSCRIPTION_RESOURCE_NAME]
+    subscription.method(params=subscription.params)
+
+    url = captured["url"]
+    assert "expand[0]=data.discounts" in url
+    assert "expand[1]=data.items.data.discounts" in url
+    # The doubled-bracket form is the bug — Stripe rejects it.
+    assert "expand[][0]" not in url
+
+
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        # InvalidRequestError requires a positional `param` — the regression that broke imports.
+        lambda msg: stripe_lib.InvalidRequestError(msg, "expand[]"),
+        lambda msg: stripe_lib.PermissionError(msg),
+        lambda msg: stripe_lib.AuthenticationError(msg),
+        lambda msg: stripe_lib.APIConnectionError(msg),
+    ],
+)
+def test_call_stripe_cleans_message_and_preserves_error_type(error_factory):
+    """_call_stripe must re-raise the same StripeError subclass with a cleaned message.
+    Reconstructing via `type(e)(message=...)` broke for subclasses with extra required
+    args (e.g. InvalidRequestError's `param`), so we mutate the message in place instead."""
+    raw = "The provided key 'rk_live_" + ("*" * 80) + "gbeftZ' is invalid"
+
+    def boom():
+        raise error_factory(raw)
+
+    with pytest.raises(stripe_lib.StripeError) as exc_info:
+        _call_stripe(boom)
+
+    raised = exc_info.value
+    assert type(raised) is type(error_factory(raw))
+    assert "*" * 80 not in str(raised)
+    assert "rk_live_***gbeftZ" in str(raised)
+
+
+def test_call_stripe_passes_through_successful_result():
+    assert _call_stripe(lambda x: x + 1, 41) == 42
 
 
 def test_validate_credentials_nested_resources_have_registered_parents():

--- a/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
+++ b/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
@@ -5,6 +5,7 @@ import pytest
 from unittest import mock
 
 import stripe as stripe_lib
+from stripe._http_client import HTTPClient
 
 from posthog.models.integration import Integration
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
@@ -572,19 +573,18 @@ def test_subscription_expand_encodes_as_array_not_object():
     can't catch this because it intercepts above the SDK's query-string encoding."""
     captured: dict[str, str] = {}
 
-    class RecordingHTTPClient:
+    class RecordingHTTPClient(HTTPClient):
         name = "recording"
 
-        def request_with_retries(self, method, url, headers, post_data=None, **kwargs):
+        def request_with_retries(self, method, url, headers, post_data=None, max_network_retries=None, *, _usage=None):
             captured["url"] = url
             body = '{"object":"list","data":[],"has_more":false,"url":"/v1/subscriptions"}'
             return body, 200, {"request-id": "req_test"}
 
-        def request_stream_with_retries(self, *args, **kwargs):
+        def request_stream_with_retries(
+            self, method, url, headers, post_data=None, max_network_retries=None, *, _usage=None
+        ):
             raise NotImplementedError
-
-        def close(self):
-            pass
 
     client = stripe_lib.StripeClient("sk_test_x", http_client=RecordingHTTPClient())
     resources = _build_resources(client)


### PR DESCRIPTION
## Problem

Stripe data warehouse imports were failing on the subscription endpoint with:

```
Invalid string: {"0":"data.discounts","1":"data.items.data.discounts"}
```

surfaced as a confusing `TypeError: InvalidRequestError.__init__() missing 1 required positional argument: 'param'`.

Two bugs were layered on top of each other:

1. **Wrong expand param shape.** The subscription list passes the discount expand as a *list* under the key `"expand[]"`. The Stripe SDK encodes a list value under `"expand[]"` as `expand[][0]=…&expand[][1]=…` (doubled brackets), which Stripe parses as an array containing a single object and rejects with the `Invalid string: {...}` error above.
2. **Error-cleaning wrapper masked the real error.** `_call_stripe` re-raised cleaned `StripeError`s via `type(e)(message=cleaned)`. `StripeError` subclasses have differing constructor signatures — `InvalidRequestError.__init__` requires a positional `param` — so reconstruction itself threw a `TypeError`, hiding the genuine Stripe error in tracebacks.

## Changes

- Use the key `"expand"` (no brackets) for the subscription discount expand. With a list value the SDK emits Stripe's standard `expand[0]=…&expand[1]=…` array form — identical to what `subscriptions.list(expand=[...])` generates. The neighbouring `prices` resource keeps `"expand[]"` because its value is a scalar (`expand[]=data.tiers`), which is already correct.
- `_call_stripe` now mutates the existing exception's message in place (`_message` / `args`) and re-raises the same instance, preserving the exact type and all attributes regardless of constructor signature.

## How did you test this code?

I'm an agent. I added/updated automated tests and verified the encoding against the real Stripe SDK; I did not run a live import.

- `test_subscription_expand_encodes_as_array_not_object` — new end-to-end encoding regression that drives the real SDK and asserts the query string is `expand[0]=…`, not `expand[][0]=…`. The previous mock-based test couldn't catch this because it intercepted above the SDK's query-string encoding.
- `test_subscription_list_uses_expand_for_discounts` — updated to assert the corrected `"expand"` key.
- `test_call_stripe_cleans_message_and_preserves_error_type` — new parameterized test covering `InvalidRequestError`, `PermissionError`, `AuthenticationError`, and `APIConnectionError`, plus a passthrough case.

The test module's `minio_client` fixture requires the dev stack, so I validated the logic via a standalone Django-bootstrapped script that reproduces the exact encoded request URL.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Started from an error-tracking stack trace. The masking `TypeError` was traced to the `_call_stripe` reconstruction added in a prior PR; the underlying invalid-expand error was traced to the discount-expand feature. Confirmed the precise failure mode by capturing the SDK's encoded query string for both `"expand"` and `"expand[]"` + list forms, which showed `expand[][0]` (rejected) vs `expand[0]` (accepted). Chose in-place message mutation over reconstruction because it is signature-agnostic across all `StripeError` subclasses.
