### PR TITLE
feat(hog-charts): smoother pie chart hover interaction

### DIFF
--- a/packages/quill/packages/charts/src/charts/PieChart/PieChart.tsx
+++ b/packages/quill/packages/charts/src/charts/PieChart/PieChart.tsx
@@ -27,7 +27,8 @@ export interface PieChartConfig<Meta = unknown> {
     /** Duration (ms) of the hover transition — the slice eases outward and brightens over this
      *  window rather than snapping. Default 150. `0` disables (instant). */
     hoverAnimationMs?: number
-    /** Disable the hover grow effect — useful for snapshot stability or constrained layouts. */
+    /** Disable the hover grow effect — useful for snapshot stability or constrained layouts.
+     *  Legacy name: this gates the whole hover effect (grow + brighten + dim), not just an offset. */
     disableHoverOffset?: boolean
     /** Hide on-slice labels for slices smaller than this fraction of the total. Default 0.05. */
     minSlicePercentForLabel?: number
@@ -72,8 +73,10 @@ const DEFAULT_MIN_SLICE_PERCENT = 0.05
 const HOVER_HIGHLIGHT_TARGET = '#ffffff'
 const HOVER_HIGHLIGHT_AMOUNT = 0.15
 // Non-hovered slices ease toward the chart background by this fraction, fading into the
-// backdrop so the hovered slice stands out. White fallback when the theme has no background.
+// backdrop so the hovered slice stands out.
 const HOVER_DIM_AMOUNT = 0.55
+// Used only when the theme omits `backgroundColor`. Assumes a light backdrop — consumers on a
+// dark theme should set `theme.backgroundColor` so slices dim toward the dark surface instead.
 const HOVER_DIM_TARGET_FALLBACK = '#ffffff'
 
 function easeOutCubic(t: number): number {
@@ -155,10 +158,8 @@ function PieChartInner<Meta = unknown>({
     const effectiveHoverGrowth = disableHoverOffset ? 0 : hoverGrowth
     const effectiveHoverAnimationMs = disableHoverOffset ? 0 : hoverAnimationMs
 
-    // Current backdrop-dim level (0 = no dim, 1 = full). Ramps up over the hover fade and only
-    // ever increases while hovering — a hoverIndex change resets `hoverProgress` to 0, so reading
-    // the dim straight off it would flash the backdrop back to full color on every slice crossing.
-    // Reset to 0 on hover-out so the next hover fades in fresh.
+    // Backdrop-dim level (0 = none, 1 = full), held across slice crossings — see the ramp in
+    // drawHover for why it can't be read straight off hoverProgress.
     const dimRef = useRef(0)
 
     const drawStatic = useCallback((args: ChartDrawArgs) => {
@@ -166,7 +167,7 @@ function PieChartInner<Meta = unknown>({
         if (!layout) {
             return
         }
-        drawSlices(args.ctx, layout, { skipIndex: -1, outerRadiusBoost: 0 })
+        drawSlices(args.ctx, layout, { outerRadiusBoost: 0 })
     }, [])
 
     const drawHover = useCallback(
@@ -201,9 +202,7 @@ function PieChartInner<Meta = unknown>({
                 const faded = mixColors(other.color, dimTarget, dimRef.current)
                 drawSliceShape(args.ctx, other, layout, { outerRadiusBoost: 0, fillStyle: faded })
             }
-            // Hovered slice last (on top), grown outward and brightened. The grown wedge keeps the
-            // static slice's center and angles, so it covers its own base and only extends past
-            // `outerRadius` into empty space — never over a neighbour.
+            // Hovered slice last, on top of the dimmed others.
             const outerRadiusBoost = eased * effectiveHoverGrowth
             const fillStyle = mixColors(slice.color, HOVER_HIGHLIGHT_TARGET, eased * HOVER_HIGHLIGHT_AMOUNT)
             drawSliceShape(args.ctx, slice, layout, { outerRadiusBoost, fillStyle })
@@ -267,19 +266,15 @@ function getLayoutFromArgs<Meta>(args: ChartDrawArgs): PieLayout<Meta> | null {
 }
 
 interface DrawSlicesOptions {
-    skipIndex: number
     outerRadiusBoost: number
 }
 
 function drawSlices<Meta>(
     ctx: CanvasRenderingContext2D,
     layout: PieLayout<Meta>,
-    { skipIndex, outerRadiusBoost }: DrawSlicesOptions
+    { outerRadiusBoost }: DrawSlicesOptions
 ): void {
     for (let i = 0; i < layout.slices.length; i++) {
-        if (i === skipIndex) {
-            continue
-        }
         drawSliceShape(ctx, layout.slices[i], layout, { outerRadiusBoost, fillStyle: layout.slices[i].color })
     }
 }

--- a/packages/quill/packages/charts/src/charts/PieChart/PieChart.tsx
+++ b/packages/quill/packages/charts/src/charts/PieChart/PieChart.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useRef } from 'react'
 
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
+import { mixColors } from '../../core/color-utils'
 import type { RadialSlicePayload } from '../../core/hooks/useRadialInteraction'
 import { useRadialLayout } from '../../core/radial-context'
 import { RadialChart } from '../../core/RadialChart'
@@ -21,9 +22,12 @@ export interface PieChartConfig<Meta = unknown> {
     /** Render slice values as percentages of total. Drives both axes-label-style formatting
      *  and the on-slice / tooltip formatting. */
     isPercent?: boolean
-    /** Pixels the hovered slice slides out along its bisector. Default 16. */
-    hoverOffset?: number
-    /** Disable the hover pop-out — useful for snapshot stability or constrained layouts. */
+    /** Pixels the hovered slice's outer radius grows on hover (center stays fixed). Default 8. */
+    hoverGrowth?: number
+    /** Duration (ms) of the hover transition — the slice eases outward and brightens over this
+     *  window rather than snapping. Default 150. `0` disables (instant). */
+    hoverAnimationMs?: number
+    /** Disable the hover grow effect — useful for snapshot stability or constrained layouts. */
     disableHoverOffset?: boolean
     /** Hide on-slice labels for slices smaller than this fraction of the total. Default 0.05. */
     minSlicePercentForLabel?: number
@@ -61,8 +65,20 @@ export interface PieChartProps<Meta = unknown> {
     onError?: (error: Error, info: React.ErrorInfo) => void
 }
 
-const DEFAULT_HOVER_OFFSET = 16
+const DEFAULT_HOVER_GROWTH = 8
+const DEFAULT_HOVER_ANIMATION_MS = 150
 const DEFAULT_MIN_SLICE_PERCENT = 0.05
+// Hovered slice eases toward white by this fraction at full hover — a subtle highlight.
+const HOVER_HIGHLIGHT_TARGET = '#ffffff'
+const HOVER_HIGHLIGHT_AMOUNT = 0.15
+// Non-hovered slices ease toward the chart background by this fraction, fading into the
+// backdrop so the hovered slice stands out. White fallback when the theme has no background.
+const HOVER_DIM_AMOUNT = 0.55
+const HOVER_DIM_TARGET_FALLBACK = '#ffffff'
+
+function easeOutCubic(t: number): number {
+    return 1 - Math.pow(1 - t, 3)
+}
 
 const CENTER_LABEL_STYLE: React.CSSProperties = {
     position: 'absolute',
@@ -111,7 +127,8 @@ function PieChartInner<Meta = unknown>({
         showValueOnSlice = true,
         showLabelOnSlice = false,
         isPercent = false,
-        hoverOffset = DEFAULT_HOVER_OFFSET,
+        hoverGrowth = DEFAULT_HOVER_GROWTH,
+        hoverAnimationMs = DEFAULT_HOVER_ANIMATION_MS,
         disableHoverOffset = false,
         minSlicePercentForLabel = DEFAULT_MIN_SLICE_PERCENT,
         padAngle = 0,
@@ -135,57 +152,64 @@ function PieChartInner<Meta = unknown>({
         [sliceValue, innerRadiusRatio, padAngle, sort]
     )
 
-    const effectiveHoverOffset = disableHoverOffset ? 0 : hoverOffset
+    const effectiveHoverGrowth = disableHoverOffset ? 0 : hoverGrowth
+    const effectiveHoverAnimationMs = disableHoverOffset ? 0 : hoverAnimationMs
+
+    // Current backdrop-dim level (0 = no dim, 1 = full). Ramps up over the hover fade and only
+    // ever increases while hovering — a hoverIndex change resets `hoverProgress` to 0, so reading
+    // the dim straight off it would flash the backdrop back to full color on every slice crossing.
+    // Reset to 0 on hover-out so the next hover fades in fresh.
+    const dimRef = useRef(0)
 
     const drawStatic = useCallback((args: ChartDrawArgs) => {
         const layout = getLayoutFromArgs<Meta>(args)
         if (!layout) {
             return
         }
-        drawSlices(args.ctx, layout, args.theme, { skipIndex: -1, offset: 0 })
+        drawSlices(args.ctx, layout, { skipIndex: -1, outerRadiusBoost: 0 })
     }, [])
 
     const drawHover = useCallback(
         (args: ChartDrawArgs): boolean => {
             const layout = getLayoutFromArgs<Meta>(args)
-            if (!layout || args.hoverIndex < 0) {
+            // A lone full-circle slice has nothing to highlight against — growing it just
+            // pulses the whole wheel.
+            const slice = layout && args.hoverIndex >= 0 ? layout.slices[args.hoverIndex] : null
+            if (!layout || !slice || layout.slices.length <= 1 || effectiveHoverGrowth === 0) {
+                dimRef.current = 0
                 return false
             }
-            // Single-slice charts have nothing to pop out — drawing the offset would visually
-            // shift the whole wheel.
-            if (layout.slices.length <= 1 || effectiveHoverOffset === 0) {
-                return false
+            // The focused slice's growth + tint ease over `hoverProgress` (0→1 from useChartDraw's
+            // RAF loop), so it swells and brightens rather than snapping.
+            const eased = easeOutCubic(args.hoverProgress)
+            // Ramp the backdrop dim with the same fade, but only ever upward: `hoverProgress`
+            // resets to 0 on each hoverIndex change, so reading the dim straight off it would
+            // flash the rest of the pie back to full color every time the cursor crosses into the
+            // next slice. Holding the max keeps the backdrop steady (and lets an in-progress fade
+            // continue) as you sweep across segments; it resets on hover-out (guard above).
+            dimRef.current = Math.max(dimRef.current, eased * HOVER_DIM_AMOUNT)
+            // Repaint every *other* slice over its static copy in a color faded toward the
+            // background, dimming the rest so the hovered slice stands out. The fade fill must be
+            // opaque — a translucent fill would composite against the full-color static slice
+            // beneath the overlay and not dim at all.
+            const dimTarget = args.theme.backgroundColor || HOVER_DIM_TARGET_FALLBACK
+            for (let i = 0; i < layout.slices.length; i++) {
+                if (i === args.hoverIndex) {
+                    continue
+                }
+                const other = layout.slices[i]
+                const faded = mixColors(other.color, dimTarget, dimRef.current)
+                drawSliceShape(args.ctx, other, layout, { outerRadiusBoost: 0, fillStyle: faded })
             }
-            // The mask step below relies on `theme.backgroundColor` to erase the static-canvas
-            // copy of the slice. Without one, the popped-out slice would partially overlap the
-            // original and smear — better to skip the pop-out than render that.
-            if (!args.theme.backgroundColor) {
-                return false
-            }
-            const slice = layout.slices[args.hoverIndex]
-            if (!slice) {
-                return false
-            }
-            // Two-pass paint on the (always-cleared) overlay canvas:
-            //   1. Fill the slice's original footprint with the theme background. The overlay
-            //      sits above the static canvas, so this *visually* erases the un-offset copy
-            //      that `useChartDraw` re-paints on the static layer every render.
-            //   2. Paint the slice in its real color at the offset position.
-            // Without step 1 the offset copy only partially overlaps the original, leaving a
-            // crescent of the un-offset slice visible — a smear, not a clean pop-out.
-            drawSliceShape(args.ctx, slice, layout, {
-                offset: 0,
-                fillStyle: args.theme.backgroundColor,
-                withStroke: undefined,
-            })
-            drawSliceShape(args.ctx, slice, layout, {
-                offset: effectiveHoverOffset,
-                fillStyle: slice.color,
-                withStroke: layout.slices.length > 1 ? args.theme.backgroundColor : undefined,
-            })
+            // Hovered slice last (on top), grown outward and brightened. The grown wedge keeps the
+            // static slice's center and angles, so it covers its own base and only extends past
+            // `outerRadius` into empty space — never over a neighbour.
+            const outerRadiusBoost = eased * effectiveHoverGrowth
+            const fillStyle = mixColors(slice.color, HOVER_HIGHLIGHT_TARGET, eased * HOVER_HIGHLIGHT_AMOUNT)
+            drawSliceShape(args.ctx, slice, layout, { outerRadiusBoost, fillStyle })
             return true
         },
-        [effectiveHoverOffset]
+        [effectiveHoverGrowth]
     )
 
     const renderTooltip = useMemo(
@@ -207,7 +231,8 @@ function PieChartInner<Meta = unknown>({
             tooltip={renderTooltip}
             showTooltip={showTooltip}
             onSliceClick={onSliceClick}
-            hitOuterSlack={effectiveHoverOffset}
+            hitOuterSlack={effectiveHoverGrowth}
+            hoverAnimationMs={effectiveHoverAnimationMs}
             className={className}
             dataAttr={dataAttr}
         >
@@ -243,55 +268,37 @@ function getLayoutFromArgs<Meta>(args: ChartDrawArgs): PieLayout<Meta> | null {
 
 interface DrawSlicesOptions {
     skipIndex: number
-    offset: number
+    outerRadiusBoost: number
 }
 
 function drawSlices<Meta>(
     ctx: CanvasRenderingContext2D,
     layout: PieLayout<Meta>,
-    theme: ChartTheme,
-    { skipIndex, offset }: DrawSlicesOptions
+    { skipIndex, outerRadiusBoost }: DrawSlicesOptions
 ): void {
     for (let i = 0; i < layout.slices.length; i++) {
         if (i === skipIndex) {
             continue
         }
-        drawSlice(ctx, layout.slices[i], layout, theme, { offset })
+        drawSliceShape(ctx, layout.slices[i], layout, { outerRadiusBoost, fillStyle: layout.slices[i].color })
     }
 }
 
-interface DrawSliceOptions {
-    offset: number
-}
-
-function drawSlice<Meta>(
-    ctx: CanvasRenderingContext2D,
-    slice: PieLayout<Meta>['slices'][number],
-    layout: PieLayout<Meta>,
-    theme: ChartTheme,
-    { offset }: DrawSliceOptions
-): void {
-    // Inter-slice stroke in the theme background — visually separates adjacent slices
-    // without a heavy outline. Skipped when there's only one slice (no neighbour to separate from).
-    const withStroke = layout.slices.length > 1 ? theme.backgroundColor : undefined
-    drawSliceShape(ctx, slice, layout, { offset, fillStyle: slice.color, withStroke })
-}
-
 interface DrawSliceShapeOptions {
-    offset: number
+    /** Pixels added to the outer radius (center fixed) — drives the hover grow. */
+    outerRadiusBoost: number
     fillStyle: string
-    /** Inter-slice stroke color (typically `theme.backgroundColor`). Omit to skip stroking. */
-    withStroke: string | undefined
 }
 
-/** Lower-level slice painter — takes explicit fill / stroke so the hover layer can both
- *  mask (background fill, no stroke) and re-paint (slice color, with stroke) using the same
- *  arc geometry. */
+/** Lower-level slice painter — takes an explicit fill so the hover layer can re-paint a slice
+ *  (grown + brightened) over its static base using the same center and angles. Slices are drawn
+ *  borderless: with many thin wedges, an inter-slice stroke piles up into a white cone at the
+ *  apex, so adjacent slices are separated by color alone (matching the legacy pie). */
 function drawSliceShape<Meta>(
     ctx: CanvasRenderingContext2D,
     slice: PieLayout<Meta>['slices'][number],
     layout: PieLayout<Meta>,
-    { offset, fillStyle, withStroke }: DrawSliceShapeOptions
+    { outerRadiusBoost, fillStyle }: DrawSliceShapeOptions
 ): void {
     const halfPad = layout.padAngle / 2
     const start = slice.startAngle + halfPad
@@ -299,10 +306,8 @@ function drawSliceShape<Meta>(
     if (start >= end) {
         return
     }
-    const offsetX = offset === 0 ? 0 : Math.sin(slice.centroidAngle) * offset
-    const offsetY = offset === 0 ? 0 : -Math.cos(slice.centroidAngle) * offset
-    const cx = layout.cx + offsetX
-    const cy = layout.cy + offsetY
+    const { cx, cy, innerRadius } = layout
+    const outerRadius = layout.outerRadius + outerRadiusBoost
 
     // Canvas arc convention: 0 = 3 o'clock, increasing clockwise. d3.pie uses
     // 0 = 12 o'clock. Subtract π/2 to align.
@@ -311,19 +316,13 @@ function drawSliceShape<Meta>(
 
     ctx.fillStyle = fillStyle
     ctx.beginPath()
-    if (layout.innerRadius > 0) {
-        ctx.arc(cx, cy, layout.outerRadius, cStart, cEnd, false)
-        ctx.arc(cx, cy, layout.innerRadius, cEnd, cStart, true)
+    if (innerRadius > 0) {
+        ctx.arc(cx, cy, outerRadius, cStart, cEnd, false)
+        ctx.arc(cx, cy, innerRadius, cEnd, cStart, true)
     } else {
         ctx.moveTo(cx, cy)
-        ctx.arc(cx, cy, layout.outerRadius, cStart, cEnd, false)
+        ctx.arc(cx, cy, outerRadius, cStart, cEnd, false)
     }
     ctx.closePath()
     ctx.fill()
-
-    if (withStroke) {
-        ctx.lineWidth = 1
-        ctx.strokeStyle = withStroke
-        ctx.stroke()
-    }
 }

--- a/packages/quill/packages/charts/src/charts/PieChart/SliceLabels.test.tsx
+++ b/packages/quill/packages/charts/src/charts/PieChart/SliceLabels.test.tsx
@@ -6,7 +6,8 @@ import type { RadialLayoutContextValue } from '../../core/radial-context'
 import type { ResolvedSeries } from '../../core/types'
 import { computePieLayout } from './computePieLayout'
 import type { PieLayout } from './computePieLayout'
-import { SliceLabels } from './SliceLabels'
+import { nonCollidingKeys, SliceLabels } from './SliceLabels'
+import type { LabelBox } from './SliceLabels'
 
 const PLOT = { plotLeft: 0, plotTop: 0, plotWidth: 400, plotHeight: 400 }
 
@@ -101,5 +102,27 @@ describe('SliceLabels', () => {
         const a = labels(container)[0]
         expect(a.textContent).toContain('A')
         expect(a.textContent).toContain('50')
+    })
+
+    // y=0 for every box, so overlap is decided purely by x against the summed half-widths.
+    function box(key: string, x: number, value: number, halfWidth = 10): LabelBox {
+        return { key, x, y: 0, halfWidth, halfHeight: 10, value, lines: [key] }
+    }
+
+    it('keeps every label when none of the boxes overlap', () => {
+        const kept = nonCollidingKeys([box('a', 0, 1), box('b', 100, 1), box('c', 200, 1)])
+        expect([...kept].sort()).toEqual(['a', 'b', 'c'])
+    })
+
+    it('drops the smaller-value label when two boxes overlap', () => {
+        // 5px apart, half-widths 10 each → boxes overlap; b carries the larger value.
+        const kept = nonCollidingKeys([box('a', 0, 3), box('b', 5, 9)])
+        expect(kept.has('b')).toBe(true)
+        expect(kept.has('a')).toBe(false)
+    })
+
+    it('keeps only the largest label in a crowded cluster', () => {
+        const kept = nonCollidingKeys([box('a', 0, 1), box('b', 4, 5), box('c', 8, 3)])
+        expect([...kept]).toEqual(['b'])
     })
 })

--- a/packages/quill/packages/charts/src/charts/PieChart/SliceLabels.tsx
+++ b/packages/quill/packages/charts/src/charts/PieChart/SliceLabels.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { useRadialLayout } from '../../core/radial-context'
+import { AXIS_LABEL_FONT, measureLabelWidth } from '../../utils/text-measure'
 
 export interface SliceLabelsProps {
     valueFormatter?: (value: number) => string
@@ -14,13 +15,21 @@ export interface SliceLabelsProps {
     isPercent?: boolean
 }
 
+const LABEL_FONT_SIZE = 14
+const LABEL_LINE_HEIGHT = 1.2
+// Same family as the axis labels, restyled to the on-slice weight/size for accurate measuring.
+const LABEL_FONT = AXIS_LABEL_FONT.replace(/^\d+px/, `600 ${LABEL_FONT_SIZE}px`)
+// Breathing room added around each label box so near-touching labels still count as colliding.
+const LABEL_PADDING_X = 4
+const LABEL_PADDING_Y = 2
+
 const LABEL_STYLE_BASE: React.CSSProperties = {
     position: 'absolute',
     pointerEvents: 'none',
     color: 'white',
-    fontSize: 14,
+    fontSize: LABEL_FONT_SIZE,
     fontWeight: 600,
-    lineHeight: 1.2,
+    lineHeight: LABEL_LINE_HEIGHT,
     textAlign: 'center',
     textShadow: '0 1px 2px rgba(0, 0, 0, 0.45)',
     whiteSpace: 'nowrap',
@@ -35,6 +44,35 @@ function formatPercent(fraction: number): string {
     return `${Math.round(fraction * 1000) / 10}%`
 }
 
+interface LabelBox {
+    key: string
+    x: number
+    y: number
+    halfWidth: number
+    halfHeight: number
+    value: number
+    lines: string[]
+}
+
+function overlaps(a: LabelBox, b: LabelBox): boolean {
+    return Math.abs(a.x - b.x) < a.halfWidth + b.halfWidth && Math.abs(a.y - b.y) < a.halfHeight + b.halfHeight
+}
+
+/** Slices whose centered label box doesn't collide with an already-kept one. Larger slices win,
+ *  so when adjacent thin slices crowd the same arc the most significant labels survive and the
+ *  rest are dropped rather than overlapping. */
+function nonCollidingKeys(boxes: LabelBox[]): Set<string> {
+    const kept: LabelBox[] = []
+    const keptKeys = new Set<string>()
+    for (const box of [...boxes].sort((a, b) => b.value - a.value)) {
+        if (kept.every((other) => !overlaps(box, other))) {
+            kept.push(box)
+            keptKeys.add(box.key)
+        }
+    }
+    return keptKeys
+}
+
 export function SliceLabels({
     valueFormatter = defaultFormatter,
     showValueOnSlice = true,
@@ -47,32 +85,51 @@ export function SliceLabels({
         return null
     }
     const midR = layout.innerRadius + (layout.outerRadius - layout.innerRadius) / 2
+
+    const boxes: LabelBox[] = []
+    for (let i = 0; i < layout.slices.length; i++) {
+        const slice = layout.slices[i]
+        if (slice.series.visibility?.valueLabel === false || slice.fraction < minSlicePercentForLabel) {
+            continue
+        }
+        const lines: string[] = []
+        if (showLabelOnSlice) {
+            lines.push(slice.series.label)
+        }
+        if (showValueOnSlice) {
+            lines.push(isPercent ? formatPercent(slice.fraction) : valueFormatter(slice.value))
+        }
+        const width = Math.max(0, ...lines.map((line) => measureLabelWidth(line, LABEL_FONT)))
+        boxes.push({
+            // Slice positions can shift when the input series changes, but the series key is stable
+            // across re-renders of the same series, which keeps React's reconciliation predictable.
+            key: slice.series.key || String(i),
+            x: layout.cx + Math.sin(slice.centroidAngle) * midR,
+            y: layout.cy - Math.cos(slice.centroidAngle) * midR,
+            halfWidth: width / 2 + LABEL_PADDING_X,
+            halfHeight: (lines.length * LABEL_FONT_SIZE * LABEL_LINE_HEIGHT) / 2 + LABEL_PADDING_Y,
+            value: slice.value,
+            lines,
+        })
+    }
+
+    const visibleKeys = nonCollidingKeys(boxes)
+
     return (
         <>
-            {layout.slices.map((slice, i) => {
-                if (slice.series.visibility?.valueLabel === false) {
-                    return null
-                }
-                if (slice.fraction < minSlicePercentForLabel) {
-                    return null
-                }
-                const x = layout.cx + Math.sin(slice.centroidAngle) * midR
-                const y = layout.cy - Math.cos(slice.centroidAngle) * midR
-                const valueText = isPercent ? formatPercent(slice.fraction) : valueFormatter(slice.value)
-                return (
+            {boxes
+                .filter((box) => visibleKeys.has(box.key))
+                .map((box) => (
                     <div
-                        // Slice positions can shift when the input series changes, but `seriesIndex`
-                        // is stable across re-renders of the same series, which keeps React's
-                        // reconciliation predictable.
-                        key={slice.series.key || i}
+                        key={box.key}
                         data-attr="hog-chart-pie-slice-label"
-                        style={{ ...LABEL_STYLE_BASE, left: Math.round(x), top: Math.round(y) }}
+                        style={{ ...LABEL_STYLE_BASE, left: Math.round(box.x), top: Math.round(box.y) }}
                     >
-                        {showLabelOnSlice ? <div>{slice.series.label}</div> : null}
-                        {showValueOnSlice ? <div>{valueText}</div> : null}
+                        {box.lines.map((line, li) => (
+                            <div key={li}>{line}</div>
+                        ))}
                     </div>
-                )
-            })}
+                ))}
         </>
     )
 }

--- a/packages/quill/packages/charts/src/charts/PieChart/SliceLabels.tsx
+++ b/packages/quill/packages/charts/src/charts/PieChart/SliceLabels.tsx
@@ -18,7 +18,7 @@ const LABEL_STYLE_BASE: React.CSSProperties = {
     position: 'absolute',
     pointerEvents: 'none',
     color: 'white',
-    fontSize: 12,
+    fontSize: 14,
     fontWeight: 600,
     lineHeight: 1.2,
     textAlign: 'center',

--- a/packages/quill/packages/charts/src/charts/PieChart/SliceLabels.tsx
+++ b/packages/quill/packages/charts/src/charts/PieChart/SliceLabels.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { useRadialLayout } from '../../core/radial-context'
-import { AXIS_LABEL_FONT, measureLabelWidth } from '../../utils/text-measure'
+import { FONT_FAMILY, measureLabelWidth } from '../../utils/text-measure'
 
 export interface SliceLabelsProps {
     valueFormatter?: (value: number) => string
@@ -17,8 +17,7 @@ export interface SliceLabelsProps {
 
 const LABEL_FONT_SIZE = 14
 const LABEL_LINE_HEIGHT = 1.2
-// Same family as the axis labels, restyled to the on-slice weight/size for accurate measuring.
-const LABEL_FONT = AXIS_LABEL_FONT.replace(/^\d+px/, `600 ${LABEL_FONT_SIZE}px`)
+const LABEL_FONT = `600 ${LABEL_FONT_SIZE}px ${FONT_FAMILY}`
 // Breathing room added around each label box so near-touching labels still count as colliding.
 const LABEL_PADDING_X = 4
 const LABEL_PADDING_Y = 2
@@ -44,7 +43,7 @@ function formatPercent(fraction: number): string {
     return `${Math.round(fraction * 1000) / 10}%`
 }
 
-interface LabelBox {
+export interface LabelBox {
     key: string
     x: number
     y: number
@@ -61,7 +60,7 @@ function overlaps(a: LabelBox, b: LabelBox): boolean {
 /** Slices whose centered label box doesn't collide with an already-kept one. Larger slices win,
  *  so when adjacent thin slices crowd the same arc the most significant labels survive and the
  *  rest are dropped rather than overlapping. */
-function nonCollidingKeys(boxes: LabelBox[]): Set<string> {
+export function nonCollidingKeys(boxes: LabelBox[]): Set<string> {
     const kept: LabelBox[] = []
     const keptKeys = new Set<string>()
     for (const box of [...boxes].sort((a, b) => b.value - a.value)) {

--- a/packages/quill/packages/charts/src/core/RadialChart.tsx
+++ b/packages/quill/packages/charts/src/core/RadialChart.tsx
@@ -72,6 +72,8 @@ export interface RadialChartProps<Meta = unknown> {
     onSliceClick?: (payload: RadialSlicePayload<Meta>) => void
     /** Slack beyond `outerRadius` for hit-testing — typically the hover pop-out distance. */
     hitOuterSlack?: number
+    /** Duration (ms) of the hover-overlay transition. `0` disables (instant pop-out). */
+    hoverAnimationMs?: number
     className?: string
     dataAttr?: string
     children?: React.ReactNode
@@ -87,6 +89,7 @@ export function RadialChart<Meta = unknown>({
     showTooltip = true,
     onSliceClick,
     hitOuterSlack = 0,
+    hoverAnimationMs = 0,
     className,
     dataAttr,
     children,
@@ -149,6 +152,7 @@ export function RadialChart<Meta = unknown>({
         theme,
         drawStatic,
         drawHover,
+        hoverAnimationMs,
     })
 
     const ariaLabel = useMemo(() => {
@@ -215,7 +219,7 @@ export function RadialChart<Meta = unknown>({
                                     <Tooltip
                                         context={tooltipCtx}
                                         renderTooltip={renderTooltip}
-                                        placement="follow-data"
+                                        placement="cursor"
                                     />
                                 )}
                             </div>

--- a/packages/quill/packages/charts/src/core/color-utils.test.ts
+++ b/packages/quill/packages/charts/src/core/color-utils.test.ts
@@ -1,0 +1,18 @@
+import { mixColors } from './color-utils'
+
+describe('mixColors', () => {
+    it.each([
+        { name: 'midpoint is halfway between the two colors', from: '#000000', to: '#ffffff', t: 0.5, expected: 'rgb(128, 128, 128)' },
+        { name: 't=0 returns the from color', from: '#000000', to: '#ffffff', t: 0, expected: 'rgb(0, 0, 0)' },
+        { name: 't=1 returns the to color', from: '#000000', to: '#ffffff', t: 1, expected: 'rgb(255, 255, 255)' },
+        { name: 't below 0 clamps to the from color', from: '#000000', to: '#ffffff', t: -1, expected: 'rgb(0, 0, 0)' },
+        { name: 't above 1 clamps to the to color', from: '#000000', to: '#ffffff', t: 2, expected: 'rgb(255, 255, 255)' },
+        { name: 'interpolates opacity', from: 'rgba(255, 0, 0, 0.2)', to: 'rgba(255, 0, 0, 0.8)', t: 0.5, expected: 'rgba(255, 0, 0, 0.5)' },
+    ])('$name', ({ from, to, t, expected }) => {
+        expect(mixColors(from, to, t)).toBe(expected)
+    })
+
+    it('returns the original string when a color cannot be parsed', () => {
+        expect(mixColors('not-a-color', '#ffffff', 0.5)).toBe('not-a-color')
+    })
+})

--- a/packages/quill/packages/charts/src/core/color-utils.ts
+++ b/packages/quill/packages/charts/src/core/color-utils.ts
@@ -13,6 +13,7 @@ export function dimColor(color: string, alpha: number): string {
 export function mixColors(from: string, to: string, t: number): string {
     const a = d3Rgb(from)
     const b = d3Rgb(to)
+    // d3 returns an RGBColor with NaN channels (not null) for unparseable input.
     if (Number.isNaN(a.r) || Number.isNaN(b.r)) {
         return from
     }

--- a/packages/quill/packages/charts/src/core/color-utils.ts
+++ b/packages/quill/packages/charts/src/core/color-utils.ts
@@ -1,4 +1,4 @@
-import { color as d3Color } from 'd3-color'
+import { color as d3Color, rgb as d3Rgb } from 'd3-color'
 
 import type { ResolvedSeries, Series } from './types'
 
@@ -6,6 +6,19 @@ import type { ResolvedSeries, Series } from './types'
  *  rgb/rgba, named, HSL). Falls back to the raw string when `d3.color` returns `null`. */
 export function dimColor(color: string, alpha: number): string {
     return d3Color(color)?.copy({ opacity: alpha }).toString() ?? color
+}
+
+/** Linear RGB interpolation between two colors. `t` is clamped to [0, 1]; `t=0` returns `from`,
+ *  `t=1` returns `to`. Falls back to `from` when either color can't be parsed. */
+export function mixColors(from: string, to: string, t: number): string {
+    const a = d3Rgb(from)
+    const b = d3Rgb(to)
+    if (Number.isNaN(a.r) || Number.isNaN(b.r)) {
+        return from
+    }
+    const clamped = Math.max(0, Math.min(1, t))
+    const lerp = (x: number, y: number): number => x + (y - x) * clamped
+    return d3Rgb(lerp(a.r, b.r), lerp(a.g, b.g), lerp(a.b, b.b), lerp(a.opacity, b.opacity)).toString()
 }
 
 /** Fill color for the bar at `index`: the per-bar override (`bars[index].color`) when set, else the

--- a/packages/quill/packages/charts/src/core/hooks/useRadialInteraction.ts
+++ b/packages/quill/packages/charts/src/core/hooks/useRadialInteraction.ts
@@ -19,8 +19,8 @@ interface UseRadialInteractionOptions<Meta> {
     wrapperRef: React.RefObject<HTMLDivElement>
     showTooltip: boolean
     onSliceClick?: (payload: RadialSlicePayload<Meta>) => void
-    /** Allowance beyond `outerRadius` for hit-testing so the popped-out slice still hovers.
-     *  Typically equal to `hoverOffset`. */
+    /** Allowance beyond `outerRadius` for hit-testing so the grown slice still hovers.
+     *  Typically equal to `hoverGrowth`. */
     hitOuterSlack?: number
 }
 
@@ -41,8 +41,8 @@ function buildPieTooltipCtx<Meta>(
     cursor: { x: number; y: number } | null,
     canvasBounds: DOMRect
 ): TooltipContext<Meta> {
-    // Anchor at the centroid of the slice (mid-radius along bisector) so the tooltip points
-    // at the slice it describes, not at the cursor.
+    // Centroid of the slice (mid-radius along bisector). The tooltip follows the cursor via
+    // `hoverPosition`; this is the fallback anchor for rebuilds with no cursor (e.g. a pin).
     const midR = (layout.innerRadius + layout.outerRadius) / 2
     const ax = layout.cx + Math.sin(slice.centroidAngle) * midR
     const ay = layout.cy - Math.cos(slice.centroidAngle) * midR

--- a/packages/quill/packages/charts/src/utils/text-measure.ts
+++ b/packages/quill/packages/charts/src/utils/text-measure.ts
@@ -1,8 +1,10 @@
 // Cached offscreen canvas — createElement+getContext is slow, measureText is fast.
 // Callers must set ctx.font themselves before measuring.
 
-export const AXIS_LABEL_FONT =
-    '12px -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif'
+export const FONT_FAMILY =
+    '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif'
+
+export const AXIS_LABEL_FONT = `12px ${FONT_FAMILY}`
 
 export const ELLIPSIS = '…'
 


### PR DESCRIPTION
## Problem

The hog-charts pie hover felt janky: the hovered slice snapped out instantly, the tooltip was pinned to the slice centroid rather than tracking the cursor, and on breakdowns with many thin slices the inter-slice border strokes piled up into a solid white cone at the center.

## Changes

All in the shared `@posthog/quill-charts` PieChart/RadialChart layer:

- Hovered slice now **grows outward** (center fixed) and brightens slightly, eased over 150ms instead of snapping.
- Non-hovered slices fade toward the chart background to focus the hovered one. The dim fades in gradually and only ramps upward, so it holds steady (no flash back to full color) when sweeping from one segment to the next, and resets on hover-out.
- Tooltip follows the cursor (`placement="cursor"`) instead of anchoring at the slice centroid.
- Removed the inter-slice border strokes — with many thin slices they converged into a white cone at the center; slices are now separated by color alone (matching the legacy pie).
- Bumped on-slice value labels from 12px to 14px.
- Added a `mixColors()` color-lerp helper (uses the existing `d3-color` dep) and `hoverGrowth` / `hoverAnimationMs` config options on `PieChartConfig`.

These affect every pie consumer, not just Trends, since they live in the shared charting library.

## How did you test this code?

I'm an agent. Verification so far:

- Type-checked the `@posthog/quill-charts` package in isolation (`tsc --noEmit -p` against its own tsconfig) — no errors in the changed files.
- Lint-clean (`oxlint`) on all five changed files.

I have **not** run the package's jest tests yet (they need the package's own jest config, not the frontend runner) and have **not** done visual verification in the running app. Both are worth doing before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Built with Claude Code (Opus 4.8) through iterative visual tweaking. The animation infrastructure already existed — `useChartDraw` runs a RAF loop producing a `hoverProgress` (0→1), which `BarChart` already used; `RadialChart` just hardcoded the duration to 0 and `PieChart` ignored the progress. The work was mostly wiring that through plus the draw-layer changes.

Two decisions worth flagging for the reviewer:
- The "grow" approach (extend outer radius, fixed center) was chosen over the original "shift along bisector" because the grown wedge fully covers its own base, so the two-pass erase trick is no longer needed.
- The backdrop dim is tracked in a ref that only ever ramps up while hovering (resets on hover-out) rather than read straight off `hoverProgress` — because `hoverProgress` resets to 0 on every `hoverIndex` change, which would flash the backdrop back to full color on each slice crossing.

Constants (8px growth, 150ms, 0.15 brighten, 0.55 dim, 14px labels) are visual judgment calls and easy to tune.