### PR TITLE
fix: Reload experiments when menu loads

### DIFF
--- a/frontend/src/toolbar/experiments/ExperimentsToolbarMenu.tsx
+++ b/frontend/src/toolbar/experiments/ExperimentsToolbarMenu.tsx
@@ -3,6 +3,7 @@ import { useActions, useValues } from 'kea'
 import { IconPlus } from '@posthog/icons'
 import { LemonBanner } from '@posthog/lemon-ui'
 
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
@@ -21,9 +22,11 @@ import { joinWithUiHost } from '~/toolbar/utils'
 const ExperimentsListToolbarMenu = (): JSX.Element => {
     const { searchTerm } = useValues(experimentsLogic)
     const { newExperiment } = useActions(experimentsTabLogic)
-    const { setSearchTerm } = useActions(experimentsLogic)
+    const { setSearchTerm, getExperiments } = useActions(experimentsLogic)
     const { allExperiments, sortedExperiments, allExperimentsLoading } = useValues(experimentsLogic)
     const { uiHost } = useValues(toolbarConfigLogic)
+
+    useOnMountEffect(getExperiments)
 
     const isWebExperimentsDisabled = Boolean(window?.parent?.posthog?.config?.disable_web_experiments)
 


### PR DESCRIPTION
## Problem

There seems to be a race condition where we try to load web/no-code experiments before auth has finished, meaning an empty list is shown to users even when web experiments exist.

## Changes

Follow the same pattern as actions and use `useOnMountEffect` to always load experiments when the menu loads.