### PR TITLE
fix(taxonomic-filter): commit SQL expression in headless menu

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -1079,6 +1079,50 @@ describe('taxonomicFilterLogic', () => {
             expect(personsGroup?.getValue?.(person as any)).toBe(expected)
         })
     })
+
+    describe('SQL expression (HogQLExpression) group commits its value', () => {
+        let hogqlLogic: ReturnType<typeof taxonomicFilterLogic.build>
+        const onChange = jest.fn()
+
+        beforeEach(() => {
+            onChange.mockClear()
+            hogqlLogic = taxonomicFilterLogic({
+                taxonomicFilterLogicKey: 'hogqlExpressionTest',
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.HogQLExpression],
+                onChange,
+            })
+            hogqlLogic.mount()
+        })
+
+        afterEach(() => {
+            hogqlLogic.unmount()
+        })
+
+        it('getValue returns the expression so the headless menu can commit it', () => {
+            const group = hogqlLogic.values.taxonomicGroups.find(
+                (g) => g.type === TaxonomicFilterGroupType.HogQLExpression
+            )
+            expect(group?.getValue).toBeDefined() // oxlint-disable-line jest/no-restricted-matchers
+            // The headless menu synthesizes an item carrying the expression in `value`.
+            const item = { name: 'properties.$current_url', value: 'properties.$current_url' }
+            expect(group?.getValue?.(item as any)).toBe('properties.$current_url')
+        })
+
+        it('selectItem with the derived value fires onChange with the expression, not null', async () => {
+            const group = hogqlLogic.values.taxonomicGroups.find(
+                (g) => g.type === TaxonomicFilterGroupType.HogQLExpression
+            )!
+            const item = { name: 'properties.$current_url', value: 'properties.$current_url' }
+            // Mirror TaxonomicFilterMenu's handleCommit: the value is derived via group.getValue.
+            const value = group.getValue?.(item as any) ?? null
+
+            await expectLogic(hogqlLogic, () => {
+                hogqlLogic.actions.selectItem(group, value, item as any)
+            }).toDispatchActions(['selectItem'])
+
+            expect(onChange).toHaveBeenCalledWith(group, 'properties.$current_url', item)
+        })
+    })
 })
 
 describe('redistributeTopMatches', () => {

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1348,6 +1348,12 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         categoryLabel: () => 'SQL expression',
                         type: TaxonomicFilterGroupType.HogQLExpression,
                         render: InlineHogQLEditor,
+                        // The headless menu derives the committed value via
+                        // group.getValue(item); without this the SQL expression
+                        // resolves to null and the selection is silently dropped.
+                        // The legacy InlineHogQLEditor passes its value straight
+                        // to selectItem, so it never relied on getValue.
+                        getValue: (option) => (option as { value?: TaxonomicFilterValue }).value ?? option.name,
                         getPopoverHeader: () => 'SQL expression',
                         componentProps: { metadataSource, ...hogQLExpressionComponentProps },
                     },


### PR DESCRIPTION
## Problem

In the new headless `TaxonomicFilterMenu` (gated by `taxonomic-filter-menu-rebuild`), adding a **SQL expression** does nothing: you paste an expression, click **Add SQL expression**, the popover closes, and no filter is applied. Reported internally against the in-progress rebuild.

Root cause: the headless menu derives a committed selection's value generically via `group.getValue(item)` (`menu/TaxonomicFilterMenu.tsx` `handleCommit`). The `HogQLExpression` ("SQL expression") group is the **only** group with no `getValue`, so the value resolves to `null`. `selectItem` then fires `onChange(group, null, item)` and the expression the user typed never reaches the consumer.

This only affects the new menu. The legacy `InlineHogQLEditor` passes its value straight to `selectItem` (`InfiniteSelectResults.tsx`), so it never relied on `getValue` — which is exactly why the group never needed one before.

## Changes

- Add a `getValue` to the `HogQLExpression` group in `taxonomicFilterLogic.tsx` that reads the expression from the committed item (`value`, falling back to `name`). The headless `HogQLEditor` already stores the expression in `item.value`, so the commit path now carries the real expression through to `onChange`.

This is additive and safe for the legacy flow, which doesn't call `getValue` for HogQL.

## How did you test this code?

I'm an agent (PostHog Slack app). I did **not** manually test in a browser. Automated tests only:

- Added two regression tests in `taxonomicFilterLogic.test.ts` under "SQL expression (HogQLExpression) group commits its value":
  - `getValue` returns the expression for a synthesized `{ name, value }` item.
  - mirroring `handleCommit`'s value derivation, `selectItem` fires `onChange` with the expression string (not `null`).
- Ran locally (jest): `taxonomicFilterLogic.test.ts` and `menu/Combobox.test.tsx` — **69 passed**. Without the fix, both new tests fail (`getValue` undefined → value `null`).

A browser check of the actual paste → Add SQL expression → filter-applied flow against the flag-on menu would be a good manual confirmation before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) from a Slack bug report on the new taxonomic filter. I traced the commit path: `HogQLEditor` → `handleCommit` (`itemValue = entry.group.getValue?.(mergedItem) ?? null`) → `selectItem` → `onChange`, and found the `HogQLExpression` group had no `getValue` so the value was lost.

Considered two fixes: (a) a fallback in the menu's `handleCommit` to read `extra.value`, or (b) giving the group a `getValue`. Chose (b) — it fixes the bug at the data-model layer so any generic consumer of the group works, and matches how every other group already exposes its value. The mandatory `/modifying-taxonomic-filter` skill was reviewed; this change touches no ordering, promotion, position-0, tab rendering, or telemetry shapes, so it's clear of the human-sign-off rules.
