### PR TITLE
feat: show bot messages in threads

### DIFF
--- a/products/conversations/backend/api/tests/test_reaction_backfill.py
+++ b/products/conversations/backend/api/tests/test_reaction_backfill.py
@@ -43,9 +43,10 @@ class TestBackfillThreadReplies(BaseTest):
         client.conversations_replies.return_value = {"messages": replies}
         return client
 
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
     @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": "a@x.com", "avatar": None})
     @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_backfills_thread_replies_as_comments(self, _mock_files, _mock_user):
+    def test_backfills_thread_replies_as_comments(self, _mock_files, _mock_user, _mock_bot):
         replies = [
             _make_slack_reply(PARENT_TS, text="parent"),
             _make_slack_reply("1700000000.000200", user="U1", text="first reply"),
@@ -63,9 +64,10 @@ class TestBackfillThreadReplies(BaseTest):
         self.ticket.refresh_from_db()
         assert self.ticket.unread_team_count == 3  # 1 original + 2 backfilled
 
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
     @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": "a@x.com", "avatar": None})
     @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_calls_conversations_replies_with_correct_args(self, _mock_files, _mock_user):
+    def test_calls_conversations_replies_with_correct_args(self, _mock_files, _mock_user, _mock_bot):
         replies = [
             _make_slack_reply(PARENT_TS, text="parent"),
             _make_slack_reply("1700000000.000200", text="reply"),
@@ -78,15 +80,14 @@ class TestBackfillThreadReplies(BaseTest):
 
     @parameterized.expand(
         [
-            ("bot_id", {"bot_id": "B123"}),
-            ("bot_message_subtype", {"subtype": "bot_message"}),
             ("message_changed_subtype", {"subtype": "message_changed"}),
             ("message_deleted_subtype", {"subtype": "message_deleted"}),
         ]
     )
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
     @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": None, "avatar": None})
     @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_skips_filtered_message_types(self, _name, extra_fields, _mock_files, _mock_user):
+    def test_skips_non_message_subtypes(self, _name, extra_fields, _mock_files, _mock_user, _mock_bot):
         replies = [
             _make_slack_reply(PARENT_TS, text="parent"),
             _make_slack_reply("1700000000.000200", text="filtered", **extra_fields),
@@ -100,9 +101,49 @@ class TestBackfillThreadReplies(BaseTest):
         assert comments.count() == 1
         assert comments[0].content == "human reply"
 
+    @parameterized.expand(
+        [
+            ("bot_id", {"bot_id": "B_OTHER"}),
+            ("bot_message_subtype", {"subtype": "bot_message"}),
+        ]
+    )
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "OtherBot", "email": None, "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_allows_other_bot_replies(self, _name, extra_fields, _mock_files, _mock_user, _mock_bot):
+        replies = [
+            _make_slack_reply(PARENT_TS, text="parent"),
+            _make_slack_reply("1700000000.000200", user="U_OTHER_BOT", text="bot reply", **extra_fields),
+        ]
+        client = self._mock_client(replies)
+
+        _backfill_thread_replies(client, self.team, self.ticket, CHANNEL, PARENT_TS)
+
+        comments = Comment.objects.filter(item_id=str(self.ticket.id))
+        assert comments.count() == 1
+        assert comments[0].content == "bot reply"
+
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "OurBot", "email": None, "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_skips_own_bot_replies(self, _mock_files, _mock_user, _mock_bot):
+        replies = [
+            _make_slack_reply(PARENT_TS, text="parent"),
+            _make_slack_reply("1700000000.000200", user="U_OWN_BOT", text="Ticket #1 created", bot_id="B_OWN"),
+            _make_slack_reply("1700000000.000300", text="human reply"),
+        ]
+        client = self._mock_client(replies)
+
+        _backfill_thread_replies(client, self.team, self.ticket, CHANNEL, PARENT_TS)
+
+        comments = Comment.objects.filter(item_id=str(self.ticket.id))
+        assert comments.count() == 1
+        assert comments[0].content == "human reply"
+
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
     @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": None, "avatar": None})
     @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_skips_empty_replies(self, _mock_files, _mock_user):
+    def test_skips_empty_replies(self, _mock_files, _mock_user, _mock_bot):
         replies = [
             _make_slack_reply(PARENT_TS, text="parent"),
             _make_slack_reply("1700000000.000200", text="   "),
@@ -115,9 +156,10 @@ class TestBackfillThreadReplies(BaseTest):
         comments = Comment.objects.filter(item_id=str(self.ticket.id))
         assert comments.count() == 1
 
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
     @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": None, "avatar": None})
     @patch(f"{MODULE}.extract_slack_files")
-    def test_includes_file_only_replies(self, mock_files, _mock_user):
+    def test_includes_file_only_replies(self, mock_files, _mock_user, _mock_bot):
         mock_files.return_value = [{"url": "https://example.com/img.png", "name": "img.png", "mimetype": "image/png"}]
         replies = [
             _make_slack_reply(PARENT_TS, text="parent"),
@@ -135,9 +177,10 @@ class TestBackfillThreadReplies(BaseTest):
         assert comments.count() == 1
         assert comments[0].item_context["slack_images"] is not None
 
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
     @patch(f"{MODULE}.resolve_slack_user")
     @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_caches_user_lookups(self, _mock_files, mock_user):
+    def test_caches_user_lookups(self, _mock_files, mock_user, _mock_bot):
         mock_user.return_value = {"name": "Alice", "email": None, "avatar": None}
         replies = [
             _make_slack_reply(PARENT_TS, text="parent"),
@@ -181,9 +224,10 @@ class TestBackfillThreadReplies(BaseTest):
         self.ticket.refresh_from_db()
         assert self.ticket.unread_team_count == 1
 
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
     @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Bob", "email": "b@x.com", "avatar": "http://av"})
     @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_stores_slack_user_info_in_item_context(self, _mock_files, _mock_user):
+    def test_stores_slack_user_info_in_item_context(self, _mock_files, _mock_user, _mock_bot):
         replies = [
             _make_slack_reply(PARENT_TS, text="parent"),
             _make_slack_reply("1700000000.000200", user="U_BOB", text="hello"),

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -5,6 +5,8 @@ from products.conversations.backend.models import Ticket
 from products.conversations.backend.models.constants import Channel, ChannelDetail
 from products.conversations.backend.slack import handle_support_mention, handle_support_message, handle_support_reaction
 
+MODULE = "products.conversations.backend.slack"
+
 
 class TestSlackMessageRouting(BaseTest):
     def setUp(self):
@@ -113,3 +115,96 @@ class TestSlackMessageRouting(BaseTest):
 
         mock_create_or_update.assert_called_once()
         assert mock_create_or_update.call_args.kwargs["channel_detail"] == ChannelDetail.SLACK_EMOJI_REACTION
+
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_top_level_bot_message_does_not_create_ticket(self, mock_create_or_update):
+        handle_support_message(
+            {
+                "type": "message",
+                "channel": "C_CONFIG",
+                "ts": "1700000000.000100",
+                "user": "U_BOT",
+                "text": "Automated alert",
+                "bot_id": "B123",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_create_or_update.assert_not_called()
+
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_top_level_bot_message_subtype_does_not_create_ticket(self, mock_create_or_update):
+        handle_support_message(
+            {
+                "type": "message",
+                "subtype": "bot_message",
+                "channel": "C_CONFIG",
+                "ts": "1700000000.000100",
+                "user": "U_BOT",
+                "text": "Webhook post",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_create_or_update.assert_not_called()
+
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_other_bot_thread_reply_creates_comment(self, mock_create_or_update, _mock_client, _mock_bot_id):
+        Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.SLACK,
+            widget_session_id="",
+            distinct_id="",
+            slack_channel_id="C_CONFIG",
+            slack_thread_ts="1700000000.000100",
+        )
+
+        handle_support_message(
+            {
+                "type": "message",
+                "channel": "C_CONFIG",
+                "thread_ts": "1700000000.000100",
+                "ts": "1700000000.000200",
+                "user": "U_OTHER_BOT",
+                "text": "Bot summary",
+                "bot_id": "B_OTHER",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_create_or_update.assert_called_once()
+        assert mock_create_or_update.call_args.kwargs["is_thread_reply"] is True
+
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_own_bot_thread_reply_is_skipped(self, mock_create_or_update, _mock_client, _mock_bot_id):
+        Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.SLACK,
+            widget_session_id="",
+            distinct_id="",
+            slack_channel_id="C_CONFIG",
+            slack_thread_ts="1700000000.000100",
+        )
+
+        handle_support_message(
+            {
+                "type": "message",
+                "channel": "C_CONFIG",
+                "thread_ts": "1700000000.000100",
+                "ts": "1700000000.000200",
+                "user": "U_OWN_BOT",
+                "text": "Ticket #1 created",
+                "bot_id": "B_OWN",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_create_or_update.assert_not_called()

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -541,9 +541,11 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
     if not channel:
         return
 
-    # Skip bot messages to prevent loops
-    if event.get("bot_id") or event.get("subtype") in ("bot_message", "message_changed", "message_deleted"):
+    # Always skip non-message subtypes
+    if event.get("subtype") in ("message_changed", "message_deleted"):
         return
+
+    is_bot = bool(event.get("bot_id") or event.get("subtype") == "bot_message")
 
     slack_user_id = event.get("user")
     text = event.get("text", "")
@@ -560,6 +562,13 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
     message_ts = event.get("ts")
 
     if thread_ts:
+        if is_bot:
+            # Allow other bots' thread replies but skip our own bot to prevent loops
+            client = get_slack_client(team)
+            own_bot_user_id = get_bot_user_id(client) if client else None
+            if own_bot_user_id and slack_user_id == own_bot_user_id:
+                return
+
         # Thread replies should sync even outside a configured channel when a
         # ticket already exists for that thread (e.g. ticket created via @mention).
         if not Ticket.objects.filter(team=team, slack_channel_id=channel, slack_thread_ts=thread_ts).exists():
@@ -578,6 +587,10 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
             is_thread_reply=True,
             slack_team_id=slack_team_id,
         )
+        return
+
+    # Top-level bot messages don't create tickets
+    if is_bot:
         return
 
     if channel not in configured_channels:
@@ -671,6 +684,7 @@ def _backfill_thread_replies(
         thread_reply_count=len(thread_replies),
     )
 
+    own_bot_user_id = get_bot_user_id(client)
     user_cache: dict[str, dict] = {}
     posthog_user_cache: dict[str, User | None] = {}
     comments_to_create: list[Comment] = []
@@ -678,11 +692,14 @@ def _backfill_thread_replies(
     team_message_count = 0
 
     for reply in thread_replies:
-        # Match the bot/subtype filtering from handle_support_message
-        if reply.get("bot_id") or reply.get("subtype") in ("bot_message", "message_changed", "message_deleted"):
+        if reply.get("subtype") in ("message_changed", "message_deleted"):
             continue
 
+        # Skip our own bot's messages to prevent loops, but allow other bots
         reply_user = reply.get("user", "")
+        if own_bot_user_id and reply_user == own_bot_user_id:
+            continue
+
         reply_text = reply.get("text", "")
         reply_blocks = reply.get("blocks")
         reply_files = reply.get("files")

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -564,8 +564,11 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
     if thread_ts:
         if is_bot:
             # Allow other bots' thread replies but skip our own bot to prevent loops
-            client = get_slack_client(team)
-            own_bot_user_id = get_bot_user_id(client) if client else None
+            try:
+                client = get_slack_client(team)
+                own_bot_user_id = get_bot_user_id(client)
+            except Exception:
+                own_bot_user_id = None
             if own_bot_user_id and slack_user_id == own_bot_user_id:
                 return
 


### PR DESCRIPTION
We filter out bots when creating tickets, but we should not filter then out in threads to keep the context.