### PR TITLE
fix(ingestion): make person prefetch best-effort so it can't crash workers

### DIFF
--- a/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
@@ -97,13 +97,13 @@ export function createPostTeamPreprocessingSubpipeline<TInput extends PostTeamPr
             // Refresh TTLs for overflow lane events (keeps Redis flags alive)
             .pipeBatch(createOverflowLaneTTLRefreshStep(overflowLaneTTLRefreshService))
             // Prefetch must run after cookieless, as cookieless changes distinct IDs.
-            // Retry transient persons-Postgres failures (e.g. PgBouncer scale-down) instead
-            // of letting them crash the consumer loop.
-            .pipeBatchWithRetry(prefetchPersonsStep(personsStore, personsPrefetchEnabled), {
-                tries: 3,
-                sleepMs: 100,
-            })
-            // Batch insert personless distinct IDs after prefetch (uses prefetch cache)
+            // Prefetch is fire-and-forget (best-effort cache warming), so retry here would be a
+            // no-op — transient persons-Postgres failures are swallowed inside prefetchPersons so
+            // they can't surface as an unhandled rejection and crash the worker.
+            .pipeBatch(prefetchPersonsStep(personsStore, personsPrefetchEnabled))
+            // Batch insert personless distinct IDs after prefetch (uses prefetch cache).
+            // This step awaits its DB write, so retry transient persons-Postgres failures
+            // (e.g. PgBouncer scale-down) instead of letting them crash the consumer loop.
             .pipeBatchWithRetry(processPersonlessDistinctIdsBatchStep(personsStore, personsPrefetchEnabled), {
                 tries: 3,
                 sleepMs: 100,

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -4,7 +4,7 @@ import { INGESTION_WARNINGS_OUTPUT } from '~/ingestion/common/outputs'
 import { IngestionOutputs } from '~/ingestion/outputs/ingestion-outputs'
 import { createMockIngestionOutputs } from '~/tests/helpers/mock-ingestion-outputs'
 import { InternalPerson, TeamId } from '~/types'
-import { MessageSizeTooLarge } from '~/utils/db/error'
+import { DependencyUnavailableError, MessageSizeTooLarge } from '~/utils/db/error'
 import { PostgresRouter } from '~/utils/db/postgres'
 
 import { emitIngestionWarning } from '../../../ingestion/common/ingestion-warnings'
@@ -2653,10 +2653,12 @@ describe('BatchWritingPersonStore', () => {
             expect(mockRepo.fetchPerson).not.toHaveBeenCalled()
         })
 
-        it('should resolve (not reject) when the batch fetch fails', async () => {
+        it('should resolve (not reject) on a transient persons-Postgres failure', async () => {
             const personStoreForBatch = getPersonsStore()
 
-            mockRepo.fetchPersonsByDistinctIds.mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
+            mockRepo.fetchPersonsByDistinctIds.mockRejectedValueOnce(
+                new DependencyUnavailableError('connect ECONNREFUSED', 'Postgres', new Error('connect ECONNREFUSED'))
+            )
 
             // Prefetch is fired without being awaited by its pipeline step, so a rejection here would
             // surface as an unhandled rejection and crash the worker. It must resolve instead.
@@ -2668,10 +2670,23 @@ describe('BatchWritingPersonStore', () => {
             expect(personStoreForBatch.getCheckCache().has(`${teamId}:user-1`)).toBe(false)
         })
 
+        it('should rethrow an unexpected batch fetch failure rather than mask it', async () => {
+            const personStoreForBatch = getPersonsStore()
+
+            // A non-transient error (e.g. a broken query) must surface loudly, not be swallowed.
+            mockRepo.fetchPersonsByDistinctIds.mockRejectedValueOnce(new Error('something unexpected'))
+
+            await expect(personStoreForBatch.prefetchPersons([{ teamId, distinctId: 'user-1' }])).rejects.toThrow(
+                'something unexpected'
+            )
+        })
+
         it('should let fetchForUpdate fall back to an on-demand fetch after a failed prefetch', async () => {
             const personStoreForBatch = getPersonsStore()
 
-            mockRepo.fetchPersonsByDistinctIds.mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
+            mockRepo.fetchPersonsByDistinctIds.mockRejectedValueOnce(
+                new DependencyUnavailableError('connect ECONNREFUSED', 'Postgres', new Error('connect ECONNREFUSED'))
+            )
 
             await personStoreForBatch.prefetchPersons([{ teamId, distinctId: 'user-1' }])
 

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -2696,5 +2696,45 @@ describe('BatchWritingPersonStore', () => {
             expect(result).toEqual(person)
             expect(mockRepo.fetchPerson).toHaveBeenCalledTimes(1)
         })
+
+        it('should propagate a transient in-flight failure to fetchForChecking, not report the person absent', async () => {
+            const personStoreForBatch = getPersonsStore()
+
+            // Control when the batch fetch settles so fetchForChecking piggybacks on the in-flight prefetch.
+            let rejectFetch: (reason: Error) => void
+            const fetchPromise = new Promise<InternalPerson[]>((_resolve, reject) => {
+                rejectFetch = reject
+            })
+            mockRepo.fetchPersonsByDistinctIds.mockReturnValueOnce(fetchPromise)
+
+            const prefetch = personStoreForBatch.prefetchPersons([{ teamId, distinctId: 'user-1' }])
+            const checking = personStoreForBatch.fetchForChecking(teamId, 'user-1')
+
+            rejectFetch!(new DependencyUnavailableError('connect ECONNREFUSED', 'Postgres', new Error('boom')))
+
+            // Must reject so the per-distinct-id pipeline retries — not resolve null ("person absent"),
+            // which would make processPersonlessStep create a fake person for an event that has a real one.
+            await expect(checking).rejects.toThrow('connect ECONNREFUSED')
+            // The fire-and-forget prefetch itself still recovers so it can't crash the worker.
+            await expect(prefetch).resolves.toBeUndefined()
+        })
+
+        it('should propagate a transient in-flight failure to fetchForUpdate rather than silently refetch', async () => {
+            const personStoreForBatch = getPersonsStore()
+
+            let rejectFetch: (reason: Error) => void
+            const fetchPromise = new Promise<InternalPerson[]>((_resolve, reject) => {
+                rejectFetch = reject
+            })
+            mockRepo.fetchPersonsByDistinctIds.mockReturnValueOnce(fetchPromise)
+
+            const prefetch = personStoreForBatch.prefetchPersons([{ teamId, distinctId: 'user-1' }])
+            const update = personStoreForBatch.fetchForUpdate(teamId, 'user-1')
+
+            rejectFetch!(new DependencyUnavailableError('connect ECONNREFUSED', 'Postgres', new Error('boom')))
+
+            await expect(update).rejects.toThrow('connect ECONNREFUSED')
+            await expect(prefetch).resolves.toBeUndefined()
+        })
     })
 })

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -2652,5 +2652,34 @@ describe('BatchWritingPersonStore', () => {
             expect(mockRepo.fetchPersonsByDistinctIds).toHaveBeenCalledTimes(1)
             expect(mockRepo.fetchPerson).not.toHaveBeenCalled()
         })
+
+        it('should resolve (not reject) when the batch fetch fails', async () => {
+            const personStoreForBatch = getPersonsStore()
+
+            mockRepo.fetchPersonsByDistinctIds.mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
+
+            // Prefetch is fired without being awaited by its pipeline step, so a rejection here would
+            // surface as an unhandled rejection and crash the worker. It must resolve instead.
+            await expect(
+                personStoreForBatch.prefetchPersons([{ teamId, distinctId: 'user-1' }])
+            ).resolves.toBeUndefined()
+
+            // Nothing should have been cached for the failed entry
+            expect(personStoreForBatch.getCheckCache().has(`${teamId}:user-1`)).toBe(false)
+        })
+
+        it('should let fetchForUpdate fall back to an on-demand fetch after a failed prefetch', async () => {
+            const personStoreForBatch = getPersonsStore()
+
+            mockRepo.fetchPersonsByDistinctIds.mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
+
+            await personStoreForBatch.prefetchPersons([{ teamId, distinctId: 'user-1' }])
+
+            // The failed prefetch left the caches empty, so fetchForUpdate must do its own fetch.
+            const result = await personStoreForBatch.fetchForUpdate(teamId, 'user-1')
+
+            expect(result).toEqual(person)
+            expect(mockRepo.fetchPerson).toHaveBeenCalledTimes(1)
+        })
     })
 })

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -15,7 +15,7 @@ import {
     Team,
 } from '../../../types'
 import { CreatePersonResult, MoveDistinctIdsResult } from '../../../utils/db/db'
-import { DependencyUnavailableError, MessageSizeTooLarge } from '../../../utils/db/error'
+import { MessageSizeTooLarge } from '../../../utils/db/error'
 import { logger } from '../../../utils/logger'
 import { BatchWritingStore } from '../stores/batch-writing-store'
 import {
@@ -775,14 +775,15 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
             this.fetchPromisesForChecking.set(cacheKey, keyPromise)
         }
 
-        // Recover from transient persons-Postgres unavailability so this best-effort, fire-and-forget
-        // warmer can't crash the worker. The failure is not masked: consumers still observe the
-        // rejection on their per-key promise and retry it in the per-distinct-id pipeline — we only
-        // swallow the redundant fire-and-forget copy. Any other error is rethrown so an unexpected
-        // failure (e.g. a broken query) surfaces instead of being silently masked.
+        // Recover from a retriable failure (e.g. transient persons-Postgres unavailability) so this
+        // best-effort, fire-and-forget warmer can't crash the worker. The failure is not masked:
+        // consumers still observe the rejection on their per-key promise and retry it in the
+        // per-distinct-id pipeline — we only swallow the redundant fire-and-forget copy. We recover
+        // only on an explicit `isRetriable === true`, not the pipeline's `!== false`: an unflagged
+        // error (e.g. a broken query) should rethrow and crash loudly rather than be silently masked.
         await batchFetchPromise.catch((error) => {
-            if (error instanceof DependencyUnavailableError) {
-                logger.warn('⚠️', 'prefetchPersons failed on transient persons-Postgres error', {
+            if (error?.isRetriable === true) {
+                logger.warn('⚠️', 'prefetchPersons failed on a retriable persons-Postgres error', {
                     error: String(error),
                 })
                 return

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -683,6 +683,13 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
         return fetchPromise
     }
 
+    /**
+     * Best-effort cache warmer for the given distinct IDs. Resolves successfully even when the
+     * underlying batch fetch fails: callers fire this without awaiting it, so a rejection would
+     * become an unhandled rejection and crash the worker. On failure the caches are left empty and
+     * fetchForChecking/fetchForUpdate fall back to an on-demand fetch (with their own retry/error
+     * handling), so this method never throws.
+     */
     async prefetchPersons(teamDistinctIds: { teamId: number; distinctId: string }[]): Promise<void> {
         if (teamDistinctIds.length === 0) {
             return
@@ -747,6 +754,18 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                 }
 
                 return personsByKey
+            })
+            .catch((error) => {
+                // Prefetch is best-effort and is fired without being awaited by its pipeline step.
+                // A rejection here would otherwise become an unhandled rejection and crash the worker
+                // (both this chain and the per-key promises registered below would reject). On failure
+                // (e.g. transient persons-Postgres unavailability) leave the caches empty and resolve to
+                // an empty map: fetchForChecking/fetchForUpdate then fall back to an on-demand fetch,
+                // which carries its own retry/error handling in the per-distinct-id pipeline.
+                logger.warn('⚠️', 'prefetchPersons failed, falling back to on-demand fetch', {
+                    error: String(error),
+                })
+                return new Map<string, InternalPerson>()
             })
             .finally(() => {
                 // Clean up the promises after completion

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -685,11 +685,11 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
 
     /**
      * Best-effort cache warmer for the given distinct IDs. Callers fire this without awaiting it,
-     * so any rejection becomes an unhandled rejection that exits the worker. It therefore recovers
-     * from transient persons-Postgres unavailability (DependencyUnavailableError) by resolving to an
-     * empty cache — fetchForChecking/fetchForUpdate fall back to an on-demand fetch (with their own
-     * retry/error handling). Any other error is rethrown: an unexpected prefetch failure (e.g. a
-     * broken query) should crash loudly rather than be silently masked.
+     * so its own rejection would become an unhandled rejection that exits the worker — so it swallows
+     * transient persons-Postgres unavailability (DependencyUnavailableError) here. The failure is not
+     * masked: each per-key promise (awaited by fetchForChecking/fetchForUpdate) still rejects, so a
+     * consumer propagates the error and the per-distinct-id pipeline retries it. Any other error
+     * (e.g. a broken query) is rethrown so it crashes loudly rather than being silently masked.
      */
     async prefetchPersons(teamDistinctIds: { teamId: number; distinctId: string }[]): Promise<void> {
         if (teamDistinctIds.length === 0) {
@@ -756,21 +756,6 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
 
                 return personsByKey
             })
-            .catch((error) => {
-                // Only recover from transient persons-Postgres/PgBouncer unavailability, which is the
-                // known crash cause: this step is fired without being awaited, so a rejection becomes
-                // an unhandled rejection and exits the worker. On a transient failure leave the caches
-                // empty and resolve to an empty map — fetchForChecking/fetchForUpdate then fall back to
-                // an on-demand fetch, which carries its own retry/error handling in the per-distinct-id
-                // pipeline. Any other error is unexpected and rethrown rather than silently masked.
-                if (error instanceof DependencyUnavailableError) {
-                    logger.warn('⚠️', 'prefetchPersons failed on transient persons-Postgres error', {
-                        error: String(error),
-                    })
-                    return new Map<string, InternalPerson>()
-                }
-                throw error
-            })
             .finally(() => {
                 // Clean up the promises after completion
                 for (const { cacheKey } of uncachedEntries) {
@@ -778,21 +763,32 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                 }
             })
 
-        // Register per-key promises so fetchForChecking/fetchForUpdate will wait on them.
-        // These resolve to null on any fetch failure so they never dangle as rejected promises:
-        // consumers fall back to an on-demand fetch, and the single source of truth for surfacing an
-        // unexpected failure is the awaited batch fetch below.
+        // Register per-key promises so fetchForChecking/fetchForUpdate can wait on the in-flight
+        // batch. On failure these reject, so a consumer propagates the error (and a transient
+        // DependencyUnavailableError is retried in the per-distinct-id pipeline) rather than seeing a
+        // misleading "person absent" null. The throwaway catch only marks the promise handled so an
+        // unconsumed key (its event may be dropped before the fetch) can't become an unhandled
+        // rejection — it does not change what awaiting consumers observe.
         for (const { cacheKey } of uncachedEntries) {
-            const keyPromise = batchFetchPromise
-                .then((personsByKey) => personsByKey.get(cacheKey) ?? null)
-                .catch(() => null)
+            const keyPromise = batchFetchPromise.then((personsByKey) => personsByKey.get(cacheKey) ?? null)
+            keyPromise.catch(() => {})
             this.fetchPromisesForChecking.set(cacheKey, keyPromise)
         }
 
-        // Await the batch fetch so callers who await prefetchPersons() get blocking behavior.
-        // On an unexpected (non-transient) failure this rethrows, surfacing the error instead of
-        // silently masking it.
-        await batchFetchPromise
+        // Recover from transient persons-Postgres unavailability so this best-effort, fire-and-forget
+        // warmer can't crash the worker. The failure is not masked: consumers still observe the
+        // rejection on their per-key promise and retry it in the per-distinct-id pipeline — we only
+        // swallow the redundant fire-and-forget copy. Any other error is rethrown so an unexpected
+        // failure (e.g. a broken query) surfaces instead of being silently masked.
+        await batchFetchPromise.catch((error) => {
+            if (error instanceof DependencyUnavailableError) {
+                logger.warn('⚠️', 'prefetchPersons failed on transient persons-Postgres error', {
+                    error: String(error),
+                })
+                return
+            }
+            throw error
+        })
     }
 
     async fetchForUpdate(teamId: Team['id'], distinctId: string): Promise<InternalPerson | null> {

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -15,7 +15,7 @@ import {
     Team,
 } from '../../../types'
 import { CreatePersonResult, MoveDistinctIdsResult } from '../../../utils/db/db'
-import { MessageSizeTooLarge } from '../../../utils/db/error'
+import { DependencyUnavailableError, MessageSizeTooLarge } from '../../../utils/db/error'
 import { logger } from '../../../utils/logger'
 import { BatchWritingStore } from '../stores/batch-writing-store'
 import {
@@ -684,11 +684,12 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
     }
 
     /**
-     * Best-effort cache warmer for the given distinct IDs. Resolves successfully even when the
-     * underlying batch fetch fails: callers fire this without awaiting it, so a rejection would
-     * become an unhandled rejection and crash the worker. On failure the caches are left empty and
-     * fetchForChecking/fetchForUpdate fall back to an on-demand fetch (with their own retry/error
-     * handling), so this method never throws.
+     * Best-effort cache warmer for the given distinct IDs. Callers fire this without awaiting it,
+     * so any rejection becomes an unhandled rejection that exits the worker. It therefore recovers
+     * from transient persons-Postgres unavailability (DependencyUnavailableError) by resolving to an
+     * empty cache — fetchForChecking/fetchForUpdate fall back to an on-demand fetch (with their own
+     * retry/error handling). Any other error is rethrown: an unexpected prefetch failure (e.g. a
+     * broken query) should crash loudly rather than be silently masked.
      */
     async prefetchPersons(teamDistinctIds: { teamId: number; distinctId: string }[]): Promise<void> {
         if (teamDistinctIds.length === 0) {
@@ -756,16 +757,19 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                 return personsByKey
             })
             .catch((error) => {
-                // Prefetch is best-effort and is fired without being awaited by its pipeline step.
-                // A rejection here would otherwise become an unhandled rejection and crash the worker
-                // (both this chain and the per-key promises registered below would reject). On failure
-                // (e.g. transient persons-Postgres unavailability) leave the caches empty and resolve to
-                // an empty map: fetchForChecking/fetchForUpdate then fall back to an on-demand fetch,
-                // which carries its own retry/error handling in the per-distinct-id pipeline.
-                logger.warn('⚠️', 'prefetchPersons failed, falling back to on-demand fetch', {
-                    error: String(error),
-                })
-                return new Map<string, InternalPerson>()
+                // Only recover from transient persons-Postgres/PgBouncer unavailability, which is the
+                // known crash cause: this step is fired without being awaited, so a rejection becomes
+                // an unhandled rejection and exits the worker. On a transient failure leave the caches
+                // empty and resolve to an empty map — fetchForChecking/fetchForUpdate then fall back to
+                // an on-demand fetch, which carries its own retry/error handling in the per-distinct-id
+                // pipeline. Any other error is unexpected and rethrown rather than silently masked.
+                if (error instanceof DependencyUnavailableError) {
+                    logger.warn('⚠️', 'prefetchPersons failed on transient persons-Postgres error', {
+                        error: String(error),
+                    })
+                    return new Map<string, InternalPerson>()
+                }
+                throw error
             })
             .finally(() => {
                 // Clean up the promises after completion
@@ -774,15 +778,20 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                 }
             })
 
-        // Register per-key promises so fetchForChecking/fetchForUpdate will wait on them
+        // Register per-key promises so fetchForChecking/fetchForUpdate will wait on them.
+        // These resolve to null on any fetch failure so they never dangle as rejected promises:
+        // consumers fall back to an on-demand fetch, and the single source of truth for surfacing an
+        // unexpected failure is the awaited batch fetch below.
         for (const { cacheKey } of uncachedEntries) {
-            const keyPromise = batchFetchPromise.then((personsByKey) => {
-                return personsByKey.get(cacheKey) ?? null
-            })
+            const keyPromise = batchFetchPromise
+                .then((personsByKey) => personsByKey.get(cacheKey) ?? null)
+                .catch(() => null)
             this.fetchPromisesForChecking.set(cacheKey, keyPromise)
         }
 
-        // Await the batch fetch so callers who await prefetchPersons() get blocking behavior
+        // Await the batch fetch so callers who await prefetchPersons() get blocking behavior.
+        // On an unexpected (non-transient) failure this rethrows, surfacing the error instead of
+        // silently masking it.
         await batchFetchPromise
     }
 


### PR DESCRIPTION
## Problem

`ingestion-analytics-main` workers were restarting during transient persons-Postgres unavailability (e.g. a PgBouncer scale-down returning `ECONNREFUSED` on `:6543`).

The crash is an **unhandled promise rejection**. `prefetchPersonsStep` fires `personsStore.prefetchPersons(...)` as a best-effort cache warmer **without awaiting it**. When the underlying batch fetch (`fetchPersonsByDistinctIds`) rejects, nothing has a handler attached:

- the discarded outer promise from the fire-and-forget call, and
- the per-key promises `prefetchPersons` registers for `fetchForChecking`/`fetchForUpdate` to await later

both reject before any consumer attaches. Node emits `unhandledRejection`, and the server lifecycle (`base-server.ts`) turns that into `process.exit(1)` → pod restart.

A previous change wrapped the prefetch step in `pipeBatchWithRetry`, but that was a no-op: the step returns immediately and never awaits the fetch, so the retry observed nothing.

## Changes

- **Stop the fire-and-forget promise from crashing the worker.** The awaited batch fetch inside `prefetchPersons` swallows a **retriable** failure (`error?.isRetriable === true` — e.g. the transient `DependencyUnavailableError` that `handlePostgresError` raises for PgBouncer unavailability) and logs a warning. The polarity is deliberately `=== true`, not the pipeline's `!== false`: an unflagged error (e.g. a broken query) is **rethrown** so it crashes loudly rather than being silently masked.
- **Don't mask the failure — propagate it.** The per-key promises that `fetchForChecking`/`fetchForUpdate` await still **reject** on failure, so a consumer propagates the error and the per-distinct-id pipeline's `builder.retry` retries the retriable error — the same handling a direct fetch failure already gets. A throwaway `.catch(() => {})` only keeps an unconsumed key (its event dropped before the fetch) from dangling as an unhandled rejection.
  - This matters because `fetchForChecking` returns the per-key promise's value **directly**. An earlier iteration resolved it to `null` on failure, but `null` reads as "person absent" — `processPersonlessStep` would then create a *fake* person for an event that has a real one. Rejecting avoids that.
- **Drop the no-op retry wrapper** around the prefetch step. The retry on the personless-distinct-id step (which **does** await its write) is kept.

## How did you test this code?

I'm an agent. Added unit tests in `batch-writing-person-store.test.ts`: `prefetchPersons` resolves on a retriable failure (no worker crash); rethrows an unexpected error rather than masking it; and **in-flight regression tests for both `fetchForChecking` and `fetchForUpdate`** asserting they propagate (reject) a transient failure instead of reporting the person absent / silently refetching. The regression tests were confirmed by stashing the fix (they fail: "promise resolved instead of rejected") and restoring it (they pass). Full `batch-writing-person-store` suite (80 pass), plus `pnpm build` and `pnpm lint` clean. No manual/production testing performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Diagnosed from a 15-minute log export: 10 paired "Unhandled Promise Rejection → Shutting down" sequences across distinct pods, clustered on two short PgBouncer blips, all originating in `fetchPersonsByDistinctIds`.

Design iterated over review: (1) catching only at the fire-and-forget call site was rejected — the per-key promises stored for later consumers reject before a consumer attaches, so the handler must sit on the batch fetch; (2) resolving the per-key promises to `null` was rejected because `fetchForChecking` returns that value directly and a `null` causes `processPersonlessStep` to fabricate a person — so they reject and propagate into the pipeline's existing retry instead; (3) the recovery condition moved from `instanceof DependencyUnavailableError` to `error?.isRetriable === true` to match the codebase's retry convention and cover future retriable types (identical behaviour today). The FK `23503` person-merge races and `fetchPerson`/`fetchGroup` `ECONNRESET` errors in the same window were confirmed to be logged-and-handled, not crash sources.

Known follow-up (not in this PR): `ECONNRESET` and `08P01 "pooler is shutting down"` are not in `POSTGRES_UNAVAILABLE_ERROR_MESSAGES`, so they don't become `DependencyUnavailableError` and would hit the rethrow path; adding them to that allowlist would let this check recover them automatically.
