### PR TITLE
fix(phai): guide agent to search docs when billing data is unavailable

### DIFF
--- a/ee/hogai/chat_agent/prompts/base.py
+++ b/ee/hogai/chat_agent/prompts/base.py
@@ -243,6 +243,7 @@ TOOL_USAGE_POLICY_PROMPT = """
 - The only tool you can't invoke with others at the same time is `web_search`. Only invoke it alone.
 - Retry failed tool calls only if the error proposes retrying, or suggests how to fix tool arguments
 - Before describing PostHog support capabilities, data management operations (such as deleting or modifying events), or directing users to contact support, you must search the documentation first using the `search` tool with kind="docs" to verify what is currently offered.
+- Before answering questions about PostHog billing, pricing, plans, or add-ons, you must search the documentation first using the `search` tool with kind="docs" to verify current pricing details. If the billing tool returned no data, do not guess or infer how plans or pricing work — search the docs and be transparent that you cannot access the user's specific billing information.
 </tool_usage_policy>
 """.strip()
 

--- a/ee/hogai/tools/read_billing_tool/prompts.py
+++ b/ee/hogai/tools/read_billing_tool/prompts.py
@@ -1,3 +1,10 @@
+BILLING_CONTEXT_UNAVAILABLE_PROMPT = (
+    "No billing information available. "
+    "Do not guess or infer billing details, plan pricing, or how specific plans work. "
+    'Search the PostHog documentation using the `search` tool with kind="docs" for the relevant billing or pricing topic, '
+    "and be transparent with the user that you cannot see their specific billing details."
+)
+
 BILLING_CONTEXT_PROMPT = """
 <billing_context>
 The user's organization has {{subscription_level}} subscription{{#billing_plan}} ({{billing_plan}}){{/billing_plan}}.

--- a/ee/hogai/tools/read_billing_tool/test/test_nodes.py
+++ b/ee/hogai/tools/read_billing_tool/test/test_nodes.py
@@ -23,6 +23,7 @@ from posthog.schema import (
 )
 
 from ee.hogai.context.context import AssistantContextManager
+from ee.hogai.tools.read_billing_tool.prompts import BILLING_CONTEXT_UNAVAILABLE_PROMPT
 from ee.hogai.tools.read_billing_tool.tool import ReadBillingTool
 from ee.hogai.utils.types import AssistantState
 
@@ -43,7 +44,7 @@ class TestBillingNode(ClickhouseTestMixin, NonAtomicBaseTest):
     async def test_run_with_no_billing_context(self):
         with patch.object(self.tool._context_manager, "get_billing_context", return_value=None):
             result = await self.tool.execute()
-            self.assertEqual(result, "No billing information available")
+            self.assertEqual(result, BILLING_CONTEXT_UNAVAILABLE_PROMPT)
 
     async def test_run_with_billing_context(self):
         billing_context = MaxBillingContext(

--- a/ee/hogai/tools/read_billing_tool/tool.py
+++ b/ee/hogai/tools/read_billing_tool/tool.py
@@ -14,7 +14,7 @@ from ee.hogai.tool import MaxSubtool
 from ee.hogai.tool_errors import MaxToolFatalError
 from ee.hogai.utils.types import AssistantState
 
-from .prompts import BILLING_CONTEXT_PROMPT
+from .prompts import BILLING_CONTEXT_PROMPT, BILLING_CONTEXT_UNAVAILABLE_PROMPT
 
 # sync with frontend/src/scenes/billing/constants.ts
 USAGE_TYPES = [
@@ -55,7 +55,7 @@ class ReadBillingTool(MaxSubtool):
     async def execute(self) -> str:
         billing_context = self._context_manager.get_billing_context()
         if not billing_context:
-            return "No billing information available"
+            return BILLING_CONTEXT_UNAVAILABLE_PROMPT
         formatted_billing_context = await self._format_billing_context(billing_context)
         return formatted_billing_context
 


### PR DESCRIPTION
## Problem

When a PostHog AI user asks about billing or pricing and the billing tool returns no data (e.g., the user isn't an org admin/owner), the agent fabricates a confident but potentially wrong answer instead of searching documentation or being transparent about the limitation.

This was observed in a real user session where the agent incorrectly told a user that the Boost add-on fee "replaces" their event-based spend, when in fact it's an additional charge on top. The user had to correct the agent.

## Changes

- Added a `BILLING_CONTEXT_UNAVAILABLE_PROMPT` in the billing tool prompts that instructs the agent not to guess, to search docs instead, and to be transparent with the user
- Updated `ReadBillingTool.execute()` to return this prompt instead of a bare "No billing information available" string
- Extended the tool usage policy to mandate a docs search before answering any billing/pricing question, especially when billing data is unavailable
- Updated the existing test to assert against the new prompt constant

## How did you test this code?

This PR was agent-authored. All pre-commit hooks (lint, format, type check) passed. The existing test for the no-billing-context case was updated to match the new prompt constant. The DB-dependent test suite has a pre-existing setup issue unrelated to this change — CI will run the full suite.

## Docs update

No docs changes needed — this is an internal agent prompt change.

## 🤖 Agent context

Investigated a real user session (AI observability trace `4873b5fa-21a2-4e2b-9199-23fb3697dbee`) where the agent gave wrong billing advice. Analyzed all 5 traces in the session using PostHog MCP tools to understand the failure chain: billing tool returned empty → agent fabricated answer → memory collector stored the fabrication as fact → agent cited its own stored guess.

Explored the agent architecture (`ee/hogai/`) to understand mode routing, tool fallback patterns, and how other read_data handlers guide the agent on failure. The fix follows the established pattern of providing actionable guidance in tool return messages while also reinforcing the behavior at the system prompt level via the tool usage policy.