### PR TITLE
chore(llma): tell agents to link skills by name not id

### DIFF
--- a/products/ai_observability/mcp/tools.yaml
+++ b/products/ai_observability/mcp/tools.yaml
@@ -899,7 +899,9 @@ tools:
         title: Get skill
         description: >
             Get a specific agent skill by name, including its full body content, metadata, and file manifest. Follows
-            the Agent Skills specification (agentskills.io).
+            the Agent Skills specification (agentskills.io). To link a user to this skill in the PostHog app, build the
+            URL from the skill `name`, not its `id`: `/llm-analytics/skills/<name>` (e.g.
+            `/llm-analytics/skills/pr-shepherd`). The `id` (UUID) is not a valid route segment and will 404.
     llma-skill-list:
         operation: llm_skills_list
         enabled: true
@@ -913,7 +915,9 @@ tools:
         description: >
             List all agent skills stored for the current team. Returns skill names and descriptions for discovery — use
             descriptions to determine which skill to fetch for a given task. Does not return skill body content (use
-            llma-skill-get to fetch full content).
+            llma-skill-get to fetch full content). To link a user to a skill in the PostHog app, build the URL from the
+            skill `name`, not its `id`: `/llm-analytics/skills/<name>` (e.g. `/llm-analytics/skills/pr-shepherd`). The
+            `id` (UUID) is not a valid route segment and will 404.
     llma-skill-resolve:
         operation: llm_skills_resolve_name_retrieve
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -3320,7 +3320,7 @@
         }
     },
     "llma-skill-get": {
-        "description": "Get a specific agent skill by name, including its full body content, metadata, and file manifest. Follows the Agent Skills specification (agentskills.io).",
+        "description": "Get a specific agent skill by name, including its full body content, metadata, and file manifest. Follows the Agent Skills specification (agentskills.io). To link a user to this skill in the PostHog app, build the URL from the skill `name`, not its `id`: `/llm-analytics/skills/<name>` (e.g. `/llm-analytics/skills/pr-shepherd`). The `id` (UUID) is not a valid route segment and will 404.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get skill",
@@ -3334,7 +3334,7 @@
         }
     },
     "llma-skill-list": {
-        "description": "List all agent skills stored for the current team. Returns skill names and descriptions for discovery — use descriptions to determine which skill to fetch for a given task. Does not return skill body content (use llma-skill-get to fetch full content).",
+        "description": "List all agent skills stored for the current team. Returns skill names and descriptions for discovery — use descriptions to determine which skill to fetch for a given task. Does not return skill body content (use llma-skill-get to fetch full content). To link a user to a skill in the PostHog app, build the URL from the skill `name`, not its `id`: `/llm-analytics/skills/<name>` (e.g. `/llm-analytics/skills/pr-shepherd`). The `id` (UUID) is not a valid route segment and will 404.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "List skills",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -3574,7 +3574,7 @@
         }
     },
     "llma-skill-get": {
-        "description": "Get a specific agent skill by name, including its full body content, metadata, and file manifest. Follows the Agent Skills specification (agentskills.io).",
+        "description": "Get a specific agent skill by name, including its full body content, metadata, and file manifest. Follows the Agent Skills specification (agentskills.io). To link a user to this skill in the PostHog app, build the URL from the skill `name`, not its `id`: `/llm-analytics/skills/<name>` (e.g. `/llm-analytics/skills/pr-shepherd`). The `id` (UUID) is not a valid route segment and will 404.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get skill",
@@ -3588,7 +3588,7 @@
         }
     },
     "llma-skill-list": {
-        "description": "List all agent skills stored for the current team. Returns skill names and descriptions for discovery — use descriptions to determine which skill to fetch for a given task. Does not return skill body content (use llma-skill-get to fetch full content).",
+        "description": "List all agent skills stored for the current team. Returns skill names and descriptions for discovery — use descriptions to determine which skill to fetch for a given task. Does not return skill body content (use llma-skill-get to fetch full content). To link a user to a skill in the PostHog app, build the URL from the skill `name`, not its `id`: `/llm-analytics/skills/<name>` (e.g. `/llm-analytics/skills/pr-shepherd`). The `id` (UUID) is not a valid route segment and will 404.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "List skills",


### PR DESCRIPTION
## Problem

The skill store app route is keyed by skill **name** (`/llm-analytics/skills/:name`), but the `llma-skill-list` and `llma-skill-get` MCP tools surface the skill `id` (a UUID) prominently with nothing signalling that the route is name-keyed. The natural move for an agent — "I have an `id`, so the link is `.../skills/<id>`" — produces a URL that 404s every time. This bit a real session: an agent confidently handed over a dead link to a skill.

## Changes

- Added a short URL-building hint to the `llma-skill-list` and `llma-skill-get` tool descriptions in `products/ai_observability/mcp/tools.yaml`: link from the skill `name`, not its `id`, because the `id` is not a valid route segment.
- Regenerated the embedded copies of those descriptions in `services/mcp/schema/generated-tool-definitions.json` and `tool-definitions-all.json`.
- (Out of band, not in this diff) the companion `posthog-skills-store` skill in the PostHog store got the same "Linking to a skill in the app" guidance.

## How did you test this code?

I'm an agent. I did not run the full `pnpm generate-tools` codegen locally because it requires a running Postgres + the OpenAPI schema, neither of which was available in this environment. The description field is a verbatim YAML-fold passthrough from `tools.yaml` into the generated JSON, so I hand-applied the exact folded string to both generated files and validated they remain well-formed JSON. CI's generated-types/tools check will confirm the regenerated output matches.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by PostHog Code (Claude Opus) at Paul's direction. The trigger was a 404 on a hand-built skill link: the agent had constructed the URL from the UUID `id` returned by `llma-skill-list`. Root cause found by reading `products/ai_observability/manifest.tsx`, where the route `/llm-analytics/skills/:name` (canonical `/prompt-management/skills/:name`) is clearly name-keyed.

Two fixes were chosen so the guidance lands wherever an agent looks: the MCP tool descriptions (this PR) and the `posthog-skills-store` skill body (updated live in the store). Editing the generated JSON by hand was a deliberate trade-off to avoid standing up the DB for a pure description-string change — flagged above for the reviewer.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
