### PR TITLE
feat(insights): support OR between filters on a single series

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
@@ -150,7 +150,9 @@ describe('actionsAndEventsToSeries', () => {
                 type: 'events',
                 order: 0,
                 name: 'item1',
-                properties: [{ type: PropertyFilterType.Event, key: 'a', value: 'x', operator: PropertyOperator.Exact }],
+                properties: [
+                    { type: PropertyFilterType.Event, key: 'a', value: 'x', operator: PropertyOperator.Exact },
+                ],
             },
         ]
 

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
@@ -122,6 +122,43 @@ describe('actionsAndEventsToSeries', () => {
         ])
     })
 
+    it('carries a series propertiesOperator onto the node', () => {
+        const events: ActionFilter[] = [
+            {
+                id: '$pageview',
+                type: 'events',
+                order: 0,
+                name: 'item1',
+                properties: [
+                    { type: PropertyFilterType.Event, key: 'a', value: 'x', operator: PropertyOperator.Exact },
+                    { type: PropertyFilterType.Event, key: 'b', value: 'y', operator: PropertyOperator.Exact },
+                ],
+                propertiesOperator: FilterLogicalOperator.Or,
+            },
+        ]
+
+        const result = actionsAndEventsToSeries({ events }, true, MathAvailability.None)
+
+        expect(result[0].propertiesOperator).toEqual(FilterLogicalOperator.Or)
+        expect(result[0].properties).toHaveLength(2)
+    })
+
+    it('omits propertiesOperator when not set', () => {
+        const events: ActionFilter[] = [
+            {
+                id: '$pageview',
+                type: 'events',
+                order: 0,
+                name: 'item1',
+                properties: [{ type: PropertyFilterType.Event, key: 'a', value: 'x', operator: PropertyOperator.Exact }],
+            },
+        ]
+
+        const result = actionsAndEventsToSeries({ events }, true, MathAvailability.None)
+
+        expect(result[0].propertiesOperator).toBeUndefined()
+    })
+
     it('converts lifecycle data warehouse series to lifecycle nodes', () => {
         const data_warehouse: LifecycleDatawarehouseFilter[] = [
             {

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -167,7 +167,11 @@ export const legacyEntityToNode = (
     }
 
     if (includeProperties) {
-        shared = { ...shared, properties: cleanEntityProperties(entity.properties) } as any
+        shared = {
+            ...shared,
+            properties: cleanEntityProperties(entity.properties),
+            propertiesOperator: entity.propertiesOperator || undefined,
+        } as any
     }
 
     if (mathAvailability !== MathAvailability.None) {

--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.test.ts
@@ -13,6 +13,7 @@ import {
 import {
     BreakdownAttributionType,
     ChartDisplayType,
+    FilterLogicalOperator,
     FunnelConversionWindowTimeUnit,
     FunnelPathType,
     FunnelStepReference,
@@ -22,6 +23,8 @@ import {
     LifecycleFilterType,
     PathType,
     PathsFilterType,
+    PropertyFilterType,
+    PropertyOperator,
     StepOrderValue,
     StickinessFilterType,
     TrendsFilterType,
@@ -136,6 +139,27 @@ describe('queryNodeToFilter', () => {
             show_multiple_y_axes: false,
         }
         expect(result).toEqual(filters)
+    })
+
+    test('round-trips a series propertiesOperator onto the legacy filter', () => {
+        const query: TrendsQuery = {
+            kind: NodeKind.TrendsQuery,
+            series: [
+                {
+                    kind: NodeKind.EventsNode,
+                    event: '$pageview',
+                    properties: [
+                        { type: PropertyFilterType.Event, key: 'a', value: 'x', operator: PropertyOperator.Exact },
+                        { type: PropertyFilterType.Event, key: 'b', value: 'y', operator: PropertyOperator.Exact },
+                    ],
+                    propertiesOperator: FilterLogicalOperator.Or,
+                },
+            ],
+        }
+
+        const result = queryNodeToFilter(query)
+
+        expect(result.events?.[0].propertiesOperator).toEqual(FilterLogicalOperator.Or)
     })
 
     test('round-trips axis labels through legacy trends filters', () => {

--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
@@ -83,6 +83,7 @@ export const seriesNodeToFilter = (
         math_group_type_index: node.math_group_type_index,
         optionalInFunnel: node.optionalInFunnel,
         properties: node.properties as any, // TODO,
+        propertiesOperator: node.propertiesOperator,
         ...(isDataWarehouseNode(node)
             ? {
                   table_name: node.table_name,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -247,6 +247,10 @@
                     },
                     "type": "array"
                 },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
+                },
                 "response": {
                     "type": "object"
                 },
@@ -4040,6 +4044,10 @@
                     },
                     "type": "array"
                 },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
+                },
                 "version": {
                     "description": "version of the node, used for schema migrations",
                     "type": "number"
@@ -4222,6 +4230,10 @@
                         "$ref": "#/definitions/AssistantPropertyFilter"
                     },
                     "type": "array"
+                },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
                 },
                 "version": {
                     "description": "version of the node, used for schema migrations",
@@ -11623,6 +11635,10 @@
                             },
                             "type": "array"
                         },
+                        "propertiesOperator": {
+                            "$ref": "#/definitions/FilterLogicalOperator",
+                            "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
+                        },
                         "response": {
                             "type": "object"
                         },
@@ -11697,6 +11713,10 @@
                                 "$ref": "#/definitions/AnyPropertyFilter"
                             },
                             "type": "array"
+                        },
+                        "propertiesOperator": {
+                            "$ref": "#/definitions/FilterLogicalOperator",
+                            "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
                         },
                         "response": {
                             "type": "object"
@@ -11781,6 +11801,10 @@
                                 "$ref": "#/definitions/AnyPropertyFilter"
                             },
                             "type": "array"
+                        },
+                        "propertiesOperator": {
+                            "$ref": "#/definitions/FilterLogicalOperator",
+                            "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
                         },
                         "response": {
                             "type": "object"
@@ -14453,6 +14477,10 @@
                     },
                     "type": "array"
                 },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
+                },
                 "response": {
                     "type": "object"
                 },
@@ -16194,6 +16222,10 @@
                     },
                     "type": "array"
                 },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
+                },
                 "response": {
                     "type": "object"
                 },
@@ -17633,6 +17665,10 @@
                     },
                     "type": "array"
                 },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
+                },
                 "response": {
                     "type": "object"
                 },
@@ -18233,6 +18269,10 @@
                         "$ref": "#/definitions/AnyPropertyFilter"
                     },
                     "type": "array"
+                },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
                 },
                 "response": {
                     "type": "object"
@@ -20714,6 +20754,10 @@
                     },
                     "type": "array"
                 },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
+                },
                 "response": {
                     "type": "object"
                 },
@@ -20796,6 +20840,10 @@
                         "$ref": "#/definitions/AnyPropertyFilter"
                     },
                     "type": "array"
+                },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
                 },
                 "response": {
                     "type": "object"
@@ -21042,6 +21090,10 @@
                         "$ref": "#/definitions/AnyPropertyFilter"
                     },
                     "type": "array"
+                },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
                 },
                 "response": {
                     "type": "object"
@@ -21576,6 +21628,10 @@
                         "$ref": "#/definitions/AnyPropertyFilter"
                     },
                     "type": "array"
+                },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
                 },
                 "response": {
                     "type": "object"
@@ -23805,6 +23861,10 @@
                         "$ref": "#/definitions/AnyPropertyFilter"
                     },
                     "type": "array"
+                },
+                "propertiesOperator": {
+                    "$ref": "#/definitions/FilterLogicalOperator",
+                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`."
                 },
                 "response": {
                     "type": "object"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -803,6 +803,8 @@ export interface EntityNode extends Node {
     math_group_type_index?: 0 | 1 | 2 | 3 | 4
     /** Properties configurable in the interface */
     properties?: AnyPropertyFilter[]
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperator
     /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
     fixedProperties?: AnyPropertyFilter[]
     optionalInFunnel?: boolean

--- a/frontend/src/queries/validators.js
+++ b/frontend/src/queries/validators.js
@@ -6973,12 +6973,17 @@ const schema80 = {
             items: { $ref: '#/definitions/AnyPropertyFilter' },
             type: 'array',
         },
+        propertiesOperator: {
+            $ref: '#/definitions/FilterLogicalOperator',
+            description: 'Logical operator used to combine `properties` for this series. Defaults to `AND`.',
+        },
         response: { type: 'object' },
         version: { description: 'version of the node, used for schema migrations', type: 'number' },
     },
     required: ['kind'],
     type: 'object',
 }
+const schema93 = { enum: ['AND', 'OR'], type: 'string' }
 const schema82 = {
     anyOf: [
         { $ref: '#/definitions/BaseMathType' },
@@ -8315,30 +8320,53 @@ function validate85(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                     var valid0 = true
                                                                                 }
                                                                                 if (valid0) {
-                                                                                    if (data.response !== undefined) {
-                                                                                        let data19 = data.response
+                                                                                    if (
+                                                                                        data.propertiesOperator !==
+                                                                                        undefined
+                                                                                    ) {
+                                                                                        let data19 =
+                                                                                            data.propertiesOperator
                                                                                         const _errs37 = errors
                                                                                         if (
+                                                                                            typeof data19 !== 'string'
+                                                                                        ) {
+                                                                                            validate85.errors = [
+                                                                                                {
+                                                                                                    instancePath:
+                                                                                                        instancePath +
+                                                                                                        '/propertiesOperator',
+                                                                                                    schemaPath:
+                                                                                                        '#/definitions/FilterLogicalOperator/type',
+                                                                                                    keyword: 'type',
+                                                                                                    params: {
+                                                                                                        type: 'string',
+                                                                                                    },
+                                                                                                    message:
+                                                                                                        'must be string',
+                                                                                                },
+                                                                                            ]
+                                                                                            return false
+                                                                                        }
+                                                                                        if (
                                                                                             !(
-                                                                                                data19 &&
-                                                                                                typeof data19 ==
-                                                                                                    'object' &&
-                                                                                                !Array.isArray(data19)
+                                                                                                data19 === 'AND' ||
+                                                                                                data19 === 'OR'
                                                                                             )
                                                                                         ) {
                                                                                             validate85.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
-                                                                                                        '/response',
+                                                                                                        '/propertiesOperator',
                                                                                                     schemaPath:
-                                                                                                        '#/properties/response/type',
-                                                                                                    keyword: 'type',
+                                                                                                        '#/definitions/FilterLogicalOperator/enum',
+                                                                                                    keyword: 'enum',
                                                                                                     params: {
-                                                                                                        type: 'object',
+                                                                                                        allowedValues:
+                                                                                                            schema93.enum,
                                                                                                     },
                                                                                                     message:
-                                                                                                        'must be object',
+                                                                                                        'must be equal to one of the allowed values',
                                                                                                 },
                                                                                             ]
                                                                                             return false
@@ -8349,38 +8377,81 @@ function validate85(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                     }
                                                                                     if (valid0) {
                                                                                         if (
-                                                                                            data.version !== undefined
+                                                                                            data.response !== undefined
                                                                                         ) {
-                                                                                            let data20 = data.version
-                                                                                            const _errs39 = errors
+                                                                                            let data20 = data.response
+                                                                                            const _errs40 = errors
                                                                                             if (
                                                                                                 !(
+                                                                                                    data20 &&
                                                                                                     typeof data20 ==
-                                                                                                        'number' &&
-                                                                                                    isFinite(data20)
+                                                                                                        'object' &&
+                                                                                                    !Array.isArray(
+                                                                                                        data20
+                                                                                                    )
                                                                                                 )
                                                                                             ) {
                                                                                                 validate85.errors = [
                                                                                                     {
                                                                                                         instancePath:
                                                                                                             instancePath +
-                                                                                                            '/version',
+                                                                                                            '/response',
                                                                                                         schemaPath:
-                                                                                                            '#/properties/version/type',
+                                                                                                            '#/properties/response/type',
                                                                                                         keyword: 'type',
                                                                                                         params: {
-                                                                                                            type: 'number',
+                                                                                                            type: 'object',
                                                                                                         },
                                                                                                         message:
-                                                                                                            'must be number',
+                                                                                                            'must be object',
                                                                                                     },
                                                                                                 ]
                                                                                                 return false
                                                                                             }
                                                                                             var valid0 =
-                                                                                                _errs39 === errors
+                                                                                                _errs40 === errors
                                                                                         } else {
                                                                                             var valid0 = true
+                                                                                        }
+                                                                                        if (valid0) {
+                                                                                            if (
+                                                                                                data.version !==
+                                                                                                undefined
+                                                                                            ) {
+                                                                                                let data21 =
+                                                                                                    data.version
+                                                                                                const _errs42 = errors
+                                                                                                if (
+                                                                                                    !(
+                                                                                                        typeof data21 ==
+                                                                                                            'number' &&
+                                                                                                        isFinite(data21)
+                                                                                                    )
+                                                                                                ) {
+                                                                                                    validate85.errors =
+                                                                                                        [
+                                                                                                            {
+                                                                                                                instancePath:
+                                                                                                                    instancePath +
+                                                                                                                    '/version',
+                                                                                                                schemaPath:
+                                                                                                                    '#/properties/version/type',
+                                                                                                                keyword:
+                                                                                                                    'type',
+                                                                                                                params: {
+                                                                                                                    type: 'number',
+                                                                                                                },
+                                                                                                                message:
+                                                                                                                    'must be number',
+                                                                                                            },
+                                                                                                        ]
+                                                                                                    return false
+                                                                                                }
+                                                                                                var valid0 =
+                                                                                                    _errs42 === errors
+                                                                                            } else {
+                                                                                                var valid0 = true
+                                                                                            }
                                                                                         }
                                                                                     }
                                                                                 }
@@ -8417,7 +8488,7 @@ function validate85(data, { instancePath = '', parentData, parentDataProperty, r
     validate85.errors = vErrors
     return errors === 0
 }
-const schema93 = {
+const schema94 = {
     additionalProperties: false,
     properties: {
         custom_name: { type: 'string' },
@@ -8442,6 +8513,10 @@ const schema93 = {
             description: 'Properties configurable in the interface',
             items: { $ref: '#/definitions/AnyPropertyFilter' },
             type: 'array',
+        },
+        propertiesOperator: {
+            $ref: '#/definitions/FilterLogicalOperator',
+            description: 'Logical operator used to combine `properties` for this series. Defaults to `AND`.',
         },
         response: { type: 'object' },
         version: { description: 'version of the node, used for schema migrations', type: 'number' },
@@ -8469,7 +8544,7 @@ function validate93(data, { instancePath = '', parentData, parentDataProperty, r
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema93.properties, key0)) {
+                    if (!func2.call(schema94.properties, key0)) {
                         validate93.errors = [
                             {
                                 instancePath,
@@ -8649,7 +8724,7 @@ function validate93(data, { instancePath = '', parentData, parentDataProperty, r
                                                         keyword: 'enum',
                                                         params: {
                                                             allowedValues:
-                                                                schema93.properties.math_group_type_index.enum,
+                                                                schema94.properties.math_group_type_index.enum,
                                                         },
                                                         message: 'must be equal to one of the allowed values',
                                                     },
@@ -8861,26 +8936,44 @@ function validate93(data, { instancePath = '', parentData, parentDataProperty, r
                                                                             var valid0 = true
                                                                         }
                                                                         if (valid0) {
-                                                                            if (data.response !== undefined) {
-                                                                                let data16 = data.response
+                                                                            if (data.propertiesOperator !== undefined) {
+                                                                                let data16 = data.propertiesOperator
                                                                                 const _errs31 = errors
+                                                                                if (typeof data16 !== 'string') {
+                                                                                    validate93.errors = [
+                                                                                        {
+                                                                                            instancePath:
+                                                                                                instancePath +
+                                                                                                '/propertiesOperator',
+                                                                                            schemaPath:
+                                                                                                '#/definitions/FilterLogicalOperator/type',
+                                                                                            keyword: 'type',
+                                                                                            params: { type: 'string' },
+                                                                                            message: 'must be string',
+                                                                                        },
+                                                                                    ]
+                                                                                    return false
+                                                                                }
                                                                                 if (
                                                                                     !(
-                                                                                        data16 &&
-                                                                                        typeof data16 == 'object' &&
-                                                                                        !Array.isArray(data16)
+                                                                                        data16 === 'AND' ||
+                                                                                        data16 === 'OR'
                                                                                     )
                                                                                 ) {
                                                                                     validate93.errors = [
                                                                                         {
                                                                                             instancePath:
                                                                                                 instancePath +
-                                                                                                '/response',
+                                                                                                '/propertiesOperator',
                                                                                             schemaPath:
-                                                                                                '#/properties/response/type',
-                                                                                            keyword: 'type',
-                                                                                            params: { type: 'object' },
-                                                                                            message: 'must be object',
+                                                                                                '#/definitions/FilterLogicalOperator/enum',
+                                                                                            keyword: 'enum',
+                                                                                            params: {
+                                                                                                allowedValues:
+                                                                                                    schema93.enum,
+                                                                                            },
+                                                                                            message:
+                                                                                                'must be equal to one of the allowed values',
                                                                                         },
                                                                                     ]
                                                                                     return false
@@ -8890,35 +8983,69 @@ function validate93(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                 var valid0 = true
                                                                             }
                                                                             if (valid0) {
-                                                                                if (data.version !== undefined) {
-                                                                                    let data17 = data.version
-                                                                                    const _errs33 = errors
+                                                                                if (data.response !== undefined) {
+                                                                                    let data17 = data.response
+                                                                                    const _errs34 = errors
                                                                                     if (
                                                                                         !(
-                                                                                            typeof data17 == 'number' &&
-                                                                                            isFinite(data17)
+                                                                                            data17 &&
+                                                                                            typeof data17 == 'object' &&
+                                                                                            !Array.isArray(data17)
                                                                                         )
                                                                                     ) {
                                                                                         validate93.errors = [
                                                                                             {
                                                                                                 instancePath:
                                                                                                     instancePath +
-                                                                                                    '/version',
+                                                                                                    '/response',
                                                                                                 schemaPath:
-                                                                                                    '#/properties/version/type',
+                                                                                                    '#/properties/response/type',
                                                                                                 keyword: 'type',
                                                                                                 params: {
-                                                                                                    type: 'number',
+                                                                                                    type: 'object',
                                                                                                 },
                                                                                                 message:
-                                                                                                    'must be number',
+                                                                                                    'must be object',
                                                                                             },
                                                                                         ]
                                                                                         return false
                                                                                     }
-                                                                                    var valid0 = _errs33 === errors
+                                                                                    var valid0 = _errs34 === errors
                                                                                 } else {
                                                                                     var valid0 = true
+                                                                                }
+                                                                                if (valid0) {
+                                                                                    if (data.version !== undefined) {
+                                                                                        let data18 = data.version
+                                                                                        const _errs36 = errors
+                                                                                        if (
+                                                                                            !(
+                                                                                                typeof data18 ==
+                                                                                                    'number' &&
+                                                                                                isFinite(data18)
+                                                                                            )
+                                                                                        ) {
+                                                                                            validate93.errors = [
+                                                                                                {
+                                                                                                    instancePath:
+                                                                                                        instancePath +
+                                                                                                        '/version',
+                                                                                                    schemaPath:
+                                                                                                        '#/properties/version/type',
+                                                                                                    keyword: 'type',
+                                                                                                    params: {
+                                                                                                        type: 'number',
+                                                                                                    },
+                                                                                                    message:
+                                                                                                        'must be number',
+                                                                                                },
+                                                                                            ]
+                                                                                            return false
+                                                                                        }
+                                                                                        var valid0 = _errs36 === errors
+                                                                                    } else {
+                                                                                        var valid0 = true
+                                                                                    }
                                                                                 }
                                                                             }
                                                                         }
@@ -8953,7 +9080,7 @@ function validate93(data, { instancePath = '', parentData, parentDataProperty, r
     validate93.errors = vErrors
     return errors === 0
 }
-const schema95 = {
+const schema97 = {
     additionalProperties: false,
     properties: {
         custom_name: { type: 'string' },
@@ -8979,6 +9106,10 @@ const schema95 = {
             description: 'Properties configurable in the interface',
             items: { $ref: '#/definitions/AnyPropertyFilter' },
             type: 'array',
+        },
+        propertiesOperator: {
+            $ref: '#/definitions/FilterLogicalOperator',
+            description: 'Logical operator used to combine `properties` for this series. Defaults to `AND`.',
         },
         response: { type: 'object' },
         table_name: { type: 'string' },
@@ -9014,7 +9145,7 @@ function validate99(data, { instancePath = '', parentData, parentDataProperty, r
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema95.properties, key0)) {
+                    if (!func2.call(schema97.properties, key0)) {
                         validate99.errors = [
                             {
                                 instancePath,
@@ -9216,7 +9347,7 @@ function validate99(data, { instancePath = '', parentData, parentDataProperty, r
                                                             keyword: 'enum',
                                                             params: {
                                                                 allowedValues:
-                                                                    schema95.properties.math_group_type_index.enum,
+                                                                    schema97.properties.math_group_type_index.enum,
                                                             },
                                                             message: 'must be equal to one of the allowed values',
                                                         },
@@ -9445,29 +9576,50 @@ function validate99(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                 var valid0 = true
                                                                             }
                                                                             if (valid0) {
-                                                                                if (data.response !== undefined) {
-                                                                                    let data17 = data.response
+                                                                                if (
+                                                                                    data.propertiesOperator !==
+                                                                                    undefined
+                                                                                ) {
+                                                                                    let data17 = data.propertiesOperator
                                                                                     const _errs32 = errors
+                                                                                    if (typeof data17 !== 'string') {
+                                                                                        validate99.errors = [
+                                                                                            {
+                                                                                                instancePath:
+                                                                                                    instancePath +
+                                                                                                    '/propertiesOperator',
+                                                                                                schemaPath:
+                                                                                                    '#/definitions/FilterLogicalOperator/type',
+                                                                                                keyword: 'type',
+                                                                                                params: {
+                                                                                                    type: 'string',
+                                                                                                },
+                                                                                                message:
+                                                                                                    'must be string',
+                                                                                            },
+                                                                                        ]
+                                                                                        return false
+                                                                                    }
                                                                                     if (
                                                                                         !(
-                                                                                            data17 &&
-                                                                                            typeof data17 == 'object' &&
-                                                                                            !Array.isArray(data17)
+                                                                                            data17 === 'AND' ||
+                                                                                            data17 === 'OR'
                                                                                         )
                                                                                     ) {
                                                                                         validate99.errors = [
                                                                                             {
                                                                                                 instancePath:
                                                                                                     instancePath +
-                                                                                                    '/response',
+                                                                                                    '/propertiesOperator',
                                                                                                 schemaPath:
-                                                                                                    '#/properties/response/type',
-                                                                                                keyword: 'type',
+                                                                                                    '#/definitions/FilterLogicalOperator/enum',
+                                                                                                keyword: 'enum',
                                                                                                 params: {
-                                                                                                    type: 'object',
+                                                                                                    allowedValues:
+                                                                                                        schema93.enum,
                                                                                                 },
                                                                                                 message:
-                                                                                                    'must be object',
+                                                                                                    'must be equal to one of the allowed values',
                                                                                             },
                                                                                         ]
                                                                                         return false
@@ -9477,50 +9629,55 @@ function validate99(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                     var valid0 = true
                                                                                 }
                                                                                 if (valid0) {
-                                                                                    if (data.table_name !== undefined) {
-                                                                                        const _errs34 = errors
+                                                                                    if (data.response !== undefined) {
+                                                                                        let data18 = data.response
+                                                                                        const _errs35 = errors
                                                                                         if (
-                                                                                            typeof data.table_name !==
-                                                                                            'string'
+                                                                                            !(
+                                                                                                data18 &&
+                                                                                                typeof data18 ==
+                                                                                                    'object' &&
+                                                                                                !Array.isArray(data18)
+                                                                                            )
                                                                                         ) {
                                                                                             validate99.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
-                                                                                                        '/table_name',
+                                                                                                        '/response',
                                                                                                     schemaPath:
-                                                                                                        '#/properties/table_name/type',
+                                                                                                        '#/properties/response/type',
                                                                                                     keyword: 'type',
                                                                                                     params: {
-                                                                                                        type: 'string',
+                                                                                                        type: 'object',
                                                                                                     },
                                                                                                     message:
-                                                                                                        'must be string',
+                                                                                                        'must be object',
                                                                                                 },
                                                                                             ]
                                                                                             return false
                                                                                         }
-                                                                                        var valid0 = _errs34 === errors
+                                                                                        var valid0 = _errs35 === errors
                                                                                     } else {
                                                                                         var valid0 = true
                                                                                     }
                                                                                     if (valid0) {
                                                                                         if (
-                                                                                            data.timestamp_field !==
+                                                                                            data.table_name !==
                                                                                             undefined
                                                                                         ) {
-                                                                                            const _errs36 = errors
+                                                                                            const _errs37 = errors
                                                                                             if (
-                                                                                                typeof data.timestamp_field !==
+                                                                                                typeof data.table_name !==
                                                                                                 'string'
                                                                                             ) {
                                                                                                 validate99.errors = [
                                                                                                     {
                                                                                                         instancePath:
                                                                                                             instancePath +
-                                                                                                            '/timestamp_field',
+                                                                                                            '/table_name',
                                                                                                         schemaPath:
-                                                                                                            '#/properties/timestamp_field/type',
+                                                                                                            '#/properties/table_name/type',
                                                                                                         keyword: 'type',
                                                                                                         params: {
                                                                                                             type: 'string',
@@ -9532,48 +9689,87 @@ function validate99(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                                 return false
                                                                                             }
                                                                                             var valid0 =
-                                                                                                _errs36 === errors
+                                                                                                _errs37 === errors
                                                                                         } else {
                                                                                             var valid0 = true
                                                                                         }
                                                                                         if (valid0) {
                                                                                             if (
-                                                                                                data.version !==
+                                                                                                data.timestamp_field !==
                                                                                                 undefined
                                                                                             ) {
-                                                                                                let data20 =
-                                                                                                    data.version
-                                                                                                const _errs38 = errors
+                                                                                                const _errs39 = errors
                                                                                                 if (
-                                                                                                    !(
-                                                                                                        typeof data20 ==
-                                                                                                            'number' &&
-                                                                                                        isFinite(data20)
-                                                                                                    )
+                                                                                                    typeof data.timestamp_field !==
+                                                                                                    'string'
                                                                                                 ) {
                                                                                                     validate99.errors =
                                                                                                         [
                                                                                                             {
                                                                                                                 instancePath:
                                                                                                                     instancePath +
-                                                                                                                    '/version',
+                                                                                                                    '/timestamp_field',
                                                                                                                 schemaPath:
-                                                                                                                    '#/properties/version/type',
+                                                                                                                    '#/properties/timestamp_field/type',
                                                                                                                 keyword:
                                                                                                                     'type',
                                                                                                                 params: {
-                                                                                                                    type: 'number',
+                                                                                                                    type: 'string',
                                                                                                                 },
                                                                                                                 message:
-                                                                                                                    'must be number',
+                                                                                                                    'must be string',
                                                                                                             },
                                                                                                         ]
                                                                                                     return false
                                                                                                 }
                                                                                                 var valid0 =
-                                                                                                    _errs38 === errors
+                                                                                                    _errs39 === errors
                                                                                             } else {
                                                                                                 var valid0 = true
+                                                                                            }
+                                                                                            if (valid0) {
+                                                                                                if (
+                                                                                                    data.version !==
+                                                                                                    undefined
+                                                                                                ) {
+                                                                                                    let data21 =
+                                                                                                        data.version
+                                                                                                    const _errs41 =
+                                                                                                        errors
+                                                                                                    if (
+                                                                                                        !(
+                                                                                                            typeof data21 ==
+                                                                                                                'number' &&
+                                                                                                            isFinite(
+                                                                                                                data21
+                                                                                                            )
+                                                                                                        )
+                                                                                                    ) {
+                                                                                                        validate99.errors =
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    instancePath:
+                                                                                                                        instancePath +
+                                                                                                                        '/version',
+                                                                                                                    schemaPath:
+                                                                                                                        '#/properties/version/type',
+                                                                                                                    keyword:
+                                                                                                                        'type',
+                                                                                                                    params: {
+                                                                                                                        type: 'number',
+                                                                                                                    },
+                                                                                                                    message:
+                                                                                                                        'must be number',
+                                                                                                                },
+                                                                                                            ]
+                                                                                                        return false
+                                                                                                    }
+                                                                                                    var valid0 =
+                                                                                                        _errs41 ===
+                                                                                                        errors
+                                                                                                } else {
+                                                                                                    var valid0 = true
+                                                                                                }
                                                                                             }
                                                                                         }
                                                                                     }
@@ -10313,7 +10509,7 @@ function validate79(data, { instancePath = '', parentData, parentDataProperty, r
     validate79.errors = vErrors
     return errors === 0
 }
-const schema96 = {
+const schema99 = {
     additionalProperties: false,
     properties: {
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
@@ -10335,8 +10531,8 @@ const schema96 = {
     required: ['kind', 'metric_type', 'series'],
     type: 'object',
 }
-const schema99 = { enum: ['strict', 'unordered', 'ordered'], type: 'string' }
-const schema101 = {
+const schema102 = { enum: ['strict', 'unordered', 'ordered'], type: 'string' }
+const schema104 = {
     discriminator: { propertyName: 'kind' },
     oneOf: [
         { $ref: '#/definitions/EventsNode' },
@@ -10473,7 +10669,7 @@ function validate107(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema96.properties, key0)) {
+                    if (!func2.call(schema99.properties, key0)) {
                         validate107.errors = [
                             {
                                 instancePath,
@@ -10607,7 +10803,7 @@ function validate107(data, { instancePath = '', parentData, parentDataProperty, 
                                                     instancePath: instancePath + '/funnel_order_type',
                                                     schemaPath: '#/definitions/StepOrderValue/enum',
                                                     keyword: 'enum',
-                                                    params: { allowedValues: schema99.enum },
+                                                    params: { allowedValues: schema102.enum },
                                                     message: 'must be equal to one of the allowed values',
                                                 },
                                             ]
@@ -10939,7 +11135,7 @@ function validate107(data, { instancePath = '', parentData, parentDataProperty, 
     validate107.errors = vErrors
     return errors === 0
 }
-const schema102 = {
+const schema105 = {
     additionalProperties: false,
     properties: {
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
@@ -10963,7 +11159,7 @@ const schema102 = {
     required: ['denominator', 'kind', 'metric_type', 'numerator'],
     type: 'object',
 }
-const schema105 = {
+const schema108 = {
     additionalProperties: false,
     properties: {
         ignore_zeros: { type: 'boolean' },
@@ -11009,7 +11205,7 @@ function validate115(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema102.properties, key0)) {
+                    if (!func2.call(schema105.properties, key0)) {
                         validate115.errors = [
                             {
                                 instancePath,
@@ -11929,7 +12125,7 @@ function validate115(data, { instancePath = '', parentData, parentDataProperty, 
     validate115.errors = vErrors
     return errors === 0
 }
-const schema108 = {
+const schema111 = {
     additionalProperties: false,
     properties: {
         breakdownFilter: { $ref: '#/definitions/BreakdownFilter' },
@@ -11993,7 +12189,7 @@ function validate120(data, { instancePath = '', parentData, parentDataProperty, 
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (!func2.call(schema108.properties, key0)) {
+                    if (!func2.call(schema111.properties, key0)) {
                         validate120.errors = [
                             {
                                 instancePath,
@@ -12492,7 +12688,7 @@ function validate120(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                     keyword: 'enum',
                                                                                                     params: {
                                                                                                         allowedValues:
-                                                                                                            schema108
+                                                                                                            schema111
                                                                                                                 .properties
                                                                                                                 .start_handling
                                                                                                                 .enum,

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterGroup/actionFilterGroupLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterGroup/actionFilterGroupLogic.ts
@@ -40,9 +40,14 @@ export const actionFilterGroupLogic = kea<actionFilterGroupLogicType>([
     actions({
         addNestedFilter: (id: string, name: string, type: EntityType) => ({ id, name, type }),
         updateNestedFilter: (nestedIndex: number, updates: Partial<LocalFilter>) => ({ nestedIndex, updates }),
-        updateNestedFilterProperties: (nestedIndex: number, properties: AnyPropertyFilter[]) => ({
+        updateNestedFilterProperties: (
+            nestedIndex: number,
+            properties: AnyPropertyFilter[],
+            propertiesOperator?: FilterLogicalOperator | null
+        ) => ({
             nestedIndex,
             properties,
+            propertiesOperator,
         }),
         removeNestedFilter: (nestedIndex: number) => ({ nestedIndex }),
         setMath: (selectedMath: string | undefined, defaultMathHogQLExpression: string) => ({
@@ -124,9 +129,13 @@ export const actionFilterGroupLogic = kea<actionFilterGroupLogicType>([
                 newFilters[nestedIndex] = { ...newFilters[nestedIndex], ...updates }
                 updateGroup(newFilters)
             },
-            updateNestedFilterProperties: ({ nestedIndex, properties }) => {
+            updateNestedFilterProperties: ({ nestedIndex, properties, propertiesOperator }) => {
                 const newFilters = [...values.nestedFilters]
-                newFilters[nestedIndex] = { ...newFilters[nestedIndex], properties }
+                newFilters[nestedIndex] = {
+                    ...newFilters[nestedIndex],
+                    properties,
+                    ...(propertiesOperator !== undefined ? { propertiesOperator } : {}),
+                }
                 updateGroup(newFilters)
             },
             removeNestedFilter: ({ nestedIndex }) => {

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterGroup/nestedFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterGroup/nestedFilterLogic.ts
@@ -1,6 +1,6 @@
 import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 
-import { AnyPropertyFilter } from '~/types'
+import { AnyPropertyFilter, FilterLogicalOperator } from '~/types'
 
 import { LocalFilter } from '../entityFilterLogic'
 import { actionFilterGroupLogic } from './actionFilterGroupLogic'
@@ -37,7 +37,11 @@ export const nestedFilterLogic = kea<nestedFilterLogicType>([
     actions({
         updateFilter: (filter: Partial<LocalFilter> & { index: number }) => ({ filter }),
         removeLocalFilter: (filter: { index: number }) => ({ filter }),
-        updateFilterProperty: (filter: { index: number; properties: AnyPropertyFilter[] }) => ({ filter }),
+        updateFilterProperty: (filter: {
+            index: number
+            properties: AnyPropertyFilter[]
+            propertiesOperator?: FilterLogicalOperator | null
+        }) => ({ filter }),
         setEntityFilterVisibility: (index: number, value: boolean) => ({ index, value }),
         // Stub actions that ActionFilterRow may call but we don't need for nested filters
         selectFilter: () => ({}),
@@ -73,7 +77,7 @@ export const nestedFilterLogic = kea<nestedFilterLogicType>([
             actions.removeNestedFilter(props.nestedIndex)
         },
         updateFilterProperty: ({ filter }) => {
-            actions.updateNestedFilterProperties(props.nestedIndex, filter.properties)
+            actions.updateNestedFilterProperties(props.nestedIndex, filter.properties, filter.propertiesOperator)
         },
     })),
 ])

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -32,11 +32,13 @@ import { teamLogic } from 'scenes/teamLogic'
 import { MathCategory, mathTypeToApiValues, mathsLogic } from 'scenes/trends/mathsLogic'
 
 import { actionsModel } from '~/models/actionsModel'
+import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
 import { NodeKind } from '~/queries/schema/schema-general'
 import {
     AnyPropertyFilter,
     BaseMathType,
     EntityTypes,
+    FilterLogicalOperator,
     InsightShortId,
     PropertyFilterType,
     PropertyFilterValue,
@@ -661,10 +663,25 @@ export function ActionFilterRow({
 
             {propertyFiltersVisible && (
                 <div className={`ActionFilterRow-filters${filtersLeftPadding ? ' pl-7' : ''}`}>
+                    {(filter.properties?.length || 0) > 1 && (
+                        <AndOrFilterSelect
+                            value={filter.propertiesOperator || FilterLogicalOperator.And}
+                            onChange={(propertiesOperator) =>
+                                updateFilterProperty({
+                                    index,
+                                    properties: filter.properties || [],
+                                    propertiesOperator,
+                                })
+                            }
+                            suffix={['filter for this series', 'filters for this series']}
+                        />
+                    )}
                     <PropertyFilters
                         pageKey={`${index}-${value}-${typeKey}-filter`}
                         propertyFilters={filter.properties}
                         onChange={onPropertyChange}
+                        orFiltering={filter.propertiesOperator === FilterLogicalOperator.Or}
+                        propertyGroupType={filter.propertiesOperator || FilterLogicalOperator.And}
                         showNestedArrow={showNestedArrow}
                         disablePopover={!propertyFiltersPopover}
                         metadataSource={

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -169,9 +169,11 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
             filter: Partial<EntityFilter> & {
                 index?: number
                 properties: AnyPropertyFilter[]
+                propertiesOperator?: FilterLogicalOperator | null
             }
         ) => ({
             properties: filter.properties,
+            propertiesOperator: filter.propertiesOperator,
             index: filter.index,
         }),
         setFilters: (filters: LocalFilter[]) => ({ filters }),
@@ -319,9 +321,17 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
             )
             !props.singleMode && actions.selectFilter(null)
         },
-        updateFilterProperty: async ({ properties, index }) => {
+        updateFilterProperty: async ({ properties, propertiesOperator, index }) => {
             actions.setFilters(
-                values.localFilters.map((filter, i) => (i === index ? { ...filter, properties } : filter))
+                values.localFilters.map((filter, i) =>
+                    i === index
+                        ? {
+                              ...filter,
+                              properties,
+                              ...(propertiesOperator !== undefined ? { propertiesOperator } : {}),
+                          }
+                        : filter
+                )
             )
         },
         updateFilterMath: async ({ index, ...mathProperties }) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1455,6 +1455,8 @@ export interface ActionFilter extends EntityFilter {
     math_group_type_index?: integer | null
     math_hogql?: string | null
     properties?: AnyPropertyFilter[]
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperator | null
     type: EntityType
     days?: string[] // TODO: why was this added here?
     operator?: FilterLogicalOperator | null

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -1,6 +1,6 @@
 import re
 from collections.abc import Callable
-from typing import Literal, Optional, TypeGuard, cast
+from typing import Literal, Optional, Protocol, TypeGuard, cast, runtime_checkable
 
 from django.db import models
 from django.db.models import Q
@@ -1214,6 +1214,39 @@ def property_to_expr(
     raise NotImplementedError(
         f"property_to_expr not implemented for filter type {type(property).__name__} and {property.type}"
     )
+
+
+@runtime_checkable
+class _SeriesLikeNode(Protocol):
+    """An insight series/entity node exposing editable property filters."""
+
+    @property
+    def properties(self) -> Optional[list]: ...
+
+
+def entity_properties_to_expr(
+    entity: _SeriesLikeNode,
+    team: Team,
+    scope: Literal[
+        "event", "person", "group", "session", "replay", "replay_entity", "revenue_analytics", "log_resource"
+    ] = "event",
+    strict: bool = False,
+) -> ast.Expr:
+    """Combine a series' own property filters into a single expression.
+
+    `property_to_expr` ANDs a plain list of properties together. A series can instead opt into
+    combining its property filters with OR through the `propertiesOperator` field on the node, so the
+    OR scope stays local to that series rather than affecting the whole insight.
+    """
+    properties = entity.properties or []
+    exprs = [property_to_expr(prop, team, scope, strict=strict) for prop in properties]
+    if len(exprs) == 0:
+        return ast.Constant(value=1)
+    if len(exprs) == 1:
+        return exprs[0]
+    if getattr(entity, "propertiesOperator", None) == FilterLogicalOperator.OR_:
+        return ast.Or(exprs=exprs)
+    return ast.And(exprs=exprs)
 
 
 def steps_to_expr(steps: list[ActionStepJSON], team: Team, events_alias: Optional[str] = None) -> ast.Expr:

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -9,6 +9,8 @@ from parameterized import parameterized
 
 from posthog.schema import (
     EmptyPropertyFilter,
+    EventsNode,
+    FilterLogicalOperator,
     FlagPropertyFilter,
     HogQLPropertyFilter,
     HogQLQueryModifiers,
@@ -24,6 +26,7 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.printer.utils import prepare_and_print_ast
 from posthog.hogql.property import (
+    entity_properties_to_expr,
     entity_to_expr,
     has_aggregation,
     map_virtual_properties,
@@ -113,6 +116,31 @@ class TestProperty(BaseTest):
         # Missing group_type_index
         self.assertEqual(
             self._property_to_expr({"type": "group", "key": "a", "value": "b"}, strict=False), self._parse_expr("1")
+        )
+
+    def test_entity_properties_to_expr_operator(self):
+        p1 = {"type": "event", "key": "a", "value": "x", "operator": "exact"}
+        p2 = {"type": "event", "key": "b", "value": "y", "operator": "exact"}
+
+        # Default combines a series' own property filters with AND
+        node_and = EventsNode(event="$pageview", properties=[p1, p2])
+        self.assertEqual(
+            clear_locations(entity_properties_to_expr(node_and, self.team)),
+            ast.And(exprs=[self._property_to_expr(p1), self._property_to_expr(p2)]),
+        )
+
+        # propertiesOperator=OR combines them with OR, scoped to this series only
+        node_or = EventsNode(event="$pageview", properties=[p1, p2], propertiesOperator=FilterLogicalOperator.OR_)
+        self.assertEqual(
+            clear_locations(entity_properties_to_expr(node_or, self.team)),
+            ast.Or(exprs=[self._property_to_expr(p1), self._property_to_expr(p2)]),
+        )
+
+        # A single property is returned as-is, regardless of the operator
+        node_single = EventsNode(event="$pageview", properties=[p1], propertiesOperator=FilterLogicalOperator.OR_)
+        self.assertEqual(
+            clear_locations(entity_properties_to_expr(node_single, self.team)),
+            self._property_to_expr(p1),
         )
 
     def test_property_to_expr_group_scope(self):

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -25,7 +25,7 @@ from posthog.hogql.database.models import (
     UUIDDatabaseField,
 )
 from posthog.hogql.parser import parse_expr
-from posthog.hogql.property import action_to_expr, property_to_expr
+from posthog.hogql.property import action_to_expr, entity_properties_to_expr
 
 from posthog.clickhouse.materialized_columns import ColumnName
 from posthog.clickhouse.query_tagging import tag_contains_user_hogql
@@ -378,7 +378,7 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
         filter_expr: ast.Expr | None = None
         if step_entity.properties is not None and step_entity.properties != []:
             # add property filters
-            filter_expr = property_to_expr(step_entity.properties, self.context.team)
+            filter_expr = entity_properties_to_expr(step_entity, self.context.team)
             filters.append(filter_expr)
 
         if step_entity.math == FunnelMathType.FIRST_TIME_FOR_USER:

--- a/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
@@ -23,7 +23,7 @@ from posthog.schema import (
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import to_printed_hogql
-from posthog.hogql.property import action_to_expr, property_to_expr
+from posthog.hogql.property import action_to_expr, entity_properties_to_expr, property_to_expr
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.caching.insights_api import BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL, REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL
@@ -369,7 +369,7 @@ class LifecycleQueryRunner(AnalyticsQueryRunner[LifecycleQueryResponse]):
                 else:
                     raise ValueError(f"Invalid series kind: {series.kind}")
                 if series.properties is not None and series.properties != []:
-                    event_filters.append(property_to_expr(series.properties, self.team))
+                    event_filters.append(entity_properties_to_expr(series, self.team))
         with self.timings.measure("test_account_filters"):
             if (
                 self.query.filterTestAccounts

--- a/posthog/hogql_queries/insights/trends/calendar_heatmap_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/calendar_heatmap_query_runner.py
@@ -26,7 +26,7 @@ from posthog.schema import (
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.parser import parse_select
-from posthog.hogql.property import action_to_expr, property_to_expr
+from posthog.hogql.property import action_to_expr, entity_properties_to_expr, property_to_expr
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
 
@@ -314,7 +314,7 @@ class CalendarHeatmapQueryRunner(AnalyticsQueryRunner[CalendarHeatmapResponse]):
         if self.query.series and len(self.query.series) > 0:
             series = self.query.series[0]
             if hasattr(series, "properties") and series.properties is not None and series.properties != []:
-                property_exprs.append(property_to_expr(series.properties, team=self.team))
+                property_exprs.append(entity_properties_to_expr(series, team=self.team))
 
         if len(property_exprs) == 0:
             return ast.Constant(value=True)

--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -22,7 +22,7 @@ from posthog.schema import (
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.parser import parse_expr
-from posthog.hogql.property import action_to_expr, property_to_expr
+from posthog.hogql.property import action_to_expr, entity_properties_to_expr, property_to_expr
 from posthog.hogql.timings import HogQLTimings
 
 from posthog.hogql_queries.insights.trends.aggregation_operations import (
@@ -336,7 +336,7 @@ class TrendsActorsQueryBuilder:
         conditions: list[ast.Expr] = []
 
         if self.entity.properties is not None and self.entity.properties != []:
-            conditions.append(property_to_expr(self.entity.properties, self.team))
+            conditions.append(entity_properties_to_expr(self.entity, self.team))
 
         return conditions
 

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -16,7 +16,7 @@ from posthog.schema import (
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext, get_breakdown_limit_for_context
 from posthog.hogql.parser import parse_expr, parse_select
-from posthog.hogql.property import action_to_expr, property_to_expr
+from posthog.hogql.property import action_to_expr, entity_properties_to_expr, property_to_expr
 from posthog.hogql.timings import HogQLTimings
 
 from posthog.hogql_queries.insights.data_warehouse_mixin import DataWarehouseInsightQueryMixin
@@ -835,7 +835,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
 
         # Series Filters
         if series.properties is not None and series.properties != []:
-            filters.append(property_to_expr(series.properties, self.team))
+            filters.append(entity_properties_to_expr(series, self.team))
 
         # Breakdown
         if not ignore_breakdowns and breakdown is not None:

--- a/posthog/hogql_queries/insights/trends/utils.py
+++ b/posthog/hogql_queries/insights/trends/utils.py
@@ -13,7 +13,7 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
-from posthog.hogql.property import action_to_expr, property_to_expr
+from posthog.hogql.property import action_to_expr, entity_properties_to_expr
 
 from posthog.constants import UNIQUE_GROUPS
 
@@ -76,14 +76,14 @@ def group_node_to_expr(group: GroupNode, team: Team) -> ast.Expr | None:
                 right=ast.Constant(value=str(node.event)),
             )
             if node.properties is not None and node.properties != []:
-                node_expr = ast.And(exprs=[node_expr, property_to_expr(node.properties, team)])
+                node_expr = ast.And(exprs=[node_expr, entity_properties_to_expr(node, team)])
             group_filters.append(node_expr)
         elif isinstance(node, ActionsNode):
             try:
                 action = Action.objects.get(pk=int(node.id), team__project_id=team.project_id)
                 node_expr = action_to_expr(action)
                 if node.properties is not None and node.properties != []:
-                    node_expr = ast.And(exprs=[node_expr, property_to_expr(node.properties, team)])
+                    node_expr = ast.And(exprs=[node_expr, entity_properties_to_expr(node, team)])
                 group_filters.append(node_expr)
             except Action.DoesNotExist:
                 pass

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -11225,6 +11225,10 @@ class AssistantTrendsActionsNode(BaseModel):
         ]
         | None
     ) = None
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
@@ -11288,6 +11292,10 @@ class AssistantTrendsEventsNode(BaseModel):
         ]
         | None
     ) = None
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
@@ -14375,6 +14383,10 @@ class ConversionGoalFilter1(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     schema_map: dict[str, str | Any]
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
@@ -14461,6 +14473,10 @@ class ConversionGoalFilter2(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     schema_map: dict[str, str | Any]
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
@@ -14550,6 +14566,10 @@ class ConversionGoalFilter3(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     schema_map: dict[str, str | Any]
     table_name: str
@@ -15591,6 +15611,10 @@ class DataWarehouseNode(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     table_name: str
     timestamp_field: str
@@ -15926,6 +15950,10 @@ class EntityNode(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -16258,6 +16286,10 @@ class EventsNode(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -16447,6 +16479,10 @@ class ExperimentDataWarehouseNode(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     table_name: str
     timestamp_field: str
@@ -16645,6 +16681,10 @@ class FunnelExclusionActionsNode(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -16732,6 +16772,10 @@ class FunnelExclusionEventsNode(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -16818,6 +16862,10 @@ class FunnelsDataWarehouseNode(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     table_name: str
     timestamp_field: str
@@ -17207,6 +17255,10 @@ class LifecycleDataWarehouseNode(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     table_name: str
     timestamp_field: str
@@ -21992,6 +22044,10 @@ class ActionsNode(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
@@ -24049,6 +24105,10 @@ class GroupNode(BaseModel):
         ]
         | None
     ) = Field(default=None, description="Properties configurable in the interface")
+    propertiesOperator: FilterLogicalOperator | None = Field(
+        default=None,
+        description=("Logical operator used to combine `properties` for this series. Defaults to `AND`."),
+    )
     response: dict[str, Any] | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -1446,6 +1446,8 @@ export interface EventsNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: EventsNodeApiResponse
     /** version of the node, used for schema migrations */
     version?: number | null
@@ -1525,6 +1527,8 @@ export interface ActionsNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: ActionsNodeApiResponse
     /** version of the node, used for schema migrations */
     version?: number | null
@@ -1607,6 +1611,8 @@ export interface DataWarehouseNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: DataWarehouseNodeApiResponse
     table_name: string
     timestamp_field: string
@@ -1694,6 +1700,8 @@ export interface GroupNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: GroupNodeApiResponse
     /** version of the node, used for schema migrations */
     version?: number | null
@@ -2031,6 +2039,8 @@ export interface FunnelExclusionEventsNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: FunnelExclusionEventsNodeApiResponse
     /** version of the node, used for schema migrations */
     version?: number | null
@@ -2112,6 +2122,8 @@ export interface FunnelExclusionActionsNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: FunnelExclusionActionsNodeApiResponse
     /** version of the node, used for schema migrations */
     version?: number | null
@@ -2290,6 +2302,8 @@ export interface FunnelsDataWarehouseNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: FunnelsDataWarehouseNodeApiResponse
     table_name: string
     timestamp_field: string
@@ -2949,6 +2963,8 @@ export interface LifecycleDataWarehouseNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: LifecycleDataWarehouseNodeApiResponse
     table_name: string
     timestamp_field: string
@@ -4817,6 +4833,8 @@ export interface ExperimentDataWarehouseNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: ExperimentDataWarehouseNodeApiResponse
     table_name: string
     timestamp_field: string
@@ -6053,6 +6071,8 @@ export interface ConversionGoalFilter1Api {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: ConversionGoalFilter1ApiResponse
     schema_map: ConversionGoalFilter1ApiSchemaMap
     /** version of the node, used for schema migrations */
@@ -6137,6 +6157,8 @@ export interface ConversionGoalFilter2Api {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: ConversionGoalFilter2ApiResponse
     schema_map: ConversionGoalFilter2ApiSchemaMap
     /** version of the node, used for schema migrations */
@@ -6224,6 +6246,8 @@ export interface ConversionGoalFilter3Api {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: ConversionGoalFilter3ApiResponse
     schema_map: ConversionGoalFilter3ApiSchemaMap
     table_name: string

--- a/products/product_analytics/backend/hogql_queries/stickiness/stickiness_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/stickiness/stickiness_query_runner.py
@@ -20,7 +20,7 @@ from posthog.schema import (
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.parser import parse_expr, parse_select
-from posthog.hogql.property import action_to_expr, property_to_expr
+from posthog.hogql.property import action_to_expr, entity_properties_to_expr, property_to_expr
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
 
@@ -435,7 +435,7 @@ class StickinessQueryRunner(AnalyticsQueryRunner[StickinessQueryResponse]):
 
         # Series Filters
         if series.properties is not None and series.properties != []:
-            filters.append(property_to_expr(series.properties, self.team))
+            filters.append(entity_properties_to_expr(series, self.team))
 
         # Ignore empty groups
         if series.math == "unique_group" and series.math_group_type_index is not None:

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -1139,6 +1139,8 @@ export interface EventsNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: EventsNodeApiResponse
     /** version of the node, used for schema migrations */
     version?: number | null
@@ -1218,6 +1220,8 @@ export interface ActionsNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: ActionsNodeApiResponse
     /** version of the node, used for schema migrations */
     version?: number | null
@@ -1300,6 +1304,8 @@ export interface DataWarehouseNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: DataWarehouseNodeApiResponse
     table_name: string
     timestamp_field: string
@@ -1387,6 +1393,8 @@ export interface GroupNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: GroupNodeApiResponse
     /** version of the node, used for schema migrations */
     version?: number | null
@@ -1724,6 +1732,8 @@ export interface FunnelExclusionEventsNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: FunnelExclusionEventsNodeApiResponse
     /** version of the node, used for schema migrations */
     version?: number | null
@@ -1805,6 +1815,8 @@ export interface FunnelExclusionActionsNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: FunnelExclusionActionsNodeApiResponse
     /** version of the node, used for schema migrations */
     version?: number | null
@@ -1983,6 +1995,8 @@ export interface FunnelsDataWarehouseNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: FunnelsDataWarehouseNodeApiResponse
     table_name: string
     timestamp_field: string
@@ -2642,6 +2656,8 @@ export interface LifecycleDataWarehouseNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: LifecycleDataWarehouseNodeApiResponse
     table_name: string
     timestamp_field: string
@@ -4510,6 +4526,8 @@ export interface ExperimentDataWarehouseNodeApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: ExperimentDataWarehouseNodeApiResponse
     table_name: string
     timestamp_field: string
@@ -5746,6 +5764,8 @@ export interface ConversionGoalFilter1Api {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: ConversionGoalFilter1ApiResponse
     schema_map: ConversionGoalFilter1ApiSchemaMap
     /** version of the node, used for schema migrations */
@@ -5830,6 +5850,8 @@ export interface ConversionGoalFilter2Api {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: ConversionGoalFilter2ApiResponse
     schema_map: ConversionGoalFilter2ApiSchemaMap
     /** version of the node, used for schema migrations */
@@ -5917,6 +5939,8 @@ export interface ConversionGoalFilter3Api {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+    propertiesOperator?: FilterLogicalOperatorApi | null
     response?: ConversionGoalFilter3ApiResponse
     schema_map: ConversionGoalFilter3ApiSchemaMap
     table_name: string

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1572,6 +1572,8 @@ export namespace Schemas {
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: ActionsNodeResponse;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -1950,6 +1952,8 @@ export namespace Schemas {
       orderBy?: string[] | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: EventsNodeResponse;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -1977,6 +1981,8 @@ export namespace Schemas {
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: DataWarehouseNodeResponse;
       table_name: string;
       timestamp_field: string;
@@ -2009,6 +2015,8 @@ export namespace Schemas {
       orderBy?: string[] | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: GroupNodeResponse;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -2262,6 +2270,8 @@ export namespace Schemas {
       orderBy?: string[] | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: FunnelExclusionEventsNodeResponse;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -2288,6 +2298,8 @@ export namespace Schemas {
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: FunnelExclusionActionsNodeResponse;
       /** version of the node, used for schema migrations */
       version?: number | null;
@@ -2415,6 +2427,8 @@ export namespace Schemas {
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: FunnelsDataWarehouseNodeResponse;
       table_name: string;
       timestamp_field: string;
@@ -2910,6 +2924,8 @@ export namespace Schemas {
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: LifecycleDataWarehouseNodeResponse;
       table_name: string;
       timestamp_field: string;
@@ -3328,6 +3344,8 @@ export namespace Schemas {
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: ExperimentDataWarehouseNodeResponse;
       table_name: string;
       timestamp_field: string;
@@ -5740,6 +5758,8 @@ export namespace Schemas {
       orderBy?: string[] | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: ConversionGoalFilter1Response;
       schema_map: ConversionGoalFilter1SchemaMap;
       /** version of the node, used for schema migrations */
@@ -5769,6 +5789,8 @@ export namespace Schemas {
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: ConversionGoalFilter2Response;
       schema_map: ConversionGoalFilter2SchemaMap;
       /** version of the node, used for schema migrations */
@@ -5801,6 +5823,8 @@ export namespace Schemas {
       optionalInFunnel?: boolean | null;
       /** Properties configurable in the interface */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /** Logical operator used to combine `properties` for this series. Defaults to `AND`. */
+      propertiesOperator?: FilterLogicalOperator | null;
       response?: ConversionGoalFilter3Response;
       schema_map: ConversionGoalFilter3SchemaMap;
       table_name: string;

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -391,6 +391,8 @@ const MathType = z.union([
     CalendarHeatmapMathType,
 ])
 
+const FilterLogicalOperator = z.enum(['AND', 'OR'])
+
 const AssistantTrendsEventsNode = z.object({
     custom_name: z.string().optional(),
     event: z.string().nullable().describe('The event or `null` for all events.').optional(),
@@ -409,6 +411,9 @@ const AssistantTrendsEventsNode = z.object({
     name: z.string().optional(),
     optionalInFunnel: z.coerce.boolean().optional(),
     properties: z.array(AssistantPropertyFilter).optional(),
+    propertiesOperator: FilterLogicalOperator.describe(
+        'Logical operator used to combine `properties` for this series. Defaults to `AND`.'
+    ).optional(),
     version: z.coerce.number().describe('version of the node, used for schema migrations').optional(),
 })
 
@@ -430,6 +435,9 @@ const AssistantTrendsActionsNode = z.object({
     name: z.string().describe('Action name from the plan.'),
     optionalInFunnel: z.coerce.boolean().optional(),
     properties: z.array(AssistantPropertyFilter).optional(),
+    propertiesOperator: FilterLogicalOperator.describe(
+        'Logical operator used to combine `properties` for this series. Defaults to `AND`.'
+    ).optional(),
     version: z.coerce.number().describe('version of the node, used for schema migrations').optional(),
 })
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends-actors.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends-actors.json
@@ -1378,6 +1378,11 @@
                                         },
                                         "type": "array"
                                     },
+                                    "propertiesOperator": {
+                                        "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`.",
+                                        "enum": ["AND", "OR"],
+                                        "type": "string"
+                                    },
                                     "version": {
                                         "description": "version of the node, used for schema migrations",
                                         "type": "number"
@@ -2051,6 +2056,11 @@
                                             ]
                                         },
                                         "type": "array"
+                                    },
+                                    "propertiesOperator": {
+                                        "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`.",
+                                        "enum": ["AND", "OR"],
+                                        "type": "string"
                                     },
                                     "version": {
                                         "description": "version of the node, used for schema migrations",
@@ -2964,6 +2974,11 @@
                                                             },
                                                             "type": "array"
                                                         },
+                                                        "propertiesOperator": {
+                                                            "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`.",
+                                                            "enum": ["AND", "OR"],
+                                                            "type": "string"
+                                                        },
                                                         "version": {
                                                             "description": "version of the node, used for schema migrations",
                                                             "type": "number"
@@ -3736,6 +3751,11 @@
                                                                 ]
                                                             },
                                                             "type": "array"
+                                                        },
+                                                        "propertiesOperator": {
+                                                            "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`.",
+                                                            "enum": ["AND", "OR"],
+                                                            "type": "string"
                                                         },
                                                         "version": {
                                                             "description": "version of the node, used for schema migrations",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends.json
@@ -1288,6 +1288,11 @@
                                 },
                                 "type": "array"
                             },
+                            "propertiesOperator": {
+                                "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`.",
+                                "enum": ["AND", "OR"],
+                                "type": "string"
+                            },
                             "version": {
                                 "description": "version of the node, used for schema migrations",
                                 "type": "number"
@@ -1927,6 +1932,11 @@
                                     ]
                                 },
                                 "type": "array"
+                            },
+                            "propertiesOperator": {
+                                "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`.",
+                                "enum": ["AND", "OR"],
+                                "type": "string"
                             },
                             "version": {
                                 "description": "version of the node, used for schema migrations",
@@ -2801,6 +2811,11 @@
                                                     },
                                                     "type": "array"
                                                 },
+                                                "propertiesOperator": {
+                                                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`.",
+                                                    "enum": ["AND", "OR"],
+                                                    "type": "string"
+                                                },
                                                 "version": {
                                                     "description": "version of the node, used for schema migrations",
                                                     "type": "number"
@@ -3548,6 +3563,11 @@
                                                         ]
                                                     },
                                                     "type": "array"
+                                                },
+                                                "propertiesOperator": {
+                                                    "description": "Logical operator used to combine `properties` for this series. Defaults to `AND`.",
+                                                    "enum": ["AND", "OR"],
+                                                    "type": "string"
                                                 },
                                                 "version": {
                                                     "description": "version of the node, used for schema migrations",


### PR DESCRIPTION
## Problem

When building an insight series, the property filters you add to that series are always combined with **AND**. The global filters section below the series already supports a match-all / match-any (AND/OR) toggle, but there was no equivalent at the series level.

This matters when you want an OR condition scoped to **one specific series** (e.g. "series B where `country = US` OR `country = CA`") without affecting the other series — something the global filter can't express because it applies to every series at once.

## Changes

- **Schema**: added an optional `propertiesOperator` (`FilterLogicalOperator`, defaults to `AND`) to the series/entity node (`EntityNode`) and to the legacy `ActionFilter` type. Regenerated `schema.json`, `validators.js`, and `schema.py` via the canonical codegen.
- **Conversion layer**: `propertiesOperator` now round-trips through `legacyEntityToNode` / `seriesNodeToFilter` and the `entityFilterLogic` / `actionFilterGroupLogic` / `nestedFilterLogic` update paths, so it survives the legacy-filter ↔ query-node bridge (including grouped series).
- **UI**: a match-all / match-any toggle (`AndOrFilterSelect`, the same control the global section uses) appears on a series once it has more than one property filter. In OR mode the series' filters render with the inline "or" styling.
- **Backend**: new `entity_properties_to_expr` helper in `posthog/hogql/property.py` combines a series' own `properties` with `AND` or `OR` based on `propertiesOperator`. Wired into every series/step builder: trends, trends actors, funnels, lifecycle, stickiness, calendar heatmap, and trends breakdown nodes. Global query-level properties are untouched.

The OR scope stays strictly local to the series — global filters and other series keep their existing behavior, and absence of the field is treated as `AND` (fully backwards compatible).

## How did you test this code?

I'm an agent (PostHog Slack app). I did **not** manually test in the running app — the UI toggle should be verified by a human. Automated checks I actually ran locally:

- **Backend**: added `test_entity_properties_to_expr_operator` in `posthog/hogql/test/test_property.py` covering AND (default), OR, and the single-property short-circuit. (Could not execute the backend suite here — no Postgres/Django in the environment — so this needs CI to run.)
- **Frontend (jest, passing locally)**: added round-trip tests in `filtersToQueryNode.test.ts` (forward) and `queryNodeToFilter.test.ts` (reverse); re-ran `entityFilterLogic.test.ts`. All 59 + 11 tests pass.
- `ruff check` / `ruff format --check` clean on all changed Python files.
- `tsc --noEmit` reports **no errors in any changed file** (after running kea-typegen).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Opus) in response to a request to bring the existing global match-all / match-any capability down to the per-series level.

Key design decision: rather than widen the series `properties` field to a full `AnyPropertyFilter[] | PropertyGroupFilter` union (matching the global section), I added a single `propertiesOperator` toggle alongside the existing flat `properties` list. The entity-properties pipeline (`cleanEntityProperties`) is built around a flat list and explicitly rejects nested groups, and the `.properties` array is read in many places — a union would have a large, risky blast radius. A single operator delivers exactly the requested behavior (OR the filters on this series) with minimal surface area, reuses the existing `AndOrFilterSelect` UI and `property_to_expr` logic, and mirrors the legacy `ActionFilter.operator` field that already existed. Nested groups per series can be a follow-up if needed.

Agent-authored — requires human review; please sanity-check the UI toggle in-app.
