### PR TITLE
chore(modeling): update management command to handle revenue analytics

### DIFF
--- a/products/data_modeling/backend/api/dag.py
+++ b/products/data_modeling/backend/api/dag.py
@@ -5,7 +5,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
-from products.data_modeling.backend.models import DAG
+from products.data_modeling.backend.models import DAG, REVENUE_ANALYTICS_DAG_NAME
 from products.warehouse_sources.backend.models.external_data_schema import (
     sync_frequency_interval_to_sync_frequency,
     sync_frequency_to_sync_frequency_interval,
@@ -56,8 +56,8 @@ class DAGSerializer(serializers.ModelSerializer):
         return value
 
     def validate_name(self, value: str) -> str:
-        if self.instance is not None and self.instance.is_default and value != self.instance.name:
-            raise serializers.ValidationError("The default DAG cannot be renamed.")
+        if self.instance is not None and self.instance.is_reserved and value != self.instance.name:
+            raise serializers.ValidationError(f"The {self.instance.name} DAG cannot be renamed.")
         return value
 
     def create(self, validated_data: dict) -> DAG:
@@ -84,6 +84,10 @@ class DAGViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return queryset.filter(team_id=self.team_id).annotate(node_count=Count("node")).order_by("name")
 
     def perform_destroy(self, instance: DAG) -> None:
-        if instance.is_default:
-            raise ValidationError("The default DAG cannot be deleted.")
+        if instance.name == REVENUE_ANALYTICS_DAG_NAME:
+            raise ValidationError(
+                "The Revenue Analytics DAG cannot be deleted. You must disable revenue analytics to remove this DAG."
+            )
+        if instance.is_reserved:
+            raise ValidationError(f"The {instance.name} DAG cannot be deleted.")
         instance.delete()

--- a/products/data_modeling/backend/api/test/test_dag_api.py
+++ b/products/data_modeling/backend/api/test/test_dag_api.py
@@ -2,7 +2,7 @@ from posthog.test.base import APIBaseTest
 
 from rest_framework import status
 
-from products.data_modeling.backend.models import DAG, Node, NodeType
+from products.data_modeling.backend.models import DAG, REVENUE_ANALYTICS_DAG_NAME, Node, NodeType
 
 
 class TestDAGViewSet(APIBaseTest):
@@ -77,6 +77,27 @@ class TestDAGViewSet(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         dag.refresh_from_db()
         self.assertEqual(dag.name, "Default")
+
+    def test_cannot_delete_revenue_analytics_dag(self):
+        dag = DAG.get_or_create_revenue_analytics(self.team)
+
+        response = self.client.delete(f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("disable revenue analytics", response.json()["detail"].lower())
+        self.assertTrue(DAG.objects.filter(team=self.team, id=dag.id).exists())
+
+    def test_cannot_rename_revenue_analytics_dag(self):
+        dag = DAG.get_or_create_revenue_analytics(self.team)
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/",
+            {"name": "renamed"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        dag.refresh_from_db()
+        self.assertEqual(dag.name, REVENUE_ANALYTICS_DAG_NAME)
 
     def test_node_count_reflects_nodes(self):
         dag = DAG.objects.create(team=self.team, name="my_dag")

--- a/products/data_modeling/backend/management/commands/migrate_teams_to_dag_schedules.py
+++ b/products/data_modeling/backend/management/commands/migrate_teams_to_dag_schedules.py
@@ -17,22 +17,37 @@ from temporalio.client import (
 )
 from temporalio.common import RetryPolicy, SearchAttributePair, TypedSearchAttributes
 
+from posthog.models import Team
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import create_schedule, delete_schedule, schedule_exists
-from posthog.temporal.common.search_attributes import POSTHOG_DAG_ID_KEY, POSTHOG_ORG_ID_KEY, POSTHOG_TEAM_ID_KEY
+from posthog.temporal.common.search_attributes import (
+    POSTHOG_DAG_ID_KEY,
+    POSTHOG_ORG_ID_KEY,
+    POSTHOG_SCHEDULE_TYPE_KEY,
+    POSTHOG_TEAM_ID_KEY,
+)
 from posthog.temporal.data_modeling.workflows.execute_dag import ExecuteDAGInputs
 
-from products.data_modeling.backend.models import DAG, Node
+from products.data_modeling.backend.models import DAG, DEFAULT_DAG_NAME, REVENUE_ANALYTICS_DAG_NAME, Node
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_modeling.backend.schedule import build_schedule_spec
+from products.data_modeling.backend.services.saved_query_dag_sync import sync_saved_query_to_dag
 
 logger = structlog.get_logger(__name__)
 
 BATCH_DELAY_SECONDS = 0.5
 
+# Tags the revenue analytics v2 schedule via the PostHogScheduleType search attribute so it can
+# be found without scanning every schedule. Matches DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS.
+REVENUE_ANALYTICS_SCHEDULE_TYPE = "revenue_analytics"
+
 
 class Command(BaseCommand):
-    help = "Migrate teams from per-node v1 schedules to a single per-DAG v2 schedule"
+    help = (
+        "Migrate teams from per-saved-query v1 schedules to per-DAG v2 schedules. "
+        "Revenue analytics managed-viewset views are routed into a dedicated, protected "
+        "'Revenue Analytics' DAG with its own schedule; everything else stays on the Default DAG."
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -42,6 +57,12 @@ class Command(BaseCommand):
             help="Comma separated list of team IDs to migrate",
         )
         parser.add_argument(
+            "--start-after-team-id",
+            default=None,
+            type=int,
+            help="Resume after this team ID (exclusive), following the team_id ordering used by this command",
+        )
+        parser.add_argument(
             "--dry-run",
             action="store_true",
             default=False,
@@ -49,63 +70,86 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        dags = DAG.objects.select_related("team")
-        if options.get("team_ids") is not None:
-            try:
-                team_ids = [int(tid) for tid in options["team_ids"].split(",")]
-            except ValueError:
-                raise CommandError("team_ids must be a comma separated list of team IDs")
-            dags = dags.filter(team_id__in=team_ids)
-        dags = dags.order_by("team_id")
-        total = dags.count()
+        team_ids = self._get_team_ids(options)
+        total = len(team_ids)
         if total == 0:
-            raise CommandError("No DAGs found matching filters")
-        logger.info(f"Found {total} DAG(s) to process")
+            raise CommandError("No teams with scheduled saved queries found matching filters")
+
+        logger.info(f"Found {total} team(s) to process")
         if not options["dry_run"] and not settings.TEST:
-            confirm = input(f"\n\tWill migrate {total} DAGs to v2 schedules. Proceed? (y/n) ")
+            confirm = input(f"\n\tWill migrate {total} teams to v2 schedules. Proceed? (y/n) ")
             if confirm.strip().lower() != "y":
                 logger.info("Aborting")
                 return
+
+        teams_by_id = {team.id: team for team in Team.objects.filter(id__in=team_ids)}
         migrated = 0
         skipped = 0
         failed = 0
-        for i, dag in enumerate(dags.iterator()):
+        for i, team_id in enumerate(team_ids):
+            team = teams_by_id.get(team_id)
+            if team is None:
+                continue
             try:
-                result = self._migrate_dag(dag, dry_run=options["dry_run"])
-                if result:
+                if self._migrate_team(team, dry_run=options["dry_run"]):
                     migrated += 1
                 else:
                     skipped += 1
             except Exception:
                 failed += 1
-                logger.exception("Failed to migrate DAG", dag_id=str(dag.id), team_id=dag.team_id)
+                logger.exception("Failed to migrate team", team_id=team_id)
             logger.info(f"Progress: {i + 1}/{total} (migrated={migrated}, skipped={skipped}, failed={failed})")
             if not options["dry_run"]:
                 time.sleep(BATCH_DELAY_SECONDS)
+
         if options["dry_run"]:
             logger.info(f"Dry run complete. Would migrate: {migrated}, Would skip: {skipped}")
         else:
             logger.info(f"Done! Migrated: {migrated}, Skipped: {skipped}, Failed: {failed}")
 
-    def _migrate_dag(self, dag: DAG, *, dry_run: bool) -> bool:
-        """Migrate a single DAG to a v2 schedule.
+    def _get_team_ids(self, options) -> list[int]:
+        team_ids_qs = (
+            DataWarehouseSavedQuery.objects.filter(sync_frequency_interval__isnull=False, deleted=False)
+            .values_list("team_id", flat=True)
+            .distinct()
+        )
+        if options.get("team_ids") is not None:
+            try:
+                team_id_filter = [int(tid) for tid in options["team_ids"].split(",")]
+            except ValueError:
+                raise CommandError("team_ids must be a comma separated list of team IDs")
+            team_ids_qs = team_ids_qs.filter(team_id__in=team_id_filter)
+        if options.get("start_after_team_id") is not None:
+            team_ids_qs = team_ids_qs.filter(team_id__gt=options["start_after_team_id"])
+        return sorted(team_ids_qs)
 
-        Returns True if migrated, False if skipped.
-        """
+    def _migrate_team(self, team: Team, *, dry_run: bool) -> bool:
+        """Migrate a single team's schedules. Returns True if anything was migrated."""
+        did_something = False
+        # Non-managed models keep the existing per-DAG flow (one v2 schedule per Default DAG).
+        for dag in DAG.objects.filter(team=team).exclude(name=REVENUE_ANALYTICS_DAG_NAME).select_related("team"):
+            if self._migrate_dag(dag, dry_run=dry_run):
+                did_something = True
+        # Revenue analytics managed-viewset views get their own dedicated DAG and schedule.
+        if self._migrate_revenue_analytics(team, dry_run=dry_run):
+            did_something = True
+        return did_something
+
+    def _migrate_dag(self, dag: DAG, *, dry_run: bool) -> bool:
+        """Migrate a single non-managed DAG to a v2 schedule. Returns True if migrated."""
         team = dag.team
-        # find all materialized nodes in this DAG that have saved queries with sync schedules
+        # materialized non-managed nodes whose saved queries have sync schedules
         scheduled_nodes = Node.objects.filter(
             dag=dag,
             saved_query__isnull=False,
             saved_query__sync_frequency_interval__isnull=False,
             saved_query__deleted=False,
+            saved_query__managed_viewset__isnull=True,
         ).select_related("saved_query")
         if not scheduled_nodes.exists():
-            logger.info("No scheduled nodes found, skipping", dag_id=str(dag.id), team_id=team.pk)
             return False
         # check that all scheduled saved queries share the same sync frequency
-        distinct_intervals = scheduled_nodes.values_list("saved_query__sync_frequency_interval", flat=True).distinct()
-        intervals = list(distinct_intervals)
+        intervals = list(scheduled_nodes.values_list("saved_query__sync_frequency_interval", flat=True).distinct())
         if len(intervals) != 1:
             logger.warning(
                 "DAG has multiple sync frequencies, skipping",
@@ -125,105 +169,218 @@ class Command(BaseCommand):
                 scheduled_nodes=scheduled_nodes.count(),
             )
             return True
-        # create the v2 DAG schedule
+
         temporal = sync_connect()
         schedule_id = str(dag.id)
         if schedule_exists(temporal, schedule_id=schedule_id):
             logger.info("V2 schedule already exists, skipping creation", dag_id=str(dag.id), team_id=team.pk)
-        else:
-            inputs = ExecuteDAGInputs(
-                team_id=team.pk,
-                dag_id=str(dag.id),
-                node_ids=None,
-                duckgres_only=False,
-            )
-            spec = build_schedule_spec(
-                entity_id=dag.id,
-                interval=interval,
-                team_timezone=team.timezone,
-            )
-            schedule = Schedule(
-                action=ScheduleActionStartWorkflow(
-                    "data-modeling-execute-dag",
-                    asdict(inputs),
-                    id=f"execute-dag-{dag.id}",
-                    task_queue=str(settings.DATA_MODELING_TASK_QUEUE),
-                    retry_policy=RetryPolicy(
-                        initial_interval=timedelta(seconds=10),
-                        maximum_interval=timedelta(seconds=60),
-                        maximum_attempts=3,
-                        non_retryable_error_types=["NondeterminismError", "CancelledError"],
-                    ),
-                ),
-                spec=spec,
-                state=ScheduleState(note=f"DAG schedule for team {team.pk}"),
-                policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
-            )
-            search_attributes = TypedSearchAttributes(
-                search_attributes=[
-                    SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=team.pk),
-                    SearchAttributePair(key=POSTHOG_ORG_ID_KEY, value=str(team.organization_id)),
-                    SearchAttributePair(key=POSTHOG_DAG_ID_KEY, value=str(dag.id)),
-                ]
-            )
-            create_schedule(
-                temporal,
-                id=schedule_id,
-                schedule=schedule,
-                trigger_immediately=False,
-                search_attributes=search_attributes,
-            )
-            logger.info("Created v2 DAG schedule", dag_id=str(dag.id), team_id=team.pk, interval=str(interval))
-            # update the DAG only after schedule creation succeeded
-            dag.name = "Default"
-            dag.sync_frequency_interval = interval
-            dag.save(update_fields=["name", "sync_frequency_interval"])
-            logger.info("Renamed DAG", dag_id=str(dag.id), team_id=team.pk)
-            # delete old per-node schedules
-            deleted_count = 0
-            failed_schedule_ids: list[str] = []
-            for node in scheduled_nodes:
-                saved_query = node.saved_query
-                if saved_query is None:
-                    continue
-                try:
-                    delete_schedule(temporal, schedule_id=str(saved_query.id))
-                    deleted_count += 1
-                except temporalio.service.RPCError as e:
-                    if e.status == temporalio.service.RPCStatusCode.NOT_FOUND:
-                        logger.warning(
-                            "Old schedule not found (already deleted?)",
-                            saved_query_id=str(saved_query.id),
-                            team_id=team.pk,
-                        )
-                    else:
-                        failed_schedule_ids.append(str(saved_query.id))
-                        logger.exception(
-                            "Failed to delete old schedule",
-                            saved_query_id=str(saved_query.id),
-                            team_id=team.pk,
-                        )
-            if failed_schedule_ids:
-                logger.warning(
-                    "Some old schedules could not be deleted",
-                    dag_id=str(dag.id),
-                    team_id=team.pk,
-                    failed_schedule_ids=failed_schedule_ids,
-                )
-            logger.info(
-                "Deleted old per-node schedules",
-                dag_id=str(dag.id),
-                team_id=team.pk,
-                deleted=deleted_count,
-                total=scheduled_nodes.count(),
-            )
-            # null out sync_frequency_interval on migrated saved queries so v1 schedules are not re-created
-            migrated_sq_ids = [node.saved_query_id for node in scheduled_nodes if node.saved_query_id is not None]
-            DataWarehouseSavedQuery.objects.filter(id__in=migrated_sq_ids).update(sync_frequency_interval=None)
-            logger.info(
-                "Cleared sync_frequency_interval on saved queries",
-                dag_id=str(dag.id),
-                team_id=team.pk,
-                count=len(migrated_sq_ids),
-            )
+            return True
+
+        self._create_dag_schedule(temporal, dag=dag, team=team, interval=interval)
+        logger.info("Created v2 DAG schedule", dag_id=str(dag.id), team_id=team.pk, interval=str(interval))
+        # update the DAG only after schedule creation succeeded
+        if dag.name != DEFAULT_DAG_NAME:
+            dag.name = DEFAULT_DAG_NAME
+        dag.sync_frequency_interval = interval
+        dag.save(update_fields=["name", "sync_frequency_interval"])
+        logger.info("Renamed DAG", dag_id=str(dag.id), team_id=team.pk)
+
+        saved_queries = [node.saved_query for node in scheduled_nodes if node.saved_query is not None]
+        self._delete_v1_schedules(temporal, saved_queries, team)
+        # null out sync_frequency_interval so v1 schedules are not re-created
+        DataWarehouseSavedQuery.objects.filter(id__in=[sq.id for sq in saved_queries]).update(
+            sync_frequency_interval=None
+        )
+        logger.info(
+            "Cleared sync_frequency_interval on saved queries",
+            dag_id=str(dag.id),
+            team_id=team.pk,
+            count=len(saved_queries),
+        )
         return True
+
+    def _migrate_revenue_analytics(self, team: Team, *, dry_run: bool) -> bool:
+        """Route a team's managed-viewset views into a dedicated Revenue Analytics DAG + schedule.
+
+        Returns True if migrated.
+        """
+        managed_sqs = list(
+            DataWarehouseSavedQuery.objects.filter(
+                team=team,
+                managed_viewset__isnull=False,
+                sync_frequency_interval__isnull=False,
+                deleted=False,
+            )
+        )
+        if not managed_sqs:
+            return False
+        intervals = {sq.sync_frequency_interval for sq in managed_sqs}
+        if len(intervals) != 1:
+            logger.warning(
+                "Revenue analytics saved queries have multiple sync frequencies, skipping",
+                team_id=team.pk,
+                intervals=[str(i) for i in intervals],
+            )
+            return False
+        interval = cast(timedelta, next(iter(intervals)))
+        if dry_run:
+            logger.info(
+                "Would migrate revenue analytics to a dedicated DAG",
+                team_id=team.pk,
+                saved_queries=len(managed_sqs),
+                interval=str(interval),
+            )
+            return True
+
+        ra_dag = DAG.get_or_create_revenue_analytics(team)
+        self._sync_nodes_into_dag(managed_sqs, ra_dag, team)
+        # move the views out of any other DAG (e.g. the Default DAG from the 0006 node backfill)
+        Node.objects.filter(saved_query__in=managed_sqs).exclude(dag=ra_dag).delete()
+        logger.info(
+            "Moved revenue analytics views into dedicated DAG",
+            dag_id=str(ra_dag.id),
+            team_id=team.pk,
+            count=len(managed_sqs),
+        )
+
+        temporal = sync_connect()
+        schedule_id = str(ra_dag.id)
+        if schedule_exists(temporal, schedule_id=schedule_id):
+            logger.info(
+                "Revenue analytics v2 schedule already exists, skipping creation",
+                dag_id=str(ra_dag.id),
+                team_id=team.pk,
+            )
+        else:
+            self._create_dag_schedule(
+                temporal,
+                dag=ra_dag,
+                team=team,
+                interval=interval,
+                schedule_type=REVENUE_ANALYTICS_SCHEDULE_TYPE,
+            )
+            logger.info(
+                "Created revenue analytics v2 DAG schedule",
+                dag_id=str(ra_dag.id),
+                team_id=team.pk,
+                interval=str(interval),
+            )
+        if ra_dag.sync_frequency_interval != interval:
+            ra_dag.sync_frequency_interval = interval
+            ra_dag.save(update_fields=["sync_frequency_interval"])
+
+        self._delete_v1_schedules(temporal, managed_sqs, team)
+        DataWarehouseSavedQuery.objects.filter(id__in=[sq.id for sq in managed_sqs]).update(
+            sync_frequency_interval=None
+        )
+        logger.info(
+            "Cleared sync_frequency_interval on revenue analytics saved queries",
+            team_id=team.pk,
+            count=len(managed_sqs),
+        )
+        return True
+
+    def _sync_nodes_into_dag(self, saved_queries: list[DataWarehouseSavedQuery], dag: DAG, team: Team) -> None:
+        """Ensure each saved query has a Node in `dag`, syncing in dependency order.
+
+        `resolve_dependency_to_node` only finds existing view nodes in the target DAG, so views
+        that depend on each other must be synced parents-first. We retry in passes until a pass
+        makes no progress, then log whatever could not be resolved.
+        """
+        remaining = list(saved_queries)
+        while remaining:
+            progressed: list[DataWarehouseSavedQuery] = []
+            still: list[DataWarehouseSavedQuery] = []
+            for sq in remaining:
+                try:
+                    sync_saved_query_to_dag(sq, dag=dag)
+                    progressed.append(sq)
+                except Exception:
+                    still.append(sq)
+            if not progressed:
+                for sq in still:
+                    logger.warning(
+                        "Could not sync saved query into DAG (unresolved dependencies)",
+                        saved_query_id=str(sq.id),
+                        team_id=team.pk,
+                    )
+                return
+            remaining = still
+
+    def _create_dag_schedule(
+        self,
+        temporal,
+        *,
+        dag: DAG,
+        team: Team,
+        interval: timedelta,
+        schedule_type: str | None = None,
+    ) -> None:
+        inputs = ExecuteDAGInputs(team_id=team.pk, dag_id=str(dag.id), node_ids=None, duckgres_only=False)
+        spec = build_schedule_spec(entity_id=dag.id, interval=interval, team_timezone=team.timezone)
+        schedule = Schedule(
+            action=ScheduleActionStartWorkflow(
+                "data-modeling-execute-dag",
+                asdict(inputs),
+                id=f"execute-dag-{dag.id}",
+                task_queue=str(settings.DATA_MODELING_TASK_QUEUE),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=10),
+                    maximum_interval=timedelta(seconds=60),
+                    maximum_attempts=3,
+                    non_retryable_error_types=["NondeterminismError", "CancelledError"],
+                ),
+            ),
+            spec=spec,
+            state=ScheduleState(note=f"DAG schedule for team {team.pk}"),
+            policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+        )
+        search_attributes = [
+            SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=team.pk),
+            SearchAttributePair(key=POSTHOG_ORG_ID_KEY, value=str(team.organization_id)),
+            SearchAttributePair(key=POSTHOG_DAG_ID_KEY, value=str(dag.id)),
+        ]
+        if schedule_type is not None:
+            search_attributes.append(SearchAttributePair(key=POSTHOG_SCHEDULE_TYPE_KEY, value=schedule_type))
+        create_schedule(
+            temporal,
+            id=str(dag.id),
+            schedule=schedule,
+            trigger_immediately=False,
+            search_attributes=TypedSearchAttributes(search_attributes=search_attributes),
+        )
+
+    def _delete_v1_schedules(self, temporal, saved_queries: list[DataWarehouseSavedQuery], team: Team) -> None:
+        """Delete the old per-saved-query v1 (data-modeling-run) schedules."""
+        deleted_count = 0
+        failed_schedule_ids: list[str] = []
+        for saved_query in saved_queries:
+            try:
+                delete_schedule(temporal, schedule_id=str(saved_query.id))
+                deleted_count += 1
+            except temporalio.service.RPCError as e:
+                if e.status == temporalio.service.RPCStatusCode.NOT_FOUND:
+                    logger.warning(
+                        "Old schedule not found (already deleted?)",
+                        saved_query_id=str(saved_query.id),
+                        team_id=team.pk,
+                    )
+                else:
+                    failed_schedule_ids.append(str(saved_query.id))
+                    logger.exception(
+                        "Failed to delete old schedule",
+                        saved_query_id=str(saved_query.id),
+                        team_id=team.pk,
+                    )
+        if failed_schedule_ids:
+            logger.warning(
+                "Some old schedules could not be deleted",
+                team_id=team.pk,
+                failed_schedule_ids=failed_schedule_ids,
+            )
+        logger.info(
+            "Deleted old v1 schedules",
+            team_id=team.pk,
+            deleted=deleted_count,
+            total=len(saved_queries),
+        )

--- a/products/data_modeling/backend/management/commands/test/test_migrate_teams_to_dag_schedules.py
+++ b/products/data_modeling/backend/management/commands/test/test_migrate_teams_to_dag_schedules.py
@@ -1,0 +1,165 @@
+from datetime import timedelta
+
+import pytest
+from posthog.test.base import BaseTest
+from unittest import mock
+
+from django.core.management import call_command
+
+from posthog.temporal.common.search_attributes import POSTHOG_SCHEDULE_TYPE_KEY
+
+from products.data_modeling.backend.management.commands.migrate_teams_to_dag_schedules import Command
+from products.data_modeling.backend.models import DAG, DEFAULT_DAG_NAME, REVENUE_ANALYTICS_DAG_NAME, Node
+from products.data_modeling.backend.models.datawarehouse_managed_viewset import DataWarehouseManagedViewSet
+from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.data_modeling.backend.services.saved_query_dag_sync import sync_saved_query_to_dag
+from products.data_warehouse.backend.types import DataWarehouseManagedViewSetKind
+
+COMMAND_PATH = "products.data_modeling.backend.management.commands.migrate_teams_to_dag_schedules"
+
+
+@pytest.mark.django_db
+class TestMigrateTeamsToDagSchedules(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.schedule_exists_patch = mock.patch(f"{COMMAND_PATH}.schedule_exists", return_value=False)
+        self.create_schedule_patch = mock.patch(f"{COMMAND_PATH}.create_schedule")
+        self.delete_schedule_patch = mock.patch(f"{COMMAND_PATH}.delete_schedule")
+        self.sync_connect_patch = mock.patch(f"{COMMAND_PATH}.sync_connect", return_value=mock.MagicMock())
+        self.mock_schedule_exists = self.schedule_exists_patch.start()
+        self.mock_create_schedule = self.create_schedule_patch.start()
+        self.mock_delete_schedule = self.delete_schedule_patch.start()
+        self.sync_connect_patch.start()
+        self.addCleanup(self.schedule_exists_patch.stop)
+        self.addCleanup(self.create_schedule_patch.stop)
+        self.addCleanup(self.delete_schedule_patch.stop)
+        self.addCleanup(self.sync_connect_patch.stop)
+
+    def _create_model(self, name: str, interval: timedelta = timedelta(hours=24)) -> DataWarehouseSavedQuery:
+        sq = DataWarehouseSavedQuery.objects.create(
+            name=name,
+            team=self.team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+            sync_frequency_interval=interval,
+            is_materialized=True,
+        )
+        sync_saved_query_to_dag(sq)  # creates a node in the Default DAG
+        return sq
+
+    def _create_managed_view(
+        self, name: str, query: str = "SELECT 1", interval: timedelta = timedelta(hours=12)
+    ) -> DataWarehouseSavedQuery:
+        mv, _ = DataWarehouseManagedViewSet.objects.get_or_create(
+            team=self.team, kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS
+        )
+        sq = DataWarehouseSavedQuery.objects.create(
+            name=name,
+            team=self.team,
+            query={"query": query, "kind": "HogQLQuery"},
+            managed_viewset=mv,
+            sync_frequency_interval=interval,
+            is_materialized=True,
+            origin=DataWarehouseSavedQuery.Origin.MANAGED_VIEWSET,
+        )
+        return sq
+
+    def _run(self):
+        call_command("migrate_teams_to_dag_schedules", team_ids=str(self.team.id))
+
+    def _schedule_calls_by_id(self) -> dict:
+        return {c.kwargs["id"]: c.kwargs["search_attributes"] for c in self.mock_create_schedule.call_args_list}
+
+    def test_managed_views_get_dedicated_protected_dag_and_tagged_schedule(self):
+        sq1 = self._create_managed_view("revenue_view_1")
+        sq2 = self._create_managed_view("revenue_view_2")
+        # simulate the 0006 backfill having placed them in the Default DAG
+        sync_saved_query_to_dag(sq1)
+        sync_saved_query_to_dag(sq2)
+
+        self._run()
+
+        ra_dag = DAG.objects.get(team=self.team, name=REVENUE_ANALYTICS_DAG_NAME)
+        # both views moved into the RA DAG and out of every other DAG
+        for sq in (sq1, sq2):
+            assert Node.objects.filter(dag=ra_dag, saved_query=sq).exists()
+            assert not Node.objects.filter(saved_query=sq).exclude(dag=ra_dag).exists()
+
+        calls = self._schedule_calls_by_id()
+        assert str(ra_dag.id) in calls
+        assert calls[str(ra_dag.id)].get(POSTHOG_SCHEDULE_TYPE_KEY) == "revenue_analytics"
+
+        # old v1 schedules deleted and intervals nulled so v1 isn't re-created
+        deleted_ids = {c.kwargs["schedule_id"] for c in self.mock_delete_schedule.call_args_list}
+        assert {str(sq1.id), str(sq2.id)} <= deleted_ids
+        sq1.refresh_from_db()
+        sq2.refresh_from_db()
+        assert sq1.sync_frequency_interval is None
+        assert sq2.sync_frequency_interval is None
+
+    def test_non_managed_models_stay_on_default_dag(self):
+        sq = self._create_model("plain_model")
+
+        self._run()
+
+        default_dag = DAG.objects.get(team=self.team, name=DEFAULT_DAG_NAME)
+        assert not DAG.objects.filter(team=self.team, name=REVENUE_ANALYTICS_DAG_NAME).exists()
+
+        calls = self._schedule_calls_by_id()
+        assert str(default_dag.id) in calls
+        # the Default schedule is not tagged as revenue analytics
+        assert calls[str(default_dag.id)].get(POSTHOG_SCHEDULE_TYPE_KEY) is None
+        sq.refresh_from_db()
+        assert sq.sync_frequency_interval is None
+
+    def test_mixed_team_splits_into_two_schedules(self):
+        plain = self._create_model("plain_model")
+        managed = self._create_managed_view("revenue_view")
+        sync_saved_query_to_dag(managed)  # backfilled into Default
+
+        self._run()
+
+        default_dag = DAG.objects.get(team=self.team, name=DEFAULT_DAG_NAME)
+        ra_dag = DAG.objects.get(team=self.team, name=REVENUE_ANALYTICS_DAG_NAME)
+
+        calls = self._schedule_calls_by_id()
+        assert calls[str(default_dag.id)].get(POSTHOG_SCHEDULE_TYPE_KEY) is None
+        assert calls[str(ra_dag.id)].get(POSTHOG_SCHEDULE_TYPE_KEY) == "revenue_analytics"
+
+        assert Node.objects.filter(dag=default_dag, saved_query=plain).exists()
+        assert Node.objects.filter(dag=ra_dag, saved_query=managed).exists()
+        assert not Node.objects.filter(dag=default_dag, saved_query=managed).exists()
+
+    def test_managed_only_team_creates_no_default_schedule(self):
+        self._create_managed_view("revenue_view_1")
+        self._create_managed_view("revenue_view_2")
+
+        self._run()
+
+        ra_dag = DAG.objects.get(team=self.team, name=REVENUE_ANALYTICS_DAG_NAME)
+        calls = self._schedule_calls_by_id()
+        assert list(calls.keys()) == [str(ra_dag.id)]
+
+    def test_idempotent_when_schedule_already_exists(self):
+        self._create_managed_view("revenue_view")
+        self.mock_schedule_exists.return_value = True
+
+        self._run()
+
+        self.mock_create_schedule.assert_not_called()
+
+    def test_sync_nodes_multi_pass_handles_dependency_order(self):
+        # view_a can only resolve after view_b is in the DAG; passing a-first forces a retry
+        view_a = self._create_managed_view("view_a")
+        view_b = self._create_managed_view("view_b")
+        ra_dag = DAG.get_or_create_revenue_analytics(self.team)
+        synced: list = []
+
+        def fake_sync(sq, dag=None):
+            if sq.id == view_a.id and view_b.id not in synced:
+                raise Exception("dependency not ready")
+            synced.append(sq.id)
+
+        with mock.patch(f"{COMMAND_PATH}.sync_saved_query_to_dag", side_effect=fake_sync):
+            Command()._sync_nodes_into_dag([view_a, view_b], ra_dag, self.team)
+
+        assert synced == [view_b.id, view_a.id]

--- a/products/data_modeling/backend/models/__init__.py
+++ b/products/data_modeling/backend/models/__init__.py
@@ -1,4 +1,4 @@
-from .dag import DAG, DEFAULT_DAG_NAME
+from .dag import DAG, DEFAULT_DAG_NAME, RESERVED_DAG_NAMES, REVENUE_ANALYTICS_DAG_NAME
 from .data_modeling_job import DataModelingJob, DataModelingJobEngine, DataModelingJobStatus
 from .datawarehouse_managed_viewset import DataWarehouseManagedViewSet
 from .datawarehouse_saved_query import DataWarehouseSavedQuery
@@ -13,6 +13,8 @@ from .node import Node, NodeType
 __all__ = [
     "DAG",
     "DEFAULT_DAG_NAME",
+    "RESERVED_DAG_NAMES",
+    "REVENUE_ANALYTICS_DAG_NAME",
     "CycleDetectionError",
     "DAGMismatchError",
     "DataModelingEdgeManager",

--- a/products/data_modeling/backend/models/dag.py
+++ b/products/data_modeling/backend/models/dag.py
@@ -11,6 +11,10 @@ if TYPE_CHECKING:
     from posthog.models import Team
 
 DEFAULT_DAG_NAME = "Default"
+REVENUE_ANALYTICS_DAG_NAME = "Revenue Analytics"
+# DAGs that PostHog creates and manages on the user's behalf. They cannot be renamed or
+# deleted through the API.
+RESERVED_DAG_NAMES = frozenset({DEFAULT_DAG_NAME, REVENUE_ANALYTICS_DAG_NAME})
 
 
 class DAG(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
@@ -29,9 +33,18 @@ class DAG(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
         dag, _ = cls.objects.get_or_create(team=team, name=DEFAULT_DAG_NAME)
         return dag
 
+    @classmethod
+    def get_or_create_revenue_analytics(cls, team: Team) -> DAG:
+        dag, _ = cls.objects.get_or_create(team=team, name=REVENUE_ANALYTICS_DAG_NAME)
+        return dag
+
     @property
     def is_default(self) -> bool:
         return self.name == DEFAULT_DAG_NAME
+
+    @property
+    def is_reserved(self) -> bool:
+        return self.name in RESERVED_DAG_NAMES
 
     class Meta:
         db_table = "posthog_datamodelingdag"

--- a/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
@@ -20,11 +20,32 @@ from posthog.hogql.database.models import (
 from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDTModel, sane_repr
 
+from products.data_modeling.backend.models.dag import DAG, REVENUE_ANALYTICS_DAG_NAME
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_warehouse.backend.types import DataWarehouseManagedViewSetKind
 from products.revenue_analytics.backend.views.schemas import SCHEMAS as REVENUE_ANALYTICS_SCHEMAS
 
 logger = structlog.get_logger(__name__)
+
+
+def _delete_dag_schedule_best_effort(schedule_id: str, team_id: int) -> None:
+    """Delete a v2 (data-modeling-execute-dag) Temporal schedule, swallowing errors.
+
+    Runs after the DB transaction commits, so a Temporal hiccup never rolls back the deletion.
+    """
+    # Local imports keep the Temporal client off the model import path.
+    import temporalio  # noqa: PLC0415
+
+    from posthog.temporal.common.client import sync_connect  # noqa: PLC0415
+    from posthog.temporal.common.schedule import delete_schedule  # noqa: PLC0415
+
+    try:
+        delete_schedule(sync_connect(), schedule_id=schedule_id)
+    except temporalio.service.RPCError as e:
+        if e.status != temporalio.service.RPCStatusCode.NOT_FOUND:
+            logger.warning("failed_to_delete_revenue_analytics_dag_schedule", team_id=team_id, schedule_id=schedule_id)
+    except Exception:
+        logger.warning("failed_to_delete_revenue_analytics_dag_schedule", team_id=team_id, schedule_id=schedule_id)
 
 
 @dataclass
@@ -221,6 +242,9 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
 
                     capture_exception(e, {"managed_viewset_id": self.id, "view_name": view.name})
 
+            if self.kind == DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS:
+                self._delete_revenue_analytics_dag()
+
             logger.info(
                 "managed_viewset_deleted_with_views",
                 team_id=self.team_id,
@@ -230,6 +254,19 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
 
             self.delete()
         return views_deleted
+
+    def _delete_revenue_analytics_dag(self) -> None:
+        """Delete the protected Revenue Analytics DAG (and its v2 schedule) for this team, if present.
+
+        The DAG is API-protected, so disabling revenue analytics is the only way to remove it.
+        """
+        ra_dag = DAG.objects.filter(team_id=self.team_id, name=REVENUE_ANALYTICS_DAG_NAME).first()
+        if ra_dag is None:
+            return
+        schedule_id = str(ra_dag.id)
+        team_id = self.team_id
+        ra_dag.delete()  # cascades Nodes and Edges
+        transaction.on_commit(lambda: _delete_dag_schedule_best_effort(schedule_id, team_id))
 
     def to_saved_query_metadata(self, name: str):
         if self.kind != DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS:

--- a/products/data_modeling/backend/test/test_managed_viewset_dag_cleanup.py
+++ b/products/data_modeling/backend/test/test_managed_viewset_dag_cleanup.py
@@ -1,0 +1,40 @@
+import pytest
+from posthog.test.base import BaseTest
+from unittest import mock
+
+from products.data_modeling.backend.models import DAG, Node, NodeType
+from products.data_modeling.backend.models.datawarehouse_managed_viewset import DataWarehouseManagedViewSet
+from products.data_warehouse.backend.types import DataWarehouseManagedViewSetKind
+
+MODEL_PATH = "products.data_modeling.backend.models.datawarehouse_managed_viewset"
+
+
+@pytest.mark.django_db
+class TestRevenueAnalyticsDagCleanup(BaseTest):
+    def test_delete_with_views_deletes_revenue_analytics_dag_and_schedule(self):
+        mv = DataWarehouseManagedViewSet.objects.create(
+            team=self.team, kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS
+        )
+        ra_dag = DAG.get_or_create_revenue_analytics(self.team)
+        Node.objects.create(team=self.team, dag=ra_dag, name="some_table", type=NodeType.TABLE)
+
+        with (
+            mock.patch(f"{MODEL_PATH}._delete_dag_schedule_best_effort") as mock_delete_schedule,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            mv.delete_with_views()
+
+        assert not DAG.objects.filter(id=ra_dag.id).exists()
+        assert not Node.objects.filter(dag_id=ra_dag.id).exists()
+        mock_delete_schedule.assert_called_once_with(str(ra_dag.id), self.team.id)
+
+    def test_delete_with_views_is_noop_when_no_revenue_analytics_dag(self):
+        mv = DataWarehouseManagedViewSet.objects.create(
+            team=self.team, kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS
+        )
+
+        with mock.patch(f"{MODEL_PATH}._delete_dag_schedule_best_effort") as mock_delete_schedule:
+            mv.delete_with_views()
+
+        mock_delete_schedule.assert_not_called()
+        assert not DataWarehouseManagedViewSet.objects.filter(id=mv.id).exists()


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

rev analytics views aren't migrated to DAGs so we can't truly get off v1 unless we move them over too...

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

migrate them to their own reserved and protected dag.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

tests

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->

<!-- gg:stack-start -->
## gg stack

- **#61401 `andrew/ra-dag-and-migration` 👈 this PR**
<!-- gg:stack-end -->
