### PR TITLE
feat(funnels): improve breakdown bar layout, scroll shadow, and tooltip anchoring

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2085,13 +2085,13 @@ snapshots:
     insights-funnelpropertycorrelationtable--default--light:
         hash: v1.k794b7964.46127dfa894a9b46a595c1b48b9bd8996a2851ce5ae04e70c4f1ee43d2d818ec.dddj8FIYUsb6XDaYbe4eQ_k4bJ5NY2kvo6m3KFS3Vwg
     insights-funnelstepsbarchart--breakdown--dark:
-        hash: v1.k794b7964.63df19cde8f7f89c150d30193c048bce1e870840d46faeae19f7ce870c6e3dc4.g7tolr-QiuWK37B5sTScwyOtBOqQPWzo8xeolSJTyqw
+        hash: v1.k794b7964.28f056919e92f43ac53bab269d7dec2eedb51ce406bb8090496238f003fcd355._h95-MRPmAZ028oZLvOcuwEOv7MpFMGSvfruoivv7Z8
     insights-funnelstepsbarchart--breakdown--light:
-        hash: v1.k794b7964.1756a0ad7f62391063419d1e06b8ec5b96363ebc190bf06b456ef42a5cb54e90.REPttMoN0bjSw-5bby2FH2RrgfM0tQQKDPCkoj00T8g
+        hash: v1.k794b7964.706b6d4d7e1f8353ce4973b3a7dc48f13689ae002661ccf2e71de2b94a75dcb0.EpenDRyiFz5CS8Bx9COz-ldw9gN0G0f2o1xCIWRiDbg
     insights-funnelstepsbarchart--default--dark:
-        hash: v1.k794b7964.343d6f9338ccca79f5fdc4d89743ddde0653472078edce3a14e94033f3e473e7.FLZZ7r2xhSL6EzdbtcwCJy7BIoaylsYWs_NmAQOsjFg
+        hash: v1.k794b7964.818214b8cbcdf48a5e7a2f255ea6c42dfe70427e2dd1a20e850329d5dadd65bc.PJSUc2WsEHJY33hYYODoUtT6r3DfURZpebRTp-EKyxc
     insights-funnelstepsbarchart--default--light:
-        hash: v1.k794b7964.86e53149def5039ee2e1e0722ad6aa5edd77d0a52c53ee915ab1d63742f580ef.-tCw9bfxPaUe6lDvT1LDuZBq0WImmDMKx5dce8Qg1f4
+        hash: v1.k794b7964.5194595dedee64e6f1a7b2e34fd5a57647281f5e602996c8f402454eb3b999a8.nqlR2OXM-KhgDmfF3wdsjp6dSpZ6HfwcFFc5DcTpgM8
     insights-insightstable--aggregation--dark:
         hash: v1.k794b7964.7ca9378b33815143119b6263ad32770289133ce2faa21251189b505821d7d846.NXyGQGn0JrsrEWfzXtZTntAvvx5CSTKBLXWWdzgkCI8
     insights-insightstable--aggregation--light:

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -309,6 +309,39 @@ function BarChartInner<Meta = unknown>({
                     }
                     return d3Scales.band.bandwidth()
                 },
+                // Resolve the grouped bar under the cursor so the tooltip anchors on that bar's
+                // edge instead of the whole group. Vertical grouped only — other layouts fall
+                // back to the band-center / group-extent anchor.
+                bandSlotAtCursor: (label: string, cursor: { x: number; y: number }) => {
+                    const groupScale = d3Scales.group
+                    const start = d3Scales.band(label)
+                    if (isHorizontal || barLayout !== 'grouped' || !groupScale || start == null) {
+                        return undefined
+                    }
+                    const bandwidth = groupScale.bandwidth()
+                    const local = cursor.x - start
+                    let nearestOffset: number | undefined
+                    let nearestDistance = Infinity
+                    for (const key of groupScale.domain()) {
+                        const offset = groupScale(key)
+                        if (offset == null) {
+                            continue
+                        }
+                        if (local >= offset && local <= offset + bandwidth) {
+                            nearestOffset = offset
+                            break
+                        }
+                        const distance = Math.abs(local - (offset + bandwidth / 2))
+                        if (distance < nearestDistance) {
+                            nearestDistance = distance
+                            nearestOffset = offset
+                        }
+                    }
+                    if (nearestOffset == null) {
+                        return undefined
+                    }
+                    return { center: start + nearestOffset + bandwidth / 2, width: bandwidth }
+                },
                 _private: barChartPrivate,
             }
         },

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -54,6 +54,7 @@ import {
     findVisibleStackedSegment,
     iterBarsAtCursor,
     isStackedLayout,
+    resolveGroupedBandSlot,
 } from './utils/bars-under-cursor'
 
 function bandCenter(scales: BarChartPrivate['__barChart'], label: string): number | undefined {
@@ -309,39 +310,12 @@ function BarChartInner<Meta = unknown>({
                     }
                     return d3Scales.band.bandwidth()
                 },
-                // Resolve the grouped bar under the cursor so the tooltip anchors on that bar's
-                // edge instead of the whole group. Vertical grouped only — other layouts fall
-                // back to the band-center / group-extent anchor.
-                bandSlotAtCursor: (label: string, cursor: { x: number; y: number }) => {
-                    const groupScale = d3Scales.group
-                    const start = d3Scales.band(label)
-                    if (isHorizontal || barLayout !== 'grouped' || !groupScale || start == null) {
-                        return undefined
-                    }
-                    const bandwidth = groupScale.bandwidth()
-                    const local = cursor.x - start
-                    let nearestOffset: number | undefined
-                    let nearestDistance = Infinity
-                    for (const key of groupScale.domain()) {
-                        const offset = groupScale(key)
-                        if (offset == null) {
-                            continue
-                        }
-                        if (local >= offset && local <= offset + bandwidth) {
-                            nearestOffset = offset
-                            break
-                        }
-                        const distance = Math.abs(local - (offset + bandwidth / 2))
-                        if (distance < nearestDistance) {
-                            nearestDistance = distance
-                            nearestOffset = offset
-                        }
-                    }
-                    if (nearestOffset == null) {
-                        return undefined
-                    }
-                    return { center: start + nearestOffset + bandwidth / 2, width: bandwidth }
-                },
+                // Anchor the tooltip on the grouped bar under the cursor instead of the whole
+                // group. Vertical grouped only; other layouts fall back to the band-center anchor.
+                bandSlotAtCursor: (label: string, cursor: { x: number; y: number }) =>
+                    isHorizontal || barLayout !== 'grouped'
+                        ? undefined
+                        : resolveGroupedBandSlot(d3Scales, label, cursor.x),
                 _private: barChartPrivate,
             }
         },

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -53,9 +53,9 @@ import {
     barContainsPointOnBandAxis,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
-    iterBarsAtCursor,
+    groupedBandSlotAtCursor,
     isStackedLayout,
-    resolveGroupedBandSlot,
+    iterBarsAtCursor,
 } from './utils/bars-under-cursor'
 
 function bandCenter(scales: BarChartPrivate['__barChart'], label: string): number | undefined {
@@ -312,7 +312,7 @@ function BarChartInner<Meta = unknown>({
                 bandSlotAtCursor: (label: string, cursor: { x: number; y: number }) =>
                     isHorizontal || barLayout !== 'grouped'
                         ? undefined
-                        : resolveGroupedBandSlot(d3Scales, label, cursor.x),
+                        : groupedBandSlotAtCursor(d3Scales, label, cursor.x),
                 _private: barChartPrivate,
             }
         },

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -27,6 +27,7 @@ import {
     computePercentStackData,
     computeStackData,
     createBarScales,
+    groupedBandSlot,
     type StackedBand,
     yTickCountForHeight,
 } from '../../core/scales'
@@ -66,12 +67,8 @@ function bandCenter(scales: BarChartPrivate['__barChart'], label: string): numbe
  *  to anchor on the current-period bar in compare-against-previous grouped layouts.
  *  Returns undefined when the layout isn't grouped or the series isn't in the group scale. */
 function groupedBarCenter(scales: BarChartPrivate['__barChart'], label: string, seriesKey: string): number | undefined {
-    const start = scales.band(label)
-    const groupOffset = scales.group?.(seriesKey)
-    if (start == null || groupOffset == null) {
-        return undefined
-    }
-    return start + groupOffset + (scales.group?.bandwidth() ?? 0) / 2
+    const slot = groupedBandSlot(scales, label, seriesKey)
+    return slot && slot.x + slot.width / 2
 }
 
 export interface BarChartProps<Meta = unknown> {

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.test.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.test.ts
@@ -7,7 +7,7 @@ import {
     barContainsPointOnBandAxis,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
-    resolveGroupedBandSlot,
+    groupedBandSlotAtCursor,
 } from './bars-under-cursor'
 
 const verticalBar: BarRect = { x: 100, y: 120, width: 50, height: 200, corners: {}, dataIndex: 0 }
@@ -166,7 +166,7 @@ describe('findVisibleStackedSegment — overdraw clip', () => {
     })
 })
 
-describe('resolveGroupedBandSlot', () => {
+describe('groupedBandSlotAtCursor', () => {
     const labels = ['x', 'y']
     const series: Series[] = [
         { key: 'a', label: 'A', data: [1, 1] },
@@ -182,20 +182,20 @@ describe('resolveGroupedBandSlot', () => {
     const farRight = start + 1000
 
     it.each(['a', 'b', 'c'])('returns the slot of the bar the cursor sits inside (%s)', (key) => {
-        expect(resolveGroupedBandSlot(grouped, 'x', centerOf(key))).toEqual({ x: slotXOf(key), width: bandwidth })
+        expect(groupedBandSlotAtCursor(grouped, 'x', centerOf(key))).toEqual({ x: slotXOf(key), width: bandwidth })
     })
 
     it('snaps to the nearest bar by center when the cursor falls outside the bars', () => {
-        expect(resolveGroupedBandSlot(grouped, 'x', farLeft)?.x).toBeCloseTo(slotXOf('a'), 5)
-        expect(resolveGroupedBandSlot(grouped, 'x', farRight)?.x).toBeCloseTo(slotXOf('c'), 5)
+        expect(groupedBandSlotAtCursor(grouped, 'x', farLeft)?.x).toBeCloseTo(slotXOf('a'), 5)
+        expect(groupedBandSlotAtCursor(grouped, 'x', farRight)?.x).toBeCloseTo(slotXOf('c'), 5)
     })
 
     it('returns undefined for an unknown label', () => {
-        expect(resolveGroupedBandSlot(grouped, 'missing', start)).toBeUndefined()
+        expect(groupedBandSlotAtCursor(grouped, 'missing', start)).toBeUndefined()
     })
 
     it('returns undefined when there is no group scale (non-grouped layout)', () => {
         const stacked = createBarScales(series, labels, dimensions, { barLayout: 'stacked' })
-        expect(resolveGroupedBandSlot(stacked, 'x', start)).toBeUndefined()
+        expect(groupedBandSlotAtCursor(stacked, 'x', start)).toBeUndefined()
     })
 })

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.test.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.test.ts
@@ -7,6 +7,7 @@ import {
     barContainsPointOnBandAxis,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
+    resolveGroupedBandSlot,
 } from './bars-under-cursor'
 
 const verticalBar: BarRect = { x: 100, y: 120, width: 50, height: 200, corners: {}, dataIndex: 0 }
@@ -162,5 +163,36 @@ describe('findVisibleStackedSegment — overdraw clip', () => {
         const smallWidth = Math.abs(scales.value(20) - scales.value(0))
         expect(visible?.series.key).toBe('big')
         expect(visible?.nextSmallerExtent).toBeCloseTo(smallWidth, 5)
+    })
+})
+
+describe('resolveGroupedBandSlot', () => {
+    const labels = ['x', 'y']
+    const series: Series[] = [
+        { key: 'a', label: 'A', data: [1, 1] },
+        { key: 'b', label: 'B', data: [2, 2] },
+        { key: 'c', label: 'C', data: [3, 3] },
+    ]
+    const grouped = createBarScales(series, labels, dimensions, { barLayout: 'grouped', axisOrientation: 'vertical' })
+    const start = grouped.band('x')!
+    const bandwidth = grouped.group!.bandwidth()
+    const centerOf = (key: string): number => start + grouped.group!(key)! + bandwidth / 2
+
+    it.each(['a', 'b', 'c'])('returns the slot of the bar the cursor sits inside (%s)', (key) => {
+        expect(resolveGroupedBandSlot(grouped, 'x', centerOf(key))).toEqual({ center: centerOf(key), width: bandwidth })
+    })
+
+    it('snaps to the nearest bar by center when the cursor falls in the inter-bar padding', () => {
+        expect(resolveGroupedBandSlot(grouped, 'x', start - 1000)?.center).toBeCloseTo(centerOf('a'), 5)
+        expect(resolveGroupedBandSlot(grouped, 'x', start + 1000)?.center).toBeCloseTo(centerOf('c'), 5)
+    })
+
+    it('returns undefined for an unknown label', () => {
+        expect(resolveGroupedBandSlot(grouped, 'missing', start)).toBeUndefined()
+    })
+
+    it('returns undefined when there is no group scale (non-grouped layout)', () => {
+        const stacked = createBarScales(series, labels, dimensions, { barLayout: 'stacked' })
+        expect(resolveGroupedBandSlot(stacked, 'x', start)).toBeUndefined()
     })
 })

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.test.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.test.ts
@@ -176,15 +176,18 @@ describe('resolveGroupedBandSlot', () => {
     const grouped = createBarScales(series, labels, dimensions, { barLayout: 'grouped', axisOrientation: 'vertical' })
     const start = grouped.band('x')!
     const bandwidth = grouped.group!.bandwidth()
-    const centerOf = (key: string): number => start + grouped.group!(key)! + bandwidth / 2
+    const slotXOf = (key: string): number => start + grouped.group!(key)!
+    const centerOf = (key: string): number => slotXOf(key) + bandwidth / 2
+    const farLeft = start - 1000
+    const farRight = start + 1000
 
     it.each(['a', 'b', 'c'])('returns the slot of the bar the cursor sits inside (%s)', (key) => {
-        expect(resolveGroupedBandSlot(grouped, 'x', centerOf(key))).toEqual({ center: centerOf(key), width: bandwidth })
+        expect(resolveGroupedBandSlot(grouped, 'x', centerOf(key))).toEqual({ x: slotXOf(key), width: bandwidth })
     })
 
-    it('snaps to the nearest bar by center when the cursor falls in the inter-bar padding', () => {
-        expect(resolveGroupedBandSlot(grouped, 'x', start - 1000)?.center).toBeCloseTo(centerOf('a'), 5)
-        expect(resolveGroupedBandSlot(grouped, 'x', start + 1000)?.center).toBeCloseTo(centerOf('c'), 5)
+    it('snaps to the nearest bar by center when the cursor falls outside the bars', () => {
+        expect(resolveGroupedBandSlot(grouped, 'x', farLeft)?.x).toBeCloseTo(slotXOf('a'), 5)
+        expect(resolveGroupedBandSlot(grouped, 'x', farRight)?.x).toBeCloseTo(slotXOf('c'), 5)
     })
 
     it('returns undefined for an unknown label', () => {

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
@@ -121,8 +121,9 @@ export function resolveBarsAtCursor(
 
 /** Resolve the grouped bar nearest the cursor along the band axis, returning its center and
  *  width. `bandAxisCursor` is the cursor coordinate on the band axis (x for vertical charts).
- *  A cursor inside a slot picks that slot; one in the inter-bar padding picks the nearest by
- *  center. Returns undefined for non-grouped layouts (no `group` scale) or an unknown label. */
+ *  Returns undefined for non-grouped layouts (no `group` scale) or an unknown label.
+ *  A `scaleBand` is uniform, so the nearest slot is the cursor's offset from the first slot
+ *  center divided by the step — O(1), no scan over the domain. */
 export function resolveGroupedBandSlot(
     scales: BarScaleSet,
     label: string,
@@ -130,28 +131,16 @@ export function resolveGroupedBandSlot(
 ): BandSlot | undefined {
     const { band, group } = scales
     const start = band(label)
-    if (!group || start == null) {
+    const domain = group?.domain()
+    if (!group || start == null || !domain?.length) {
         return undefined
     }
     const width = group.bandwidth()
-    const local = bandAxisCursor - start
-    let nearestOffset: number | undefined
-    let nearestDistance = Infinity
-    for (const key of group.domain()) {
-        const offset = group(key)
-        if (offset == null) {
-            continue
-        }
-        if (local >= offset && local <= offset + width) {
-            return { center: start + offset + width / 2, width }
-        }
-        const distance = Math.abs(local - (offset + width / 2))
-        if (distance < nearestDistance) {
-            nearestDistance = distance
-            nearestOffset = offset
-        }
-    }
-    return nearestOffset == null ? undefined : { center: start + nearestOffset + width / 2, width }
+    const step = group.step()
+    const firstCenter = (group(domain[0]) ?? 0) + width / 2
+    const rawIndex = Math.round((bandAxisCursor - start - firstCenter) / step)
+    const index = Math.max(0, Math.min(domain.length - 1, rawIndex))
+    return { center: start + firstCenter + index * step, width }
 }
 
 /** Pixel coordinate of a bar's baseline (value-0) edge — the side the bar grows from. */

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
@@ -119,6 +119,47 @@ export function resolveBarsAtCursor(
     return { hits, strictHit }
 }
 
+/** Band-axis center and width of a single bar — lets a tooltip anchor on the hovered bar. */
+export interface BandSlot {
+    center: number
+    width: number
+}
+
+/** Resolve the grouped bar nearest the cursor along the band axis, returning its center and
+ *  width. `bandAxisCursor` is the cursor coordinate on the band axis (x for vertical charts).
+ *  A cursor inside a slot picks that slot; one in the inter-bar padding picks the nearest by
+ *  center. Returns undefined for non-grouped layouts (no `group` scale) or an unknown label. */
+export function resolveGroupedBandSlot(
+    scales: BarScaleSet,
+    label: string,
+    bandAxisCursor: number
+): BandSlot | undefined {
+    const { band, group } = scales
+    const start = band(label)
+    if (!group || start == null) {
+        return undefined
+    }
+    const width = group.bandwidth()
+    const local = bandAxisCursor - start
+    let nearestOffset: number | undefined
+    let nearestDistance = Infinity
+    for (const key of group.domain()) {
+        const offset = group(key)
+        if (offset == null) {
+            continue
+        }
+        if (local >= offset && local <= offset + width) {
+            return { center: start + offset + width / 2, width }
+        }
+        const distance = Math.abs(local - (offset + width / 2))
+        if (distance < nearestDistance) {
+            nearestDistance = distance
+            nearestOffset = offset
+        }
+    }
+    return nearestOffset == null ? undefined : { center: start + nearestOffset + width / 2, width }
+}
+
 /** Pixel coordinate of a bar's baseline (value-0) edge — the side the bar grows from. */
 function barBaseline(bar: BarRect, isHorizontal: boolean): number {
     return isHorizontal ? bar.x : bar.y + bar.height

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
@@ -124,7 +124,7 @@ export function resolveBarsAtCursor(
  *  Returns undefined for non-grouped layouts (no `group` scale) or an unknown label.
  *  A `scaleBand` is uniform, so the nearest slot index is the cursor's offset from the first
  *  slot center divided by the step — O(1), no scan over the domain. */
-export function resolveGroupedBandSlot(
+export function groupedBandSlotAtCursor(
     scales: BarScaleSet,
     label: string,
     bandAxisCursor: number

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
@@ -1,6 +1,6 @@
 import { computeBarAtIndex } from '../../../core/bar-layout'
 import type { BarRect } from '../../../core/canvas-renderer'
-import type { BarScaleSet, StackedBand } from '../../../core/scales'
+import { type BarScaleSet, groupedBandSlot, type StackedBand } from '../../../core/scales'
 import type { BandSlot, Series } from '../../../core/types'
 import { DEFAULT_Y_AXIS_ID } from '../../../core/types'
 
@@ -119,11 +119,11 @@ export function resolveBarsAtCursor(
     return { hits, strictHit }
 }
 
-/** Resolve the grouped bar nearest the cursor along the band axis, returning its center and
- *  width. `bandAxisCursor` is the cursor coordinate on the band axis (x for vertical charts).
+/** Resolve the grouped bar nearest the cursor along the band axis, returning its `{ x, width }`
+ *  slot. `bandAxisCursor` is the cursor coordinate on the band axis (x for vertical charts).
  *  Returns undefined for non-grouped layouts (no `group` scale) or an unknown label.
- *  A `scaleBand` is uniform, so the nearest slot is the cursor's offset from the first slot
- *  center divided by the step — O(1), no scan over the domain. */
+ *  A `scaleBand` is uniform, so the nearest slot index is the cursor's offset from the first
+ *  slot center divided by the step — O(1), no scan over the domain. */
 export function resolveGroupedBandSlot(
     scales: BarScaleSet,
     label: string,
@@ -135,12 +135,11 @@ export function resolveGroupedBandSlot(
     if (!group || start == null || !domain?.length) {
         return undefined
     }
-    const width = group.bandwidth()
     const step = group.step()
-    const firstCenter = (group(domain[0]) ?? 0) + width / 2
+    const firstCenter = (group(domain[0]) ?? 0) + group.bandwidth() / 2
     const rawIndex = Math.round((bandAxisCursor - start - firstCenter) / step)
     const index = Math.max(0, Math.min(domain.length - 1, rawIndex))
-    return { center: start + firstCenter + index * step, width }
+    return groupedBandSlot(scales, label, domain[index])
 }
 
 /** Pixel coordinate of a bar's baseline (value-0) edge — the side the bar grows from. */

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
@@ -1,7 +1,7 @@
 import { computeBarAtIndex } from '../../../core/bar-layout'
 import type { BarRect } from '../../../core/canvas-renderer'
 import type { BarScaleSet, StackedBand } from '../../../core/scales'
-import type { Series } from '../../../core/types'
+import type { BandSlot, Series } from '../../../core/types'
 import { DEFAULT_Y_AXIS_ID } from '../../../core/types'
 
 export type BarLayout = 'stacked' | 'grouped' | 'percent'
@@ -117,12 +117,6 @@ export function resolveBarsAtCursor(
         }
     }
     return { hits, strictHit }
-}
-
-/** Band-axis center and width of a single bar — lets a tooltip anchor on the hovered bar. */
-export interface BandSlot {
-    center: number
-    width: number
 }
 
 /** Resolve the grouped bar nearest the cursor along the band axis, returning its center and

--- a/packages/quill/packages/charts/src/charts/BoxPlot/computeBoxLayout.ts
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/computeBoxLayout.ts
@@ -1,5 +1,6 @@
 import type { BoxRect } from '../../core/canvas-renderer'
-import type { BarScaleSet } from '../../core/scales'
+import { type BarScaleSet, groupedBandSlot } from '../../core/scales'
+import type { BandSlot } from '../../core/types'
 
 export type { BoxRect }
 
@@ -35,11 +36,6 @@ export interface BoxPlotSeries<Meta = unknown> {
     }
 }
 
-interface BoxBandRect {
-    x: number
-    width: number
-}
-
 /** Resolve only the band-axis extent of a (series, x) slot. Cheap — touches the band/group
  *  scales and nothing on the value axis — so callers like band-only hit-testing don't pay
  *  for six value-axis lookups they'd immediately throw away. */
@@ -48,18 +44,13 @@ export function computeBoxBand(
     label: string,
     scales: BarScaleSet,
     grouped: boolean
-): BoxBandRect | null {
+): BandSlot | null {
+    if (grouped) {
+        return groupedBandSlot(scales, label, seriesKey) ?? null
+    }
     const bandStart = scales.band(label)
     if (bandStart == null) {
         return null
-    }
-    if (grouped) {
-        const groupOffset = scales.group?.(seriesKey)
-        const groupBandwidth = scales.group?.bandwidth()
-        if (groupOffset == null || groupBandwidth == null) {
-            return null
-        }
-        return { x: bandStart + groupOffset, width: groupBandwidth }
     }
     return { x: bandStart, width: scales.band.bandwidth() }
 }

--- a/packages/quill/packages/charts/src/charts/BoxPlot/computeBoxLayout.ts
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/computeBoxLayout.ts
@@ -35,7 +35,7 @@ export interface BoxPlotSeries<Meta = unknown> {
     }
 }
 
-interface BandSlot {
+interface BoxBandRect {
     x: number
     width: number
 }
@@ -48,7 +48,7 @@ export function computeBoxBand(
     label: string,
     scales: BarScaleSet,
     grouped: boolean
-): BandSlot | null {
+): BoxBandRect | null {
     const bandStart = scales.band(label)
     if (bandStart == null) {
         return null

--- a/packages/quill/packages/charts/src/core/bar-layout.ts
+++ b/packages/quill/packages/charts/src/core/bar-layout.ts
@@ -1,5 +1,5 @@
 import type { BarRect, BarRoundedCorners } from './canvas-renderer'
-import type { BarScaleSet, StackedBand } from './scales'
+import { type BarScaleSet, groupedBandSlot, type StackedBand } from './scales'
 import type { Series } from './types'
 
 /** Brand for the BarChart `ChartScales._private` slot — populated by BarChart and
@@ -161,15 +161,13 @@ export function computeBarAtIndex({
     const bandWidth = scales.band.bandwidth()
 
     if (isGrouped) {
-        const groupOffsetForKey = scales.group?.(series.key)
+        const slot = groupedBandSlot(scales, label, series.key)
         const valuePixel = scales.value(raw)
-        if (groupOffsetForKey == null || !isFinite(valuePixel)) {
+        if (!slot || !isFinite(valuePixel)) {
             return null
         }
-        const groupBandWidth = scales.group?.bandwidth() ?? bandWidth
         const corners = cornersFor(isHorizontal, raw >= 0, shouldRoundCap)
-        const start = bandStart + groupOffsetForKey
-        return makeBarRect(isHorizontal, start, groupBandWidth, scales.value(0), valuePixel, corners, dataIndex)
+        return makeBarRect(isHorizontal, slot.x, slot.width, scales.value(0), valuePixel, corners, dataIndex)
     }
 
     const topPixel = scales.value(stackedBand!.top[dataIndex])

--- a/packages/quill/packages/charts/src/core/bar-scales.test.ts
+++ b/packages/quill/packages/charts/src/core/bar-scales.test.ts
@@ -1,5 +1,5 @@
 import { dimensions, makeSeries } from '../testing'
-import { createBarScales } from './scales'
+import { createBarScales, groupedBandSlot } from './scales'
 
 describe('hog-charts bar scales', () => {
     describe('createBarScales — vertical orientation (default)', () => {
@@ -208,6 +208,31 @@ describe('hog-charts bar scales', () => {
             const domain = value.domain()
             expect(domain[0]).toBeLessThanOrEqual(-10)
             expect(domain[1]).toBeGreaterThanOrEqual(0)
+        })
+    })
+
+    describe('groupedBandSlot', () => {
+        const series = [
+            makeSeries({ key: 's1', data: [1, 2] }),
+            makeSeries({ key: 's2', data: [3, 4] }),
+        ]
+        const grouped = createBarScales(series, ['a', 'b'], dimensions, { barLayout: 'grouped' })
+
+        it("returns the series' band-axis slot within the band", () => {
+            const start = grouped.band('a')!
+            expect(groupedBandSlot(grouped, 'a', 's2')).toEqual({
+                x: start + grouped.group!('s2')!,
+                width: grouped.group!.bandwidth(),
+            })
+        })
+
+        it('returns undefined for a series not in the group scale', () => {
+            expect(groupedBandSlot(grouped, 'a', 'missing')).toBeUndefined()
+        })
+
+        it('returns undefined for non-grouped layouts (no group scale)', () => {
+            const stacked = createBarScales(series, ['a', 'b'], dimensions, { barLayout: 'stacked' })
+            expect(groupedBandSlot(stacked, 'a', 's1')).toBeUndefined()
         })
     })
 })

--- a/packages/quill/packages/charts/src/core/hooks/useChartInteraction.ts
+++ b/packages/quill/packages/charts/src/core/hooks/useChartInteraction.ts
@@ -100,7 +100,10 @@ export function useChartInteraction<Meta = unknown>({
                 interactionAxis,
                 prev.hoverPosition,
                 effectivePositionResolveRef.current,
-                scales.extent?.(labels[prev.dataIndex])
+                scales.extent?.(labels[prev.dataIndex]),
+                prev.hoverPosition
+                    ? scales.bandSlotAtCursor?.(labels[prev.dataIndex], prev.hoverPosition)
+                    : undefined
             )
         },
         // resolveValueRef / effectivePositionResolveRef are stable
@@ -170,7 +173,8 @@ export function useChartInteraction<Meta = unknown>({
                         interactionAxis,
                         { x: mouseX, y: mouseY },
                         effectivePositionResolve,
-                        scales.extent?.(labels[index])
+                        scales.extent?.(labels[index]),
+                        scales.bandSlotAtCursor?.(labels[index], { x: mouseX, y: mouseY })
                     )
                 )
             }

--- a/packages/quill/packages/charts/src/core/interaction.ts
+++ b/packages/quill/packages/charts/src/core/interaction.ts
@@ -123,7 +123,7 @@ export function buildTooltipContext<Meta = unknown>(
         valueAnchor = interactionAxis === 'y' ? Math.max(...valuePixels) : Math.min(...valuePixels)
     }
 
-    const bandAxisCoord = bandSlot?.center ?? bandPixel
+    const bandAxisCoord = bandSlot ? bandSlot.x + bandSlot.width / 2 : bandPixel
     const position: TooltipContext<Meta>['position'] =
         interactionAxis === 'y' ? { x: valueAnchor, y: bandAxisCoord } : { x: bandAxisCoord, y: valueAnchor }
     const extentWidth = bandSlot?.width ?? positionExtent

--- a/packages/quill/packages/charts/src/core/interaction.ts
+++ b/packages/quill/packages/charts/src/core/interaction.ts
@@ -78,7 +78,10 @@ export function buildTooltipContext<Meta = unknown>(
     resolvePositionValue: ResolveValueFn = resolveValue,
     /** Optional horizontal data-extent centered on the categorical axis position — bar charts
      *  pass band width so the tooltip can anchor at the band edge instead of its center. */
-    positionExtent?: number
+    positionExtent?: number,
+    /** Optional per-bar anchor for grouped layouts — overrides the band-axis center and extent
+     *  so the tooltip anchors on the hovered bar rather than the whole group. */
+    bandSlot?: { center: number; width: number }
 ): TooltipContext<Meta> | null {
     if (dataIndex < 0 || dataIndex >= labels.length) {
         return null
@@ -119,10 +122,12 @@ export function buildTooltipContext<Meta = unknown>(
         valueAnchor = interactionAxis === 'y' ? Math.max(...valuePixels) : Math.min(...valuePixels)
     }
 
+    const bandAxisCoord = bandSlot?.center ?? bandPixel
     const position: TooltipContext<Meta>['position'] =
-        interactionAxis === 'y' ? { x: valueAnchor, y: bandPixel } : { x: bandPixel, y: valueAnchor }
-    if (positionExtent != null && positionExtent > 0) {
-        position.width = positionExtent
+        interactionAxis === 'y' ? { x: valueAnchor, y: bandAxisCoord } : { x: bandAxisCoord, y: valueAnchor }
+    const extentWidth = bandSlot?.width ?? positionExtent
+    if (extentWidth != null && extentWidth > 0) {
+        position.width = extentWidth
     }
 
     return {

--- a/packages/quill/packages/charts/src/core/interaction.ts
+++ b/packages/quill/packages/charts/src/core/interaction.ts
@@ -2,6 +2,7 @@ import { bisector } from 'd3-array'
 
 import { barColorAt } from './color-utils'
 import type {
+    BandSlot,
     ChartDimensions,
     PointClickData,
     ResolvedSeries,
@@ -81,7 +82,7 @@ export function buildTooltipContext<Meta = unknown>(
     positionExtent?: number,
     /** Optional per-bar anchor for grouped layouts — overrides the band-axis center and extent
      *  so the tooltip anchors on the hovered bar rather than the whole group. */
-    bandSlot?: { center: number; width: number }
+    bandSlot?: BandSlot
 ): TooltipContext<Meta> | null {
     if (dataIndex < 0 || dataIndex >= labels.length) {
         return null

--- a/packages/quill/packages/charts/src/core/scales.ts
+++ b/packages/quill/packages/charts/src/core/scales.ts
@@ -10,7 +10,7 @@ import {
 } from 'd3-scale'
 import { stack as stackGen, stackOffsetDiverging, stackOffsetExpand, stackOffsetNone } from 'd3-shape'
 
-import type { ChartDimensions, ChartScales, ResolveValueFn, Series, ValueDomain } from './types'
+import type { BandSlot, ChartDimensions, ChartScales, ResolveValueFn, Series, ValueDomain } from './types'
 import { DEFAULT_Y_AXIS_ID } from './types'
 
 /** Inner padding fraction applied to the band scale when `BarChartConfig.bars.bandPadding` is unset. */
@@ -375,6 +375,19 @@ export interface BarScaleSet {
     value: D3YScale
     /** Sub-band for grouped layout — maps a series key to its offset inside a band. */
     group?: ScaleBand<string>
+}
+
+/** Band-axis slot of one series's bar within a grouped band: `{ x, width }` along the band axis.
+ *  The single source of truth for grouped bar geometry — used for drawing, hit-testing, and
+ *  tooltip anchoring. Returns undefined for non-grouped layouts or a series not in the group. */
+export function groupedBandSlot(scales: BarScaleSet, label: string, seriesKey: string): BandSlot | undefined {
+    const start = scales.band(label)
+    const group = scales.group
+    const offset = group?.(seriesKey)
+    if (start == null || group == null || offset == null) {
+        return undefined
+    }
+    return { x: start + offset, width: group.bandwidth() }
 }
 
 export function createBarScales(

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -332,6 +332,12 @@ export interface YAxisScale {
     position: 'left' | 'right'
 }
 
+/** Band-axis center and width of a single bar — lets a tooltip anchor on the hovered bar. */
+export interface BandSlot {
+    center: number
+    width: number
+}
+
 /** Generic scale interface that Chart uses for shared overlays and interaction. */
 export interface ChartScales {
     /** Maps a label to an x pixel coordinate. For chart types where data points
@@ -354,7 +360,7 @@ export interface ChartScales {
      *  and cursor (canvas pixels), returns the band-axis center and width of the specific bar
      *  under the cursor, so the tooltip anchors on that bar rather than the whole group. Falls
      *  back to `x`/`extent` when absent or when it returns undefined. */
-    bandSlotAtCursor?: (label: string, cursor: { x: number; y: number }) => { center: number; width: number } | undefined
+    bandSlotAtCursor?: (label: string, cursor: { x: number; y: number }) => BandSlot | undefined
     /** Chart-type-private slot. Library code MUST NOT read this — it is populated by
      *  individual chart implementations (e.g. LineChart stashes raw d3 scales here so
      *  its `drawStatic` can use them) and is opaque to the base Chart and overlays.

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -350,6 +350,11 @@ export interface ChartScales {
      *  band width so {@link TooltipContext.position.width} carries it through to the
      *  tooltip overlay. Point-style charts (line, scatter) leave it unset. */
     extent?: (label: string) => number | undefined
+    /** Optional cursor-aware band-slot resolver for grouped layouts. Given the hovered label
+     *  and cursor (canvas pixels), returns the band-axis center and width of the specific bar
+     *  under the cursor, so the tooltip anchors on that bar rather than the whole group. Falls
+     *  back to `x`/`extent` when absent or when it returns undefined. */
+    bandSlotAtCursor?: (label: string, cursor: { x: number; y: number }) => { center: number; width: number } | undefined
     /** Chart-type-private slot. Library code MUST NOT read this — it is populated by
      *  individual chart implementations (e.g. LineChart stashes raw d3 scales here so
      *  its `drawStatic` can use them) and is opaque to the base Chart and overlays.

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -332,9 +332,10 @@ export interface YAxisScale {
     position: 'left' | 'right'
 }
 
-/** Band-axis center and width of a single bar — lets a tooltip anchor on the hovered bar. */
+/** Band-axis slot of a single bar: left-edge coordinate (`x`) and width along the band axis.
+ *  Callers derive the center as `x + width / 2` (e.g. to anchor a tooltip on the hovered bar). */
 export interface BandSlot {
-    center: number
+    x: number
     width: number
 }
 
@@ -357,9 +358,9 @@ export interface ChartScales {
      *  tooltip overlay. Point-style charts (line, scatter) leave it unset. */
     extent?: (label: string) => number | undefined
     /** Optional cursor-aware band-slot resolver for grouped layouts. Given the hovered label
-     *  and cursor (canvas pixels), returns the band-axis center and width of the specific bar
-     *  under the cursor, so the tooltip anchors on that bar rather than the whole group. Falls
-     *  back to `x`/`extent` when absent or when it returns undefined. */
+     *  and cursor (canvas pixels), returns the `{ x, width }` slot of the specific bar under the
+     *  cursor, so the tooltip anchors on that bar rather than the whole group. Falls back to
+     *  `x`/`extent` when absent or when it returns undefined. */
     bandSlotAtCursor?: (label: string, cursor: { x: number; y: number }) => BandSlot | undefined
     /** Chart-type-private slot. Library code MUST NOT read this — it is populated by
      *  individual chart implementations (e.g. LineChart stashes raw d3 scales here so

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -78,10 +78,7 @@ export function FunnelStepsBarChart({
     const showTime = steps.some((step) => step.average_conversion_time != null)
 
     const breakdownCount = series.length
-    const isBreakdown = breakdownCount > 1
-    const stepWidthPx = isBreakdown
-        ? Math.max(BASE_STEP_WIDTH_PX, breakdownCount * PER_BAR_WIDTH_PX)
-        : BASE_STEP_WIDTH_PX
+    const stepWidthPx = Math.max(BASE_STEP_WIDTH_PX, breakdownCount * PER_BAR_WIDTH_PX)
     const barsWidth = steps.length * stepWidthPx
     const chartWidth = DEFAULT_MARGINS.left + barsWidth + DEFAULT_MARGINS.right
 

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -6,6 +6,7 @@ import { BarChart, DEFAULT_MARGINS } from '@posthog/quill-charts'
 import type { BarChartConfig, PointClickData, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { StepLegend } from 'scenes/funnels/FunnelBarVertical/StepLegend'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { funnelPersonsModalLogic } from 'scenes/funnels/funnelPersonsModalLogic'
@@ -18,11 +19,11 @@ import { ChartParams, type FunnelStepWithConversionMetrics } from '~/types'
 import { FunnelStepsBarTooltip } from './FunnelStepsBarTooltip'
 import { buildFunnelStepsBarData, type FunnelStepsBarSeriesMeta } from './funnelStepsBarTransforms'
 
-const STEP_WIDTH_PX = 240
-const BAND_PADDING = 0.04
-const STEP_BAND_WIDTH_PX = STEP_WIDTH_PX * (1 - BAND_PADDING)
+const BASE_STEP_WIDTH_PX = 240
+const PER_BAR_WIDTH_PX = 20
+const BAND_PADDING = 0.1
 
-const baseChartConfig: BarChartConfig = {
+const chartConfig: BarChartConfig = {
     barLayout: 'grouped',
     showGrid: true,
     bars: {
@@ -75,8 +76,16 @@ export function FunnelStepsBarChart({
 
     const groupTypeLabel = aggregationLabel(querySource?.aggregation_group_type_index).plural
     const showTime = steps.some((step) => step.average_conversion_time != null)
-    const barsWidth = steps.length * STEP_WIDTH_PX
+
+    const breakdownCount = series.length
+    const isBreakdown = breakdownCount > 1
+    const stepWidthPx = isBreakdown
+        ? Math.max(BASE_STEP_WIDTH_PX, breakdownCount * PER_BAR_WIDTH_PX)
+        : BASE_STEP_WIDTH_PX
+    const barsWidth = steps.length * stepWidthPx
     const chartWidth = DEFAULT_MARGINS.left + barsWidth + DEFAULT_MARGINS.right
+
+    const stepBandWidthPx = stepWidthPx * (1 - BAND_PADDING)
 
     const onPointClick = useCallback(
         (clickData: PointClickData<FunnelStepsBarSeriesMeta>): void => {
@@ -109,15 +118,15 @@ export function FunnelStepsBarChart({
     }
 
     return (
-        <div className="flex w-full flex-1 flex-col overflow-x-auto" data-attr="funnel-steps-bar-chart">
-            <div className="flex flex-1 flex-col">
+        <ScrollableShadows direction="horizontal" className="flex-1" contentClassName="flex h-full flex-col">
+            <div className="flex flex-1 flex-col" data-attr="funnel-steps-bar-chart">
                 {/* eslint-disable-next-line react/forbid-dom-props */}
                 <div className="flex min-h-[150px] flex-1" style={{ width: chartWidth }}>
                     <BarChart<FunnelStepsBarSeriesMeta>
                         series={series}
                         labels={labels}
                         theme={theme}
-                        config={baseChartConfig}
+                        config={chartConfig}
                         tooltip={renderTooltip}
                         onPointClick={showPersonsModal ? onPointClick : undefined}
                         onError={handleChartError}
@@ -135,7 +144,7 @@ export function FunnelStepsBarChart({
                                 className={`flex min-w-0 flex-1 ${stepIndex === 0 ? 'justify-start' : 'justify-center'}`}
                             >
                                 {/* eslint-disable-next-line react/forbid-dom-props */}
-                                <div className="min-w-0 overflow-hidden" style={{ width: STEP_BAND_WIDTH_PX }}>
+                                <div className="min-w-0 overflow-hidden" style={{ width: stepBandWidthPx }}>
                                     <StepLegend
                                         step={step}
                                         stepIndex={stepIndex}
@@ -149,6 +158,6 @@ export function FunnelStepsBarChart({
                     </div>
                 </div>
             </div>
-        </div>
+        </ScrollableShadows>
     )
 }


### PR DESCRIPTION
## Problem

The hog-charts funnel steps bar chart had a few rough edges with breakdowns: every breakdown variant was squeezed into a fixed-width step, so the per-step groups read as too close together and individual bars got thin; there was no visual cue that the chart could scroll when it overflowed; and grouped-bar tooltips anchored at the edge of the whole step group rather than the bar actually under the cursor (even though the tooltip content was already for the single hovered bar).

## Changes

- Funnel steps bar chart: grow each step's width with the number of breakdown bars (`PER_BAR_WIDTH_PX`) instead of cramming them into a fixed band, so breakdown bars stay readable and the chart scrolls horizontally.
- Wrapped the chart in `ScrollableShadows` (horizontal) so there's a scroll-shadow affordance on overflow; kept the chart filling its container height via `contentClassName="flex h-full flex-col"`.
- Simplified band padding to a single `BAND_PADDING` constant (the per-breakdown vs single distinction was visually imperceptible).
- quill-charts: added an optional `bandSlotAtCursor` to the `ChartScales` contract, implemented in `BarChart` for vertical grouped layouts, and wired it through `buildTooltipContext` / `useChartInteraction` so grouped-bar tooltips anchor on the hovered bar. Horizontal and non-grouped charts fall back to the previous behavior.

## How did you test this code?

I'm an agent — I did not manually test this in the browser. Automated checks I ran:

- Charts jest suites via the frontend jest config: `BarChart`, `interaction`, `bar-scales`, and `TrendsBarChart` — 172 tests pass.
- Per-file `tsc --noEmit` on each changed file.

Visual verification of the breakdown funnel (bar spacing, scroll shadow, tooltip anchoring) is still worth a look before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Iterative session driven by the author tuning the chart visually.

Key decisions:
- For wider breakdown bars, first tried tweaking quill's `groupPadding` (gap between bars within a group), then rejected that in favor of scaling each step's width by the breakdown count — it's cleaner and scales naturally as more breakdown values appear. The `groupPadding` plumbing added to quill was reverted.
- For the tooltip, considered the config-only route (`placement: 'cursor'`) but chose a library-level fix: the tooltip content was already narrowed to the single hovered bar, so anchoring at the group edge was effectively a latent bug. `bandSlotAtCursor` fixes it for all vertical grouped bar charts (funnel breakdowns, trends comparison).