### PR TITLE
chore(ci): add opt-in fail-fast experiment to cancel tainted PR CI

### DIFF
--- a/.github/scripts/ci-fail-fast.js
+++ b/.github/scripts/ci-fail-fast.js
@@ -1,0 +1,103 @@
+// CI Fail-Fast — when a required CI workflow fails on a PR, cancel the sibling CI
+// runs still in flight for the same commit. A tainted run is rarely salvaged by
+// re-running just the failed check; the usual next step is a new push, which
+// re-runs everything anyway, so finishing the rest burns runner minutes for a
+// result nobody reads.
+//
+// Driven by two environment inputs (set from `vars` / workflow env in the YAML):
+//   CI_FAIL_FAST_MODE      "off" (default) | "dry" | "on"
+//   CI_FAIL_FAST_ALLOWLIST JSON array of workflow names that may be cancelled
+//
+// "dry" logs what it WOULD cancel and cancels nothing — the safe rollout default
+// that doubles as the data source for the pristine-vs-tainted experiment (grep
+// run logs for the FAIL_FAST_DATA line).
+
+const ACTIVE_STATUSES = new Set(['queued', 'in_progress', 'requested', 'waiting', 'pending'])
+
+// Pure: of the runs sharing a commit, pick the ones safe to cancel.
+function selectCancellableRuns({ runs, sourceRunId, allow }) {
+    return runs.filter((r) => {
+        if (r.id === sourceRunId) return false // never the run that triggered us
+        if (!ACTIVE_STATUSES.has(r.status)) return false // already finished
+        if (r.event !== 'pull_request') return false // never a push/master run sharing the SHA
+        return allow.has(r.name) // allowlist only — never deploys or container builds
+    })
+}
+
+function parseAllowlist(raw) {
+    if (!raw) return new Set()
+    return new Set(
+        JSON.parse(raw)
+            .map((s) => String(s).trim())
+            .filter(Boolean)
+    )
+}
+
+const shortSha = (sha) => (sha || '').slice(0, 7)
+
+module.exports = async ({ github, context, core }) => {
+    const mode = (process.env.CI_FAIL_FAST_MODE || 'off').trim()
+    const allow = parseAllowlist(process.env.CI_FAIL_FAST_ALLOWLIST)
+    const source = context.payload.workflow_run
+    const headSha = source.head_sha
+    const prNumber = source.pull_requests?.[0]?.number ?? null
+    const live = mode === 'on'
+    const label = live
+        ? { gerund: 'Cancelling', past: 'Cancelled' }
+        : { gerund: '[dry-run] Would cancel', past: 'Would cancel' }
+
+    const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        head_sha: headSha,
+        event: 'pull_request', // narrow server-side; selectCancellableRuns re-checks defensively
+        per_page: 100,
+    })
+    const cancellable = selectCancellableRuns({ runs, sourceRunId: source.id, allow })
+
+    // Structured record for the pristine-vs-tainted experiment, greppable via the
+    // Actions API. Captures the half you cannot reconstruct later: how much was
+    // still in flight at the moment of failure.
+    console.log(
+        `FAIL_FAST_DATA ${JSON.stringify({
+            mode,
+            sha: headSha,
+            pr: prNumber,
+            trigger: { workflow: source.name, run_id: source.id, conclusion: source.conclusion },
+            cancellable: cancellable.map((r) => ({ workflow: r.name, run_id: r.id, status: r.status })),
+            count: cancellable.length,
+        })}`
+    )
+
+    if (cancellable.length === 0) {
+        core.notice(`No sibling CI runs in flight for ${shortSha(headSha)} (triggered by ${source.name} failure)`)
+    }
+    for (const r of cancellable) {
+        core.notice(`${label.gerund}: ${r.name} #${r.id} (${r.status})`)
+        if (live) {
+            await github.rest.actions
+                .cancelWorkflowRun({ owner: context.repo.owner, repo: context.repo.repo, run_id: r.id })
+                // A near-simultaneous failure can cancel the same run first; that 409 is expected.
+                .catch((e) => core.warning(`Could not cancel ${r.name} #${r.id}: ${e.message}`))
+        }
+    }
+
+    const prNote = prNumber ? ` (PR #${prNumber})` : ''
+    const headline = cancellable.length
+        ? `${label.past} ${cancellable.length} sibling CI run(s) on ${shortSha(headSha)}${prNote} after ${source.name} failed`
+        : ''
+
+    const table = cancellable.map((r) => `| ${r.name} | ${r.status} |`).join('\n')
+    await core.summary
+        .addHeading(`CI Fail-Fast — ${mode.toUpperCase()}`)
+        .addRaw(`Triggered by **${source.name}** failing on \`${shortSha(headSha)}\`${prNote}.\n\n`)
+        .addRaw(headline ? `${headline}:\n\n| Workflow | Status |\n| --- | --- |\n${table}\n` : 'No sibling CI runs were in flight.\n')
+        .write()
+
+    core.setOutput('mode', mode)
+    core.setOutput('count', String(cancellable.length))
+    core.setOutput('summary', headline ? `${headline}: ${cancellable.map((r) => r.name).join(', ')}` : '')
+}
+
+module.exports.selectCancellableRuns = selectCancellableRuns
+module.exports.parseAllowlist = parseAllowlist

--- a/.github/scripts/ci-fail-fast.test.js
+++ b/.github/scripts/ci-fail-fast.test.js
@@ -1,0 +1,160 @@
+// Run with: node --test .github/scripts/ci-fail-fast.test.js
+
+const { describe, it } = require('node:test')
+const assert = require('node:assert/strict')
+
+const failFast = require('./ci-fail-fast')
+const { selectCancellableRuns, parseAllowlist } = failFast
+
+const ALLOW = new Set(['Backend CI', 'Frontend CI', 'Rust CI'])
+
+const makeRun = (over = {}) => ({
+    id: 1,
+    name: 'Backend CI',
+    status: 'in_progress',
+    event: 'pull_request',
+    ...over,
+})
+
+// Minimal call-recording mock (no jest in the node:test runner).
+function recordingFn(impl) {
+    const fn = (...args) => {
+        fn.calls.push(args)
+        return impl ? impl(...args) : undefined
+    }
+    fn.calls = []
+    return fn
+}
+
+function makeMocks({ runs, mode }) {
+    const outputs = {}
+    const cancelWorkflowRun = recordingFn(async () => ({}))
+    const github = {
+        paginate: recordingFn(async () => runs),
+        rest: { actions: { listWorkflowRunsForRepo: recordingFn(), cancelWorkflowRun } },
+    }
+    const summaryChain = {
+        addHeading: () => summaryChain,
+        addRaw: () => summaryChain,
+        write: recordingFn(async () => {}),
+    }
+    const core = {
+        notice: recordingFn(),
+        warning: recordingFn(),
+        setOutput: recordingFn((k, v) => {
+            outputs[k] = v
+        }),
+        summary: summaryChain,
+    }
+    const context = {
+        repo: { owner: 'PostHog', repo: 'posthog' },
+        payload: {
+            workflow_run: {
+                id: 999,
+                name: 'Frontend CI',
+                conclusion: 'failure',
+                head_sha: 'abcdef1234567890',
+                event: 'pull_request',
+                pull_requests: [{ number: 42 }],
+            },
+        },
+    }
+    process.env.CI_FAIL_FAST_MODE = mode
+    process.env.CI_FAIL_FAST_ALLOWLIST = JSON.stringify([...ALLOW])
+    return { github, core, context, outputs, cancelWorkflowRun }
+}
+
+// Wire up mocks, run the action, hand back the mock bag for assertions.
+async function runFailFast(opts) {
+    const m = makeMocks(opts)
+    await failFast({ github: m.github, context: m.context, core: m.core })
+    return m
+}
+
+describe('ci-fail-fast', () => {
+    describe('parseAllowlist', () => {
+        it('returns an empty set for missing input', () => {
+            assert.equal(parseAllowlist(undefined).size, 0)
+            assert.equal(parseAllowlist('').size, 0)
+        })
+
+        it('parses, trims, and drops blanks', () => {
+            const set = parseAllowlist('[" Backend CI ", "Rust CI", ""]')
+            assert.deepEqual([...set], ['Backend CI', 'Rust CI'])
+        })
+    })
+
+    describe('selectCancellableRuns', () => {
+        const cases = [
+            ['keeps an active, allowlisted PR run', makeRun(), true],
+            ['drops the source run itself', makeRun({ id: 999 }), false, 999],
+            ['drops finished runs', makeRun({ status: 'completed' }), false],
+            ['drops non-PR runs (push sharing the SHA)', makeRun({ event: 'push' }), false],
+            ['drops workflows not on the allowlist', makeRun({ name: 'Container Images CD' }), false],
+            ['keeps queued runs', makeRun({ status: 'queued' }), true],
+        ]
+
+        for (const [title, run, expected, sourceRunId = 999] of cases) {
+            it(title, () => {
+                const got = selectCancellableRuns({ runs: [run], sourceRunId, allow: ALLOW })
+                assert.equal(got.length === 1, expected)
+            })
+        }
+
+        it('filters a mixed batch down to the cancellable runs', () => {
+            const runs = [
+                makeRun({ id: 1, name: 'Backend CI' }),
+                makeRun({ id: 2, name: 'Rust CI', status: 'queued' }),
+                makeRun({ id: 3, name: 'Deploy', event: 'pull_request' }), // not allowlisted
+                makeRun({ id: 4, name: 'Backend CI', status: 'completed' }), // finished
+                makeRun({ id: 999, name: 'Frontend CI' }), // source
+            ]
+            const got = selectCancellableRuns({ runs, sourceRunId: 999, allow: ALLOW })
+            assert.deepEqual(
+                got.map((r) => r.id),
+                [1, 2]
+            )
+        })
+    })
+
+    describe('run()', () => {
+        const siblings = [
+            makeRun({ id: 1, name: 'Backend CI' }),
+            makeRun({ id: 2, name: 'Rust CI', status: 'queued' }),
+            makeRun({ id: 999, name: 'Frontend CI' }), // source, excluded
+        ]
+
+        it('dry mode cancels nothing but reports the count', async () => {
+            const { outputs, cancelWorkflowRun } = await runFailFast({ runs: siblings, mode: 'dry' })
+            assert.equal(cancelWorkflowRun.calls.length, 0)
+            assert.equal(outputs.mode, 'dry')
+            assert.equal(outputs.count, '2')
+            assert.match(outputs.summary, /Would cancel 2 sibling/)
+        })
+
+        it('on mode cancels each sibling run', async () => {
+            const { outputs, cancelWorkflowRun } = await runFailFast({ runs: siblings, mode: 'on' })
+            assert.equal(cancelWorkflowRun.calls.length, 2)
+            assert.deepEqual(
+                cancelWorkflowRun.calls.map((c) => c[0].run_id).sort(),
+                [1, 2]
+            )
+            assert.equal(outputs.count, '2')
+        })
+
+        it('emits an empty summary output when nothing is in flight', async () => {
+            const { outputs } = await runFailFast({ runs: [siblings[2]], mode: 'on' })
+            assert.equal(outputs.count, '0')
+            assert.equal(outputs.summary, '')
+        })
+
+        it('swallows a cancel error without throwing', async () => {
+            const { github, core, context } = makeMocks({ runs: siblings, mode: 'on' })
+            github.rest.actions.cancelWorkflowRun = recordingFn(async () => {
+                throw new Error('409 already cancelled')
+            })
+            await failFast({ github, context, core })
+            assert.equal(core.warning.calls.length, 2)
+        })
+    })
+})

--- a/.github/workflows/ci-fail-fast.yml
+++ b/.github/workflows/ci-fail-fast.yml
@@ -1,0 +1,85 @@
+name: CI Fail-Fast
+
+# When a required CI workflow concludes in failure on a PR, cancel the sibling CI
+# runs still in flight for the same commit. A tainted run is rarely salvaged by
+# re-running just the failed check — the usual next step is a new push, which
+# re-runs everything anyway — so finishing the rest burns runner minutes for a
+# result nobody reads.
+#
+# Gated by the CI_FAIL_FAST repository variable (Settings -> Secrets and variables
+# -> Actions -> Variables). `vars` is not available in `on:`, so the trigger always
+# fires and the job `if:` does the gating (one skipped job per failure when off):
+#   unset / "off" -> job skipped, no-op
+#   "dry"         -> log what WOULD be cancelled, cancel nothing (safe rollout)
+#   "on"          -> actually cancel
+#
+# Optional: set the CI_FAIL_FAST_SLACK_CHANNEL variable to mirror each action to a
+# Slack channel (silent if unset).
+#
+# The workflow_run.workflows trigger and CANCELLABLE_WORKFLOWS must stay in sync,
+# and both mirror REQUIRED_WORKFLOWS in ci-master-status.yml (the canonical
+# required-CI set).
+
+on:
+    workflow_run:
+        workflows:
+            - 'Backend CI'
+            - 'Node.js CI'
+            - 'Frontend CI'
+            - 'Storybook'
+            - 'Security'
+            - 'Dagster CI'
+            - 'E2E CI Playwright'
+            - 'Rust CI'
+            - 'LLM Services CI'
+        types: [completed]
+
+permissions:
+    contents: read
+    actions: write # cancel sibling runs
+
+env:
+    # Keep in sync with the workflow_run.workflows trigger above and with
+    # REQUIRED_WORKFLOWS in ci-master-status.yml.
+    CANCELLABLE_WORKFLOWS: '["Backend CI","Node.js CI","Frontend CI","Storybook","Security","Dagster CI","E2E CI Playwright","Rust CI","LLM Services CI"]'
+
+jobs:
+    cancel-siblings:
+        name: Cancel tainted sibling CI runs
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        # Only on PR failures, never master/push (which share no cancel intent), and
+        # only when the toggle is dry or on. `cancelled` never matches, so our own
+        # cancellations cannot cascade.
+        if: >-
+            ${{ (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out')
+                && github.event.workflow_run.event == 'pull_request'
+                && (vars.CI_FAIL_FAST == 'dry' || vars.CI_FAIL_FAST == 'on') }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  # Only the cancel script is needed — skip the rest of the monorepo.
+                  sparse-checkout: .github/scripts/ci-fail-fast.js
+                  sparse-checkout-cone-mode: false
+
+            - name: Cancel sibling runs
+              id: cancel
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              env:
+                  CI_FAIL_FAST_MODE: ${{ vars.CI_FAIL_FAST }}
+                  CI_FAIL_FAST_ALLOWLIST: ${{ env.CANCELLABLE_WORKFLOWS }}
+              with:
+                  script: |
+                      const run = require('./.github/scripts/ci-fail-fast.js')
+                      await run({ github, context, core })
+
+            # Optional visibility — silent unless CI_FAIL_FAST_SLACK_CHANNEL is set.
+            - name: Notify Slack
+              if: steps.cancel.outputs.summary != '' && vars.CI_FAIL_FAST_SLACK_CHANNEL != ''
+              uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: "${{ vars.CI_FAIL_FAST_SLACK_CHANNEL }}"
+                      text: "${{ steps.cancel.outputs.summary }}"

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -48,3 +48,6 @@ jobs:
 
             - name: Master CI alerts tests (Node)
               run: node --test .github/scripts/ci-alerts-devex.test.js
+
+            - name: CI fail-fast tests (Node)
+              run: node --test .github/scripts/ci-fail-fast.test.js


### PR DESCRIPTION
## Problem

When one required check fails on a PR (often a flaky one), the other CI workflows for that commit keep running to completion. That work is usually wasted: re-running a single failed check rarely yields a green PR, so people just push again — which re-runs everything anyway. The in-flight siblings burn runner minutes nobody reads.

This is the "pristine vs tainted CI" idea. Whether it actually saves compute depends on data we don't have yet, so this ships as a measurement-first experiment, off by default.

## Changes

A `workflow_run` reactor that, when a required workflow fails on a PR, looks at the **other** in-flight CI runs for that commit and (optionally) cancels them. Reuses the privileged pattern already in `ci-master-status.yml` — no third-party action.

**Toggle — `CI_FAIL_FAST` repo variable. Ships off.**

| Value | Behavior |
| --- | --- |
| unset / `off` | no-op (job skips) |
| `dry` | logs what it *would* cancel (incl. how much was in flight), cancels nothing |
| `on` | cancels |

`vars` can't gate `on:`, so the job `if:` does it (one skipped job per failure when off).

**Scope / safety**

- PR runs only — never master/push
- Allowlist = the required-CI set — never deploys or container builds
- Skips the triggering run; `cancelled` can't re-trigger, so no cascade
- Simultaneous-failure races are swallowed (expected 409s)

**Rollout**

1. Merge — inert until the variable is set
2. `gh variable set CI_FAIL_FAST --body dry` → each failure logs a `FAIL_FAST_DATA` line (which sibling runs were live + their age = the experiment data)
3. Only if the data supports it → `--body on`. Reverting is one variable change, no PR.

**Tradeoff:** a *flaky* failure is the worst case (cancel-then-full-re-run beats re-running one job). The `dry` data quantifies how often that happens before anyone flips `on`.

## Note on backend cancellation

Folklore says backend pytest "never cancels even when GitHub sends the signal." I checked: the claimed mechanism (bash blocked in `wait` swallowing the trap) does **not** match the code — the Django Core step runs pytest in the foreground (`ci-backend.yml:1877`), no `&`/`wait`/`trap`. The turbo Products path (`pnpm→turbo→pytest`) is the only plausible signal-swallowing layer, and actual cancel latency is **unmeasured**. So this PR does not assume a dependency — `dry` mode measures whether cancelling backend actually frees runners. The separate signal-fanout PR (#60203) is complementary (it makes a cancel stop pytest fast) and is validated as working — its red was a concurrency false-negative, not a signal-fanout failure.

## How did you test this code?

I'm an agent (Claude Code). Ran locally:

- `node --test .github/scripts/ci-fail-fast.test.js` — 13 cases (run selection + dry/on/empty/error paths)
- `actionlint` v1.7.12 (repo-pinned) on both workflows — clean

No live cancellation against GitHub was run; that's what `dry` mode is for post-merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code at Raúl's direction, from a Slack thread floating "if a required check fails, stop all CI". We compared GitHub's native options (`fail-fast`/`needs`/`concurrency`) and third-party actions (`potiuk/cancel-workflow-runs`, `styfle/cancel-workflow-action`), and chose an in-house `workflow_run` reactor mirroring `ci-master-status.yml` — no stale dependency, full control over scoping. The toggle is tri-state so the safe default (`dry`) doubles as the data source for the pristine-vs-tainted question. Before finalizing, the thread's backend-cancellation claims were independently checked against the repo and the Actions API; the description reflects what verified (the #60203 false-negative) and what didn't (the asserted signal mechanism). Logic lives in `.github/scripts/ci-fail-fast.js` with `node --test` coverage.
