### PR TITLE
revert(ci): undo gating prod deploy dispatch on backend tests

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -23,14 +23,11 @@ jobs:
         name: Build and push PostHog
         if: github.repository == 'PostHog/posthog'
         runs-on: depot-ubuntu-latest
-        # Bumped from 30: the deploy dispatch now waits for backend CI on this commit
-        # before firing, so the job stays alive through the build + the wait window.
-        timeout-minutes: 75
+        timeout-minutes: 30
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary
             packages: write # allow push to ghcr.io
-            checks: read # allow reading backend CI check results to gate the deploy
 
         steps:
             - name: Check out
@@ -139,43 +136,6 @@ jobs:
                   posthog-token: ${{secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN}}
                   event: 'posthog-image-build'
                   properties: '{"status": "failure", "commit_hash": "${{ github.sha }}"}'
-
-            # Gate the deploy on backend CI. The image is already built and pushed above
-            # (ci-backend.yml runs in parallel on the same commit) — we only hold the
-            # deploy *dispatch* to Charts until this commit's backend suite is green.
-            # A stale merge once shipped a red master commit to prod because the dispatch
-            # fired regardless of test results; this is the backstop. Cross-workflow
-            # check-waiting on the same SHA mirrors the pattern in ci-hobby.yml.
-            - name: Wait for backend tests to pass
-              # Only gate automatic master pushes. A manual workflow_dispatch is the
-              # break-glass: it skips the wait so an operator can force a deploy.
-              if: github.event_name == 'push'
-              id: wait-for-backend
-              uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  checkName: Django Tests Pass
-                  ref: ${{ github.sha }}
-                  timeoutSeconds: 2700
-                  intervalSeconds: 30
-
-            - name: Block deploy if backend tests did not pass
-              if: github.event_name == 'push'
-              env:
-                  BACKEND_CONCLUSION: ${{ steps.wait-for-backend.outputs.conclusion }}
-              run: |
-                  conclusion="$BACKEND_CONCLUSION"
-                  # `skipped` = the backend suite didn't run for this commit; nothing to gate on.
-                  if [ "$conclusion" = "skipped" ]; then
-                    echo "Backend tests skipped for this commit — proceeding with deploy."
-                    exit 0
-                  fi
-                  if [ "$conclusion" != "success" ]; then
-                    echo "::error::Backend CI for this commit is '${conclusion:-incomplete/timed out}'. Not deploying."
-                    echo "Fix CI and re-run, or trigger this workflow via workflow_dispatch to override."
-                    exit 1
-                  fi
-                  echo "Backend tests passed — proceeding with deploy."
 
             - name: get deployer token
               id: deployer


### PR DESCRIPTION
## Problem

Reverts [chore(ci): gate prod deploy dispatch on backend tests (#61012)](https://github.com/PostHog/posthog/pull/61012).

That PR held the prod deploy dispatch in `container-images-cd.yml` until this commit's `Django Tests Pass` check succeeded (via `fountainhead/action-wait-for-check`). We're backing it out.

## Changes

Restores `container-images-cd.yml` to its pre-#61012 state:

- Removes the `Wait for backend tests to pass` and `Block deploy if backend tests did not pass` steps — the deploy dispatch to Charts fires again right after the image build/push, with no dependency on backend CI.
- Drops the `checks: read` permission added to read CI results.
- Restores the job `timeout-minutes` from 75 back to 30 (the bump existed only to cover the wait window).

Net: `1 insertion, 41 deletions`, a clean `git revert` of the squash commit with no conflicts.

## How did you test this code?

Agent-assisted; no live workflow run — the prod CD path can't be safely exercised from a branch. This is a straight `git revert` of `1e31ebb`, verified to reverse exactly the lines #61012 added (timeout back to 30, both gate steps and the `checks: read` permission removed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — infra/CI only. Add `skip-inkeep-docs`.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Mechanical revert of the deploy-gate PR via `git revert` on the squash merge commit; no manual edits to the resulting diff. Opened as a draft for the author/reviewer to decide whether to land.
