### PR TITLE
fix: use secrets AWS profiles and handle AccessDeniedException in codec server

### DIFF
--- a/bin/temporal-codec-server
+++ b/bin/temporal-codec-server
@@ -28,6 +28,7 @@ import subprocess
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
+from urllib.parse import urlparse
 
 from cryptography.fernet import Fernet
 from temporalio.api.common.v1 import Payload
@@ -117,9 +118,10 @@ class CodecHandler(BaseHTTPRequestHandler):
         if not self._is_origin_allowed():
             self.send_error(403, "Origin not allowed")
             return
-        if self.path == "/decode":
+        path = urlparse(self.path).path
+        if path == "/decode":
             self._handle_decode()
-        elif self.path == "/encode":
+        elif path == "/encode":
             self._handle_passthrough()
         else:
             self.send_error(404)

--- a/bin/temporal-codec-server
+++ b/bin/temporal-codec-server
@@ -33,8 +33,8 @@ from cryptography.fernet import Fernet
 from temporalio.api.common.v1 import Payload
 
 REGIONS = {
-    "us": {"aws_profile": "prod-us", "aws_region": "us-east-1"},
-    "eu": {"aws_profile": "prod-eu", "aws_region": "eu-central-1"},
+    "us": {"aws_profile": "prod-us-secrets", "aws_region": "us-east-1"},
+    "eu": {"aws_profile": "prod-eu-secrets", "aws_region": "eu-central-1"},
 }
 
 AWS_SECRET_NAME = "temporal-worker-shared-secrets"
@@ -63,9 +63,10 @@ def get_fernet(region: str) -> Fernet:
         if isinstance(e, ClientError) and e.response["Error"]["Code"] not in (
             "ExpiredToken",
             "ExpiredTokenException",
+            "AccessDeniedException",
         ):
             raise
-        print(f"AWS SSO session expired for profile '{profile}', logging in...")
+        print(f"AWS SSO session not active for profile '{profile}', logging in...")
         subprocess.run(["aws", "sso", "login", "--profile", profile], check=True)
         session = boto3.Session(profile_name=profile)
         client = session.client("secretsmanager", region_name=aws_region)


### PR DESCRIPTION
## Problem

`bin/temporal-codec-server` had two issues:

1. `AccessDeniedException` was missing from the SSO retry list, causing crashes instead of re-authentication. The script was also using `prod-us`/`prod-eu` AWS profiles which lack the required Secrets Manager permissions — the correct profiles are `prod-us-secrets`/`prod-eu-secrets`.
2. When using the codec server from `cloud.temporal.io`, requests arrive with a query string (`/decode?preserveStorageRefs=true`). The server was comparing `self.path` (which includes the query string) against the literal `/decode`, causing a 404 with no CORS headers — surfaced in the browser as a CORS error.

## Changes

- Use `prod-us-secrets` and `prod-eu-secrets` AWS profiles (which have the required Secrets Manager permissions)
- Add `AccessDeniedException` to the SSO retry error codes so the script re-authenticates instead of crashing
- Strip query string from the request path before matching routes so `cloud.temporal.io` requests with `?preserveStorageRefs=true` are handled correctly

## How did you test this code?

Both fixes were verified locally by reproducing the errors and confirming they resolved after the changes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored with Claude Code.