### PR TITLE
chore(recording-rasterizer): let chrome sandbox start in local dev container

### DIFF
--- a/bin/temporal-recording-rasterizer-worker
+++ b/bin/temporal-recording-rasterizer-worker
@@ -71,12 +71,16 @@ fi
 # and uses host.docker.internal for services running natively on the host
 # (recording-api, Django).
 
+# Local-dev only: lets Chromium's sandbox initialize in the emulated container; stays ON, never used in prod.
+chrome_sandbox_opts=(--security-opt seccomp=unconfined) # nosemgrep: trailofbits.generic.container-privileged.container-privileged
+
 echo "Starting recording-rasterizer container..."
 docker run --rm \
     --name "$CONTAINER_NAME" \
     --network posthog_default \
     --platform linux/amd64 \
     --add-host localhost:host-gateway \
+    "${chrome_sandbox_opts[@]}" \
     -e TEMPORAL_HOST="${TEMPORAL_HOST:-posthog-temporal-1}" \
     -e TEMPORAL_PORT="${TEMPORAL_PORT:-7233}" \
     -e RECORDING_API_BASE_URL="${RECORDING_API_BASE_URL:-http://host.docker.internal:6741}" \


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

local rasterizer broken with error:

```
[15:16:22.639] INFO: connected to temporal

    source: "rasterizer"

    address: "temporal:7233"

[15:16:23.257] ERROR: worker failed to start

    source: "rasterizer"

    error: "Failed to launch the browser process:  Code: null\n\nstderr:\n[0603/221623.212840:FATAL:content/browser/zygote_host/zygote_host_impl_linux.cc:128] No usable sandbox! I

f you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/

docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on d

eveloping with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.\n\nTROUBLESHOOTING: https://pptr.dev/tro ubleshooting\n"
```

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

add `--security-opt seccomp=unconfined`to allow chrome's sandox to start

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

ran the raterizer process in hogli locally, it now runs

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->