### PR TITLE
chore(ci): devex alerts use dedicated slack token

### DIFF
--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -48,7 +48,7 @@ jobs:
             - name: Reconcile master CI incident with Slack
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               env:
-                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEVEX_BOT_TOKEN }}
               with:
                   script: |
                       const script = require('./.github/scripts/ci-alerts-devex.js')


### PR DESCRIPTION
## Problem

The #alerts-devex master-CI alerter posts via the shared `SLACK_BOT_TOKEN`, whose Slack app was deactivated. Every scheduled run fails with `account_inactive`, so no alerts post.

## Changes

Repoint the alerter to a dedicated DevEx Slack app via a new `SLACK_DEVEX_BOT_TOKEN` secret. One line — the script still reads the value as `SLACK_BOT_TOKEN`, only the secret source changes.

The secret and app are already set up, with the bot invited to #alerts-devex (scopes `chat:write`, `channels:history`).

## How did you test this code?

Agent (Claude Code), no manual testing beyond a workflow run. Triggered the workflow via `workflow_dispatch` on this branch with the secret in place: green, `Action: none` (master healthy) — the token authenticates and `conversations.history` reads the channel, with no `account_inactive` or `not_in_channel`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code at Raúl's direction. One-line secret swap from the deactivated shared `SLACK_BOT_TOKEN` to a dedicated `SLACK_DEVEX_BOT_TOKEN`; verified via a manual `workflow_dispatch` run on the branch.
