### PR TITLE
fix(nodejs): personhog error context when requests fail

### DIFF
--- a/nodejs/src/ingestion/personhog/grpc-retry.ts
+++ b/nodejs/src/ingestion/personhog/grpc-retry.ts
@@ -36,6 +36,12 @@ export async function withRetry<T>(
         } catch (error) {
             lastError = error
             if (!isRetryable(error) || attempt === maxRetries) {
+                if (error instanceof ConnectError) {
+                    logger.error(`[PersonHog] gRPC call failed in ${label}`, {
+                        code: Code[error.code],
+                        message: error.message,
+                    })
+                }
                 throw error
             }
             logger.warn(`[${label}] Retryable gRPC error, retrying`, {

--- a/nodejs/src/ingestion/personhog/grpc-retry.ts
+++ b/nodejs/src/ingestion/personhog/grpc-retry.ts
@@ -36,12 +36,9 @@ export async function withRetry<T>(
         } catch (error) {
             lastError = error
             if (!isRetryable(error) || attempt === maxRetries) {
-                if (error instanceof ConnectError) {
-                    logger.error(`[PersonHog] gRPC call failed in ${label}`, {
-                        code: Code[error.code],
-                        message: error.message,
-                    })
-                }
+                logger.error(`[PersonHog] gRPC call failed in ${label}`, {
+                    error: String(error),
+                })
                 throw error
             }
             logger.warn(`[${label}] Retryable gRPC error, retrying`, {

--- a/nodejs/src/ingestion/personhog/personhog-group-read-repository.ts
+++ b/nodejs/src/ingestion/personhog/personhog-group-read-repository.ts
@@ -28,7 +28,7 @@ export class PersonHogGroupReadRepository implements GroupReadRepository {
             group_properties: Record<string, any>
         }[]
     > {
-        return withRetry('PersonHogGroupReadRepository', () =>
+        return withRetry('PersonHogGroupReadRepository.fetchGroupsByKeys', () =>
             timedGrpc(this.clientLabel, 'fetchGroupsByKeys', () =>
                 this.grpcClient.groups.fetchGroupsByKeys(teamIds, groupTypeIndexes, groupKeys, callerTag)
             )
@@ -39,7 +39,7 @@ export class PersonHogGroupReadRepository implements GroupReadRepository {
         teamIds: TeamId[],
         callerTag?: string
     ): Promise<Record<string, { group_type: string; group_type_index: GroupTypeIndex }[]>> {
-        return withRetry('PersonHogGroupReadRepository', () =>
+        return withRetry('PersonHogGroupReadRepository.fetchGroupTypesByTeamIds', () =>
             timedGrpc(this.clientLabel, 'fetchGroupTypesByTeamIds', () =>
                 this.grpcClient.groups.fetchGroupTypesByTeamIds(teamIds, callerTag)
             )

--- a/nodejs/src/ingestion/personhog/personhog-person-read-repository.ts
+++ b/nodejs/src/ingestion/personhog/personhog-person-read-repository.ts
@@ -19,7 +19,7 @@ export class PersonHogPersonReadRepository implements PersonReadRepository {
     ) {}
 
     async fetchPerson(teamId: number, distinctId: string, callerTag?: string): Promise<InternalPerson | undefined> {
-        const results = await withRetry('PersonHogPersonReadRepository', () =>
+        const results = await withRetry('PersonHogPersonReadRepository.fetchPerson', () =>
             timedGrpc(this.clientLabel, 'fetchPerson', () =>
                 this.grpcClient.persons.fetchPersonsByDistinctIds([{ teamId, distinctId }], callerTag)
             )
@@ -31,7 +31,7 @@ export class PersonHogPersonReadRepository implements PersonReadRepository {
         teamPersons: { teamId: TeamId; distinctId: string }[],
         callerTag?: string
     ): Promise<InternalPersonWithDistinctId[]> {
-        return withRetry('PersonHogPersonReadRepository', () =>
+        return withRetry('PersonHogPersonReadRepository.fetchPersonsByDistinctIds', () =>
             timedGrpc(this.clientLabel, 'fetchPersonsByDistinctIds', () =>
                 this.grpcClient.persons.fetchPersonsByDistinctIds(teamPersons, callerTag)
             )
@@ -42,7 +42,7 @@ export class PersonHogPersonReadRepository implements PersonReadRepository {
         teamPersons: { teamId: TeamId; personId: string }[],
         callerTag?: string
     ): Promise<InternalPerson[]> {
-        return withRetry('PersonHogPersonReadRepository', () =>
+        return withRetry('PersonHogPersonReadRepository.fetchPersonsByPersonIds', () =>
             timedGrpc(this.clientLabel, 'fetchPersonsByPersonIds', () =>
                 this.grpcClient.persons.fetchPersonsByPersonIds(teamPersons, callerTag)
             )
@@ -55,7 +55,7 @@ export class PersonHogPersonReadRepository implements PersonReadRepository {
         options?: { limitPerPerson?: number },
         callerTag?: string
     ): Promise<Record<string, string[]>> {
-        return withRetry('PersonHogPersonReadRepository', () =>
+        return withRetry('PersonHogPersonReadRepository.fetchDistinctIdsForPersons', () =>
             timedGrpc(this.clientLabel, 'fetchDistinctIdsForPersons', () =>
                 this.grpcClient.persons.getDistinctIdsForPersons(
                     teamId,


### PR DESCRIPTION
## Problem

When personhog client calls failed, there was no obvious direct attribution to the personhog client / call failing in the error logs.

## Changes

Add a tagged error log to personhog failures in the grpc retry code before re-throwing the error.

## How did you test this code?

Just an added error log.