### PR TITLE
feat(flags): add Type column to feature flags list

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4851,9 +4851,9 @@ snapshots:
     scenes-app-feature-flags--feature-flag-not-found--light:
         hash: v1.k794b7964.e784cb2f06f9bfcbc6743df7815cbf7c815da053481b08baecb4a088910f3afa.9OxM372yUO63hbW3CfWOXwnUJD3dTv8EKpc-J3i9HOo
     scenes-app-feature-flags--feature-flags-list--dark:
-        hash: v1.k794b7964.5ad67a530f4fd9dece77e0d132cd0def3a8ab2e043b05e25c31d79a2d2eccda5.orssD24mqErPMp3PmiYNM9UJNror3yKoN8L8qY_CIQg
+        hash: v1.k794b7964.2730a9e4846c16869c821c34dcf59d7fb86ee63a3fc91857cf19b72face208b3.OgQAw3la22Mh824WdrYvhRwGI-FayVzs61pVUwE6obo
     scenes-app-feature-flags--feature-flags-list--light:
-        hash: v1.k794b7964.433b55d4b908553bd3e5128fb13ca8edb6d6f142fd4103a0bb89bba772c8cbc5.tCKa7paABYG2BW5NxwcHE8QUmDKCeR1UEMmw5N3RoyQ
+        hash: v1.k794b7964.9f31458f9371ccf1f6ba09cd3728a71c1b1d496b951cc942d6a173d10fa5786d.KAGRvF0AJDFLtof4mRa3aEXUcIc_B0eHSqpDoTHvKws
     scenes-app-feature-flags--new-feature-flag--dark:
         hash: v1.k794b7964.b8f6e0b677fa753d25fd9710066d8864cce28c2b8f17e96abd343d91ad72e95c.JX-Y63wT7ojk44kJmYVE9jeRnPRmyMqhkUytg1Opfjo
     scenes-app-feature-flags--new-feature-flag--light:

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -404,6 +404,24 @@ export function OverviewTab({
             },
         },
         {
+            title: 'Type',
+            width: 120,
+            render: function RenderType(_, featureFlag: FeatureFlagType) {
+                const label = featureFlag.is_remote_configuration
+                    ? 'Remote config'
+                    : (featureFlag.experiment_set?.length || 0) > 0
+                      ? 'Experiment'
+                      : (featureFlag.filters?.multivariate?.variants?.length || 0) > 0
+                        ? 'Multiple variants'
+                        : 'Boolean'
+                return (
+                    <LemonTag type="default" className="whitespace-nowrap">
+                        {label}
+                    </LemonTag>
+                )
+            },
+        },
+        {
             title: 'Tags',
             dataIndex: 'tags' as keyof FeatureFlagType,
             render: function Render(_, featureFlag: FeatureFlagType) {

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -58,7 +58,7 @@ import {
 import { ApprovalsPromoBanner } from './ApprovalsPromoBanner'
 import { BulkDeleteResultsModal } from './BulkDeleteResultsModal'
 import { FeatureFlagFiltersSection } from './FeatureFlagFilters'
-import { FLAGS_PER_PAGE, FeatureFlagsTab, featureFlagsLogic } from './featureFlagsLogic'
+import { FLAGS_PER_PAGE, FeatureFlagsTab, featureFlagsLogic, flagMatchesType } from './featureFlagsLogic'
 import { flagSelectionLogic } from './flagSelectionLogic'
 import { OverlayForNewFeatureFlagMenu } from './NewFeatureFlagMenu'
 import ProjectsGrid from './projects-grid/ProjectsGrid'
@@ -408,13 +408,13 @@ export function OverviewTab({
             width: 120,
             render: function RenderType(_, featureFlag: FeatureFlagType) {
                 const labels: string[] = []
-                if (featureFlag.is_remote_configuration) {
+                if (flagMatchesType(featureFlag, 'remote_config')) {
                     labels.push('Remote config')
                 }
-                if ((featureFlag.experiment_set?.length || 0) > 0) {
+                if (flagMatchesType(featureFlag, 'experiment')) {
                     labels.push('Experiment')
                 }
-                if ((featureFlag.filters?.multivariate?.variants?.length || 0) > 0) {
+                if (flagMatchesType(featureFlag, 'multivariant')) {
                     labels.push('Multiple variants')
                 }
                 if (labels.length === 0) {

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -407,17 +407,27 @@ export function OverviewTab({
             title: 'Type',
             width: 120,
             render: function RenderType(_, featureFlag: FeatureFlagType) {
-                const label = featureFlag.is_remote_configuration
-                    ? 'Remote config'
-                    : (featureFlag.experiment_set?.length || 0) > 0
-                      ? 'Experiment'
-                      : (featureFlag.filters?.multivariate?.variants?.length || 0) > 0
-                        ? 'Multiple variants'
-                        : 'Boolean'
+                const labels: string[] = []
+                if (featureFlag.is_remote_configuration) {
+                    labels.push('Remote config')
+                }
+                if ((featureFlag.experiment_set?.length || 0) > 0) {
+                    labels.push('Experiment')
+                }
+                if ((featureFlag.filters?.multivariate?.variants?.length || 0) > 0) {
+                    labels.push('Multiple variants')
+                }
+                if (labels.length === 0) {
+                    labels.push('Boolean')
+                }
                 return (
-                    <LemonTag type="default" className="whitespace-nowrap">
-                        {label}
-                    </LemonTag>
+                    <div className="flex flex-wrap gap-1">
+                        {labels.map((label) => (
+                            <LemonTag key={label} type="default" className="whitespace-nowrap">
+                                {label}
+                            </LemonTag>
+                        ))}
+                    </div>
                 )
             },
         },

--- a/frontend/src/scenes/feature-flags/__mocks__/feature_flags.json
+++ b/frontend/src/scenes/feature-flags/__mocks__/feature_flags.json
@@ -216,6 +216,45 @@
             },
             "created_at": "2022-02-08T16:51:27.696618Z",
             "updated_at": "2022-02-08T16:51:27.696618Z"
+        },
+        {
+            "id": 1801,
+            "name": "",
+            "key": "signup-cta-experiment",
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 100
+                    }
+                ],
+                "multivariate": {
+                    "variants": [
+                        {
+                            "key": "control",
+                            "name": "",
+                            "rollout_percentage": 50
+                        },
+                        {
+                            "key": "test",
+                            "name": "",
+                            "rollout_percentage": 50
+                        }
+                    ]
+                }
+            },
+            "deleted": false,
+            "active": true,
+            "experiment_set": [42],
+            "created_by": {
+                "id": 6352,
+                "uuid": "cf25089d-71f1-4f70-9d0b-7577e47d78c1",
+                "distinct_id": "8ed346b4-01e9-44e2-b5a1-286cb131a400",
+                "first_name": "Cameron",
+                "email": "cameron@posthog.com"
+            },
+            "created_at": "2022-02-08T20:54:04.344072Z",
+            "updated_at": "2022-02-08T20:54:04.344072Z"
         }
     ]
 }


### PR DESCRIPTION
## Problem

On the feature flags overview table the filter bar exposes a **Type** dropdown (Boolean / Multiple variants / Experiment / Remote config), but the table itself has no **Type** column — so users can filter on a flag property they can't actually see. Reported from a support ticket.

## Changes

Adds a **Type** column (placed right after **Key**) to the feature flags overview table. The label is derived from the same fields the backend `type` filter uses (`products/feature_flags/backend/api/feature_flag.py`):

- `is_remote_configuration` → **Remote config**
- linked `experiment_set` → **Experiment**. Experiments have **Multiple variants** so will show two types present, for user expectations when filtering.
- `filters.multivariate.variants` non-empty → **Multiple variants**
- otherwise → **Boolean**

Rendered as a `LemonTag`, matching the existing **Runtime** / **Status** column styling. No API change — all fields are already returned by the list endpoint.

<img width="1570" height="713" alt="Screenshot 2026-06-03 at 2 26 26 PM" src="https://github.com/user-attachments/assets/07f3d0a4-ef01-4937-8dbe-a1087f32a5e4" />

## How did you test this code?

I'm an agent (PostHog Slack app). I have **not** run the app or manual tests. Changes are type-safe against `FeatureFlagType` (`is_remote_configuration`, `experiment_set`, `filters.multivariate.variants` all exist on the type). The existing `FeatureFlags.stories.tsx` visual-regression snapshots will need to be regenerated to include the new column.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) in response to a support ticket: the feature flags table lets you filter by Type but never displayed Type as a column. I traced the filter UI (`FeatureFlagFilters.tsx`) and the backend filter logic (`feature_flag.py`) to confirm the four canonical types and their definitions, then added a column deriving the label from those same fields. Considered aligning column precedence exactly with the backend filter's mutually-exclusive choices but chose the overview-page precedence (remote config → experiment → multivariate → boolean) as the clearer product framing, noted above. Requires human review and snapshot regeneration before merge.
