### PR TITLE
fix(integrations): don't gate public slack channels on installer membership

### DIFF
--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -192,21 +192,28 @@ class TestSlackIntegration:
         mock_webclient_class.return_value = mock_client
 
         mock_client.conversations_info.return_value = {
-            "channel": {"id": "C123", "name": "general", "is_private": False, "is_ext_shared": False, "num_members": 10}
+            "channel": {
+                "id": "C123",
+                "name": "general",
+                "is_private": False,
+                "is_ext_shared": False,
+                "is_member": True,
+                "num_members": 10,
+            }
         }
-
-        mock_client.conversations_members.return_value = {"members": ["test_user_id", "U2", "U3"]}
 
         slack = SlackIntegration(self.integration)
         channel = slack.get_channel_by_id("C123", True, "test_user_id")
 
         mock_client.conversations_info.assert_called_once_with(channel="C123", include_num_members=True)
-        mock_client.conversations_members.assert_called_once_with(channel="C123", limit=11)
+        # Public channels must not be gated on the installer's membership.
+        mock_client.conversations_members.assert_not_called()
 
         assert channel is not None
         assert channel["id"] == "C123"
         assert channel["name"] == "general"
         assert not channel["is_private"]
+        assert channel["is_member"]
         assert not channel["is_private_without_access"]
 
     @patch("posthog.models.integration.WebClient")
@@ -215,22 +222,77 @@ class TestSlackIntegration:
         mock_webclient_class.return_value = mock_client
 
         mock_client.conversations_info.return_value = {
-            "channel": {"id": "C123", "name": "general", "is_private": False, "is_ext_shared": False, "num_members": 10}
+            "channel": {
+                "id": "C123",
+                "name": "general",
+                "is_private": False,
+                "is_ext_shared": False,
+                "is_member": True,
+                "num_members": 10,
+            }
         }
-
-        mock_client.conversations_members.return_value = {"members": ["test_user_id", "U2", "U3"]}
 
         slack = SlackIntegration(self.integration)
         channel = slack.get_channel_by_id("C123", False, "test_user_id")
 
         mock_client.conversations_info.assert_called_once_with(channel="C123", include_num_members=True)
-        mock_client.conversations_members.assert_called_once_with(channel="C123", limit=11)
+        mock_client.conversations_members.assert_not_called()
 
         assert channel is not None
         assert channel["id"] == "C123"
         assert channel["name"] == "general"
         assert not channel["is_private"]
+        assert channel["is_member"]
         assert not channel["is_private_without_access"]
+
+    @patch("posthog.models.integration.WebClient")
+    def test_get_channel_by_id_public_when_installer_not_a_member(self, mock_webclient_class):
+        # Regression: a public channel the bot is in but the installer isn't must still resolve,
+        # otherwise the picker shows "PostHog Slack App is not in this channel" for channels the
+        # bot can post to. Reported for the Slack channel picker in messaging workflows.
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+
+        mock_client.conversations_info.return_value = {
+            "channel": {
+                "id": "C123",
+                "name": "general",
+                "is_private": False,
+                "is_ext_shared": False,
+                "is_member": True,
+                "num_members": 10,
+            }
+        }
+        # The installer is NOT in the channel's member list.
+        mock_client.conversations_members.return_value = {"members": ["U2", "U3"]}
+
+        slack = SlackIntegration(self.integration)
+        channel = slack.get_channel_by_id("C123", False, "test_user_id")
+
+        mock_client.conversations_members.assert_not_called()
+
+        assert channel is not None
+        assert channel["id"] == "C123"
+        assert channel["name"] == "general"
+        assert channel["is_member"]
+        assert not channel["is_private_without_access"]
+
+    @patch("posthog.models.integration.WebClient")
+    def test_get_channel_by_id_private_when_installer_not_a_member(self, mock_webclient_class):
+        # Private channels stay gated on the installer's membership so we don't leak their name.
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+
+        mock_client.conversations_info.return_value = {
+            "channel": {"id": "C123", "name": "secret", "is_private": True, "is_ext_shared": False, "num_members": 10}
+        }
+        mock_client.conversations_members.return_value = {"members": ["U2", "U3"]}
+
+        slack = SlackIntegration(self.integration)
+        channel = slack.get_channel_by_id("C123", True, "test_user_id")
+
+        mock_client.conversations_members.assert_called_once_with(channel="C123", limit=11)
+        assert channel is None
 
     def test_granted_scopes_parses_comma_separated_string(self):
         self.integration.config["scope"] = "chat:write,users:read,users:read.email"

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1171,18 +1171,27 @@ class SlackIntegration:
         try:
             response = self.client.conversations_info(channel=channel_id, include_num_members=True)
             channel = response["channel"]
-            members_response = self.client.conversations_members(channel=channel_id, limit=channel["num_members"] + 1)
-            isMember = authed_user in members_response["members"]
+            is_private = channel["is_private"]
 
-            if not isMember:
-                return None
+            # Only private channels are gated on the installer's membership: surfacing a private
+            # channel they aren't in would leak its name. Public channels are postable by the bot
+            # whether or not the installer happens to be a member, so don't hide them — `is_member`
+            # already reflects *bot* membership, which is what the "app is not in this channel"
+            # warning keys off. Gating public channels here made that warning fire for any channel
+            # the installer wasn't personally in, even though the bot was.
+            if is_private and authed_user is not None:
+                members_response = self.client.conversations_members(
+                    channel=channel_id, limit=channel["num_members"] + 1
+                )
+                if authed_user not in members_response["members"]:
+                    return None
 
-            isPrivateWithoutAccess = channel["is_private"] and not should_include_private_channels
+            isPrivateWithoutAccess = is_private and not should_include_private_channels
 
             return {
                 "id": channel["id"],
                 "name": PRIVATE_CHANNEL_WITHOUT_ACCESS if isPrivateWithoutAccess else channel["name"],
-                "is_private": channel["is_private"],
+                "is_private": is_private,
                 "is_member": channel.get("is_member", True),
                 "is_ext_shared": channel["is_ext_shared"],
                 "is_private_without_access": isPrivateWithoutAccess,


### PR DESCRIPTION
## Problem

Selecting a channel in the Slack channel picker (subscriptions, alerts, and messaging workflows) incorrectly showed:

> The PostHog Slack App is not in this channel. Please add it to the channel otherwise Subscriptions will fail to be delivered.

…even when the PostHog bot was already invited to the channel and messages delivered fine.

Closes #59919

### Root cause

The picker's warning is driven by each channel's `is_member` flag, and a channel that isn't in the list at all reads as "not a member". `SlackIntegration.get_channel_by_id` returned `None` whenever the integration's **installer** (`authed_user`) was not a member of the channel — and it applied that check to **public** channels too:

```python
isMember = authed_user in members_response["members"]
if not isMember:
    return None
```

That installer-membership gate was originally added (#30487) to avoid leaking **private** channels the user can't see. It only became user-visible as a regression once the picker moved to server-side search + pagination (#60267): channels beyond the first page now resolve **only** through this by-id lookup. So a public channel the bot can post to — but that the person who set up the integration isn't personally in (the common case for an alerts/notifications channel) — dropped out of the picker's list, and the warning fired every time.

`is_member` in the returned payload already reflects **bot** membership (from `conversations.info`), which is exactly what the warning should key off.

## Changes

- `get_channel_by_id` now gates the installer-membership check on **private channels only**. Public channels resolve regardless of installer membership, carrying their real `is_member` (bot) value.
- Private-channel behavior is unchanged: a private channel the installer isn't in still returns `None` so its name isn't leaked.
- Bonus: skips a redundant `conversations.members` API call for the common public-channel path.

## How did you test this code?

I'm an agent (PostHog Slack app). I could not run the Django suite in my environment (no DB), so:

- Added/updated automated tests in `posthog/api/test/test_integration.py`:
  - `test_get_channel_by_id_public_when_installer_not_a_member` — regression coverage: public channel, bot is a member, installer is not → resolves with `is_member=True`.
  - `test_get_channel_by_id_private_when_installer_not_a_member` — private channel, installer not a member → still returns `None`.
  - Updated the existing public-channel tests to assert `conversations.members` is no longer called for public channels.
- Verified both changed files byte-compile, and ran a standalone simulation of the new `get_channel_by_id` branch logic across all five public/private × membership combinations.

**Please run `hogli test posthog/api/test/test_integration.py -k get_channel_by_id` before merging.**

## 🤖 Agent context

Authored by the PostHog Slack app while investigating a user-reported regression. The investigation traced the warning from the frontend picker (`SlackIntegrationHelpers.tsx` → `slackIntegrationLogic.isMemberOfSlackChannel`) to the backend `get_channel_by_id`, then through git history to identify the server-side pagination rework (#60267) as what exposed the long-standing over-broad membership gate from #30487.

The fix was deliberately scoped to the backend by-id path; the channel **list** path was already correct (public channels come from `conversations.list`, private from `users.conversations`). An alternative — loosening the frontend banner — was rejected because the backend was returning genuinely wrong data (hiding postable public channels).

Requires human review; not self-merged.
