### PR TITLE
chore(ci): add WF005 setup-action token lint (blocking)

### DIFF
--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -19,6 +19,7 @@ from hogli_commands.workflow_lint.checks.dorny_negation import DornyNegationChec
 from hogli_commands.workflow_lint.checks.job_timeouts import JobTimeoutsCheck
 from hogli_commands.workflow_lint.checks.pr_concurrency import PrConcurrencyCheck
 from hogli_commands.workflow_lint.checks.semgrep_services_coverage import SemgrepServicesCoverageCheck
+from hogli_commands.workflow_lint.checks.setup_action_token import SetupActionTokenCheck
 from hogli_commands.workflow_lint.model import PR_TRIGGERS, Workflow, WorkflowParseError, read_workflows
 
 
@@ -518,6 +519,82 @@ class TestSemgrepServicesCoverageCheck:
         [issue] = SemgrepServicesCoverageCheck(repo_root=repo_root).run(_read_all(workflows_dir)).issues
         assert issue.workflow == "ci-security.yaml"
         assert "services/worker/" in issue.message
+
+
+# ---------------------------------------------------------------------------
+# SetupActionTokenCheck
+# ---------------------------------------------------------------------------
+
+
+_SETUP_UV = "astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78"
+
+
+_SETUP_PY = "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405"
+_SETUP_NODE = "actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238"
+_SETUP_GO = "actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5"
+
+
+def _setup_step(uses: str, with_block: str = "") -> str:
+    indented = textwrap.indent(textwrap.dedent(with_block).strip(), " " * 22)
+    with_part = f"\n                    with:\n{indented}" if with_block else ""
+    return f"""
+            name: x
+            on: [pull_request]
+            jobs:
+              j:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - uses: {uses}{with_part}
+            """
+
+
+class TestSetupActionTokenCheck:
+    @pytest.mark.parametrize(
+        "uses,with_block",
+        [
+            # no `token:` input → defaults to the workflow GITHUB_TOKEN
+            (_SETUP_PY, "python-version-file: pyproject.toml"),
+            (_SETUP_NODE, "node-version-file: .nvmrc"),
+            (_SETUP_GO, "go-version-file: go.mod"),
+            # explicit default token (bare github.token / secrets.GITHUB_TOKEN)
+            (_SETUP_PY, "python-version-file: pyproject.toml\ntoken: ${{ github.token }}"),
+            (_SETUP_NODE, "node-version-file: .nvmrc\ntoken: ${{ github.token }}"),
+            (_SETUP_GO, "go-version-file: go.mod\ntoken: ${{ secrets.GITHUB_TOKEN }}"),
+        ],
+    )
+    def test_warns_on_default_token(self, tmp_path: Path, uses: str, with_block: str) -> None:
+        _write(tmp_path, "wf.yml", _setup_step(uses, with_block))
+        [issue] = SetupActionTokenCheck().run(_read_all(tmp_path)).issues
+        assert issue.workflow == "wf.yml"
+        assert "GITHUB_TOKEN" in issue.message
+
+    def test_passes_on_app_token_fallback(self, tmp_path: Path) -> None:
+        # The established repo pattern (app token, default-token fallback for forks).
+        _write(
+            tmp_path,
+            "wf.yml",
+            _setup_step(
+                _SETUP_PY,
+                "python-version-file: pyproject.toml\ntoken: ${{ steps.app-token.outputs.token || github.token }}",
+            ),
+        )
+        assert SetupActionTokenCheck().run(_read_all(tmp_path)).issues == []
+
+    def test_passes_on_secret_pat(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            _setup_step(_SETUP_NODE, "node-version-file: .nvmrc\ntoken: ${{ secrets.GH_COM_PAT }}"),
+        )
+        assert SetupActionTokenCheck().run(_read_all(tmp_path)).issues == []
+
+    def test_ignores_unrelated_setup_actions(self, tmp_path: Path) -> None:
+        _write(tmp_path, "wf.yml", _setup_step(_SETUP_UV, "version: '0.11.14'"))
+        assert SetupActionTokenCheck().run(_read_all(tmp_path)).issues == []
+
+    def test_is_blocking(self) -> None:
+        assert SetupActionTokenCheck().blocking is True
 
 
 # ---------------------------------------------------------------------------

--- a/tools/hogli-commands/hogli_commands/workflow_lint/check.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/check.py
@@ -44,11 +44,16 @@ class WorkflowCheck(ABC):
     - ``id``: stable, machine-friendly identifier (used by ``--check`` filter).
     - ``label``: short human-readable name shown in CLI output and GH annotations.
     - ``description``: one-line summary; shown by ``--list``.
+    - ``blocking``: when False, issues are reported as warnings and do not fail
+      the command. Use for a rule mid-rollout (the violation set is known and
+      being migrated) so it guides new code without blocking every PR until the
+      backlog is cleared.
     """
 
     id: str
     label: str
     description: str
+    blocking: bool = True
 
     @abstractmethod
     def run(self, workflows: list[Workflow]) -> CheckResult: ...

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/__init__.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/__init__.py
@@ -16,12 +16,14 @@ from .dorny_negation import DornyNegationCheck
 from .job_timeouts import JobTimeoutsCheck
 from .pr_concurrency import PrConcurrencyCheck
 from .semgrep_services_coverage import SemgrepServicesCoverageCheck
+from .setup_action_token import SetupActionTokenCheck
 
 CHECKS: list[WorkflowCheck] = [
     JobTimeoutsCheck(),
     PrConcurrencyCheck(),
     DornyNegationCheck(),
     SemgrepServicesCoverageCheck(),
+    SetupActionTokenCheck(),
 ]
 
 

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/setup_action_token.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/setup_action_token.py
@@ -1,0 +1,99 @@
+"""``actions/setup-{node,python,go}`` should not resolve versions on the default ``GITHUB_TOKEN``.
+
+Each of these actions resolves its version from the ``actions/{node,python,go}-versions``
+manifest via an authenticated GitHub API call, then downloads — once per job —
+whenever the pinned version is not already in the runner tool-cache. That call
+is authenticated with the step's ``token`` input, which defaults to the
+workflow ``GITHUB_TOKEN``:
+
+    token: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+
+So the manifest call lands on the per-repo ``GITHUB_TOKEN`` bucket (15,000
+req/hr on GitHub Enterprise Cloud, shared by every job of every run). The
+actions document the ``token`` input as the rate-limit lever; passing an
+app-scoped token moves the call off the shared default bucket — the same
+offload pattern already used for ``dorny/paths-filter``.
+
+All call sites are migrated, so this rule is blocking: a new ``setup-*`` step on
+the default token fails CI. The accepted pattern is
+``token: ${{ steps.<id>.outputs.token || github.token }}`` — an app-scoped token
+with a default-token fallback for forks.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ..check import CheckResult, Issue, WorkflowCheck
+from ..model import Workflow
+
+SETUP_PREFIXES = (
+    "actions/setup-node@",
+    "actions/setup-python@",
+    "actions/setup-go@",
+)
+
+# Token expression that resolves to nothing but the default GITHUB_TOKEN — i.e.
+# no app-scoped fallback. The accepted pattern, `${{ steps.app-token.outputs.token
+# || github.token }}`, contains `outputs.token` and so does NOT match here.
+_DEFAULT_TOKEN_ONLY = re.compile(
+    r"^\$\{\{\s*(github\.token|secrets\.GITHUB_TOKEN)\s*\}\}$",
+)
+
+
+class SetupActionTokenCheck(WorkflowCheck):
+    id = "WF005-setup-action-token"
+    label = "setup-* off default token"
+    description = "actions/setup-{node,python,go} should pass an app-scoped token (not the default GITHUB_TOKEN)"
+    blocking = True  # all call sites migrated — enforce going forward
+
+    @property
+    def fix_hint(self) -> str | None:
+        return (
+            "Mint a setup-action GitHub token in the job and pass it to the setup step's "
+            "`token:` input, e.g.\n"
+            "    - uses: actions/create-github-app-token@<sha>\n"
+            "      id: setup-gh-token\n"
+            "      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository\n"
+            "      continue-on-error: true  # no-op to the default token until the secret exists\n"
+            "      with:\n"
+            "        client-id: ${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_APP_ID }}\n"
+            "        private-key: ${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_PRIVATE_KEY }}\n"
+            "    - uses: actions/setup-python@<sha>\n"
+            "      with:\n"
+            "        python-version-file: pyproject.toml\n"
+            "        token: ${{ steps.setup-gh-token.outputs.token || github.token }}\n"
+            "This moves the version-manifest API call off the shared per-repo GITHUB_TOKEN bucket."
+        )
+
+    def run(self, workflows: list[Workflow]) -> CheckResult:
+        result = CheckResult()
+        for wf in workflows:
+            for job in wf.jobs:
+                for step in job.steps:
+                    if step.uses is None or not step.uses.startswith(SETUP_PREFIXES):
+                        continue
+                    token = (step.with_ or {}).get("token")
+                    if isinstance(token, str) and not _DEFAULT_TOKEN_ONLY.match(token.strip()):
+                        continue  # references an app-scoped (or other non-default) token
+                    detail = (
+                        "no `token:` input (defaults to GITHUB_TOKEN)"
+                        if token is None
+                        else "uses the default GITHUB_TOKEN"
+                    )
+                    result.issues.append(
+                        Issue(
+                            workflow=wf.path.name,
+                            job=job.name,
+                            step=step.ref,
+                            message=(
+                                f"{step.uses.split('@')[0]} {detail} — its version-manifest API call "
+                                "counts against the shared per-repo GITHUB_TOKEN bucket; pass an app-scoped token"
+                            ),
+                            file=str(wf.path),
+                        )
+                    )
+        return result
+
+
+__all__ = ["SetupActionTokenCheck"]

--- a/tools/hogli-commands/hogli_commands/workflow_lint/cli.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/cli.py
@@ -27,12 +27,17 @@ def _gh_annotation(level: str, check_label: str, issue: Issue) -> None:
 
 
 def _run_one(check: WorkflowCheck, workflows: list[Workflow]) -> int:
-    """Run a single check, print results, return the issue count."""
+    """Run a single check, print results, return the issue count.
+
+    Non-blocking checks render as warnings and never fail the command — the
+    caller decides what to do with the count based on ``check.blocking``.
+    """
     click.echo(f"  {check.id} ({check.label})...")
     result = check.run(workflows)
+    level, mark = ("error", "✗") if check.blocking else ("warning", "⚠")
     for issue in result.issues:
-        click.echo(f"    ✗ {issue.render()}")
-        _gh_annotation("error", check.label, issue)
+        click.echo(f"    {mark} {issue.render()}")
+        _gh_annotation(level, check.label, issue)
     if not result.issues:
         click.echo("    ✓ ok")
     return len(result.issues)
@@ -84,18 +89,27 @@ def cmd_lint_workflows(check_id: str | None, list_checks: bool, workflows_dir: P
     click.echo(f"Linting {len(workflows)} workflow(s) with {len(selected)} check(s):\n")
 
     total_issues = 0
+    warning_count = 0
     failing_checks: list[WorkflowCheck] = []
+    warning_checks: list[WorkflowCheck] = []
     for check in selected:
         issues = _run_one(check, workflows)
-        total_issues += issues
-        if issues:
+        if not issues:
+            continue
+        if check.blocking:
+            total_issues += issues
             failing_checks.append(check)
+        else:
+            warning_count += issues
+            warning_checks.append(check)
 
     click.echo("")
+    for check in failing_checks + warning_checks:
+        if check.fix_hint:
+            click.echo(f"Fix for {check.id}:\n{check.fix_hint}\n")
+    if warning_checks:
+        click.echo(f"⚠ {warning_count} non-blocking warning(s) across {len(warning_checks)} check(s)")
     if failing_checks:
-        for check in failing_checks:
-            if check.fix_hint:
-                click.echo(f"Fix for {check.id}:\n{check.fix_hint}\n")
         click.echo(f"✗ {total_issues} issue(s) across {len(failing_checks)} check(s)")
         raise SystemExit(1)
 


### PR DESCRIPTION
## Problem

`actions/setup-{node,python,go}` resolve their version manifest via an authenticated GitHub API call whose `token` defaults to the `GITHUB_TOKEN`, consuming the shared per-repo rate-limit bucket. We've migrated those calls onto a dedicated App-token bucket ([#61238](https://github.com/PostHog/posthog/pull/61238) + the remaining-migrations PR [#61383](https://github.com/PostHog/posthog/pull/61383)), but nothing stops a new or edited workflow from regressing back onto the default token.

## Changes

- Adds `WF005-setup-action-token` to `hogli lint:workflows`: flags any `actions/setup-{node,python,go}` step still on the default token — no `token:` input, or a bare `github.token` / `secrets.GITHUB_TOKEN` — with a fix-it message pointing at the App-token mint pattern.
- Adds a `blocking` severity to the workflow-lint framework so a rule *can* ship as a non-blocking warning during a rollout. `WF005` ships **blocking**: every call site is migrated, so a new `setup-*` step on the default token fails CI.

## Stack / merge order

This is the last PR of the setup-action token offload, and it ships the rule **already enforced** (no land-non-blocking-then-flip). It must merge **after** the two migration PRs:

- [#61238](https://github.com/PostHog/posthog/pull/61238) — first migration batch (**merged**)
- [#61383](https://github.com/PostHog/posthog/pull/61383) — remaining migrations

Until #61383 is in master, this PR's `ci-lint-workflows` check is **red by design**: the blocking rule still sees the setup-* call sites #61383 migrates. Once #61383 merges, a rebase turns it green. Merge order: **#61383, then this**.

## Bot-review adjustments

Folded the review feedback from the earlier (non-blocking) revision into this one:

- **Ships blocking, no flip** — per the base-class docstring thread, the rule is born enforced rather than non-blocking-then-flipped; dropped the now-superfluous "flip to True once the tree is clean" line.
- **Parameterized the warning-path tests** over `setup-node` / `setup-python` / `setup-go`, closing the `setup-go` coverage gap (greptile).
- **Dropped the stray colon** in the rule `description` (greptile).

## How did you test this code?

I'm an agent (Claude Code) — no manual testing claimed. Automated:

- `hogli test tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py` — 40 passing (`test_is_blocking` asserts `blocking is True`).
- `hogli lint:workflows --check WF005-setup-action-token` on this branch exits 1, flagging exactly the setup-* call sites #61383 migrates — goes to zero once #61383 is in master.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Add the `skip-inkeep-docs` label — no user-facing docs impact.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8). Final PR of the setup-action token offload: ships the `WF005` rule already enforced (blocking) once the migration PRs land, rather than landing non-blocking and flipping later — matching the maintainer's note on the original review thread. Rebased onto master (which now carries #61238) and folded the earlier blocking-flip plus the greptile/review fixes into the single commit.

Human owner: requires human review — do not self-merge or auto-approve.
