### PR TITLE
fix(data-warehouse): correct new source skill link

### DIFF
--- a/products/data_warehouse/skills/suggesting-data-imports/SKILL.md
+++ b/products/data_warehouse/skills/suggesting-data-imports/SKILL.md
@@ -87,7 +87,7 @@ Common join patterns:
 
 - **Don't guess table names.** Always check `posthog:read-data-warehouse-schema` and `posthog:external-data-schemas-list` before saying data doesn't exist.
 - **Check prefixes.** Imported tables are often prefixed (e.g. `stripe_charges` not `charges`). The user might not know the prefix.
-- **OAuth sources require the UI.** Some sources (Google Ads, Meta Ads, Hubspot with OAuth) require browser-based OAuth flows. You can't complete these via MCP — direct the user to the PostHog UI at `/data-warehouse/new`.
+- **OAuth sources require the UI.** Some sources (Google Ads, Meta Ads, Hubspot with OAuth) require browser-based OAuth flows. You can't complete these via MCP — direct the user to the PostHog UI at `/data-warehouse/new-source`.
 - **Not all systems are supported.** If the user's system isn't in the wizard list, suggest using Postgres/MySQL as a bridge if they can export to a database, or mention that custom sources can be requested.
 
 ## Related tools


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The data import guidance for agents pointed users to a stale Data warehouse source creation route. Agents following that skill could send users to a page that does not match the current frontend route.

## Changes

Updated the `suggesting-data-imports` skill to point OAuth source setup guidance at `/data-warehouse/new-source`, matching the frontend route constants.

## How did you test this code?

As an agent, I verified this markdown-only change with route-reference searches and whitespace validation:

- `rg "/data-warehouse/new" products/data_warehouse/skills`
- `rg "/data-warehouse/new-source" products/data_warehouse/skills/suggesting-data-imports/SKILL.md`
- `git diff --check`

`hogli lint:skills` could not be run because the local flox manifest fails before activation and `hogli` is not importable outside flox in this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No external docs update needed; this changes agent skill guidance only.

## 🤖 Agent context

Auth-backed PostHog MCP tools were unavailable in the agent session, and the browser fallback redirected to login. While investigating the reported bad Data warehouse link, I found the stale route in the product skill itself and updated it to match the route defined by the frontend manifest.

The change is intentionally narrow: it only corrects the stale skill route and leaves the rest of the data import workflow untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1b44040-5eaf-48fa-a948-6e08af2e4bf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b44040-5eaf-48fa-a948-6e08af2e4bf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

