### PR TITLE
fix(flags): return JSON for invalid project token

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -375,10 +375,22 @@ impl IntoResponse for FlagError {
                 (StatusCode::BAD_REQUEST, "The distinct_id field is missing from the request. Please include a valid identifier.".to_string())
             }
             FlagError::NoTokenError => {
-                (StatusCode::UNAUTHORIZED, "No API token provided. Please include a valid API token in your request.".to_string())
+                let response = AuthenticationErrorResponse {
+                    error_type: "authentication_error".to_string(),
+                    code: "not_authenticated".to_string(),
+                    detail: "No API token provided. Please include a valid API token in your request.".to_string(),
+                    attr: None,
+                };
+                return (StatusCode::UNAUTHORIZED, Json(response)).into_response();
             }
             FlagError::TokenValidationError => {
-                (StatusCode::UNAUTHORIZED, "The provided API key is invalid or has expired. Please check your API key and try again.".to_string())
+                let response = AuthenticationErrorResponse {
+                    error_type: "authentication_error".to_string(),
+                    code: "authentication_failed".to_string(),
+                    detail: "The provided API key is invalid or has expired. Please check your API key and try again.".to_string(),
+                    attr: None,
+                };
+                return (StatusCode::UNAUTHORIZED, Json(response)).into_response();
             }
             FlagError::PersonalApiKeyInvalid => {
                 let response = AuthenticationErrorResponse {

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1335,17 +1335,17 @@ async fn test_invalid_project_api_key() {
         "Should return 401 for invalid token. Body: {body_text}"
     );
 
-    // Verify the response body format (if JSON)
-    if let Ok(body) = serde_json::from_str::<Value>(&body_text) {
-        assert_eq!(body["type"], "authentication_error");
-        assert_eq!(body["code"], "not_authenticated");
-    } else {
-        // If not JSON, verify the error message mentions invalid API key
-        assert!(
-            body_text.contains("API key is invalid") || body_text.contains("expired"),
-            "Body should mention invalid API key. Got: {body_text}"
-        );
-    }
+    // An invalid project token must return the structured DRF-style JSON envelope,
+    // matching the secret/personal API key paths.
+    let body: Value = serde_json::from_str(&body_text)
+        .unwrap_or_else(|_| panic!("Body should be JSON. Got: {body_text}"));
+    assert_eq!(body["type"], "authentication_error");
+    assert_eq!(body["code"], "authentication_failed");
+    assert_eq!(
+        body["detail"],
+        "The provided API key is invalid or has expired. Please check your API key and try again."
+    );
+    assert_eq!(body["attr"], Value::Null);
 }
 
 #[tokio::test]

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -421,10 +421,14 @@ async fn it_rejects_missing_token() -> Result<()> {
         .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::UNAUTHORIZED, res.status());
+    let json_data = res.json::<Value>().await?;
+    assert_eq!(json_data["type"], "authentication_error");
+    assert_eq!(json_data["code"], "not_authenticated");
     assert_eq!(
-        res.text().await?,
+        json_data["detail"],
         "No API token provided. Please include a valid API token in your request."
     );
+    assert_eq!(json_data["attr"], Value::Null);
     Ok(())
 }
 
@@ -442,10 +446,14 @@ async fn it_rejects_invalid_token() -> Result<()> {
         .send_flags_request(payload.to_string(), Some("1"), None)
         .await;
     assert_eq!(StatusCode::UNAUTHORIZED, res.status());
+    let json_data = res.json::<Value>().await?;
+    assert_eq!(json_data["type"], "authentication_error");
+    assert_eq!(json_data["code"], "authentication_failed");
     assert_eq!(
-        res.text().await?,
+        json_data["detail"],
         "The provided API key is invalid or has expired. Please check your API key and try again."
     );
+    assert_eq!(json_data["attr"], Value::Null);
     Ok(())
 }
 


### PR DESCRIPTION
Closes #55610

When a project token was invalid the flags endpoints returned a plain text error even though the secret and personal API key paths already returned a clean JSON body. This change makes the invalid project token case and the missing token case return the same JSON shape with a type, code, detail and attr field so every flags auth error looks the same. The status code stays the same and only the body format changes. Both the flags and flags definitions endpoints share the same error handling so both are covered, and the tests were updated to check the new JSON body.
