### PR TITLE
chore(replay): set explicit canvas replay default in shared config

### DIFF
--- a/common/replay-shared/src/rrweb-plugins/common-replayer-config.test.ts
+++ b/common/replay-shared/src/rrweb-plugins/common-replayer-config.test.ts
@@ -1,0 +1,22 @@
+import { COMMON_REPLAYER_CONFIG } from './index'
+
+// posthog-js/* ships ESM that the test transform can't load directly; these values are
+// only used by sibling plugins, not by the config object under test.
+jest.mock('posthog-js/rrweb', () => ({
+    Replayer: jest.fn(),
+    canvasMutation: jest.fn(),
+}))
+jest.mock('posthog-js/rrweb-types', () => ({
+    EventType: {},
+    IncrementalSource: {},
+}))
+
+describe('COMMON_REPLAYER_CONFIG', () => {
+    it('keeps the replay iframe scriptless by never enabling UNSAFE_replayCanvas', () => {
+        // UNSAFE_replayCanvas makes rrweb add `allow-scripts` to the replay iframe sandbox.
+        // Combined with the `allow-same-origin` rrweb requires, that pair lets untrusted
+        // recorded content remove its own sandbox and run with full app-origin access.
+        // PostHog renders canvas via CanvasReplayerPlugin instead, so this must stay off.
+        expect(COMMON_REPLAYER_CONFIG.UNSAFE_replayCanvas).toBe(false)
+    })
+})

--- a/common/replay-shared/src/rrweb-plugins/index.ts
+++ b/common/replay-shared/src/rrweb-plugins/index.ts
@@ -70,6 +70,11 @@ const shopifyShorthandCSSFix =
 export const COMMON_REPLAYER_CONFIG: Partial<playerConfig> = {
     triggerFocus: false,
     insertStyleRules: [defaultStyleRules, shopifyShorthandCSSFix],
+    // Keep the replay iframe scriptless. UNSAFE_replayCanvas makes rrweb add `allow-scripts`
+    // to the sandbox, which combined with the required `allow-same-origin` lets untrusted
+    // recorded content escape the sandbox into the app origin. Canvas is replayed via
+    // CanvasReplayerPlugin instead, which needs no in-frame scripting.
+    UNSAFE_replayCanvas: false,
 }
 
 export { AudioMuteReplayerPlugin } from './audio-mute-plugin'


### PR DESCRIPTION
Pin `UNSAFE_replayCanvas` off in `COMMON_REPLAYER_CONFIG` and add a regression test so the shared replayer config keeps it disabled. `UNSAFE_replayCanvas` is an extremely important protection and so we want to ensure it never gets enabled.