### PR TITLE
fix(flags): normalize non-string payloads to JSON strings

### DIFF
--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -1352,23 +1352,20 @@ class FeatureFlagSerializer(
             raise serializers.ValidationError("Payloads must be passed as a dictionary")
 
         for key, value in payloads.items():
-            if isinstance(value, dict):
-                # Normalize JSON object payloads (e.g. from the API) to strings,
-                # matching what the UI sends.
-                try:
-                    payloads[key] = json.dumps(value)
-                except (TypeError, ValueError):
-                    raise serializers.ValidationError("Payload value is not valid JSON")
-            elif isinstance(value, str):
-                try:
+            try:
+                if isinstance(value, str):
+                    # An incoming string is already the canonical stored form; just check it parses.
                     json.loads(value)
-                except json.JSONDecodeError:
-                    raise serializers.ValidationError("Payload value is not valid JSON")
-            else:
-                try:
-                    json.dumps(value)
-                except (TypeError, ValueError):
-                    raise serializers.ValidationError("Payload value is not valid JSON")
+                else:
+                    # Normalize any non-string JSON value (objects, arrays, numbers, booleans, null)
+                    # to a JSON string, matching what the UI sends.
+                    payloads[key] = json.dumps(value)
+            except json.JSONDecodeError:
+                raise serializers.ValidationError("Payload value is not valid JSON")
+            except (TypeError, ValueError):
+                # Defensive: request bodies are JSON-parsed, so values are always JSON-native
+                # (str/int/float/bool/None/dict/list) and serializable. Unreachable via the API.
+                raise serializers.ValidationError("Payload value could not be serialized to JSON")
 
         if filters.get("multivariate"):
             if not all(key in variants for key in payloads):

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -2249,6 +2249,39 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         decrypted = get_decrypted_flag_payload(stored, should_decrypt=True)
         self.assertEqual(decrypted, plaintext)
 
+    @parameterized.expand(
+        [
+            ("number", 42),
+            ("boolean", True),
+            ("null", None),
+            ("array", [1, 2, 3]),
+            ("object", {"key": "value"}),
+        ]
+    )
+    def test_update_encrypted_flag_encrypts_non_string_payload(self, _name, raw_value):
+        # A non-str JSON payload is normalized to a JSON string before encryption,
+        # so it encrypts cleanly instead of raising on `.encode()`.
+        flag = self._create_encrypted_flag()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{flag.id}/",
+            {
+                "has_encrypted_payloads": True,
+                "filters": {
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                    "payloads": {"true": raw_value},
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+        flag.refresh_from_db()
+        stored = flag.filters["payloads"]["true"]
+        self.assertNotEqual(stored, json.dumps(raw_value))
+        decrypted = get_decrypted_flag_payload(stored, should_decrypt=True)
+        self.assertEqual(json.loads(decrypted), raw_value)
+
     def test_update_encrypted_flag_downgrade_clears_payload(self):
         flag = self._create_encrypted_flag()
 
@@ -5367,22 +5400,44 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertIsInstance(stored_payload, str)
         self.assertEqual(json.loads(stored_payload), {"key": "value"})
 
-        # Other valid JSON types (number, boolean, null, array) should be accepted
-        number_payload = self._create_flag_with_properties(
-            "number-payload-flag",
+    @parameterized.expand(
+        [
+            ("number", 42),
+            ("boolean", True),
+            ("null", None),
+            ("array", [1, 2, 3]),
+        ]
+    )
+    def test_non_string_payloads_are_normalized_to_json_strings(self, name, raw_value):
+        # Other valid JSON types (number, boolean, null, array) are accepted and
+        # normalized to JSON strings, matching how object payloads are stored.
+        response = self._create_flag_with_properties(
+            f"{name}-payload-flag",
             [{"key": "key", "value": "value", "type": "person"}],
-            payloads={"true": 42},
+            payloads={"true": raw_value},
             expected_status=status.HTTP_201_CREATED,
         )
-        self.assertEqual(number_payload.status_code, status.HTTP_201_CREATED)
+        stored = response.json()["filters"]["payloads"]["true"]
+        self.assertIsInstance(stored, str)
+        self.assertEqual(json.loads(stored), raw_value)
 
-        boolean_payload = self._create_flag_with_properties(
-            "boolean-payload-flag",
+    @parameterized.expand(
+        [
+            ("empty", ""),
+            ("whitespace", "   "),
+        ]
+    )
+    def test_blank_string_payloads_are_rejected(self, name, blank_value):
+        # An empty or whitespace-only string isn't valid JSON (the common "user cleared
+        # the field" case), so it's rejected rather than coerced.
+        response = self._create_flag_with_properties(
+            f"{name}-payload-flag",
             [{"key": "key", "value": "value", "type": "person"}],
-            payloads={"true": True},
-            expected_status=status.HTTP_201_CREATED,
+            payloads={"true": blank_value},
+            expected_status=status.HTTP_400_BAD_REQUEST,
         )
-        self.assertEqual(boolean_payload.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["detail"], "Payload value is not valid JSON")
 
     def test_creating_feature_flag_with_behavioral_cohort(self):
         cohort_valid_for_ff = Cohort.objects.create(


### PR DESCRIPTION
## Problem

Encrypted feature flag payloads call `.encode("utf-8")` at encryption time, which requires a string. A non-string scalar payload (for example, a number like `42`) reached the encryptor un-normalized and crashed.

Payload normalization was also inconsistent. Object payloads were normalized to JSON strings, but other non-string JSON types (numbers, booleans, arrays, `null`) were validated and then stored un-normalized: the `else` branch called `json.dumps(value)` but discarded the result.

## Changes

- Normalize every non-string payload value (object, array, number, boolean, `null`) to a JSON string during validation, matching the existing object-payload behavior and what the UI sends. Encryption now always receives a string.
- Collapse the duplicate `dict` / `else` validation branches into one `str` / non-`str` split with distinct error messages: `"Payload value is not valid JSON"` for an unparseable string, `"Payload value could not be serialized to JSON"` for a non-serializable value.
- Parameterize the encrypted non-string payload test over number, boolean, null, array, and object; parameterize the create-path normalization test; add empty and whitespace-string rejection cases.

### Payload normalization and existing flags

This normalizes new writes. Existing flags with raw scalar payloads keep their current stored form until their next save, then converge automatically. There is no backfill; convergence is per-write.

Read paths send payloads verbatim, and the client SDKs that parse payloads (js, node, python, iOS, Android, Flutter, PHP, Ruby) guard on is-string and return the same value for both `42` and `"42"`. Go returns the JSON text as a string either way, and .NET already expects a JSON-string payload, so this aligns with it. The one SDK that passes payloads through without parsing is Elixir (remote-only): a scalar payload there changes from `42` to `"42"` once a flag re-saves, consistent with how Elixir already surfaces object payloads, which were normalized to strings in migration `1015`.

## How did you test this code?

Automated tests in `products/feature_flags/backend/api/test/test_feature_flag.py`:

- `test_update_encrypted_flag_encrypts_non_string_payload`, parameterized over number, boolean, null, array, and object, confirms each type normalizes to a JSON string, encrypts, and round-trips on decrypt.
- `test_non_string_payloads_are_normalized_to_json_strings` (number, boolean, null, array) confirms create-path storage as a JSON string.
- `test_validation_payloads` covers object normalization, the invalid-JSON-string 400, and the new empty and whitespace-string 400 cases.

All 10 selected cases pass. `ruff check` and `ruff format` are clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.