### PR TITLE
fix(oauth): expand OIDC-only DCR/CIMD tokens for MCP init

### DIFF
--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -2314,6 +2314,91 @@ class TestOAuthAPI(APIBaseTest):
         self.assertNotIn("error=invalid_scope", redirect_to)
         self.assertIn("code=", redirect_to)
 
+    @parameterized.expand(
+        [
+            ("dcr", "is_dcr_client"),
+            ("cimd", "is_cimd_client"),
+        ]
+    )
+    def test_dynamic_client_oidc_only_scope_expands_only_to_bootstrap_scopes(self, _name, dynamic_flag):
+        setattr(self.public_application, dynamic_flag, True)
+        self.public_application.save()
+
+        auth_data = {
+            "client_id": self.public_application.client_id,
+            "redirect_uri": "https://example.com/callback",
+            "response_type": "code",
+            "code_challenge": self.code_challenge,
+            "code_challenge_method": "S256",
+            "allow": True,
+            "access_level": OAuthApplicationAccessLevel.ALL.value,
+            "scoped_organizations": [],
+            "scoped_teams": [],
+            "scope": "openid",
+        }
+
+        response = self.client.post("/oauth/authorize/", auth_data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        code = response.json()["redirect_to"].split("code=")[1].split("&")[0]
+
+        token_response = self.post(
+            "/oauth/token/",
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "client_id": self.public_application.client_id,
+                "redirect_uri": "https://example.com/callback",
+                "code_verifier": self.code_verifier,
+            },
+        )
+        self.assertEqual(token_response.status_code, status.HTTP_200_OK)
+
+        access_token = OAuthAccessToken.objects.get(token=token_response.json()["access_token"])
+        granted_scopes = set((access_token.scope or "").split())
+        self.assertEqual(granted_scopes, {"openid", "profile", "email", "introspection", "user:read"})
+        self.assertNotIn("insight:write", granted_scopes)
+        self.assertNotIn("feature_flag:write", granted_scopes)
+
+    def test_dynamic_client_oidc_only_scope_respects_app_ceiling(self):
+        self.public_application.is_dcr_client = True
+        self.public_application.scopes = ["experiment:read"]
+        self.public_application.save()
+
+        auth_data = {
+            "client_id": self.public_application.client_id,
+            "redirect_uri": "https://example.com/callback",
+            "response_type": "code",
+            "code_challenge": self.code_challenge,
+            "code_challenge_method": "S256",
+            "allow": True,
+            "access_level": OAuthApplicationAccessLevel.ALL.value,
+            "scoped_organizations": [],
+            "scoped_teams": [],
+            "scope": "openid",
+        }
+
+        response = self.client.post("/oauth/authorize/", auth_data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        code = response.json()["redirect_to"].split("code=")[1].split("&")[0]
+
+        token_response = self.post(
+            "/oauth/token/",
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "client_id": self.public_application.client_id,
+                "redirect_uri": "https://example.com/callback",
+                "code_verifier": self.code_verifier,
+            },
+        )
+        self.assertEqual(token_response.status_code, status.HTTP_200_OK)
+
+        access_token = OAuthAccessToken.objects.get(token=token_response.json()["access_token"])
+        granted_scopes = set((access_token.scope or "").split())
+        self.assertEqual(granted_scopes, {"openid", "profile", "email", "introspection"})
+        self.assertNotIn("user:read", granted_scopes)
+        self.assertNotIn("experiment:read", granted_scopes)
+
     def test_authorize_wildcard_rejected_when_app_ceiling_set(self):
         self._set_ceiling("experiment:read")
         response = self.client.get(f"{self.base_authorization_url}&scope=*")
@@ -2754,6 +2839,8 @@ class TestOAuthAPI(APIBaseTest):
         granted_scopes = set((access_token.scope or "").split())
         self.assertIn("openid", granted_scopes)
         self.assertIn("user:read", granted_scopes)
+        self.assertNotIn("insight:write", granted_scopes)
+        self.assertNotIn("feature_flag:write", granted_scopes)
 
     def test_non_dcr_client_gets_default_token_expiry(self):
         self.public_application.is_dcr_client = False

--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -2749,6 +2749,12 @@ class TestOAuthAPI(APIBaseTest):
         time_diff = abs((access_token.expires - expected_expiry).total_seconds())
         self.assertLess(time_diff, 60)
 
+        # OIDC-only scope requests from DCR clients must expand to resource scopes
+        # (notably user:read) so MCP init can call /api/users/@me/.
+        granted_scopes = set((access_token.scope or "").split())
+        self.assertIn("openid", granted_scopes)
+        self.assertIn("user:read", granted_scopes)
+
     def test_non_dcr_client_gets_default_token_expiry(self):
         self.public_application.is_dcr_client = False
         self.public_application.save()

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -248,6 +248,9 @@ class OAuthAuthorizationSerializer(serializers.Serializer):
 
 
 class OAuthValidator(OAuth2Validator):
+    # Minimum resource scope dynamic MCP/API clients need to bootstrap via /api/users/@me/.
+    _DYNAMIC_CLIENT_BOOTSTRAP_SCOPES: frozenset[str] = frozenset({"user:read"})
+
     def _is_dynamic_client(self, request) -> bool:
         """Check if the client was registered dynamically (DCR or CIMD)."""
         if hasattr(request, "client") and request.client:
@@ -396,10 +399,12 @@ class OAuthValidator(OAuth2Validator):
             # for `/api/users/@me/`), the MCP server introspects the token as
             # active but init fails — surfacing as HTTP 500 before #57906 and as
             # an opaque failure for clients that don't handle insufficient_scope.
-            # Dynamic clients are API/MCP integrations, not login-only OIDC apps,
-            # so expand OIDC-only requests to the app's effective ceiling.
+            # Grant only bootstrap scopes here; tool-specific scopes should be
+            # obtained via insufficient_scope step-up instead of broad pre-grants.
             if self._is_dynamic_client(request):
-                request.scopes = sorted(requested | effective | self._ALWAYS_ALLOWED_SCOPES)
+                request.scopes = sorted(
+                    requested | (effective & self._DYNAMIC_CLIENT_BOOTSTRAP_SCOPES) | self._ALWAYS_ALLOWED_SCOPES
+                )
             return True
 
         if has_ceiling:

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -391,6 +391,15 @@ class OAuthValidator(OAuth2Validator):
 
         to_check = requested - self._ALWAYS_ALLOWED_SCOPES
         if not to_check:
+            # MCP clients (DCR/CIMD) often request OIDC scopes only during the
+            # RFC 9728 discovery flow. Without resource scopes (notably `user:read`
+            # for `/api/users/@me/`), the MCP server introspects the token as
+            # active but init fails — surfacing as HTTP 500 before #57906 and as
+            # an opaque failure for clients that don't handle insufficient_scope.
+            # Dynamic clients are API/MCP integrations, not login-only OIDC apps,
+            # so expand OIDC-only requests to the app's effective ceiling.
+            if self._is_dynamic_client(request):
+                request.scopes = sorted(requested | effective | self._ALWAYS_ALLOWED_SCOPES)
             return True
 
         if has_ceiling:

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -32,7 +32,12 @@ from posthog.clickhouse.query_tagging import tag_queries
 from posthog.constants import AvailableFeature
 from posthog.helpers.two_factor_session import enforce_two_factor
 from posthog.jwt import PosthogJwtAudience, decode_jwt, get_oidc_public_key
-from posthog.models.oauth import OAuthAccessToken, OAuthApplication, OAuthApplicationAuthBrand
+from posthog.models.oauth import (
+    OAuthAccessToken,
+    OAuthApplication,
+    OAuthApplicationAuthBrand,
+    find_oauth_access_token,
+)
 from posthog.models.personal_api_key import (
     LEGACY_PERSONAL_API_KEY_SALT,
     PERSONAL_API_KEY_AUTH_COUNTER,
@@ -812,7 +817,10 @@ class OAuthAccessTokenAuthentication(authentication.BaseAuthentication):
 
     def _validate_token(self, token: str):
         try:
-            access_token = OAuthAccessToken.objects.select_related("user").get(token=token)
+            access_token = find_oauth_access_token(token)
+
+            if access_token is None:
+                return None
 
             if access_token.is_expired():
                 raise AuthenticationFailed(detail="Access token has expired.")
@@ -828,8 +836,6 @@ class OAuthAccessTokenAuthentication(authentication.BaseAuthentication):
 
             return access_token
 
-        except OAuthAccessToken.DoesNotExist:
-            return None
         except AuthenticationFailed:
             raise
         except Exception:

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -111,16 +111,21 @@ export class StateManager {
         projectId?: number
     }> {
         const [{ scoped_organizations, scoped_teams }, user] = await Promise.all([this.getApiKey(), this.getUser()])
-        const { organization: activeOrganization, team: activeTeam } = user
+        const activeOrganization = user.organization ?? undefined
+        const activeTeam = user.team ?? undefined
 
         // Team-scoped key: prefer the active team if the scope allows it,
         // otherwise pick the first scoped team deterministically. The org is
         // omitted here — `getAnalyticsContext` recovers it from the project.
         if (scoped_teams.length > 0) {
-            if (scoped_teams.includes(activeTeam.id)) {
+            if (activeTeam && scoped_teams.includes(activeTeam.id)) {
                 return { projectId: activeTeam.id }
             }
             return { projectId: scoped_teams[0]! }
+        }
+
+        if (!activeOrganization || !activeTeam) {
+            return {}
         }
 
         // No team scoping: prefer the user's active org/team when the scope

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -254,20 +254,18 @@ export function buildInsufficientScopeChallenge(error: PostHogPermissionError): 
 // `findPostHogPermissionError` for the full reasoning.
 const MISSING_SCOPE_MESSAGE_PATTERN = /Missing PostHog API scope: ['"]([^'"]+)['"]/
 const BACKEND_SCOPE_MESSAGE_PATTERN = /API key missing required scope ['"]([^'"]+)['"]/
+const MISSING_SCOPE_PATTERNS = [MISSING_SCOPE_MESSAGE_PATTERN, BACKEND_SCOPE_MESSAGE_PATTERN]
 
 /**
  * Walk `Error.cause` chains to find a wrapped PostHogPermissionError.
  * Tool-level wrappers (e.g. `throw new Error("Failed to X: ...", { cause })`)
  * hide the underlying permission error, so callers must unwrap before acting.
  *
- * Fallback for the Cloudflare Durable Object RPC boundary: errors thrown
- * inside the DO arrive in the worker as plain Errors — `cause`, the
- * PostHogPermissionError prototype, and any custom own-properties have all
- * been stripped by the cross-isolate serializer, leaving just `name`,
- * `message`, and `stack`. Without this fallback, a permission error from
- * `_fetchUser` (or any other init-time API call) gets mapped to an opaque
- * 500 in `onCatchErrorHandler` and OAuth-aware MCP clients never see the
- * 403 + `WWW-Authenticate: insufficient_scope` they need to re-consent.
+ * Fallback for runtime boundaries and wrapper code that leave us with a plain
+ * Error message instead of the original `cause` chain. Without this fallback,
+ * permission errors from init-time API calls can become opaque 500s and
+ * OAuth-aware MCP clients never see the 403 + `WWW-Authenticate:
+ * insufficient_scope` they need to re-consent.
  *
  * The literal `Missing PostHog API scope: 'X'` shape produced by the
  * `PostHogPermissionError` constructor is the one piece of information that
@@ -287,7 +285,7 @@ export function findPostHogPermissionError(error: unknown): PostHogPermissionErr
     }
 
     if (error instanceof Error && typeof error.message === 'string') {
-        for (const pattern of [MISSING_SCOPE_MESSAGE_PATTERN, BACKEND_SCOPE_MESSAGE_PATTERN]) {
+        for (const pattern of MISSING_SCOPE_PATTERNS) {
             const match = pattern.exec(error.message)
             if (match) {
                 const missingScope = match[1]!

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -253,6 +253,7 @@ export function buildInsufficientScopeChallenge(error: PostHogPermissionError): 
 // `cause` and the custom subclass prototype — see the fallback in
 // `findPostHogPermissionError` for the full reasoning.
 const MISSING_SCOPE_MESSAGE_PATTERN = /Missing PostHog API scope: ['"]([^'"]+)['"]/
+const BACKEND_SCOPE_MESSAGE_PATTERN = /API key missing required scope ['"]([^'"]+)['"]/
 
 /**
  * Walk `Error.cause` chains to find a wrapped PostHogPermissionError.
@@ -286,15 +287,17 @@ export function findPostHogPermissionError(error: unknown): PostHogPermissionErr
     }
 
     if (error instanceof Error && typeof error.message === 'string') {
-        const match = MISSING_SCOPE_MESSAGE_PATTERN.exec(error.message)
-        if (match) {
-            const missingScope = match[1]!
-            return new PostHogPermissionError({
-                detail: `API key missing required scope '${missingScope}'`,
-                missingScope,
-                url: '',
-                method: '',
-            })
+        for (const pattern of [MISSING_SCOPE_MESSAGE_PATTERN, BACKEND_SCOPE_MESSAGE_PATTERN]) {
+            const match = pattern.exec(error.message)
+            if (match) {
+                const missingScope = match[1]!
+                return new PostHogPermissionError({
+                    detail: `API key missing required scope '${missingScope}'`,
+                    missingScope,
+                    url: '',
+                    method: '',
+                })
+            }
         }
     }
 

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -140,6 +140,22 @@ describe('StateManager', () => {
             expect(await cache.get('projectId')).toBe('456')
         })
 
+        it('returns empty context when the user has no active org or team', async () => {
+            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(mockApiKey)
+            vi.spyOn(stateManager, 'getUser').mockResolvedValue({
+                ...mockUser,
+                organization: null,
+                team: null,
+            } as unknown as ApiUser)
+
+            const result = await stateManager.setDefaultOrganizationAndProject()
+
+            expect(result.organizationId).toBeUndefined()
+            expect(result.projectId).toBeUndefined()
+            expect(await cache.get('orgId')).toBeUndefined()
+            expect(await cache.get('projectId')).toBeUndefined()
+        })
+
         it("should use user's active org and team when org is in scoped list", async () => {
             const scopedOrgApiKey = {
                 ...mockApiKey,

--- a/services/mcp/tests/unit/permission-errors.test.ts
+++ b/services/mcp/tests/unit/permission-errors.test.ts
@@ -194,6 +194,17 @@ describe('findPostHogPermissionError', () => {
             expect(recovered?.missingScope).toBe('insight:write')
         })
 
+        it('reconstructs from backend permission_denied detail shape', () => {
+            const stripped = new Error(
+                "Failed to get user: API key missing required scope 'user:read'"
+            )
+
+            const recovered = findPostHogPermissionError(stripped)
+
+            expect(recovered).toBeInstanceOf(PostHogPermissionError)
+            expect(recovered?.missingScope).toBe('user:read')
+        })
+
         it('returns undefined for unrelated error messages even when shape-similar', () => {
             expect(findPostHogPermissionError(new Error('Something about scope but not the literal'))).toBeUndefined()
             expect(findPostHogPermissionError(new Error('Missing PostHog API scope without quotes'))).toBeUndefined()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

OAuth bearer tokens on `POST https://mcp.posthog.com/mcp` can return HTTP 500 while personal API keys (`phx_`) on the same endpoint succeed. The failure mode matches MCP init calling `GET /api/users/@me/`, which requires `user:read`, while OAuth introspection still reports the token as active.

## Changes

- Expand OIDC-only scope requests (`openid`, `profile`, `email`, etc.) to the application's effective resource scope ceiling for DCR/CIMD OAuth clients during `/oauth/authorize`. These dynamic clients are MCP/API integrations, not login-only OIDC apps; leaving them with identity scopes alone breaks MCP initialization.
- Teach MCP `findPostHogPermissionError` to also recover missing scopes from the backend `permission_denied` detail string (`API key missing required scope '…'`), covering cases where the Cloudflare Durable Object RPC boundary strips `Error.cause`.

## How did you test this code?

Cloud agent session — automated tests were not run locally because the dev environment lacks a configured Python runtime (`python`/`hogli` unavailable). Added/extended unit tests:

- `posthog/api/oauth/test_views.py::TestOAuthAPI::test_dcr_client_gets_extended_token_expiry` — asserts DCR tokens minted with `scope=openid` also carry `user:read`
- `services/mcp/tests/unit/permission-errors.test.ts` — backend detail shape recovery

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update — internal OAuth scope resolution fix; user-facing behavior is "OAuth MCP works again after re-auth".

## 🤖 Agent context

- Investigated support ticket: OAuth MCP 500 vs API-key 200 on `POST /mcp` for Claude Code plugin v1.1.13 (US region).
- Traced auth paths: `phx_` → `/api/personal_api_keys/@current`; `pha_` → introspect fallback. Init always hits `/api/users/@me/` for `distinct_id` + default org/project.
- Root cause: `OAuthValidator.validate_scopes` accepts OIDC-only requests without adding resource scopes. Introspect succeeds; `users/@me` fails on missing `user:read`. Pre-#57906 this surfaced as opaque 500 across the DO RPC boundary; post-#57906 it should be 403 + `insufficient_scope`, but tokens remain broken until re-consent.
- Chose server-side expansion for DCR/CIMD clients rather than globally forcing resource scopes (preserves intentional OIDC-only tokens for static OAuth apps like userinfo-only flows).
- MCP error-pattern hardening is belt-and-suspenders for remaining 500 cases when permission errors lose their typed wrapper.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6a5f6b5-ae91-45e6-a066-d55633979ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6a5f6b5-ae91-45e6-a066-d55633979ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

