### PR TITLE
chore(ci): add fast typecheck/build gates for agent services

### DIFF
--- a/.github/workflows/ci-agent-console.yml
+++ b/.github/workflows/ci-agent-console.yml
@@ -1,0 +1,114 @@
+name: Agent console CI
+
+# Fast type-check / build gate for the agent-console Next.js app. Catches
+# type and build errors in ~minutes on a cheap runner, before the expensive
+# multi-arch container build in ci-agent-container.yml ever starts.
+
+on:
+    push:
+        branches: [master]
+    pull_request:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    changes:
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        name: Determine need to run agent-console checks
+        outputs:
+            agent-console: ${{ steps.filter.outputs.agent-console || 'true' }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              id: app-token
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+              id: filter
+              if: github.event_name != 'push' # Run all checks on master push
+              with:
+                  token: ${{ steps.app-token.outputs.token || github.token }}
+                  filters: |
+                      agent-console:
+                        - 'services/agent-console/**'
+                        - 'packages/agent-chat/**'
+                        - 'packages/quill/**'
+                        - '.github/workflows/ci-agent-console.yml'
+                        - 'pnpm-lock.yaml'
+                        - 'pnpm-workspace.yaml'
+
+    build-and-test:
+        name: Build & Type check
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        needs: changes
+        if: needs.changes.outputs.agent-console == 'true'
+        env:
+            NEXT_TELEMETRY_DISABLED: '1'
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+            - name: Setup Node.js
+              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+              with:
+                  node-version-file: .nvmrc
+                  cache: 'pnpm'
+
+            - name: Install dependencies
+              run: pnpm --filter=@posthog/agent-console... install --frozen-lockfile
+
+            # `@posthog/quill` ships `main: ./dist/index.cjs`; the console
+            # resolves it at type-check and build time, so build it first.
+            # Mirrors services/agent-console/Dockerfile.
+            - name: Build quill
+              run: pnpm --dir packages/quill -r --filter '@posthog/quill-*' --filter '@posthog/quill' build
+
+            - name: Type check
+              run: cd services/agent-console && pnpm typescript:check
+
+            - name: Build
+              run: cd services/agent-console && pnpm build
+
+            - name: Build Storybook
+              run: cd services/agent-console && pnpm build-storybook
+
+    # Collation job for required status check.
+    agent_console_checks:
+        needs: [changes, build-and-test]
+        name: Agent console checks pass
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        if: always()
+        steps:
+            - name: Check all agent-console jobs
+              run: |
+                  if [[ "${{ needs.changes.result }}" == "failure" ]]; then
+                    echo "Change detection job failed."
+                    exit 1
+                  fi
+
+                  if [[ "${{ needs.changes.outputs.agent-console }}" != "true" ]]; then
+                    echo "Agent console checks were skipped (no relevant changes)."
+                    exit 0
+                  fi
+
+                  if [[ "${{ needs.build-and-test.result }}" != "success" && "${{ needs.build-and-test.result }}" != "skipped" ]]; then
+                    echo "Agent console build/type-check failed."
+                    exit 1
+                  fi
+
+                  echo "All agent-console checks passed."

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -1,0 +1,125 @@
+name: Agents CI
+
+# Fast type-check / build / unit-test gate for the agent-platform node
+# services bundled into the posthog-agents image (ingress, runner, janitor,
+# migrations, shared, tools, sandbox-host) plus the esbuild bundler package.
+# Runs on a cheap runner in ~minutes, before the expensive multi-arch
+# container build in ci-agent-container.yml. The agent-console app has its
+# own workflow (ci-agent-console.yml).
+#
+# The agent-tests integration harness is intentionally excluded: it needs a
+# live stack (Postgres, gateway) and belongs in a stack-backed job.
+
+on:
+    push:
+        branches: [master]
+    pull_request:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    changes:
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        name: Determine need to run agents checks
+        outputs:
+            agents: ${{ steps.filter.outputs.agents || 'true' }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              id: app-token
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+              id: filter
+              if: github.event_name != 'push' # Run all checks on master push
+              with:
+                  token: ${{ steps.app-token.outputs.token || github.token }}
+                  filters: |
+                      agents:
+                        - 'services/agents/**'
+                        - 'services/agent-ingress/**'
+                        - 'services/agent-runner/**'
+                        - 'services/agent-janitor/**'
+                        - 'services/agent-migrations/**'
+                        - 'services/agent-shared/**'
+                        - 'services/agent-tools/**'
+                        - 'services/agent-tests/**'
+                        - 'services/agent-sandbox-host/**'
+                        - '.github/workflows/ci-agents.yml'
+                        - 'pnpm-lock.yaml'
+                        - 'pnpm-workspace.yaml'
+
+    build-and-test:
+        name: Build & Test
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        needs: changes
+        if: needs.changes.outputs.agents == 'true'
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+            - name: Setup Node.js
+              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+              with:
+                  node-version-file: .nvmrc
+                  cache: 'pnpm'
+
+            # node-rdkafka / ioredis are optional deps of agent-shared; pnpm
+            # tolerates a native-build failure here, the bundle loads them lazily.
+            - name: Install dependencies
+              run: pnpm --filter './services/agent*' --filter '!@posthog/agent-console' install --frozen-lockfile
+
+            - name: Type check
+              run: pnpm -r --filter './services/agent*' --filter '!@posthog/agent-console' run typescript:check
+
+            - name: Build agents bundle
+              run: pnpm --filter=@posthog/agents-image run build
+
+            # DB-backed suites probe and self-skip when Postgres is unreachable.
+            # Excluded: agent-tests (integration harness, needs a live stack);
+            # agent-migrations (no test files + no local vitest config, so vitest
+            # climbs to the repo-root postcss config whose deps aren't installed
+            # here — it's still covered by the type check and bundle build above).
+            - name: Run unit tests
+              run: pnpm -r --filter './services/agent*' --filter '!@posthog/agent-console' --filter '!@posthog/agent-tests' --filter '!@posthog/agent-migrations' run test
+
+    # Collation job for required status check.
+    agents_checks:
+        needs: [changes, build-and-test]
+        name: Agents checks pass
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        if: always()
+        steps:
+            - name: Check all agents jobs
+              run: |
+                  if [[ "${{ needs.changes.result }}" == "failure" ]]; then
+                    echo "Change detection job failed."
+                    exit 1
+                  fi
+
+                  if [[ "${{ needs.changes.outputs.agents }}" != "true" ]]; then
+                    echo "Agents checks were skipped (no relevant changes)."
+                    exit 0
+                  fi
+
+                  if [[ "${{ needs.build-and-test.result }}" != "success" && "${{ needs.build-and-test.result }}" != "skipped" ]]; then
+                    echo "Agents build/test failed."
+                    exit 1
+                  fi
+
+                  echo "All agents checks passed."


### PR DESCRIPTION
## Problem

Type and build errors in the agent-platform node services only surface inside the multi-arch Depot container build in `ci-agent-container.yml` — the slowest and most expensive place possible. A recent one-line `noImplicitAny` error in an `agent-console` Storybook file failed a full multi-platform image build instead of a quick check. The esbuild-bundled services (`posthog-agents`) get no type check at all, since esbuild strips types without verifying them.

## Changes

Adds two lightweight CI workflows that run on a cheap `ubuntu-latest` runner in ~minutes, before the container build, mirroring the existing `ci-oauth-proxy.yml` / `ci-mcp.yml` pattern (a `changes` paths filter, a work job, and a collation "checks pass" job for a required status check):

- **`ci-agent-console.yml`** — for `@posthog/agent-console`: `typescript:check` (this alone catches the regression that prompted this work, since `tsc --noEmit` covers `src/**/*.tsx`), `next build`, and `build-storybook` (after building `quill`, which the console resolves at build time).
- **`ci-agents.yml`** — for the `posthog-agents` bundle (ingress, runner, janitor, migrations, shared, tools, sandbox-host) plus the esbuild bundler package: `typescript:check` across all, the esbuild bundle build, and unit tests.

Both skip cleanly on unrelated PRs, so they stay backwards-compatible with in-flight branches that haven't rebased.

The `agent-tests` integration harness is intentionally excluded — it needs a live stack (Postgres, gateway) and belongs in a stack-backed job like `ci-mcp.yml`'s integration job.

## How did you test this code?

I'm an agent. I could not execute these workflows locally (the sandbox has Node 22, not the required 24, and deps weren't installed), so they're validated by structure rather than a live run:

- Both files parse as valid YAML and every job declares `timeout-minutes` (per the repo CI rules).
- The pnpm filter expressions were confirmed via `pnpm m ls` to resolve to exactly the intended package sets — the console workflow excludes the bundle, and the agents workflow excludes both `agent-console` and the heavyweight `agent-tests` harness.

The first CI run on this PR is the real confirmation.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code at the request of @benjackwhite, as a follow-up to the `agent-console` build fix in #61432. The fix itself was trivial; the durable prevention is moving the type check out of the expensive container build into a fast pre-build gate. I chose two separate workflows (console vs. the rest of the agent services) to mirror the existing container-build matrix split, and excluded the `agent-tests` integration harness because it requires infra a lightweight gate shouldn't stand up. DB-backed unit suites already probe-and-skip when Postgres is unreachable, so they run safely without a stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XgX34L61mR7dS8c9WqZR7)_