### PR TITLE
chore(personhog): route method layer to storage metrics

### DIFF
--- a/rust/personhog-common/src/grpc.rs
+++ b/rust/personhog-common/src/grpc.rs
@@ -315,10 +315,9 @@ where
     }
 
     fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
-        let method = extract_grpc_method(request.uri().path());
+        let method: Arc<str> = Arc::from(extract_grpc_method(request.uri().path()));
         let client = extract_client_name(&request);
         let caller_tag = extract_caller_tag(&request);
-        let method_arc: Arc<str> = Arc::from(method.as_str());
         gauge!("grpc_server_requests_in_flight", "method" => method.clone(), "client" => client.clone())
             .increment(1.0);
 
@@ -327,14 +326,14 @@ where
         // sees CLIENT_NAME, CALLER_TAG, and METHOD_NAME.
         let inner = CLIENT_NAME.sync_scope(client.clone(), || {
             CALLER_TAG.sync_scope(caller_tag.clone(), || {
-                METHOD_NAME.sync_scope(method_arc.clone(), || self.inner.call(request))
+                METHOD_NAME.sync_scope(method.clone(), || self.inner.call(request))
             })
         });
 
         GrpcMetricsFuture {
             inner: CLIENT_NAME.scope(
                 client.clone(),
-                CALLER_TAG.scope(caller_tag, METHOD_NAME.scope(method_arc, inner)),
+                CALLER_TAG.scope(caller_tag, METHOD_NAME.scope(method.clone(), inner)),
             ),
             method,
             client,
@@ -355,7 +354,7 @@ where
 pub struct GrpcMetricsFuture<F> {
     #[pin]
     inner: TaskLocalFuture<Arc<str>, TaskLocalFuture<Arc<str>, TaskLocalFuture<Arc<str>, F>>>,
-    method: String,
+    method: Arc<str>,
     client: Arc<str>,
     start: Instant,
     emit_processing_time_header: bool,

--- a/rust/personhog-common/src/grpc.rs
+++ b/rust/personhog-common/src/grpc.rs
@@ -36,6 +36,10 @@ tokio::task_local! {
     /// Per-request caller tag, set by `GrpcMetricsLayer` and readable
     /// anywhere in the request's async call chain via `current_caller_tag()`.
     pub static CALLER_TAG: Arc<str>;
+
+    /// Per-request gRPC method name, set by `GrpcMetricsLayer` and readable
+    /// anywhere in the request's async call chain via `current_method_name()`.
+    pub static METHOD_NAME: Arc<str>;
 }
 
 /// Get the current client name from the task-local, or `"unknown"` if not set.
@@ -51,6 +55,13 @@ pub fn current_client_name() -> Arc<str> {
 pub fn current_caller_tag() -> Arc<str> {
     CALLER_TAG
         .try_with(|t| t.clone())
+        .unwrap_or_else(|_| Arc::from("unknown"))
+}
+
+/// Get the current gRPC method name from the task-local, or `"unknown"` if not set.
+pub fn current_method_name() -> Arc<str> {
+    METHOD_NAME
+        .try_with(|m| m.clone())
         .unwrap_or_else(|_| Arc::from("unknown"))
 }
 
@@ -307,18 +318,24 @@ where
         let method = extract_grpc_method(request.uri().path());
         let client = extract_client_name(&request);
         let caller_tag = extract_caller_tag(&request);
+        let method_arc: Arc<str> = Arc::from(method.as_str());
         gauge!("grpc_server_requests_in_flight", "method" => method.clone(), "client" => client.clone())
             .increment(1.0);
 
         let start = Instant::now();
-        // Call inner inside both scopes so any synchronous work in call()
-        // sees CLIENT_NAME and CALLER_TAG.
+        // Call inner inside all scopes so any synchronous work in call()
+        // sees CLIENT_NAME, CALLER_TAG, and METHOD_NAME.
         let inner = CLIENT_NAME.sync_scope(client.clone(), || {
-            CALLER_TAG.sync_scope(caller_tag.clone(), || self.inner.call(request))
+            CALLER_TAG.sync_scope(caller_tag.clone(), || {
+                METHOD_NAME.sync_scope(method_arc.clone(), || self.inner.call(request))
+            })
         });
 
         GrpcMetricsFuture {
-            inner: CLIENT_NAME.scope(client.clone(), CALLER_TAG.scope(caller_tag, inner)),
+            inner: CLIENT_NAME.scope(
+                client.clone(),
+                CALLER_TAG.scope(caller_tag, METHOD_NAME.scope(method_arc, inner)),
+            ),
             method,
             client,
             start,
@@ -329,14 +346,15 @@ where
 
 /// Future returned by [`GrpcMetricsService`].
 ///
-/// Wraps the inner service future with task-local client name and caller tag
-/// propagation, and records request metrics (counter, histogram, in-flight
-/// gauge) on completion or cancellation. Lives inline in the caller's async
-/// state machine — no heap allocation or dynamic dispatch.
+/// Wraps the inner service future with task-local client name, caller tag,
+/// and method name propagation, and records request metrics (counter,
+/// histogram, in-flight gauge) on completion or cancellation. Lives inline
+/// in the caller's async state machine — no heap allocation or dynamic dispatch.
 #[pin_project(PinnedDrop)]
+#[allow(clippy::type_complexity)]
 pub struct GrpcMetricsFuture<F> {
     #[pin]
-    inner: TaskLocalFuture<Arc<str>, TaskLocalFuture<Arc<str>, F>>,
+    inner: TaskLocalFuture<Arc<str>, TaskLocalFuture<Arc<str>, TaskLocalFuture<Arc<str>, F>>>,
     method: String,
     client: Arc<str>,
     start: Instant,

--- a/rust/personhog-replica/src/storage/postgres/cohort.rs
+++ b/rust/personhog-replica/src/storage/postgres/cohort.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use async_trait::async_trait;
 
-use personhog_common::grpc::current_client_name;
+use personhog_common::grpc::{current_client_name, current_method_name};
 
 use super::{ConsistencyLevel, PostgresStorage, DB_QUERY_DURATION, DB_ROWS_RETURNED};
 use crate::storage::error::StorageResult;
@@ -22,6 +22,7 @@ impl CohortStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -30,6 +31,7 @@ impl CohortStorage for PostgresStorage {
             ),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -83,11 +85,13 @@ impl CohortStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             ("operation".to_string(), "count_cohort_members".to_string()),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -112,10 +116,12 @@ impl CohortStorage for PostgresStorage {
 
     async fn delete_cohort_member(&self, cohort_id: i64, person_id: i64) -> StorageResult<bool> {
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             ("operation".to_string(), "delete_cohort_member".to_string()),
             ("pool".to_string(), "primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -145,6 +151,7 @@ impl CohortStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             (
                 "operation".to_string(),
@@ -152,6 +159,7 @@ impl CohortStorage for PostgresStorage {
             ),
             ("pool".to_string(), "bulk_primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -201,10 +209,12 @@ impl CohortStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             ("operation".to_string(), "insert_cohort_members".to_string()),
             ("pool".to_string(), "primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -244,6 +254,7 @@ impl CohortStorage for PostgresStorage {
         consistency: ConsistencyLevel,
     ) -> StorageResult<(Vec<i64>, Option<i64>)> {
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -252,6 +263,7 @@ impl CohortStorage for PostgresStorage {
             ),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 

--- a/rust/personhog-replica/src/storage/postgres/cohort.rs
+++ b/rust/personhog-replica/src/storage/postgres/cohort.rs
@@ -60,6 +60,7 @@ impl CohortStorage for PostgresStorage {
                     "check_cohort_membership".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             member_ids.len() as f64,
         );
@@ -191,6 +192,7 @@ impl CohortStorage for PostgresStorage {
                     "delete_cohort_members_bulk".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             result.rows_affected() as f64,
         );
@@ -239,6 +241,7 @@ impl CohortStorage for PostgresStorage {
             &[
                 ("operation".to_string(), "insert_cohort_members".to_string()),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             result.rows_affected() as f64,
         );
@@ -295,6 +298,7 @@ impl CohortStorage for PostgresStorage {
                     "list_cohort_member_ids".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );

--- a/rust/personhog-replica/src/storage/postgres/distinct_id.rs
+++ b/rust/personhog-replica/src/storage/postgres/distinct_id.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use futures::stream::{self, StreamExt, TryStreamExt};
 
-use personhog_common::grpc::current_client_name;
+use personhog_common::grpc::{current_client_name, current_method_name};
 
 use super::{
     ConsistencyLevel, PostgresStorage, DB_BULK_CHUNKS, DB_QUERY_DURATION, DB_ROWS_RETURNED,
@@ -20,6 +20,7 @@ impl DistinctIdLookup for PostgresStorage {
         limit: Option<i64>,
     ) -> StorageResult<Vec<DistinctIdWithVersion>> {
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -28,6 +29,7 @@ impl DistinctIdLookup for PostgresStorage {
             ),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -94,6 +96,7 @@ impl DistinctIdLookup for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::bulk_pool_label(consistency);
         let labels = [
             (
@@ -102,6 +105,7 @@ impl DistinctIdLookup for PostgresStorage {
             ),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 

--- a/rust/personhog-replica/src/storage/postgres/distinct_id.rs
+++ b/rust/personhog-replica/src/storage/postgres/distinct_id.rs
@@ -77,6 +77,7 @@ impl DistinctIdLookup for PostgresStorage {
                     "get_distinct_ids_for_person".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );
@@ -178,6 +179,7 @@ impl DistinctIdLookup for PostgresStorage {
                     "get_distinct_ids_for_persons".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );

--- a/rust/personhog-replica/src/storage/postgres/feature_flag.rs
+++ b/rust/personhog-replica/src/storage/postgres/feature_flag.rs
@@ -106,6 +106,7 @@ impl FeatureFlagStorage for PostgresStorage {
                     "get_hash_key_override_context".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );

--- a/rust/personhog-replica/src/storage/postgres/feature_flag.rs
+++ b/rust/personhog-replica/src/storage/postgres/feature_flag.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use sqlx::FromRow;
 
-use personhog_common::grpc::current_client_name;
+use personhog_common::grpc::{current_client_name, current_method_name};
 
 use super::{ConsistencyLevel, PostgresStorage, DB_QUERY_DURATION, DB_ROWS_RETURNED};
 use crate::storage::error::StorageResult;
@@ -35,6 +35,7 @@ impl FeatureFlagStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -43,6 +44,7 @@ impl FeatureFlagStorage for PostgresStorage {
             ),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -151,6 +153,7 @@ impl FeatureFlagStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             (
                 "operation".to_string(),
@@ -158,6 +161,7 @@ impl FeatureFlagStorage for PostgresStorage {
             ),
             ("pool".to_string(), "primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -190,6 +194,7 @@ impl FeatureFlagStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             (
                 "operation".to_string(),
@@ -197,6 +202,7 @@ impl FeatureFlagStorage for PostgresStorage {
             ),
             ("pool".to_string(), "primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 

--- a/rust/personhog-replica/src/storage/postgres/group.rs
+++ b/rust/personhog-replica/src/storage/postgres/group.rs
@@ -109,6 +109,7 @@ impl GroupStorage for PostgresStorage {
             &[
                 ("operation".to_string(), "get_groups".to_string()),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );
@@ -171,6 +172,7 @@ impl GroupStorage for PostgresStorage {
             &[
                 ("operation".to_string(), "get_groups_batch".to_string()),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             groups.len() as f64,
         );
@@ -234,6 +236,7 @@ impl GroupStorage for PostgresStorage {
                     "get_group_type_mappings_by_team_id".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );
@@ -293,6 +296,7 @@ impl GroupStorage for PostgresStorage {
                     "get_group_type_mappings_by_team_ids".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );
@@ -346,6 +350,7 @@ impl GroupStorage for PostgresStorage {
                     "get_group_type_mappings_by_project_id".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );
@@ -403,6 +408,7 @@ impl GroupStorage for PostgresStorage {
                     "get_group_type_mappings_by_project_ids".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );
@@ -450,6 +456,7 @@ impl GroupStorage for PostgresStorage {
                     "count_group_type_mappings".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );
@@ -590,6 +597,7 @@ impl GroupStorage for PostgresStorage {
             &[
                 ("operation".to_string(), "list_groups".to_string()),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             groups.len() as f64,
         );
@@ -756,6 +764,7 @@ impl GroupStorage for PostgresStorage {
                 ),
                 ("pool".to_string(), "bulk_primary".to_string()),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             result.rows_affected() as f64,
         );
@@ -931,6 +940,7 @@ impl GroupStorage for PostgresStorage {
                 ),
                 ("pool".to_string(), "bulk_primary".to_string()),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             result.rows_affected() as f64,
         );

--- a/rust/personhog-replica/src/storage/postgres/group.rs
+++ b/rust/personhog-replica/src/storage/postgres/group.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
-use personhog_common::grpc::current_client_name;
+use personhog_common::grpc::{current_client_name, current_method_name};
 
 use super::{ConsistencyLevel, PostgresStorage, DB_QUERY_DURATION, DB_ROWS_RETURNED};
 use crate::storage::error::StorageResult;
@@ -18,11 +18,13 @@ impl GroupStorage for PostgresStorage {
         consistency: ConsistencyLevel,
     ) -> StorageResult<Option<Group>> {
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             ("operation".to_string(), "get_group".to_string()),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -63,11 +65,13 @@ impl GroupStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             ("operation".to_string(), "get_groups".to_string()),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -123,11 +127,13 @@ impl GroupStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             ("operation".to_string(), "get_groups_batch".to_string()),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -188,6 +194,7 @@ impl GroupStorage for PostgresStorage {
         consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<GroupTypeMapping>> {
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -196,6 +203,7 @@ impl GroupStorage for PostgresStorage {
             ),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -243,6 +251,7 @@ impl GroupStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -251,6 +260,7 @@ impl GroupStorage for PostgresStorage {
             ),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -296,6 +306,7 @@ impl GroupStorage for PostgresStorage {
         consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<GroupTypeMapping>> {
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -304,6 +315,7 @@ impl GroupStorage for PostgresStorage {
             ),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -351,6 +363,7 @@ impl GroupStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -359,6 +372,7 @@ impl GroupStorage for PostgresStorage {
             ),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -401,6 +415,7 @@ impl GroupStorage for PostgresStorage {
         consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<(i64, i64)>> {
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -409,6 +424,7 @@ impl GroupStorage for PostgresStorage {
             ),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -448,6 +464,7 @@ impl GroupStorage for PostgresStorage {
         consistency: ConsistencyLevel,
     ) -> StorageResult<Option<GroupTypeMapping>> {
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -456,6 +473,7 @@ impl GroupStorage for PostgresStorage {
             ),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -497,11 +515,13 @@ impl GroupStorage for PostgresStorage {
         include_properties: bool,
     ) -> StorageResult<(Vec<Group>, bool)> {
         let client = current_client_name();
+        let method = current_method_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             ("operation".to_string(), "list_groups".to_string()),
             ("pool".to_string(), pool_label.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -590,10 +610,12 @@ impl GroupStorage for PostgresStorage {
         created_at: DateTime<Utc>,
     ) -> StorageResult<Group> {
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             ("operation".to_string(), "create_group".to_string()),
             ("pool".to_string(), "primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -635,10 +657,12 @@ impl GroupStorage for PostgresStorage {
         created_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> StorageResult<Option<Group>> {
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             ("operation".to_string(), "update_group".to_string()),
             ("pool".to_string(), "primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -692,6 +716,7 @@ impl GroupStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             (
                 "operation".to_string(),
@@ -699,6 +724,7 @@ impl GroupStorage for PostgresStorage {
             ),
             ("pool".to_string(), "bulk_primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -752,6 +778,7 @@ impl GroupStorage for PostgresStorage {
         default_columns: Option<&[String]>,
     ) -> StorageResult<Option<GroupTypeMapping>> {
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             (
                 "operation".to_string(),
@@ -759,6 +786,7 @@ impl GroupStorage for PostgresStorage {
             ),
             ("pool".to_string(), "primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -825,6 +853,7 @@ impl GroupStorage for PostgresStorage {
         group_type_index: i32,
     ) -> StorageResult<bool> {
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             (
                 "operation".to_string(),
@@ -832,6 +861,7 @@ impl GroupStorage for PostgresStorage {
             ),
             ("pool".to_string(), "primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -861,6 +891,7 @@ impl GroupStorage for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             (
                 "operation".to_string(),
@@ -868,6 +899,7 @@ impl GroupStorage for PostgresStorage {
             ),
             ("pool".to_string(), "bulk_primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 

--- a/rust/personhog-replica/src/storage/postgres/mod.rs
+++ b/rust/personhog-replica/src/storage/postgres/mod.rs
@@ -97,7 +97,8 @@ impl PostgresStorage {
     }
 
     /// Acquire a connection from the given pool, recording the acquisition time
-    /// as `personhog_replica_db_pool_acquire_duration_ms` with `pool` and `client` labels.
+    /// as `personhog_replica_db_pool_acquire_duration_ms` with `pool`, `client`,
+    /// and `method` labels.
     pub(crate) async fn acquire_timed(
         pool: &PgPool,
         pool_label: &str,
@@ -112,6 +113,10 @@ impl PostgresStorage {
                 (
                     "client".to_string(),
                     personhog_common::grpc::current_client_name().to_string(),
+                ),
+                (
+                    "method".to_string(),
+                    personhog_common::grpc::current_method_name().to_string(),
                 ),
             ],
             elapsed_ms,

--- a/rust/personhog-replica/src/storage/postgres/person.rs
+++ b/rust/personhog-replica/src/storage/postgres/person.rs
@@ -5,7 +5,7 @@ use futures::stream::{self, StreamExt, TryStreamExt};
 use sqlx::postgres::PgPool;
 use uuid::Uuid;
 
-use personhog_common::grpc::current_client_name;
+use personhog_common::grpc::{current_client_name, current_method_name};
 
 use super::{PostgresStorage, DB_BULK_CHUNKS, DB_QUERY_DURATION, DB_ROWS_RETURNED};
 use crate::storage::error::{StorageError, StorageResult};
@@ -23,10 +23,12 @@ impl PersonLookup for PostgresStorage {
         person_id: i64,
     ) -> StorageResult<Option<Person>> {
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             ("operation".to_string(), "get_person_by_id".to_string()),
             ("pool".to_string(), POOL_LABEL.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -55,10 +57,12 @@ impl PersonLookup for PostgresStorage {
 
     async fn get_person_by_uuid(&self, team_id: i64, uuid: Uuid) -> StorageResult<Option<Person>> {
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             ("operation".to_string(), "get_person_by_uuid".to_string()),
             ("pool".to_string(), POOL_LABEL.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -96,10 +100,12 @@ impl PersonLookup for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             ("operation".to_string(), "get_persons_by_ids".to_string()),
             ("pool".to_string(), BULK_POOL_LABEL.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -168,10 +174,12 @@ impl PersonLookup for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             ("operation".to_string(), "get_persons_by_uuids".to_string()),
             ("pool".to_string(), BULK_POOL_LABEL.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -235,6 +243,7 @@ impl PersonLookup for PostgresStorage {
         distinct_id: &str,
     ) -> StorageResult<Option<Person>> {
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             (
                 "operation".to_string(),
@@ -242,6 +251,7 @@ impl PersonLookup for PostgresStorage {
             ),
             ("pool".to_string(), POOL_LABEL.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -281,6 +291,7 @@ impl PersonLookup for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             (
                 "operation".to_string(),
@@ -288,6 +299,7 @@ impl PersonLookup for PostgresStorage {
             ),
             ("pool".to_string(), BULK_POOL_LABEL.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -382,10 +394,12 @@ impl PersonLookup for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             ("operation".to_string(), "delete_persons".to_string()),
             ("pool".to_string(), "bulk_primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -442,6 +456,7 @@ impl PersonLookup for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             (
                 "operation".to_string(),
@@ -449,6 +464,7 @@ impl PersonLookup for PostgresStorage {
             ),
             ("pool".to_string(), "bulk_primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -505,6 +521,7 @@ impl PersonLookup for PostgresStorage {
         }
 
         let client = current_client_name();
+        let method = current_method_name();
         let labels = [
             (
                 "operation".to_string(),
@@ -512,6 +529,7 @@ impl PersonLookup for PostgresStorage {
             ),
             ("pool".to_string(), BULK_POOL_LABEL.to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), method.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -606,6 +624,7 @@ async fn delete_persons_by_ids_chunk(
         ),
         ("pool".to_string(), "bulk_primary".to_string()),
         ("client".to_string(), client.to_string()),
+        ("method".to_string(), current_method_name().to_string()),
     ];
     let _chunk_timer = common_metrics::timing_guard(DB_QUERY_DURATION, &chunk_labels);
 

--- a/rust/personhog-replica/src/storage/postgres/person.rs
+++ b/rust/personhog-replica/src/storage/postgres/person.rs
@@ -156,6 +156,7 @@ impl PersonLookup for PostgresStorage {
             &[
                 ("operation".to_string(), "get_persons_by_ids".to_string()),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );
@@ -230,6 +231,7 @@ impl PersonLookup for PostgresStorage {
             &[
                 ("operation".to_string(), "get_persons_by_uuids".to_string()),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );
@@ -378,6 +380,7 @@ impl PersonLookup for PostgresStorage {
                     "get_persons_by_distinct_ids_in_team".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             found.len() as f64,
         );
@@ -569,6 +572,7 @@ impl PersonLookup for PostgresStorage {
                     "get_persons_by_distinct_ids_cross_team".to_string(),
                 ),
                 ("client".to_string(), client.to_string()),
+                ("method".to_string(), method.to_string()),
             ],
             rows.len() as f64,
         );
@@ -651,6 +655,7 @@ async fn delete_persons_by_ids_chunk(
             ),
             ("pool".to_string(), "bulk_primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), current_method_name().to_string()),
         ],
         did_result.rows_affected() as f64,
     );
@@ -676,6 +681,7 @@ async fn delete_persons_by_ids_chunk(
             ),
             ("pool".to_string(), "bulk_primary".to_string()),
             ("client".to_string(), client.to_string()),
+            ("method".to_string(), current_method_name().to_string()),
         ],
         result.rows_affected() as f64,
     );


### PR DESCRIPTION
## Problem

We didn't have a gRPC method label on the storage level metrics in personhog replica. This meant that filtering our latency decomposition dashboards by method would zero out all storage level metrics

## Changes

Routes the gRPC method label into the storage layer and sets it as the label on the metrics.

## How did you test this code?

just adding metrics. ran the current CI/tests