### PR TITLE
fix: display dotnet stack frame modules

### DIFF
--- a/frontend/src/lib/components/Errors/Frame/RawFrame.tsx
+++ b/frontend/src/lib/components/Errors/Frame/RawFrame.tsx
@@ -1,5 +1,5 @@
 import { ErrorTrackingStackFrame, ErrorTrackingStackFrameRecord } from '../types'
-import { formatFrameSource, formatResolvedName } from '../utils'
+import { formatFrameResolvedName, formatFrameSource } from '../utils'
 
 export function RawFrame({
     frame,
@@ -8,12 +8,13 @@ export function RawFrame({
     frame: ErrorTrackingStackFrame
     record?: ErrorTrackingStackFrameRecord
 }): JSX.Element {
-    const resolvedName = formatResolvedName(frame)
+    const resolvedName = formatFrameResolvedName(frame)
     const source = formatFrameSource(frame)
     return (
         <>
             <p className="font-mono indent-[1rem] whitespace-no-wrap mb-0 line-clamp-1">
-                File "{source}"{frame.line ? `, line: ${frame.line}` : ''}
+                {source}
+                {frame.line ? `, line: ${frame.line}` : ''}
                 {resolvedName ? `, in: ${resolvedName}` : ''}
             </p>
             {record && record.context?.line.line && (

--- a/frontend/src/lib/components/Errors/Frame/RawFrame.tsx
+++ b/frontend/src/lib/components/Errors/Frame/RawFrame.tsx
@@ -1,5 +1,5 @@
 import { ErrorTrackingStackFrame, ErrorTrackingStackFrameRecord } from '../types'
-import { formatResolvedName } from '../utils'
+import { formatFrameSource, formatResolvedName } from '../utils'
 
 export function RawFrame({
     frame,
@@ -9,10 +9,11 @@ export function RawFrame({
     record?: ErrorTrackingStackFrameRecord
 }): JSX.Element {
     const resolvedName = formatResolvedName(frame)
+    const source = formatFrameSource(frame)
     return (
         <>
             <p className="font-mono indent-[1rem] whitespace-no-wrap mb-0 line-clamp-1">
-                File "{frame.source || 'Unknown Source'}"{frame.line ? `, line: ${frame.line}` : ''}
+                File "{source}"{frame.line ? `, line: ${frame.line}` : ''}
                 {resolvedName ? `, in: ${resolvedName}` : ''}
             </p>
             {record && record.context?.line.line && (

--- a/frontend/src/lib/components/Errors/utils.test.ts
+++ b/frontend/src/lib/components/Errors/utils.test.ts
@@ -1,5 +1,11 @@
 import { ExceptionAttributes } from './types'
-import { getExceptionAttributes, getExceptionList } from './utils'
+import {
+    formatFrameSource,
+    formatFunctionName,
+    formatResolvedName,
+    getExceptionAttributes,
+    getExceptionList,
+} from './utils'
 
 describe('Error Display', () => {
     it('can read sentry stack trace when $exception_list is not present', () => {
@@ -169,5 +175,32 @@ describe('Error Display', () => {
             ingestionErrors: undefined,
             handled: true,
         })
+    })
+
+    it('uses the module as a source fallback when a frame has no source path', () => {
+        expect(formatFrameSource({ source: 'Program.cs', module: 'NoPdbLib.Thrower' })).toEqual('Program.cs')
+        expect(formatFrameSource({ source: null, module: 'NoPdbLib.Thrower' })).toEqual('NoPdbLib.Thrower')
+        expect(formatFrameSource({ source: null, module: null })).toEqual('Unknown Source')
+    })
+
+    it('qualifies dotnet function names with the frame module', () => {
+        expect(formatResolvedName({ lang: 'dotnet', module: 'NoPdbLib.Thrower', resolved_name: 'Boom' })).toEqual(
+            'NoPdbLib.Thrower.Boom'
+        )
+        expect(
+            formatResolvedName({
+                lang: 'dotnet',
+                module: 'NoPdbLib.Thrower',
+                resolved_name: 'NoPdbLib.Thrower.Boom',
+            })
+        ).toEqual('NoPdbLib.Thrower.Boom')
+        expect(
+            formatFunctionName({
+                lang: 'dotnet',
+                module: 'NoPdbLib.Thrower',
+                resolved_name: null,
+                mangled_name: 'Boom',
+            })
+        ).toEqual('NoPdbLib.Thrower.Boom')
     })
 })

--- a/frontend/src/lib/components/Errors/utils.test.ts
+++ b/frontend/src/lib/components/Errors/utils.test.ts
@@ -1,5 +1,6 @@
 import { ExceptionAttributes } from './types'
 import {
+    formatFrameResolvedName,
     formatFrameSource,
     formatFunctionName,
     formatResolvedName,
@@ -178,22 +179,23 @@ describe('Error Display', () => {
     })
 
     it('uses the module as a source fallback when a frame has no source path', () => {
-        expect(formatFrameSource({ source: 'Program.cs', module: 'NoPdbLib.Thrower' })).toEqual('Program.cs')
-        expect(formatFrameSource({ source: null, module: 'NoPdbLib.Thrower' })).toEqual('NoPdbLib.Thrower')
+        expect(formatFrameSource({ source: 'Program.cs', module: 'NoPdbLib.Thrower' })).toEqual('File "Program.cs"')
+        expect(formatFrameSource({ source: null, module: 'NoPdbLib.Thrower' })).toEqual('Module "NoPdbLib.Thrower"')
         expect(formatFrameSource({ source: null, module: null })).toEqual('Unknown Source')
     })
 
     it('qualifies dotnet function names with the frame module', () => {
         expect(formatResolvedName({ lang: 'dotnet', module: 'NoPdbLib.Thrower', resolved_name: 'Boom' })).toEqual(
-            'NoPdbLib.Thrower.Boom'
+            'Boom'
         )
         expect(
-            formatResolvedName({
+            formatFrameResolvedName({
                 lang: 'dotnet',
                 module: 'NoPdbLib.Thrower',
+                source: null,
                 resolved_name: 'NoPdbLib.Thrower.Boom',
             })
-        ).toEqual('NoPdbLib.Thrower.Boom')
+        ).toEqual('Boom')
         expect(
             formatFunctionName({
                 lang: 'dotnet',

--- a/frontend/src/lib/components/Errors/utils.ts
+++ b/frontend/src/lib/components/Errors/utils.ts
@@ -242,13 +242,33 @@ export function formatResolvedName(
     if (!frame.resolved_name || frame.resolved_name === '?') {
         return null
     }
-    return frame.module && shouldQualifyFunctionName(frame.lang)
+    return frame.module && frame.lang === 'java'
         ? qualifyFunctionName(frame.module, frame.resolved_name)
         : frame.resolved_name
 }
 
 export function formatFrameSource(frame: Pick<ErrorTrackingStackFrame, 'source' | 'module'>): string {
-    return frame.source || frame.module || 'Unknown Source'
+    if (frame.source) {
+        return `File "${frame.source}"`
+    }
+
+    if (frame.module) {
+        return `Module "${frame.module}"`
+    }
+
+    return 'Unknown Source'
+}
+
+export function formatFrameResolvedName(
+    frame: Pick<ErrorTrackingStackFrame, 'module' | 'resolved_name' | 'lang' | 'source'>
+): string | null {
+    const resolvedName = formatResolvedName(frame)
+
+    if (!frame.source && frame.module && resolvedName?.startsWith(`${frame.module}.`)) {
+        return resolvedName.slice(frame.module.length + 1)
+    }
+
+    return resolvedName
 }
 
 function shouldQualifyFunctionName(lang: string): boolean {

--- a/frontend/src/lib/components/Errors/utils.ts
+++ b/frontend/src/lib/components/Errors/utils.ts
@@ -230,9 +230,9 @@ export function formatFunctionName(
     frame: Pick<ErrorTrackingStackFrame, 'module' | 'resolved_name' | 'lang' | 'mangled_name'>
 ): string | undefined {
     const functionName: string | undefined = frame.resolved_name ?? frame.mangled_name ?? undefined
-    return match([frame.lang, frame.module, functionName])
-        .with(['java', P.string, P.string], ([_, module, functionName]) => `${module}.${functionName}`)
-        .with(['java', P.string, P.nullish], ([_, module]) => `${module}`)
+    return match([shouldQualifyFunctionName(frame.lang), frame.module, functionName])
+        .with([true, P.string, P.string], ([_, module, functionName]) => qualifyFunctionName(module, functionName))
+        .with([true, P.string, P.nullish], ([_, module]) => `${module}`)
         .otherwise(() => functionName)
 }
 
@@ -242,7 +242,21 @@ export function formatResolvedName(
     if (!frame.resolved_name || frame.resolved_name === '?') {
         return null
     }
-    return frame.module && frame.lang === 'java' ? `${frame.module}.${frame.resolved_name}` : frame.resolved_name
+    return frame.module && shouldQualifyFunctionName(frame.lang)
+        ? qualifyFunctionName(frame.module, frame.resolved_name)
+        : frame.resolved_name
+}
+
+export function formatFrameSource(frame: Pick<ErrorTrackingStackFrame, 'source' | 'module'>): string {
+    return frame.source || frame.module || 'Unknown Source'
+}
+
+function shouldQualifyFunctionName(lang: string): boolean {
+    return lang === 'java' || lang === 'dotnet'
+}
+
+function qualifyFunctionName(module: string, functionName: string): string {
+    return functionName === module || functionName.startsWith(`${module}.`) ? functionName : `${module}.${functionName}`
 }
 
 export function formatType(exception: Pick<ErrorTrackingException, 'module' | 'type' | 'stacktrace'>): string {

--- a/products/error_tracking/frontend/hooks/use-stacktrace-display.tsx
+++ b/products/error_tracking/frontend/hooks/use-stacktrace-display.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 
 import { errorPropertiesLogic } from 'lib/components/Errors/errorPropertiesLogic'
 import { ErrorTrackingException } from 'lib/components/Errors/types'
-import { formatResolvedName, formatType } from 'lib/components/Errors/utils'
+import { formatFrameSource, formatResolvedName, formatType } from 'lib/components/Errors/utils'
 
 export const useStacktraceDisplay = (): { ready: boolean; stacktraceText: string } => {
     const { exceptionList, stackFrameRecords } = useValues(errorPropertiesLogic)
@@ -25,7 +25,8 @@ function generateExceptionText(exception: ErrorTrackingException, stackFrameReco
     for (const frame of frames) {
         const inAppMarker = frame.in_app ? ' [IN-APP]' : ''
         const resolvedName = formatResolvedName(frame)
-        result += `\n${inAppMarker}  File "${frame.source || 'Unknown Source'}"${frame.line ? `, line: ${frame.line}` : ''}${resolvedName ? `, in: ${resolvedName}` : ''}`
+        const source = formatFrameSource(frame)
+        result += `\n${inAppMarker}  File "${source}"${frame.line ? `, line: ${frame.line}` : ''}${resolvedName ? `, in: ${resolvedName}` : ''}`
 
         const frameRecord = stackFrameRecords[frame.raw_id]
         if (frameRecord?.context?.line?.line) {

--- a/products/error_tracking/frontend/hooks/use-stacktrace-display.tsx
+++ b/products/error_tracking/frontend/hooks/use-stacktrace-display.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 
 import { errorPropertiesLogic } from 'lib/components/Errors/errorPropertiesLogic'
 import { ErrorTrackingException } from 'lib/components/Errors/types'
-import { formatFrameSource, formatResolvedName, formatType } from 'lib/components/Errors/utils'
+import { formatFrameResolvedName, formatFrameSource, formatType } from 'lib/components/Errors/utils'
 
 export const useStacktraceDisplay = (): { ready: boolean; stacktraceText: string } => {
     const { exceptionList, stackFrameRecords } = useValues(errorPropertiesLogic)
@@ -24,9 +24,9 @@ function generateExceptionText(exception: ErrorTrackingException, stackFrameReco
 
     for (const frame of frames) {
         const inAppMarker = frame.in_app ? ' [IN-APP]' : ''
-        const resolvedName = formatResolvedName(frame)
+        const resolvedName = formatFrameResolvedName(frame)
         const source = formatFrameSource(frame)
-        result += `\n${inAppMarker}  File "${source}"${frame.line ? `, line: ${frame.line}` : ''}${resolvedName ? `, in: ${resolvedName}` : ''}`
+        result += `\n${inAppMarker}  ${source}${frame.line ? `, line: ${frame.line}` : ''}${resolvedName ? `, in: ${resolvedName}` : ''}`
 
         const frameRecord = stackFrameRecords[frame.raw_id]
         if (frameRecord?.context?.line?.line) {


### PR DESCRIPTION
## Summary

- Shows module names for resolved error frames when no source file is available.
- Labels source-less module fallbacks as `Module` instead of `File`.
- Avoids repeated module prefixes in raw stacktrace rows and copied stacktrace text.

## Tests

- `pnpm --filter=@posthog/frontend jest -- frontend/src/lib/components/Errors/utils.test.ts --runInBand`
- `pnpm format:frontend:check`
- `pnpm lint:js`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter=@posthog/frontend typescript:check`
- Local repro in `/Users/cat/p/experiments/dotnet-stacktrace-source-repro`
- `~/.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/master`
