### PR TITLE
fix(insights): only cap dashboard bar rows on tiles, not the insight page

### DIFF
--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -112,7 +112,7 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
         }
         if (display === ChartDisplayType.ActionsBar || display === ChartDisplayType.ActionsUnstackedBar) {
             if (hogChartsTrendsEnabled) {
-                return <TrendsBarChart context={context} inSharedMode={inSharedMode} />
+                return <TrendsBarChart context={context} inSharedMode={inSharedMode} embedded={embedded} />
             }
             if (hogChartsStickinessEnabled) {
                 return <StickinessBarChart context={context} />
@@ -143,7 +143,7 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
         }
         if (display === ChartDisplayType.ActionsBarValue) {
             if (hogChartsTrendsEnabled) {
-                return <TrendsBarChart context={context} inSharedMode={inSharedMode} />
+                return <TrendsBarChart context={context} inSharedMode={inSharedMode} embedded={embedded} />
             }
             return <ActionsHorizontalBar {...commonProps} />
         }

--- a/frontend/src/test/insight-testing/render-insight.tsx
+++ b/frontend/src/test/insight-testing/render-insight.tsx
@@ -86,6 +86,8 @@ export interface RenderInsightProps {
     featureFlags?: Record<string, string | boolean>
     context?: QueryContext<InsightVizNode>
     inSharedMode?: boolean
+    /** Render as a fixed-height dashboard/card tile rather than the full insight page. */
+    embedded?: boolean
 }
 
 function InsightWrapper({
@@ -93,11 +95,13 @@ function InsightWrapper({
     showFilters = false,
     context,
     inSharedMode,
+    embedded,
 }: {
     query: InsightQuery
     showFilters: boolean
     context?: QueryContext<InsightVizNode>
     inSharedMode?: boolean
+    embedded?: boolean
 }): JSX.Element {
     const [vizQuery, setVizQuery] = useState<InsightVizNode>({
         kind: NodeKind.InsightVizNode,
@@ -119,6 +123,7 @@ function InsightWrapper({
             setQuery={setVizQuery}
             context={context}
             inSharedMode={inSharedMode}
+            embedded={embedded}
         />
     )
 }
@@ -132,6 +137,7 @@ export function renderInsight(props: RenderInsightProps = {}): ReturnType<typeof
             showFilters={props.showFilters ?? true}
             context={props.context}
             inSharedMode={props.inSharedMode}
+            embedded={props.embedded}
         />
     )
 }

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
@@ -345,6 +345,57 @@ describe('TrendsBarChart (ActionsBarValue)', () => {
         )
     })
 
+    // A dashboard/card tile is a fixed height, so the chart caps the breakdown rows to those that
+    // fit. The full insight page is `embedded: false` — even when opened from a dashboard, where
+    // `dashboardId` is in the URL — so it must keep growing to render every breakdown row.
+    it.each([
+        { name: 'insight page (not embedded) renders every breakdown bar', embedded: false, expectAllRows: true },
+        {
+            name: 'dashboard tile (embedded) caps bars to those that fit the tile',
+            embedded: true,
+            expectAllRows: false,
+        },
+    ])('$name', async ({ embedded, expectAllRows }) => {
+        const totalRows = 20
+        const manyBreakdowns = {
+            results: Array.from({ length: totalRows }, (_, i) => ({
+                action: { id: '$napped', type: 'events', name: 'Napped', order: 0 },
+                label: `value ${i}`,
+                count: totalRows - i,
+                aggregated_value: totalRows - i,
+                data: [totalRows - i],
+                labels: ['Day 1'],
+                days: ['2024-01-01'],
+                breakdown_value: `value-${i}`,
+            })),
+        }
+        renderInsight({
+            query: aggregatedBar({
+                series: [{ kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' }],
+                breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
+            }),
+            embedded,
+            featureFlags: HOG_CHARTS_FLAG,
+            mocks: {
+                additionalMockResponses: [{ match: (q) => q.kind === NodeKind.TrendsQuery, response: manyBreakdowns }],
+            },
+        })
+        await screen.findByRole('img', { name: /chart with/i }, { timeout: 5000 })
+
+        await waitFor(
+            () => {
+                const ticks = getHogChart().yTicks()
+                if (expectAllRows) {
+                    expect(ticks).toHaveLength(totalRows)
+                } else {
+                    expect(ticks.length).toBeGreaterThan(0)
+                    expect(ticks.length).toBeLessThan(totalRows)
+                }
+            },
+            { timeout: 5000 }
+        )
+    })
+
     it('omits the header from the tooltip', async () => {
         renderInsight({
             query: aggregatedBar(),

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -50,6 +50,8 @@ import {
 interface TrendsBarChartProps {
     context?: QueryContext<InsightVizNode>
     inSharedMode?: boolean
+    /** True when rendered as a fixed-height dashboard/card tile, false on the full insight page. */
+    embedded?: boolean
 }
 
 const EMPTY_LABELS: string[] = []
@@ -77,7 +79,11 @@ const resolveGroupTypeLabel = (
 
 const handleChartError = makeChartErrorHandler('trends-bar-chart')
 
-export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChartProps): JSX.Element | null {
+export function TrendsBarChart({
+    context,
+    inSharedMode = false,
+    embedded = false,
+}: TrendsBarChartProps): JSX.Element | null {
     const theme = useMemo(() => buildTheme(), [])
     const { insightProps, insight } = useValues(insightLogic)
 
@@ -242,8 +248,10 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
             // Breakdown values become category (y-axis) labels here; truncate long ones (e.g. URLs)
             // so they don't grow the margin and push the plot off screen. Full value shows on hover.
             maxCategoryLabelWidth: MAX_CATEGORY_LABEL_WIDTH,
-            // Always render every breakdown row — grow the chart and let the tile scroll rather than
-            // dropping rows. This keeps dashboard tiles consistent with the full insight view.
+            // Dashboard/card tiles are a fixed height, so cap the rows to those that fit. The full
+            // insight page is `embedded: false` — even when opened from a dashboard (dashboardId in
+            // the URL) — so it keeps the grow-to-fit-all behavior and renders every breakdown row.
+            bars: { fitToHeight: embedded },
         }
     }, [
         yAxisScaleType,
@@ -252,6 +260,7 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
         trendsFilter?.yAxisLabel,
         displayLabels,
         labels,
+        embedded,
     ])
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -79,7 +79,7 @@ const handleChartError = makeChartErrorHandler('trends-bar-chart')
 
 export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChartProps): JSX.Element | null {
     const theme = useMemo(() => buildTheme(), [])
-    const { insightProps, insight, isInDashboardContext } = useValues(insightLogic)
+    const { insightProps, insight } = useValues(insightLogic)
 
     const {
         indexedResults,
@@ -242,9 +242,8 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
             // Breakdown values become category (y-axis) labels here; truncate long ones (e.g. URLs)
             // so they don't grow the margin and push the plot off screen. Full value shows on hover.
             maxCategoryLabelWidth: MAX_CATEGORY_LABEL_WIDTH,
-            // On a dashboard the tile is a fixed height: fit the rows that fit instead of growing
-            // the tile and scrolling. On the full insight page, keep the grow-to-fit-all behavior.
-            bars: { fitToHeight: isInDashboardContext },
+            // Always render every breakdown row — grow the chart and let the tile scroll rather than
+            // dropping rows. This keeps dashboard tiles consistent with the full insight view.
         }
     }, [
         yAxisScaleType,
@@ -253,7 +252,6 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
         trendsFilter?.yAxisLabel,
         displayLabels,
         labels,
-        isInDashboardContext,
     ])
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal


### PR DESCRIPTION
## Problem

A trends horizontal aggregated bar chart (the breakdown "bar value" display) with the `product-analytics-hog-charts-trends` flag on was silently capping the number of visible bars to roughly whatever fit the tile height — users reported seeing far fewer bars than their breakdown had values.

The cap itself (`fitToHeight`) is correct **on a dashboard tile**, which is a fixed height. The bug was the gate: it keyed off `isInDashboardContext`, which is just `!!insightProps.dashboardId`. That flag is **also true on the full insight page when the insight is opened from a dashboard** (the URL carries `dashboardId` so dashboard-level overrides apply). So the insight page — which can grow freely — was being treated like a fixed-height tile and dropping the tail of the breakdown. This is why the reporter couldn't reproduce locally (opening the insight directly, no `dashboardId`) but hit it in product (clicking through from a dashboard).

## Changes

Gate `fitToHeight` on `embedded` instead of `isInDashboardContext`.

`embedded` is the signal that the insight is rendered as a fixed-height dashboard/card tile — it's set by `InsightCard` and flows `InsightCard → Query → InsightViz → InsightVizDisplay → TrendInsight`. The full insight page (`InsightAsScene`) renders with `embedded: false` regardless of whether `dashboardId` is present.

Result:

| Surface | `dashboardId` | `embedded` | Behaviour |
| --- | --- | --- | --- |
| Dashboard tile | set | `true` | cap rows to those that fit (unchanged) |
| Insight page (opened from a dashboard) | set | `false` | **grow to show every breakdown row** |
| Insight page (opened directly) | absent | `false` | grow to show every breakdown row |

`embedded` is threaded from `Trends.tsx` into `TrendsBarChart`. The `renderInsight` test helper gains `embedded` support, and a parameterized test covers both paths.

## How did you test this code?

I'm an agent — automated tests only, no manual/visual testing.

- Added a parameterized test in `TrendsBarChart.test.tsx` that injects 20 breakdown values (test `plotHeight ≈ 340px`, so the `~24px`/row cap truncates): the non-embedded case renders all 20 bands, the embedded case renders fewer. Both pass and the embedded assertion (`< 20`) proves the cap actually fires.
- Full `TrendsBarChart.test.tsx` suite: 29/29 passing.
- The `fitToHeight` truncation mechanism itself is already unit-tested in the charts package (`core/scales.test.ts`).
- Type-checked the changed source files in isolation (clean; the only reported error is pre-existing unrelated narrowed-program noise).

A reviewer should sanity-check visually: a high-cardinality breakdown bar-value insight should cap bars on a dashboard tile but show all of them on the insight page (including when opened from that dashboard).

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) for the human author, who diagnosed the symptom (bars capped on a chart opened from a dashboard; resolved by disabling the hog-charts-trends flag) and clarified the desired behaviour: keep the cap on real dashboard tiles, but never cap the full insight page.

An earlier iteration of this branch removed `fitToHeight` outright; that was wrong because it also dropped the cap on genuine dashboard tiles. The final approach keys off `embedded` — the existing "rendered as a fixed-height card" signal — which distinguishes a tile from the insight page where `isInDashboardContext` (`!!dashboardId`) cannot. `isInDashboardContext` is no longer used by this component.
