### PR TITLE
feat(caching): dedicated cache alias for ai-gateway hypercache reads

### DIFF
--- a/posthog/caching/ai_gateway_redis_cache.py
+++ b/posthog/caching/ai_gateway_redis_cache.py
@@ -1,0 +1,1 @@
+AI_GATEWAY_DEDICATED_CACHE_ALIAS = "ai_gateway_dedicated"

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -530,6 +530,9 @@ if not EMBEDDING_API_URL:
 # This allows feature-flags service to have dedicated Redis for better resource isolation
 FLAGS_REDIS_URL = os.getenv("FLAGS_REDIS_URL", None)
 
+# Dedicated Redis for ai-gateway HyperCache reads
+AI_GATEWAY_REDIS_URL = os.getenv("AI_GATEWAY_REDIS_URL", None)
+
 # Rust feature flags service URL
 # This is used to proxy flag evaluation requests to the Rust feature flags service
 FEATURE_FLAGS_SERVICE_URL = os.getenv("FEATURE_FLAGS_SERVICE_URL", "http://localhost:3001")
@@ -570,6 +573,20 @@ if FLAGS_REDIS_URL:
     CACHES[FLAGS_DEDICATED_CACHE_ALIAS] = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": FLAGS_REDIS_URL,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "COMPRESSOR": "posthog.caching.zstd_compressor.ZstdCompressor",
+        },
+        "KEY_PREFIX": "posthog",
+    }
+
+# Dedicated cache for the ai-gateway service (if configured)
+if AI_GATEWAY_REDIS_URL:
+    from posthog.caching.ai_gateway_redis_cache import AI_GATEWAY_DEDICATED_CACHE_ALIAS
+
+    CACHES[AI_GATEWAY_DEDICATED_CACHE_ALIAS] = {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": AI_GATEWAY_REDIS_URL,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "COMPRESSOR": "posthog.caching.zstd_compressor.ZstdCompressor",

--- a/posthog/storage/team_llm_gateway_policy_cache.py
+++ b/posthog/storage/team_llm_gateway_policy_cache.py
@@ -27,7 +27,7 @@ from django.db import OperationalError
 
 import structlog
 
-from posthog.caching.flags_redis_cache import FLAGS_DEDICATED_CACHE_ALIAS
+from posthog.caching.ai_gateway_redis_cache import AI_GATEWAY_DEDICATED_CACHE_ALIAS
 from posthog.models.team.team import Team
 from posthog.storage.cache_expiry_manager import refresh_expiring_caches as refresh_generic
 from posthog.storage.hypercache import HyperCache, HyperCacheStoreMissing, KeyType
@@ -95,7 +95,7 @@ team_llm_gateway_policy_hypercache = HyperCache(
     batch_load_fn=_batch_load_llm_gateway_policy,
     cache_ttl=LLM_GATEWAY_POLICY_CACHE_TTL,
     cache_miss_ttl=LLM_GATEWAY_POLICY_CACHE_MISS_TTL,
-    cache_alias=FLAGS_DEDICATED_CACHE_ALIAS if FLAGS_DEDICATED_CACHE_ALIAS in settings.CACHES else None,
+    cache_alias=(AI_GATEWAY_DEDICATED_CACHE_ALIAS if AI_GATEWAY_DEDICATED_CACHE_ALIAS in settings.CACHES else None),
     expiry_sorted_set_key=LLM_GATEWAY_POLICY_CACHE_EXPIRY_SORTED_SET,
 )
 

--- a/posthog/storage/team_llm_gateway_policy_signal_handlers.py
+++ b/posthog/storage/team_llm_gateway_policy_signal_handlers.py
@@ -106,7 +106,7 @@ def _value_changed(instance: Team, snapshot_attr: str, field_name: str) -> bool:
 
 
 def _update_cache_on_save(sender: type[Team], instance: Team, created: bool, **kwargs: Any) -> None:
-    if not settings.FLAGS_REDIS_URL:
+    if not settings.AI_GATEWAY_REDIS_URL:
         return
 
     old_api_token: str | None = instance.__dict__.get(_LOADED_API_TOKEN_ATTR)
@@ -153,7 +153,7 @@ def _update_cache_on_save(sender: type[Team], instance: Team, created: bool, **k
 
 
 def _clear_cache_on_delete(sender: type[Team], instance: Team, **kwargs: Any) -> None:
-    if not settings.FLAGS_REDIS_URL:
+    if not settings.AI_GATEWAY_REDIS_URL:
         return
 
     kinds = ["redis"] if settings.TEST else None

--- a/posthog/storage/test/test_team_llm_gateway_policy_cache.py
+++ b/posthog/storage/test/test_team_llm_gateway_policy_cache.py
@@ -116,7 +116,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
     @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.settings")
     @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.update_team_llm_gateway_policy_cache_task.delay")
     def test_team_save_enqueues_update(self, mock_delay, mock_settings, mock_transaction):
-        mock_settings.FLAGS_REDIS_URL = "redis://localhost"
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
         mock_transaction.on_commit.side_effect = lambda fn: fn()
 
         self.team.llm_gateway_revoked_at = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
@@ -126,8 +126,8 @@ class TestLLMGatewayPolicySignals(BaseTest):
 
     @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.settings")
     @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.update_team_llm_gateway_policy_cache_task.delay")
-    def test_team_save_noop_without_flags_redis_url(self, mock_delay, mock_settings):
-        mock_settings.FLAGS_REDIS_URL = None
+    def test_team_save_noop_without_ai_gateway_redis_url(self, mock_delay, mock_settings):
+        mock_settings.AI_GATEWAY_REDIS_URL = None
 
         self.team.llm_gateway_revoked_at = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
         self.team.save()
@@ -137,7 +137,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
     @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.settings")
     @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.clear_team_llm_gateway_policy_cache")
     def test_team_delete_clears_cache(self, mock_clear, mock_settings):
-        mock_settings.FLAGS_REDIS_URL = "redis://localhost"
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
         mock_settings.TEST = True
 
         team = Team.objects.create(organization=self.organization, name="Doomed")
@@ -155,7 +155,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
         Otherwise a holder of the rotated token keeps hitting the gateway via
         the stale cached policy until the 7-day TTL expires.
         """
-        mock_settings.FLAGS_REDIS_URL = "redis://localhost"
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
         mock_settings.TEST = True
         mock_transaction.on_commit.side_effect = lambda fn: fn()
 
@@ -174,7 +174,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
         """A save that touches no tracked field (api_token, llm_gateway_enabled_at,
         llm_gateway_revoked_at) must not invalidate the cache; the async task still
         refreshes the blob."""
-        mock_settings.FLAGS_REDIS_URL = "redis://localhost"
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
         mock_settings.TEST = True
         mock_transaction.on_commit.side_effect = lambda fn: fn()
 
@@ -198,7 +198,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
         for the full cache TTL and a holder of the token keeps hitting the
         gateway as if the team were active.
         """
-        mock_settings.FLAGS_REDIS_URL = "redis://localhost"
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
         mock_settings.TEST = True
         mock_transaction.on_commit.side_effect = lambda fn: fn()
 
@@ -221,7 +221,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
         gateway would keep treating the team as not-enrolled and 401 every
         request even after admin flips them on.
         """
-        mock_settings.FLAGS_REDIS_URL = "redis://localhost"
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
         mock_settings.TEST = True
         mock_transaction.on_commit.side_effect = lambda fn: fn()
 
@@ -243,7 +243,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
         B. post_save re-snapshots the saved token so the second save compares
         against B, instead of clearing A twice and leaking B for the full cache TTL.
         """
-        mock_settings.FLAGS_REDIS_URL = "redis://localhost"
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
         mock_settings.TEST = True
         mock_transaction.on_commit.side_effect = lambda fn: fn()
 
@@ -271,7 +271,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
         snapshot to avoid a lazy load; the pre_save fallback captures the old
         value from the DB before the UPDATE runs.
         """
-        mock_settings.FLAGS_REDIS_URL = "redis://localhost"
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
         mock_settings.TEST = True
         mock_transaction.on_commit.side_effect = lambda fn: fn()
 
@@ -296,7 +296,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
         signals; a future refactor that fires clear per field would double the
         Redis traffic on every admin enable-after-revoke.
         """
-        mock_settings.FLAGS_REDIS_URL = "redis://localhost"
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
         mock_settings.TEST = True
         mock_transaction.on_commit.side_effect = lambda fn: fn()
 
@@ -320,7 +320,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
         avoid a lazy load; the pre_save fallback captures the old value from
         the DB before the UPDATE runs.
         """
-        mock_settings.FLAGS_REDIS_URL = "redis://localhost"
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
         mock_settings.TEST = True
         mock_transaction.on_commit.side_effect = lambda fn: fn()
 
@@ -343,7 +343,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
         invalidate twice. post_save re-snapshots the saved value so the second
         save compares against t1 instead of seeing "unchanged" and skipping.
         """
-        mock_settings.FLAGS_REDIS_URL = "redis://localhost"
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
         mock_settings.TEST = True
         mock_transaction.on_commit.side_effect = lambda fn: fn()
 

--- a/posthog/tasks/team_llm_gateway_policy.py
+++ b/posthog/tasks/team_llm_gateway_policy.py
@@ -54,8 +54,8 @@ def refresh_expiring_llm_gateway_policy_cache_entries() -> None:
     threshold, so simultaneous expiry of the 7-day TTL across the team pool
     cannot cause a DB-lookup spike.
     """
-    if not settings.FLAGS_REDIS_URL:
-        logger.info("Flags Redis URL not set, skipping llm-gateway policy cache refresh")
+    if not settings.AI_GATEWAY_REDIS_URL:
+        logger.info("AI gateway Redis URL not set, skipping llm-gateway policy cache refresh")
         return
 
     start_time = time.time()


### PR DESCRIPTION
## Overview

Wire a new `ai_gateway_dedicated` cache alias backed by `AI_GATEWAY_REDIS_URL`. The `llm_gateway_policy` HyperCache moves to it; `team_metadata` is unchanged. ai-gateway reads from a cluster scoped to its workload instead of sharing `flags_dedicated`.

The policy blob already carries `id` and `api_token` via `LLM_GATEWAY_POLICY_FIELDS`, so ai-gateway can derive everything it needs from a single read.

## Changes

- `posthog/caching/ai_gateway_redis_cache.py`: new file defining `AI_GATEWAY_DEDICATED_CACHE_ALIAS`.
- `posthog/settings/data_stores.py`: reads `AI_GATEWAY_REDIS_URL` from env; conditionally registers `CACHES["ai_gateway_dedicated"]` with the same backend/options as `flags_dedicated`.
- `posthog/storage/team_llm_gateway_policy_cache.py`: `cache_alias` for the policy HyperCache points at `ai_gateway_dedicated`.
- `posthog/storage/team_llm_gateway_policy_signal_handlers.py`: both guards check `AI_GATEWAY_REDIS_URL`.
- `posthog/storage/test/test_team_llm_gateway_policy_cache.py`: mocked env vars switched to match; the no-op test renamed to reflect the new var.

When `AI_GATEWAY_REDIS_URL` is unset the alias doesn't register and the policy cache falls back to the default cache, same as every other HyperCache today.

## Risk

Low. No behavior change until the sibling chart change sets `AI_GATEWAY_REDIS_URL` on posthog-django pods. Rollback is a revert.

## Verification

- `ruff check` clean on touched files.
- Smoke import via `django.setup()` confirms `team_llm_gateway_policy_hypercache.cache_client` falls back to the default `ConnectionProxy` when env is unset.
- `pytest --collect-only` collects all tests across `test_team_llm_gateway_policy_cache.py`, `test_team_metadata_cache.py`, and `test_team_metadata_signals.py`.
- Full pytest needs the dev compose stack (ClickHouse + Postgres), which I don't have spun up locally; relying on CI for the end-to-end run.

Sibling PRs: PostHog/charts#11715, PostHog/ai-gateway#78.

## 🤖 Agent context

Co-authored with Claude Code.
