### PR TITLE
fix(dagster): raise memory ceiling for duckling events export

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1044,6 +1044,18 @@ def export_events_to_duckling_s3(
 
     where_clause = f"team_id = {team_id} AND toDate(timestamp) = '{date_str}'"
 
+    # Event rows are wide (large properties/person_properties JSON), and the Parquet
+    # writer buffers whole row groups across parallel encoding threads — this is where
+    # the export OOMs (ParquetBlockOutputFormat in the stack trace), not the scan. Raise
+    # the memory ceiling and shrink the row-group buffer so the writer holds less at once.
+    export_settings = settings.copy()
+    export_settings.update(
+        {
+            "max_memory_usage": 100 * 1024 * 1024 * 1024,  # 100GB, matching the full-persons export
+            "output_format_parquet_row_group_size": 100_000,  # fewer rows buffered per group (default 1M)
+        }
+    )
+
     # ClickHouse uses its EC2 instance role - no credentials needed
     # The duckling bucket policy allows the ClickHouse EC2 role
     export_sql = f"""
@@ -1073,7 +1085,7 @@ def export_events_to_duckling_s3(
     )
 
     try:
-        _execute_export_with_retry(client, export_sql, settings, info)
+        _execute_export_with_retry(client, export_sql, export_settings, info)
         context.log.info(f"Successfully exported events for {info}")
         logger.info("duckling_export_success", team_id=team_id, date=date_str)
         return s3_path

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1045,14 +1045,17 @@ def export_events_to_duckling_s3(
     where_clause = f"team_id = {team_id} AND toDate(timestamp) = '{date_str}'"
 
     # Event rows are wide (large properties/person_properties JSON), and the Parquet
-    # writer buffers whole row groups across parallel encoding threads — this is where
-    # the export OOMs (ParquetBlockOutputFormat in the stack trace), not the scan. Raise
-    # the memory ceiling and shrink the row-group buffer so the writer holds less at once.
+    # writer buffers a full row group per encoding thread before flushing — this is where
+    # the export OOMs (ParquetBlockOutputFormat in the stack trace), not the scan. Peak
+    # memory is ~ row_group_size * bytes_per_row * threads, so the 1M-row default builds
+    # multi-GB groups that blow the limit under parallel encoding. 250k rows lands each
+    # group in Parquet's recommended byte range (~hundreds of MB) while keeping read
+    # efficiency near the default; the raised ceiling is headroom on top.
     export_settings = settings.copy()
     export_settings.update(
         {
             "max_memory_usage": 100 * 1024 * 1024 * 1024,  # 100GB, matching the full-persons export
-            "output_format_parquet_row_group_size": 100_000,  # fewer rows buffered per group (default 1M)
+            "output_format_parquet_row_group_size": 250_000,  # down from the 1M default
         }
     )
 


### PR DESCRIPTION
## Problem

The Dagster `duckling_events_backfill` op (events export in the duckling backfill job) was failing with ClickHouse `Code: 241` — query memory limit exceeded at exactly 50 GiB. The events export path used the shared `DEFAULT_CLICKHOUSE_SETTINGS`, which caps `max_memory_usage` at 50 GB, while the full-persons export path already overrode this to 100 GB locally. The events path had never received the same treatment.

The stack trace shows the OOM happened inside the **Parquet output writer** (`ParquetBlockOutputFormat` → `writePage`), not the scan or join. Event rows are wide (large `properties` / `person_properties` JSON), and ClickHouse buffers entire row groups across parallel encoding threads, so memory scales with row-group size × thread count.

## Changes

Scoped a settings override in `export_events_to_duckling_s3`, mirroring the existing full-persons override pattern rather than bumping the global default:

- `max_memory_usage` → 100 GB (matching the full-persons export)
- `output_format_parquet_row_group_size` → 100K rows (down from the 1M default), shrinking the writer's per-group working set — this directly targets the allocation that blew up, so raising the ceiling isn't just deferring the failure to a larger dataset.

No external-sort spilling was added (unlike the full-persons path) because the events query is a plain `SELECT ... WHERE` with no `GROUP BY` / `ORDER BY` — there's nothing to spill; the memory is purely in the output buffer.

## How did you test this code?

I'm an agent. I did **not** run the Dagster job or exercise this against a live ClickHouse cluster. I verified the change passes `ruff check` / `ruff format` and the repo's pre-commit hooks (lint + `ty check`). The behavioral fix should be validated by re-running the affected backfill partition.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at the request of @fuziontech, who hit the 50 GiB OOM in the duckling events export and asked to raise the query memory limit.

Key decisions:
- **Scoped the override to the events export** rather than raising the shared `DEFAULT_CLICKHOUSE_SETTINGS`, to keep the per-day persons export and other callers on the existing 50 GB default and avoid surprise memory pressure elsewhere.
- **Added the Parquet row-group setting** because the stack trace pinpointed the OOM in the Parquet writer, not the query plan — raising the ceiling alone would only postpone the failure.
- **Open question for the reviewer:** the 100 GB ceiling assumes DATA nodes can accommodate that per query alongside concurrent load. If these run several-at-once on the same host, the number may need tuning or concurrency gating.
