### PR TITLE
chore(ci): double semgrep job timeouts

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
     semgrep-python:
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 30
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
@@ -42,7 +42,7 @@ jobs:
 
     semgrep-go:
         runs-on: ubuntu-latest
-        timeout-minutes: 5
+        timeout-minutes: 10
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
@@ -66,7 +66,7 @@ jobs:
 
     semgrep-rust:
         runs-on: ubuntu-latest
-        timeout-minutes: 5
+        timeout-minutes: 10
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
@@ -92,7 +92,7 @@ jobs:
 
     semgrep-js:
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
@@ -115,7 +115,7 @@ jobs:
 
     semgrep-products-frontend:
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
@@ -139,7 +139,7 @@ jobs:
     # scans GitHub Actions and other repo-wide config
     semgrep-general:
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
@@ -182,7 +182,7 @@ jobs:
     # See `.semgrep/devex-rules/README.md`.
     semgrep-devex:
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
@@ -216,7 +216,7 @@ jobs:
 
     semgrep-test-rules:
         runs-on: ubuntu-latest
-        timeout-minutes: 5
+        timeout-minutes: 10
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 


### PR DESCRIPTION
## Problem

The semgrep jobs in `ci-security.yaml` have been hitting their `timeout-minutes` limits — the `semgrep-python` and `semgrep-devex` jobs in particular have been failing on timeout rather than on real findings. A timed-out job is a false negative that forces a re-run and burns runner credits.

## Changes

Doubled the `timeout-minutes` on every semgrep scan job to give the scans headroom:

| Job | Before | After |
| --- | --- | --- |
| `semgrep-python` | 15 | 30 |
| `semgrep-go` | 5 | 10 |
| `semgrep-rust` | 5 | 10 |
| `semgrep-js` | 10 | 20 |
| `semgrep-products-frontend` | 10 | 20 |
| `semgrep-general` | 10 | 20 |
| `semgrep-devex` | 10 | 20 |
| `semgrep-test-rules` | 5 | 10 |

The `semgrep_checks` aggregator job (a trivial outcome check) is left at 5 minutes.

## How did you test this code?

I'm an agent. This is a CI config-only change; no automated tests were run. Correctness is verifiable by inspection of the YAML diff.

## 🤖 Agent context

Authored by Claude Code at the request of the human author. The task was to raise the semgrep CI timeouts by at least 2x after observing devex and python jobs timing out. Each scan job's `timeout-minutes` was doubled; the aggregator job was left unchanged since it does no scanning.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SaXdMGsbqxkf1kko2v4gcN)_