### PR TITLE
feat(replay-vision): polish observation list and detail page

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1159,7 +1159,7 @@ snapshots:
     components-playerinspector-itemevent--group-identify-event--dark:
         hash: v1.k794b7964.4f0f997a83425992a237b9c4a5a38666eb8f3e91e57e563b829f4ecc5b965dfd.djHvv-d41HLFU0j_Az9KZ93XgjcF1oYJwmHEo2e17z8
     components-playerinspector-itemevent--group-identify-event--light:
-        hash: v1.k794b7964.69d03f8ad23b981e50e815dcc6ca94f95908d13da0addbd661c55d18e2ea67b7.IowCBRQ3gDYM1um7R44ZsKDvprJa6dfd74qRbch3Kc4
+        hash: v1.k794b7964.ed4760f6685bc2356c2746506344b45b087eb660012986ae6388e05cbb0bd0f9._U5Uca4f8m8wKB_2o-gs-qqlgvyohoX5iD9VWfTg5YU
     components-playerinspector-itemevent--page-view-with-current-url--dark:
         hash: v1.k794b7964.a06535c28915e5b1c0f62592e4dd65db81b4a8ecc7aeeee69b754cc7153acd9b.HKrdTa2eeocbXhdEA41LY_DBHawsNXC1eFo6MRR-Ahs
     components-playerinspector-itemevent--page-view-with-current-url--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1159,7 +1159,7 @@ snapshots:
     components-playerinspector-itemevent--group-identify-event--dark:
         hash: v1.k794b7964.4f0f997a83425992a237b9c4a5a38666eb8f3e91e57e563b829f4ecc5b965dfd.djHvv-d41HLFU0j_Az9KZ93XgjcF1oYJwmHEo2e17z8
     components-playerinspector-itemevent--group-identify-event--light:
-        hash: v1.k794b7964.ed4760f6685bc2356c2746506344b45b087eb660012986ae6388e05cbb0bd0f9._U5Uca4f8m8wKB_2o-gs-qqlgvyohoX5iD9VWfTg5YU
+        hash: v1.k794b7964.69d03f8ad23b981e50e815dcc6ca94f95908d13da0addbd661c55d18e2ea67b7.IowCBRQ3gDYM1um7R44ZsKDvprJa6dfd74qRbch3Kc4
     components-playerinspector-itemevent--page-view-with-current-url--dark:
         hash: v1.k794b7964.a06535c28915e5b1c0f62592e4dd65db81b4a8ecc7aeeee69b754cc7153acd9b.HKrdTa2eeocbXhdEA41LY_DBHawsNXC1eFo6MRR-Ahs
     components-playerinspector-itemevent--page-view-with-current-url--light:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -48,6 +48,7 @@ def capture_internal(
     properties: dict[str, Any],
     sent_at: Optional[datetime | str] = None,
     process_person_profile: bool = False,
+    event_uuid: Optional[str] = None,
 ) -> Response:
     """
     capture_internal submits a single-event capture request payload to the capture-rs backend service.
@@ -64,6 +65,9 @@ def capture_internal(
         sent_at: time the client submitted this event (optional; typically, let capture_internal set this)
         process_person_profile: if TRUE, process the person profile for the event according to the caller's settings.
                                 if FALSE, disable person processing for this event.
+        event_uuid: optional deterministic UUID to assign to the event (default: capture-rs assigns a fresh UUIDv7).
+                    Use this when the caller needs a stable, queryable event UUID — e.g. to link back to the event
+                    from an admin UI. Must be a parseable UUID string.
 
     Returns:
         Response object, the result of POSTing the event payload to the capture-rs backend service.
@@ -81,7 +85,15 @@ def capture_internal(
     )
 
     event_payload = prepare_capture_internal_payload(
-        token, event_name, event_source, distinct_id, timestamp, properties, sent_at, process_person_profile
+        token,
+        event_name,
+        event_source,
+        distinct_id,
+        timestamp,
+        properties,
+        sent_at,
+        process_person_profile,
+        event_uuid,
     )
 
     # determine if this is a recordings or events type, route to correct capture endpoint
@@ -178,6 +190,7 @@ def prepare_capture_internal_payload(
     properties: dict[str, Any],
     sent_at: Optional[datetime | str] = None,
     process_person_profile: bool = False,
+    event_uuid: Optional[str] = None,
 ) -> dict[str, Any]:
     # mark event as internal for observability
     properties["capture_internal"] = True
@@ -214,7 +227,7 @@ def prepare_capture_internal_payload(
     elif isinstance(timestamp, datetime):
         timestamp = timestamp.replace(tzinfo=UTC).isoformat()
 
-    return {
+    payload: dict[str, Any] = {
         "api_key": token,
         "timestamp": timestamp,
         "distinct_id": distinct_id,
@@ -222,3 +235,6 @@ def prepare_capture_internal_payload(
         "event": event_name,
         "properties": properties,
     }
+    if event_uuid:
+        payload["uuid"] = event_uuid
+    return payload

--- a/products/replay_vision/backend/temporal/activities/emit_observation_event.py
+++ b/products/replay_vision/backend/temporal/activities/emit_observation_event.py
@@ -73,5 +73,7 @@ def _emit_event(inputs: EmitObservationEventInputs) -> None:
         timestamp=datetime.now(UTC),
         properties=properties,
         process_person_profile=False,
+        # Make the captured event UUID equal to observation.id so the admin UI can link back to it directly.
+        event_uuid=str(observation.id),
     )
     response.raise_for_status()

--- a/products/replay_vision/backend/temporal/activities/fetch_session_events.py
+++ b/products/replay_vision/backend/temporal/activities/fetch_session_events.py
@@ -65,7 +65,7 @@ async def fetch_session_events_activity(inputs: FetchSessionEventsInputs) -> Non
     payload = await sync_to_async(_fetch_payload)(inputs.team_id, inputs.session_id)
     if payload is None:
         raise IneligibleSessionError(
-            f"Session {inputs.session_id} has no events to analyze",
+            "No events to analyze",
             kind=IneligibleSessionKind.NO_EVENTS,
         )
 
@@ -78,25 +78,25 @@ def _fetch_payload(team_id: int, session_id: str) -> ScannerLlmInputs | None:
     metadata = events_obj.get_metadata(session_id=session_id, team=team)
     if metadata is None:
         raise IneligibleSessionError(
-            f"No replay metadata found for session {session_id}",
+            "No replay metadata found",
             kind=IneligibleSessionKind.NO_RECORDING,
         )
     duration_seconds = float(metadata["duration"])
     if duration_seconds < MIN_SESSION_DURATION_FOR_VIDEO_SCANNER_S:
         raise IneligibleSessionError(
-            f"Session {session_id} is only {duration_seconds}s long; min is {MIN_SESSION_DURATION_FOR_VIDEO_SCANNER_S}s",
+            f"Only {duration_seconds}s long; min is {MIN_SESSION_DURATION_FOR_VIDEO_SCANNER_S}s",
             kind=IneligibleSessionKind.TOO_SHORT,
         )
     # `RecordingMetadata` types this as `int` but it can be missing on sparse fixtures; default to 0.
     active_seconds = metadata.get("active_seconds") or 0
     if active_seconds < MIN_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S:
         raise IneligibleSessionError(
-            f"Session {session_id} has only {active_seconds}s of active interaction; min is {MIN_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
+            f"Only {active_seconds}s of active interaction; min is {MIN_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
             kind=IneligibleSessionKind.TOO_INACTIVE,
         )
     if active_seconds > MAX_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S:
         raise IneligibleSessionError(
-            f"Session {session_id} has {active_seconds}s of active interaction; max is {MAX_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
+            f"{active_seconds}s of active interaction; max is {MAX_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
             kind=IneligibleSessionKind.TOO_LONG,
         )
 

--- a/products/replay_vision/backend/tests/test_temporal.py
+++ b/products/replay_vision/backend/tests/test_temporal.py
@@ -774,7 +774,7 @@ class TestFetchSessionEventsActivity:
                     "active_seconds": 5,
                 },
                 "too_short",
-                "is only 5",
+                "Only 5",
             ),
             (
                 {
@@ -784,7 +784,7 @@ class TestFetchSessionEventsActivity:
                     "active_seconds": 3,  # under 10s floor
                 },
                 "too_inactive",
-                "has only 3",
+                "Only 3s of active",
             ),
             (
                 {
@@ -794,7 +794,7 @@ class TestFetchSessionEventsActivity:
                     "active_seconds": 5000,  # over 3600 cap
                 },
                 "too_long",
-                "has 5000",
+                "5000s of active",
             ),
         ],
     )

--- a/products/replay_vision/frontend/components/ObservationCard.tsx
+++ b/products/replay_vision/frontend/components/ObservationCard.tsx
@@ -12,16 +12,37 @@ import {
     scannerTypeLabel,
 } from '../replay_scanners/types'
 
-export function ObservationStatusTag({ status }: { status: ReplayObservationApi['status'] }): JSX.Element {
+export function ObservationStatusTag({
+    status,
+    errorReason,
+}: {
+    status: ReplayObservationApi['status']
+    errorReason?: string | null
+}): JSX.Element {
     if (status === 'succeeded') {
         return <LemonTag type="success">Succeeded</LemonTag>
     }
     if (status === 'failed') {
-        return <LemonTag type="danger">Failed</LemonTag>
+        const parsed = errorReason ? parseFailureReason(errorReason) : null
+        const tooltip =
+            [parsed?.label, parsed ? failureKindDescription(parsed.kind) : null, parsed?.message ?? errorReason]
+                .filter(Boolean)
+                .join('\n\n') || null
+        return (
+            <Tooltip title={tooltip}>
+                <LemonTag type="danger">Failed</LemonTag>
+            </Tooltip>
+        )
     }
     if (status === 'ineligible') {
         // Muted, not danger — the session was skipped at the gate, not a scanner failure.
-        return <LemonTag type="muted">Ineligible</LemonTag>
+        const parsed = errorReason ? parseIneligibleReason(errorReason) : null
+        const tooltip = [parsed?.label, parsed?.message ?? errorReason].filter(Boolean).join('\n\n') || null
+        return (
+            <Tooltip title={tooltip}>
+                <LemonTag type="muted">Ineligible</LemonTag>
+            </Tooltip>
+        )
     }
     if (status === 'running') {
         return (
@@ -306,14 +327,7 @@ export function ObservationConfidence({ result }: { result: Record<string, unkno
 
 export function ObservationResultSummary({ observation }: { observation: ReplayObservationApi }): JSX.Element {
     if (observation.status === 'ineligible') {
-        const parsed = parseIneligibleReason(observation.error_reason)
-        const label = parsed?.label ?? 'Ineligible'
-        const detail = parsed?.message ?? observation.error_reason
-        return (
-            <Tooltip title={detail || label}>
-                <span className="text-muted text-sm">{label}</span>
-            </Tooltip>
-        )
+        return <span className="text-muted text-sm">—</span>
     }
     if (observation.status === 'failed') {
         const parsed = parseFailureReason(observation.error_reason)
@@ -388,7 +402,7 @@ export function ObservationDockCard({
         <div className="border rounded p-3 bg-surface-primary space-y-2">
             <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2 min-w-0">
-                    <ObservationStatusTag status={observation.status} />
+                    <ObservationStatusTag status={observation.status} errorReason={observation.error_reason} />
                     <span className="font-semibold text-sm truncate">{snapshot?.name || 'Scanner'}</span>
                     {scannerType && <span className="text-muted text-xs">{scannerTypeLabel(scannerType)}</span>}
                 </div>

--- a/products/replay_vision/frontend/components/ObservationCard.tsx
+++ b/products/replay_vision/frontend/components/ObservationCard.tsx
@@ -1,4 +1,4 @@
-import { IconRewindPlay, IconSparkles, IconWarning } from '@posthog/icons'
+import { IconRewindPlay, IconSparkles } from '@posthog/icons'
 import { LemonTag, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { colonDelimitedDuration } from 'lib/utils'
@@ -326,22 +326,8 @@ export function ObservationConfidence({ result }: { result: Record<string, unkno
 }
 
 export function ObservationResultSummary({ observation }: { observation: ReplayObservationApi }): JSX.Element {
-    if (observation.status === 'ineligible') {
+    if (observation.status === 'ineligible' || observation.status === 'failed') {
         return <span className="text-muted text-sm">—</span>
-    }
-    if (observation.status === 'failed') {
-        const parsed = parseFailureReason(observation.error_reason)
-        const label = parsed?.label ?? 'Failed'
-        const description = parsed ? failureKindDescription(parsed.kind) : null
-        const detail = parsed?.message ?? observation.error_reason
-        const tooltip = [description, detail].filter(Boolean).join('\n\n') || 'Unknown error'
-        return (
-            <Tooltip title={tooltip}>
-                <span className="inline-flex items-center gap-1 text-danger text-sm">
-                    <IconWarning /> {label}
-                </span>
-            </Tooltip>
-        )
     }
     const snapshot = observation.scanner_snapshot
     const result = readResult(observation)

--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -22,15 +22,20 @@ import { ProductKey } from '~/queries/schema/schema-general'
 
 import {
     CitedText,
-    FailureDetail,
-    IneligibleDetail,
     ObservationConfidence,
     ObservationPrimaryOutput,
     ObservationStatusTag,
     readConfig,
     readResult,
 } from '../components/ObservationCard'
-import { modelLabel, scannerTypeLabel } from '../replay_scanners/types'
+import {
+    failureKindDescription,
+    modelLabel,
+    parseFailureReason,
+    parseIneligibleReason,
+    type ScannerType,
+    scannerTypeLabel,
+} from '../replay_scanners/types'
 import { replayObservationLogic } from './replayObservationLogic'
 import { ReplayObservationSceneLogicProps, replayObservationSceneLogic } from './replayObservationSceneLogic'
 
@@ -38,6 +43,22 @@ export const scene: SceneExport<ReplayObservationSceneLogicProps> = {
     component: ReplayObservationSceneComponent,
     logic: replayObservationSceneLogic,
     productKey: ProductKey.REPLAY_VISION,
+}
+
+const SUCCEEDED_OUTPUT_LABEL: Record<ScannerType, string> = {
+    classifier: 'Tags',
+    summarizer: 'Summary',
+    monitor: 'Verdict',
+    scorer: 'Score',
+}
+
+function LabeledRow({ label, children }: { label: string; children: React.ReactNode }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-1">
+            <div className="text-xs text-muted">{label}</div>
+            {children}
+        </div>
+    )
 }
 
 function AutoSeekToTime({
@@ -122,6 +143,16 @@ export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): J
     const scorerMin = scorerScale && typeof scorerScale.min === 'number' ? scorerScale.min : null
     const scorerMax = scorerScale && typeof scorerScale.max === 'number' ? scorerScale.max : null
     const scorerLabel = scorerScale && typeof scorerScale.label === 'string' ? scorerScale.label : null
+    const ineligibleParsed =
+        observation.status === 'ineligible' && observation.error_reason
+            ? parseIneligibleReason(observation.error_reason)
+            : null
+    const ineligibleMessage = ineligibleParsed ? ineligibleParsed.message || null : observation.error_reason || null
+    const failedParsed =
+        observation.status === 'failed' && observation.error_reason
+            ? parseFailureReason(observation.error_reason)
+            : null
+    const failedMessage = failedParsed ? failedParsed.message || null : observation.error_reason || null
     const durationMs =
         observation.started_at && observation.completed_at
             ? dayjs(observation.completed_at).diff(observation.started_at)
@@ -155,40 +186,94 @@ export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): J
                     <div className="text-sm font-medium">Result</div>
 
                     {observation.status === 'failed' && observation.error_reason && (
-                        <FailureDetail errorReason={observation.error_reason} />
+                        <div className="flex flex-col gap-3">
+                            {scannerType && (
+                                <LabeledRow label="Type">
+                                    <LemonTag type="option" className="self-start">
+                                        {scannerTypeLabel(scannerType)}
+                                    </LemonTag>
+                                </LabeledRow>
+                            )}
+                            {prompt && (
+                                <LabeledRow label="Prompt">
+                                    <p className="text-sm text-default m-0 leading-snug">{prompt}</p>
+                                </LabeledRow>
+                            )}
+                            <LabeledRow label="Reason">
+                                <LemonTag type="danger" className="self-start">
+                                    {failedParsed?.label ?? 'Failed'}
+                                </LemonTag>
+                            </LabeledRow>
+                            {failedParsed && (
+                                <LabeledRow label="What this means">
+                                    <p className="text-sm text-default m-0 leading-snug">
+                                        {failureKindDescription(failedParsed.kind)}
+                                    </p>
+                                </LabeledRow>
+                            )}
+                            {failedMessage && (
+                                <LabeledRow label="Details">
+                                    <p className="text-sm text-default m-0 leading-snug font-mono">{failedMessage}</p>
+                                </LabeledRow>
+                            )}
+                        </div>
                     )}
 
                     {observation.status === 'ineligible' && observation.error_reason && (
-                        <IneligibleDetail errorReason={observation.error_reason} />
+                        <div className="flex flex-col gap-3">
+                            {scannerType && (
+                                <LabeledRow label="Type">
+                                    <LemonTag type="option" className="self-start">
+                                        {scannerTypeLabel(scannerType)}
+                                    </LemonTag>
+                                </LabeledRow>
+                            )}
+                            {prompt && (
+                                <LabeledRow label="Prompt">
+                                    <p className="text-sm text-default m-0 leading-snug">{prompt}</p>
+                                </LabeledRow>
+                            )}
+                            <LabeledRow label="Reason">
+                                <LemonTag type="muted" className="self-start">
+                                    {ineligibleParsed?.label ?? 'Ineligible'}
+                                </LemonTag>
+                            </LabeledRow>
+                            {ineligibleMessage && (
+                                <LabeledRow label="Details">
+                                    <p className="text-sm text-default m-0 leading-snug">{ineligibleMessage}</p>
+                                </LabeledRow>
+                            )}
+                        </div>
                     )}
 
                     {observation.status === 'succeeded' && snapshot && result && (
                         <div className="flex flex-col gap-3">
                             {scannerType && (
-                                <div className="flex flex-col gap-1">
-                                    <div className="text-xs text-muted">Type</div>
+                                <LabeledRow label="Type">
                                     <LemonTag type="option" className="self-start">
                                         {scannerTypeLabel(scannerType)}
                                     </LemonTag>
-                                </div>
+                                </LabeledRow>
                             )}
                             {prompt && scannerType !== 'summarizer' && (
-                                <div className="flex flex-col gap-1">
-                                    <div className="text-xs text-muted">Prompt</div>
+                                <LabeledRow label="Prompt">
                                     <p className="text-sm text-default m-0 leading-snug">{prompt}</p>
-                                </div>
+                                </LabeledRow>
                             )}
-                            <div className="flex flex-col gap-1">
-                                {scannerType === 'classifier' && <div className="text-xs text-muted">Tags</div>}
-                                {scannerType === 'summarizer' && <div className="text-xs text-muted">Summary</div>}
-                                {scannerType === 'monitor' && <div className="text-xs text-muted">Verdict</div>}
-                                {scannerType === 'scorer' && <div className="text-xs text-muted">Score</div>}
+                            <LabeledRow label={scannerType ? SUCCEEDED_OUTPUT_LABEL[scannerType] : ''}>
                                 <ObservationPrimaryOutput
                                     observation={observation}
                                     showPrompt={false}
                                     onSeek={seekEmbeddedPlayer}
                                 />
-                            </div>
+                            </LabeledRow>
+                            {observation.completed_at && (
+                                <LabeledRow label="Event">
+                                    <Link to={urls.event(observation.id, observation.completed_at)}>
+                                        $recording_observed
+                                    </Link>
+                                </LabeledRow>
+                            )}
                         </div>
                     )}
 
@@ -207,7 +292,9 @@ export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): J
                                 <CitedText text={reasoning} segments={reasoningSegments} onSeek={seekEmbeddedPlayer} />
                             </p>
                         ) : (
-                            <p className="text-muted text-sm m-0">No reasoning provided.</p>
+                            <p className="text-muted text-sm m-0">
+                                {observation.status === 'succeeded' ? 'No reasoning provided.' : 'N/A'}
+                            </p>
                         )}
                     </section>
                 )}

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
@@ -134,7 +134,7 @@ export function ScannerObservationsTable({ scannerId, tabId }: { scannerId: stri
         {
             title: 'Status',
             key: 'status',
-            render: (_, obs) => <ObservationStatusTag status={obs.status} />,
+            render: (_, obs) => <ObservationStatusTag status={obs.status} errorReason={obs.error_reason} />,
         },
         {
             title: 'Result',

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -14,14 +14,20 @@ import { ScannerInsightsChart } from './ScannerInsightsChart'
 function OverviewPanel({
     title,
     subtitle,
+    disabled,
     children,
 }: {
     title: string
     subtitle?: React.ReactNode
+    disabled?: boolean
     children: React.ReactNode
 }): JSX.Element {
     return (
-        <div className="border rounded p-4 bg-surface-primary space-y-3">
+        <div
+            className={`border rounded p-4 space-y-3 ${
+                disabled ? 'bg-surface-secondary opacity-60' : 'bg-surface-primary'
+            }`}
+        >
             <div className="flex items-baseline justify-between gap-2">
                 <span className="text-sm font-medium">{title}</span>
                 {subtitle && <span className="text-xs text-muted tabular-nums">{subtitle}</span>}
@@ -72,11 +78,14 @@ function MonitorOverview({ scannerId, tabId }: { scannerId: string; tabId: strin
 }
 
 function ClassifierOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element | null {
-    const { classifierTagStats } = useValues(replayScannerLogic({ id: scannerId, tabId }))
+    const { scanner, classifierTagStats } = useValues(replayScannerLogic({ id: scannerId, tabId }))
     const { fixedRanked, freeformRanked, totalWithTags } = classifierTagStats
-    if (totalWithTags === 0) {
+    // Wait for the scanner config — without it `freeformAllowed` defaults to `false` and the panel flashes the
+    // "disabled" copy while the config is still loading.
+    if (totalWithTags === 0 || !scanner || scanner.scanner_type !== 'classifier') {
         return null
     }
+    const freeformAllowed = !!scanner.scanner_config.allow_freeform_tags
 
     const renderRanked = (ranked: [string, number][], emptyMessage: string): JSX.Element => {
         if (ranked.length === 0) {
@@ -104,8 +113,19 @@ function ClassifierOverview({ scannerId, tabId }: { scannerId: string; tabId: st
                 {renderRanked(fixedRanked, 'No fixed-vocabulary tags emitted yet.')}
             </OverviewPanel>
 
-            <OverviewPanel title="Top freeform tags" subtitle="outside configured vocabulary">
-                {renderRanked(freeformRanked, 'No freeform tags emitted.')}
+            <OverviewPanel
+                title="Top freeform tags"
+                subtitle={freeformAllowed ? 'outside configured vocabulary' : 'disabled'}
+                disabled={!freeformAllowed}
+            >
+                {freeformAllowed ? (
+                    renderRanked(freeformRanked, 'No freeform tags emitted yet.')
+                ) : (
+                    <div className="text-muted text-sm">
+                        Freeform tags are disabled for this scanner — the model can only pick from your configured
+                        vocabulary. Enable "Allow freeform tags" in the scanner config to let it propose new ones.
+                    </div>
+                )}
             </OverviewPanel>
         </div>
     )


### PR DESCRIPTION
## Problem

Rough edges across the Replay Vision observation surfaces — ineligibility reasons rendered as if they were classifier output, ineligible/failed detail pages were bare, the freeform-tags overview panel looked broken when freeform was off, and there was no link from an observation to the event it emitted.

## Changes

- Observation list: ineligible rows show `—` in the Result column; reason moves to a tooltip on the status badge (failed too).
- Observation detail: ineligible and failed Result cards mirror the succeeded layout (Type → Prompt → Reason → Details). Reasoning card stays but shows `N/A` for non-succeeded.
- Observation Result card: link to the emitted `$recording_observed` event (succeeded only).
- `capture_internal` gains an optional `event_uuid` kwarg so internal callers can pin the captured event UUID. The `$recording_observed` emit passes `observation.id`, so the link resolves to the real event row.
- Classifier overview: freeform-tags panel greys out when `allow_freeform_tags` is off; panel waits for the scanner config to load so it doesn't flash "disabled".
- Backend: drop the embedded session UUID from ineligibility messages.

## How did you test this code?

Agent-authored — no manual UI testing. Backend tests pass locally (`test_temporal::TestFetchSessionEventsActivity`, `test_capture_internal`). `$recording_observed` events emitted *before* this deploys still have a random UUID, so the Result-card link will 404 for those rows; the closed-beta data set is small and self-repairs on next emit.

## 🤖 Agent context

Authored by Claude (Opus 4.7) via Claude Code, directed by @TueHaulund.