### PR TITLE
chore(capture): preserve cookieless identity inputs on heatmap redirect

### DIFF
--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -2022,13 +2022,12 @@ mod tests {
         );
     }
 
-    /// Regression for the PR #57253 follow-up: a `$cookieless_mode` event
-    /// with heatmap data must produce a redirect that carries every property
-    /// the cookieless identity hash reads in
-    /// `nodejs/src/ingestion/cookieless/cookieless-manager.ts`. Without these,
-    /// the ingestion pipeline emits `cookieless_missing_user_agent` against
-    /// the redirect and silently drops every heatmap/scroll-depth data point
-    /// from cookieless-mode customers.
+    /// A `$cookieless_mode` event with heatmap data must produce a redirect
+    /// that carries every property the cookieless identity hash reads in
+    /// `nodejs/src/ingestion/cookieless/cookieless-manager.ts`. Without
+    /// these, the ingestion pipeline emits `cookieless_missing_user_agent`
+    /// against the redirect and silently drops every heatmap/scroll-depth
+    /// data point from cookieless-mode customers.
     #[test]
     fn test_create_heatmap_redirect_preserves_cookieless_identity_inputs() {
         let now = Utc::now();

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -32,6 +32,14 @@ use crate::{
 /// Property keys the heatmap pipeline reads from a redirected event. The
 /// redirect carries only these (plus `distinct_id` and `$cookieless_mode`,
 /// which are needed for the routing key).
+///
+/// The `$raw_user_agent`, `$ip`, `$host`, `$timezone`, and `$cookieless_extra`
+/// keys are not consumed by the heatmap extractor itself, but the ingestion
+/// pipeline runs cookieless identity resolution against every event before
+/// any extractor sees it. Cookieless-mode events with these properties
+/// stripped get dropped with a `cookieless_missing_user_agent` warning
+/// before the heatmap pipeline can run, so the redirect must preserve them
+/// for cookieless customers' heatmap and scroll-depth data to survive.
 const HEATMAP_PROPERTY_KEYS: &[&str] = &[
     "$heatmap_data",
     "$viewport_height",
@@ -40,6 +48,11 @@ const HEATMAP_PROPERTY_KEYS: &[&str] = &[
     "$prev_pageview_pathname",
     "$prev_pageview_max_scroll",
     "$current_url",
+    "$raw_user_agent",
+    "$ip",
+    "$host",
+    "$timezone",
+    "$cookieless_extra",
 ];
 
 /// True when this event carries data that the heatmap extraction pipeline
@@ -1893,6 +1906,18 @@ mod tests {
         properties.insert("$viewport_width".to_string(), json!(1440));
         properties.insert("$session_id".to_string(), json!("session-abc"));
         properties.insert("$current_url".to_string(), json!("https://example.com"));
+        // Cookieless identity inputs. Carrier events emitted by the JS SDK in
+        // cookieless mode set these, and the ingestion pipeline drops events
+        // with `cookieless_missing_user_agent` if `$raw_user_agent` is absent
+        // on a `$cookieless_mode` event — so the redirect must carry them.
+        properties.insert(
+            "$raw_user_agent".to_string(),
+            json!("Mozilla/5.0 (test agent)"),
+        );
+        properties.insert("$ip".to_string(), json!("203.0.113.7"));
+        properties.insert("$host".to_string(), json!("example.com"));
+        properties.insert("$timezone".to_string(), json!("Europe/London"));
+        properties.insert("$cookieless_extra".to_string(), json!("extra-hash-input"));
         properties.insert(
             "other_prop".to_string(),
             json!("should_not_appear_in_redirect"),
@@ -1979,6 +2004,13 @@ mod tests {
         assert!(data.properties.contains_key("$viewport_width"));
         assert!(data.properties.contains_key("$session_id"));
         assert!(data.properties.contains_key("$current_url"));
+        // Cookieless identity inputs must survive the redirect; without them
+        // the ingestion pipeline drops cookieless-mode heatmap events.
+        assert!(data.properties.contains_key("$raw_user_agent"));
+        assert!(data.properties.contains_key("$ip"));
+        assert!(data.properties.contains_key("$host"));
+        assert!(data.properties.contains_key("$timezone"));
+        assert!(data.properties.contains_key("$cookieless_extra"));
         assert_eq!(data.distinct_id, Some(json!("test_user")));
         assert!(
             !data.properties.contains_key("distinct_id"),
@@ -1986,8 +2018,50 @@ mod tests {
         );
         assert!(
             !data.properties.contains_key("other_prop"),
-            "redirect should only contain heatmap properties"
+            "redirect should only contain heatmap and cookieless-identity properties"
         );
+    }
+
+    /// Regression for the PR #57253 follow-up: a `$cookieless_mode` event
+    /// with heatmap data must produce a redirect that carries every property
+    /// the cookieless identity hash reads in
+    /// `nodejs/src/ingestion/cookieless/cookieless-manager.ts`. Without these,
+    /// the ingestion pipeline emits `cookieless_missing_user_agent` against
+    /// the redirect and silently drops every heatmap/scroll-depth data point
+    /// from cookieless-mode customers.
+    #[test]
+    fn test_create_heatmap_redirect_preserves_cookieless_identity_inputs() {
+        let now = Utc::now();
+        let context = create_test_context(now, None);
+        let mut event = build_heatmap_carrier_event(HeatmapShape::HeatmapData);
+        event
+            .properties
+            .insert("$cookieless_mode".to_string(), json!(true));
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+
+        let redirect = create_heatmap_redirect(&event, historical_cfg, &context)
+            .unwrap()
+            .expect("redirect should be created");
+
+        let data: RawEvent = serde_json::from_str(&redirect.event.data).unwrap();
+        for key in [
+            "$raw_user_agent",
+            "$ip",
+            "$host",
+            "$timezone",
+            "$cookieless_extra",
+            "$cookieless_mode",
+        ] {
+            assert!(
+                data.properties.contains_key(key),
+                "cookieless redirect must carry {key}"
+            );
+            assert_eq!(
+                data.properties.get(key),
+                event.properties.get(key),
+                "cookieless redirect must preserve {key} value verbatim"
+            );
+        }
     }
 
     #[test]
@@ -2268,6 +2342,29 @@ mod tests {
             redirect_raw.properties.get("$current_url"),
             Some(&json!("https://example.com")),
         );
+        // Cookieless identity inputs must survive the redirect end-to-end.
+        // Without them the ingestion pipeline drops the redirect with
+        // `cookieless_missing_user_agent` before the heatmap extractor runs.
+        assert_eq!(
+            redirect_raw.properties.get("$raw_user_agent"),
+            Some(&json!("Mozilla/5.0 (test agent)")),
+        );
+        assert_eq!(
+            redirect_raw.properties.get("$ip"),
+            Some(&json!("203.0.113.7")),
+        );
+        assert_eq!(
+            redirect_raw.properties.get("$host"),
+            Some(&json!("example.com")),
+        );
+        assert_eq!(
+            redirect_raw.properties.get("$timezone"),
+            Some(&json!("Europe/London")),
+        );
+        assert_eq!(
+            redirect_raw.properties.get("$cookieless_extra"),
+            Some(&json!("extra-hash-input")),
+        );
         // distinct_id is required for routing-key generation; it's pre-resolved
         // onto the top-level field rather than left in properties.
         assert_eq!(redirect_raw.distinct_id, Some(json!("test_user")));
@@ -2275,10 +2372,11 @@ mod tests {
             !redirect_raw.properties.contains_key("distinct_id"),
             "distinct_id is on the top-level field, not in properties"
         );
-        // The redirect must NOT carry unrelated user properties — only what the heatmap pipeline reads.
+        // The redirect must NOT carry unrelated user properties — only what
+        // the heatmap pipeline reads plus the cookieless identity inputs.
         assert!(
             !redirect_raw.properties.contains_key("other_prop"),
-            "redirect must only carry heatmap properties"
+            "redirect must only carry heatmap and cookieless-identity properties"
         );
 
         // Shape-specific payload properties.


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/57253 introduced a heatmap-redirect path in capture that builds a stripped `$$heatmap` event carrying only the property keys the heatmap extractor reads. The stripped redirect drops `$raw_user_agent`, `$host`, `$timezone`, `$cookieless_extra`, and `$ip` — all of which the cookieless identity gate reads upstream of the heatmap extractor. For cookieless-mode customers this means every redirect hits the gate, gets dropped with `cookieless_missing_user_agent`, and their heatmap/scroll-depth data silently disappears at ingestion.

This extends `HEATMAP_PROPERTY_KEYS` to also carry the five cookieless-identity inputs so the redirect survives the gate. Non-cookieless traffic is unaffected (the gate skips events without `$cookieless_mode`).
