### PR TITLE
chore(cohort): misc cohort api personhog migration

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -66,7 +66,7 @@ from posthog.models.cohort.util import (
 from posthog.models.cohort.validation import CohortTypeValidationSerializer
 from posthog.models.filters.filter import Filter
 from posthog.models.person.person import READ_DB_FOR_PERSONS, PersonDistinctId
-from posthog.models.person.util import validate_person_uuids_exist
+from posthog.models.person.util import get_person_by_uuid, validate_person_uuids_exist
 from posthog.models.property.property import Property, PropertyGroup
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDT
@@ -1475,15 +1475,10 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
             raise ValidationError("person_id must be a valid UUID")
 
         # Check if person exists and belongs to this team
-        try:
-            person_uuid = (
-                # nosemgrep: no-direct-persons-db-orm
-                Person.objects.db_manager(READ_DB_FOR_PERSONS)
-                .get(team_id=self.team_id, uuid=person_id)
-                .uuid  # nosemgrep: no-direct-persons-db-orm
-            )  # nosemgrep: no-direct-persons-db-orm
-        except Person.DoesNotExist:
+        person = get_person_by_uuid(team_id=self.team_id, uuid=person_id)
+        if person is None:
             raise NotFound("Person with this UUID does not exist in the cohort's team")
+        person_uuid = person.uuid
 
         # Remove is idempotent - succeeds even if person wasn't in cohort (handles CH/PG sync issues)
         cohort.remove_user_by_uuid(str(person_uuid), team_id=self.team_id)

--- a/posthog/api/test/test_cohort_personhog.py
+++ b/posthog/api/test/test_cohort_personhog.py
@@ -1,10 +1,12 @@
-"""Tests that validate_person_uuids_exist produces identical results
+"""Tests that cohort API endpoints produce identical results
 via the ORM and personhog paths."""
 
-from posthog.test.base import BaseTest
+from posthog.test.base import APIBaseTest, BaseTest
 
 from parameterized import parameterized_class
+from rest_framework import status
 
+from posthog.models import Cohort
 from posthog.models.person import Person
 from posthog.models.person.util import validate_person_uuids_exist
 from posthog.personhog_client.test_helpers import PersonhogTestMixin
@@ -70,3 +72,36 @@ class TestValidatePersonUuidsExist(PersonhogTestMixin, BaseTest):
         assert len(uuids) > 0
         assert all(isinstance(u, str) for u in uuids)
         self._assert_personhog_called("get_persons_by_uuids")
+
+
+UUID_NONEXISTENT = "550e8400-e29b-41d4-a716-446655440099"
+
+
+@parameterized_class(("personhog",), [(False,), (True,)])
+class TestRemovePersonFromStaticCohort(PersonhogTestMixin, APIBaseTest):
+    def test_removes_person_and_routes_through_personhog(self):
+        person = self._seed_person(team=self.team, distinct_ids=["d1"], properties={"email": "test@test.com"})
+        cohort = Cohort.objects.create(team=self.team, name="static", is_static=True)
+        cohort.insert_users_by_list(["d1"])
+
+        resp = self.client.patch(
+            f"/api/projects/{self.team.id}/cohorts/{cohort.id}/remove_person_from_static_cohort",
+            {"person_id": str(person.uuid)},
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.json()["success"] is True
+        self._assert_personhog_called("get_person_by_uuid")
+
+    def test_returns_404_for_nonexistent_person(self):
+        cohort = Cohort.objects.create(team=self.team, name="static", is_static=True)
+
+        resp = self.client.patch(
+            f"/api/projects/{self.team.id}/cohorts/{cohort.id}/remove_person_from_static_cohort",
+            {"person_id": UUID_NONEXISTENT},
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        self._assert_personhog_called("get_person_by_uuid")


### PR DESCRIPTION
## Problem

There was a person lookup in the cohort api code that wasn't moved to looking person up through personhog

## Changes

replace remove static cohort member ORM call with a personhog call

## How did you test this code?

Added paramerterized tests
