### PR TITLE
fix(llma): hide responses-only OpenAI models from BYOK picker

### DIFF
--- a/posthog/temporal/ai_observability/test_run_evaluation.py
+++ b/posthog/temporal/ai_observability/test_run_evaluation.py
@@ -750,7 +750,7 @@ class TestRunEvaluationWorkflow:
             "team_id": team.id,
             "model_configuration": {
                 "provider": "openai",
-                "model": "o3-pro",
+                "model": "gpt-5.4",
                 "provider_key_id": None,
             },
         }

--- a/products/ai_observability/backend/api/test/test_proxy.py
+++ b/products/ai_observability/backend/api/test/test_proxy.py
@@ -200,7 +200,7 @@ class TestTrialModelEnforcement(APIBaseTest):
 
     @parameterized.expand(
         [
-            ("expensive_openai", "o3-pro", "openai"),
+            ("expensive_openai", "gpt-5.4", "openai"),
             ("expensive_anthropic", "claude-opus-4-6", "anthropic"),
         ]
     )
@@ -236,7 +236,7 @@ class TestTrialModelEnforcement(APIBaseTest):
             encrypted_config={"api_key": "sk-test-key"},
             created_by=self.user,
         )
-        payload = self._completion_payload("o3-pro", "openai")
+        payload = self._completion_payload("gpt-5.4", "openai")
         payload["provider_key_id"] = str(byok_key.id)
         response = self.client.post(
             "/api/llm_proxy/completion/",

--- a/products/ai_observability/backend/llm/providers/openai.py
+++ b/products/ai_observability/backend/llm/providers/openai.py
@@ -46,22 +46,29 @@ class OpenAIConfig:
 
     SUPPORTED_MODELS: list[str] = [
         "gpt-5.4",
-        "gpt-5.2-pro",
         "gpt-5.2",
         "gpt-5.1",
-        "gpt-5-pro",
         "gpt-5-nano",
         "gpt-5-mini",
         "gpt-5",
-        "o3-pro",
         "gpt-4.1-nano",
         "gpt-4.1-mini",
         "gpt-4.1",
         "o4-mini",
         "o3",
-        "o1-pro",
         "o3-mini",
     ]
+
+    # "Pro" tier models are served only by the Responses API, so they 404 on chat
+    # completions. Excluded from the picker (curated list + list_models discovery).
+    RESPONSES_ONLY_MODELS: frozenset[str] = frozenset(
+        {
+            "gpt-5.2-pro",
+            "gpt-5-pro",
+            "o1-pro",
+            "o3-pro",
+        }
+    )
 
     # Models available to trial users (PostHog pays). Excludes expensive
     # "pro" tiers and includes one flagship model for quality evaluation.
@@ -77,17 +84,13 @@ class OpenAIConfig:
 
     SUPPORTED_MODELS_WITH_THINKING: list[str] = [
         "gpt-5.4",
-        "gpt-5.2-pro",
         "gpt-5.2",
         "gpt-5.1",
-        "gpt-5-pro",
         "gpt-5-nano",
         "gpt-5-mini",
         "gpt-5",
-        "o3-pro",
         "o4-mini",
         "o3",
-        "o1-pro",
         "o3-mini",
     ]
 
@@ -387,7 +390,9 @@ Return ONLY the JSON object, no other text or markdown formatting."""
             filtered = [
                 m
                 for m in api_models
-                if m.id not in supported and m.id.startswith(("gpt-", "o1", "o3", "o4", "chatgpt-"))
+                if m.id not in supported
+                and m.id not in OpenAIConfig.RESPONSES_ONLY_MODELS
+                and m.id.startswith(("gpt-", "o1", "o3", "o4", "chatgpt-"))
             ]
             filtered.sort(key=lambda m: m.created, reverse=True)
             other = [m.id for m in filtered]

--- a/products/ai_observability/backend/llm/providers/test/test_openai_adapter.py
+++ b/products/ai_observability/backend/llm/providers/test/test_openai_adapter.py
@@ -19,6 +19,38 @@ class TestOpenAIRecommendedModels:
         assert OpenAIAdapter.recommended_models() == set(OpenAIConfig.SUPPORTED_MODELS)
 
 
+def _api_model(model_id: str, created: int) -> MagicMock:
+    model = MagicMock()
+    model.id = model_id
+    model.created = created
+    return model
+
+
+class TestOpenAIListModels:
+    @parameterized.expand(sorted(OpenAIConfig.RESPONSES_ONLY_MODELS))
+    def test_responses_only_model_is_not_picker_eligible(self, model: str):
+        assert model not in OpenAIConfig.SUPPORTED_MODELS
+        assert model not in OpenAIConfig.SUPPORTED_MODELS_WITH_THINKING
+
+    def test_list_models_without_key_returns_supported_models(self):
+        assert OpenAIAdapter.list_models() == OpenAIConfig.SUPPORTED_MODELS
+
+    def test_list_models_excludes_responses_only_models_from_api_discovery(self):
+        api_models = [
+            _api_model("o3-pro", 300),
+            _api_model("gpt-5-pro", 200),
+            _api_model("gpt-6-future", 100),
+        ]
+        mock_client = MagicMock()
+        mock_client.models.list.return_value = api_models
+
+        with patch("products.ai_observability.backend.llm.providers.openai.openai.OpenAI", return_value=mock_client):
+            result = OpenAIAdapter.list_models(api_key="sk-test")
+
+        assert "gpt-6-future" in result
+        assert OpenAIConfig.RESPONSES_ONLY_MODELS.isdisjoint(result)
+
+
 class TestBuildAnalyticsKwargs:
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

Picking an OpenAI "pro" tier model (`gpt-5.2-pro`, `gpt-5-pro`, `o1-pro`, `o3-pro`) as a judge crashes because we only use the chat completions interface, which they don't support.

## Changes

Remove them from the supported list to prevent the crashes.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests I ran locally (all passing):

- `products/ai_observability/backend/llm/providers/test/test_openai_adapter.py` — added a parameterized invariant that each responses-only model is absent from both supported lists, plus a `list_models()` test proving API-discovered pro models are dropped while a new normal model passes through.
- `products/ai_observability/backend/api/test/test_proxy.py` and `posthog/temporal/ai_observability/test_run_evaluation.py` — existing suites pass; swapped a now-removed `o3-pro` fixture for a still-supported model (`gpt-5.4`).

I also verified the root cause against the real OpenAI API through the adapter code path: the four pro models return a 404 on chat completions while a normal model (`gpt-5-mini`) succeeds.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed — this only adjusts which models appear in the BYOK picker.

## 🤖 Agent context

Authored with PostHog Code (Claude). Investigation started from an inbox signal report; the report's root-cause diagnosis (responses-only models hitting chat completions) was confirmed both by reading the adapter and by a live call against the real OpenAI API. Along the way the report's impact framing was found to understate scope (the same error spanned two error-tracking fingerprints over several days, not a short window).

Decision: chose the interim "remove from picker" approach over full Responses-API routing for a fast, low-risk fix, after scoping both. Notably, removing the models from `SUPPORTED_MODELS` alone is **not** sufficient — `list_models()` re-surfaces them via API discovery — so the fix also filters them there. The proper Responses-API routing is left as a tracked follow-up.

Agent-authored; requires human review.
