### PR TITLE
chore(personhog): enforce message size after compression

### DIFF
--- a/rust/personhog-common/src/async_gzip.rs
+++ b/rust/personhog-common/src/async_gzip.rs
@@ -192,6 +192,22 @@ where
                 .unwrap_or("unknown"),
         );
 
+        let client: Arc<str> = Arc::from(
+            request
+                .headers()
+                .get("x-client-name")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("unknown"),
+        );
+
+        let caller_tag: Arc<str> = Arc::from(
+            request
+                .headers()
+                .get("x-caller-tag")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or(""),
+        );
+
         let config = self.config.clone();
         let mut inner = self.inner.clone();
 
@@ -258,7 +274,9 @@ where
             // Client doesn't accept gzip — return the collected body uncompressed.
             if !accepts_gzip {
                 counter!("grpc_gzip_responses_total", "outcome" => "passthrough_no_gzip", "method" => method.clone()).increment(1);
-                if let Some(body) = check_response_size(&config, &method, total_size) {
+                if let Some(body) =
+                    check_response_size(&config, &method, &client, &caller_tag, total_size)
+                {
                     return Ok(Response::from_parts(parts, body));
                 }
                 let data = concat_chunks(&chunks);
@@ -277,7 +295,9 @@ where
                 || already_compressed
             {
                 counter!("grpc_gzip_responses_total", "outcome" => "passthrough_small", "method" => method.clone()).increment(1);
-                if let Some(body) = check_response_size(&config, &method, total_size) {
+                if let Some(body) =
+                    check_response_size(&config, &method, &client, &caller_tag, total_size)
+                {
                     return Ok(Response::from_parts(parts, body));
                 }
                 let gzip_overhead_ms = gzip_start.elapsed().as_secs_f64() * 1000.0;
@@ -308,8 +328,13 @@ where
                     // Size check on the compressed output — this is the actual
                     // number of bytes that will go over the wire.
                     let compressed_frame_size = GRPC_HEADER_SIZE + bytes.len();
-                    if let Some(body) = check_response_size(&config, &method, compressed_frame_size)
-                    {
+                    if let Some(body) = check_response_size(
+                        &config,
+                        &method,
+                        &client,
+                        &caller_tag,
+                        compressed_frame_size,
+                    ) {
                         return Ok(Response::from_parts(parts, body));
                     }
 
@@ -359,6 +384,8 @@ where
 fn check_response_size(
     config: &AsyncGzipConfig,
     method: &Arc<str>,
+    client: &Arc<str>,
+    caller_tag: &Arc<str>,
     size: usize,
 ) -> Option<ResponseBody> {
     let limit = config.max_response_size?;
@@ -371,6 +398,7 @@ fn check_response_size(
     counter!(
         "grpc_gzip_response_over_limit_total",
         "method" => method.clone(),
+        "client" => client.clone(),
         "enforced" => if enforced { "true" } else { "false" },
     )
     .increment(1);
@@ -380,6 +408,8 @@ fn check_response_size(
             response_size_bytes = size,
             limit_bytes = limit,
             method = %method,
+            client = %client,
+            caller_tag = %caller_tag,
             "oversized gRPC response (monitor mode)"
         );
         return None;
@@ -389,6 +419,8 @@ fn check_response_size(
         response_size_bytes = size,
         limit_bytes = limit,
         method = %method,
+        client = %client,
+        caller_tag = %caller_tag,
         "rejecting oversized gRPC response"
     );
 

--- a/rust/personhog-common/src/async_gzip.rs
+++ b/rust/personhog-common/src/async_gzip.rs
@@ -258,8 +258,8 @@ where
             // Client doesn't accept gzip — return the collected body uncompressed.
             if !accepts_gzip {
                 counter!("grpc_gzip_responses_total", "outcome" => "passthrough_no_gzip", "method" => method.clone()).increment(1);
-                if let Some(resp) = check_response_size(&config, &method, total_size) {
-                    return Ok(resp);
+                if let Some(body) = check_response_size(&config, &method, total_size) {
+                    return Ok(Response::from_parts(parts, body));
                 }
                 let data = concat_chunks(&chunks);
                 let boxed: ResponseBody = Box::pin(PrecomputedBody::new(data, trailers));
@@ -277,8 +277,8 @@ where
                 || already_compressed
             {
                 counter!("grpc_gzip_responses_total", "outcome" => "passthrough_small", "method" => method.clone()).increment(1);
-                if let Some(resp) = check_response_size(&config, &method, total_size) {
-                    return Ok(resp);
+                if let Some(body) = check_response_size(&config, &method, total_size) {
+                    return Ok(Response::from_parts(parts, body));
                 }
                 let gzip_overhead_ms = gzip_start.elapsed().as_secs_f64() * 1000.0;
                 set_gzip_overhead_header(&mut parts, method.clone(), gzip_overhead_ms);
@@ -308,9 +308,9 @@ where
                     // Size check on the compressed output — this is the actual
                     // number of bytes that will go over the wire.
                     let compressed_frame_size = GRPC_HEADER_SIZE + bytes.len();
-                    if let Some(resp) = check_response_size(&config, &method, compressed_frame_size)
+                    if let Some(body) = check_response_size(&config, &method, compressed_frame_size)
                     {
-                        return Ok(resp);
+                        return Ok(Response::from_parts(parts, body));
                     }
 
                     let mut frame = BytesMut::with_capacity(GRPC_HEADER_SIZE + bytes.len());
@@ -352,26 +352,36 @@ where
 }
 
 /// Checks the response size against the configured limit. In enforce mode,
-/// returns a gRPC OUT_OF_RANGE error response. In monitor mode, emits a metric
-/// and returns `None` so the caller can proceed normally.
+/// returns a rejection body that the caller should wrap with the original
+/// response `parts` (preserving headers like `Content-Type: application/grpc`).
+/// In monitor mode, emits a metric and returns `None` so the caller proceeds
+/// normally.
 fn check_response_size(
     config: &AsyncGzipConfig,
     method: &Arc<str>,
     size: usize,
-) -> Option<Response<ResponseBody>> {
+) -> Option<ResponseBody> {
     let limit = config.max_response_size?;
     if size <= limit {
         return None;
     }
 
+    let enforced = config.max_response_size_enforce;
+
     counter!(
         "grpc_gzip_response_over_limit_total",
         "method" => method.clone(),
-        "enforced" => if config.max_response_size_enforce { "true" } else { "false" },
+        "enforced" => if enforced { "true" } else { "false" },
     )
     .increment(1);
 
-    if !config.max_response_size_enforce {
+    if !enforced {
+        warn!(
+            response_size_bytes = size,
+            limit_bytes = limit,
+            method = %method,
+            "oversized gRPC response (monitor mode)"
+        );
         return None;
     }
 
@@ -388,8 +398,7 @@ fn check_response_size(
     if let Ok(hv) = HeaderValue::from_str(&msg) {
         trailers.insert("grpc-message", hv);
     }
-    let boxed: ResponseBody = Box::pin(PrecomputedBody::trailers_only(trailers));
-    Some(Response::new(boxed))
+    Some(Box::pin(PrecomputedBody::trailers_only(trailers)))
 }
 
 // ============================================================
@@ -614,7 +623,14 @@ mod tests {
                 data: Some(self.body.clone()),
                 trailers: self.trailers.clone(),
             };
-            Box::pin(async { Ok(Response::new(body)) })
+            Box::pin(async {
+                let mut resp = Response::new(body);
+                resp.headers_mut().insert(
+                    "content-type",
+                    HeaderValue::from_static("application/grpc+proto"),
+                );
+                Ok(resp)
+            })
         }
     }
 
@@ -1097,10 +1113,15 @@ mod tests {
             ..default_test_config()
         };
 
-        let (_parts, data, trailers) = call_layer(service, config, Some("gzip")).await;
+        let (parts, data, trailers) = call_layer(service, config, Some("gzip")).await;
         assert!(data.is_empty(), "rejected response should have no data");
         let trailers = trailers.expect("should have trailers");
         assert_eq!(trailers.get("grpc-status").unwrap(), "11"); // OUT_OF_RANGE
+                                                                // Verify the original response headers (e.g. content-type) are preserved
+        assert_eq!(
+            parts.headers.get("content-type").unwrap(),
+            "application/grpc+proto"
+        );
     }
 
     #[tokio::test]
@@ -1114,10 +1135,14 @@ mod tests {
         };
 
         // No gzip header — uncompressed passthrough, still size-checked
-        let (_parts, data, trailers) = call_layer(service, config, None).await;
+        let (parts, data, trailers) = call_layer(service, config, None).await;
         assert!(data.is_empty(), "rejected response should have no data");
         let trailers = trailers.expect("should have trailers");
         assert_eq!(trailers.get("grpc-status").unwrap(), "11");
+        assert_eq!(
+            parts.headers.get("content-type").unwrap(),
+            "application/grpc+proto"
+        );
     }
 
     #[tokio::test]

--- a/rust/personhog-common/src/async_gzip.rs
+++ b/rust/personhog-common/src/async_gzip.rs
@@ -67,6 +67,23 @@ pub struct AsyncGzipConfig {
     /// than this pass through uncompressed — the gzip header overhead would
     /// make them larger, and the CPU cost isn't worth it.
     pub min_payload_size: usize,
+
+    /// Maximum response payload size (bytes) after compression (or uncompressed
+    /// if gzip is not negotiated). When a response exceeds this limit, behavior
+    /// depends on `max_response_size_enforce`: in enforce mode, the response is
+    /// rejected with an OUT_OF_RANGE gRPC error; in monitor mode, a metric is
+    /// emitted but the response is delivered normally. `None` disables the check.
+    ///
+    /// This replaces tonic's `max_encoding_message_size` as the primary guardrail
+    /// because tonic's check runs before this layer's gzip compression, rejecting
+    /// responses that would compress well below the limit.
+    pub max_response_size: Option<usize>,
+
+    /// When true, responses exceeding `max_response_size` are rejected with a
+    /// gRPC OUT_OF_RANGE error. When false (monitor mode), the metric fires
+    /// but the response is delivered normally — useful for observing violations
+    /// before enabling enforcement.
+    pub max_response_size_enforce: bool,
 }
 
 impl AsyncGzipConfig {
@@ -75,7 +92,15 @@ impl AsyncGzipConfig {
             enabled,
             compression_level: compression_level.clamp(1, 9),
             min_payload_size,
+            max_response_size: None,
+            max_response_size_enforce: false,
         }
+    }
+
+    pub fn with_max_response_size(mut self, max_bytes: Option<usize>, enforce: bool) -> Self {
+        self.max_response_size = max_bytes;
+        self.max_response_size_enforce = enforce;
+        self
     }
 }
 
@@ -85,6 +110,8 @@ impl Default for AsyncGzipConfig {
             enabled: false,
             compression_level: 6,
             min_payload_size: 256,
+            max_response_size: None,
+            max_response_size_enforce: false,
         }
     }
 }
@@ -172,22 +199,12 @@ where
             let response = inner.call(request).await?;
             let (mut parts, body) = response.into_parts();
 
-            // When compression isn't requested, pass the original body through
-            // without collecting or copying — zero overhead for the common case
-            // where the client doesn't accept gzip or the feature is disabled.
-            if !accepts_gzip {
-                counter!("grpc_gzip_responses_total", "outcome" => "passthrough", "method" => method.clone()).increment(1);
-                let body = body.map_err(|e| Status::internal(e.to_string()));
-                let boxed: ResponseBody = Box::pin(body);
-                return Ok(Response::from_parts(parts, boxed));
-            }
-
             let gzip_start = Instant::now();
 
-            // Gather body data chunks and trailers separately. For unary RPCs,
-            // tonic produces one or more data frames (split at ~32KB boundaries)
-            // followed by a trailers frame. We keep chunks as individual Bytes
-            // references to avoid copying them into a contiguous buffer.
+            // Always collect the body so we can enforce size limits on all
+            // response paths. For unary RPCs this is a single frame — the
+            // overhead is one Vec allocation and Bytes reference copies (no
+            // data copying for the common single-chunk case).
             let mut chunks: Vec<Bytes> = Vec::new();
             let mut trailers: Option<HeaderMap> = None;
             let mut total_size: usize = 0;
@@ -238,6 +255,17 @@ where
             )
             .record(gzip_start.elapsed().as_secs_f64() * 1000.0);
 
+            // Client doesn't accept gzip — return the collected body uncompressed.
+            if !accepts_gzip {
+                counter!("grpc_gzip_responses_total", "outcome" => "passthrough_no_gzip", "method" => method.clone()).increment(1);
+                if let Some(resp) = check_response_size(&config, &method, total_size) {
+                    return Ok(resp);
+                }
+                let data = concat_chunks(&chunks);
+                let boxed: ResponseBody = Box::pin(PrecomputedBody::new(data, trailers));
+                return Ok(Response::from_parts(parts, boxed));
+            }
+
             let payload_size = total_size.saturating_sub(GRPC_HEADER_SIZE);
             let already_compressed = chunks.iter().find_map(|c| c.first().copied()) == Some(1);
 
@@ -248,7 +276,10 @@ where
                 || payload_size < config.min_payload_size
                 || already_compressed
             {
-                counter!("grpc_gzip_responses_total", "outcome" => "passthrough", "method" => method.clone()).increment(1);
+                counter!("grpc_gzip_responses_total", "outcome" => "passthrough_small", "method" => method.clone()).increment(1);
+                if let Some(resp) = check_response_size(&config, &method, total_size) {
+                    return Ok(resp);
+                }
                 let gzip_overhead_ms = gzip_start.elapsed().as_secs_f64() * 1000.0;
                 set_gzip_overhead_header(&mut parts, method.clone(), gzip_overhead_ms);
                 let data = concat_chunks(&chunks);
@@ -273,6 +304,14 @@ where
                     histogram!("grpc_gzip_compressed_bytes", "method" => method.clone())
                         .record(bytes.len() as f64);
                     counter!("grpc_gzip_responses_total", "outcome" => "compressed", "method" => method.clone()).increment(1);
+
+                    // Size check on the compressed output — this is the actual
+                    // number of bytes that will go over the wire.
+                    let compressed_frame_size = GRPC_HEADER_SIZE + bytes.len();
+                    if let Some(resp) = check_response_size(&config, &method, compressed_frame_size)
+                    {
+                        return Ok(resp);
+                    }
 
                     let mut frame = BytesMut::with_capacity(GRPC_HEADER_SIZE + bytes.len());
                     frame.put_u8(1); // compression flag
@@ -310,6 +349,47 @@ where
             }
         })
     }
+}
+
+/// Checks the response size against the configured limit. In enforce mode,
+/// returns a gRPC OUT_OF_RANGE error response. In monitor mode, emits a metric
+/// and returns `None` so the caller can proceed normally.
+fn check_response_size(
+    config: &AsyncGzipConfig,
+    method: &Arc<str>,
+    size: usize,
+) -> Option<Response<ResponseBody>> {
+    let limit = config.max_response_size?;
+    if size <= limit {
+        return None;
+    }
+
+    counter!(
+        "grpc_gzip_response_over_limit_total",
+        "method" => method.clone(),
+        "enforced" => if config.max_response_size_enforce { "true" } else { "false" },
+    )
+    .increment(1);
+
+    if !config.max_response_size_enforce {
+        return None;
+    }
+
+    warn!(
+        response_size_bytes = size,
+        limit_bytes = limit,
+        method = %method,
+        "rejecting oversized gRPC response"
+    );
+
+    let mut trailers = HeaderMap::new();
+    trailers.insert("grpc-status", HeaderValue::from_static("11")); // OUT_OF_RANGE
+    let msg = format!("response size {size} bytes exceeds limit of {limit} bytes");
+    if let Ok(hv) = HeaderValue::from_str(&msg) {
+        trailers.insert("grpc-message", hv);
+    }
+    let boxed: ResponseBody = Box::pin(PrecomputedBody::trailers_only(trailers));
+    Some(Response::new(boxed))
 }
 
 // ============================================================
@@ -465,6 +545,8 @@ mod tests {
             enabled: true,
             compression_level: 6,
             min_payload_size: 0,
+            max_response_size: None,
+            max_response_size_enforce: false,
         }
     }
 
@@ -999,5 +1081,91 @@ mod tests {
             Some(_) => panic!("header should be absent"),
             None => panic!("header should be present"),
         }
+    }
+
+    // ============================================================
+    // Response size limit tests
+    // ============================================================
+
+    #[tokio::test]
+    async fn enforce_rejects_oversized_compressed_response() {
+        let payload = vec![42u8; 10_000];
+        let service = MockGrpcService::new(&payload);
+        let config = AsyncGzipConfig {
+            max_response_size: Some(10), // tiny limit — compressed output will exceed
+            max_response_size_enforce: true,
+            ..default_test_config()
+        };
+
+        let (_parts, data, trailers) = call_layer(service, config, Some("gzip")).await;
+        assert!(data.is_empty(), "rejected response should have no data");
+        let trailers = trailers.expect("should have trailers");
+        assert_eq!(trailers.get("grpc-status").unwrap(), "11"); // OUT_OF_RANGE
+    }
+
+    #[tokio::test]
+    async fn enforce_rejects_oversized_uncompressed_response() {
+        let payload = vec![42u8; 10_000];
+        let service = MockGrpcService::new(&payload);
+        let config = AsyncGzipConfig {
+            max_response_size: Some(100),
+            max_response_size_enforce: true,
+            ..default_test_config()
+        };
+
+        // No gzip header — uncompressed passthrough, still size-checked
+        let (_parts, data, trailers) = call_layer(service, config, None).await;
+        assert!(data.is_empty(), "rejected response should have no data");
+        let trailers = trailers.expect("should have trailers");
+        assert_eq!(trailers.get("grpc-status").unwrap(), "11");
+    }
+
+    #[tokio::test]
+    async fn monitor_mode_delivers_oversized_response() {
+        let payload = vec![42u8; 10_000];
+        let service = MockGrpcService::new(&payload);
+        let config = AsyncGzipConfig {
+            max_response_size: Some(10),      // tiny limit
+            max_response_size_enforce: false, // monitor only
+            ..default_test_config()
+        };
+
+        let (parts, data, _trailers) = call_layer(service, config, Some("gzip")).await;
+        // Response should still be delivered despite exceeding the limit
+        assert_eq!(parts.headers.get(GRPC_ENCODING).unwrap(), "gzip");
+        let (compressed, compressed_payload) = parse_grpc_frame(&data);
+        assert!(compressed);
+        assert_eq!(gzip_decompress(&compressed_payload), payload);
+    }
+
+    #[tokio::test]
+    async fn enforce_allows_response_under_limit() {
+        let payload = b"small payload";
+        let service = MockGrpcService::new(payload);
+        let config = AsyncGzipConfig {
+            max_response_size: Some(1_000_000), // generous limit
+            max_response_size_enforce: true,
+            ..default_test_config()
+        };
+
+        let (parts, data, trailers) = call_layer(service, config, Some("gzip")).await;
+        assert_eq!(parts.headers.get(GRPC_ENCODING).unwrap(), "gzip");
+        let (compressed, compressed_payload) = parse_grpc_frame(&data);
+        assert!(compressed);
+        assert_eq!(gzip_decompress(&compressed_payload), payload);
+        let trailers = trailers.expect("trailers should be present");
+        assert_eq!(trailers.get("grpc-status").unwrap(), "0");
+    }
+
+    #[tokio::test]
+    async fn no_limit_allows_any_size() {
+        let payload = vec![42u8; 100_000];
+        let service = MockGrpcService::new(&payload);
+        let config = default_test_config(); // max_response_size = None
+
+        let (parts, data, _trailers) = call_layer(service, config, Some("gzip")).await;
+        assert_eq!(parts.headers.get(GRPC_ENCODING).unwrap(), "gzip");
+        let (_, compressed_payload) = parse_grpc_frame(&data);
+        assert_eq!(gzip_decompress(&compressed_payload), payload);
     }
 }

--- a/rust/personhog-replica/src/config.rs
+++ b/rust/personhog-replica/src/config.rs
@@ -115,6 +115,18 @@ pub struct Config {
     /// than this pass through uncompressed.
     #[envconfig(default = "256")]
     pub gzip_min_payload_size: usize,
+
+    /// Maximum response size (bytes) enforced after gzip compression. Applies
+    /// to the final wire size — compressed bytes for gzip responses, raw bytes
+    /// for uncompressed passthrough. 0 = disabled. Default 4 MiB.
+    #[envconfig(default = "4194304")]
+    pub gzip_max_response_size: usize,
+
+    /// When true, responses exceeding `gzip_max_response_size` are rejected
+    /// with a gRPC OUT_OF_RANGE error. When false, the metric fires but the
+    /// response is delivered normally (monitor mode).
+    #[envconfig(default = "false")]
+    pub gzip_max_response_size_enforce: bool,
 }
 
 impl Config {

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -324,9 +324,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!(
             level = gzip_config.compression_level,
             min_payload_size = gzip_config.min_payload_size,
-            max_response_size = ?gzip_config.max_response_size,
-            max_response_size_enforce = gzip_config.max_response_size_enforce,
             "Async gzip response compression enabled"
+        );
+    }
+    if let Some(limit) = gzip_config.max_response_size {
+        tracing::info!(
+            limit_bytes = limit,
+            enforce = gzip_config.max_response_size_enforce,
+            "Response size limit active"
         );
     }
     if max_concurrent_requests > 0 {

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -308,16 +308,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let max_send = config.grpc_max_send_message_size;
     let max_recv = config.grpc_max_recv_message_size;
     let max_concurrent_requests = config.max_concurrent_requests;
+    let max_response_size = if config.gzip_max_response_size > 0 {
+        Some(config.gzip_max_response_size)
+    } else {
+        None
+    };
     let gzip_config = AsyncGzipConfig::new(
         config.gzip_response_compression,
         config.gzip_compression_level,
         config.gzip_min_payload_size,
-    );
+    )
+    .with_max_response_size(max_response_size, config.gzip_max_response_size_enforce);
 
     if gzip_config.enabled {
         tracing::info!(
             level = gzip_config.compression_level,
             min_payload_size = gzip_config.min_payload_size,
+            max_response_size = ?gzip_config.max_response_size,
+            max_response_size_enforce = gzip_config.max_response_size_enforce,
             "Async gzip response compression enabled"
         );
     }


### PR DESCRIPTION
## Problem

tonic's message size enforcement occurs before our custom compression layer - meaning we reject events as "over 4mb" when the final returned payload may be well under. 

## Changes

- move message size enforcement to the compression layer
- toggle an enforcement mode so we can have reporting before we enable
- to follow up, we'll want to set the tonic limit back to its large default so it's effectively disabled
