### PR TITLE
fix(session-replay): apply view recordings filter over defaults

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -6,7 +6,13 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
-import { ActionFilter, FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
+import {
+    ActionFilter,
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyOperator,
+    RecordingUniversalFilters,
+} from '~/types'
 
 import { deletedRecordingsLogic } from '../deletedRecordingsLogic'
 import { playerSettingsLogic } from '../player/playerSettingsLogic'
@@ -622,51 +628,45 @@ describe('sessionRecordingsPlaylistLogic', () => {
                 })
         })
 
-        it('applies URL filters on top of defaults, ignoring stale persisted filters', async () => {
+        it.each<[string, Partial<RecordingUniversalFilters>]>([
+            ['date_from', { date_from: '-30d' }],
+            ['filter_test_accounts', { filter_test_accounts: true }],
+            [
+                'duration',
+                {
+                    duration: [
+                        {
+                            type: PropertyFilterType.Recording,
+                            key: 'duration',
+                            operator: PropertyOperator.LessThan,
+                            value: 600,
+                        },
+                    ],
+                },
+            ],
+        ])('resets stale %s to default when a URL filter omits it', async (_field, staleFilters) => {
+            const filterGroup = {
+                type: FilterLogicalOperator.And,
+                values: [
+                    {
+                        type: FilterLogicalOperator.And,
+                        values: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
+                    },
+                ],
+            }
+
             // stale persisted state from a prior visit
             await expectLogic(logic, () => {
-                logic.actions.setFilters({
-                    date_from: '-30d',
-                    filter_test_accounts: true,
-                    duration: [{ key: 'duration', operator: 'lt', type: 'recording', value: 600 }],
-                })
+                logic.actions.setFilters(staleFilters)
             }).toDispatchActions(['setFilters'])
 
             // "View recordings" navigation carrying only filter_group
-            router.actions.push('/replay', {
-                filters: {
-                    filter_group: {
-                        type: FilterLogicalOperator.And,
-                        values: [
-                            {
-                                type: FilterLogicalOperator.And,
-                                values: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
-                            },
-                        ],
-                    },
-                },
-            })
+            router.actions.push('/replay', { filters: { filter_group: filterGroup } })
 
             await expectLogic(logic)
                 .toDispatchActions(['setFilters'])
                 .toMatchValues({
-                    filters: {
-                        date_from: '-3d',
-                        date_to: null,
-                        duration: [{ key: 'active_seconds', operator: 'gt', type: 'recording', value: 5 }],
-                        filter_group: {
-                            type: FilterLogicalOperator.And,
-                            values: [
-                                {
-                                    type: FilterLogicalOperator.And,
-                                    values: [{ id: '1', name: 'View Recording', order: 0, type: 'actions' }],
-                                },
-                            ],
-                        },
-                        filter_test_accounts: false,
-                        order: 'start_time',
-                        order_direction: 'DESC',
-                    },
+                    filters: { ...getDefaultFilters(), filter_group: filterGroup },
                 })
         })
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -622,6 +622,55 @@ describe('sessionRecordingsPlaylistLogic', () => {
                 })
         })
 
+        it('applies URL filters on top of defaults, ignoring stale persisted filters', async () => {
+            // simulate stale state left over from a prior visit (e.g. localStorage-persisted)
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({
+                    date_from: '-30d',
+                    filter_test_accounts: true,
+                    duration: [{ key: 'duration', operator: 'lt', type: 'recording', value: 600 }],
+                })
+            }).toDispatchActions(['setFilters'])
+
+            // a "View recordings" navigation carries only filter_group - the omitted fields must
+            // fall back to defaults, not inherit the stale persisted values
+            router.actions.push('/replay', {
+                filters: {
+                    filter_group: {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                type: FilterLogicalOperator.And,
+                                values: [{ id: '1', type: 'actions', order: 0, name: 'View Recording' }],
+                            },
+                        ],
+                    },
+                },
+            })
+
+            await expectLogic(logic)
+                .toDispatchActions(['setFilters'])
+                .toMatchValues({
+                    filters: {
+                        date_from: '-3d',
+                        date_to: null,
+                        duration: [{ key: 'active_seconds', operator: 'gt', type: 'recording', value: 5 }],
+                        filter_group: {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    type: FilterLogicalOperator.And,
+                                    values: [{ id: '1', name: 'View Recording', order: 0, type: 'actions' }],
+                                },
+                            ],
+                        },
+                        filter_test_accounts: false,
+                        order: 'start_time',
+                        order_direction: 'DESC',
+                    },
+                })
+        })
+
         describe('deleting recordings', () => {
             it('otherRecordings filters out deleted recording ids', async () => {
                 await expectLogic(logic)

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -623,7 +623,7 @@ describe('sessionRecordingsPlaylistLogic', () => {
         })
 
         it('applies URL filters on top of defaults, ignoring stale persisted filters', async () => {
-            // simulate stale state left over from a prior visit (e.g. localStorage-persisted)
+            // stale persisted state from a prior visit
             await expectLogic(logic, () => {
                 logic.actions.setFilters({
                     date_from: '-30d',
@@ -632,8 +632,7 @@ describe('sessionRecordingsPlaylistLogic', () => {
                 })
             }).toDispatchActions(['setFilters'])
 
-            // a "View recordings" navigation carries only filter_group - the omitted fields must
-            // fall back to defaults, not inherit the stale persisted values
+            // "View recordings" navigation carrying only filter_group
             router.actions.push('/replay', {
                 filters: {
                     filter_group: {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -1693,8 +1693,15 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             }
 
             if (isReplayURLSearchParams(params)) {
+                // Treat the URL as the source of truth for an externally-applied filter (e.g.
+                // "View recordings"). Layer it onto the defaults rather than the current state,
+                // which may be stale localStorage-persisted filters - otherwise fields the URL
+                // omits (date range, duration, test accounts) silently inherit old values and it
+                // looks like the filter wasn't applied.
                 const updatedFilters = {
-                    ...(params.filters && !equal(params.filters, values.filters) ? params.filters : {}),
+                    ...(params.filters && !equal(params.filters, values.filters)
+                        ? { ...getDefaultFilters(props.personUUID, props.pinnedFilters), ...params.filters }
+                        : {}),
                     ...(params.order && !equal(params.order, values.filters.order) ? { order: params.order } : {}),
                     ...(params.order_direction && !equal(params.order_direction, values.filters.order_direction)
                         ? { order_direction: params.order_direction }

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -1693,12 +1693,9 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             }
 
             if (isReplayURLSearchParams(params)) {
-                // Treat the URL as the source of truth for an externally-applied filter (e.g.
-                // "View recordings"). Layer it onto the defaults rather than the current state,
-                // which may be stale localStorage-persisted filters - otherwise fields the URL
-                // omits (date range, duration, test accounts) silently inherit old values and it
-                // looks like the filter wasn't applied.
                 const updatedFilters = {
+                    // layer URL filters onto defaults, not the persisted state, so fields the URL
+                    // omits don't inherit stale values
                     ...(params.filters && !equal(params.filters, values.filters)
                         ? { ...getDefaultFilters(props.personUUID, props.pinnedFilters), ...params.filters }
                         : {}),


### PR DESCRIPTION
## Problem

Clicking **"View recordings"** on an event, person, cohort, etc. navigates to the replay scene with a filter in the URL, but the filter often appeared not to be applied — the recordings list didn't match what the user expected.

The "View recordings" entry points only put `filter_group` in the URL. The replay playlist logic's `filters` reducer is persisted to `localStorage`, so on mount the stale persisted filters rehydrate first, then `urlToAction` merged the incoming `filter_group` **on top of that persisted state**. Every field the URL omits (`date_from`, `date_to`, `duration`, `filter_test_accounts`) silently inherited whatever the user last had in that replay tab — e.g. a stale `-30d` date range — so the result didn't match a fresh application of the filter.

This is the frontend half of a session-replay support report (the other half — a mobile bottom-sheet missing from a recording — is a mobile SDK issue and is tracked separately).

## Changes

In `sessionRecordingsPlaylistLogic` `urlToAction`, when applying URL filters, layer them onto `getDefaultFilters(...)` rather than the current (possibly stale, persisted) `values.filters`. Fields the URL omits now fall back to defaults instead of inheriting old values. The normal in-scene round-trip is unaffected because `actionToUrl` writes the full filter object to the URL, so `{ ...defaults, ...fullFilters } === fullFilters`.

## How did you test this code?

I'm an agent. I added an automated logic test (`applies URL filters on top of defaults, ignoring stale persisted filters`) that seeds stale filters (`date_from: -30d`, `filter_test_accounts: true`, custom duration), then pushes a `filter_group`-only URL and asserts the result resets to defaults (`-3d`, `false`, default duration). It fails on the old code and passes on the new. Ran the playlist logic URL-filter tests locally via jest — all pass. No manual UI testing performed.

## 🤖 Agent context

Authored with Cursor (Claude Opus 4.8) while triaging a session-replay support ticket. Diagnosis traced the report to the persisted-filter-vs-URL merge in `urlToAction` (no legacy/universal filter shape mismatch — all entry points already use the universal shape). Considered resetting omitted fields only for "external" navigations, but layering URL filters onto defaults is simpler and behaves identically for the in-scene round-trip since `actionToUrl` always writes the full filter set. A separate `urlToAction`/`actionToUrl` recursion guard exists on another branch and is intentionally out of scope here.

Made with [Cursor](https://cursor.com)