### PR TITLE
chore(data-warehouse): remove unreleasedSource flag from Slack source

### DIFF
--- a/posthog/temporal/data_imports/sources/slack/source.py
+++ b/posthog/temporal/data_imports/sources/slack/source.py
@@ -83,7 +83,6 @@ class SlackSource(ResumableSource[SlackSourceConfig, SlackResumeConfig], Webhook
             caption="Connect your Slack workspace to sync channels, users, and messages.",
             iconPath="/static/services/slack.png",
             featureFlag="slack-dwh",
-            unreleasedSource=True,
             releaseStatus="alpha",
             fields=cast(
                 list[FieldType],


### PR DESCRIPTION
## Problem

The Slack data warehouse source does not appear in the public sources list on [posthog.com/data-stack/sources](https://posthog.com/data-stack/sources). That page is built from the live `public_source_configs` API, and posthog.com filters out any source where `unreleasedSource` is `true`. The Slack source config sets `unreleasedSource=True`, so it is silently excluded from the website even though the source and its docs exist.

## Changes

Removed `unreleasedSource=True` from the Slack source's `get_source_config` in `posthog/temporal/data_imports/sources/slack/source.py`. Once this ships, the next posthog.com build picks the Slack source up automatically.

The `slack-dwh` feature flag and `releaseStatus="alpha"` are intentionally left in place — those continue to gate in-app availability and signal maturity; only the website-visibility flag is removed.

## How did you test this code?

I'm an agent (PostHog Code). I did not run manual testing. There are no existing tests asserting on `unreleasedSource`/`releaseStatus` for the Slack source (`posthog/temporal/data_imports/sources/slack/`), so no test updates were required. The change is a single-field removal from a config object.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by PostHog Code at a user's request. The user noticed the Slack source was missing from posthog.com/data-stack/sources. I traced the website's source list back through `useSourcePlatforms` → the `allPostHogSource` GraphQL nodes (filtered by `unreleased: { ne: true }`) → the `public_source_configs` API, confirmed the live API returned `unreleasedSource: true` for Slack, and located the flag in this file. The minimal fix is removing that one flag; I deliberately left the feature flag and alpha status untouched since the request was specifically to remove `unreleasedSource`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
