### PR TITLE
fix(slack-app): remap stale thread-mapped integration to candidate sibling

### DIFF
--- a/products/slack_app/backend/services/integration_resolver.py
+++ b/products/slack_app/backend/services/integration_resolver.py
@@ -54,6 +54,8 @@ def resolve_from_candidates(
     accessible = (
         candidates if accessible_team_ids is None else [i for i in candidates if i.team_id in accessible_team_ids]
     )
+    candidate_ids = {c.id for c in candidates}
+    candidates_by_team_id = {c.team_id: c for c in candidates}
 
     if channel and thread_ts and slack_team_id:
         thread_match = (
@@ -63,13 +65,18 @@ def resolve_from_candidates(
             .select_related("integration")
             .first()
         )
-        # Honour the thread mapping only if the acting user still has access to
-        # its project. A revoked-access user replying in an existing agent
-        # thread must not bypass the access check via thread continuity.
-        if thread_match is not None and (
-            accessible_team_ids is None or thread_match.integration.team_id in accessible_team_ids
-        ):
-            return ResolutionResult(integration=thread_match.integration, source="thread", candidates=accessible)
+        if thread_match is not None:
+            # If the mapped row is out of the current candidate set (kind drift),
+            # route through the canonical candidate for the same team in this
+            # workspace so the mapping's ``task_run`` linkage stays intact.
+            mapped = thread_match.integration
+            target: Integration | None = (
+                mapped if mapped.id in candidate_ids else candidates_by_team_id.get(mapped.team_id)
+            )
+            # Access check on the resolved target so a user whose access was
+            # revoked can't ride the thread mapping past the gate.
+            if target is not None and (accessible_team_ids is None or target.team_id in accessible_team_ids):
+                return ResolutionResult(integration=target, source="thread", candidates=accessible)
 
     if slack_user_id:
         # One query returns at most two rows: the per-user row and the
@@ -84,7 +91,6 @@ def resolve_from_candidates(
             )
         )
         defaults.sort(key=lambda d: d.slack_user_id is None)
-        candidate_ids = {c.id for c in candidates}
         for default in defaults:
             if accessible_team_ids is not None and default.default_integration.team_id not in accessible_team_ids:
                 continue

--- a/products/slack_app/backend/tests/test_integration_resolver.py
+++ b/products/slack_app/backend/tests/test_integration_resolver.py
@@ -7,6 +7,7 @@ from posthog.models.user import User
 
 from products.slack_app.backend.models import SlackSettings, SlackThreadTaskMapping
 from products.slack_app.backend.services.integration_resolver import load_integrations
+from products.tasks.backend.models import Task, TaskRun
 
 WORKSPACE = "T_WS"
 SLACK_USER = "U001"
@@ -51,21 +52,29 @@ class TestResolveIntegration:
             )
         )
 
-    def test_thread_mapping_wins_over_everything(self):
-        from products.tasks.backend.models import Task, TaskRun
-
-        task = Task.objects.create(team=self.team_b, title="t")
-        task_run = TaskRun.objects.create(team=self.team_b, task=task)
-        SlackThreadTaskMapping.objects.create(
-            team=self.team_b,
-            integration=self.integration_b,
+    def _mk_thread_mapping(
+        self,
+        *,
+        team: Team,
+        integration: Integration,
+        channel: str = "C1",
+        thread_ts: str = "123.456",
+    ) -> SlackThreadTaskMapping:
+        task = Task.objects.create(team=team, title="t")
+        task_run = TaskRun.objects.create(team=team, task=task)
+        return SlackThreadTaskMapping.objects.create(
+            team=team,
+            integration=integration,
             slack_workspace_id=WORKSPACE,
-            channel="C1",
-            thread_ts="123.456",
+            channel=channel,
+            thread_ts=thread_ts,
             task=task,
             task_run=task_run,
             mentioning_slack_user_id=SLACK_USER,
         )
+
+    def test_thread_mapping_wins_over_everything(self):
+        self._mk_thread_mapping(team=self.team_b, integration=self.integration_b)
         # Even with an unrelated user_default pointing at A, the thread mapping wins.
         SlackSettings.objects.create(
             default_integration=self.integration_a,
@@ -90,20 +99,7 @@ class TestResolveIntegration:
         # (it's in `other_org`). The thread match must be skipped — a user
         # whose access was revoked or who never had access can't drive the
         # thread just by replying to it.
-        from products.tasks.backend.models import Task, TaskRun
-
-        task = Task.objects.create(team=self.team_c, title="t")
-        task_run = TaskRun.objects.create(team=self.team_c, task=task)
-        SlackThreadTaskMapping.objects.create(
-            team=self.team_c,
-            integration=self.integration_c,
-            slack_workspace_id=WORKSPACE,
-            channel="C1",
-            thread_ts="123.456",
-            task=task,
-            task_run=task_run,
-            mentioning_slack_user_id=SLACK_USER,
-        )
+        self._mk_thread_mapping(team=self.team_c, integration=self.integration_c)
 
         result = load_integrations(
             slack_team_id=WORKSPACE,
@@ -118,6 +114,58 @@ class TestResolveIntegration:
         # accessible candidates (A, B).
         assert result.source == "needs_picker"
         assert {i.id for i in result.candidates} == {self.integration_a.id, self.integration_b.id}
+
+    def test_thread_mapping_remaps_to_sibling_when_mapped_integration_out_of_lookup(self):
+        # Older mapping points at a sibling Integration row of a different kind
+        # for the same team in this workspace. The resolver must remap to the
+        # in-set sibling and keep the mapping's task_run linkage rather than
+        # fall back to the picker.
+        legacy_integration = Integration.objects.create(
+            team=self.team_b,
+            kind="slack-posthog-code",
+            integration_id=WORKSPACE,
+            sensitive_config={"access_token": "xoxb-legacy"},
+        )
+        self._mk_thread_mapping(team=self.team_b, integration=legacy_integration)
+
+        result = load_integrations(
+            slack_team_id=WORKSPACE,
+            kinds=["slack"],
+            slack_user_id=SLACK_USER,
+            user=self.user,
+            channel="C1",
+            thread_ts="123.456",
+        )
+
+        assert result.source == "thread"
+        assert result.integration == self.integration_b
+
+    def test_thread_mapping_falls_through_when_no_sibling_for_team(self):
+        # The mapping points at an Integration whose team has no candidate in
+        # the current lookup at all (kind drift left no replacement). Without a
+        # sibling to remap to, the resolver must fall through to the next
+        # branch rather than route to a row that isn't in the candidate set.
+        self.integration_b.delete()
+        legacy_integration = Integration.objects.create(
+            team=self.team_b,
+            kind="slack-posthog-code",
+            integration_id=WORKSPACE,
+            sensitive_config={"access_token": "xoxb-legacy"},
+        )
+        self._mk_thread_mapping(team=self.team_b, integration=legacy_integration)
+
+        result = load_integrations(
+            slack_team_id=WORKSPACE,
+            kinds=["slack"],
+            slack_user_id=SLACK_USER,
+            user=self.user,
+            channel="C1",
+            thread_ts="123.456",
+        )
+
+        # Only integration_a remains accessible → resolves as sole candidate.
+        assert result.source == "sole_candidate"
+        assert result.integration == self.integration_a
 
     def test_user_default_used_when_accessible(self):
         SlackSettings.objects.create(


### PR DESCRIPTION
## Problem

After [#60689](https://github.com/PostHog/posthog/pull/60689) unified the coding-agent Slack flow from `kind="slack-posthog-code"` onto `kind="slack"`, every Slack thread that already had a `SlackThreadTaskMapping` pointing at a `slack-posthog-code` row started getting the project picker on every `@PostHog` mention — even when the workspace and user had perfectly valid `SlackSettings` defaults.

Trace:

1. `load_integrations` now filters candidates by `kind="slack"`, so the older `slack-posthog-code` row for the same workspace+team is no longer in `candidate_ids`.
2. `resolve_from_candidates` finds the existing `SlackThreadTaskMapping`, checks team-accessibility, and returns the mapped Integration unconditionally as the resolution.
3. The caller's `result.integration in candidates` check (`products/slack_app/backend/api.py:1539`) sees a row outside the candidate set, sets `target = None`, and falls through to `_post_pick_a_project_hint`.

Because the mapping is keyed on `(workspace, channel, thread_ts)` — not per-user — `@PostHog project <id>` doesn't fix it: it only rewrites `SlackSettings`, which the resolver never reaches in this code path.

## Changes

Make the thread-mapping branch in `resolve_from_candidates` symmetrical to the `SlackSettings` branch already a few lines below it: if the mapped Integration row isn't in the current candidate set, remap to the canonical candidate for the same team in this workspace before returning. The mapping's `task_run` linkage is preserved, so reply-forwarding to a running agent task in the same thread is unaffected. If no sibling candidate exists for that team at all, fall through cleanly to the next branch.

The hoisted `candidate_ids` set is now computed once at the top of the function (was previously computed inside the `SlackSettings` loop).

### Follow-up worth considering separately

The cleaner long-term design is to drop the `integration_id` FK from `SlackThreadTaskMapping` (and similarly from `SlackUserProfileCache` / the workspace half of `SlackSettings`) and resolve `(slack_workspace_id, team_id)` → Integration at read time. The natural key is `(slack_workspace_id, channel, thread_ts)` anyway, which Slack guarantees is globally unique. That removes this whole class of staleness bug by construction. Not bundled here because it touches the model, the unique constraint, and every read site — better as its own change.

## How did you test this code?

- New automated tests in `products/slack_app/backend/tests/test_integration_resolver.py` cover both the remap case and the no-sibling fall-through. Full file: `hogli test products/slack_app/backend/tests/test_integration_resolver.py` → 17 passed.
- Verified locally by reproducing the bug against the dev Postgres: created a workspace with both a `slack-posthog-code` row and a `slack` sibling for the same team, planted a `SlackThreadTaskMapping` against the legacy row, and called `load_integrations` directly. Confirmed `source="thread"` resolved to the `slack` sibling with this patch applied; reverting the patch reproduces the picker fall-through.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs touched.

## 🤖 Agent context

Authored with Claude. 