### PR TITLE
feat(analytics-platform): add cache-key debug logging to lazy computation

### DIFF
--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -28,9 +28,10 @@ from posthog.hogql.printer import prepare_and_print_ast
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.preaggregation.sql import DISTRIBUTED_PREAGGREGATION_RESULTS_TABLE
-from posthog.clickhouse.query_tagging import tags_context
+from posthog.clickhouse.query_tagging import get_query_tag_value, tags_context
 from posthog.models.team import Team
 from posthog.settings import DEBUG, HOGQL_INCREASED_MAX_EXECUTION_TIME, TEST
+from posthog.settings.utils import get_from_env, str_to_bool
 from posthog.utils import relative_date_parse_with_delta_mapping
 
 from products.analytics_platform.backend.lazy_computation.computation_notifications import (
@@ -73,6 +74,17 @@ DEFAULT_CH_START_GRACE_PERIOD_SECONDS = 60  # 1 minute
 # where `insert_quorum=auto` waits 600s for an acknowledgement that never comes (the local
 # replica writes immediately but ClickHouse still blocks on the quorum protocol).
 PREAGGREGATION_INSERT_QUORUM: str | int = 0 if TEST or DEBUG else "auto"
+
+# Debug aid for cache-key matching. When enabled, every execute() emits a
+# `lazy_computation.cache_key` log with the hash and the exact inputs that
+# produced it (normalized query, timezone, breakdown fields). The eager warmer
+# and the user read path both pass through here, so two log lines with the same
+# `team_id`/`table` but different `query_hash` reveal *which* input diverged —
+# the read serves a different cache entry than the warmer populated. Off by
+# default; the `repr(query)` payload is large, so only flip it on for a debugging
+# window. Join on `query_hash` to the existing `lazy_computation.executed` log
+# (jobs_created / cache_state / ready) to see the values the key resolved to.
+LOG_CACHE_KEY_DETAILS = get_from_env("LAZY_COMPUTATION_LOG_CACHE_KEY_DETAILS", False, type_cast=str_to_bool)
 
 
 # Mirrors the `lazy_computation.executed` structured log so the same outcomes
@@ -722,6 +734,23 @@ class LazyComputationExecutor:
         """
         insert_fn = run_insert or (lambda t, j: run_lazy_computation_insert(t, j, query_info))
         query_hash = compute_query_hash(query_info)
+
+        if LOG_CACHE_KEY_DETAILS:
+            logger.info(
+                "lazy_computation.cache_key",
+                query_hash=query_hash,
+                table=str(query_info.table),
+                team_id=team.id,
+                timezone=query_info.timezone,
+                breakdown_fields=query_info.breakdown_fields,
+                trigger=get_query_tag_value("trigger"),
+                query_type=get_query_tag_value("query_type"),
+                time_range_start=str(start),
+                time_range_end=str(end),
+                # The exact string fed into the hash (see compute_query_hash). Diff
+                # this between a warmer line and a reader line to find the divergent input.
+                normalized_query=repr(query_info.query),
+            )
 
         errors: list[str] = []
         failures = 0

--- a/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
@@ -10,6 +10,7 @@ from django.utils import timezone as django_timezone
 
 from clickhouse_driver.errors import ServerException
 from parameterized import parameterized
+from structlog.testing import capture_logs
 
 from posthog.schema import BaseMathType, DateRange, EventsNode, HogQLQueryModifiers, TrendsQuery
 
@@ -2672,3 +2673,38 @@ class TestIsNonRetryableError(BaseTest):
     def test_generic_exception_is_retryable(self):
         error = Exception("Something went wrong")
         assert is_non_retryable_error(error) is False
+
+
+_CACHE_KEY_FLAG = "products.analytics_platform.backend.lazy_computation.lazy_computation_executor.LOG_CACHE_KEY_DETAILS"
+
+
+class TestCacheKeyLogging(BaseTest):
+    def _query_info(self) -> QueryInfo:
+        select = parse_select("SELECT uniqExact(person_id) FROM events WHERE event = '$pageview'")
+        assert isinstance(select, ast.SelectQuery)
+        return QueryInfo(query=select, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+
+    def _execute_empty_range(self) -> list:
+        # A zero-width range does no insert/Redis work but still computes the hash
+        # and emits the cache-key log before the executor loop.
+        instant = datetime(2024, 1, 1, tzinfo=UTC)
+        with capture_logs() as logs:
+            LazyComputationExecutor().execute(self.team, self._query_info(), instant, instant)
+        return [entry for entry in logs if entry["event"] == "lazy_computation.cache_key"]
+
+    @patch(_CACHE_KEY_FLAG, True)
+    def test_logs_cache_key_inputs_when_enabled(self):
+        cache_key_logs = self._execute_empty_range()
+
+        assert len(cache_key_logs) == 1
+        entry = cache_key_logs[0]
+        assert entry["query_hash"] == compute_query_hash(self._query_info())
+        assert entry["team_id"] == self.team.id
+        assert entry["timezone"] == "UTC"
+        assert entry["table"] == str(LazyComputationTable.PREAGGREGATION_RESULTS)
+        # The normalized query is the exact string fed into the hash, so it can be diffed.
+        assert "$pageview" in entry["normalized_query"]
+
+    @patch(_CACHE_KEY_FLAG, False)
+    def test_no_cache_key_log_when_disabled(self):
+        assert self._execute_empty_range() == []


### PR DESCRIPTION
## Problem

When the web-analytics lazy precompute warmer and the user read path produce different cache keys, the result is a cold recompute instead of a warm read — but the framework only logs the final `query_hash`, not the inputs that produced it. There's no way to tell *why* two keys diverged (filter expr? timezone? breakdown?), which makes debugging warmer↔reader mismatches guesswork.

## Changes

Adds an opt-in `lazy_computation.cache_key` structured log, emitted once per `execute()` at the single point where `compute_query_hash` runs — so it covers both the eager warmer and the user read path, and the two can be diffed directly.

- Gated by `LAZY_COMPUTATION_LOG_CACHE_KEY_DETAILS` (env, default off) — the `repr(query)` payload is large, so it's only for a debugging window.
- Logs `query_hash` + the exact hash inputs (`normalized_query` = `repr(query_info.query)`, `timezone`, `breakdown_fields`) plus `team_id`, `trigger`, `query_type`, and the time range.
- Join on `query_hash` to the existing `lazy_computation.executed` log to see the values the key resolved to (`cache_state`, `jobs_created`, `ready`).

## How did you test this code?

I'm an agent. Added `TestCacheKeyLogging` (uses a zero-width range so no ClickHouse/Redis side effects) asserting the log fires with the right inputs when enabled and is silent when disabled. Ran it locally (2 passed); pre-commit `ruff` + `ty` pass.

## 🤖 Agent context

Authored with Claude Code while debugging why team 2's web-analytics lazy reads weren't reliably warm. Root cause turned out to be freshness (today-bucket 15-min TTL) rather than key mismatch, but the inputs-level log is the tool that proves which of the two it is on any given tile. Placed the log in the framework chokepoint (`execute()`) rather than the web-analytics callers so it covers every lazy product and both sides of the warm/read path. Gated behind an env flag so it's safe to leave merged.
