### PR TITLE
fix(ingestion): retry transient persons-Postgres failures in batch steps

### DIFF
--- a/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
@@ -96,10 +96,18 @@ export function createPostTeamPreprocessingSubpipeline<TInput extends PostTeamPr
             .pipeBatch(createOnlyCookielessRateLimitToOverflowStep(preservePartitionLocality, overflowRedirectService))
             // Refresh TTLs for overflow lane events (keeps Redis flags alive)
             .pipeBatch(createOverflowLaneTTLRefreshStep(overflowLaneTTLRefreshService))
-            // Prefetch must run after cookieless, as cookieless changes distinct IDs
-            .pipeBatch(prefetchPersonsStep(personsStore, personsPrefetchEnabled))
+            // Prefetch must run after cookieless, as cookieless changes distinct IDs.
+            // Retry transient persons-Postgres failures (e.g. PgBouncer scale-down) instead
+            // of letting them crash the consumer loop.
+            .pipeBatchWithRetry(prefetchPersonsStep(personsStore, personsPrefetchEnabled), {
+                tries: 3,
+                sleepMs: 100,
+            })
             // Batch insert personless distinct IDs after prefetch (uses prefetch cache)
-            .pipeBatch(processPersonlessDistinctIdsBatchStep(personsStore, personsPrefetchEnabled))
+            .pipeBatchWithRetry(processPersonlessDistinctIdsBatchStep(personsStore, personsPrefetchEnabled), {
+                tries: 3,
+                sleepMs: 100,
+            })
             // Prefetch hog functions for all teams in the batch
             .pipeBatch(createPrefetchHogFunctionsStep(hogTransformer, cdpHogWatcherSampleRate))
     )


### PR DESCRIPTION
## Problem

When PgBouncer in front of the persons Postgres scales down, in-flight connections are refused (`ECONNREFUSED … :6543`). Two batch steps in the analytics ingestion pipeline — `prefetchPersonsStep` and `processPersonlessDistinctIdsBatchStep` — talk to persons-Postgres through a plain `.pipeBatch(...)` with **no retry coverage**. The resulting `DependencyUnavailableError` (which is flagged retriable) propagates uncaught through `eachBatch` and the consumer loop, which is intentionally fail-fast, so the worker pod crashes and restarts.

These steps run *before* the per-distinct-id pipeline, which is the only part of the flow wrapped in retry logic (`builder.retry`). So the existing retry never gets a chance to absorb the blip — the crash happens earlier, in the unwrapped batch steps.

The connection error itself is transient: a fresh connection re-resolves DNS and lands on a surviving PgBouncer. The pods crash only because the retry window was effectively zero for these steps.

## Changes

Wrap both Postgres-touching batch steps with `pipeBatchWithRetry`, using the same retry strategy already used by the per-distinct-id pipeline (`tries: 3`, `sleepMs: 100`, exponential backoff). Each retry acquires a fresh pool connection, so it naturally reconnects through a healthy PgBouncer instead of crashing the consumer loop.

Both steps are safe to retry:

- `prefetchPersonsStep` → `fetchPersonsByDistinctIds` is a pure `SELECT`.
- `processPersonlessDistinctIdsBatchStep` → `addPersonlessDistinctIdsBatch` is a single-statement `INSERT … ON CONFLICT (team_id, distinct_id) DO UPDATE` (unique-key UPSERT) run outside any caller-held transaction. Retries cannot duplicate rows or corrupt data; `created_at` is preserved on conflict and `RETURNING` stays accurate. The step's LRU cache write happens only after a successful await, so a failed attempt does not poison the cache.

Non-retriable errors still go to the DLQ via the existing `withBatchRetry` behavior, and genuinely unexpected errors still surface loudly.

## How did you test this code?

I'm an agent. I ran the automated checks locally — `pnpm build` (TypeScript compile) and `pnpm lint` (eslint) in `nodejs/`, both pass. No new tests were added; this change reuses the existing, already-tested `pipeBatchWithRetry` / `withBatchRetry` path and only changes pipeline composition.

## 🤖 Agent context

Authored with Claude Code at the request of the human author. Investigation started from a 15-minute production log export showing ingestion-analytics pod crashes. Traced the crash from the `ECONNREFUSED :6543` stack frames to the two unwrapped batch steps in `post-team-preprocessing-subpipeline.ts`, rather than the retry-wrapped per-distinct-id pipeline that was the initial suspect.

Decisions:
- Chose to wrap the two specific batch steps with the existing `pipeBatchWithRetry` rather than adding retry at the Postgres-primitive or repository layer. Considered the lower layers (they would cover all callers uniformly), but went with the targeted, lowest-risk change that matches the strategy already used elsewhere in the pipeline. The broader layering question is noted for a possible follow-up.
- Verified idempotency of the write step's SQL before enabling retry, to rule out data duplication.
