### PR TITLE
fix(docker): version-agnostic nginx unit python type

### DIFF
--- a/unit.json.tpl
+++ b/unit.json.tpl
@@ -39,7 +39,7 @@
     },
     "applications": {
         "posthog": {
-            "type": "python 3.12",
+            "type": "python 3",
             "processes": $NGINX_UNIT_APP_PROCESSES,
             "working_directory": "/code",
             "path": ".",
@@ -51,7 +51,7 @@
             }
         },
         "metrics": {
-            "type": "python 3.12",
+            "type": "python 3",
             "processes": 1,
             "working_directory": "/code/bin",
             "path": ".",


### PR DESCRIPTION
## Problem

`unit.json.tpl` (the Nginx Unit config for the production web image) hardcodes the Python minor version in the `type` field: `"python 3.12"`. Nginx Unit binds an application only when a matching language module is installed, so any image that ships a different Python minor makes Unit reject the *entire* config and bind nothing to `:8000`. The web container then fails its readiness probe with `connection refused` and never becomes ready — with no Python traceback, because the app never loads.

This surfaced while validating the Python 3.13 cutover (the bump-to-3.13.13 PR, #59440): the 3.13 image ships only the 3.13 Unit module, so the stale `"python 3.12"` literal silently broke startup.

## Changes

- **`unit.json.tpl`**: both app `type`s → `"python 3"`, the documented version-agnostic form that matches any installed `python3` module and survives future minor bumps. It also matches the current 3.12 image, so this is safe to land independently of (and ahead of) the cutover.
- **`docs/internal/upgrading-python.md`**: a checklist of everything that has to move when bumping the Python version, with this Unit gotcha called out so it isn't missed again.

## How did you test this code?

Agent-authored — no runtime test in this PR; the change is a one-line config literal. `"python 3"` is the version-agnostic form from Nginx Unit's config docs (Unit picks the most specific installed `python3` module), and it resolves the `connection refused` startup failure observed when a 3.13 image ran with the old `"python 3.12"` literal. Validate on the test deployment per the new doc before relying on it with the cutover.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus) at the author's direction. Root cause was found in a debugging session when a 3.13 test image left the web pod stuck `0/1 Running` with `/_readyz` refusing connections; the cause was Unit rejecting its config because the image had only the 3.13 language module while `unit.json.tpl` still requested `python 3.12`. Chose `"python 3"` over `"python 3.13"` so the literal never needs touching on future bumps — pinning to a minor only buys a hard-fail-on-mismatch we don't want here. Split into a standalone PR off master rather than folding into the cutover branch, since `"python 3"` is valid on the current 3.12 image and can land first to de-risk the bump.
