### PR TITLE
fix(customer-analytics): stabilize flaky accounts row-expansion snapshots

### DIFF
--- a/products/customer_analytics/frontend/components/Accounts/AccountsTab.stories.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTab.stories.tsx
@@ -91,10 +91,17 @@ const ACCOUNT_WITHOUT_LINKS = {
     updated_at: '2026-05-15T10:30:00Z',
 }
 
-async function expandFirstRow(canvasElement: HTMLElement): Promise<void> {
+// Expanding a row mounts UsefulLinks (loads the account async) and the notes table
+// (loads notebooks async). Both start as skeletons and resolve later, which changes
+// the expansion's width and height. Awaiting the settled content here keeps the
+// snapshot deterministic — otherwise it races the loads and the Useful links sidebar
+// is sometimes absent, sometimes present (the flaky ~7% height/width diff).
+async function expandFirstRow(canvasElement: HTMLElement, notesLoadedText: string): Promise<void> {
     const canvas = within(canvasElement)
-    const expandBtn = await canvas.findByTitle('Show more')
-    await userEvent.click(expandBtn)
+    await userEvent.click(await canvas.findByTitle('Show more'))
+    await canvas.findByText('Useful links')
+    await canvas.findByText('Organization')
+    await canvas.findByText(notesLoadedText)
 }
 
 function mockAccountsQuery(rows: AccountRow[]): (req: { body: unknown }) => [number, unknown] | undefined {
@@ -176,7 +183,7 @@ export const RowExpandedEmpty: Story = {
         }),
     ],
     play: async ({ canvasElement }) => {
-        await expandFirstRow(canvasElement)
+        await expandFirstRow(canvasElement, 'No notes linked to this account yet.')
     },
 }
 
@@ -226,7 +233,7 @@ export const RowExpandedWithNote: Story = {
         }),
     ],
     play: async ({ canvasElement }) => {
-        await expandFirstRow(canvasElement)
+        await expandFirstRow(canvasElement, 'Q2 expansion call')
     },
 }
 
@@ -244,6 +251,6 @@ export const RowExpandedLinksDisabled: Story = {
         }),
     ],
     play: async ({ canvasElement }) => {
-        await expandFirstRow(canvasElement)
+        await expandFirstRow(canvasElement, 'No notes linked to this account yet.')
     },
 }


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

The accounts row-expansion storybook snapshots flap in CI and four of them are quarantined.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Await the expanded row's async loads (account links + notebooks) in the `play` functions before the snapshot is taken
- Snapshot now captures the settled expansion instead of racing the loads, which was producing ~7% structural diffs
- Affects `RowExpandedEmpty`, `RowExpandedWithNote`, `RowExpandedLinksDisabled`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Agent-authored. Lint/format only. Snapshot stability is verified by the visual-review run on this PR — the four quarantined snapshots need re-baselining and unquarantining once a few runs are clean.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Authored by Claude Code. Root cause confirmed by diffing the committed baseline (no "Useful links" sidebar) against the current render (sidebar present, 7.4% diff / SSIM 0.85): the expansion mounts `accountLinksLogic` and `accountNotebooksLogic`, both async, but `play()` returned right after the expand click — so the snapshot raced the loads. The fix awaits the loaded content (`Useful links`, a link label, and the per-story notes state) so React has committed the final layout before the runner captures. The `default`/`empty` stories were left alone — their recent churn is benign `diff=0` content-hash noise, not a layout race.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
