### PR TITLE
chore(error-tracking): use personhog only repos

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -1015,6 +1015,7 @@ describe('hog flow processing', () => {
                     }
                     return Promise.resolve(result)
                 }),
+                fetchGroupTypesByProjectIds: jest.fn().mockResolvedValue({}),
             }
 
             processor['groupsManager'] = new GroupsManagerService(hub.teamManager, mockGroupRepo)

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
@@ -326,6 +326,7 @@ describe('BatchExportHogFunctionService', () => {
                     }
                     return Promise.resolve(result)
                 }),
+                fetchGroupTypesByProjectIds: jest.fn().mockResolvedValue({}),
             }
 
             api['batchExportHogFunctionService']['groupsManager'] = new GroupsManagerService(

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -11,7 +11,8 @@ import { PostgresUse } from '~/utils/db/postgres'
 import { ErrorTrackingSettingsManager } from '~/utils/error-tracking-settings-manager'
 import { parseJSON } from '~/utils/json-parse'
 import { UUIDT } from '~/utils/utils'
-import { PersonRepository } from '~/worker/ingestion/persons/repositories/person-repository'
+import { PersonReadRepository } from '~/worker/ingestion/persons/repositories/person-repository'
+import { ReadOnlyGroupTypeManager } from '~/worker/ingestion/readonly-group-type-manager'
 
 import { IngestionOutputs } from '../outputs/ingestion-outputs'
 import { SingleIngestionOutput } from '../outputs/single-ingestion-output'
@@ -55,24 +56,11 @@ jest.mock('../../utils/logger', () => ({
     },
 }))
 
-// Create a mock PersonRepository to avoid database schema issues
-const createMockPersonRepository = (): jest.Mocked<PersonRepository> => ({
+const createMockPersonRepository = (): jest.Mocked<PersonReadRepository> => ({
     fetchPerson: jest.fn().mockResolvedValue(undefined),
     fetchPersonsByDistinctIds: jest.fn().mockResolvedValue([]),
-    fetchPersonsByPersonIds: jest.fn(),
+    fetchPersonsByPersonIds: jest.fn().mockResolvedValue([]),
     fetchDistinctIdsForPersons: jest.fn().mockResolvedValue({}),
-    createPerson: jest.fn(),
-    updatePerson: jest.fn(),
-    updatePersonAssertVersion: jest.fn(),
-    updatePersonsBatch: jest.fn(),
-    deletePerson: jest.fn(),
-    addDistinctId: jest.fn(),
-    addPersonlessDistinctId: jest.fn(),
-    addPersonlessDistinctIdForMerge: jest.fn(),
-    addPersonlessDistinctIdsBatch: jest.fn(),
-    personPropertiesSize: jest.fn(),
-    updateCohortsAndFeatureFlagsForMerge: jest.fn(),
-    inTransaction: jest.fn(),
 })
 
 // Mock the CymbalClient to avoid real HTTP calls
@@ -207,10 +195,14 @@ describe('ErrorTrackingConsumer', () => {
             teamManager: hub.teamManager,
             errorTrackingSettingsManager: new ErrorTrackingSettingsManager(hub.postgres),
             hogTransformer: mockHogTransformer,
-            groupTypeManager: hub.groupTypeManager,
+            groupTypeManager: new ReadOnlyGroupTypeManager({
+                fetchGroupsByKeys: jest.fn().mockResolvedValue([]),
+                fetchGroupTypesByTeamIds: jest.fn().mockResolvedValue({}),
+                fetchGroupTypesByProjectIds: jest.fn().mockResolvedValue({}),
+            }),
             cookielessManager: hub.cookielessManager,
             redisPool: hub.redisPool,
-            personRepository: hub.personRepository,
+            personRepository: createMockPersonRepository(),
         }
         const consumer = new ErrorTrackingConsumer(config, deps)
         // Replace Kafka consumer with mock to avoid actual connections
@@ -252,10 +244,6 @@ describe('ErrorTrackingConsumer', () => {
         await resetTestDatabase()
         hub = await createHub()
         team = await getFirstTeam(hub.postgres)
-
-        // Replace the real personRepository with a mock to avoid database schema issues
-        // (the test database may be missing the last_seen_at column)
-        hub.personRepository = createMockPersonRepository()
 
         consumer = await createConsumer(hub)
     })

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -17,8 +17,8 @@ import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-re
 import { logger } from '../../utils/logger'
 import { PromiseScheduler } from '../../utils/promise-scheduler'
 import { TeamManager } from '../../utils/team-manager'
-import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
-import { PersonRepository } from '../../worker/ingestion/persons/repositories/person-repository'
+import { PersonReadRepository } from '../../worker/ingestion/persons/repositories/person-repository'
+import { ReadOnlyGroupTypeManager } from '../../worker/ingestion/readonly-group-type-manager'
 import { OverflowOutput } from '../common/outputs'
 import { CookielessManager } from '../cookieless/cookieless-manager'
 import { BatchPipelineUnwrapper } from '../pipelines/batch-pipeline-unwrapper'
@@ -100,10 +100,10 @@ export interface ErrorTrackingConsumerDeps {
     /** Only required when the rate limiter is enabled; constructed alongside it. */
     errorTrackingSettingsManager?: ErrorTrackingSettingsManager
     hogTransformer: ErrorTrackingHogTransformer
-    groupTypeManager: GroupTypeManager
+    groupTypeManager: ReadOnlyGroupTypeManager
     cookielessManager: CookielessManager
     redisPool: GenericPool<Redis>
-    personRepository: PersonRepository
+    personRepository: PersonReadRepository
 }
 
 // Batch processing status - useful for tracking failures (batch sizes already tracked by KafkaConsumer)

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
@@ -9,8 +9,8 @@ import { parseJSON } from '~/utils/json-parse'
 import { PromiseScheduler } from '~/utils/promise-scheduler'
 import { TeamManager } from '~/utils/team-manager'
 import { UUIDT } from '~/utils/utils'
-import { GroupTypeManager } from '~/worker/ingestion/group-type-manager'
-import { PersonRepository } from '~/worker/ingestion/persons/repositories/person-repository'
+import { PersonReadRepository } from '~/worker/ingestion/persons/repositories/person-repository'
+import { ReadOnlyGroupTypeManager } from '~/worker/ingestion/readonly-group-type-manager'
 
 import { TophogOutput } from '../common/outputs'
 import { COOKIELESS_SENTINEL_VALUE, CookielessManager } from '../cookieless/cookieless-manager'
@@ -48,10 +48,10 @@ jest.mock('~/utils/logger', () => ({
 describe('ErrorTrackingPipeline', () => {
     let mockKafkaProducer: jest.Mocked<KafkaProducerWrapper>
     let mockTeamManager: jest.Mocked<TeamManager>
-    let mockPersonRepository: jest.Mocked<PersonRepository>
+    let mockPersonRepository: jest.Mocked<PersonReadRepository>
     let mockHogTransformer: jest.Mocked<ErrorTrackingHogTransformer>
     let mockCymbalClient: jest.Mocked<CymbalClient>
-    let mockGroupTypeManager: jest.Mocked<GroupTypeManager>
+    let mockGroupTypeManager: jest.Mocked<ReadOnlyGroupTypeManager>
     let mockEventIngestionRestrictionManager: jest.Mocked<EventIngestionRestrictionManager>
     let mockCookielessManager: jest.Mocked<CookielessManager>
     let promiseScheduler: PromiseScheduler
@@ -247,7 +247,7 @@ describe('ErrorTrackingPipeline', () => {
             personPropertiesSize: jest.fn(),
             updateCohortsAndFeatureFlagsForMerge: jest.fn(),
             inTransaction: jest.fn(),
-        } as unknown as jest.Mocked<PersonRepository>
+        } as unknown as jest.Mocked<PersonReadRepository>
 
         // HogTransformer mock that passes through events unchanged by default
         mockHogTransformer = {
@@ -268,7 +268,7 @@ describe('ErrorTrackingPipeline', () => {
             fetchGroupTypes: jest.fn().mockResolvedValue({}),
             fetchGroupTypeIndex: jest.fn(),
             insertGroupType: jest.fn(),
-        } as unknown as jest.Mocked<GroupTypeManager>
+        } as unknown as jest.Mocked<ReadOnlyGroupTypeManager>
 
         mockEventIngestionRestrictionManager = {
             getAppliedRestrictions: jest.fn().mockReturnValue(new Set()),

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
@@ -5,8 +5,8 @@ import { ErrorTrackingSettings, ErrorTrackingSettingsManager } from '~/utils/err
 import { EventIngestionRestrictionManager } from '~/utils/event-ingestion-restrictions'
 import { PromiseScheduler } from '~/utils/promise-scheduler'
 import { TeamManager } from '~/utils/team-manager'
-import { GroupTypeManager } from '~/worker/ingestion/group-type-manager'
-import { PersonRepository } from '~/worker/ingestion/persons/repositories/person-repository'
+import { PersonReadRepository } from '~/worker/ingestion/persons/repositories/person-repository'
+import { ReadOnlyGroupTypeManager } from '~/worker/ingestion/readonly-group-type-manager'
 
 import {
     AppMetricsOutput,
@@ -69,10 +69,10 @@ export interface ErrorTrackingPipelineConfig {
     groupId: string
     promiseScheduler: PromiseScheduler
     teamManager: TeamManager
-    personRepository: PersonRepository
+    personRepository: PersonReadRepository
     hogTransformer: ErrorTrackingHogTransformer | null
     cymbalClient: CymbalClient
-    groupTypeManager: GroupTypeManager
+    groupTypeManager: ReadOnlyGroupTypeManager
     cookielessManager: CookielessManager
     eventIngestionRestrictionManager: EventIngestionRestrictionManager
     overflowEnabled: boolean

--- a/nodejs/src/ingestion/error-tracking/person-properties-step.test.ts
+++ b/nodejs/src/ingestion/error-tracking/person-properties-step.test.ts
@@ -5,14 +5,14 @@ import { createTestTeam } from '~/tests/helpers/team'
 import { InternalPerson } from '~/types'
 import {
     InternalPersonWithDistinctId,
-    PersonRepository,
+    PersonReadRepository,
 } from '~/worker/ingestion/persons/repositories/person-repository'
 
 import { PipelineResultType, isOkResult } from '../pipelines/results'
 import { createFetchPersonBatchStep } from './person-properties-step'
 
 describe('createFetchPersonBatchStep', () => {
-    let mockPersonRepository: jest.Mocked<PersonRepository>
+    let mockPersonRepository: jest.Mocked<PersonReadRepository>
     let step: ReturnType<typeof createFetchPersonBatchStep>
 
     const team = createTestTeam({ id: 123 })
@@ -38,18 +38,6 @@ describe('createFetchPersonBatchStep', () => {
             fetchPersonsByDistinctIds: jest.fn(),
             fetchPersonsByPersonIds: jest.fn(),
             fetchDistinctIdsForPersons: jest.fn(),
-            createPerson: jest.fn(),
-            updatePerson: jest.fn(),
-            updatePersonAssertVersion: jest.fn(),
-            updatePersonsBatch: jest.fn(),
-            deletePerson: jest.fn(),
-            addDistinctId: jest.fn(),
-            addPersonlessDistinctId: jest.fn(),
-            addPersonlessDistinctIdForMerge: jest.fn(),
-            addPersonlessDistinctIdsBatch: jest.fn(),
-            personPropertiesSize: jest.fn(),
-            updateCohortsAndFeatureFlagsForMerge: jest.fn(),
-            inTransaction: jest.fn(),
         }
         step = createFetchPersonBatchStep(mockPersonRepository)
     })
@@ -102,7 +90,6 @@ describe('createFetchPersonBatchStep', () => {
                 { teamId: 123, distinctId: 'user-1' },
                 { teamId: 123, distinctId: 'user-2' },
             ],
-            true, // useReadReplica
             'error-tracking/person-properties'
         )
     })
@@ -205,7 +192,6 @@ describe('createFetchPersonBatchStep', () => {
         // Should only query for the event with distinct_id
         expect(mockPersonRepository.fetchPersonsByDistinctIds).toHaveBeenCalledWith(
             [{ teamId: 123, distinctId: 'user-123' }],
-            true,
             'error-tracking/person-properties'
         )
     })

--- a/nodejs/src/ingestion/error-tracking/person-properties-step.ts
+++ b/nodejs/src/ingestion/error-tracking/person-properties-step.ts
@@ -1,6 +1,6 @@
 import { PluginEvent } from '~/plugin-scaffold'
 import { Person, Team } from '~/types'
-import { PersonRepository } from '~/worker/ingestion/persons/repositories/person-repository'
+import { PersonReadRepository } from '~/worker/ingestion/persons/repositories/person-repository'
 
 import { BatchProcessingStep } from '../pipelines/base-batch-pipeline'
 import { PipelineResult, ok } from '../pipelines/results'
@@ -28,7 +28,7 @@ function personKey(teamId: number, distinctId: string): string {
  * This is a batch step to avoid N+1 queries when processing multiple events.
  */
 export function createFetchPersonBatchStep<T extends PersonPropertiesInput>(
-    personRepository: PersonRepository
+    personRepository: PersonReadRepository
 ): BatchProcessingStep<T, T & { person: Person | null }> {
     return async function fetchPersonBatchStep(inputs: T[]): Promise<PipelineResult<T & { person: Person | null }>[]> {
         if (inputs.length === 0) {
@@ -43,7 +43,7 @@ export function createFetchPersonBatchStep<T extends PersonPropertiesInput>(
         // Batch fetch all persons in a single query
         const persons =
             lookups.length > 0
-                ? await personRepository.fetchPersonsByDistinctIds(lookups, true, 'error-tracking/person-properties')
+                ? await personRepository.fetchPersonsByDistinctIds(lookups, 'error-tracking/person-properties')
                 : []
 
         // Build lookup map

--- a/nodejs/src/ingestion/event-processing/readonly-process-groups-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/readonly-process-groups-step.test.ts
@@ -1,7 +1,7 @@
 import { createTestTeam } from '../../../tests/helpers/team'
 import { PreIngestionEvent, ProjectId, Team, TimestampFormat } from '../../types'
 import { castTimestampOrNow } from '../../utils/utils'
-import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
+import { ReadOnlyGroupTypeManager } from '../../worker/ingestion/readonly-group-type-manager'
 import { PipelineResultType } from '../pipelines/results'
 import { createReadOnlyProcessGroupsStep } from './readonly-process-groups-step'
 
@@ -23,7 +23,7 @@ type TestInput = {
 }
 
 describe('createReadOnlyProcessGroupsStep', () => {
-    let mockGroupTypeManager: jest.Mocked<Pick<GroupTypeManager, 'fetchGroupTypes'>>
+    let mockGroupTypeManager: jest.Mocked<Pick<ReadOnlyGroupTypeManager, 'fetchGroupTypes'>>
 
     beforeEach(() => {
         jest.clearAllMocks()
@@ -59,7 +59,9 @@ describe('createReadOnlyProcessGroupsStep', () => {
     ])('$desc', async ({ processPerson, hasGroups, expectFetchGroupTypes }) => {
         mockGroupTypeManager.fetchGroupTypes.mockResolvedValue({ org: 0 })
 
-        const step = createReadOnlyProcessGroupsStep<TestInput>(mockGroupTypeManager as unknown as GroupTypeManager)
+        const step = createReadOnlyProcessGroupsStep<TestInput>(
+            mockGroupTypeManager as unknown as ReadOnlyGroupTypeManager
+        )
         const result = await step(
             createInput({
                 processPerson,
@@ -80,7 +82,9 @@ describe('createReadOnlyProcessGroupsStep', () => {
     it('enriches properties with $group_N using read-only fetch', async () => {
         mockGroupTypeManager.fetchGroupTypes.mockResolvedValue({ org: 0, project: 1 })
 
-        const step = createReadOnlyProcessGroupsStep<TestInput>(mockGroupTypeManager as unknown as GroupTypeManager)
+        const step = createReadOnlyProcessGroupsStep<TestInput>(
+            mockGroupTypeManager as unknown as ReadOnlyGroupTypeManager
+        )
         const input = createInput({
             preparedEvent: createTestPreIngestionEvent({
                 properties: { $groups: { org: 'posthog', project: 'posthog-js' } },
@@ -101,7 +105,9 @@ describe('createReadOnlyProcessGroupsStep', () => {
     it('skips unknown group types without writing', async () => {
         mockGroupTypeManager.fetchGroupTypes.mockResolvedValue({ org: 0 })
 
-        const step = createReadOnlyProcessGroupsStep<TestInput>(mockGroupTypeManager as unknown as GroupTypeManager)
+        const step = createReadOnlyProcessGroupsStep<TestInput>(
+            mockGroupTypeManager as unknown as ReadOnlyGroupTypeManager
+        )
         const input = createInput({
             preparedEvent: createTestPreIngestionEvent({
                 properties: { $groups: { org: 'posthog', unknown_type: 'value' } },

--- a/nodejs/src/ingestion/event-processing/readonly-process-groups-step.ts
+++ b/nodejs/src/ingestion/event-processing/readonly-process-groups-step.ts
@@ -1,5 +1,5 @@
 import { PreIngestionEvent, Team } from '../../types'
-import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
+import { ReadOnlyGroupTypeManager } from '../../worker/ingestion/readonly-group-type-manager'
 import { ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 import { enrichPropertiesWithGroupTypes } from './groups'
@@ -13,7 +13,7 @@ export interface ReadOnlyProcessGroupsStepInput {
 export type ReadOnlyProcessGroupsStepResult<TInput> = TInput
 
 export function createReadOnlyProcessGroupsStep<TInput extends ReadOnlyProcessGroupsStepInput>(
-    groupTypeManager: GroupTypeManager
+    groupTypeManager: ReadOnlyGroupTypeManager
 ): ProcessingStep<TInput, ReadOnlyProcessGroupsStepResult<TInput>> {
     return async function readOnlyProcessGroupsStep(input: TInput) {
         const { preparedEvent, team, processPerson } = input

--- a/nodejs/src/ingestion/personhog/personhog-group-read-repository.ts
+++ b/nodejs/src/ingestion/personhog/personhog-group-read-repository.ts
@@ -1,4 +1,4 @@
-import { GroupTypeIndex, TeamId } from '../../types'
+import { GroupTypeIndex, ProjectId, TeamId } from '../../types'
 import { GroupReadRepository } from '../../worker/ingestion/groups/repositories/group-repository.interface'
 import { PersonHogClient } from './client'
 import { withRetry } from './grpc-retry'
@@ -42,6 +42,17 @@ export class PersonHogGroupReadRepository implements GroupReadRepository {
         return withRetry('PersonHogGroupReadRepository', () =>
             timedGrpc(this.clientLabel, 'fetchGroupTypesByTeamIds', () =>
                 this.grpcClient.groups.fetchGroupTypesByTeamIds(teamIds, callerTag)
+            )
+        )
+    }
+
+    async fetchGroupTypesByProjectIds(
+        projectIds: ProjectId[],
+        callerTag?: string
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
+        return withRetry('PersonHogGroupReadRepository', () =>
+            timedGrpc(this.clientLabel, 'fetchGroupTypesByProjectIds', () =>
+                this.grpcClient.groups.fetchGroupTypesByProjectIds(projectIds, callerTag)
             )
         )
     }

--- a/nodejs/src/servers/error-tracking-server.ts
+++ b/nodejs/src/servers/error-tracking-server.ts
@@ -36,7 +36,9 @@ import {
 import { ErrorTrackingConsumer } from '../ingestion/error-tracking/error-tracking-consumer'
 import { createOutputsRegistry } from '../ingestion/error-tracking/outputs/registry'
 import { KafkaProducerRegistry } from '../ingestion/outputs/kafka-producer-registry'
-import { buildGroupRepository, buildPersonRepository, createPersonHogClient } from '../ingestion/personhog'
+import { createPersonHogClient } from '../ingestion/personhog'
+import { PersonHogGroupReadRepository } from '../ingestion/personhog/personhog-group-read-repository'
+import { PersonHogPersonReadRepository } from '../ingestion/personhog/personhog-person-read-repository'
 import { PluginServerService, RedisPool } from '../types'
 import { ServerCommands } from '../utils/commands'
 import { PostgresRouter } from '../utils/db/postgres'
@@ -46,9 +48,7 @@ import { GeoIPService } from '../utils/geoip'
 import { logger } from '../utils/logger'
 import { PubSub } from '../utils/pubsub'
 import { TeamManager } from '../utils/team-manager'
-import { GroupTypeManager } from '../worker/ingestion/group-type-manager'
-import { PostgresGroupRepository } from '../worker/ingestion/groups/repositories/postgres-group-repository'
-import { PostgresPersonRepository } from '../worker/ingestion/persons/repositories/postgres-person-repository'
+import { ReadOnlyGroupTypeManager } from '../worker/ingestion/readonly-group-type-manager'
 import { BaseServerConfig, CleanupResources, NodeServer, ServerLifecycle } from './base-server'
 
 /**
@@ -169,22 +169,14 @@ export class ErrorTrackingServer implements NodeServer {
         const personhogClient = createPersonHogClient(this.config)
         const clientLabel = this.config.PLUGIN_SERVER_MODE ?? 'unknown'
 
-        const postgresPersonRepository = new PostgresPersonRepository(this.postgres)
-        const personRepository = buildPersonRepository(
-            personhogClient,
-            postgresPersonRepository,
-            this.config.PERSONHOG_PERSONS_ROLLOUT_PERCENTAGE,
-            this.config.PERSONHOG_PERSONS_ROLLOUT_TEAM_IDS,
-            clientLabel
-        )
-        const postgresGroupRepository = new PostgresGroupRepository(this.postgres)
-        const groupRepository = buildGroupRepository(
-            personhogClient,
-            postgresGroupRepository,
-            this.config.PERSONHOG_GROUPS_ROLLOUT_PERCENTAGE,
-            this.config.PERSONHOG_GROUPS_ROLLOUT_TEAM_IDS,
-            clientLabel
-        )
+        if (!personhogClient) {
+            throw new Error(
+                'PersonHog client is required for error tracking — set PERSONHOG_ENABLED=true and PERSONHOG_ADDR'
+            )
+        }
+
+        const personRepository = new PersonHogPersonReadRepository(personhogClient, clientLabel)
+        const groupRepository = new PersonHogGroupReadRepository(personhogClient, clientLabel)
         const encryptedFields = new EncryptedFields(this.config.ENCRYPTION_SALT_KEYS)
         const integrationManager = new IntegrationManagerService(this.pubsub, this.postgres, encryptedFields)
 
@@ -240,7 +232,7 @@ export class ErrorTrackingServer implements NodeServer {
                     teamManager,
                     errorTrackingSettingsManager,
                     hogTransformer: createHogTransformerService(this.config, hogTransformerDeps),
-                    groupTypeManager: new GroupTypeManager(groupRepository, teamManager),
+                    groupTypeManager: new ReadOnlyGroupTypeManager(groupRepository),
                     cookielessManager: this.cookielessManager!,
                     redisPool: this.redisPool!,
                     personRepository,

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -854,6 +854,7 @@ export interface EventPropertyType {
 }
 
 export type GroupTypeToColumnIndex = Record<string, GroupTypeIndex>
+export type GroupTypesByProjectId = Record<ProjectId, GroupTypeToColumnIndex>
 
 export enum PropertyUpdateOperation {
     Set = 'set',

--- a/nodejs/src/worker/ingestion/group-type-manager.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.ts
@@ -1,4 +1,4 @@
-import { GroupTypeIndex, GroupTypeToColumnIndex, ProjectId, Team, TeamId } from '../../types'
+import { GroupTypeIndex, GroupTypeToColumnIndex, GroupTypesByProjectId, ProjectId, Team, TeamId } from '../../types'
 import { timeoutGuard } from '../../utils/db/utils'
 import { LazyLoader } from '../../utils/lazy-loader'
 import { captureTeamEvent } from '../../utils/posthog'
@@ -7,8 +7,6 @@ import { GroupRepository } from './groups/repositories/group-repository.interfac
 
 /** How many unique group types to allow per team */
 export const MAX_GROUP_TYPES_PER_TEAM = 5
-
-export type GroupTypesByProjectId = Record<ProjectId, GroupTypeToColumnIndex>
 
 export class GroupTypeManager {
     private loader: LazyLoader<GroupTypeToColumnIndex>

--- a/nodejs/src/worker/ingestion/groups/repositories/group-repository.interface.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/group-repository.interface.ts
@@ -14,9 +14,9 @@ import { GroupRepositoryTransaction } from './group-repository-transaction.inter
 
 /**
  * Read-only group lookups backed by personhog gRPC. Used by services that
- * only need to fetch group data (CDP). Always uses eventual consistency.
- * Independent of GroupRepository — the two interfaces have different
- * parameter shapes reflecting their different backends and consumers.
+ * only need to fetch group data (CDP, error tracking). Always uses eventual
+ * consistency. Independent of GroupRepository — the two interfaces have
+ * different parameter shapes reflecting their different backends and consumers.
  */
 export interface GroupReadRepository {
     fetchGroupsByKeys(
@@ -35,6 +35,11 @@ export interface GroupReadRepository {
 
     fetchGroupTypesByTeamIds(
         teamIds: TeamId[],
+        callerTag?: string
+    ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
+
+    fetchGroupTypesByProjectIds(
+        projectIds: ProjectId[],
         callerTag?: string
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>>
 }

--- a/nodejs/src/worker/ingestion/readonly-group-type-manager.ts
+++ b/nodejs/src/worker/ingestion/readonly-group-type-manager.ts
@@ -1,0 +1,62 @@
+import { GroupTypeToColumnIndex, ProjectId } from '../../types'
+import { timeoutGuard } from '../../utils/db/utils'
+import { LazyLoader } from '../../utils/lazy-loader'
+import { GroupReadRepository } from './groups/repositories/group-repository.interface'
+
+export type GroupTypesByProjectId = Record<ProjectId, GroupTypeToColumnIndex>
+
+/**
+ * Read-only group type manager backed by a GroupReadRepository. Provides
+ * cached lookups of project → group type mappings without write capability.
+ * Used by services that only need to resolve existing group types (error
+ * tracking, CDP) rather than create new ones (ingestion pipeline).
+ */
+export class ReadOnlyGroupTypeManager {
+    private loader: LazyLoader<GroupTypeToColumnIndex>
+
+    constructor(private groupRepository: GroupReadRepository) {
+        this.loader = new LazyLoader({
+            name: 'ReadOnlyGroupTypeManager',
+            refreshAgeMs: 30_000,
+            refreshJitterMs: 0,
+            loader: async (projectIds: string[]) => {
+                const response: Record<string, GroupTypeToColumnIndex> = {}
+                const timeout = timeoutGuard(`Still running "fetchGroupTypes". Timeout warning after 30 sec!`)
+                try {
+                    const projectIdNumbers = projectIds.map((id) => parseInt(id) as ProjectId)
+                    const groupTypesByProject = await this.groupRepository.fetchGroupTypesByProjectIds(
+                        projectIdNumbers,
+                        'ingestion/group-type-resolution'
+                    )
+
+                    for (const [projectIdStr, groupTypes] of Object.entries(groupTypesByProject)) {
+                        const groupTypeMapping: GroupTypeToColumnIndex = {}
+                        for (const groupType of groupTypes) {
+                            groupTypeMapping[groupType.group_type] = groupType.group_type_index
+                        }
+                        response[projectIdStr] = groupTypeMapping
+                    }
+
+                    for (const projectId of projectIds) {
+                        response[projectId] = response[projectId] ?? {}
+                    }
+                } finally {
+                    clearTimeout(timeout)
+                }
+                return response
+            },
+        })
+    }
+
+    public async fetchGroupTypes(projectId: ProjectId): Promise<GroupTypeToColumnIndex> {
+        return (await this.loader.get(projectId.toString())) ?? {}
+    }
+
+    public async fetchGroupTypesForProjects(projectIds: ProjectId[] | Set<ProjectId>): Promise<GroupTypesByProjectId> {
+        const results = await this.loader.getMany(Array.from(projectIds).map((id) => id.toString()))
+
+        return Object.fromEntries(
+            Object.entries(results).map(([projectId, groupTypes]) => [projectId, groupTypes ?? {}])
+        )
+    }
+}

--- a/nodejs/src/worker/ingestion/readonly-group-type-manager.ts
+++ b/nodejs/src/worker/ingestion/readonly-group-type-manager.ts
@@ -1,9 +1,7 @@
-import { GroupTypeToColumnIndex, ProjectId } from '../../types'
+import { GroupTypeToColumnIndex, GroupTypesByProjectId, ProjectId } from '../../types'
 import { timeoutGuard } from '../../utils/db/utils'
 import { LazyLoader } from '../../utils/lazy-loader'
 import { GroupReadRepository } from './groups/repositories/group-repository.interface'
-
-export type GroupTypesByProjectId = Record<ProjectId, GroupTypeToColumnIndex>
 
 /**
  * Read-only group type manager backed by a GroupReadRepository. Provides

--- a/nodejs/tests/helpers/cdp.ts
+++ b/nodejs/tests/helpers/cdp.ts
@@ -39,6 +39,7 @@ function buildTestCdpProducerRegistry(
 const noopGroupReadRepository: GroupReadRepository = {
     fetchGroupsByKeys: () => Promise.resolve([]),
     fetchGroupTypesByTeamIds: () => Promise.resolve({}),
+    fetchGroupTypesByProjectIds: () => Promise.resolve({}),
 }
 
 const noopPersonReadRepository: PersonReadRepository = {


### PR DESCRIPTION
## Problem

now that error tracking has cut over to personhog for person and group traffic, update it to have no postgres dep.

## Changes

- migrate to using personhog person and group read only repositories