### PR TITLE
fix(data-modeling): skip v1 scheduling for saved queries on a v2 DAG

### DIFF
--- a/products/data_modeling/backend/models/datawarehouse_saved_query.py
+++ b/products/data_modeling/backend/models/datawarehouse_saved_query.py
@@ -178,16 +178,18 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
             unpause_saved_query_schedule,
         )
 
-        # If this query's DAG already runs on a v2 schedule, that schedule materializes it. Never
-        # create or revive a per-query v1 schedule, and clear any lingering frequency that would
-        # cause one to be recreated.
-        if self.id in get_v2_saved_query_ids([self.id]):
-            if self.sync_frequency_interval is not None:
-                self.sync_frequency_interval = None
-                self.save(update_fields=["sync_frequency_interval"])
-            return
-
         try:
+            # If this query's DAG already runs on a v2 schedule, that schedule materializes it. Never
+            # create or revive a per-query v1 schedule, and clear any lingering frequency that would
+            # cause one to be recreated. This Temporal lookup stays inside the try so that, if it
+            # fails, we honor the failure contract below rather than leaving is_materialized=True
+            # with no schedule backing it.
+            if self.id in get_v2_saved_query_ids([self.id]):
+                if self.sync_frequency_interval is not None:
+                    self.sync_frequency_interval = None
+                    self.save(update_fields=["sync_frequency_interval"])
+                return
+
             self.setup_model_paths()
 
             schedule_exists = saved_query_workflow_exists(self)

--- a/products/data_modeling/backend/models/datawarehouse_saved_query.py
+++ b/products/data_modeling/backend/models/datawarehouse_saved_query.py
@@ -171,11 +171,21 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
         If the workflow fails to schedule, it will disable materialization for this view.
         This also guarantees model paths are properly created or updated.
         """
+        from products.data_modeling.backend.schedule import get_v2_saved_query_ids
         from products.data_warehouse.backend.data_load.saved_query_service import (
             saved_query_workflow_exists,
             sync_saved_query_workflow,
             unpause_saved_query_schedule,
         )
+
+        # If this query's DAG already runs on a v2 schedule, that schedule materializes it. Never
+        # create or revive a per-query v1 schedule, and clear any lingering frequency that would
+        # cause one to be recreated.
+        if self.id in get_v2_saved_query_ids([self.id]):
+            if self.sync_frequency_interval is not None:
+                self.sync_frequency_interval = None
+                self.save(update_fields=["sync_frequency_interval"])
+            return
 
         try:
             self.setup_model_paths()

--- a/products/data_modeling/backend/test/test_schedule_materialization.py
+++ b/products/data_modeling/backend/test/test_schedule_materialization.py
@@ -47,3 +47,17 @@ class TestScheduleMaterializationV2Guard(BaseTest):
         sync_wf.assert_called_once()
         self.sq.refresh_from_db()
         assert self.sq.sync_frequency_interval == timedelta(hours=12)
+
+    def test_disables_materialization_when_v2_lookup_fails(self):
+        self.sq.is_materialized = True
+        self.sq.save(update_fields=["is_materialized"])
+        with (
+            mock.patch(GET_V2_DAG_IDS, side_effect=Exception("temporal unavailable")),
+            mock.patch(f"{SERVICE}.sync_saved_query_workflow") as sync_wf,
+            mock.patch(f"{SERVICE}.saved_query_workflow_exists", return_value=False),
+            mock.patch.object(DataWarehouseSavedQuery, "setup_model_paths"),
+        ):
+            self.sq.schedule_materialization()
+        sync_wf.assert_not_called()
+        self.sq.refresh_from_db()
+        assert self.sq.is_materialized is False

--- a/products/data_modeling/backend/test/test_schedule_materialization.py
+++ b/products/data_modeling/backend/test/test_schedule_materialization.py
@@ -1,0 +1,49 @@
+from datetime import timedelta
+
+from posthog.test.base import BaseTest
+from unittest import mock
+
+from products.data_modeling.backend.models import DAG, Node
+from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.data_modeling.backend.models.node import NodeType
+
+SERVICE = "products.data_warehouse.backend.data_load.saved_query_service"
+GET_V2_DAG_IDS = "products.data_modeling.backend.schedule.get_v2_scheduled_dag_ids"
+
+
+class TestScheduleMaterializationV2Guard(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.dag = DAG.objects.create(team=self.team, name="Default")
+        self.sq = DataWarehouseSavedQuery.objects.create(
+            name="view",
+            team=self.team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+            sync_frequency_interval=timedelta(hours=12),
+        )
+        Node.objects.create(team=self.team, dag=self.dag, saved_query=self.sq, type=NodeType.VIEW)
+
+    def test_skips_v1_and_nulls_frequency_when_dag_on_v2(self):
+        with (
+            mock.patch(GET_V2_DAG_IDS, return_value={str(self.dag.id)}),
+            mock.patch(f"{SERVICE}.sync_saved_query_workflow") as sync_wf,
+            mock.patch(f"{SERVICE}.saved_query_workflow_exists", return_value=False),
+            mock.patch.object(DataWarehouseSavedQuery, "setup_model_paths") as setup_paths,
+        ):
+            self.sq.schedule_materialization()
+        sync_wf.assert_not_called()
+        setup_paths.assert_not_called()
+        self.sq.refresh_from_db()
+        assert self.sq.sync_frequency_interval is None
+
+    def test_creates_v1_schedule_when_dag_not_on_v2(self):
+        with (
+            mock.patch(GET_V2_DAG_IDS, return_value=set()),
+            mock.patch(f"{SERVICE}.sync_saved_query_workflow") as sync_wf,
+            mock.patch(f"{SERVICE}.saved_query_workflow_exists", return_value=False),
+            mock.patch.object(DataWarehouseSavedQuery, "setup_model_paths"),
+        ):
+            self.sq.schedule_materialization()
+        sync_wf.assert_called_once()
+        self.sq.refresh_from_db()
+        assert self.sq.sync_frequency_interval == timedelta(hours=12)


### PR DESCRIPTION
## Problem

`DataWarehouseSavedQuery.schedule_materialization()` always (re)creates a per-query v1 `data-modeling-run` Temporal schedule. Once a query's DAG has been migrated to a v2 `data-modeling-execute-dag` schedule, that DAG schedule already materializes the query — so the per-query schedule double-schedules the work, and any path that calls `schedule_materialization` (the Revenue Analytics `sync_views`, endpoint refresh, the `materialize` endpoint) silently revives v1 within ~12h of a v2 migration.

## Changes

Guard `schedule_materialization`: if the query belongs to a DAG that already runs on a v2 schedule (`get_v2_saved_query_ids`), clear any lingering `sync_frequency_interval` (so nothing recreates a v1 schedule later) and return without touching v1. Because the guard lives in the single method every caller funnels through, it covers all entry points at once. Before any DAG is on v2 the guard is a no-op, so this is safe to ship ahead of the migration.

## How did you test this code?

I'm an agent (Claude Code); no manual Temporal exercise. Added `TestScheduleMaterializationV2Guard` with two cases: (1) DAG on v2 → `sync_saved_query_workflow` is not called, `setup_model_paths` is not called, and `sync_frequency_interval` is nulled; (2) DAG not on v2 → v1 schedule is created and the frequency is preserved. `hogli test products/data_modeling/backend/test/test_schedule_materialization.py` passes; ran ruff check/format.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Stacked on top of the `get_v2_scheduled_dag_ids` client-side-listing fix (that guard raised in some Temporal configs, so it had to land first). This is the central leak guard; the materialize/endpoint marker-set paths are intentionally left alone because this method nulls the frequency back for v2 queries, so a per-call-site guard isn't needed.

<!-- gg:stack-start -->
## gg stack

- **#61447 `andrew/schedule-materialization-v2-guard` 👈 this PR**
<!-- gg:stack-end -->
