### PR TITLE
fix(slack_app): tag latest thread actor in multiplayer replies

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -1202,6 +1202,15 @@ def forward_posthog_code_followup_activity(
     ):
         return True
 
+    # Record who triggered this turn so async reply paths (agent relays via the
+    # relay API, workflow-driven status updates) tag them instead of the
+    # thread's original mentioner. The thread creator stays in
+    # ``mentioning_slack_user_id``; the live actor lives on
+    # ``latest_actor_slack_user_id``.
+    if slack_user_id != mapping.latest_actor_slack_user_id:
+        mapping.latest_actor_slack_user_id = slack_user_id
+        mapping.save(update_fields=["latest_actor_slack_user_id", "updated_at"])
+
     if task_run.is_terminal:
         return _resume_task_with_new_run(
             mapping,

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -1202,17 +1202,8 @@ def forward_posthog_code_followup_activity(
     ):
         return True
 
-    # Record who triggered this turn so async reply paths (agent relays via the
-    # relay API, workflow-driven status updates) tag them instead of the
-    # thread's original mentioner. The thread creator stays in
-    # ``mentioning_slack_user_id``; the live actor lives on
-    # ``latest_actor_slack_user_id``.
-    #
-    # Edge case (accepted): two concurrent follow-ups can race on this write —
-    # the loser's UPDATE may land second and overwrite the actually-newer
-    # message's actor. Worst case is a wrong @mention on the next bot reply;
-    # if it becomes user-visible, the fix is a monotonic UPDATE keyed on a
-    # ``latest_actor_message_ts`` column using Slack's per-channel ``ts``.
+    # Record the live actor so async reply paths tag them instead of the
+    # thread's original mentioner. Concurrent follow-ups can race here; see PR.
     if slack_user_id != mapping.latest_actor_slack_user_id:
         mapping.latest_actor_slack_user_id = slack_user_id
         mapping.save(update_fields=["latest_actor_slack_user_id", "updated_at"])

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -1207,6 +1207,12 @@ def forward_posthog_code_followup_activity(
     # thread's original mentioner. The thread creator stays in
     # ``mentioning_slack_user_id``; the live actor lives on
     # ``latest_actor_slack_user_id``.
+    #
+    # Edge case (accepted): two concurrent follow-ups can race on this write —
+    # the loser's UPDATE may land second and overwrite the actually-newer
+    # message's actor. Worst case is a wrong @mention on the next bot reply;
+    # if it becomes user-visible, the fix is a monotonic UPDATE keyed on a
+    # ``latest_actor_message_ts`` column using Slack's per-channel ``ts``.
     if slack_user_id != mapping.latest_actor_slack_user_id:
         mapping.latest_actor_slack_user_id = slack_user_id
         mapping.save(update_fields=["latest_actor_slack_user_id", "updated_at"])

--- a/products/slack_app/backend/migrations/0006_slackthreadtaskmapping_latest_actor_slack_user_id.py
+++ b/products/slack_app/backend/migrations/0006_slackthreadtaskmapping_latest_actor_slack_user_id.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("slack_app", "0005_slackchannel"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="slackthreadtaskmapping",
+            name="latest_actor_slack_user_id",
+            field=models.CharField(blank=True, max_length=64, null=True),
+        ),
+    ]

--- a/products/slack_app/backend/migrations/max_migration.txt
+++ b/products/slack_app/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0005_slackchannel
+0006_slackthreadtaskmapping_latest_actor_slack_user_id

--- a/products/slack_app/backend/models.py
+++ b/products/slack_app/backend/models.py
@@ -27,6 +27,7 @@ class SlackThreadTaskMapping(UUIDModel):
         related_name="slack_thread_mappings",
     )
     mentioning_slack_user_id = models.CharField(max_length=64)
+    latest_actor_slack_user_id = models.CharField(max_length=64, null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -214,9 +214,20 @@ class SlackThreadHandler:
 
         self._delete_progress_and_post(header, blocks)
 
-    def post_pr_opened(self, pr_url: str, task_url: str | None) -> None:
-        """Post PR opened message with action buttons."""
-        mention_prefix = f"<@{self.context.mentioning_slack_user_id}> " if self.context.mentioning_slack_user_id else ""
+    def post_pr_opened(
+        self,
+        pr_url: str,
+        task_url: str | None,
+        reply_target_slack_user_id: str | None = None,
+    ) -> None:
+        """Post PR opened message with action buttons.
+
+        ``reply_target_slack_user_id`` is the resolved actor — typically the
+        most recent thread participant, computed by the caller via
+        ``resolve_reply_target_slack_user_id``. ``None`` produces an untagged
+        message.
+        """
+        mention_prefix = f"<@{reply_target_slack_user_id}> " if reply_target_slack_user_id else ""
         header = f"{mention_prefix}Pull request opened."
 
         buttons: list[dict[str, Any]] = [
@@ -386,3 +397,13 @@ class SlackThreadHandler:
             )
         except Exception as e:
             logger.exception("slack_completion_post_failed", error=str(e))
+
+
+def resolve_reply_target_slack_user_id(mapping: Any) -> str | None:
+    """Pick the Slack user id the bot should tag in its next reply.
+
+    Prefers the most recent thread participant
+    (``latest_actor_slack_user_id``), falling back to the thread creator
+    (``mentioning_slack_user_id``) for runs that haven't seen a follow-up yet.
+    """
+    return mapping.latest_actor_slack_user_id or mapping.mentioning_slack_user_id

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -223,9 +223,7 @@ class SlackThreadHandler:
         """Post PR opened message with action buttons.
 
         ``reply_target_slack_user_id`` is the resolved actor — typically the
-        most recent thread participant, computed by the caller via
-        ``resolve_reply_target_slack_user_id``. ``None`` produces an untagged
-        message.
+        most recent thread participant. ``None`` produces an untagged message.
         """
         mention_prefix = f"<@{reply_target_slack_user_id}> " if reply_target_slack_user_id else ""
         header = f"{mention_prefix}Pull request opened."
@@ -397,13 +395,3 @@ class SlackThreadHandler:
             )
         except Exception as e:
             logger.exception("slack_completion_post_failed", error=str(e))
-
-
-def resolve_reply_target_slack_user_id(mapping: Any) -> str | None:
-    """Pick the Slack user id the bot should tag in its next reply.
-
-    Prefers the most recent thread participant
-    (``latest_actor_slack_user_id``), falling back to the thread creator
-    (``mentioning_slack_user_id``) for runs that haven't seen a follow-up yet.
-    """
-    return mapping.latest_actor_slack_user_id or mapping.mentioning_slack_user_id

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -873,7 +873,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
     @patch("posthog.temporal.ai.posthog_code_slack_mention.send_user_message")
     @patch("posthog.temporal.ai.posthog_code_slack_mention.SlackIntegration")
     def test_successful_forwarding(self, mock_slack_cls, mock_send, mock_token):
-        self._create_mapping()
+        mapping = self._create_mapping()
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
         mock_send.return_value = _command_result(
@@ -898,6 +898,14 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance.client.reactions_remove.assert_not_called()
         # Response is delivered by relayAgentResponse from the agent-server, not by this activity.
         mock_slack_instance.client.chat_postMessage.assert_not_called()
+        # The follow-up sender is recorded on the mapping so async reply paths
+        # tag the latest actor instead of the original thread creator
+        # (multiplayer support). The creator (``mentioning_slack_user_id``)
+        # remains immutable; the latest-actor field receives the live actor
+        # even when it's the same person as the creator (one-time seed).
+        mapping.refresh_from_db()
+        assert mapping.latest_actor_slack_user_id == "U_ALICE"
+        assert mapping.mentioning_slack_user_id == "U_ALICE"
 
     @patch("posthog.temporal.ai.posthog_code_slack_mention.create_sandbox_connection_token", return_value="jwt-token")
     @patch("posthog.temporal.ai.posthog_code_slack_mention.send_user_message")

--- a/products/slack_app/backend/tests/test_post_slack_update.py
+++ b/products/slack_app/backend/tests/test_post_slack_update.py
@@ -30,6 +30,13 @@ class TestPostSlackUpdate(TestCase):
         )
         self._access_patcher.start()
         self.addCleanup(self._access_patcher.stop)
+        # The activity reads the reply target from the live mapping; default it
+        # to None so tests that don't care about tagging behavior aren't forced
+        # to set up the model. Tests that do care override the mock locally.
+        self._mapping_patcher = patch("products.slack_app.backend.models.SlackThreadTaskMapping")
+        mock_mapping_class = self._mapping_patcher.start()
+        mock_mapping_class.objects.filter.return_value.first.return_value = None
+        self.addCleanup(self._mapping_patcher.stop)
 
     def _make_mock_run(self, status: str, **kwargs):
         mock_run = MagicMock()
@@ -138,6 +145,7 @@ class TestPostSlackUpdate(TestCase):
         mock_update_reaction.assert_called_once_with("eyes")
         mock_delete_progress.assert_called_once()
 
+    @patch("products.slack_app.backend.models.SlackThreadTaskMapping")
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "post_or_update_progress")
@@ -152,6 +160,7 @@ class TestPostSlackUpdate(TestCase):
         mock_post_progress,
         mock_update_reaction,
         mock_delete_progress,
+        mock_mapping_class,
     ):
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.IN_PROGRESS,
@@ -160,13 +169,18 @@ class TestPostSlackUpdate(TestCase):
             state={},
         )
         mock_task_run_class.objects.select_related.return_value.get.return_value = mock_run
+        # Reply target now resolves from the live mapping, not the workflow context.
+        mock_mapping = MagicMock()
+        mock_mapping.latest_actor_slack_user_id = "U123"
+        mock_mapping.mentioning_slack_user_id = "U_ORIG"
+        mock_mapping_class.objects.filter.return_value.first.return_value = mock_mapping
 
         post_slack_update(
             PostSlackUpdateInput(
                 run_id="run-1",
                 slack_thread_context={
                     **self.slack_thread_context,
-                    "mentioning_slack_user_id": "U123",
+                    "mentioning_slack_user_id": "U_ORIG",
                 },
             )
         )
@@ -174,6 +188,7 @@ class TestPostSlackUpdate(TestCase):
         mock_post_pr_opened.assert_called_once_with(
             "https://github.com/org/repo/pull/1",
             "http://localhost:8000/project/1/tasks/10?runId=run-1",
+            reply_target_slack_user_id="U123",
         )
         mock_update_reaction.assert_called_once_with("eyes")
         mock_delete_progress.assert_called_once()

--- a/products/slack_app/backend/tests/test_post_slack_update.py
+++ b/products/slack_app/backend/tests/test_post_slack_update.py
@@ -30,9 +30,10 @@ class TestPostSlackUpdate(TestCase):
         )
         self._access_patcher.start()
         self.addCleanup(self._access_patcher.stop)
-        # The activity reads the reply target from the live mapping; default it
-        # to None so tests that don't care about tagging behavior aren't forced
-        # to set up the model. Tests that do care override the mock locally.
+        # The PR-opened notification path resolves the reply target from a live
+        # SlackThreadTaskMapping. Default that lookup to "no mapping" so tests
+        # that don't exercise multiplayer tagging aren't forced to seed the
+        # model; tests that care override the mock locally.
         self._mapping_patcher = patch("products.slack_app.backend.models.SlackThreadTaskMapping")
         mock_mapping_class = self._mapping_patcher.start()
         mock_mapping_class.objects.filter.return_value.first.return_value = None

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -268,3 +268,40 @@ class TestSlackThreadHandlerWithoutTaskUrl(TestCase):
 
         mock_client.chat_postMessage.assert_called_once()
         assert _action_blocks(mock_client.chat_postMessage.call_args.kwargs) == []
+
+
+class TestPostPrOpenedReplyTarget(TestCase):
+    """``post_pr_opened`` no longer owns the mention-target decision — the
+    caller resolves the Slack user id and passes it in. The handler just
+    embeds it (or omits the prefix entirely when it's ``None``).
+    """
+
+    def _context(self) -> SlackThreadContext:
+        return SlackThreadContext(integration_id=1, channel="C001", thread_ts="1.0")
+
+    @parameterized.expand(
+        [
+            ("explicit_actor_tags_them", "ULATEST", "<@ULATEST> Pull request opened."),
+            ("none_means_no_tag", None, "Pull request opened."),
+        ]
+    )
+    @patch.object(SlackThreadHandler, "_get_client")
+    def test_post_pr_opened_uses_caller_supplied_target(
+        self,
+        _name: str,
+        reply_target: str | None,
+        expected_text_start: str,
+        mock_get_client,
+    ):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        handler = SlackThreadHandler(self._context())
+
+        handler.post_pr_opened(
+            "https://github.com/org/repo/pull/1",
+            task_url=None,
+            reply_target_slack_user_id=reply_target,
+        )
+
+        kwargs = mock_client.chat_postMessage.call_args.kwargs
+        assert kwargs["text"].startswith(expected_text_start)

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -42,12 +42,7 @@ def _viewer_has_posthog_code_access(viewer: User | None) -> bool:
 @close_db_connections
 def post_slack_update(input: PostSlackUpdateInput) -> None:
     """Post Slack update based on current task run state. Idempotent."""
-    from products.slack_app.backend.models import SlackThreadTaskMapping
-    from products.slack_app.backend.slack_thread import (
-        SlackThreadContext,
-        SlackThreadHandler,
-        resolve_reply_target_slack_user_id,
-    )
+    from products.slack_app.backend.slack_thread import SlackThreadContext, SlackThreadHandler
     from products.tasks.backend.models import TaskRun
 
     try:
@@ -59,12 +54,6 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
     try:
         context = SlackThreadContext.from_dict(input.slack_thread_context)
         handler = SlackThreadHandler(context)
-        # Resolve the reply target from the live mapping rather than the
-        # frozen workflow context — multiplayer follow-ups update the
-        # mapping's ``latest_actor_slack_user_id`` so subsequent bot replies
-        # tag the current actor instead of the thread starter.
-        mapping = SlackThreadTaskMapping.objects.filter(task_run=task_run).first()
-        reply_target_slack_user_id = resolve_reply_target_slack_user_id(mapping) if mapping else None
         creator_has_access = _viewer_has_posthog_code_access(task_run.task.created_by)
         task_url: str | None = (
             f"{settings.SITE_URL}/project/{task_run.task.team_id}/tasks/{task_run.task_id}?runId={task_run.id}"
@@ -109,7 +98,7 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
             handler.post_error(error, task_url)
         else:
             if pr_url:
-                _post_pr_opened_notification_once(task_run, handler, pr_url, task_url, reply_target_slack_user_id)
+                _post_pr_opened_notification_once(task_run, handler, pr_url, task_url)
                 # Task is still running (PR opened mid-run) — keep the :eyes: reaction
                 # so the thread reads as in-progress until it genuinely completes.
                 handler.update_reaction("eyes")
@@ -141,10 +130,20 @@ def _post_pr_opened_notification_once(
     handler,
     pr_url: str,
     task_url: str | None,
-    reply_target_slack_user_id: str | None,
 ) -> None:
     if _is_pr_opened_notified(task_run, pr_url):
         return
+
+    # Resolve the reply target from the live mapping at the moment we actually
+    # post — multiplayer follow-ups update ``latest_actor_slack_user_id`` so
+    # the PR notification tags the current actor instead of the thread starter.
+    # Deferred here (not in the activity's hot path) because the mapping is
+    # only needed when we're about to post a fresh PR-opened message.
+    from products.slack_app.backend.models import SlackThreadTaskMapping
+    from products.slack_app.backend.slack_thread import resolve_reply_target_slack_user_id
+
+    mapping = SlackThreadTaskMapping.objects.filter(task_run=task_run).first()
+    reply_target_slack_user_id = resolve_reply_target_slack_user_id(mapping) if mapping else None
 
     handler.post_pr_opened(pr_url, task_url, reply_target_slack_user_id=reply_target_slack_user_id)
 

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -9,6 +9,7 @@ from posthog.models.user import User
 from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.utils import close_db_connections
 
+from products.slack_app.backend.models import SlackThreadTaskMapping
 from products.tasks.backend.access import has_tasks_access
 
 logger = get_logger(__name__)
@@ -134,16 +135,12 @@ def _post_pr_opened_notification_once(
     if _is_pr_opened_notified(task_run, pr_url):
         return
 
-    # Resolve the reply target from the live mapping at the moment we actually
-    # post — multiplayer follow-ups update ``latest_actor_slack_user_id`` so
-    # the PR notification tags the current actor instead of the thread starter.
-    # Deferred here (not in the activity's hot path) because the mapping is
-    # only needed when we're about to post a fresh PR-opened message.
-    from products.slack_app.backend.models import SlackThreadTaskMapping
-    from products.slack_app.backend.slack_thread import resolve_reply_target_slack_user_id
-
+    # Resolve the reply target from the live mapping so the PR notification
+    # tags the current actor instead of the thread starter.
     mapping = SlackThreadTaskMapping.objects.filter(task_run=task_run).first()
-    reply_target_slack_user_id = resolve_reply_target_slack_user_id(mapping) if mapping else None
+    reply_target_slack_user_id = (
+        (mapping.latest_actor_slack_user_id or mapping.mentioning_slack_user_id) if mapping else None
+    )
 
     handler.post_pr_opened(pr_url, task_url, reply_target_slack_user_id=reply_target_slack_user_id)
 

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -9,7 +9,6 @@ from posthog.models.user import User
 from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.utils import close_db_connections
 
-from products.slack_app.backend.models import SlackThreadTaskMapping
 from products.tasks.backend.access import has_tasks_access
 
 logger = get_logger(__name__)
@@ -132,6 +131,8 @@ def _post_pr_opened_notification_once(
     pr_url: str,
     task_url: str | None,
 ) -> None:
+    from products.slack_app.backend.models import SlackThreadTaskMapping
+
     if _is_pr_opened_notified(task_run, pr_url):
         return
 

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -42,7 +42,12 @@ def _viewer_has_posthog_code_access(viewer: User | None) -> bool:
 @close_db_connections
 def post_slack_update(input: PostSlackUpdateInput) -> None:
     """Post Slack update based on current task run state. Idempotent."""
-    from products.slack_app.backend.slack_thread import SlackThreadContext, SlackThreadHandler
+    from products.slack_app.backend.models import SlackThreadTaskMapping
+    from products.slack_app.backend.slack_thread import (
+        SlackThreadContext,
+        SlackThreadHandler,
+        resolve_reply_target_slack_user_id,
+    )
     from products.tasks.backend.models import TaskRun
 
     try:
@@ -54,6 +59,12 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
     try:
         context = SlackThreadContext.from_dict(input.slack_thread_context)
         handler = SlackThreadHandler(context)
+        # Resolve the reply target from the live mapping rather than the
+        # frozen workflow context — multiplayer follow-ups update the
+        # mapping's ``latest_actor_slack_user_id`` so subsequent bot replies
+        # tag the current actor instead of the thread starter.
+        mapping = SlackThreadTaskMapping.objects.filter(task_run=task_run).first()
+        reply_target_slack_user_id = resolve_reply_target_slack_user_id(mapping) if mapping else None
         creator_has_access = _viewer_has_posthog_code_access(task_run.task.created_by)
         task_url: str | None = (
             f"{settings.SITE_URL}/project/{task_run.task.team_id}/tasks/{task_run.task_id}?runId={task_run.id}"
@@ -98,7 +109,7 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
             handler.post_error(error, task_url)
         else:
             if pr_url:
-                _post_pr_opened_notification_once(task_run, handler, pr_url, task_url)
+                _post_pr_opened_notification_once(task_run, handler, pr_url, task_url, reply_target_slack_user_id)
                 # Task is still running (PR opened mid-run) — keep the :eyes: reaction
                 # so the thread reads as in-progress until it genuinely completes.
                 handler.update_reaction("eyes")
@@ -125,11 +136,17 @@ def _get_stage_from_status(status: str, stage: str | None = None) -> str:
     return status_map.get(status, "In progress...")
 
 
-def _post_pr_opened_notification_once(task_run, handler, pr_url: str, task_url: str | None) -> None:
+def _post_pr_opened_notification_once(
+    task_run,
+    handler,
+    pr_url: str,
+    task_url: str | None,
+    reply_target_slack_user_id: str | None,
+) -> None:
     if _is_pr_opened_notified(task_run, pr_url):
         return
 
-    handler.post_pr_opened(pr_url, task_url)
+    handler.post_pr_opened(pr_url, task_url, reply_target_slack_user_id=reply_target_slack_user_id)
 
     _mark_pr_opened_notified(task_run, pr_url)
 

--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -261,11 +261,7 @@ class RelaySlackMessageInput:
 @close_db_connections
 def relay_slack_message(input: RelaySlackMessageInput) -> None:
     from products.slack_app.backend.models import SlackThreadTaskMapping
-    from products.slack_app.backend.slack_thread import (
-        SlackThreadContext,
-        SlackThreadHandler,
-        resolve_reply_target_slack_user_id,
-    )
+    from products.slack_app.backend.slack_thread import SlackThreadContext, SlackThreadHandler
     from products.tasks.backend.models import TaskRun
 
     try:
@@ -305,7 +301,7 @@ def relay_slack_message(input: RelaySlackMessageInput) -> None:
     )
     handler = SlackThreadHandler(context)
 
-    target = resolve_reply_target_slack_user_id(mapping)
+    target = mapping.latest_actor_slack_user_id or mapping.mentioning_slack_user_id
     mention_prefix = f"<@{target}> " if target else ""
     if input.delete_progress:
         handler.delete_progress()

--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -261,7 +261,11 @@ class RelaySlackMessageInput:
 @close_db_connections
 def relay_slack_message(input: RelaySlackMessageInput) -> None:
     from products.slack_app.backend.models import SlackThreadTaskMapping
-    from products.slack_app.backend.slack_thread import SlackThreadContext, SlackThreadHandler
+    from products.slack_app.backend.slack_thread import (
+        SlackThreadContext,
+        SlackThreadHandler,
+        resolve_reply_target_slack_user_id,
+    )
     from products.tasks.backend.models import TaskRun
 
     try:
@@ -301,7 +305,8 @@ def relay_slack_message(input: RelaySlackMessageInput) -> None:
     )
     handler = SlackThreadHandler(context)
 
-    mention_prefix = f"<@{mapping.mentioning_slack_user_id}> " if mapping.mentioning_slack_user_id else ""
+    target = resolve_reply_target_slack_user_id(mapping)
+    mention_prefix = f"<@{target}> " if target else ""
     if input.delete_progress:
         handler.delete_progress()
     for index, chunk in enumerate(chunks):

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -108,6 +108,41 @@ class TestRelaySlackMessage(TestCase):
         self.task_run.refresh_from_db()
         assert relay_id in self.task_run.state.get("slack_sent_relay_ids", [])
 
+    @parameterized.expand(
+        [
+            # ``mentioning_slack_user_id`` is the immutable thread creator;
+            # ``latest_actor_slack_user_id`` is set by the follow-up handler
+            # when someone else (or the creator themselves) replies. The bot
+            # tags the latest actor when present, otherwise the creator.
+            ("no_actor_falls_back_to_mentioner", None, "<@U123> "),
+            ("actor_overrides_mentioner", "UBOB", "<@UBOB> "),
+        ]
+    )
+    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.update_reaction")
+    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.post_thread_message")
+    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.delete_progress")
+    def test_mention_prefix_uses_latest_actor_then_mentioner(
+        self,
+        _name,
+        latest_actor,
+        expected_prefix,
+        _mock_delete_progress,
+        mock_post,
+        _mock_update,
+    ):
+        SlackThreadTaskMapping.objects.filter(task_run=self.task_run).update(latest_actor_slack_user_id=latest_actor)
+
+        relay_slack_message(
+            RelaySlackMessageInput(
+                run_id=str(self.task_run.id),
+                relay_id=f"relay-mention-{_name}",
+                text="agent reply",
+            )
+        )
+
+        mock_post.assert_called_once()
+        assert mock_post.call_args.args[0].startswith(expected_prefix)
+
 
 class TestMarkdownToSlackMrkdwn(unittest.TestCase):
     @parameterized.expand(


### PR DESCRIPTION
## Problem

In a multiplayer Slack thread, the bot's replies (the agent's responses and the *Pull request opened* notification) tagged the user who started the thread instead of the person who actually sent the latest message.

## Changes

New nullable column `latest_actor_slack_user_id` on `SlackThreadTaskMapping`. The follow-up handler writes it on every inbound message; reply paths read the live mapping and tag the latest actor, falling back to the immutable `mentioning_slack_user_id` (thread creator) when nobody else has spoken yet.

Accepted edge case: two near-simultaneous follow-ups can race on the write, so the wrong @mention can land on the next bot reply. Annotated inline; the fix (monotonic UPDATE keyed on Slack `ts`) is straightforward to bolt on if it ever surfaces in practice.

## How did you test this code?

Tested locally — followed up in a multiplayer Slack thread and confirmed the bot tags the most-recent participant. Automated coverage updated in `test_followup_forwarding`, `test_post_slack_update`, `test_slack_thread`, and the slack_relay parameterized tests; full suite green.

## Showcase

<img width="491" height="980" alt="Screenshot 2026-06-09 at 14 05 33" src="https://github.com/user-attachments/assets/c000b600-d55f-4feb-b645-4c1d2f5d35dc" />


## 🤖 Agent context

Claude Opus 4.7.