### PR TITLE
feat(experiments): metric recalculation service and endpoints

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -45,6 +45,7 @@ from products.experiments.backend.models.experiment import (
     holdout_filters_for_flag,
 )
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
+from products.experiments.backend.result_serialization import strip_step_sessions
 from products.feature_flags.backend.api.feature_flag import FeatureFlagSerializer
 from products.feature_flags.backend.models.evaluation_context import FeatureFlagEvaluationContext
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
@@ -70,29 +71,6 @@ DEFAULT_VARIANTS = [
     {"key": "control", "name": "Control Group", "rollout_percentage": 50},
     {"key": "test", "name": "Test Variant", "rollout_percentage": 50},
 ]
-
-
-def _strip_step_sessions(result: Any) -> Any:
-    """Remove the per-session funnel actors payload from a stored experiment metric result.
-
-    `step_sessions` powers the frontend's "view sessions per step" affordance off
-    a separate per-metric query, not this timeseries endpoint. Carrying it through
-    here multiplies the response by sessions × steps × variants and pushes MCP
-    consumers past their context window with no benefit.
-    """
-    if not isinstance(result, Mapping):
-        return result
-    cleaned = {k: v for k, v in result.items() if k != "step_sessions"}
-    baseline = cleaned.get("baseline")
-    if isinstance(baseline, dict):
-        cleaned["baseline"] = {k: v for k, v in baseline.items() if k != "step_sessions"}
-    variants = cleaned.get("variant_results")
-    if isinstance(variants, list):
-        cleaned["variant_results"] = [
-            {k: v for k, v in variant.items() if k != "step_sessions"} if isinstance(variant, dict) else variant
-            for variant in variants
-        ]
-    return cleaned
 
 
 class ExperimentQueryStatus(str, Enum):
@@ -2647,7 +2625,7 @@ class ExperimentService:
                 metric_result = results_by_date[experiment_date]
 
                 if metric_result.status == "completed":
-                    timeseries[date_key] = _strip_step_sessions(metric_result.result)
+                    timeseries[date_key] = strip_step_sessions(metric_result.result)
                     completed_count += 1
                 elif metric_result.status == "failed":
                     if metric_result.error_message:

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -602,6 +602,38 @@ class CreateFromPromptInputSerializer(serializers.Serializer):
         return attrs
 
 
+class MetricRecalculationResultSerializer(serializers.Serializer):
+    """One metric's recalculated result row, read back from ExperimentMetricResult."""
+
+    metric_uuid = serializers.CharField(read_only=True, help_text="UUID of the metric this result belongs to")
+    status = serializers.ChoiceField(
+        choices=["pending", "completed", "failed"],
+        read_only=True,
+        help_text="Status of this metric's calculation in the run",
+    )
+    # JSONField mirrors the ExperimentMetricResult.result column; concrete shape comes from
+    # posthog.schema.ExperimentQueryResponse (variants/baseline/credible intervals/etc., depending on metric type).
+    result = serializers.JSONField(
+        read_only=True,
+        allow_null=True,
+        help_text="The computed metric result (ExperimentQueryResponse shape); null when status is pending or failed",
+    )
+    error_message = serializers.CharField(
+        read_only=True, allow_null=True, help_text="Error message when status is failed; otherwise null"
+    )
+
+
+class RecalculateMetricsRequestSerializer(serializers.Serializer):
+    """Request body for triggering a metrics recalculation."""
+
+    trigger = serializers.ChoiceField(
+        choices=["manual", "experiment_launch", "experiment_stop", "experiment_update"],
+        required=False,
+        default="manual",
+        help_text="What triggered this recalculation (manual is the default for user-initiated runs)",
+    )
+
+
 class ExperimentMetricsRecalculationSerializer(serializers.Serializer):
     """Serializer for metrics recalculation status responses."""
 

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -658,3 +658,11 @@ class ExperimentMetricsRecalculationSerializer(serializers.Serializer):
     is_existing = serializers.BooleanField(
         read_only=True, required=False, help_text="True if returning an existing job rather than a newly created one"
     )
+    # Populated by the GET endpoints (latest / by-id). Omitted from the POST response payload (which doesn't carry
+    # per-metric results yet — the workflow has just started).
+    results = MetricRecalculationResultSerializer(
+        many=True,
+        read_only=True,
+        required=False,
+        help_text="Per-metric results computed by this run, scoped by the run's recalc fingerprint",
+    )

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -645,6 +645,17 @@ class ExperimentMetricsRecalculationSerializer(serializers.Serializer):
         help_text="Current status of the recalculation job",
     )
     total_metrics = serializers.IntegerField(read_only=True, help_text="Total number of metrics to recalculate")
+    completed_metrics = serializers.IntegerField(
+        read_only=True,
+        help_text="Number of metrics with a COMPLETED result row in this run (derived, not stored)",
+    )
+    failed_metrics = serializers.IntegerField(
+        read_only=True,
+        help_text=(
+            "Number of failed metrics in this run (derived): FAILED result rows plus discovery-step failures "
+            "that never made it to a result row"
+        ),
+    )
     # Named metric_errors (not errors) to avoid shadowing DRF's reserved Serializer.errors property.
     metric_errors = serializers.JSONField(read_only=True, help_text="Map of metric_uuid to error details")
     trigger = serializers.ChoiceField(

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -43,6 +43,7 @@ from products.experiments.backend.llm_metric_templates import build_template, li
 # TODO: Route through facade instead of direct import
 from products.experiments.backend.models.experiment import (
     Experiment,
+    ExperimentMetricsRecalculation,
     ExperimentTimeseriesRecalculation,
     experiment_has_legacy_metrics,
 )
@@ -50,8 +51,20 @@ from products.experiments.backend.presentation.serializers import (
     CopyExperimentToProjectSerializer,
     CreateFromPromptInputSerializer,
     EndExperimentSerializer,
+    ExperimentMetricsRecalculationSerializer,
     ExperimentSerializer,
+    MetricRecalculationResultSerializer,
+    RecalculateMetricsRequestSerializer,
     ShipVariantSerializer,
+)
+from products.experiments.backend.recalculation import (
+    get_latest_recalculation,
+    get_recalculation_by_id,
+    get_run_results,
+    request_recalculation,
+)
+from products.experiments.backend.temporal.models import (
+    ExperimentMetricsRecalculationWorkflowInputs as MetricsRecalcInputs,
 )
 from products.feature_flags.backend.api.feature_flag import FeatureFlagSerializer
 from products.feature_flags.backend.models.evaluation_context import FeatureFlagEvaluationContext
@@ -795,7 +808,104 @@ class EnterpriseExperimentsViewSet(
         status_code = 200 if is_existing else 201
         return Response(result, status=status_code)
 
+    @extend_schema(
+        request=RecalculateMetricsRequestSerializer,
+        responses={
+            200: ExperimentMetricsRecalculationSerializer,
+            201: ExperimentMetricsRecalculationSerializer,
+        },
+    )
+    @action(
+        methods=["POST"],
+        detail=True,
+        url_path="metrics_recalculation",
+        required_scopes=["experiment:write"],
+    )
+    def metrics_recalculation(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        experiment: Experiment = self.get_object()
+        request_serializer = RecalculateMetricsRequestSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+        trigger = request_serializer.validated_data["trigger"]
+
+        result = request_recalculation(experiment, request.user, trigger)
+        is_existing = result.pop("is_existing", False)
+
+        if not is_existing:
+            recalculation_id = str(result["id"])
+            try:
+                temporal = sync_connect()
+                asyncio.run(
+                    temporal.start_workflow(
+                        "experiment-metrics-recalculation-workflow",
+                        MetricsRecalcInputs(recalculation_id=recalculation_id),
+                        id=f"experiment-metrics-recalculation-{recalculation_id}",
+                        task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
+                    )
+                )
+            except Exception:
+                ExperimentMetricsRecalculation.objects.filter(id=recalculation_id).update(
+                    status=ExperimentMetricsRecalculation.Status.FAILED
+                )
+                raise
+
+        return Response(
+            ExperimentMetricsRecalculationSerializer(result).data,
+            status=200 if is_existing else 201,
+        )
+
+    @extend_schema(responses={200: ExperimentMetricsRecalculationSerializer, 404: None})
+    @action(
+        methods=["GET"],
+        detail=True,
+        # NOTE: this action is declared BEFORE the by-id action so its URL pattern wins on /latest/.
+        url_path="metrics_recalculation/latest",
+        required_scopes=["experiment:read"],
+    )
+    def metrics_recalculation_latest(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        experiment: Experiment = self.get_object()
+        recalc = get_latest_recalculation(experiment)
+        if recalc is None:
+            return Response({"detail": "No completed recalculation found"}, status=404)
+        return Response(_serialize_recalculation(recalc))
+
+    @extend_schema(responses={200: ExperimentMetricsRecalculationSerializer, 404: None})
+    @action(
+        methods=["GET"],
+        detail=True,
+        # Strict UUID regex so 'latest' (the sibling action above) never matches this route.
+        url_path=r"metrics_recalculation/(?P<recalculation_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+        required_scopes=["experiment:read"],
+    )
+    def metrics_recalculation_detail(
+        self, request: Request, recalculation_id: str, *args: Any, **kwargs: Any
+    ) -> Response:
+        experiment: Experiment = self.get_object()
+        recalc = get_recalculation_by_id(experiment, recalculation_id)
+        if recalc is None:
+            return Response({"detail": "Recalculation not found"}, status=404)
+        return Response(_serialize_recalculation(recalc))
+
     @action(methods=["GET"], detail=False, url_path="stats", required_scopes=["experiment:read"])
     def stats(self, request: Request, **kwargs: Any) -> Response:
         service = ExperimentService(team=self.team, user=request.user)
         return Response(service.get_velocity_stats())
+
+
+def _serialize_recalculation(recalc: ExperimentMetricsRecalculation) -> dict:
+    """Shape an ExperimentMetricsRecalculation row + its per-run results for the GET responses."""
+    payload = {
+        "id": str(recalc.id),
+        "experiment_id": recalc.experiment_id,
+        "status": recalc.status,
+        "total_metrics": recalc.total_metrics,
+        "completed_metrics": recalc.completed_metrics,
+        "failed_metrics": recalc.failed_metrics,
+        "metric_errors": recalc.errors,
+        "trigger": recalc.trigger,
+        "created_at": recalc.created_at,
+        "started_at": recalc.started_at,
+        "completed_at": recalc.completed_at,
+    }
+    data = ExperimentMetricsRecalculationSerializer(payload).data
+    data["results"] = MetricRecalculationResultSerializer(get_run_results(recalc), many=True).data
+    return data

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -57,6 +57,7 @@ from products.experiments.backend.presentation.serializers import (
     ShipVariantSerializer,
 )
 from products.experiments.backend.recalculation import (
+    build_job_payload,
     get_latest_recalculation,
     get_recalculation_by_id,
     get_run_results,
@@ -891,23 +892,12 @@ class EnterpriseExperimentsViewSet(
 
 
 def _serialize_recalculation(recalc: ExperimentMetricsRecalculation) -> dict:
-    """Shape an ExperimentMetricsRecalculation row + its per-run results for the GET responses."""
-    payload = {
-        "id": str(recalc.id),
-        "experiment_id": recalc.experiment_id,
-        "status": recalc.status,
-        "total_metrics": recalc.total_metrics,
-        "completed_metrics": recalc.completed_metrics,
-        "failed_metrics": recalc.failed_metrics,
-        "metric_errors": recalc.errors,
-        "trigger": recalc.trigger,
-        "created_at": recalc.created_at,
-        "started_at": recalc.started_at,
-        "completed_at": recalc.completed_at,
-        # The serializer's nested results field declares this in the OpenAPI schema so the generated TS type
-        # includes `results`. The POST endpoint omits it (workflow has just started; no results yet).
-        "results": get_run_results(recalc),
-    }
-    data = ExperimentMetricsRecalculationSerializer(payload).data
-    data["results"] = MetricRecalculationResultSerializer(get_run_results(recalc), many=True).data
-    return data
+    """Shape an ExperimentMetricsRecalculation row + its per-run results for the GET responses.
+
+    Computes the per-run results once and threads them into both the derived counters and the response
+    `results` field — recomputing per-metric fingerprints once per request is enough.
+    """
+    results = get_run_results(recalc)
+    payload = build_job_payload(recalc, results=results)
+    payload["results"] = results
+    return ExperimentMetricsRecalculationSerializer(payload).data

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -800,7 +800,9 @@ class EnterpriseExperimentsViewSet(
                     )
                 )
             except Exception:
-                ExperimentTimeseriesRecalculation.objects.filter(id=recalculation_id).update(
+                # team-scoped filter: defense in depth so the rollback can never reach across teams even if
+                # recalculation_id were ever sourced from somewhere less trusted than the row we just created.
+                ExperimentTimeseriesRecalculation.objects.filter(team=self.team, id=recalculation_id).update(
                     status=ExperimentTimeseriesRecalculation.Status.FAILED
                 )
                 raise
@@ -854,7 +856,9 @@ class EnterpriseExperimentsViewSet(
                     )
                 )
             except Exception:
-                ExperimentMetricsRecalculation.objects.filter(id=recalculation_id).update(
+                # team-scoped filter: defense in depth so the rollback can never reach across teams even if
+                # recalculation_id were ever sourced from somewhere less trusted than the row we just created.
+                ExperimentMetricsRecalculation.objects.filter(team=self.team, id=recalculation_id).update(
                     status=ExperimentMetricsRecalculation.Status.FAILED
                 )
                 raise

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -822,6 +822,14 @@ class EnterpriseExperimentsViewSet(
         required_scopes=["experiment:write"],
     )
     def metrics_recalculation(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Trigger a batch recalculation of all metrics for this experiment.
+
+        Returns 201 with the new pending recalculation, or 200 with the active one if a recalculation is
+        already pending or in progress for this experiment. The response payload intentionally does not
+        include the `results` array — at POST time the workflow has just been queued and no per-metric
+        results exist yet. Clients should poll `GET metrics_recalculation/{id}/` for results as the workflow
+        progresses.
+        """
         experiment: Experiment = self.get_object()
         request_serializer = RecalculateMetricsRequestSerializer(data=request.data)
         request_serializer.is_valid(raise_exception=True)

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -835,7 +835,8 @@ class EnterpriseExperimentsViewSet(
         request_serializer.is_valid(raise_exception=True)
         trigger = request_serializer.validated_data["trigger"]
 
-        result = request_recalculation(experiment, request.user, trigger)
+        # request.user is User | AnonymousUser at the DRF level; the viewset enforces auth so it's a User here.
+        result = request_recalculation(experiment, cast(User, request.user), trigger)
         is_existing = result.pop("is_existing", False)
 
         if not is_existing:

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -837,7 +837,9 @@ class EnterpriseExperimentsViewSet(
 
         # request.user is User | AnonymousUser at the DRF level; the viewset enforces auth so it's a User here.
         result = request_recalculation(experiment, cast(User, request.user), trigger)
-        is_existing = result.pop("is_existing", False)
+        # Read without mutating — the serializer surfaces is_existing on the response so clients can detect
+        # the idempotent-reuse path without inspecting the HTTP status code.
+        is_existing = result.get("is_existing", False)
 
         if not is_existing:
             recalculation_id = str(result["id"])

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -53,7 +53,6 @@ from products.experiments.backend.presentation.serializers import (
     EndExperimentSerializer,
     ExperimentMetricsRecalculationSerializer,
     ExperimentSerializer,
-    MetricRecalculationResultSerializer,
     RecalculateMetricsRequestSerializer,
     ShipVariantSerializer,
 )
@@ -905,6 +904,9 @@ def _serialize_recalculation(recalc: ExperimentMetricsRecalculation) -> dict:
         "created_at": recalc.created_at,
         "started_at": recalc.started_at,
         "completed_at": recalc.completed_at,
+        # The serializer's nested results field declares this in the OpenAPI schema so the generated TS type
+        # includes `results`. The POST endpoint omits it (workflow has just started; no results yet).
+        "results": get_run_results(recalc),
     }
     data = ExperimentMetricsRecalculationSerializer(payload).data
     data["results"] = MetricRecalculationResultSerializer(get_run_results(recalc), many=True).data

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -1,0 +1,128 @@
+"""Service layer for experiment metrics recalculation.
+
+Module-level free functions (not methods on ExperimentService) so the API view can compose them directly:
+
+- ``request_recalculation`` — idempotent create: returns the active run if one exists, else creates a pending job.
+- ``get_latest_recalculation`` — most recent recalc row for an experiment, or ``None``.
+- ``get_run_results`` — read-back of per-metric results for a specific run, scoped by recomputing each metric's
+  per-run recalc fingerprint (no FK on ExperimentMetricResult; the scoping key lives entirely on the job row +
+  the run id).
+"""
+
+from rest_framework.exceptions import ValidationError
+
+from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
+from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
+from posthog.models.user import User
+
+from products.experiments.backend.models.experiment import (
+    Experiment,
+    ExperimentMetricResult,
+    ExperimentMetricsRecalculation,
+)
+from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
+from products.experiments.backend.temporal.recalculation_logic import _find_metric_dict
+
+
+def _serialize_job(recalc: ExperimentMetricsRecalculation, *, is_existing: bool) -> dict:
+    return {
+        "id": str(recalc.id),
+        "experiment_id": recalc.experiment_id,
+        "status": recalc.status,
+        "total_metrics": recalc.total_metrics,
+        "completed_metrics": recalc.completed_metrics,
+        "failed_metrics": recalc.failed_metrics,
+        # Output key is metric_errors (serializer field renamed to avoid shadowing Serializer.errors); the model
+        # attribute is still recalc.errors.
+        "metric_errors": recalc.errors,
+        "trigger": recalc.trigger,
+        "created_at": recalc.created_at.isoformat(),
+        "started_at": recalc.started_at.isoformat() if recalc.started_at else None,
+        "completed_at": recalc.completed_at.isoformat() if recalc.completed_at else None,
+        "is_existing": is_existing,
+    }
+
+
+def request_recalculation(experiment: Experiment, user: User, trigger: str = "manual") -> dict:
+    """Create an idempotent batch recalculation request for all experiment metrics.
+
+    If an active (pending or in_progress) run already exists for this experiment, returns the existing run's
+    serialized payload with ``is_existing=True`` — the caller should NOT start a new workflow in that case.
+    Otherwise creates a fresh pending row.
+    """
+    if not experiment.is_launched:
+        raise ValidationError("Cannot recalculate metrics for experiment that hasn't started")
+
+    existing = ExperimentMetricsRecalculation.objects.filter(
+        experiment=experiment,
+        status__in=[
+            ExperimentMetricsRecalculation.Status.PENDING,
+            ExperimentMetricsRecalculation.Status.IN_PROGRESS,
+        ],
+    ).first()
+    if existing:
+        return _serialize_job(existing, is_existing=True)
+
+    recalc = ExperimentMetricsRecalculation.objects.create(
+        team=experiment.team,
+        experiment=experiment,
+        trigger=trigger,
+        status=ExperimentMetricsRecalculation.Status.PENDING,
+        created_by=user,
+    )
+    return _serialize_job(recalc, is_existing=False)
+
+
+def get_latest_recalculation(experiment: Experiment) -> ExperimentMetricsRecalculation | None:
+    return (
+        ExperimentMetricsRecalculation.objects.filter(team=experiment.team, experiment=experiment)
+        .order_by("-created_at")
+        .first()
+    )
+
+
+def _recalc_fingerprints_for_run(experiment: Experiment, recalc: ExperimentMetricsRecalculation) -> dict[str, str]:
+    """Recompute each metric's per-run recalc fingerprint (strategy 'a': no extra storage).
+
+    Returns ``{metric_uuid: recalc_fp}`` for metrics still resolvable on the experiment. A uuid present on the job
+    but no longer on the experiment is skipped (metric removed mid-run).
+    """
+    stats_method = get_experiment_stats_method(experiment)
+    fingerprints: dict[str, str] = {}
+    for metric_uuid in recalc.metric_uuids or []:
+        metric_dict = _find_metric_dict(experiment, metric_uuid)
+        if metric_dict is None:
+            continue
+        config_fp = compute_metric_fingerprint(
+            metric_dict,
+            experiment.start_date,
+            stats_method,
+            experiment.exposure_criteria,
+            only_count_matured_users=experiment.only_count_matured_users,
+        )
+        fingerprints[metric_uuid] = compute_recalc_fingerprint(config_fp, str(recalc.id))
+    return fingerprints
+
+
+def get_run_results(recalc: ExperimentMetricsRecalculation) -> list[dict]:
+    """Return the ExperimentMetricResult rows that belong to THIS run.
+
+    Scopes by recomputing each metric's recalc fingerprint and filtering ``fingerprint__in`` — never returns
+    rows from a previous run or from the timeseries workflow (which uses config fingerprints).
+    """
+    fingerprints = _recalc_fingerprints_for_run(recalc.experiment, recalc)
+    if not fingerprints:
+        return []
+
+    rows = ExperimentMetricResult.objects.filter(
+        experiment=recalc.experiment, fingerprint__in=list(fingerprints.values())
+    )
+    return [
+        {
+            "metric_uuid": row.metric_uuid,
+            "status": row.status,
+            "result": row.result,
+            "error_message": row.error_message,
+        }
+        for row in rows
+    ]

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -9,6 +9,8 @@ Module-level free functions (not methods on ExperimentService) so the API view c
   the run id).
 """
 
+from uuid import UUID
+
 from rest_framework.exceptions import ValidationError
 
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
@@ -74,11 +76,36 @@ def request_recalculation(experiment: Experiment, user: User, trigger: str = "ma
 
 
 def get_latest_recalculation(experiment: Experiment) -> ExperimentMetricsRecalculation | None:
+    """Most recent successfully-completed recalculation for an experiment, or None.
+
+    Powers ``GET /metrics_recalculation/latest``: the frontend renders cached results from the last good run.
+    Runs that are pending/in_progress/failed are NOT returned — the client tracks those separately by id.
+    """
     return (
-        ExperimentMetricsRecalculation.objects.filter(team=experiment.team, experiment=experiment)
+        ExperimentMetricsRecalculation.objects.filter(
+            team=experiment.team,
+            experiment=experiment,
+            status=ExperimentMetricsRecalculation.Status.COMPLETED,
+        )
         .order_by("-created_at")
         .first()
     )
+
+
+def get_recalculation_by_id(experiment: Experiment, recalculation_id: str) -> ExperimentMetricsRecalculation | None:
+    """Return the recalculation row for ``recalculation_id`` if it belongs to ``experiment``, else None.
+
+    Enforces experiment scoping so the id-based GET cannot leak rows from a different experiment in the same team.
+    Team scoping is already implicit via the viewset's team filter on ``experiment``. Returns None for a malformed
+    UUID rather than raising, so the calling view can answer with a clean 404.
+    """
+    try:
+        uuid_value = UUID(recalculation_id)
+    except (ValueError, TypeError):
+        return None
+    return ExperimentMetricsRecalculation.objects.filter(
+        team=experiment.team, experiment=experiment, id=uuid_value
+    ).first()
 
 
 def _recalc_fingerprints_for_run(experiment: Experiment, recalc: ExperimentMetricsRecalculation) -> dict[str, str]:

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -12,6 +12,7 @@ Module-level free functions (not methods on ExperimentService) so the API view c
 from datetime import timedelta
 from uuid import UUID
 
+from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 
@@ -28,7 +29,7 @@ from products.experiments.backend.models.experiment import (
     ExperimentMetricsRecalculation,
 )
 from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
-from products.experiments.backend.temporal.recalculation_logic import _find_metric_dict
+from products.experiments.backend.temporal.recalculation_logic import find_metric_dict
 
 # How long an active (PENDING/IN_PROGRESS) row blocks new recalculations. Beyond this, the row is treated as
 # stale and a fresh recalc is allowed. Sized to be safely above the workflow's worst-case end-to-end runtime
@@ -48,6 +49,11 @@ def _derive_counters(recalc: ExperimentMetricsRecalculation, results: list[dict]
 
     Accepts an optional pre-computed `results` list to avoid recomputing fingerprints on the GET path where
     the same list is also surfaced to the client.
+
+    Inherits the fingerprint-divergence hazard from `get_run_results`: `completed_metrics` can silently drop
+    if experiment fields that feed the fingerprint (start_date, exposure_criteria, stats method,
+    only_count_matured_users) change between the workflow's writes and this read. `failed_metrics` is partly
+    immune because discovery-step failures come from `metric_errors` (stored on the row), not from result rows.
     """
     rows = results if results is not None else get_run_results(recalc)
     completed = sum(1 for r in rows if r["status"] == ExperimentMetricResult.Status.COMPLETED)
@@ -98,7 +104,14 @@ def request_recalculation(experiment: Experiment, user: User, trigger: str = "ma
     if not experiment.is_launched:
         raise ValidationError("Cannot recalculate metrics for experiment that hasn't started")
 
-    with team_scope(experiment.team_id, canonical=True):
+    with team_scope(experiment.team_id, canonical=True), transaction.atomic():
+        # Serialize concurrent POSTs for this experiment by locking the Experiment row up front. Without this,
+        # two simultaneous POSTs (double-click, retry storm, two tabs) both see no active recalc row and both
+        # reach .create(); the second hits the unique_active_metrics_recalculation_per_experiment constraint
+        # and returns HTTP 500. Locking the Experiment row queues the second POST behind the first, which
+        # then sees the freshly-created row in its lookup and returns is_existing=True cleanly.
+        Experiment.objects.select_for_update().filter(id=experiment.id).first()
+
         # Activity-aware staleness: PENDING rows anchor on created_at (workflow never reached its start
         # activity); IN_PROGRESS rows anchor on started_at (workflow began executing then stalled). A row past
         # the threshold is treated as dead and skipped, so a fresh recalc can start. Without this, a PENDING
@@ -176,11 +189,17 @@ def _recalc_fingerprints_for_run(experiment: Experiment, recalc: ExperimentMetri
 
     Returns ``{metric_uuid: recalc_fp}`` for metrics still resolvable on the experiment. A uuid present on the job
     but no longer on the experiment is skipped (metric removed mid-run).
+
+    Divergence hazard: the fingerprint is derived from mutable experiment fields (start_date, exposure_criteria,
+    stats method, only_count_matured_users). If any of these change between the workflow's writes and a later
+    read, the recomputed fingerprints will not match the on-disk ones and the corresponding result rows become
+    unreachable (until the experiment fields revert). This is the explicit trade-off of "no FK on
+    ExperimentMetricResult" — the snapshot lives in the fingerprint, not in a stored column.
     """
     stats_method = get_experiment_stats_method(experiment)
     fingerprints: dict[str, str] = {}
     for metric_uuid in recalc.metric_uuids or []:
-        metric_dict = _find_metric_dict(experiment, metric_uuid)
+        metric_dict = find_metric_dict(experiment, metric_uuid)
         if metric_dict is None:
             continue
         config_fp = compute_metric_fingerprint(
@@ -199,6 +218,10 @@ def get_run_results(recalc: ExperimentMetricsRecalculation) -> list[dict]:
 
     Scopes by recomputing each metric's recalc fingerprint and filtering ``fingerprint__in`` — never returns
     rows from a previous run or from the timeseries workflow (which uses config fingerprints).
+
+    See `_recalc_fingerprints_for_run` for the fingerprint-divergence hazard: if experiment fields that feed
+    the fingerprint change after the run wrote its rows, this can return [] for what is on-disk a successful
+    run. Symptom: "results disappeared after editing exposure_criteria / start_date / stats config."
     """
     fingerprints = _recalc_fingerprints_for_run(recalc.experiment, recalc)
     if not fingerprints:

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -29,7 +29,7 @@ from products.experiments.backend.models.experiment import (
     ExperimentMetricsRecalculation,
 )
 from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
-from products.experiments.backend.temporal.recalculation_logic import find_metric_dict
+from products.experiments.backend.temporal.recalculation_logic import discover_experiment_metrics, find_metric_dict
 
 # How long an active (PENDING/IN_PROGRESS) row blocks new recalculations. Beyond this, the row is treated as
 # stale and a fresh recalc is allowed. Sized to be safely above the workflow's worst-case end-to-end runtime
@@ -140,12 +140,17 @@ def request_recalculation(experiment: Experiment, user: User, trigger: str = "ma
             ],
         ).update(status=ExperimentMetricsRecalculation.Status.FAILED, completed_at=timezone.now())
 
+        # Set total_metrics up front from the experiment definition so the client can show progress
+        # ("N of M") immediately, before the workflow's discovery activity confirms the same count.
+        metrics = discover_experiment_metrics(experiment)
         recalc = ExperimentMetricsRecalculation.objects.create(
             team=experiment.team,
             experiment=experiment,
             trigger=trigger,
             status=ExperimentMetricsRecalculation.Status.PENDING,
             created_by=user,
+            total_metrics=len(metrics),
+            metric_uuids=[m.metric_uuid for m in metrics],
         )
         return build_job_payload(recalc, is_existing=False)
 

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -18,11 +18,11 @@ from django.utils import timezone
 
 from rest_framework.exceptions import ValidationError
 
-from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
-from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
 from posthog.models.scoping import team_scope
 from posthog.models.user import User
 
+from products.experiments.backend.hogql_queries.experiment_metric_fingerprint import compute_metric_fingerprint
+from products.experiments.backend.hogql_queries.utils import get_experiment_stats_method
 from products.experiments.backend.models.experiment import (
     Experiment,
     ExperimentMetricResult,

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -28,8 +28,9 @@ from products.experiments.backend.models.experiment import (
     ExperimentMetricResult,
     ExperimentMetricsRecalculation,
 )
+from products.experiments.backend.result_serialization import strip_step_sessions
 from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
-from products.experiments.backend.temporal.recalculation_logic import discover_experiment_metrics, find_metric_dict
+from products.experiments.backend.temporal.recalculation_logic import discover_metrics_for_experiment, find_metric_dict
 
 # How long an active (PENDING/IN_PROGRESS) row blocks new recalculations. Beyond this, the row is treated as
 # stale and a fresh recalc is allowed. Sized to be safely above the workflow's worst-case end-to-end runtime
@@ -142,7 +143,7 @@ def request_recalculation(experiment: Experiment, user: User, trigger: str = "ma
 
         # Set total_metrics up front from the experiment definition so the client can show progress
         # ("N of M") immediately, before the workflow's discovery activity confirms the same count.
-        metrics = discover_experiment_metrics(experiment)
+        metrics = discover_metrics_for_experiment(experiment)
         recalc = ExperimentMetricsRecalculation.objects.create(
             team=experiment.team,
             experiment=experiment,
@@ -239,7 +240,7 @@ def get_run_results(recalc: ExperimentMetricsRecalculation) -> list[dict]:
         {
             "metric_uuid": row.metric_uuid,
             "status": row.status,
-            "result": row.result,
+            "result": strip_step_sessions(row.result),
             "error_message": row.error_message,
         }
         for row in rows

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -9,7 +9,11 @@ Module-level free functions (not methods on ExperimentService) so the API view c
   the run id).
 """
 
+from datetime import timedelta
 from uuid import UUID
+
+from django.db.models import Q
+from django.utils import timezone
 
 from rest_framework.exceptions import ValidationError
 
@@ -25,6 +29,14 @@ from products.experiments.backend.models.experiment import (
 )
 from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
 from products.experiments.backend.temporal.recalculation_logic import _find_metric_dict
+
+# How long an active (PENDING/IN_PROGRESS) row blocks new recalculations. Beyond this, the row is treated as
+# stale and a fresh recalc is allowed. Sized to be safely above the workflow's worst-case end-to-end runtime
+# (discovery retries + per-metric calc retries + progress activities) so a legitimately-slow run can finish
+# without being clobbered, but tight enough that an operator can recover within an hour if the workflow
+# never started (Temporal connect failure, transient infra issue, etc.). See the rollback in views.py for the
+# happy-path failure handling; this TTL is the defense-in-depth backstop if that rollback itself fails.
+_STALE_RECALC_THRESHOLD = timedelta(minutes=30)
 
 
 def _derive_counters(recalc: ExperimentMetricsRecalculation, results: list[dict] | None = None) -> tuple[int, int]:
@@ -87,15 +99,33 @@ def request_recalculation(experiment: Experiment, user: User, trigger: str = "ma
         raise ValidationError("Cannot recalculate metrics for experiment that hasn't started")
 
     with team_scope(experiment.team_id, canonical=True):
-        existing = ExperimentMetricsRecalculation.objects.filter(
+        # Activity-aware staleness: PENDING rows anchor on created_at (workflow never reached its start
+        # activity); IN_PROGRESS rows anchor on started_at (workflow began executing then stalled). A row past
+        # the threshold is treated as dead and skipped, so a fresh recalc can start. Without this, a PENDING
+        # row left orphaned by a Temporal-connect failure that also lost its rollback UPDATE would permanently
+        # lock the experiment out of recalculations.
+        threshold = timezone.now() - _STALE_RECALC_THRESHOLD
+        existing = (
+            ExperimentMetricsRecalculation.objects.filter(experiment=experiment)
+            .filter(
+                Q(status=ExperimentMetricsRecalculation.Status.PENDING, created_at__gte=threshold)
+                | Q(status=ExperimentMetricsRecalculation.Status.IN_PROGRESS, started_at__gte=threshold)
+            )
+            .first()
+        )
+        if existing:
+            return build_job_payload(existing, is_existing=True)
+
+        # No fresh active row, but stale tombstones might still hold the per-experiment uniqueness constraint
+        # (unique_active_metrics_recalculation_per_experiment). Mark them FAILED so the constraint releases
+        # and the new row can land. Status reflects reality — these workflows are not coming back.
+        ExperimentMetricsRecalculation.objects.filter(
             experiment=experiment,
             status__in=[
                 ExperimentMetricsRecalculation.Status.PENDING,
                 ExperimentMetricsRecalculation.Status.IN_PROGRESS,
             ],
-        ).first()
-        if existing:
-            return build_job_payload(existing, is_existing=True)
+        ).update(status=ExperimentMetricsRecalculation.Status.FAILED, completed_at=timezone.now())
 
         recalc = ExperimentMetricsRecalculation.objects.create(
             team=experiment.team,

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -15,6 +15,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
+from posthog.models.scoping import team_scope
 from posthog.models.user import User
 
 from products.experiments.backend.models.experiment import (
@@ -26,23 +27,53 @@ from products.experiments.backend.temporal.recalc_fingerprint import compute_rec
 from products.experiments.backend.temporal.recalculation_logic import _find_metric_dict
 
 
-def _serialize_job(recalc: ExperimentMetricsRecalculation, *, is_existing: bool) -> dict:
-    return {
+def _derive_counters(recalc: ExperimentMetricsRecalculation, results: list[dict] | None = None) -> tuple[int, int]:
+    """Counters are not stored on the row (PR1 contract): they're derived on read from result rows + errors.
+
+    `completed_metrics` = ExperimentMetricResult rows with status=COMPLETED for this run's fingerprints.
+    `failed_metrics`    = ExperimentMetricResult rows with status=FAILED + metric_errors keys that never made
+                          it to a result row (discovery-step failures).
+
+    Accepts an optional pre-computed `results` list to avoid recomputing fingerprints on the GET path where
+    the same list is also surfaced to the client.
+    """
+    rows = results if results is not None else get_run_results(recalc)
+    completed = sum(1 for r in rows if r["status"] == ExperimentMetricResult.Status.COMPLETED)
+    failed_in_rows = sum(1 for r in rows if r["status"] == ExperimentMetricResult.Status.FAILED)
+    uuids_with_row = {r["metric_uuid"] for r in rows}
+    discovery_only_failures = sum(1 for uuid in (recalc.metric_errors or {}) if uuid not in uuids_with_row)
+    return completed, failed_in_rows + discovery_only_failures
+
+
+def build_job_payload(
+    recalc: ExperimentMetricsRecalculation,
+    *,
+    is_existing: bool | None = None,
+    results: list[dict] | None = None,
+) -> dict:
+    """Shape a recalc row + derived counters as a dict the serializer can re-serialize.
+
+    Returns model-native values (datetimes, ints, dicts) — DRF handles the wire format. The POST path passes
+    `is_existing` to signal whether the workflow needs starting; the GET paths pass `results` so the same row
+    list backs both the derived counters and the response's `results` field (no duplicate fingerprint work).
+    """
+    completed_metrics, failed_metrics = _derive_counters(recalc, results=results)
+    payload: dict = {
         "id": str(recalc.id),
         "experiment_id": recalc.experiment_id,
         "status": recalc.status,
         "total_metrics": recalc.total_metrics,
-        "completed_metrics": recalc.completed_metrics,
-        "failed_metrics": recalc.failed_metrics,
-        # Output key is metric_errors (serializer field renamed to avoid shadowing Serializer.errors); the model
-        # attribute is still recalc.errors.
-        "metric_errors": recalc.errors,
+        "completed_metrics": completed_metrics,
+        "failed_metrics": failed_metrics,
+        "metric_errors": recalc.metric_errors,
         "trigger": recalc.trigger,
-        "created_at": recalc.created_at.isoformat(),
-        "started_at": recalc.started_at.isoformat() if recalc.started_at else None,
-        "completed_at": recalc.completed_at.isoformat() if recalc.completed_at else None,
-        "is_existing": is_existing,
+        "created_at": recalc.created_at,
+        "started_at": recalc.started_at,
+        "completed_at": recalc.completed_at,
     }
+    if is_existing is not None:
+        payload["is_existing"] = is_existing
+    return payload
 
 
 def request_recalculation(experiment: Experiment, user: User, trigger: str = "manual") -> dict:
@@ -55,24 +86,25 @@ def request_recalculation(experiment: Experiment, user: User, trigger: str = "ma
     if not experiment.is_launched:
         raise ValidationError("Cannot recalculate metrics for experiment that hasn't started")
 
-    existing = ExperimentMetricsRecalculation.objects.filter(
-        experiment=experiment,
-        status__in=[
-            ExperimentMetricsRecalculation.Status.PENDING,
-            ExperimentMetricsRecalculation.Status.IN_PROGRESS,
-        ],
-    ).first()
-    if existing:
-        return _serialize_job(existing, is_existing=True)
+    with team_scope(experiment.team_id, canonical=True):
+        existing = ExperimentMetricsRecalculation.objects.filter(
+            experiment=experiment,
+            status__in=[
+                ExperimentMetricsRecalculation.Status.PENDING,
+                ExperimentMetricsRecalculation.Status.IN_PROGRESS,
+            ],
+        ).first()
+        if existing:
+            return build_job_payload(existing, is_existing=True)
 
-    recalc = ExperimentMetricsRecalculation.objects.create(
-        team=experiment.team,
-        experiment=experiment,
-        trigger=trigger,
-        status=ExperimentMetricsRecalculation.Status.PENDING,
-        created_by=user,
-    )
-    return _serialize_job(recalc, is_existing=False)
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=experiment.team,
+            experiment=experiment,
+            trigger=trigger,
+            status=ExperimentMetricsRecalculation.Status.PENDING,
+            created_by=user,
+        )
+        return build_job_payload(recalc, is_existing=False)
 
 
 def get_latest_recalculation(experiment: Experiment) -> ExperimentMetricsRecalculation | None:
@@ -81,31 +113,32 @@ def get_latest_recalculation(experiment: Experiment) -> ExperimentMetricsRecalcu
     Powers ``GET /metrics_recalculation/latest``: the frontend renders cached results from the last good run.
     Runs that are pending/in_progress/failed are NOT returned — the client tracks those separately by id.
     """
-    return (
-        ExperimentMetricsRecalculation.objects.filter(
-            team=experiment.team,
-            experiment=experiment,
-            status=ExperimentMetricsRecalculation.Status.COMPLETED,
+    with team_scope(experiment.team_id, canonical=True):
+        return (
+            ExperimentMetricsRecalculation.objects.filter(
+                team=experiment.team,
+                experiment=experiment,
+                status=ExperimentMetricsRecalculation.Status.COMPLETED,
+            )
+            .order_by("-created_at")
+            .first()
         )
-        .order_by("-created_at")
-        .first()
-    )
 
 
 def get_recalculation_by_id(experiment: Experiment, recalculation_id: str) -> ExperimentMetricsRecalculation | None:
     """Return the recalculation row for ``recalculation_id`` if it belongs to ``experiment``, else None.
 
     Enforces experiment scoping so the id-based GET cannot leak rows from a different experiment in the same team.
-    Team scoping is already implicit via the viewset's team filter on ``experiment``. Returns None for a malformed
-    UUID rather than raising, so the calling view can answer with a clean 404.
+    Returns None for a malformed UUID rather than raising, so the calling view can answer with a clean 404.
     """
     try:
         uuid_value = UUID(recalculation_id)
     except (ValueError, TypeError):
         return None
-    return ExperimentMetricsRecalculation.objects.filter(
-        team=experiment.team, experiment=experiment, id=uuid_value
-    ).first()
+    with team_scope(experiment.team_id, canonical=True):
+        return ExperimentMetricsRecalculation.objects.filter(
+            team=experiment.team, experiment=experiment, id=uuid_value
+        ).first()
 
 
 def _recalc_fingerprints_for_run(experiment: Experiment, recalc: ExperimentMetricsRecalculation) -> dict[str, str]:

--- a/products/experiments/backend/result_serialization.py
+++ b/products/experiments/backend/result_serialization.py
@@ -1,0 +1,27 @@
+"""Shared helpers for shaping ExperimentMetricResult payloads before they leave the backend."""
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def strip_step_sessions(result: Any) -> Any:
+    """Remove the per-session funnel actors payload from a stored experiment metric result.
+
+    `step_sessions` powers the frontend's "view sessions per step" affordance off
+    a separate per-metric query, not this timeseries endpoint. Carrying it through
+    here multiplies the response by sessions × steps × variants and pushes MCP
+    consumers past their context window with no benefit.
+    """
+    if not isinstance(result, Mapping):
+        return result
+    cleaned = {k: v for k, v in result.items() if k != "step_sessions"}
+    baseline = cleaned.get("baseline")
+    if isinstance(baseline, dict):
+        cleaned["baseline"] = {k: v for k, v in baseline.items() if k != "step_sessions"}
+    variants = cleaned.get("variant_results")
+    if isinstance(variants, list):
+        cleaned["variant_results"] = [
+            {k: v for k, v in variant.items() if k != "step_sessions"} if isinstance(variant, dict) else variant
+            for variant in variants
+        ]
+    return cleaned

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -88,6 +88,44 @@ def _get_recalc_state(recalculation_id: str) -> _RecalcState:
     )
 
 
+def discover_metrics_for_experiment(experiment: Experiment) -> list[ExperimentMetricToRecalculate]:
+    """Traverse the experiment definition and return the list of metrics a recalc should process.
+
+    Pure read of the experiment object — no database writes, no scoping concerns. The activity wrapper
+    (`_discover_experiment_metrics_sync`) loads + scopes + persists `metric_uuids`; the service layer can
+    call this directly when it already has the experiment in scope (e.g., to seed `total_metrics` at create
+    time so the client can show progress without waiting for the workflow's discovery activity to run).
+
+    Named `discover_metrics_for_experiment` (not `discover_experiment_metrics`) to avoid colliding with the
+    Temporal activity of the same shape in `recalculation_activities.py`, which takes a `recalculation_id`
+    instead of an Experiment.
+    """
+    metrics_to_recalculate: list[ExperimentMetricToRecalculate] = []
+
+    def _add(metric_uuid: str | None, metric_type: str) -> None:
+        if metric_uuid:
+            metrics_to_recalculate.append(
+                ExperimentMetricToRecalculate(
+                    experiment_id=experiment.id, metric_uuid=metric_uuid, metric_type=metric_type
+                )
+            )
+
+    # Inline metrics carry their uuid directly on the dict; the metric_type is the source list.
+    for source, metric_type in [(experiment.metrics, "primary"), (experiment.metrics_secondary, "secondary")]:
+        for metric in source or []:
+            _add(metric.get("uuid"), metric_type)
+
+    # Saved (shared) metrics live in the M2M through-model: uuid is on saved_metric.query["uuid"], and
+    # primary/secondary is recorded on the link's metadata["type"] (default "primary").
+    for link in experiment.experimenttosavedmetric_set.select_related("saved_metric").all():
+        saved_query = link.saved_metric.query
+        metric_uuid = saved_query.get("uuid") if saved_query else None
+        metric_type = link.metadata.get("type", "primary") if link.metadata else "primary"
+        _add(metric_uuid, metric_type)
+
+    return metrics_to_recalculate
+
+
 @database_sync_to_async
 def _discover_experiment_metrics_sync(recalculation_id: str) -> list[ExperimentMetricToRecalculate]:
     close_old_connections()
@@ -97,28 +135,7 @@ def _discover_experiment_metrics_sync(recalculation_id: str) -> list[ExperimentM
         recalculation = ExperimentMetricsRecalculation.objects.select_related("experiment").get(id=recalculation_id)
         experiment = recalculation.experiment
 
-        metrics_to_recalculate: list[ExperimentMetricToRecalculate] = []
-
-        def _add(metric_uuid: str | None, metric_type: str) -> None:
-            if metric_uuid:
-                metrics_to_recalculate.append(
-                    ExperimentMetricToRecalculate(
-                        experiment_id=experiment.id, metric_uuid=metric_uuid, metric_type=metric_type
-                    )
-                )
-
-        # Inline metrics carry their uuid directly on the dict; the metric_type is the source list.
-        for source, metric_type in [(experiment.metrics, "primary"), (experiment.metrics_secondary, "secondary")]:
-            for metric in source or []:
-                _add(metric.get("uuid"), metric_type)
-
-        # Saved (shared) metrics live in the M2M through-model: uuid is on saved_metric.query["uuid"], and
-        # primary/secondary is recorded on the link's metadata["type"] (default "primary").
-        for link in experiment.experimenttosavedmetric_set.select_related("saved_metric").all():
-            saved_query = link.saved_metric.query
-            metric_uuid = saved_query.get("uuid") if saved_query else None
-            metric_type = link.metadata.get("type", "primary") if link.metadata else "primary"
-            _add(metric_uuid, metric_type)
+        metrics_to_recalculate = discover_metrics_for_experiment(experiment)
 
         recalculation.metric_uuids = [m.metric_uuid for m in metrics_to_recalculate]
         recalculation.save(update_fields=["metric_uuids"])

--- a/products/experiments/backend/test/conftest.py
+++ b/products/experiments/backend/test/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+from posthog.models.scoping import team_scope
+
+
+@pytest.fixture(autouse=True)
+def _enter_team_scope(request):
+    """Open team_scope around every test that exposes self.team (BaseTest / APIBaseTest subclasses).
+
+    Tests without self.team get a no-op fixture; they don't hit the fail-closed ORM manager on
+    ExperimentMetricsRecalculation. (The django_db marker check that the temporal-package conftest uses
+    doesn't apply here — APIBaseTest is unittest-style via DRFTestCase, not a pytest-marked function.)
+    """
+    instance = getattr(request.node, "instance", None)
+    team = getattr(instance, "team", None) if instance is not None else None
+    if team is None:
+        yield
+        return
+    with team_scope(team.id, canonical=True):
+        yield

--- a/products/experiments/backend/test/test_metrics_recalculation_api.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_api.py
@@ -6,9 +6,8 @@ from unittest import mock
 from parameterized import parameterized
 from rest_framework import status
 
-from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
-from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
-
+from products.experiments.backend.hogql_queries.experiment_metric_fingerprint import compute_metric_fingerprint
+from products.experiments.backend.hogql_queries.utils import get_experiment_stats_method
 from products.experiments.backend.models.experiment import (
     Experiment,
     ExperimentMetricResult,

--- a/products/experiments/backend/test/test_metrics_recalculation_api.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_api.py
@@ -134,6 +134,10 @@ class TestMetricsRecalculationAPI(APIBaseTest):
             status="completed",
             query_to=datetime(2026, 6, 1, tzinfo=UTC),
         )
+        # Narrow nullable fields populated above. _launched_experiment always sets metrics + start_date,
+        # and we just set query_to on the recalc above.
+        assert exp.metrics and exp.start_date is not None
+        assert recalc.query_to is not None
         config_fp = compute_metric_fingerprint(
             exp.metrics[0],
             exp.start_date,

--- a/products/experiments/backend/test/test_metrics_recalculation_api.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_api.py
@@ -1,0 +1,194 @@
+from datetime import UTC, datetime
+
+from posthog.test.base import APIBaseTest
+from unittest import mock
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
+from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
+
+from products.experiments.backend.models.experiment import (
+    Experiment,
+    ExperimentMetricResult,
+    ExperimentMetricsRecalculation,
+)
+from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
+from products.feature_flags.backend.models.feature_flag import FeatureFlag
+
+
+def _mean_metric(uuid: str) -> dict:
+    return {
+        "uuid": uuid,
+        "kind": "ExperimentMetric",
+        "metric_type": "mean",
+        "source": {"kind": "EventsNode", "event": "purchase"},
+    }
+
+
+class TestMetricsRecalculationAPI(APIBaseTest):
+    def _flag(self, key: str) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key=key,
+            name=f"Flag for {key}",
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "name": "Control", "rollout_percentage": 50},
+                        {"key": "test", "name": "Test", "rollout_percentage": 50},
+                    ]
+                },
+            },
+        )
+
+    def _launched_experiment(self, flag_key: str = "api-flag") -> Experiment:
+        exp = Experiment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            feature_flag=self._flag(flag_key),
+            name="exp",
+            start_date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        exp.metrics = [_mean_metric("m1")]
+        exp.save()
+        return exp
+
+    def _post_url(self, exp_id: int) -> str:
+        return f"/api/projects/{self.team.id}/experiments/{exp_id}/metrics_recalculation/"
+
+    def _latest_url(self, exp_id: int) -> str:
+        return f"/api/projects/{self.team.id}/experiments/{exp_id}/metrics_recalculation/latest/"
+
+    def _by_id_url(self, exp_id: int, recalc_id: str) -> str:
+        return f"/api/projects/{self.team.id}/experiments/{exp_id}/metrics_recalculation/{recalc_id}/"
+
+    # ------------------------------------------------------------------
+    # POST /metrics_recalculation/
+    # ------------------------------------------------------------------
+
+    @mock.patch("products.experiments.backend.presentation.views.sync_connect")
+    @mock.patch("products.experiments.backend.presentation.views.asyncio.run")
+    def test_post_creates_and_starts_workflow(self, mock_run, mock_connect):
+        exp = self._launched_experiment()
+        resp = self.client.post(self._post_url(exp.id), {"trigger": "manual"}, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED, resp.content
+        body = resp.json()
+        assert body["status"] == "pending"
+        assert body["trigger"] == "manual"
+        assert ExperimentMetricsRecalculation.objects.filter(experiment=exp).count() == 1
+        assert mock_run.called
+
+    @mock.patch("products.experiments.backend.presentation.views.sync_connect")
+    @mock.patch("products.experiments.backend.presentation.views.asyncio.run")
+    def test_post_is_idempotent_returns_200(self, mock_run, mock_connect):
+        exp = self._launched_experiment()
+        first = self.client.post(self._post_url(exp.id), {"trigger": "manual"}, format="json")
+        assert first.status_code == status.HTTP_201_CREATED
+        second = self.client.post(self._post_url(exp.id), {"trigger": "manual"}, format="json")
+        assert second.status_code == status.HTTP_200_OK
+        assert second.json()["id"] == first.json()["id"]
+        assert ExperimentMetricsRecalculation.objects.filter(experiment=exp).count() == 1
+
+    @mock.patch("products.experiments.backend.presentation.views.sync_connect")
+    @mock.patch("products.experiments.backend.presentation.views.asyncio.run")
+    def test_post_rejects_unlaunched_experiment(self, mock_run, mock_connect):
+        exp = Experiment.objects.create(
+            team=self.team, created_by=self.user, feature_flag=self._flag("unlaunched"), name="draft"
+        )
+        resp = self.client.post(self._post_url(exp.id), {"trigger": "manual"}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    @mock.patch(
+        "products.experiments.backend.presentation.views.sync_connect", side_effect=RuntimeError("temporal down")
+    )
+    @mock.patch("products.experiments.backend.presentation.views.asyncio.run")
+    def test_post_marks_failed_when_workflow_start_errors(self, mock_run, mock_connect):
+        # When the workflow start fails, the view marks the freshly-created row FAILED then re-raises.
+        # The DRF test client converts the exception into a 500 response rather than propagating it.
+        exp = self._launched_experiment()
+        resp = self.client.post(self._post_url(exp.id), {"trigger": "manual"}, format="json")
+        assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        row = ExperimentMetricsRecalculation.objects.get(experiment=exp)
+        assert row.status == ExperimentMetricsRecalculation.Status.FAILED
+
+    # ------------------------------------------------------------------
+    # GET /metrics_recalculation/latest/
+    # ------------------------------------------------------------------
+
+    def test_get_latest_404_when_no_completed_run(self):
+        exp = self._launched_experiment()
+        ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="pending")
+        resp = self.client.get(self._latest_url(exp.id))
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_get_latest_returns_most_recent_completed_with_results(self):
+        exp = self._launched_experiment()
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=self.team,
+            experiment=exp,
+            metric_uuids=["m1"],
+            status="completed",
+            query_to=datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        config_fp = compute_metric_fingerprint(
+            exp.metrics[0],
+            exp.start_date,
+            get_experiment_stats_method(exp),
+            exp.exposure_criteria,
+            only_count_matured_users=exp.only_count_matured_users,
+        )
+        recalc_fp = compute_recalc_fingerprint(config_fp, str(recalc.id))
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid="m1",
+            fingerprint=recalc_fp,
+            query_from=exp.start_date,
+            query_to=recalc.query_to,
+            status="completed",
+            result={"ok": True},
+        )
+
+        resp = self.client.get(self._latest_url(exp.id))
+        assert resp.status_code == status.HTTP_200_OK, resp.content
+        body = resp.json()
+        assert body["id"] == str(recalc.id)
+        assert body["status"] == "completed"
+        assert len(body["results"]) == 1
+        assert body["results"][0]["metric_uuid"] == "m1"
+        assert body["results"][0]["result"] == {"ok": True}
+
+    # ------------------------------------------------------------------
+    # GET /metrics_recalculation/{id}/
+    # ------------------------------------------------------------------
+
+    @parameterized.expand(
+        [
+            ("pending", "pending"),
+            ("in_progress", "in_progress"),
+            ("completed", "completed"),
+            ("failed", "failed"),
+        ]
+    )
+    def test_get_by_id_returns_run_of_any_status(self, name: str, run_status: str):
+        exp = self._launched_experiment(flag_key=f"by-id-{name}")
+        row = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status=run_status)
+        resp = self.client.get(self._by_id_url(exp.id, str(row.id)))
+        assert resp.status_code == status.HTTP_200_OK, resp.content
+        assert resp.json()["status"] == run_status
+        assert resp.json()["id"] == str(row.id)
+
+    def test_get_by_id_404_for_unknown_id(self):
+        exp = self._launched_experiment()
+        resp = self.client.get(self._by_id_url(exp.id, "00000000-0000-0000-0000-000000000001"))
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_get_by_id_404_for_other_experiment_id(self):
+        exp = self._launched_experiment(flag_key="by-id-mine")
+        other = self._launched_experiment(flag_key="by-id-other")
+        row = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=other, status="completed")
+        resp = self.client.get(self._by_id_url(exp.id, str(row.id)))
+        assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/products/experiments/backend/test/test_metrics_recalculation_serializer.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_serializer.py
@@ -5,7 +5,11 @@ from parameterized import parameterized
 from posthog.models.scoping import team_scope
 
 from products.experiments.backend.models.experiment import Experiment, ExperimentMetricsRecalculation
-from products.experiments.backend.presentation.serializers import ExperimentMetricsRecalculationSerializer
+from products.experiments.backend.presentation.serializers import (
+    ExperimentMetricsRecalculationSerializer,
+    MetricRecalculationResultSerializer,
+    RecalculateMetricsRequestSerializer,
+)
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 
@@ -74,3 +78,53 @@ class TestExperimentMetricsRecalculationSerializer(BaseTest):
         # can't silently start emitting is_existing on payloads that never asked for it.
         data = ExperimentMetricsRecalculationSerializer({}).data
         assert "is_existing" not in data
+
+
+class TestRecalculateMetricsRequestSerializer(BaseTest):
+    def test_defaults_trigger_to_manual_when_omitted(self):
+        s = RecalculateMetricsRequestSerializer(data={})
+        assert s.is_valid(), s.errors
+        assert s.validated_data["trigger"] == "manual"
+
+    @parameterized.expand(
+        [
+            ("manual",),
+            ("experiment_launch",),
+            ("experiment_stop",),
+            ("experiment_update",),
+        ]
+    )
+    def test_accepts_valid_trigger(self, trigger: str):
+        s = RecalculateMetricsRequestSerializer(data={"trigger": trigger})
+        assert s.is_valid(), s.errors
+        assert s.validated_data["trigger"] == trigger
+
+    def test_rejects_unknown_trigger(self):
+        s = RecalculateMetricsRequestSerializer(data={"trigger": "nonsense"})
+        assert not s.is_valid()
+        assert "trigger" in s.errors
+
+
+class TestMetricRecalculationResultSerializer(BaseTest):
+    @parameterized.expand(
+        [
+            (
+                "completed",
+                {"metric_uuid": "m1", "status": "completed", "result": {"variants": []}, "error_message": None},
+            ),
+            (
+                "failed",
+                {"metric_uuid": "m2", "status": "failed", "result": None, "error_message": "boom"},
+            ),
+            (
+                "pending",
+                {"metric_uuid": "m3", "status": "pending", "result": None, "error_message": None},
+            ),
+        ]
+    )
+    def test_serializes_result_row(self, name: str, payload: dict):
+        data = MetricRecalculationResultSerializer(payload).data
+        assert data["metric_uuid"] == payload["metric_uuid"]
+        assert data["status"] == payload["status"]
+        assert data["result"] == payload["result"]
+        assert data["error_message"] == payload["error_message"]

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -196,6 +196,10 @@ class TestRecalculationService(BaseTest):
             status="completed",
             query_to=timezone.now(),
         )
+        # Narrow nullable fields populated above. _launched_experiment always sets metrics + start_date,
+        # and we just set query_to on the recalc above.
+        assert exp.metrics and exp.start_date is not None
+        assert recalc.query_to is not None
         config_fp = compute_metric_fingerprint(
             exp.metrics[0],
             exp.start_date,

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -8,9 +8,8 @@ from django.utils import timezone
 from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
-from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
-from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
-
+from products.experiments.backend.hogql_queries.experiment_metric_fingerprint import compute_metric_fingerprint
+from products.experiments.backend.hogql_queries.utils import get_experiment_stats_method
 from products.experiments.backend.models.experiment import (
     Experiment,
     ExperimentMetricResult,

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from posthog.test.base import BaseTest
@@ -81,6 +81,43 @@ class TestRecalculationService(BaseTest):
         assert second["id"] == first["id"]
         # Only one job row was created across both calls.
         assert ExperimentMetricsRecalculation.objects.filter(experiment=exp).count() == 1
+
+    @parameterized.expand(
+        [
+            # (name, status, stale_field) — both lifecycle anchors must release the experiment when their
+            # respective timestamp is past the staleness threshold. Without this, a Temporal-connect failure
+            # that also lost its rollback UPDATE permanently locks the experiment out of recalculations.
+            ("pending_stale_by_created_at", "pending", "created_at"),
+            ("in_progress_stale_by_started_at", "in_progress", "started_at"),
+        ]
+    )
+    def test_request_recalculation_recovers_from_stale_active_row(self, name: str, status: str, stale_field: str):
+        exp = self._launched_experiment(flag_key=f"stale-{name}")
+        long_ago = timezone.now() - timedelta(hours=2)
+        stale_kwargs: dict = {"team": self.team, "experiment": exp, "status": status}
+        if stale_field == "created_at":
+            # created_at uses auto_now_add so we have to update after create.
+            stale_row = ExperimentMetricsRecalculation.objects.create(**stale_kwargs)
+            ExperimentMetricsRecalculation.objects.filter(id=stale_row.id).update(created_at=long_ago)
+        else:
+            stale_row = ExperimentMetricsRecalculation.objects.create(**stale_kwargs, started_at=long_ago)
+
+        result = request_recalculation(exp, self.user, "manual")
+
+        # A fresh row was created (NOT the stale one) and the stale row was marked FAILED.
+        assert result["is_existing"] is False
+        assert result["id"] != str(stale_row.id)
+        stale_row.refresh_from_db()
+        assert stale_row.status == "failed"
+
+    def test_request_recalculation_does_not_recover_recent_active_row(self):
+        # Defensive: a row created N minutes ago (well under the threshold) must still block, no matter the
+        # status. This pins the threshold is doing real work and we aren't accidentally short-circuiting it.
+        exp = self._launched_experiment(flag_key="recent-pending")
+        recent_row = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="pending")
+        result = request_recalculation(exp, self.user, "manual")
+        assert result["is_existing"] is True
+        assert result["id"] == str(recent_row.id)
 
     def test_request_recalculation_rejects_unlaunched(self):
         exp = Experiment.objects.create(

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -236,6 +236,62 @@ class TestRecalculationService(BaseTest):
         assert results[0]["result"] == {"ok": True}
         assert results[0]["error_message"] is None
 
+    def test_get_run_results_strips_step_sessions(self):
+        # step_sessions carries per-step person IDs, session IDs, and event UUIDs. It powers the frontend's
+        # "view sessions per step" affordance off a separate per-metric query, so it does not belong in the
+        # recalc results payload. Mirrors the same stripping the timeseries-results path applies.
+        exp = self._launched_experiment()
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=self.team,
+            experiment=exp,
+            metric_uuids=["m1"],
+            status="completed",
+            query_to=timezone.now(),
+        )
+        assert exp.metrics and exp.start_date is not None
+        assert recalc.query_to is not None
+        config_fp = compute_metric_fingerprint(
+            exp.metrics[0],
+            exp.start_date,
+            get_experiment_stats_method(exp),
+            exp.exposure_criteria,
+            only_count_matured_users=exp.only_count_matured_users,
+        )
+        recalc_fp = compute_recalc_fingerprint(config_fp, str(recalc.id))
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid="m1",
+            fingerprint=recalc_fp,
+            query_from=exp.start_date,
+            query_to=recalc.query_to,
+            status="completed",
+            result={
+                "step_sessions": [["top-level-leak"]],
+                "baseline": {
+                    "step_sessions": [["baseline-leak"]],
+                    "count": 42,
+                },
+                "variant_results": [
+                    {
+                        "key": "test",
+                        "step_sessions": [["variant-leak"]],
+                        "count": 7,
+                    },
+                ],
+            },
+        )
+
+        results = get_run_results(recalc)
+
+        assert len(results) == 1
+        result = results[0]["result"]
+        assert "step_sessions" not in result
+        assert "step_sessions" not in result["baseline"]
+        assert result["baseline"]["count"] == 42
+        assert "step_sessions" not in result["variant_results"][0]
+        assert result["variant_results"][0]["count"] == 7
+        assert result["variant_results"][0]["key"] == "test"
+
     def test_get_run_results_returns_empty_when_no_rows_yet(self):
         exp = self._launched_experiment()
         recalc = ExperimentMetricsRecalculation.objects.create(

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -16,7 +16,12 @@ from products.experiments.backend.models.experiment import (
     ExperimentMetricResult,
     ExperimentMetricsRecalculation,
 )
-from products.experiments.backend.recalculation import get_latest_recalculation, get_run_results, request_recalculation
+from products.experiments.backend.recalculation import (
+    get_latest_recalculation,
+    get_recalculation_by_id,
+    get_run_results,
+    request_recalculation,
+)
 from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
@@ -99,18 +104,51 @@ class TestRecalculationService(BaseTest):
         row = ExperimentMetricsRecalculation.objects.get(id=result["id"])
         assert row.trigger == trigger
 
-    def test_get_latest_recalculation_returns_most_recent(self):
+    def test_get_latest_recalculation_returns_most_recent_completed(self):
+        # get_latest_recalculation filters to status='completed' (powers GET /metrics_recalculation/latest).
         exp = self._launched_experiment()
-        first = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="completed")
-        second = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="pending")
+        first_done = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="completed")
+        ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="failed")
+        second_done = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="completed")
+        # A pending run created AFTER the latest completed one must NOT be returned.
+        ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="pending")
         latest = get_latest_recalculation(exp)
         assert latest is not None
-        assert latest.id == second.id
-        assert latest.id != first.id
+        assert latest.id == second_done.id
+        assert latest.id != first_done.id
 
-    def test_get_latest_recalculation_none_when_no_runs(self):
-        exp = self._launched_experiment()
+    @parameterized.expand(
+        [
+            ("never_ran", []),
+            ("only_pending", ["pending"]),
+            ("only_failed", ["failed"]),
+            ("only_in_progress", ["in_progress"]),
+        ]
+    )
+    def test_get_latest_recalculation_none_when_no_completed(self, name: str, statuses: list[str]):
+        exp = self._launched_experiment(flag_key=f"latest-{name}")
+        for status in statuses:
+            ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status=status)
         assert get_latest_recalculation(exp) is None
+
+    def test_get_recalculation_by_id_returns_row(self):
+        exp = self._launched_experiment()
+        row = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="in_progress")
+        result = get_recalculation_by_id(exp, str(row.id))
+        assert result is not None
+        assert result.id == row.id
+
+    def test_get_recalculation_by_id_none_for_unknown_id(self):
+        exp = self._launched_experiment()
+        # Valid UUID format but no such row exists.
+        assert get_recalculation_by_id(exp, "00000000-0000-0000-0000-000000000001") is None
+
+    def test_get_recalculation_by_id_none_for_other_experiment(self):
+        # ID belongs to a different experiment in the same team — must NOT cross experiments.
+        exp = self._launched_experiment(flag_key="by-id-mine")
+        other = self._launched_experiment(flag_key="by-id-other")
+        row = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=other, status="completed")
+        assert get_recalculation_by_id(exp, str(row.id)) is None
 
     def test_get_run_results_scopes_by_recalc_fingerprint(self):
         exp = self._launched_experiment()

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -1,0 +1,172 @@
+from datetime import UTC, datetime
+
+import pytest
+from posthog.test.base import BaseTest
+
+from django.utils import timezone
+
+from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
+
+from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
+from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
+
+from products.experiments.backend.models.experiment import (
+    Experiment,
+    ExperimentMetricResult,
+    ExperimentMetricsRecalculation,
+)
+from products.experiments.backend.recalculation import get_latest_recalculation, get_run_results, request_recalculation
+from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
+from products.feature_flags.backend.models.feature_flag import FeatureFlag
+
+
+def _mean_metric(uuid: str) -> dict:
+    return {
+        "uuid": uuid,
+        "kind": "ExperimentMetric",
+        "metric_type": "mean",
+        "source": {"kind": "EventsNode", "event": "purchase"},
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+class TestRecalculationService(BaseTest):
+    def _flag(self, key: str) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key=key,
+            name=f"Flag for {key}",
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "name": "Control", "rollout_percentage": 50},
+                        {"key": "test", "name": "Test", "rollout_percentage": 50},
+                    ]
+                },
+            },
+        )
+
+    def _launched_experiment(self, flag_key: str = "svc-flag") -> Experiment:
+        exp = Experiment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            feature_flag=self._flag(flag_key),
+            name="exp",
+            start_date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        exp.metrics = [_mean_metric("m1")]
+        exp.save()
+        return exp
+
+    def test_request_recalculation_creates_pending(self):
+        exp = self._launched_experiment()
+        result = request_recalculation(exp, self.user, "manual")
+        assert result["status"] == "pending"
+        assert result["is_existing"] is False
+        assert ExperimentMetricsRecalculation.objects.filter(experiment=exp).count() == 1
+
+    def test_request_recalculation_is_idempotent(self):
+        exp = self._launched_experiment()
+        first = request_recalculation(exp, self.user, "manual")
+        second = request_recalculation(exp, self.user, "manual")
+        assert second["is_existing"] is True
+        assert second["id"] == first["id"]
+        # Only one job row was created across both calls.
+        assert ExperimentMetricsRecalculation.objects.filter(experiment=exp).count() == 1
+
+    def test_request_recalculation_rejects_unlaunched(self):
+        exp = Experiment.objects.create(
+            team=self.team, created_by=self.user, feature_flag=self._flag("unlaunched"), name="draft"
+        )
+        with pytest.raises(ValidationError):
+            request_recalculation(exp, self.user, "manual")
+
+    @parameterized.expand(
+        [
+            ("manual",),
+            ("experiment_launch",),
+            ("experiment_stop",),
+            ("experiment_update",),
+        ]
+    )
+    def test_request_recalculation_persists_trigger(self, trigger: str):
+        exp = self._launched_experiment(flag_key=f"trigger-{trigger}")
+        result = request_recalculation(exp, self.user, trigger)
+        assert result["trigger"] == trigger
+        row = ExperimentMetricsRecalculation.objects.get(id=result["id"])
+        assert row.trigger == trigger
+
+    def test_get_latest_recalculation_returns_most_recent(self):
+        exp = self._launched_experiment()
+        first = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="completed")
+        second = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="pending")
+        latest = get_latest_recalculation(exp)
+        assert latest is not None
+        assert latest.id == second.id
+        assert latest.id != first.id
+
+    def test_get_latest_recalculation_none_when_no_runs(self):
+        exp = self._launched_experiment()
+        assert get_latest_recalculation(exp) is None
+
+    def test_get_run_results_scopes_by_recalc_fingerprint(self):
+        exp = self._launched_experiment()
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=self.team,
+            experiment=exp,
+            metric_uuids=["m1"],
+            status="completed",
+            query_to=timezone.now(),
+        )
+        config_fp = compute_metric_fingerprint(
+            exp.metrics[0],
+            exp.start_date,
+            get_experiment_stats_method(exp),
+            exp.exposure_criteria,
+            only_count_matured_users=exp.only_count_matured_users,
+        )
+        recalc_fp = compute_recalc_fingerprint(config_fp, str(recalc.id))
+
+        # The row from THIS run (recalc-fingerprinted) — must be returned.
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid="m1",
+            fingerprint=recalc_fp,
+            query_from=exp.start_date,
+            query_to=recalc.query_to,
+            status="completed",
+            result={"ok": True},
+        )
+        # A stale row from another run / different fingerprint — must NOT be returned.
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid="m1",
+            fingerprint="some-other-fingerprint",
+            query_from=exp.start_date,
+            query_to=datetime(2026, 4, 1, tzinfo=UTC),
+            status="completed",
+            result={"stale": True},
+        )
+
+        results = get_run_results(recalc)
+        assert len(results) == 1
+        assert results[0]["metric_uuid"] == "m1"
+        assert results[0]["status"] == "completed"
+        assert results[0]["result"] == {"ok": True}
+        assert results[0]["error_message"] is None
+
+    def test_get_run_results_returns_empty_when_no_rows_yet(self):
+        exp = self._launched_experiment()
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=self.team, experiment=exp, metric_uuids=["m1"], status="in_progress"
+        )
+        assert get_run_results(recalc) == []
+
+    def test_get_run_results_returns_empty_when_no_metrics_persisted(self):
+        # Discovery hasn't yet persisted metric_uuids onto the job.
+        exp = self._launched_experiment()
+        recalc = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="pending")
+        assert get_run_results(recalc) == []

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -716,6 +716,133 @@ export interface EndExperimentApi {
     conclusion_comment?: string | null
 }
 
+/**
+ * * `manual` - manual
+ * `experiment_launch` - experiment_launch
+ * `experiment_stop` - experiment_stop
+ * `experiment_update` - experiment_update
+ */
+export type TriggerEnumApi = (typeof TriggerEnumApi)[keyof typeof TriggerEnumApi]
+
+export const TriggerEnumApi = {
+    Manual: 'manual',
+    ExperimentLaunch: 'experiment_launch',
+    ExperimentStop: 'experiment_stop',
+    ExperimentUpdate: 'experiment_update',
+} as const
+
+/**
+ * Request body for triggering a metrics recalculation.
+ */
+export interface RecalculateMetricsRequestApi {
+    /** What triggered this recalculation (manual is the default for user-initiated runs)
+
+  * `manual` - manual
+  * `experiment_launch` - experiment_launch
+  * `experiment_stop` - experiment_stop
+  * `experiment_update` - experiment_update */
+    trigger?: TriggerEnumApi
+}
+
+/**
+ * * `pending` - pending
+ * `in_progress` - in_progress
+ * `completed` - completed
+ * `failed` - failed
+ */
+export type ExperimentMetricsRecalculationStatusEnumApi =
+    (typeof ExperimentMetricsRecalculationStatusEnumApi)[keyof typeof ExperimentMetricsRecalculationStatusEnumApi]
+
+export const ExperimentMetricsRecalculationStatusEnumApi = {
+    Pending: 'pending',
+    InProgress: 'in_progress',
+    Completed: 'completed',
+    Failed: 'failed',
+} as const
+
+/**
+ * * `pending` - pending
+ * `completed` - completed
+ * `failed` - failed
+ */
+export type MetricRecalculationResultStatusEnumApi =
+    (typeof MetricRecalculationResultStatusEnumApi)[keyof typeof MetricRecalculationResultStatusEnumApi]
+
+export const MetricRecalculationResultStatusEnumApi = {
+    Pending: 'pending',
+    Completed: 'completed',
+    Failed: 'failed',
+} as const
+
+/**
+ * One metric's recalculated result row, read back from ExperimentMetricResult.
+ */
+export interface MetricRecalculationResultApi {
+    /** UUID of the metric this result belongs to */
+    readonly metric_uuid: string
+    /** Status of this metric's calculation in the run
+
+  * `pending` - pending
+  * `completed` - completed
+  * `failed` - failed */
+    readonly status: MetricRecalculationResultStatusEnumApi
+    /** The computed metric result (ExperimentQueryResponse shape); null when status is pending or failed */
+    readonly result: unknown
+    /**
+     * Error message when status is failed; otherwise null
+     * @nullable
+     */
+    readonly error_message: string | null
+}
+
+/**
+ * Serializer for metrics recalculation status responses.
+ */
+export interface ExperimentMetricsRecalculationApi {
+    /** Unique identifier for this recalculation job */
+    readonly id: string
+    /** ID of the experiment being recalculated */
+    readonly experiment_id: number
+    /** Current status of the recalculation job
+
+  * `pending` - pending
+  * `in_progress` - in_progress
+  * `completed` - completed
+  * `failed` - failed */
+    readonly status: ExperimentMetricsRecalculationStatusEnumApi
+    /** Total number of metrics to recalculate */
+    readonly total_metrics: number
+    /** Number of metrics successfully recalculated */
+    readonly completed_metrics: number
+    /** Number of metrics that failed to recalculate */
+    readonly failed_metrics: number
+    /** Map of metric_uuid to error details */
+    readonly metric_errors: unknown
+    /** What triggered this recalculation
+
+  * `manual` - manual
+  * `experiment_launch` - experiment_launch
+  * `experiment_stop` - experiment_stop
+  * `experiment_update` - experiment_update */
+    readonly trigger: TriggerEnumApi
+    /** When the job was created */
+    readonly created_at: string
+    /**
+     * When processing started
+     * @nullable
+     */
+    readonly started_at: string | null
+    /**
+     * When processing completed
+     * @nullable
+     */
+    readonly completed_at: string | null
+    /** True if returning an existing job rather than a newly created one */
+    readonly is_existing: boolean
+    /** Per-metric results computed by this run, scoped by the run's recalc fingerprint */
+    readonly results: readonly MetricRecalculationResultApi[]
+}
+
 export interface ShipVariantApi {
     /** The conclusion of the experiment.
      *

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -718,9 +718,9 @@ export interface EndExperimentApi {
 
 /**
  * * `manual` - manual
- * `experiment_launch` - experiment_launch
- * `experiment_stop` - experiment_stop
- * `experiment_update` - experiment_update
+ * * `experiment_launch` - experiment_launch
+ * * `experiment_stop` - experiment_stop
+ * * `experiment_update` - experiment_update
  */
 export type RecalculateMetricsRequestTriggerEnumApi =
     (typeof RecalculateMetricsRequestTriggerEnumApi)[keyof typeof RecalculateMetricsRequestTriggerEnumApi]
@@ -737,19 +737,19 @@ export const RecalculateMetricsRequestTriggerEnumApi = {
  */
 export interface RecalculateMetricsRequestApi {
     /** What triggered this recalculation (manual is the default for user-initiated runs)
-
-  * `manual` - manual
-  * `experiment_launch` - experiment_launch
-  * `experiment_stop` - experiment_stop
-  * `experiment_update` - experiment_update */
+     *
+     * * `manual` - manual
+     * * `experiment_launch` - experiment_launch
+     * * `experiment_stop` - experiment_stop
+     * * `experiment_update` - experiment_update */
     trigger?: RecalculateMetricsRequestTriggerEnumApi
 }
 
 /**
  * * `pending` - Pending
- * `in_progress` - In Progress
- * `completed` - Completed
- * `failed` - Failed
+ * * `in_progress` - In Progress
+ * * `completed` - Completed
+ * * `failed` - Failed
  */
 export type ExperimentMetricsRecalculationStatusEnumApi =
     (typeof ExperimentMetricsRecalculationStatusEnumApi)[keyof typeof ExperimentMetricsRecalculationStatusEnumApi]
@@ -763,9 +763,9 @@ export const ExperimentMetricsRecalculationStatusEnumApi = {
 
 /**
  * * `manual` - Manual
- * `experiment_launch` - Experiment Launch
- * `experiment_stop` - Experiment Stop
- * `experiment_update` - Experiment Update
+ * * `experiment_launch` - Experiment Launch
+ * * `experiment_stop` - Experiment Stop
+ * * `experiment_update` - Experiment Update
  */
 export type ExperimentMetricsRecalculationTriggerEnumApi =
     (typeof ExperimentMetricsRecalculationTriggerEnumApi)[keyof typeof ExperimentMetricsRecalculationTriggerEnumApi]
@@ -779,8 +779,8 @@ export const ExperimentMetricsRecalculationTriggerEnumApi = {
 
 /**
  * * `pending` - pending
- * `completed` - completed
- * `failed` - failed
+ * * `completed` - completed
+ * * `failed` - failed
  */
 export type MetricRecalculationResultStatusEnumApi =
     (typeof MetricRecalculationResultStatusEnumApi)[keyof typeof MetricRecalculationResultStatusEnumApi]
@@ -798,10 +798,10 @@ export interface MetricRecalculationResultApi {
     /** UUID of the metric this result belongs to */
     readonly metric_uuid: string
     /** Status of this metric's calculation in the run
-
-  * `pending` - pending
-  * `completed` - completed
-  * `failed` - failed */
+     *
+     * * `pending` - pending
+     * * `completed` - completed
+     * * `failed` - failed */
     readonly status: MetricRecalculationResultStatusEnumApi
     /** The computed metric result (ExperimentQueryResponse shape); null when status is pending or failed */
     readonly result: unknown
@@ -821,11 +821,11 @@ export interface ExperimentMetricsRecalculationApi {
     /** ID of the experiment being recalculated */
     readonly experiment_id: number
     /** Current status of the recalculation job
-
-  * `pending` - Pending
-  * `in_progress` - In Progress
-  * `completed` - Completed
-  * `failed` - Failed */
+     *
+     * * `pending` - Pending
+     * * `in_progress` - In Progress
+     * * `completed` - Completed
+     * * `failed` - Failed */
     readonly status: ExperimentMetricsRecalculationStatusEnumApi
     /** Total number of metrics to recalculate */
     readonly total_metrics: number
@@ -836,11 +836,11 @@ export interface ExperimentMetricsRecalculationApi {
     /** Map of metric_uuid to error details */
     readonly metric_errors: unknown
     /** What triggered this recalculation
-
-  * `manual` - Manual
-  * `experiment_launch` - Experiment Launch
-  * `experiment_stop` - Experiment Stop
-  * `experiment_update` - Experiment Update */
+     *
+     * * `manual` - Manual
+     * * `experiment_launch` - Experiment Launch
+     * * `experiment_stop` - Experiment Stop
+     * * `experiment_update` - Experiment Update */
     readonly trigger: ExperimentMetricsRecalculationTriggerEnumApi
     /** When the job was created */
     readonly created_at: string

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -722,9 +722,10 @@ export interface EndExperimentApi {
  * `experiment_stop` - experiment_stop
  * `experiment_update` - experiment_update
  */
-export type TriggerEnumApi = (typeof TriggerEnumApi)[keyof typeof TriggerEnumApi]
+export type RecalculateMetricsRequestTriggerEnumApi =
+    (typeof RecalculateMetricsRequestTriggerEnumApi)[keyof typeof RecalculateMetricsRequestTriggerEnumApi]
 
-export const TriggerEnumApi = {
+export const RecalculateMetricsRequestTriggerEnumApi = {
     Manual: 'manual',
     ExperimentLaunch: 'experiment_launch',
     ExperimentStop: 'experiment_stop',
@@ -741,14 +742,14 @@ export interface RecalculateMetricsRequestApi {
   * `experiment_launch` - experiment_launch
   * `experiment_stop` - experiment_stop
   * `experiment_update` - experiment_update */
-    trigger?: TriggerEnumApi
+    trigger?: RecalculateMetricsRequestTriggerEnumApi
 }
 
 /**
- * * `pending` - pending
- * `in_progress` - in_progress
- * `completed` - completed
- * `failed` - failed
+ * * `pending` - Pending
+ * `in_progress` - In Progress
+ * `completed` - Completed
+ * `failed` - Failed
  */
 export type ExperimentMetricsRecalculationStatusEnumApi =
     (typeof ExperimentMetricsRecalculationStatusEnumApi)[keyof typeof ExperimentMetricsRecalculationStatusEnumApi]
@@ -758,6 +759,22 @@ export const ExperimentMetricsRecalculationStatusEnumApi = {
     InProgress: 'in_progress',
     Completed: 'completed',
     Failed: 'failed',
+} as const
+
+/**
+ * * `manual` - Manual
+ * `experiment_launch` - Experiment Launch
+ * `experiment_stop` - Experiment Stop
+ * `experiment_update` - Experiment Update
+ */
+export type ExperimentMetricsRecalculationTriggerEnumApi =
+    (typeof ExperimentMetricsRecalculationTriggerEnumApi)[keyof typeof ExperimentMetricsRecalculationTriggerEnumApi]
+
+export const ExperimentMetricsRecalculationTriggerEnumApi = {
+    Manual: 'manual',
+    ExperimentLaunch: 'experiment_launch',
+    ExperimentStop: 'experiment_stop',
+    ExperimentUpdate: 'experiment_update',
 } as const
 
 /**
@@ -805,26 +822,26 @@ export interface ExperimentMetricsRecalculationApi {
     readonly experiment_id: number
     /** Current status of the recalculation job
 
-  * `pending` - pending
-  * `in_progress` - in_progress
-  * `completed` - completed
-  * `failed` - failed */
+  * `pending` - Pending
+  * `in_progress` - In Progress
+  * `completed` - Completed
+  * `failed` - Failed */
     readonly status: ExperimentMetricsRecalculationStatusEnumApi
     /** Total number of metrics to recalculate */
     readonly total_metrics: number
-    /** Number of metrics successfully recalculated */
+    /** Number of metrics with a COMPLETED result row in this run (derived, not stored) */
     readonly completed_metrics: number
-    /** Number of metrics that failed to recalculate */
+    /** Number of failed metrics in this run (derived): FAILED result rows plus discovery-step failures that never made it to a result row */
     readonly failed_metrics: number
     /** Map of metric_uuid to error details */
     readonly metric_errors: unknown
     /** What triggered this recalculation
 
-  * `manual` - manual
-  * `experiment_launch` - experiment_launch
-  * `experiment_stop` - experiment_stop
-  * `experiment_update` - experiment_update */
-    readonly trigger: TriggerEnumApi
+  * `manual` - Manual
+  * `experiment_launch` - Experiment Launch
+  * `experiment_stop` - Experiment Stop
+  * `experiment_update` - Experiment Update */
+    readonly trigger: ExperimentMetricsRecalculationTriggerEnumApi
     /** When the job was created */
     readonly created_at: string
     /**

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -15,6 +15,7 @@ import type {
     ExperimentApi,
     ExperimentHoldoutApi,
     ExperimentHoldoutsListParams,
+    ExperimentMetricsRecalculationApi,
     ExperimentSavedMetricApi,
     ExperimentSavedMetricsListParams,
     ExperimentsListParams,
@@ -26,6 +27,7 @@ import type {
     PatchedExperimentApi,
     PatchedExperimentHoldoutApi,
     PatchedExperimentSavedMetricApi,
+    RecalculateMetricsRequestApi,
     ShipVariantApi,
 } from './api.schemas'
 
@@ -550,6 +552,88 @@ export const experimentsLaunchCreate = async (
         ...options,
         method: 'POST',
     })
+}
+
+export const getExperimentsMetricsRecalculationCreateUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/experiments/${id}/metrics_recalculation/`
+}
+
+/**
+ * Trigger a batch recalculation of all metrics for this experiment.
+
+Returns 201 with the new pending recalculation, or 200 with the active one if a recalculation is
+already pending or in progress for this experiment. The response payload intentionally does not
+include the `results` array — at POST time the workflow has just been queued and no per-metric
+results exist yet. Clients should poll `GET metrics_recalculation/{id}/` for results as the workflow
+progresses.
+ */
+export const experimentsMetricsRecalculationCreate = async (
+    projectId: string,
+    id: number,
+    recalculateMetricsRequestApi?: RecalculateMetricsRequestApi,
+    options?: RequestInit
+): Promise<ExperimentMetricsRecalculationApi> => {
+    return apiMutator<ExperimentMetricsRecalculationApi>(getExperimentsMetricsRecalculationCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(recalculateMetricsRequestApi),
+    })
+}
+
+export const getExperimentsMetricsRecalculationRetrieveUrl = (
+    projectId: string,
+    id: number,
+    recalculationId: string
+) => {
+    return `/api/projects/${projectId}/experiments/${id}/metrics_recalculation/${recalculationId}/`
+}
+
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+
+This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+on serializer methods and converts them into proper HTTP 409 Conflict responses with
+change request details.
+ */
+export const experimentsMetricsRecalculationRetrieve = async (
+    projectId: string,
+    id: number,
+    recalculationId: string,
+    options?: RequestInit
+): Promise<ExperimentMetricsRecalculationApi> => {
+    return apiMutator<ExperimentMetricsRecalculationApi>(
+        getExperimentsMetricsRecalculationRetrieveUrl(projectId, id, recalculationId),
+        {
+            ...options,
+            method: 'GET',
+        }
+    )
+}
+
+export const getExperimentsMetricsRecalculationLatestRetrieveUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/experiments/${id}/metrics_recalculation/latest/`
+}
+
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+
+This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+on serializer methods and converts them into proper HTTP 409 Conflict responses with
+change request details.
+ */
+export const experimentsMetricsRecalculationLatestRetrieve = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<ExperimentMetricsRecalculationApi> => {
+    return apiMutator<ExperimentMetricsRecalculationApi>(
+        getExperimentsMetricsRecalculationLatestRetrieveUrl(projectId, id),
+        {
+            ...options,
+            method: 'GET',
+        }
+    )
 }
 
 export const getExperimentsPauseCreateUrl = (projectId: string, id: number) => {

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -560,12 +560,12 @@ export const getExperimentsMetricsRecalculationCreateUrl = (projectId: string, i
 
 /**
  * Trigger a batch recalculation of all metrics for this experiment.
-
-Returns 201 with the new pending recalculation, or 200 with the active one if a recalculation is
-already pending or in progress for this experiment. The response payload intentionally does not
-include the `results` array — at POST time the workflow has just been queued and no per-metric
-results exist yet. Clients should poll `GET metrics_recalculation/{id}/` for results as the workflow
-progresses.
+ *
+ * Returns 201 with the new pending recalculation, or 200 with the active one if a recalculation is
+ * already pending or in progress for this experiment. The response payload intentionally does not
+ * include the `results` array — at POST time the workflow has just been queued and no per-metric
+ * results exist yet. Clients should poll `GET metrics_recalculation/{id}/` for results as the workflow
+ * progresses.
  */
 export const experimentsMetricsRecalculationCreate = async (
     projectId: string,
@@ -591,10 +591,10 @@ export const getExperimentsMetricsRecalculationRetrieveUrl = (
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const experimentsMetricsRecalculationRetrieve = async (
     projectId: string,
@@ -617,10 +617,10 @@ export const getExperimentsMetricsRecalculationLatestRetrieveUrl = (projectId: s
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const experimentsMetricsRecalculationLatestRetrieve = async (
     projectId: string,

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -223,6 +223,29 @@ include the `results` array — at POST time the workflow has just been queued a
 results exist yet. Clients should poll `GET metrics_recalculation/{id}/` for results as the workflow
 progresses.
  */
+export const experimentsMetricsRecalculationCreateBodyTriggerDefault = `manual`
+
+export const ExperimentsMetricsRecalculationCreateBody = /* @__PURE__ */ zod
+    .object({
+        trigger: zod
+            .enum(['manual', 'experiment_launch', 'experiment_stop', 'experiment_update'])
+            .describe(
+                '\* `manual` - manual\n\* `experiment_launch` - experiment_launch\n\* `experiment_stop` - experiment_stop\n\* `experiment_update` - experiment_update'
+            )
+            .default(experimentsMetricsRecalculationCreateBodyTriggerDefault)
+            .describe(
+                'What triggered this recalculation (manual is the default for user-initiated runs)\n\n\* `manual` - manual\n\* `experiment_launch` - experiment_launch\n\* `experiment_stop` - experiment_stop\n\* `experiment_update` - experiment_update'
+            ),
+    })
+    .describe('Request body for triggering a metrics recalculation.')
+
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+
+This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+on serializer methods and converts them into proper HTTP 409 Conflict responses with
+change request details.
+ */
 export const ExperimentsRecalculateTimeseriesCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
     .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -139,11 +139,7 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
     .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
 
 /**
- * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
- *
- * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
- * on serializer methods and converts them into proper HTTP 409 Conflict responses with
- * change request details.
+ * Copy an experiment into another project in the same organization as a new draft.
  */
 export const ExperimentsCopyToProjectCreateBody = /* @__PURE__ */ zod.object({
     target_team_id: zod.number().describe('The team ID to copy the experiment to.'),

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -122,10 +122,10 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
- *
- * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
- * on serializer methods and converts them into proper HTTP 409 Conflict responses with
- * change request details.
+
+This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+on serializer methods and converts them into proper HTTP 409 Conflict responses with
+change request details.
  */
 export const ExperimentsUpdateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -139,7 +139,11 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
     .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
 
 /**
- * Copy an experiment into another project in the same organization as a new draft.
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+
+This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+on serializer methods and converts them into proper HTTP 409 Conflict responses with
+change request details.
  */
 export const ExperimentsCopyToProjectCreateBody = /* @__PURE__ */ zod.object({
     target_team_id: zod.number().describe('The team ID to copy the experiment to.'),
@@ -149,10 +153,10 @@ export const ExperimentsCopyToProjectCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
- *
- * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
- * on serializer methods and converts them into proper HTTP 409 Conflict responses with
- * change request details.
+
+This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+on serializer methods and converts them into proper HTTP 409 Conflict responses with
+change request details.
  */
 export const ExperimentsCreateExposureCohortForExperimentCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -160,10 +164,10 @@ export const ExperimentsCreateExposureCohortForExperimentCreateBody = /* @__PURE
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
- *
- * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
- * on serializer methods and converts them into proper HTTP 409 Conflict responses with
- * change request details.
+
+This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+on serializer methods and converts them into proper HTTP 409 Conflict responses with
+change request details.
  */
 export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -171,27 +175,27 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
 
 /**
  * End a running experiment without shipping a variant.
- *
- * Sets end_date to now and marks the experiment as stopped. The feature
- * flag is NOT modified — users continue to see their assigned variants
- * and exposure events ($feature_flag_called) continue to be recorded.
- * However, only data up to end_date is included in experiment results.
- *
- * Use this when:
- *
- * - You want to freeze the results window without changing which variant
- *   users see.
- * - A variant was already shipped manually via the feature flag UI and
- *   the experiment just needs to be marked complete.
- *
- * The end_date can be adjusted after ending via PATCH if it needs to be
- * backdated (e.g. to match when the flag was actually paused).
- *
- * Other options:
- * - Use ship_variant to end the experiment AND roll out a single variant to 100%% of users.
- * - Use pause to deactivate the flag without ending the experiment (stops variant assignment but does not freeze results).
- *
- * Returns 400 if the experiment is not running.
+
+Sets end_date to now and marks the experiment as stopped. The feature
+flag is NOT modified — users continue to see their assigned variants
+and exposure events ($feature_flag_called) continue to be recorded.
+However, only data up to end_date is included in experiment results.
+
+Use this when:
+
+- You want to freeze the results window without changing which variant
+  users see.
+- A variant was already shipped manually via the feature flag UI and
+  the experiment just needs to be marked complete.
+
+The end_date can be adjusted after ending via PATCH if it needs to be
+backdated (e.g. to match when the flag was actually paused).
+
+Other options:
+- Use ship_variant to end the experiment AND roll out a single variant to 100%% of users.
+- Use pause to deactivate the flag without ending the experiment (stops variant assignment but does not freeze results).
+
+Returns 400 if the experiment is not running.
  */
 export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
     conclusion: zod
@@ -211,11 +215,13 @@ export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
- * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
- *
- * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
- * on serializer methods and converts them into proper HTTP 409 Conflict responses with
- * change request details.
+ * Trigger a batch recalculation of all metrics for this experiment.
+
+Returns 201 with the new pending recalculation, or 200 with the active one if a recalculation is
+already pending or in progress for this experiment. The response payload intentionally does not
+include the `results` array — at POST time the workflow has just been queued and no per-metric
+results exist yet. Clients should poll `GET metrics_recalculation/{id}/` for results as the workflow
+progresses.
  */
 export const ExperimentsRecalculateTimeseriesCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -223,25 +229,25 @@ export const ExperimentsRecalculateTimeseriesCreateBody = /* @__PURE__ */ zod
 
 /**
  * Ship a variant and (optionally) end the experiment.
- *
- * Updates the feature flag so the selected variant gets 100% of the variant
- * distribution. By default, existing release conditions on the flag are preserved
- * untouched — the variant is served only to users who already match them. Pass
- * ``release_to_everyone: true`` to also prepend a catch-all release condition
- * that rolls the variant out to 100% of users (overrides any existing release
- * conditions on the flag).
- *
- * Can be called on both running and stopped experiments. If the experiment is
- * still running, it will also be ended (end_date set and status marked as stopped).
- * If the experiment has already ended, only the flag is rewritten - this supports
- * the "end first, ship later" workflow.
- *
- * If an approval policy requires review before changes on the flag take effect,
- * the API returns 409 with a change_request_id. The experiment is NOT ended until
- * the change request is approved and the user retries.
- *
- * Returns 400 if the experiment is in draft state, the variant_key is not found
- * on the flag, or the experiment has no linked feature flag.
+
+Updates the feature flag so the selected variant gets 100% of the variant
+distribution. By default, existing release conditions on the flag are preserved
+untouched — the variant is served only to users who already match them. Pass
+``release_to_everyone: true`` to also prepend a catch-all release condition
+that rolls the variant out to 100% of users (overrides any existing release
+conditions on the flag).
+
+Can be called on both running and stopped experiments. If the experiment is
+still running, it will also be ended (end_date set and status marked as stopped).
+If the experiment has already ended, only the flag is rewritten - this supports
+the "end first, ship later" workflow.
+
+If an approval policy requires review before changes on the flag take effect,
+the API returns 409 with a change_request_id. The experiment is NOT ended until
+the change request is approved and the user retries.
+
+Returns 400 if the experiment is in draft state, the variant_key is not found
+on the flag, or the experiment has no linked feature flag.
  */
 export const experimentsShipVariantCreateBodyReleaseToEveryoneDefault = false
 
@@ -271,12 +277,12 @@ export const ExperimentsShipVariantCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create an experiment that compares N versions of an LLM prompt using a metric template.
- *
- * The user picks 2+ versions of an existing LLMPrompt and 1+ metric templates
- * (cost / latency / eval_pass_rate). The endpoint builds the matching variants
- * (control + test-N, each named after its prompt version) and attaches one
- * metric per selected template, each scoped to the prompt's $ai_prompt_name.
- * Resulting experiment is in draft state.
+
+The user picks 2+ versions of an existing LLMPrompt and 1+ metric templates
+(cost / latency / eval_pass_rate). The endpoint builds the matching variants
+(control + test-N, each named after its prompt version) and attaches one
+metric per selected template, each scoped to the prompt's $ai_prompt_name.
+Resulting experiment is in draft state.
  */
 
 export const experimentsCreateFromPromptCreateBodyVersionsMin = 2

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -122,10 +122,10 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsUpdateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -140,10 +140,10 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsCopyToProjectCreateBody = /* @__PURE__ */ zod.object({
     target_team_id: zod.number().describe('The team ID to copy the experiment to.'),
@@ -153,10 +153,10 @@ export const ExperimentsCopyToProjectCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsCreateExposureCohortForExperimentCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -164,10 +164,10 @@ export const ExperimentsCreateExposureCohortForExperimentCreateBody = /* @__PURE
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -175,27 +175,27 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
 
 /**
  * End a running experiment without shipping a variant.
-
-Sets end_date to now and marks the experiment as stopped. The feature
-flag is NOT modified — users continue to see their assigned variants
-and exposure events ($feature_flag_called) continue to be recorded.
-However, only data up to end_date is included in experiment results.
-
-Use this when:
-
-- You want to freeze the results window without changing which variant
-  users see.
-- A variant was already shipped manually via the feature flag UI and
-  the experiment just needs to be marked complete.
-
-The end_date can be adjusted after ending via PATCH if it needs to be
-backdated (e.g. to match when the flag was actually paused).
-
-Other options:
-- Use ship_variant to end the experiment AND roll out a single variant to 100%% of users.
-- Use pause to deactivate the flag without ending the experiment (stops variant assignment but does not freeze results).
-
-Returns 400 if the experiment is not running.
+ *
+ * Sets end_date to now and marks the experiment as stopped. The feature
+ * flag is NOT modified — users continue to see their assigned variants
+ * and exposure events ($feature_flag_called) continue to be recorded.
+ * However, only data up to end_date is included in experiment results.
+ *
+ * Use this when:
+ *
+ * - You want to freeze the results window without changing which variant
+ *   users see.
+ * - A variant was already shipped manually via the feature flag UI and
+ *   the experiment just needs to be marked complete.
+ *
+ * The end_date can be adjusted after ending via PATCH if it needs to be
+ * backdated (e.g. to match when the flag was actually paused).
+ *
+ * Other options:
+ * - Use ship_variant to end the experiment AND roll out a single variant to 100%% of users.
+ * - Use pause to deactivate the flag without ending the experiment (stops variant assignment but does not freeze results).
+ *
+ * Returns 400 if the experiment is not running.
  */
 export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
     conclusion: zod
@@ -216,12 +216,12 @@ export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Trigger a batch recalculation of all metrics for this experiment.
-
-Returns 201 with the new pending recalculation, or 200 with the active one if a recalculation is
-already pending or in progress for this experiment. The response payload intentionally does not
-include the `results` array — at POST time the workflow has just been queued and no per-metric
-results exist yet. Clients should poll `GET metrics_recalculation/{id}/` for results as the workflow
-progresses.
+ *
+ * Returns 201 with the new pending recalculation, or 200 with the active one if a recalculation is
+ * already pending or in progress for this experiment. The response payload intentionally does not
+ * include the `results` array — at POST time the workflow has just been queued and no per-metric
+ * results exist yet. Clients should poll `GET metrics_recalculation/{id}/` for results as the workflow
+ * progresses.
  */
 export const experimentsMetricsRecalculationCreateBodyTriggerDefault = `manual`
 
@@ -241,10 +241,10 @@ export const ExperimentsMetricsRecalculationCreateBody = /* @__PURE__ */ zod
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsRecalculateTimeseriesCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -252,25 +252,25 @@ export const ExperimentsRecalculateTimeseriesCreateBody = /* @__PURE__ */ zod
 
 /**
  * Ship a variant and (optionally) end the experiment.
-
-Updates the feature flag so the selected variant gets 100% of the variant
-distribution. By default, existing release conditions on the flag are preserved
-untouched — the variant is served only to users who already match them. Pass
-``release_to_everyone: true`` to also prepend a catch-all release condition
-that rolls the variant out to 100% of users (overrides any existing release
-conditions on the flag).
-
-Can be called on both running and stopped experiments. If the experiment is
-still running, it will also be ended (end_date set and status marked as stopped).
-If the experiment has already ended, only the flag is rewritten - this supports
-the "end first, ship later" workflow.
-
-If an approval policy requires review before changes on the flag take effect,
-the API returns 409 with a change_request_id. The experiment is NOT ended until
-the change request is approved and the user retries.
-
-Returns 400 if the experiment is in draft state, the variant_key is not found
-on the flag, or the experiment has no linked feature flag.
+ *
+ * Updates the feature flag so the selected variant gets 100% of the variant
+ * distribution. By default, existing release conditions on the flag are preserved
+ * untouched — the variant is served only to users who already match them. Pass
+ * ``release_to_everyone: true`` to also prepend a catch-all release condition
+ * that rolls the variant out to 100% of users (overrides any existing release
+ * conditions on the flag).
+ *
+ * Can be called on both running and stopped experiments. If the experiment is
+ * still running, it will also be ended (end_date set and status marked as stopped).
+ * If the experiment has already ended, only the flag is rewritten - this supports
+ * the "end first, ship later" workflow.
+ *
+ * If an approval policy requires review before changes on the flag take effect,
+ * the API returns 409 with a change_request_id. The experiment is NOT ended until
+ * the change request is approved and the user retries.
+ *
+ * Returns 400 if the experiment is in draft state, the variant_key is not found
+ * on the flag, or the experiment has no linked feature flag.
  */
 export const experimentsShipVariantCreateBodyReleaseToEveryoneDefault = false
 
@@ -300,12 +300,12 @@ export const ExperimentsShipVariantCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create an experiment that compares N versions of an LLM prompt using a metric template.
-
-The user picks 2+ versions of an existing LLMPrompt and 1+ metric templates
-(cost / latency / eval_pass_rate). The endpoint builds the matching variants
-(control + test-N, each named after its prompt version) and attaches one
-metric per selected template, each scoped to the prompt's $ai_prompt_name.
-Resulting experiment is in draft state.
+ *
+ * The user picks 2+ versions of an existing LLMPrompt and 1+ metric templates
+ * (cost / latency / eval_pass_rate). The endpoint builds the matching variants
+ * (control + test-N, each named after its prompt version) and attaches one
+ * metric per selected template, each scoped to the prompt's $ai_prompt_name.
+ * Resulting experiment is in draft state.
  */
 
 export const experimentsCreateFromPromptCreateBodyVersionsMin = 2

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -848,6 +848,15 @@ tools:
     experiments-eligible-feature-flags:
         operation: experiments_eligible_feature_flags_retrieve
         enabled: false
+    experiments-metrics-recalculation-create:
+        operation: experiments_metrics_recalculation_create
+        enabled: false
+    experiments-metrics-recalculation-latest-retrieve:
+        operation: experiments_metrics_recalculation_latest_retrieve
+        enabled: false
+    experiments-metrics-recalculation-retrieve:
+        operation: experiments_metrics_recalculation_retrieve
+        enabled: false
     experiments-prompt-templates-retrieve:
         operation: experiments_prompt_templates_retrieve
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2893,6 +2893,8 @@ export namespace Schemas {
 
     export interface LifecycleFilter {
       showLegend?: boolean | null;
+      /** Append per-band percentage to each value label (e.g. `580 (42%)`). Requires `showValuesOnSeries` — on its own it has no visible effect. */
+      showPercentagesOnSeries?: boolean | null;
       showValuesOnSeries?: boolean | null;
       stacked?: boolean | null;
       toggledLifecycles?: LifecycleToggle[] | null;
@@ -3830,17 +3832,41 @@ export namespace Schemas {
       ErrorTrackingList: 'error_tracking_list',
     } as const;
 
+    export type WidgetDateRangeDateFrom = typeof WidgetDateRangeDateFrom[keyof typeof WidgetDateRangeDateFrom] | null;
+
+
+    export const WidgetDateRangeDateFrom = {
+      '1h': '-1h',
+      '3h': '-3h',
+      '24h': '-24h',
+      '7d': '-7d',
+      '14d': '-14d',
+      '30d': '-30d',
+      '90d': '-90d',
+    } as const;
+
+    export interface WidgetDateRange {
+      date_from?: WidgetDateRangeDateFrom;
+    }
+
+    export interface WidgetFilterEntry {
+      /** @minLength 1 */
+      filterId: string;
+      /** @minLength 1 */
+      propertyName: string;
+      /** @minLength 1 */
+      optionId: string;
+      operator: PropertyOperator;
+      value?: string | string[] | null;
+    }
+
     /**
-     * * `last_seen` - last_seen
-     * * `first_seen` - first_seen
-     * * `occurrences` - occurrences
-     * * `users` - users
-     * * `sessions` - sessions
+     * Issue ranking column.
      */
-    export type ErrorTrackingIssueOrderByEnum = typeof ErrorTrackingIssueOrderByEnum[keyof typeof ErrorTrackingIssueOrderByEnum];
+    export type ErrorTrackingListWidgetConfigOrderBy = typeof ErrorTrackingListWidgetConfigOrderBy[keyof typeof ErrorTrackingListWidgetConfigOrderBy];
 
 
-    export const ErrorTrackingIssueOrderByEnum = {
+    export const ErrorTrackingListWidgetConfigOrderBy = {
       LastSeen: 'last_seen',
       FirstSeen: 'first_seen',
       Occurrences: 'occurrences',
@@ -3849,29 +3875,23 @@ export namespace Schemas {
     } as const;
 
     /**
-     * * `ASC` - ASC
-     * * `DESC` - DESC
+     * Sort direction for orderBy.
      */
-    export type OrderDirectionEnum = typeof OrderDirectionEnum[keyof typeof OrderDirectionEnum];
+    export type ErrorTrackingListWidgetConfigOrderDirection = typeof ErrorTrackingListWidgetConfigOrderDirection[keyof typeof ErrorTrackingListWidgetConfigOrderDirection];
 
 
-    export const OrderDirectionEnum = {
+    export const ErrorTrackingListWidgetConfigOrderDirection = {
       Asc: 'ASC',
       Desc: 'DESC',
     } as const;
 
     /**
-     * * `archived` - archived
-     * * `active` - active
-     * * `resolved` - resolved
-     * * `pending_release` - pending_release
-     * * `suppressed` - suppressed
-     * * `all` - all
+     * Issue status filter.
      */
-    export type ErrorTrackingIssueStatusEnum = typeof ErrorTrackingIssueStatusEnum[keyof typeof ErrorTrackingIssueStatusEnum];
+    export type ErrorTrackingListWidgetConfigStatus = typeof ErrorTrackingListWidgetConfigStatus[keyof typeof ErrorTrackingListWidgetConfigStatus];
 
 
-    export const ErrorTrackingIssueStatusEnum = {
+    export const ErrorTrackingListWidgetConfigStatus = {
       Archived: 'archived',
       Active: 'active',
       Resolved: 'resolved',
@@ -3880,118 +3900,39 @@ export namespace Schemas {
       All: 'all',
     } as const;
 
-    /**
-     * * `user` - user
-     * * `role` - role
-     */
-    export type AssigneeTypeEnum = typeof AssigneeTypeEnum[keyof typeof AssigneeTypeEnum];
+    export type WidgetAssigneeFilterType = typeof WidgetAssigneeFilterType[keyof typeof WidgetAssigneeFilterType];
 
 
-    export const AssigneeTypeEnum = {
+    export const WidgetAssigneeFilterType = {
       User: 'user',
       Role: 'role',
     } as const;
 
-    export interface ErrorTrackingAssignee {
-      /** User ID or role UUID to filter by. */
-      id: string | number | null;
-      /** Assignee target type: user or role.
-       *
-       * * `user` - user
-       * * `role` - role */
-      type: AssigneeTypeEnum;
+    export interface WidgetAssigneeFilter {
+      id: string | number;
+      type: WidgetAssigneeFilterType;
     }
 
-    export interface WidgetFilterConfigEntry {
-      /** Filter UUID; must match the widgetFilters map key. */
-      filterId: string;
-      /** Event property key (for example $environment). */
-      propertyName: string;
-      /** Selected option id from the filter definition. */
-      optionId: string;
-      /** Property filter operator (for example exact, is_not, icontains). */
-      operator: string;
-      /** Filter value as a string, list of strings, or null. */
-      value?: unknown;
-    }
-
-    /**
-     * * `-14d` - -14d
-     * * `-1h` - -1h
-     * * `-24h` - -24h
-     * * `-30d` - -30d
-     * * `-3h` - -3h
-     * * `-7d` - -7d
-     * * `-90d` - -90d
-     */
-    export type DateFromEnum = typeof DateFromEnum[keyof typeof DateFromEnum];
-
-
-    export const DateFromEnum = {
-      '14d': '-14d',
-      '1h': '-1h',
-      '24h': '-24h',
-      '30d': '-30d',
-      '3h': '-3h',
-      '7d': '-7d',
-      '90d': '-90d',
-    } as const;
-
-    export interface WidgetDateRange {
-      /** Relative lookback window (for example '-7d'). Omit to use the project default range.
-       *
-       * * `-14d` - -14d
-       * * `-1h` - -1h
-       * * `-24h` - -24h
-       * * `-30d` - -30d
-       * * `-3h` - -3h
-       * * `-7d` - -7d
-       * * `-90d` - -90d */
-      date_from?: DateFromEnum | null;
-    }
-
-    /**
-     * Widget filter selections keyed by filter id. Each key must match the entry's filterId. Configure filters in the product UI first, then copy filter id, option id, and property name here.
-     */
-    export type ErrorTrackingListWidgetConfigWidgetFilters = {[key: string]: WidgetFilterConfigEntry};
+    export type ErrorTrackingListWidgetConfigWidgetFilters = {[key: string]: WidgetFilterEntry} | null;
 
     export interface ErrorTrackingListWidgetConfig {
+      dateRange?: WidgetDateRange | null;
+      filterTestAccounts?: boolean | null;
+      widgetFilters?: ErrorTrackingListWidgetConfigWidgetFilters;
       /**
-         * Maximum number of issues to return (page size).
+         * Maximum number of issues to return.
          * @minimum 1
          * @maximum 25
          */
       limit?: number;
-      /** Issue ranking column.
-       *
-       * * `first_seen` - first_seen
-       * * `last_seen` - last_seen
-       * * `occurrences` - occurrences
-       * * `sessions` - sessions
-       * * `users` - users */
-      orderBy?: ErrorTrackingIssueOrderByEnum;
-      /** Sort direction for orderBy.
-       *
-       * * `ASC` - ASC
-       * * `DESC` - DESC */
-      orderDirection?: OrderDirectionEnum;
-      /** Issue status filter.
-       *
-       * * `archived` - archived
-       * * `active` - active
-       * * `resolved` - resolved
-       * * `pending_release` - pending_release
-       * * `suppressed` - suppressed
-       * * `all` - all */
-      status?: ErrorTrackingIssueStatusEnum;
+      /** Issue ranking column. */
+      orderBy?: ErrorTrackingListWidgetConfigOrderBy;
+      /** Sort direction for orderBy. */
+      orderDirection?: ErrorTrackingListWidgetConfigOrderDirection;
+      /** Issue status filter. */
+      status?: ErrorTrackingListWidgetConfigStatus;
       /** Filter by assignee ({type: user|role, id}). Omit for any assignee. */
-      assignee?: ErrorTrackingAssignee | null;
-      /** Widget filter selections keyed by filter id. Each key must match the entry's filterId. Configure filters in the product UI first, then copy filter id, option id, and property name here. */
-      widgetFilters?: ErrorTrackingListWidgetConfigWidgetFilters;
-      /** Relative date range for issues (date_from only on widgets). */
-      dateRange?: WidgetDateRange | null;
-      /** When omitted, follows the project default for filtering test accounts. */
-      filterTestAccounts?: boolean;
+      assignee?: WidgetAssigneeFilter | null;
     }
 
     export interface ErrorTrackingListWidgetAddRequestOpenApi {
@@ -4008,7 +3949,7 @@ export namespace Schemas {
       /** Whether to show the description on the dashboard tile. */
       show_description?: boolean;
       widget_type: ErrorTrackingListWidgetAddRequestOpenApiWidgetType;
-      /** Configuration for the error tracking list widget. */
+      /** Configuration for the top issues widget. */
       config: ErrorTrackingListWidgetConfig;
     }
 
@@ -4020,57 +3961,47 @@ export namespace Schemas {
     } as const;
 
     /**
-     * * `activity_score` - activity_score
-     * * `click_count` - click_count
-     * * `console_error_count` - console_error_count
-     * * `duration` - duration
-     * * `recording_duration` - recording_duration
-     * * `start_time` - start_time
+     * Recording ranking column.
      */
-    export type SessionReplayListWidgetConfigOrderByEnum = typeof SessionReplayListWidgetConfigOrderByEnum[keyof typeof SessionReplayListWidgetConfigOrderByEnum];
+    export type SessionReplayListWidgetConfigOrderBy = typeof SessionReplayListWidgetConfigOrderBy[keyof typeof SessionReplayListWidgetConfigOrderBy];
 
 
-    export const SessionReplayListWidgetConfigOrderByEnum = {
+    export const SessionReplayListWidgetConfigOrderBy = {
+      StartTime: 'start_time',
       ActivityScore: 'activity_score',
+      RecordingDuration: 'recording_duration',
+      Duration: 'duration',
       ClickCount: 'click_count',
       ConsoleErrorCount: 'console_error_count',
-      Duration: 'duration',
-      RecordingDuration: 'recording_duration',
-      StartTime: 'start_time',
     } as const;
 
     /**
-     * Widget filter selections keyed by filter id. Each key must match the entry's filterId. Configure filters in the product UI first, then copy filter id, option id, and property name here.
+     * Sort direction for orderBy.
      */
-    export type SessionReplayListWidgetConfigWidgetFilters = {[key: string]: WidgetFilterConfigEntry};
+    export type SessionReplayListWidgetConfigOrderDirection = typeof SessionReplayListWidgetConfigOrderDirection[keyof typeof SessionReplayListWidgetConfigOrderDirection];
+
+
+    export const SessionReplayListWidgetConfigOrderDirection = {
+      Asc: 'ASC',
+      Desc: 'DESC',
+    } as const;
+
+    export type SessionReplayListWidgetConfigWidgetFilters = {[key: string]: WidgetFilterEntry} | null;
 
     export interface SessionReplayListWidgetConfig {
+      dateRange?: WidgetDateRange | null;
+      filterTestAccounts?: boolean | null;
+      widgetFilters?: SessionReplayListWidgetConfigWidgetFilters;
       /**
          * Maximum number of recordings to return.
          * @minimum 1
          * @maximum 25
          */
       limit?: number;
-      /** Recording ranking column.
-       *
-       * * `activity_score` - activity_score
-       * * `click_count` - click_count
-       * * `console_error_count` - console_error_count
-       * * `duration` - duration
-       * * `recording_duration` - recording_duration
-       * * `start_time` - start_time */
-      orderBy?: SessionReplayListWidgetConfigOrderByEnum;
-      /** Sort direction for orderBy.
-       *
-       * * `ASC` - ASC
-       * * `DESC` - DESC */
-      orderDirection?: OrderDirectionEnum;
-      /** Optional relative date range override. */
-      dateRange?: WidgetDateRange | null;
-      /** Widget filter selections keyed by filter id. Each key must match the entry's filterId. Configure filters in the product UI first, then copy filter id, option id, and property name here. */
-      widgetFilters?: SessionReplayListWidgetConfigWidgetFilters;
-      /** When omitted, follows the project default for filtering test accounts. */
-      filterTestAccounts?: boolean;
+      /** Recording ranking column. */
+      orderBy?: SessionReplayListWidgetConfigOrderBy;
+      /** Sort direction for orderBy. */
+      orderDirection?: SessionReplayListWidgetConfigOrderDirection;
     }
 
     export interface SessionReplayListWidgetAddRequestOpenApi {
@@ -4087,7 +4018,7 @@ export namespace Schemas {
       /** Whether to show the description on the dashboard tile. */
       show_description?: boolean;
       widget_type: SessionReplayListWidgetAddRequestOpenApiWidgetType;
-      /** Configuration for the session replay list widget. */
+      /** Configuration for the recent recordings widget. */
       config: SessionReplayListWidgetConfig;
     }
 
@@ -4098,7 +4029,7 @@ export namespace Schemas {
      */
     export interface AddDashboardWidgetsBatchRequestOpenApi {
       /**
-         * Widget tiles to add atomically. Supported widget_type values: error_tracking_list, session_replay_list. Use dashboard-widget-catalog-list for config_schema_hints per type. (1–10 per request).
+         * Widget tiles to add atomically. Supported widget_type values: error_tracking_list, session_replay_list. Use dashboard-widget-catalog-list for per-type config_schema documentation. (1–10 per request).
          * @minItems 1
          * @maxItems 10
          */
@@ -7187,6 +7118,7 @@ export namespace Schemas {
      * * `llm_analytics` - llm_analytics
      * * `sandbox` - sandbox
      * * `user_interview` - user_interview
+     * * `customer_analytics` - customer_analytics
      */
     export type AgentModeEnum = typeof AgentModeEnum[keyof typeof AgentModeEnum];
 
@@ -7204,6 +7136,7 @@ export namespace Schemas {
       LlmAnalytics: 'llm_analytics',
       Sandbox: 'sandbox',
       UserInterview: 'user_interview',
+      CustomerAnalytics: 'customer_analytics',
     } as const;
 
     export interface AggregatedSpanRow {
@@ -7879,6 +7812,18 @@ export namespace Schemas {
       /** @nullable */
       download_url: string | null;
     }
+
+    /**
+     * * `user` - user
+     * * `role` - role
+     */
+    export type AssigneeTypeEnum = typeof AssigneeTypeEnum[keyof typeof AssigneeTypeEnum];
+
+
+    export const AssigneeTypeEnum = {
+      User: 'user',
+      Role: 'role',
+    } as const;
 
     export interface AsyncDeletionStatus {
       /** The UUID of the person whose events are queued for deletion. */
@@ -11414,6 +11359,70 @@ export namespace Schemas {
       previous: string | null;
     }
 
+    export interface CohortUsedInCohort {
+      /** Cohort database ID */
+      id: number;
+      /** Cohort display name; falls back to 'Unnamed' when empty */
+      name: string;
+    }
+
+    export interface CohortUsedInCohortsBlock {
+      /** Cohorts that include this cohort as a criterion, capped at 100 results */
+      results: CohortUsedInCohort[];
+      /** Total number of cohorts referencing this cohort, before truncation */
+      total: number;
+      /** True when more cohorts exist beyond the truncation cap */
+      has_more: boolean;
+    }
+
+    export interface CohortUsedInFlag {
+      /** Feature flag database ID */
+      id: number;
+      /** Feature flag key (URL slug) */
+      key: string;
+      /**
+         * Feature flag display name
+         * @nullable
+         */
+      name: string | null;
+    }
+
+    export interface CohortUsedInFlagsBlock {
+      /** Feature flags referencing this cohort, capped at 100 results */
+      results: CohortUsedInFlag[];
+      /** Total number of feature flags referencing this cohort, before truncation */
+      total: number;
+      /** True when more feature flags exist beyond the truncation cap */
+      has_more: boolean;
+    }
+
+    export interface CohortUsedInInsight {
+      /** Insight database ID */
+      id: number;
+      /** Insight short ID used for routing in the frontend */
+      short_id: string;
+      /** Insight display name; falls back to derived name, then to 'Unnamed' when both are empty */
+      name: string;
+    }
+
+    export interface CohortUsedInInsightsBlock {
+      /** Insights referencing this cohort, capped at 100 results */
+      results: CohortUsedInInsight[];
+      /** Total number of insights referencing this cohort, before truncation */
+      total: number;
+      /** True when more insights exist beyond the truncation cap */
+      has_more: boolean;
+    }
+
+    export interface CohortUsedInResponse {
+      /** Feature flags (active and inactive, excluding soft-deleted) that reference this cohort in their targeting conditions, with truncation metadata */
+      feature_flags: CohortUsedInFlagsBlock;
+      /** Insights referencing this cohort with truncation metadata */
+      insights: CohortUsedInInsightsBlock;
+      /** Other cohorts that include this cohort as a criterion, with truncation metadata */
+      cohorts: CohortUsedInCohortsBlock;
+    }
+
     /**
      * * `private` - Private (only visible to creator)
      * * `shared` - Shared with team
@@ -11572,6 +11581,32 @@ export namespace Schemas {
     } as const;
 
     /**
+     * * `web_analytics` - Web analytics
+     * * `product_analytics` - Product analytics
+     * * `session_replay` - Session replay
+     * * `surveys` - Surveys
+     * * `feature_flags` - Feature flags
+     * * `experiments` - Experiments
+     * * `error_tracking` - Error tracking
+     * * `data_warehouse` - Data warehouse
+     * * `other` - Other
+     */
+    export type TopicEnum = typeof TopicEnum[keyof typeof TopicEnum];
+
+
+    export const TopicEnum = {
+      WebAnalytics: 'web_analytics',
+      ProductAnalytics: 'product_analytics',
+      SessionReplay: 'session_replay',
+      Surveys: 'surveys',
+      FeatureFlags: 'feature_flags',
+      Experiments: 'experiments',
+      ErrorTracking: 'error_tracking',
+      DataWarehouse: 'data_warehouse',
+      Other: 'other',
+    } as const;
+
+    /**
      * * `assistant` - Assistant
      * * `tool_call` - Tool call
      * * `deep_research` - Deep research
@@ -11595,6 +11630,18 @@ export namespace Schemas {
          * @nullable
          */
       readonly title: string | null;
+      /** Product domain the conversation is about, classified from the first question.
+       *
+       * * `web_analytics` - Web analytics
+       * * `product_analytics` - Product analytics
+       * * `session_replay` - Session replay
+       * * `surveys` - Surveys
+       * * `feature_flags` - Feature flags
+       * * `experiments` - Experiments
+       * * `error_tracking` - Error tracking
+       * * `data_warehouse` - Data warehouse
+       * * `other` - Other */
+      readonly topic: TopicEnum | null;
       readonly user: UserBasic;
       /** @nullable */
       readonly created_at: string | null;
@@ -11636,6 +11683,18 @@ export namespace Schemas {
          * @nullable
          */
       readonly title: string | null;
+      /** Product domain the conversation is about, classified from the first question.
+       *
+       * * `web_analytics` - Web analytics
+       * * `product_analytics` - Product analytics
+       * * `session_replay` - Session replay
+       * * `surveys` - Surveys
+       * * `feature_flags` - Feature flags
+       * * `experiments` - Experiments
+       * * `error_tracking` - Error tracking
+       * * `data_warehouse` - Data warehouse
+       * * `other` - Other */
+      readonly topic: TopicEnum | null;
       readonly user: UserBasic;
       /** @nullable */
       readonly created_at: string | null;
@@ -12520,6 +12579,8 @@ export namespace Schemas {
       /** @nullable */
       readonly last_refresh: string | null;
       readonly team_id: number;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     export interface DashboardCollaborator {
@@ -12538,6 +12599,45 @@ export namespace Schemas {
       date_to?: string | null;
       explicitDate?: boolean | null;
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+    }
+
+    /**
+     * * `error_tracking_list` - error_tracking_list
+     * * `session_replay_list` - session_replay_list
+     */
+    export type DashboardPatchWidgetOpenApiWidgetTypeEnum = typeof DashboardPatchWidgetOpenApiWidgetTypeEnum[keyof typeof DashboardPatchWidgetOpenApiWidgetTypeEnum];
+
+
+    export const DashboardPatchWidgetOpenApiWidgetTypeEnum = {
+      ErrorTrackingList: 'error_tracking_list',
+      SessionReplayList: 'session_replay_list',
+    } as const;
+
+    export interface DashboardPatchWidgetOpenApi {
+      /** Existing widget row ID when updating a widget tile via dashboard PATCH. */
+      id?: string;
+      /** Widget type identifier (cannot be changed on update).
+       *
+       * * `error_tracking_list` - error_tracking_list
+       * * `session_replay_list` - session_replay_list */
+      widget_type?: DashboardPatchWidgetOpenApiWidgetTypeEnum;
+      /** Widget-specific configuration. Shape depends on the tile's widget_type. */
+      config?: DashboardWidgetConfig;
+      /**
+         * Optional custom display name for the widget tile.
+         * @maxLength 400
+         * @nullable
+         */
+      name?: string | null;
+      /** Optional markdown description shown when show_description is enabled. */
+      description?: string;
+    }
+
+    export interface DashboardPatchTileOpenApi {
+      /** Dashboard tile ID to update. */
+      id?: number;
+      /** Nested widget row updates. */
+      widget?: DashboardPatchWidgetOpenApi;
     }
 
     /**
@@ -13406,6 +13506,85 @@ export namespace Schemas {
      * * `Resend` - Resend
      * * `PgAnalyze` - PgAnalyze
      * * `WorkOS` - WorkOS
+     * * `AmazonS3` - AmazonS3
+     * * `GoogleCloudStorage` - GoogleCloudStorage
+     * * `Databricks` - Databricks
+     * * `Dynamics365` - Dynamics365
+     * * `SalesforceMarketingCloud` - SalesforceMarketingCloud
+     * * `Db2` - Db2
+     * * `Heap` - Heap
+     * * `AdobeAnalytics` - AdobeAnalytics
+     * * `Matomo` - Matomo
+     * * `Optimizely` - Optimizely
+     * * `Adyen` - Adyen
+     * * `GoCardless` - GoCardless
+     * * `Mollie` - Mollie
+     * * `CheckoutCom` - CheckoutCom
+     * * `Branch` - Branch
+     * * `Criteo` - Criteo
+     * * `Outbrain` - Outbrain
+     * * `Taboola` - Taboola
+     * * `AdRoll` - AdRoll
+     * * `DisplayVideo360` - DisplayVideo360
+     * * `GoogleAdManager` - GoogleAdManager
+     * * `CampaignManager360` - CampaignManager360
+     * * `SearchAds360` - SearchAds360
+     * * `AdobeCommerce` - AdobeCommerce
+     * * `AmazonSellingPartner` - AmazonSellingPartner
+     * * `Ebay` - Ebay
+     * * `Commercetools` - Commercetools
+     * * `LightspeedRetail` - LightspeedRetail
+     * * `ShipStation` - ShipStation
+     * * `ConstantContact` - ConstantContact
+     * * `Mailgun` - Mailgun
+     * * `Eloqua` - Eloqua
+     * * `Sailthru` - Sailthru
+     * * `Ortto` - Ortto
+     * * `Attentive` - Attentive
+     * * `Kustomer` - Kustomer
+     * * `Dixa` - Dixa
+     * * `Gladly` - Gladly
+     * * `Qualtrics` - Qualtrics
+     * * `Delighted` - Delighted
+     * * `AzureDevOps` - AzureDevOps
+     * * `Rollbar` - Rollbar
+     * * `Opsgenie` - Opsgenie
+     * * `IncidentIo` - IncidentIo
+     * * `Pingdom` - Pingdom
+     * * `Cloudflare` - Cloudflare
+     * * `CosmosDB` - CosmosDB
+     * * `PlanetScale` - PlanetScale
+     * * `SapHana` - SapHana
+     * * `Rippling` - Rippling
+     * * `HiBob` - HiBob
+     * * `Personio` - Personio
+     * * `Deel` - Deel
+     * * `AdpWorkforceNow` - AdpWorkforceNow
+     * * `Paylocity` - Paylocity
+     * * `Gusto` - Gusto
+     * * `CultureAmp` - CultureAmp
+     * * `Lattice` - Lattice
+     * * `SageIntacct` - SageIntacct
+     * * `FreshBooks` - FreshBooks
+     * * `Expensify` - Expensify
+     * * `Ramp` - Ramp
+     * * `Brex` - Brex
+     * * `Coupa` - Coupa
+     * * `SapConcur` - SapConcur
+     * * `Apollo` - Apollo
+     * * `Crunchbase` - Crunchbase
+     * * `ZoomInfo` - ZoomInfo
+     * * `Clari` - Clari
+     * * `Chorus` - Chorus
+     * * `Coda` - Coda
+     * * `Guru` - Guru
+     * * `Dropbox` - Dropbox
+     * * `Docusign` - Docusign
+     * * `PandaDoc` - PandaDoc
+     * * `SapErp` - SapErp
+     * * `SapSuccessFactors` - SapSuccessFactors
+     * * `OracleEbs` - OracleEbs
+     * * `OracleFusion` - OracleFusion
      * * `Custom` - Custom
      */
     export type ExternalDataSourceTypeEnum = typeof ExternalDataSourceTypeEnum[keyof typeof ExternalDataSourceTypeEnum];
@@ -13559,6 +13738,85 @@ export namespace Schemas {
       Resend: 'Resend',
       PgAnalyze: 'PgAnalyze',
       WorkOS: 'WorkOS',
+      AmazonS3: 'AmazonS3',
+      GoogleCloudStorage: 'GoogleCloudStorage',
+      Databricks: 'Databricks',
+      Dynamics365: 'Dynamics365',
+      SalesforceMarketingCloud: 'SalesforceMarketingCloud',
+      Db2: 'Db2',
+      Heap: 'Heap',
+      AdobeAnalytics: 'AdobeAnalytics',
+      Matomo: 'Matomo',
+      Optimizely: 'Optimizely',
+      Adyen: 'Adyen',
+      GoCardless: 'GoCardless',
+      Mollie: 'Mollie',
+      CheckoutCom: 'CheckoutCom',
+      Branch: 'Branch',
+      Criteo: 'Criteo',
+      Outbrain: 'Outbrain',
+      Taboola: 'Taboola',
+      AdRoll: 'AdRoll',
+      DisplayVideo360: 'DisplayVideo360',
+      GoogleAdManager: 'GoogleAdManager',
+      CampaignManager360: 'CampaignManager360',
+      SearchAds360: 'SearchAds360',
+      AdobeCommerce: 'AdobeCommerce',
+      AmazonSellingPartner: 'AmazonSellingPartner',
+      Ebay: 'Ebay',
+      Commercetools: 'Commercetools',
+      LightspeedRetail: 'LightspeedRetail',
+      ShipStation: 'ShipStation',
+      ConstantContact: 'ConstantContact',
+      Mailgun: 'Mailgun',
+      Eloqua: 'Eloqua',
+      Sailthru: 'Sailthru',
+      Ortto: 'Ortto',
+      Attentive: 'Attentive',
+      Kustomer: 'Kustomer',
+      Dixa: 'Dixa',
+      Gladly: 'Gladly',
+      Qualtrics: 'Qualtrics',
+      Delighted: 'Delighted',
+      AzureDevOps: 'AzureDevOps',
+      Rollbar: 'Rollbar',
+      Opsgenie: 'Opsgenie',
+      IncidentIo: 'IncidentIo',
+      Pingdom: 'Pingdom',
+      Cloudflare: 'Cloudflare',
+      CosmosDB: 'CosmosDB',
+      PlanetScale: 'PlanetScale',
+      SapHana: 'SapHana',
+      Rippling: 'Rippling',
+      HiBob: 'HiBob',
+      Personio: 'Personio',
+      Deel: 'Deel',
+      AdpWorkforceNow: 'AdpWorkforceNow',
+      Paylocity: 'Paylocity',
+      Gusto: 'Gusto',
+      CultureAmp: 'CultureAmp',
+      Lattice: 'Lattice',
+      SageIntacct: 'SageIntacct',
+      FreshBooks: 'FreshBooks',
+      Expensify: 'Expensify',
+      Ramp: 'Ramp',
+      Brex: 'Brex',
+      Coupa: 'Coupa',
+      SapConcur: 'SapConcur',
+      Apollo: 'Apollo',
+      Crunchbase: 'Crunchbase',
+      ZoomInfo: 'ZoomInfo',
+      Clari: 'Clari',
+      Chorus: 'Chorus',
+      Coda: 'Coda',
+      Guru: 'Guru',
+      Dropbox: 'Dropbox',
+      Docusign: 'Docusign',
+      PandaDoc: 'PandaDoc',
+      SapErp: 'SapErp',
+      SapSuccessFactors: 'SapSuccessFactors',
+      OracleEbs: 'OracleEbs',
+      OracleFusion: 'OracleFusion',
       Custom: 'Custom',
     } as const;
 
@@ -13719,6 +13977,85 @@ export namespace Schemas {
        * * `Resend` - Resend
        * * `PgAnalyze` - PgAnalyze
        * * `WorkOS` - WorkOS
+       * * `AmazonS3` - AmazonS3
+       * * `GoogleCloudStorage` - GoogleCloudStorage
+       * * `Databricks` - Databricks
+       * * `Dynamics365` - Dynamics365
+       * * `SalesforceMarketingCloud` - SalesforceMarketingCloud
+       * * `Db2` - Db2
+       * * `Heap` - Heap
+       * * `AdobeAnalytics` - AdobeAnalytics
+       * * `Matomo` - Matomo
+       * * `Optimizely` - Optimizely
+       * * `Adyen` - Adyen
+       * * `GoCardless` - GoCardless
+       * * `Mollie` - Mollie
+       * * `CheckoutCom` - CheckoutCom
+       * * `Branch` - Branch
+       * * `Criteo` - Criteo
+       * * `Outbrain` - Outbrain
+       * * `Taboola` - Taboola
+       * * `AdRoll` - AdRoll
+       * * `DisplayVideo360` - DisplayVideo360
+       * * `GoogleAdManager` - GoogleAdManager
+       * * `CampaignManager360` - CampaignManager360
+       * * `SearchAds360` - SearchAds360
+       * * `AdobeCommerce` - AdobeCommerce
+       * * `AmazonSellingPartner` - AmazonSellingPartner
+       * * `Ebay` - Ebay
+       * * `Commercetools` - Commercetools
+       * * `LightspeedRetail` - LightspeedRetail
+       * * `ShipStation` - ShipStation
+       * * `ConstantContact` - ConstantContact
+       * * `Mailgun` - Mailgun
+       * * `Eloqua` - Eloqua
+       * * `Sailthru` - Sailthru
+       * * `Ortto` - Ortto
+       * * `Attentive` - Attentive
+       * * `Kustomer` - Kustomer
+       * * `Dixa` - Dixa
+       * * `Gladly` - Gladly
+       * * `Qualtrics` - Qualtrics
+       * * `Delighted` - Delighted
+       * * `AzureDevOps` - AzureDevOps
+       * * `Rollbar` - Rollbar
+       * * `Opsgenie` - Opsgenie
+       * * `IncidentIo` - IncidentIo
+       * * `Pingdom` - Pingdom
+       * * `Cloudflare` - Cloudflare
+       * * `CosmosDB` - CosmosDB
+       * * `PlanetScale` - PlanetScale
+       * * `SapHana` - SapHana
+       * * `Rippling` - Rippling
+       * * `HiBob` - HiBob
+       * * `Personio` - Personio
+       * * `Deel` - Deel
+       * * `AdpWorkforceNow` - AdpWorkforceNow
+       * * `Paylocity` - Paylocity
+       * * `Gusto` - Gusto
+       * * `CultureAmp` - CultureAmp
+       * * `Lattice` - Lattice
+       * * `SageIntacct` - SageIntacct
+       * * `FreshBooks` - FreshBooks
+       * * `Expensify` - Expensify
+       * * `Ramp` - Ramp
+       * * `Brex` - Brex
+       * * `Coupa` - Coupa
+       * * `SapConcur` - SapConcur
+       * * `Apollo` - Apollo
+       * * `Crunchbase` - Crunchbase
+       * * `ZoomInfo` - ZoomInfo
+       * * `Clari` - Clari
+       * * `Chorus` - Chorus
+       * * `Coda` - Coda
+       * * `Guru` - Guru
+       * * `Dropbox` - Dropbox
+       * * `Docusign` - Docusign
+       * * `PandaDoc` - PandaDoc
+       * * `SapErp` - SapErp
+       * * `SapSuccessFactors` - SapSuccessFactors
+       * * `OracleEbs` - OracleEbs
+       * * `OracleFusion` - OracleFusion
        * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
     }
@@ -14459,6 +14796,12 @@ export namespace Schemas {
       severity?: AutonomyPriorityEnum | null;
       /** Optional keys for downstream dedupe (e.g. `error_tracking_issue:<id>`). */
       dedupe_keys?: string[];
+      /**
+         * Optional category tags as lowercase kebab-case slugs (e.g. `cost-spike`, `silent-failure`), max 10. Reuse the vocabulary in your `tags:<domain>:taxonomy` scratchpad entry when a tag fits; coin a new slug when a genuinely new category emerges. Near-miss formats are normalized to slugs; persisted in the signal's `extra.tags` and on the emission row.
+         * @maxItems 10
+         * @items.maxLength 50
+         */
+      tags?: string[];
       /** Optional time window the finding refers to. */
       time_range?: TimeRange | null;
       /**
@@ -14739,6 +15082,8 @@ export namespace Schemas {
     export interface EndpointRunResponse {
       /** URL-safe endpoint name that was executed. */
       name: string;
+      /** Unique identifier for this execution. Use it to find the matching entry in the endpoint's logs. */
+      execution_id?: string;
       /** Query result rows. Each row is a list of values matching the columns order. */
       results?: unknown[];
       /** Column names from the query SELECT clause. */
@@ -15104,6 +15449,16 @@ export namespace Schemas {
       volume_buckets?: ErrorTrackingVolumeBucket[];
     }
 
+    export interface ErrorTrackingAssignee {
+      /** User ID or role UUID to filter by. */
+      id: string | number | null;
+      /** Assignee target type: user or role.
+       *
+       * * `user` - user
+       * * `role` - role */
+      type: AssigneeTypeEnum;
+    }
+
     export interface ErrorTrackingAssigneeResponse {
       /** Assignee user ID or role UUID. */
       id?: string | number | null;
@@ -15467,6 +15822,18 @@ export namespace Schemas {
     }
 
     /**
+     * * `ASC` - ASC
+     * * `DESC` - DESC
+     */
+    export type OrderDirectionEnum = typeof OrderDirectionEnum[keyof typeof OrderDirectionEnum];
+
+
+    export const OrderDirectionEnum = {
+      Asc: 'ASC',
+      Desc: 'DESC',
+    } as const;
+
+    /**
      * * `summary` - summary
      * * `stack` - stack
      * * `raw` - raw
@@ -15624,6 +15991,24 @@ export namespace Schemas {
       success: boolean;
     }
 
+    /**
+     * * `last_seen` - last_seen
+     * * `first_seen` - first_seen
+     * * `occurrences` - occurrences
+     * * `users` - users
+     * * `sessions` - sessions
+     */
+    export type ErrorTrackingIssueOrderByEnum = typeof ErrorTrackingIssueOrderByEnum[keyof typeof ErrorTrackingIssueOrderByEnum];
+
+
+    export const ErrorTrackingIssueOrderByEnum = {
+      LastSeen: 'last_seen',
+      FirstSeen: 'first_seen',
+      Occurrences: 'occurrences',
+      Users: 'users',
+      Sessions: 'sessions',
+    } as const;
+
     export interface ErrorTrackingIssueQueryRequest {
       /** Error tracking issue ID. */
       issueId: string;
@@ -15660,6 +16045,59 @@ export namespace Schemas {
       success: boolean;
       /** IDs of the new issues created by the split. */
       new_issue_ids: string[];
+    }
+
+    /**
+     * * `archived` - archived
+     * * `active` - active
+     * * `resolved` - resolved
+     * * `pending_release` - pending_release
+     * * `suppressed` - suppressed
+     * * `all` - all
+     */
+    export type ErrorTrackingIssueStatusEnum = typeof ErrorTrackingIssueStatusEnum[keyof typeof ErrorTrackingIssueStatusEnum];
+
+
+    export const ErrorTrackingIssueStatusEnum = {
+      Archived: 'archived',
+      Active: 'active',
+      Resolved: 'resolved',
+      PendingRelease: 'pending_release',
+      Suppressed: 'suppressed',
+      All: 'all',
+    } as const;
+
+    /**
+     * * `active` - active
+     * * `resolved` - resolved
+     * * `suppressed` - suppressed
+     */
+    export type ErrorTrackingIssueWriteStatusEnum = typeof ErrorTrackingIssueWriteStatusEnum[keyof typeof ErrorTrackingIssueWriteStatusEnum];
+
+
+    export const ErrorTrackingIssueWriteStatusEnum = {
+      Active: 'active',
+      Resolved: 'resolved',
+      Suppressed: 'suppressed',
+    } as const;
+
+    export interface ErrorTrackingIssueWrite {
+      /** Issue status to set. Deprecated archived and pending_release values are rejected.
+       *
+       * * `active` - active
+       * * `resolved` - resolved
+       * * `suppressed` - suppressed */
+      status?: ErrorTrackingIssueWriteStatusEnum;
+      /**
+         * Optional issue display name.
+         * @nullable
+         */
+      name?: string | null;
+      /**
+         * Optional issue description.
+         * @nullable
+         */
+      description?: string | null;
     }
 
     export interface ErrorTrackingIssuesListQueryRequest {
@@ -15756,13 +16194,32 @@ export namespace Schemas {
       nextOffset?: number;
     }
 
+    export type ErrorTrackingListWidgetCatalogEntryOpenApiWidgetType = typeof ErrorTrackingListWidgetCatalogEntryOpenApiWidgetType[keyof typeof ErrorTrackingListWidgetCatalogEntryOpenApiWidgetType];
+
+
+    export const ErrorTrackingListWidgetCatalogEntryOpenApiWidgetType = {
+      ErrorTrackingList: 'error_tracking_list',
+    } as const;
+
+    export interface ErrorTrackingListWidgetCatalogEntryOpenApi {
+      widget_type: ErrorTrackingListWidgetCatalogEntryOpenApiWidgetType;
+      group_id: string;
+      group_label: string;
+      label: string;
+      description: string;
+      /** OpenAPI config shape for this widget type (documentation; matches batch-add/PATCH schemas). */
+      readonly config_schema: ErrorTrackingListWidgetConfig;
+      /** @nullable */
+      required_product_access?: string | null;
+    }
+
     /**
      * * `error_tracking_list` - error_tracking_list
      */
-    export type ErrorTrackingListWidgetAddRequestOpenApiWidgetTypeEnum = typeof ErrorTrackingListWidgetAddRequestOpenApiWidgetTypeEnum[keyof typeof ErrorTrackingListWidgetAddRequestOpenApiWidgetTypeEnum];
+    export type ErrorTrackingListWidgetTypeEnum = typeof ErrorTrackingListWidgetTypeEnum[keyof typeof ErrorTrackingListWidgetTypeEnum];
 
 
-    export const ErrorTrackingListWidgetAddRequestOpenApiWidgetTypeEnum = {
+    export const ErrorTrackingListWidgetTypeEnum = {
       ErrorTrackingList: 'error_tracking_list',
     } as const;
 
@@ -16977,7 +17434,7 @@ export namespace Schemas {
       start_date?: string | null;
       /** @nullable */
       end_date?: string | null;
-      /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flags-get-all tool first — reuse an existing flag when possible. */
+      /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flag-get-all tool first — reuse an existing flag when possible. */
       feature_flag_key: string;
       readonly feature_flag: MinimalFeatureFlag;
       readonly holdout: ExperimentHoldout;
@@ -17012,7 +17469,7 @@ export namespace Schemas {
       type?: ExperimentTypeEnum | null;
       /** Exposure configuration including filter test accounts and custom exposure events. */
       exposure_criteria?: ExperimentApiExposureCriteria | null;
-      /** Primary experiment metrics. Each metric must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Use the event-definitions-list tool to find available events in the project. */
+      /** Primary experiment metrics. Each metric must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Use the read-data-schema tool with query kind 'events' to find available events in the project. */
       metrics?: _ExperimentApiMetricsList | null;
       /** Secondary metrics for additional measurements. Same format as primary metrics. */
       metrics_secondary?: _ExperimentApiMetricsList | null;
@@ -17719,6 +18176,85 @@ export namespace Schemas {
        * * `Resend` - Resend
        * * `PgAnalyze` - PgAnalyze
        * * `WorkOS` - WorkOS
+       * * `AmazonS3` - AmazonS3
+       * * `GoogleCloudStorage` - GoogleCloudStorage
+       * * `Databricks` - Databricks
+       * * `Dynamics365` - Dynamics365
+       * * `SalesforceMarketingCloud` - SalesforceMarketingCloud
+       * * `Db2` - Db2
+       * * `Heap` - Heap
+       * * `AdobeAnalytics` - AdobeAnalytics
+       * * `Matomo` - Matomo
+       * * `Optimizely` - Optimizely
+       * * `Adyen` - Adyen
+       * * `GoCardless` - GoCardless
+       * * `Mollie` - Mollie
+       * * `CheckoutCom` - CheckoutCom
+       * * `Branch` - Branch
+       * * `Criteo` - Criteo
+       * * `Outbrain` - Outbrain
+       * * `Taboola` - Taboola
+       * * `AdRoll` - AdRoll
+       * * `DisplayVideo360` - DisplayVideo360
+       * * `GoogleAdManager` - GoogleAdManager
+       * * `CampaignManager360` - CampaignManager360
+       * * `SearchAds360` - SearchAds360
+       * * `AdobeCommerce` - AdobeCommerce
+       * * `AmazonSellingPartner` - AmazonSellingPartner
+       * * `Ebay` - Ebay
+       * * `Commercetools` - Commercetools
+       * * `LightspeedRetail` - LightspeedRetail
+       * * `ShipStation` - ShipStation
+       * * `ConstantContact` - ConstantContact
+       * * `Mailgun` - Mailgun
+       * * `Eloqua` - Eloqua
+       * * `Sailthru` - Sailthru
+       * * `Ortto` - Ortto
+       * * `Attentive` - Attentive
+       * * `Kustomer` - Kustomer
+       * * `Dixa` - Dixa
+       * * `Gladly` - Gladly
+       * * `Qualtrics` - Qualtrics
+       * * `Delighted` - Delighted
+       * * `AzureDevOps` - AzureDevOps
+       * * `Rollbar` - Rollbar
+       * * `Opsgenie` - Opsgenie
+       * * `IncidentIo` - IncidentIo
+       * * `Pingdom` - Pingdom
+       * * `Cloudflare` - Cloudflare
+       * * `CosmosDB` - CosmosDB
+       * * `PlanetScale` - PlanetScale
+       * * `SapHana` - SapHana
+       * * `Rippling` - Rippling
+       * * `HiBob` - HiBob
+       * * `Personio` - Personio
+       * * `Deel` - Deel
+       * * `AdpWorkforceNow` - AdpWorkforceNow
+       * * `Paylocity` - Paylocity
+       * * `Gusto` - Gusto
+       * * `CultureAmp` - CultureAmp
+       * * `Lattice` - Lattice
+       * * `SageIntacct` - SageIntacct
+       * * `FreshBooks` - FreshBooks
+       * * `Expensify` - Expensify
+       * * `Ramp` - Ramp
+       * * `Brex` - Brex
+       * * `Coupa` - Coupa
+       * * `SapConcur` - SapConcur
+       * * `Apollo` - Apollo
+       * * `Crunchbase` - Crunchbase
+       * * `ZoomInfo` - ZoomInfo
+       * * `Clari` - Clari
+       * * `Chorus` - Chorus
+       * * `Coda` - Coda
+       * * `Guru` - Guru
+       * * `Dropbox` - Dropbox
+       * * `Docusign` - Docusign
+       * * `PandaDoc` - PandaDoc
+       * * `SapErp` - SapErp
+       * * `SapSuccessFactors` - SapSuccessFactors
+       * * `OracleEbs` - OracleEbs
+       * * `OracleFusion` - OracleFusion
        * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
       /** Connection credentials and a 'schemas' array. Keys depend on source_type. */
@@ -17846,11 +18382,18 @@ export namespace Schemas {
 
     export type FeatureFlagFilters = { [key: string]: unknown };
 
-    export type FeatureFlagExperimentSetMetadataItem = { [key: string]: unknown };
-
     export type FeatureFlagSurveys = { [key: string]: unknown };
 
     export type FeatureFlagFeatures = { [key: string]: unknown };
+
+    export interface FeatureFlagExperimentSetMetadata {
+      /** ID of the experiment linked to this flag. */
+      id: number;
+      /** Name of the experiment linked to this flag. */
+      name: string;
+      /** Whether the experiment is currently running (started and not yet stopped). A running experiment blocks deletion of the linked flag. */
+      is_running: boolean;
+    }
 
     /**
      * * `feature_flags` - feature_flags
@@ -17893,7 +18436,7 @@ export namespace Schemas {
       /** @nullable */
       ensure_experience_continuity?: boolean | null;
       readonly experiment_set: readonly number[];
-      readonly experiment_set_metadata: readonly FeatureFlagExperimentSetMetadataItem[];
+      readonly experiment_set_metadata: readonly FeatureFlagExperimentSetMetadata[];
       readonly surveys: FeatureFlagSurveys;
       readonly features: FeatureFlagFeatures;
       rollback_conditions?: unknown;
@@ -18387,6 +18930,11 @@ export namespace Schemas {
       tags?: string[];
       /** Evaluation contexts that control where this flag evaluates at runtime. */
       evaluation_contexts?: string[];
+      /**
+         * Whether this flag is a remote configuration flag that delivers a payload rather than gating a feature.
+         * @nullable
+         */
+      is_remote_configuration?: boolean | null;
     }
 
     export interface FeatureFlagStatusResponse {
@@ -19403,18 +19951,18 @@ export namespace Schemas {
 
     export interface HogFlowMasking {
       /**
-         * Hash TTL in seconds (60 to ~94M / 3y).
+         * Seconds (60 to ~94M / 3y) to suppress repeat firings of the same hash.
          * @minimum 60
          * @maximum 94608000
          * @nullable
          */
       ttl?: number | null;
       /**
-         * Min matching events before triggering (k-anonymity).
+         * Fire once per N matches of the same hash within ttl — a sampler: N=3 fires on the 1st, 4th, 7th… match. Omit to fire on the first match, then suppress repeats within ttl.
          * @nullable
          */
       threshold?: number | null;
-      /** HogQL template, e.g. '{person.properties.email}'. */
+      /** HogQL template defining the dedup/grouping key, e.g. '{person.id}' (once per person) within ttl. */
       hash: string;
       /** Auto-compiled from hash. Do not set. */
       bytecode?: unknown;
@@ -19593,7 +20141,7 @@ export namespace Schemas {
       readonly created_by: UserBasic;
       readonly updated_at: string;
       readonly trigger: unknown;
-      /** Optional dedup: {hash: <HogQL template>, ttl: <seconds, 60-94608000>, threshold?: <int>}. Server compiles bytecode from hash. Omit to disable. */
+      /** Optional dedup/throttle on an already-matched trigger: {hash: <HogQL template>, ttl: <seconds, 60-94608000>, threshold?: <int>}. Without threshold: fire once per hash, then suppress repeats within ttl (hash '{person.id}' = once per person per ttl). With threshold N: fire once per N matches of the same hash — a sampler, the 1st then every Nth. Throttles an already-qualifying trigger; it doesn't decide who enters. Server compiles bytecode from hash; omit to disable. */
       trigger_masking?: HogFlowMasking | null;
       /** Conversion goal: {filters: [<cond>, ...], window_minutes}. <cond>: {key, value, operator, type: event|person|group}. Empty filters = any event in window. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
       conversion?: unknown;
@@ -20071,6 +20619,8 @@ export namespace Schemas {
       _create_in_folder?: string;
       /** @nullable */
       readonly batch_export_id: string | null;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     /**
@@ -20122,6 +20672,8 @@ export namespace Schemas {
       readonly status: HogFunctionStatus | null;
       /** @nullable */
       readonly execution_order: number | null;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     export interface HogInvocationResult {
@@ -20595,6 +21147,14 @@ export namespace Schemas {
       version?: number | null;
     }
 
+    export type TraceOrderColumn = typeof TraceOrderColumn[keyof typeof TraceOrderColumn];
+
+
+    export const TraceOrderColumn = {
+      Timestamp: 'timestamp',
+      Duration: 'duration',
+    } as const;
+
     export interface TraceSpansQueryResponse {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -20632,7 +21192,10 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
-      orderBy?: LogsOrderBy | null;
+      /** Column to order by. Defaults to timestamp. `timestamp` paginates via keyset cursor (`after`); other columns via `offset`. */
+      orderBy?: TraceOrderColumn | null;
+      /** Order direction. Defaults to DESC. */
+      orderDirection?: OrderDirection2 | null;
       /** Prefetch up to this many spans per trace and include them in results */
       prefetchSpans?: number | null;
       response?: TraceSpansQueryResponse | null;
@@ -20837,6 +21400,8 @@ export namespace Schemas {
       id: string;
       inactive_seconds?: number | null;
       keypress_count?: number | null;
+      /** False when the recording was included in list results via a direct link despite not matching the filters. */
+      matches_filters?: boolean | null;
       /** List of matching events. * */
       matching_events?: MatchedRecording[] | null;
       /** count of all mouse activity in the recording, not just clicks */
@@ -21485,6 +22050,55 @@ export namespace Schemas {
     export const JsonrpcEnum = {
       '20': '2.0',
     } as const;
+
+    /**
+     * One chunk in a drill-down window over a single knowledge document.
+     *
+     * Output-only — the rows come from the `get_document_window` logic helper
+     * (a `KnowledgeSearchResult` dataclass), not the ORM, so this is a plain
+     * read serializer rather than a `ModelSerializer`.
+     */
+    export interface KnowledgeDocumentWindow {
+      /** Stable identifier of this chunk. Same value used in search results. */
+      readonly chunk_id: string;
+      /** Zero-based position of this chunk within its document. Use it as `around_ordinal` to recenter the window. */
+      readonly ordinal: number;
+      /** The chunk's text content. */
+      readonly content: string;
+      /** Breadcrumb of section headings this chunk sits under. Empty when the document has no heading structure. */
+      readonly heading_path: string;
+      /** Human label of the knowledge source this chunk belongs to. */
+      readonly source_name: string;
+      /** Title of the document this chunk belongs to. */
+      readonly document_title: string;
+    }
+
+    /**
+     * One ranked chunk from a business knowledge search.
+     *
+     * Output-only — the rows come from the ``search_knowledge_for_team`` logic
+     * helper (a ``KnowledgeSearchResult`` dataclass), not the ORM.
+     */
+    export interface KnowledgeSearchResult {
+      /** Stable identifier of this chunk. */
+      readonly chunk_id: string;
+      /** ID of the parent document. Pass to the document-window endpoint with `around_ordinal` to drill down. */
+      readonly document_id: string;
+      /** Zero-based position of this chunk within its document. Use as `around_ordinal` in the document-window endpoint. */
+      readonly ordinal: number;
+      /** ID of the knowledge source this chunk belongs to. */
+      readonly source_id: string;
+      /** Human label of the knowledge source this chunk belongs to. */
+      readonly source_name: string;
+      /** Source type (text, url, or file). */
+      readonly source_type: string;
+      /** Title of the document this chunk belongs to. */
+      readonly document_title: string;
+      /** Breadcrumb of section headings this chunk sits under. Empty when the document has no heading structure. */
+      readonly heading_path: string;
+      /** The chunk's text content. */
+      readonly content: string;
+    }
 
     /**
      * * `text` - Text
@@ -22155,6 +22769,7 @@ export namespace Schemas {
     /**
      * * `slack` - slack
      * * `webhook` - webhook
+     * * `teams` - teams
      */
     export type NotificationDestinationTypeEnum = typeof NotificationDestinationTypeEnum[keyof typeof NotificationDestinationTypeEnum];
 
@@ -22162,6 +22777,7 @@ export namespace Schemas {
     export const NotificationDestinationTypeEnum = {
       Slack: 'slack',
       Webhook: 'webhook',
+      Teams: 'teams',
     } as const;
 
     export interface LogsAlertConfiguration {
@@ -22263,10 +22879,11 @@ export namespace Schemas {
     }
 
     export interface LogsAlertCreateDestination {
-      /** Destination type — slack or webhook.
+      /** Destination type — slack, webhook, or teams.
        *
        * * `slack` - slack
-       * * `webhook` - webhook */
+       * * `webhook` - webhook
+       * * `teams` - teams */
       type: NotificationDestinationTypeEnum;
       /** Integration ID for the Slack workspace. Required when type=slack. */
       slack_workspace_id?: number;
@@ -22274,7 +22891,7 @@ export namespace Schemas {
       slack_channel_id?: string;
       /** Human-readable channel name for display. */
       slack_channel_name?: string;
-      /** HTTPS endpoint to POST to. Required when type=webhook. */
+      /** HTTPS endpoint to POST to. Required when type=webhook, or the Teams webhook URL when type=teams. */
       webhook_url?: string;
     }
 
@@ -23954,6 +24571,8 @@ export namespace Schemas {
       readonly is_2fa_enabled: boolean;
       readonly has_social_auth: boolean;
       readonly last_login: string;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     /**
@@ -25359,6 +25978,8 @@ export namespace Schemas {
       readonly id: number;
       readonly uuid: string;
       readonly organization: string;
+      /** ID of the project this environment belongs to. */
+      readonly project_id: number;
       readonly api_token: string;
       readonly name: string;
       readonly completed_snippet_onboarding: boolean;
@@ -25391,6 +26012,7 @@ export namespace Schemas {
       readonly last_used_at: string | null;
       /** @nullable */
       readonly last_rolled_at: string | null;
+      /** Project-wide API scopes granted to this key. Project secret API keys do not honor object-level access controls, so a scope can access resources of that type even when per-resource RBAC would hide them from an individual user. */
       scopes: string[];
     }
 
@@ -25647,6 +26269,11 @@ export namespace Schemas {
       emits_signals?: boolean;
       /** Increments on every config-changing save. Observations snapshot this value. */
       readonly scanner_version: number;
+      /**
+         * Latest projected observations/month for this scanner. Null until first computed.
+         * @nullable
+         */
+      readonly estimated_monthly_observations: number | null;
       /** Watermark for the scanner's last scheduled fire. Mirrors Temporal schedule state for recovery. */
       readonly last_swept_at: string;
       readonly created_at: string;
@@ -26086,6 +26713,8 @@ export namespace Schemas {
       readonly summary_outcome: Outcome | null;
       /** Load external references (linked issues) for this recording */
       readonly external_references: readonly SessionRecordingExternalReferencesItem[];
+      /** Whether this recording matched the filters of the listing query that returned it. False only when a recording requested via session_recording_id was included despite not matching the filters. */
+      readonly matches_filters: boolean;
     }
 
     export interface PaginatedSessionRecordingList {
@@ -27609,6 +28238,34 @@ export namespace Schemas {
     }
 
     /**
+     * A single message in a ticket thread (output-only).
+     */
+    export interface TicketMessage {
+      /** Message (comment) UUID. */
+      readonly id: string;
+      /** Plain-text message body. */
+      readonly content: string;
+      /** TipTap rich content JSON, if any. */
+      readonly rich_content: unknown;
+      /** One of: customer, support, AI. */
+      readonly author_type: string;
+      /** Display name of the author. */
+      readonly author_name: string;
+      /** True for internal notes not visible to the customer. */
+      readonly is_private: boolean;
+      readonly created_at: string;
+    }
+
+    export interface PaginatedTicketMessageList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: TicketMessage[];
+    }
+
+    /**
      * Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys.
      */
     export type TicketViewFilters = { [key: string]: unknown };
@@ -28038,7 +28695,7 @@ export namespace Schemas {
       /** Real-time notification types that currently have a live dispatch site. Drives the in-app notifications settings UI. Read-only. */
       readonly active_realtime_notification_types: readonly string[];
       readonly pending_invites: readonly PendingInvite[];
-      /** True if the user has at least one Personal API Key and has not yet acknowledged their existing credentials. Used to gate a one-shot review screen on first post-provisioning login. Becomes False once the user POSTs to `/api/users/@me/credentials_review_complete/`. Read-only. */
+      /** True if the user has at least one Personal API Key or passkey and has not yet acknowledged their existing credentials. Used to gate a one-shot review screen on first post-provisioning login. Becomes False once the user POSTs to `/api/users/@me/credentials_review_complete/`. Read-only. */
       readonly requires_credential_review: boolean;
     }
 
@@ -28717,6 +29374,18 @@ export namespace Schemas {
          * @nullable
          */
       readonly title?: string | null;
+      /** Product domain the conversation is about, classified from the first question.
+       *
+       * * `web_analytics` - Web analytics
+       * * `product_analytics` - Product analytics
+       * * `session_replay` - Session replay
+       * * `surveys` - Surveys
+       * * `feature_flags` - Feature flags
+       * * `experiments` - Experiments
+       * * `error_tracking` - Error tracking
+       * * `data_warehouse` - Data warehouse
+       * * `other` - Other */
+      readonly topic?: TopicEnum | null;
       readonly user?: UserBasic;
       /** @nullable */
       readonly created_at?: string | null;
@@ -28818,92 +29487,6 @@ export namespace Schemas {
       readonly created_at?: string;
       /** @nullable */
       readonly updated_at?: string | null;
-    }
-
-    export type PatchedDashboardFilters = { [key: string]: unknown };
-
-    /**
-     * @nullable
-     */
-    export type PatchedDashboardVariables = { [key: string]: unknown } | null;
-
-    /**
-     * @nullable
-     */
-    export type PatchedDashboardPersistedFilters = { [key: string]: unknown } | null;
-
-    /**
-     * @nullable
-     */
-    export type PatchedDashboardPersistedVariables = { [key: string]: unknown } | null;
-
-    export type PatchedDashboardTilesItem = { [key: string]: unknown };
-
-    /**
-     * Serializer mixin that handles tags for objects.
-     */
-    export interface PatchedDashboard {
-      readonly id?: number;
-      /**
-         * @maxLength 400
-         * @nullable
-         */
-      name?: string | null;
-      description?: string;
-      pinned?: boolean;
-      readonly created_at?: string;
-      readonly created_by?: UserBasic;
-      /** @nullable */
-      last_accessed_at?: string | null;
-      /** @nullable */
-      readonly last_viewed_at?: string | null;
-      readonly is_shared?: boolean;
-      deleted?: boolean;
-      readonly creation_mode?: CreationModeEnum;
-      readonly filters?: PatchedDashboardFilters;
-      /** @nullable */
-      readonly variables?: PatchedDashboardVariables;
-      /** Custom color mapping for breakdown values. */
-      breakdown_colors?: unknown;
-      /**
-         * ID of the color theme used for chart visualizations.
-         * @nullable
-         */
-      data_color_theme_id?: number | null;
-      tags?: unknown[];
-      restriction_level?: RestrictionLevelEnum;
-      readonly effective_restriction_level?: EffectivePrivilegeLevelEnum;
-      readonly effective_privilege_level?: EffectivePrivilegeLevelEnum;
-      /**
-         * The effective access level the user has for this object
-         * @nullable
-         */
-      readonly user_access_level?: string | null;
-      readonly access_control_version?: string;
-      /** @nullable */
-      last_refresh?: string | null;
-      /** @nullable */
-      readonly persisted_filters?: PatchedDashboardPersistedFilters;
-      /** @nullable */
-      readonly persisted_variables?: PatchedDashboardPersistedVariables;
-      readonly team_id?: number;
-      /**
-         * List of quick filter IDs associated with this dashboard
-         * @nullable
-         */
-      quick_filter_ids?: string[] | null;
-      /** @nullable */
-      readonly tiles?: readonly PatchedDashboardTilesItem[] | null;
-      /** Template key to create the dashboard from a predefined template. */
-      use_template?: string;
-      /**
-         * ID of an existing dashboard to duplicate.
-         * @nullable
-         */
-      use_dashboard?: number | null;
-      /** When deleting, also delete insights that are only on this dashboard. */
-      delete_insights?: boolean;
-      _create_in_folder?: string;
     }
 
     export interface PatchedDashboardTemplate {
@@ -29518,6 +30101,25 @@ export namespace Schemas {
       readonly cohort?: PatchedErrorTrackingIssueFullCohort;
     }
 
+    export interface PatchedErrorTrackingIssueWrite {
+      /** Issue status to set. Deprecated archived and pending_release values are rejected.
+       *
+       * * `active` - active
+       * * `resolved` - resolved
+       * * `suppressed` - suppressed */
+      status?: ErrorTrackingIssueWriteStatusEnum;
+      /**
+         * Optional issue display name.
+         * @nullable
+         */
+      name?: string | null;
+      /**
+         * Optional issue description.
+         * @nullable
+         */
+      description?: string | null;
+    }
+
     export interface PatchedErrorTrackingRelease {
       readonly id?: string;
       hash_id?: string;
@@ -29751,7 +30353,7 @@ export namespace Schemas {
       start_date?: string | null;
       /** @nullable */
       end_date?: string | null;
-      /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flags-get-all tool first — reuse an existing flag when possible. */
+      /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flag-get-all tool first — reuse an existing flag when possible. */
       feature_flag_key?: string;
       readonly feature_flag?: MinimalFeatureFlag;
       readonly holdout?: ExperimentHoldout;
@@ -29786,7 +30388,7 @@ export namespace Schemas {
       type?: ExperimentTypeEnum | null;
       /** Exposure configuration including filter test accounts and custom exposure events. */
       exposure_criteria?: ExperimentApiExposureCriteria | null;
-      /** Primary experiment metrics. Each metric must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Use the event-definitions-list tool to find available events in the project. */
+      /** Primary experiment metrics. Each metric must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Use the read-data-schema tool with query kind 'events' to find available events in the project. */
       metrics?: _ExperimentApiMetricsList | null;
       /** Secondary metrics for additional measurements. Same format as primary metrics. */
       metrics_secondary?: _ExperimentApiMetricsList | null;
@@ -30046,6 +30648,11 @@ export namespace Schemas {
       tags?: string[];
       /** Evaluation contexts that control where this flag evaluates at runtime. */
       evaluation_contexts?: string[];
+      /**
+         * Whether this flag is a remote configuration flag that delivers a payload rather than gating a feature.
+         * @nullable
+         */
+      is_remote_configuration?: boolean | null;
     }
 
     export interface PatchedFileSystem {
@@ -30239,7 +30846,7 @@ export namespace Schemas {
       readonly created_by?: UserBasic;
       readonly updated_at?: string;
       readonly trigger?: unknown;
-      /** Optional dedup: {hash: <HogQL template>, ttl: <seconds, 60-94608000>, threshold?: <int>}. Server compiles bytecode from hash. Omit to disable. */
+      /** Optional dedup/throttle on an already-matched trigger: {hash: <HogQL template>, ttl: <seconds, 60-94608000>, threshold?: <int>}. Without threshold: fire once per hash, then suppress repeats within ttl (hash '{person.id}' = once per person per ttl). With threshold N: fire once per N matches of the same hash — a sampler, the 1st then every Nth. Throttles an already-qualifying trigger; it doesn't decide who enters. Server compiles bytecode from hash; omit to disable. */
       trigger_masking?: HogFlowMasking | null;
       /** Conversion goal: {filters: [<cond>, ...], window_minutes}. <cond>: {key, value, operator, type: event|person|group}. Empty filters = any event in window. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
       conversion?: unknown;
@@ -30408,6 +31015,8 @@ export namespace Schemas {
       _create_in_folder?: string;
       /** @nullable */
       readonly batch_export_id?: string | null;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type?: SearchMatchTypeEnum | null;
     }
 
     /**
@@ -31205,6 +31814,8 @@ export namespace Schemas {
       readonly is_2fa_enabled?: boolean;
       readonly has_social_auth?: boolean;
       readonly last_login?: string;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type?: SearchMatchTypeEnum | null;
     }
 
     export interface PatchedParserRecipe {
@@ -31221,6 +31832,47 @@ export namespace Schemas {
       readonly created_at?: string;
       /** @nullable */
       readonly updated_at?: string | null;
+    }
+
+    /**
+     * OpenAPI-only PATCH body for dashboards (agents/MCP).
+     *
+     * Must be a superset of ``dashboard_patch_runtime_openapi_field_names()`` — ``extend_schema(request=...)``
+     * replaces the inferred schema entirely. Contract: ``test_dashboard_openapi.py``.
+     */
+    export interface PatchedPatchedDashboardOpenApi {
+      /**
+         * @maxLength 400
+         * @nullable
+         */
+      name?: string | null;
+      description?: string;
+      pinned?: boolean;
+      /** Custom color mapping for breakdown values. */
+      breakdown_colors?: unknown;
+      /**
+         * ID of the color theme used for chart visualizations.
+         * @nullable
+         */
+      data_color_theme_id?: number | null;
+      tags?: string[];
+      restriction_level?: EffectivePrivilegeLevelEnum;
+      /**
+         * List of quick filter IDs associated with this dashboard.
+         * @nullable
+         */
+      quick_filter_ids?: string[] | null;
+      /** Dashboard tiles to update. Widget tiles accept nested widget.config patches. */
+      tiles?: DashboardPatchTileOpenApi[];
+      /** Template key to create the dashboard from a predefined template. */
+      use_template?: string;
+      /**
+         * ID of an existing dashboard to duplicate.
+         * @nullable
+         */
+      use_dashboard?: number | null;
+      /** When deleting, also delete insights that are only on this dashboard. */
+      delete_insights?: boolean;
     }
 
     export interface PatchedPersistedFolder {
@@ -31356,6 +32008,8 @@ export namespace Schemas {
       updated_at?: string;
     };
 
+    export type PatchedProjectBackwardCompatManagedViewsets = {[key: string]: boolean};
+
     /**
      * * `30d` - 30 Days
      * * `90d` - 90 Days
@@ -31383,6 +32037,50 @@ export namespace Schemas {
       Number0: 0,
       Number1: 1,
     } as const;
+
+    export interface TeamRevenueAnalyticsConfig {
+      base_currency?: BaseCurrencyEnum;
+      events?: unknown;
+      goals?: unknown;
+      filter_test_accounts?: boolean;
+    }
+
+    export interface TeamMarketingAnalyticsConfig {
+      sources_map?: unknown;
+      conversion_goals?: unknown;
+      /**
+         * @minimum 1
+         * @maximum 90
+         */
+      attribution_window_days?: number;
+      attribution_mode?: AttributionModeEnum;
+      campaign_name_mappings?: unknown;
+      custom_source_mappings?: unknown;
+      campaign_field_preferences?: unknown;
+    }
+
+    export interface TeamCustomerAnalyticsConfig {
+      /** Event used as the activity signal (DAU/WAU/MAU). */
+      activity_event?: unknown;
+      /** Event used to count signup pageviews on dashboards. */
+      signup_pageview_event?: unknown;
+      /** Event used to count signups on dashboards. */
+      signup_event?: unknown;
+      /** Event used to count subscriptions on dashboards. */
+      subscription_event?: unknown;
+      /** Event used to count payments on dashboards. */
+      payment_event?: unknown;
+      /**
+         * Index of the group type to treat as an Account in customer analytics. Must reference an existing group type configured for the project.
+         * @nullable
+         */
+      account_group_type_index?: number | null;
+    }
+
+    export interface TeamWorkflowsConfig {
+      /** When enabled, workflows engagement activity (email sends, opens, clicks, bounces, spam reports, unsubscribes) is captured as standard PostHog events ($workflows_email_*) alongside the existing workflow metrics. */
+      capture_workflows_engagement_events?: boolean;
+    }
 
     /**
      * Mixin for serializers to add user access control fields
@@ -32172,6 +32870,50 @@ export namespace Schemas {
          * @nullable
          */
       readonly is_pending_deletion?: boolean | null;
+      /** ID of the project this environment belongs to. */
+      readonly project_id?: number;
+      /**
+         * The effective access level the user has for this object
+         * @nullable
+         */
+      readonly user_access_level?: string | null;
+      readonly managed_viewsets?: PatchedProjectBackwardCompatManagedViewsets;
+      revenue_analytics_config?: TeamRevenueAnalyticsConfig;
+      marketing_analytics_config?: TeamMarketingAnalyticsConfig;
+      customer_analytics_config?: TeamCustomerAnalyticsConfig;
+      workflows_config?: TeamWorkflowsConfig;
+      base_currency?: BaseCurrencyEnum;
+      /**
+         * Enables capturing clicks that had no effect (rage-click detection).
+         * @nullable
+         */
+      capture_dead_clicks?: boolean | null;
+      cookieless_server_hash_mode?: CookielessServerHashModeEnum | null;
+      /** @nullable */
+      human_friendly_comparison_periods?: boolean | null;
+      /** @nullable */
+      feature_flag_confirmation_enabled?: boolean | null;
+      /** @nullable */
+      feature_flag_confirmation_message?: string | null;
+      /**
+         * Whether to automatically apply default evaluation contexts to new feature flags
+         * @nullable
+         */
+      default_evaluation_contexts_enabled?: boolean | null;
+      /**
+         * Whether to require at least one evaluation context tag when creating new feature flags
+         * @nullable
+         */
+      require_evaluation_contexts?: boolean | null;
+      /**
+         * @minimum -2147483648
+         * @maximum 2147483647
+         * @nullable
+         */
+      default_data_theme?: number | null;
+      onboarding_tasks?: unknown;
+      /** @nullable */
+      web_analytics_pre_aggregated_tables_enabled?: boolean | null;
     }
 
     export interface PatchedProjectSecretAPIKey {
@@ -32187,6 +32929,7 @@ export namespace Schemas {
       readonly last_used_at?: string | null;
       /** @nullable */
       readonly last_rolled_at?: string | null;
+      /** Project-wide API scopes granted to this key. Project secret API keys do not honor object-level access controls, so a scope can access resources of that type even when per-resource RBAC would hide them from an individual user. */
       scopes?: string[];
     }
 
@@ -32260,6 +33003,11 @@ export namespace Schemas {
       emits_signals?: boolean;
       /** Increments on every config-changing save. Observations snapshot this value. */
       readonly scanner_version?: number;
+      /**
+         * Latest projected observations/month for this scanner. Null until first computed.
+         * @nullable
+         */
+      readonly estimated_monthly_observations?: number | null;
       /** Watermark for the scanner's last scheduled fire. Mirrors Temporal schedule state for recovery. */
       readonly last_swept_at?: string;
       readonly created_at?: string;
@@ -32508,6 +33256,8 @@ export namespace Schemas {
       readonly summary_outcome?: Outcome | null;
       /** Load external references (linked issues) for this recording */
       readonly external_references?: readonly PatchedSessionRecordingExternalReferencesItem[];
+      /** Whether this recording matched the filters of the listing query that returned it. False only when a recording requested via session_recording_id was included despite not matching the filters. */
+      readonly matches_filters?: boolean;
     }
 
     /**
@@ -32597,6 +33347,8 @@ export namespace Schemas {
       readonly id?: string;
       /** The `signals-scout-*` skill this config controls. Set at creation, not editable. */
       readonly skill_name?: string;
+      /** Human-readable summary of what this scout investigates, sourced from the scout skill's `description` metadata. Use it for a quick steer on the scout's focus without loading the full skill body. Empty if the skill is not currently present on the team or carries no description. */
+      readonly description?: string;
       /** Whether this scout runs on its schedule. Disabled scouts are skipped by the coordinator. */
       enabled?: boolean;
       /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. */
@@ -33637,50 +34389,6 @@ export namespace Schemas {
 
     export type PatchedTeamManagedViewsets = {[key: string]: boolean};
 
-    export interface TeamRevenueAnalyticsConfig {
-      base_currency?: BaseCurrencyEnum;
-      events?: unknown;
-      goals?: unknown;
-      filter_test_accounts?: boolean;
-    }
-
-    export interface TeamMarketingAnalyticsConfig {
-      sources_map?: unknown;
-      conversion_goals?: unknown;
-      /**
-         * @minimum 1
-         * @maximum 90
-         */
-      attribution_window_days?: number;
-      attribution_mode?: AttributionModeEnum;
-      campaign_name_mappings?: unknown;
-      custom_source_mappings?: unknown;
-      campaign_field_preferences?: unknown;
-    }
-
-    export interface TeamCustomerAnalyticsConfig {
-      /** Event used as the activity signal (DAU/WAU/MAU). */
-      activity_event?: unknown;
-      /** Event used to count signup pageviews on dashboards. */
-      signup_pageview_event?: unknown;
-      /** Event used to count signups on dashboards. */
-      signup_event?: unknown;
-      /** Event used to count subscriptions on dashboards. */
-      subscription_event?: unknown;
-      /** Event used to count payments on dashboards. */
-      payment_event?: unknown;
-      /**
-         * Index of the group type to treat as an Account in customer analytics. Must reference an existing group type configured for the project.
-         * @nullable
-         */
-      account_group_type_index?: number | null;
-    }
-
-    export interface TeamWorkflowsConfig {
-      /** When enabled, workflows engagement activity (email sends, opens, clicks, bounces, spam reports, unsubscribes) is captured as standard PostHog events ($workflows_email_*) alongside the existing workflow metrics. */
-      capture_workflows_engagement_events?: boolean;
-    }
-
     export interface PatchedTeam {
       readonly id?: number;
       readonly uuid?: string;
@@ -34118,7 +34826,7 @@ export namespace Schemas {
       /** Real-time notification types that currently have a live dispatch site. Drives the in-app notifications settings UI. Read-only. */
       readonly active_realtime_notification_types?: readonly string[];
       readonly pending_invites?: readonly PendingInvite[];
-      /** True if the user has at least one Personal API Key and has not yet acknowledged their existing credentials. Used to gate a one-shot review screen on first post-provisioning login. Becomes False once the user POSTs to `/api/users/@me/credentials_review_complete/`. Read-only. */
+      /** True if the user has at least one Personal API Key or passkey and has not yet acknowledged their existing credentials. Used to gate a one-shot review screen on first post-provisioning login. Becomes False once the user POSTs to `/api/users/@me/credentials_review_complete/`. Read-only. */
       readonly requires_credential_review?: boolean;
     }
 
@@ -34597,6 +35305,8 @@ export namespace Schemas {
       onboarding_completed_at?: string | null;
       updated_at?: string;
     };
+
+    export type ProjectBackwardCompatManagedViewsets = {[key: string]: boolean};
 
     /**
      * Mixin for serializers to add user access control fields
@@ -35386,6 +36096,50 @@ export namespace Schemas {
          * @nullable
          */
       readonly is_pending_deletion: boolean | null;
+      /** ID of the project this environment belongs to. */
+      readonly project_id: number;
+      /**
+         * The effective access level the user has for this object
+         * @nullable
+         */
+      readonly user_access_level: string | null;
+      readonly managed_viewsets: ProjectBackwardCompatManagedViewsets;
+      revenue_analytics_config?: TeamRevenueAnalyticsConfig;
+      marketing_analytics_config?: TeamMarketingAnalyticsConfig;
+      customer_analytics_config?: TeamCustomerAnalyticsConfig;
+      workflows_config?: TeamWorkflowsConfig;
+      base_currency?: BaseCurrencyEnum;
+      /**
+         * Enables capturing clicks that had no effect (rage-click detection).
+         * @nullable
+         */
+      capture_dead_clicks?: boolean | null;
+      cookieless_server_hash_mode?: CookielessServerHashModeEnum | null;
+      /** @nullable */
+      human_friendly_comparison_periods?: boolean | null;
+      /** @nullable */
+      feature_flag_confirmation_enabled?: boolean | null;
+      /** @nullable */
+      feature_flag_confirmation_message?: string | null;
+      /**
+         * Whether to automatically apply default evaluation contexts to new feature flags
+         * @nullable
+         */
+      default_evaluation_contexts_enabled?: boolean | null;
+      /**
+         * Whether to require at least one evaluation context tag when creating new feature flags
+         * @nullable
+         */
+      require_evaluation_contexts?: boolean | null;
+      /**
+         * @minimum -2147483648
+         * @maximum 2147483647
+         * @nullable
+         */
+      default_data_theme?: number | null;
+      onboarding_tasks?: unknown;
+      /** @nullable */
+      web_analytics_pre_aggregated_tables_enabled?: boolean | null;
     }
 
     /**
@@ -38828,7 +39582,7 @@ export namespace Schemas {
     export interface ScratchpadEntry {
       /** Agent-chosen semantic key, unique per team. */
       key: string;
-      /** Prose content for prompt injection. */
+      /** Prose content for prompt injection. Blank when the search projected it out (`keys_only=true`); truncated to a preview when `content_max_chars` was set. */
       content: string;
       /**
          * ISO-8601 creation timestamp.
@@ -39051,13 +39805,32 @@ export namespace Schemas {
       readonly team: number;
     }
 
+    export type SessionReplayListWidgetCatalogEntryOpenApiWidgetType = typeof SessionReplayListWidgetCatalogEntryOpenApiWidgetType[keyof typeof SessionReplayListWidgetCatalogEntryOpenApiWidgetType];
+
+
+    export const SessionReplayListWidgetCatalogEntryOpenApiWidgetType = {
+      SessionReplayList: 'session_replay_list',
+    } as const;
+
+    export interface SessionReplayListWidgetCatalogEntryOpenApi {
+      widget_type: SessionReplayListWidgetCatalogEntryOpenApiWidgetType;
+      group_id: string;
+      group_label: string;
+      label: string;
+      description: string;
+      /** OpenAPI config shape for this widget type (documentation; matches batch-add/PATCH schemas). */
+      readonly config_schema: SessionReplayListWidgetConfig;
+      /** @nullable */
+      required_product_access?: string | null;
+    }
+
     /**
      * * `session_replay_list` - session_replay_list
      */
-    export type SessionReplayListWidgetAddRequestOpenApiWidgetTypeEnum = typeof SessionReplayListWidgetAddRequestOpenApiWidgetTypeEnum[keyof typeof SessionReplayListWidgetAddRequestOpenApiWidgetTypeEnum];
+    export type SessionReplayListWidgetTypeEnum = typeof SessionReplayListWidgetTypeEnum[keyof typeof SessionReplayListWidgetTypeEnum];
 
 
-    export const SessionReplayListWidgetAddRequestOpenApiWidgetTypeEnum = {
+    export const SessionReplayListWidgetTypeEnum = {
       SessionReplayList: 'session_replay_list',
     } as const;
 
@@ -39195,6 +39968,8 @@ export namespace Schemas {
       readonly id: string;
       /** The `signals-scout-*` skill this config controls. Set at creation, not editable. */
       readonly skill_name: string;
+      /** Human-readable summary of what this scout investigates, sourced from the scout skill's `description` metadata. Use it for a quick steer on the scout's focus without loading the full skill body. Empty if the skill is not currently present on the team or carries no description. */
+      readonly description: string;
       /** Whether this scout runs on its schedule. Disabled scouts are skipped by the coordinator. */
       enabled?: boolean;
       /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. */
@@ -39211,6 +39986,30 @@ export namespace Schemas {
          */
       readonly last_run_at: string | null;
       readonly created_at: string;
+    }
+
+    /**
+     * Request body for registering a scout config without waiting for the coordinator tick.
+     *
+     * Upsert keyed on `skill_name`: if the coordinator (or a concurrent caller) already
+     * registered the row, the provided tunables are applied to it instead.
+     */
+    export interface SignalScoutConfigCreate {
+      /**
+         * The `signals-scout-*` skill to register a config for. The skill must already exist on this project — author it via the skills store first.
+         * @maxLength 200
+         */
+      skill_name: string;
+      /** Whether this scout runs on its schedule. Defaults to true. */
+      enabled?: boolean;
+      /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. Defaults to true. */
+      emit?: boolean;
+      /**
+         * Minutes between runs (10–43200). Defaults to 60 (hourly).
+         * @minimum 10
+         * @maximum 43200
+         */
+      run_interval_minutes?: number;
     }
 
     /**
@@ -39247,6 +40046,8 @@ export namespace Schemas {
        * * `P3` - P3
        * * `P4` - P4 */
       severity: AutonomyPriorityEnum | null;
+      /** Slug tags the scout attached to this finding (lowercase kebab-case, e.g. `cost-spike`). Empty list when the run set none. */
+      tags: string[];
       /** Deterministic `run:<run_id>:finding:<finding_id>` — the join key into the underlying signal store. */
       source_id: string;
       /** ISO-8601 timestamp the finding was emitted. */
@@ -39291,6 +40092,16 @@ export namespace Schemas {
       task_url?: string | null;
       /** One-paragraph close-out the scout wrote at end-of-run. Empty string for runs that errored before close-out. The dedupe key for non-emitting runs. */
       summary: string;
+      /**
+         * Full `error_message` from the linked TaskRun, surfaced only for failed/cancelled runs (null otherwise, including on success). Use `failure_reason` for a concise scan-friendly summary.
+         * @nullable
+         */
+      error?: string | null;
+      /**
+         * Concise derived reason the run didn't complete cleanly — the first line of `error` (bounded), or a status-derived fallback. Null unless the run terminated failed/cancelled. Read this to see at a glance *why* a run emitted nothing without pulling full stack traces.
+         * @nullable
+         */
+      failure_reason?: string | null;
       /** Number of findings this run actually emitted to the inbox. 0 for runs that investigated but surfaced nothing, or ran dry-run / before AI approval. `> 0` means the run produced at least one `Signal`. */
       emitted_count: number;
       /** The `finding_id`s behind `emitted_count`, in emit order. Each maps to a `Signal` with `source_id = run:<run_id>:finding:<finding_id>`. Empty for non-emitting runs. */
@@ -39335,6 +40146,16 @@ export namespace Schemas {
       task_url?: string | null;
       /** One-paragraph close-out the scout wrote at end-of-run. Empty string for runs that errored before close-out. The dedupe key for non-emitting runs. */
       summary: string;
+      /**
+         * Full `error_message` from the linked TaskRun, surfaced only for failed/cancelled runs (null otherwise, including on success). Use `failure_reason` for a concise scan-friendly summary.
+         * @nullable
+         */
+      error?: string | null;
+      /**
+         * Concise derived reason the run didn't complete cleanly — the first line of `error` (bounded), or a status-derived fallback. Null unless the run terminated failed/cancelled. Read this to see at a glance *why* a run emitted nothing without pulling full stack traces.
+         * @nullable
+         */
+      failure_reason?: string | null;
       /** Number of findings this run actually emitted to the inbox. 0 for runs that investigated but surfaced nothing, or ran dry-run / before AI approval. `> 0` means the run produced at least one `Signal`. */
       emitted_count: number;
       /** The `finding_id`s behind `emitted_count`, in emit order. Each maps to a `Signal` with `source_id = run:<run_id>:finding:<finding_id>`. Empty for non-emitting runs. */
@@ -40362,24 +41183,6 @@ export namespace Schemas {
       deleted?: boolean;
     }
 
-    export interface TaskFileRequest {
-      /** Destination folder path in the project tree (e.g. 'Tasks/Bugs'). Defaults to 'Tasks'. */
-      folder?: string;
-    }
-
-    export interface TaskFileResponse {
-      /** Identifier of the project-tree entry for this task. */
-      id: string;
-      /** Full slash-separated path of the filed task in the project tree. */
-      path: string;
-      /** File system entry type. Always 'task'. */
-      type: string;
-      /** Identifier of the task this entry points to. */
-      ref: string;
-      /** In-app link to the task. */
-      href: string;
-    }
-
     /**
      * Request body for the presence beacon and beacon-leave endpoints.
      *
@@ -41317,6 +42120,21 @@ export namespace Schemas {
       metadata: TextReprMetadata;
     }
 
+    /**
+     * Payload for posting a reply or internal note to a ticket.
+     */
+    export interface TicketReplyRequest {
+      /**
+         * Reply content in markdown.
+         * @maxLength 5000
+         */
+      message: string;
+      /** If true, store as an internal note (not sent to the customer). If false, the reply is delivered to the customer over the ticket's channel. */
+      is_private?: boolean;
+      /** Optional TipTap rich content JSON for formatted messages. */
+      rich_content?: unknown;
+    }
+
     export interface TopPage {
       /** Host for the page, if recorded. */
       host: string;
@@ -41668,6 +42486,8 @@ export namespace Schemas {
       readonly period_start: string;
       /** First moment of the next quota period (UTC); the current period's exclusive upper bound. */
       readonly period_end: string;
+      /** Sum of enabled scanners' projected observations/month across the organization. Scanners without a computed estimate contribute 0. */
+      readonly projected_monthly_observations: number;
     }
 
     /**
@@ -41772,25 +42592,7 @@ export namespace Schemas {
       is_organization_first_user: boolean;
     }
 
-    export interface WidgetCatalogEntry {
-      /** Stable widget type identifier used in API requests. */
-      widget_type: string;
-      /** Product area key for grouping related widget variants. */
-      group_id: string;
-      /** Human-readable product area label. */
-      group_label: string;
-      /** Widget variant label within the product area. */
-      label: string;
-      /** Short description of what the widget shows. */
-      description: string;
-      /** JSON schema hints for config fields (types, choices, bounds). Not a strict validator. */
-      config_schema_hints: unknown;
-      /**
-         * Product access resource required to view or run this widget, if any.
-         * @nullable
-         */
-      required_product_access?: string | null;
-    }
+    export type WidgetCatalogEntry = ErrorTrackingListWidgetCatalogEntryOpenApi | SessionReplayListWidgetCatalogEntryOpenApi;
 
     export interface WidgetCatalogResponse {
       /** Registered dashboard widget types available when dashboard-widgets is enabled. */
@@ -42415,6 +43217,18 @@ export namespace Schemas {
       count: number;
     }
 
+    /**
+     * * `timestamp` - timestamp
+     * * `duration` - duration
+     */
+    export type _TracingQueryBodyOrderByEnum = typeof _TracingQueryBodyOrderByEnum[keyof typeof _TracingQueryBodyOrderByEnum];
+
+
+    export const _TracingQueryBodyOrderByEnum = {
+      Timestamp: 'timestamp',
+      Duration: 'duration',
+    } as const;
+
     export interface _TracingQueryBody {
       /** Date range for the query. Defaults to last hour. */
       dateRange?: _TracingDateRange;
@@ -42422,19 +43236,29 @@ export namespace Schemas {
       serviceNames?: string[];
       /** Filter by HTTP status codes. */
       statusCodes?: number[];
-      /** Order results by timestamp. Defaults to latest.
+      /** Column to order by. Defaults to timestamp. Ordering by timestamp paginates via the keyset cursor ('after'); ordering by duration paginates via 'offset'.
        *
-       * * `latest` - latest
-       * * `earliest` - earliest */
-      orderBy?: OrderByEnum;
+       * * `timestamp` - timestamp
+       * * `duration` - duration */
+      orderBy?: _TracingQueryBodyOrderByEnum;
+      /** Order direction. Defaults to DESC (e.g. timestamp+DESC = newest first, duration+DESC = slowest first).
+       *
+       * * `ASC` - ASC
+       * * `DESC` - DESC */
+      orderDirection?: OrderDirectionEnum;
       /** Property filters for the query. */
       filterGroup?: _SpanPropertyFilter[];
       /** Filter to a specific trace ID (hex string). */
       traceId?: string;
       /** Max results (1-1000). Defaults to 100. */
       limit?: number;
-      /** Pagination cursor from previous response. */
+      /** Keyset pagination cursor from a previous timestamp-ordered response. */
       after?: string;
+      /**
+         * Pagination offset, used when ordering by a column (e.g. duration). Defaults to 0.
+         * @minimum 0
+         */
+      offset?: number;
       /** Filter to root spans only. Defaults to true. */
       rootSpans?: boolean;
       /** Number of child spans to prefetch per trace (1-100). */
@@ -42760,7 +43584,7 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Optional. Fuzzy match against dashboard `name` and `description` using Postgres trigram word similarity (handles typos, transpositions, and prefix-as-you-type). `name` matches rank above `description` matches. Results are ordered by relevance, then pinned status, then name. When omitted, dashboards are ordered by pinned status then alphabetical name. Capped at 200 characters; longer queries return a 400 error.
+     * Optional. Match against dashboard `name`, `description`, and tag names. Returns case-insensitive substring matches and fuzzy trigram matches (typos, transpositions, prefix-as-you-type) together, ordered exact-first, then pinned status, then name; each result's `search_match_type` is `exact` or `similar`. When omitted, dashboards are ordered by pinned status then alphabetical name. Capped at 200 characters; longer queries return a 400 error.
      */
     search?: string;
     };
@@ -43218,6 +44042,38 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    };
+
+    export type EnvironmentsEndpointsLogsRetrieveParams = {
+    /**
+     * Only return entries after this ISO 8601 timestamp.
+     */
+    after?: string;
+    /**
+     * Only return entries before this ISO 8601 timestamp.
+     */
+    before?: string;
+    /**
+     * Filter logs to a specific execution instance.
+     * @minLength 1
+     */
+    instance_id?: string;
+    /**
+     * Comma-separated log levels to include, e.g. 'WARN,ERROR'. Valid levels: DEBUG, LOG, INFO, WARN, ERROR.
+     * @minLength 1
+     */
+    level?: string;
+    /**
+     * Maximum number of log entries to return (1-500, default 50).
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number;
+    /**
+     * Case-insensitive substring search across log messages.
+     * @minLength 1
+     */
+    search?: string;
     };
 
     export type EnvironmentsEndpointsOpenapiSpecRetrieveParams = {
@@ -46529,6 +47385,10 @@ export namespace Schemas {
 
     export type EnvironmentsVisionScannersObservationsStatsRetrieveParams = {
     /**
+     * Window size in days for the coverage `recent_sessions` count. Clamped to [1, 365]. Defaults to 14 when omitted.
+     */
+    recent_days?: number;
+    /**
      * Filter to observations of a specific session recording.
      */
     session_id?: string;
@@ -46997,7 +47857,7 @@ export namespace Schemas {
      */
     order?: string;
     /**
-     * Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.
+     * Match against member `first_name`, `last_name`, and `email`. Returns case-insensitive substring matches and fuzzy trigram matches (typos, prefix-as-you-type) together, ordered exact-first; each result's `search_match_type` is `exact` or `similar`. Capped at 200 characters.
      */
     search?: string;
     };
@@ -47785,6 +48645,28 @@ export namespace Schemas {
     search?: string;
     };
 
+    export type BusinessKnowledgeDocumentsWindowListParams = {
+    /**
+     * Zero-based chunk ordinal to center the window on (from a search result).
+     */
+    around_ordinal: number;
+    /**
+     * Number of chunks before and after the center to include. Defaults to 5, clamped to [0, 15].
+     */
+    radius?: number;
+    };
+
+    export type BusinessKnowledgeDocumentsSearchListParams = {
+    /**
+     * Maximum number of ranked chunks to return. Defaults to 10, capped at 20.
+     */
+    limit?: number;
+    /**
+     * Natural-language search query. Runs hybrid (semantic + full-text) retrieval over all SAFE, READY knowledge chunks in this project.
+     */
+    query: string;
+    };
+
     export type BusinessKnowledgeSourcesListParams = {
     /**
      * Number of results to return per page.
@@ -47986,9 +48868,17 @@ export namespace Schemas {
      */
     status?: string;
     /**
-     * JSON-encoded array of tag names to filter by, e.g. `["billing","urgent"]`.
+     * JSON-encoded array of tag names; returns tickets with ANY of them (OR), e.g. `["billing","urgent"]`.
      */
     tags?: string;
+    /**
+     * JSON-encoded array of tag names; returns tickets that have ALL of them (AND), e.g. `["billing","urgent"]`.
+     */
+    tags_all?: string;
+    /**
+     * JSON-encoded array of tag names; returns tickets that have NONE of them (NOT), e.g. `["escalated"]`.
+     */
+    tags_exclude?: string;
     };
 
     export type ConversationsTicketsListChannelDetail = typeof ConversationsTicketsListChannelDetail[keyof typeof ConversationsTicketsListChannelDetail];
@@ -48024,6 +48914,17 @@ export namespace Schemas {
       Breached: 'breached',
       OnTrack: 'on-track',
     } as const;
+
+    export type ConversationsTicketsMessagesListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
 
     export type ConversationsViewsListParams = {
     /**
@@ -48112,7 +49013,7 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Optional. Fuzzy match against dashboard `name` and `description` using Postgres trigram word similarity (handles typos, transpositions, and prefix-as-you-type). `name` matches rank above `description` matches. Results are ordered by relevance, then pinned status, then name. When omitted, dashboards are ordered by pinned status then alphabetical name. Capped at 200 characters; longer queries return a 400 error.
+     * Optional. Match against dashboard `name`, `description`, and tag names. Returns case-insensitive substring matches and fuzzy trigram matches (typos, transpositions, prefix-as-you-type) together, ordered exact-first, then pinned status, then name; each result's `search_match_type` is `exact` or `similar`. When omitted, dashboards are ordered by pinned status then alphabetical name. Capped at 200 characters; longer queries return a 400 error.
      */
     search?: string;
     };
@@ -48633,6 +49534,38 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    };
+
+    export type EndpointsLogsRetrieveParams = {
+    /**
+     * Only return entries after this ISO 8601 timestamp.
+     */
+    after?: string;
+    /**
+     * Only return entries before this ISO 8601 timestamp.
+     */
+    before?: string;
+    /**
+     * Filter logs to a specific execution instance.
+     * @minLength 1
+     */
+    instance_id?: string;
+    /**
+     * Comma-separated log levels to include, e.g. 'WARN,ERROR'. Valid levels: DEBUG, LOG, INFO, WARN, ERROR.
+     * @minLength 1
+     */
+    level?: string;
+    /**
+     * Maximum number of log entries to return (1-500, default 50).
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number;
+    /**
+     * Case-insensitive substring search across log messages.
+     * @minLength 1
+     */
+    search?: string;
     };
 
     export type EndpointsOpenapiSpecRetrieveParams = {
@@ -52339,6 +53272,16 @@ export namespace Schemas {
      */
     limit?: number;
     /**
+     * Exact-match filter on the scout skill (e.g. `signals-scout-errors`). Narrows the run dump to a single scout — the primary scoping path when a specialist dedupes against its own past runs. Omit to span every scout on the team.
+     * @minLength 1
+     */
+    skill_name?: string;
+    /**
+     * Exact-match filter on the skill version. Pair with `skill_name` to pin one version; omit for all.
+     * @minimum 1
+     */
+    skill_version?: number;
+    /**
      * Case-insensitive substring match on the scout's end-of-run `summary`. Omit to skip the filter.
      * @minLength 1
      */
@@ -52346,6 +53289,15 @@ export namespace Schemas {
     };
 
     export type SignalsScoutScratchpadSearchParams = {
+    /**
+     * Truncate each entry's `content` to the first N characters (a preview). Omit for the full body. Ignored when `keys_only=true`.
+     * @minimum 0
+     */
+    content_max_chars?: number;
+    /**
+     * When true, blank each entry's `content` and return only keys + metadata. Use to scan which memories exist without pulling their (potentially large) bodies, then re-query the ones worth a full read. Takes precedence over `content_max_chars`.
+     */
+    keys_only?: boolean;
     /**
      * Max rows to return (default 20, hard cap 100).
      * @minimum 1
@@ -53052,6 +54004,10 @@ export namespace Schemas {
 
     export type VisionScannersObservationsStatsRetrieveParams = {
     /**
+     * Window size in days for the coverage `recent_sessions` count. Clamped to [1, 365]. Defaults to 14 when omitted.
+     */
+    recent_days?: number;
+    /**
      * Filter to observations of a specific session recording.
      */
     session_id?: string;
@@ -53340,6 +54296,17 @@ export namespace Schemas {
      * Filter to a single workflow (e.g. 'onboarding').
      */
     workflow_id?: string;
+    };
+
+    export type WizardSessionsLatestRetrieveParams = {
+    /**
+     * Filter to a single skill within the workflow (e.g. 'nextjs').
+     */
+    skill_id?: string;
+    /**
+     * Filter to a single workflow (e.g. 'posthog-integration').
+     */
+    workflow_id: string;
     };
 
     export type WizardSessionsStreamRetrieveParams = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11572,6 +11572,22 @@ export namespace Schemas {
       Base64: 'base64',
     } as const;
 
+    export interface ContextGeneration {
+      /**
+         * ID of the Task currently generating this folder's CONTEXT.md, or null if none.
+         * @nullable
+         */
+      task_id: string | null;
+    }
+
+    export interface ContextGenerationSet {
+      /**
+         * ID of the Task generating this folder's CONTEXT.md. Must reference a Task in the same team. Set to null to clear the association.
+         * @nullable
+         */
+      task_id: string | null;
+    }
+
     export type ConversationMessagesItem = { [key: string]: unknown };
 
     export type ConversationPendingApprovalsItem = { [key: string]: unknown };
@@ -26226,6 +26242,8 @@ export namespace Schemas {
       readonly created_by: UserBasic;
       readonly updated_at: string;
       archived?: boolean;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     export interface PaginatedProductTourList {
@@ -27850,6 +27868,8 @@ export namespace Schemas {
          */
       readonly user_access_level: string | null;
       form_content?: unknown;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     export interface PaginatedSurveyList {
@@ -49115,6 +49135,7 @@ export namespace Schemas {
      * * `Subscription` - Subscription
      * * `PersonalAPIKey` - PersonalAPIKey
      * * `ProjectSecretAPIKey` - ProjectSecretAPIKey
+     * * `OAuthApplication` - OAuthApplication
      * * `User` - User
      * * `Action` - Action
      * * `AlertConfiguration` - AlertConfiguration
@@ -49194,6 +49215,7 @@ export namespace Schemas {
       Subscription: 'Subscription',
       PersonalAPIKey: 'PersonalAPIKey',
       ProjectSecretAPIKey: 'ProjectSecretAPIKey',
+      OAuthApplication: 'OAuthApplication',
       User: 'User',
       Action: 'Action',
       AlertConfiguration: 'AlertConfiguration',
@@ -49259,6 +49281,7 @@ export namespace Schemas {
      * * `Subscription` - Subscription
      * * `PersonalAPIKey` - PersonalAPIKey
      * * `ProjectSecretAPIKey` - ProjectSecretAPIKey
+     * * `OAuthApplication` - OAuthApplication
      * * `User` - User
      * * `Action` - Action
      * * `AlertConfiguration` - AlertConfiguration
@@ -49326,6 +49349,7 @@ export namespace Schemas {
       Subscription: 'Subscription',
       PersonalAPIKey: 'PersonalAPIKey',
       ProjectSecretAPIKey: 'ProjectSecretAPIKey',
+      OAuthApplication: 'OAuthApplication',
       User: 'User',
       Action: 'Action',
       AlertConfiguration: 'AlertConfiguration',

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16852,10 +16852,10 @@ export namespace Schemas {
     } as const;
 
     /**
-     * * `pending` - pending
-    * `in_progress` - in_progress
-    * `completed` - completed
-    * `failed` - failed
+     * * `pending` - Pending
+    * `in_progress` - In Progress
+    * `completed` - Completed
+    * `failed` - Failed
      */
     export type ExperimentMetricsRecalculationStatusEnum = typeof ExperimentMetricsRecalculationStatusEnum[keyof typeof ExperimentMetricsRecalculationStatusEnum];
 
@@ -16868,15 +16868,15 @@ export namespace Schemas {
     } as const;
 
     /**
-     * * `manual` - manual
-    * `experiment_launch` - experiment_launch
-    * `experiment_stop` - experiment_stop
-    * `experiment_update` - experiment_update
+     * * `manual` - Manual
+    * `experiment_launch` - Experiment Launch
+    * `experiment_stop` - Experiment Stop
+    * `experiment_update` - Experiment Update
      */
-    export type TriggerEnum = typeof TriggerEnum[keyof typeof TriggerEnum];
+    export type ExperimentMetricsRecalculationTriggerEnum = typeof ExperimentMetricsRecalculationTriggerEnum[keyof typeof ExperimentMetricsRecalculationTriggerEnum];
 
 
-    export const TriggerEnum = {
+    export const ExperimentMetricsRecalculationTriggerEnum = {
       Manual: 'manual',
       ExperimentLaunch: 'experiment_launch',
       ExperimentStop: 'experiment_stop',
@@ -16928,26 +16928,26 @@ export namespace Schemas {
       readonly experiment_id: number;
       /** Current status of the recalculation job
 
-      * `pending` - pending
-      * `in_progress` - in_progress
-      * `completed` - completed
-      * `failed` - failed */
+      * `pending` - Pending
+      * `in_progress` - In Progress
+      * `completed` - Completed
+      * `failed` - Failed */
       readonly status: ExperimentMetricsRecalculationStatusEnum;
       /** Total number of metrics to recalculate */
       readonly total_metrics: number;
-      /** Number of metrics successfully recalculated */
+      /** Number of metrics with a COMPLETED result row in this run (derived, not stored) */
       readonly completed_metrics: number;
-      /** Number of metrics that failed to recalculate */
+      /** Number of failed metrics in this run (derived): FAILED result rows plus discovery-step failures that never made it to a result row */
       readonly failed_metrics: number;
       /** Map of metric_uuid to error details */
       readonly metric_errors: unknown;
       /** What triggered this recalculation
 
-      * `manual` - manual
-      * `experiment_launch` - experiment_launch
-      * `experiment_stop` - experiment_stop
-      * `experiment_update` - experiment_update */
-      readonly trigger: TriggerEnum;
+      * `manual` - Manual
+      * `experiment_launch` - Experiment Launch
+      * `experiment_stop` - Experiment Stop
+      * `experiment_update` - Experiment Update */
+      readonly trigger: ExperimentMetricsRecalculationTriggerEnum;
       /** When the job was created */
       readonly created_at: string;
       /**
@@ -37915,6 +37915,22 @@ export namespace Schemas {
     }
 
     /**
+     * * `manual` - manual
+    * `experiment_launch` - experiment_launch
+    * `experiment_stop` - experiment_stop
+    * `experiment_update` - experiment_update
+     */
+    export type RecalculateMetricsRequestTriggerEnum = typeof RecalculateMetricsRequestTriggerEnum[keyof typeof RecalculateMetricsRequestTriggerEnum];
+
+
+    export const RecalculateMetricsRequestTriggerEnum = {
+      Manual: 'manual',
+      ExperimentLaunch: 'experiment_launch',
+      ExperimentStop: 'experiment_stop',
+      ExperimentUpdate: 'experiment_update',
+    } as const;
+
+    /**
      * Request body for triggering a metrics recalculation.
      */
     export interface RecalculateMetricsRequest {
@@ -37924,7 +37940,7 @@ export namespace Schemas {
       * `experiment_launch` - experiment_launch
       * `experiment_stop` - experiment_stop
       * `experiment_update` - experiment_update */
-      trigger?: TriggerEnum;
+      trigger?: RecalculateMetricsRequestTriggerEnum;
     }
 
     export interface RecomputeResult {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13600,6 +13600,7 @@ export namespace Schemas {
      * * `AmazonSQS` - AmazonSQS
      * * `AmazonKinesis` - AmazonKinesis
      * * `AmazonCloudWatch` - AmazonCloudWatch
+     * * `OpenAIAds` - OpenAIAds
      * * `Custom` - Custom
      */
     export type ExternalDataSourceTypeEnum = typeof ExternalDataSourceTypeEnum[keyof typeof ExternalDataSourceTypeEnum];
@@ -13837,6 +13838,7 @@ export namespace Schemas {
       AmazonSQS: 'AmazonSQS',
       AmazonKinesis: 'AmazonKinesis',
       AmazonCloudWatch: 'AmazonCloudWatch',
+      OpenAIAds: 'OpenAIAds',
       Custom: 'Custom',
     } as const;
 
@@ -14081,6 +14083,7 @@ export namespace Schemas {
        * * `AmazonSQS` - AmazonSQS
        * * `AmazonKinesis` - AmazonKinesis
        * * `AmazonCloudWatch` - AmazonCloudWatch
+       * * `OpenAIAds` - OpenAIAds
        * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
     }
@@ -18327,6 +18330,7 @@ export namespace Schemas {
        * * `AmazonSQS` - AmazonSQS
        * * `AmazonKinesis` - AmazonKinesis
        * * `AmazonCloudWatch` - AmazonCloudWatch
+       * * `OpenAIAds` - OpenAIAds
        * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
       /** Connection credentials and a 'schemas' array. Keys depend on source_type. */
@@ -41064,6 +41068,7 @@ export namespace Schemas {
        * * `AmazonSQS` - AmazonSQS
        * * `AmazonKinesis` - AmazonKinesis
        * * `AmazonCloudWatch` - AmazonCloudWatch
+       * * `OpenAIAds` - OpenAIAds
        * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
       /** Connection details as flat keys for the source_type — the same fields the create flow accepts (host, port, password, API key, …). Checked against a live connection before being stored. */
@@ -41334,6 +41339,7 @@ export namespace Schemas {
        * * `AmazonSQS` - AmazonSQS
        * * `AmazonKinesis` - AmazonKinesis
        * * `AmazonCloudWatch` - AmazonCloudWatch
+       * * `OpenAIAds` - OpenAIAds
        * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
       /** Connection details as flat keys for the source_type (discover required fields with the wizard tool). Prefer references over raw secrets: pass {'credential_id': <id>} referencing the connection details the user stored via the connect-link page (discover ids with the stored_credentials endpoint) — they are merged in server-side and deleted once consumed. An already-connected OAuth integration can be passed via its id key instead (e.g. {'hubspot_integration_id': 123}). A 'schemas' array is NOT required — all discovered tables are enabled automatically with sensible sync defaults. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7259,7 +7259,7 @@ export namespace Schemas {
       readonly created_at: string;
       /** Optional name for the threshold. */
       name?: string;
-      /** Threshold bounds and type. Includes bounds (lower/upper floats) and type (absolute or percentage). */
+      /** Threshold bounds and type. Includes bounds (lower/upper floats) and type (absolute or percentage). For threshold-based alerts (no detector_config), at least one of lower or upper must be set. */
       configuration: InsightThreshold;
     }
 
@@ -7892,6 +7892,40 @@ export namespace Schemas {
          * @nullable
          */
       delete_verified_at: string | null;
+    }
+
+    export interface UnmatchedUtmSample {
+      /** A raw utm_source value that doesn't match the integration exactly */
+      raw_value: string;
+      /** Number of events with this raw value in the window */
+      event_count: number;
+      /**
+         * Integration suggested by token match, if any
+         * @nullable
+         */
+      suggested_integration: string | null;
+    }
+
+    export interface AttributionHealthEntry {
+      /** Integration key (e.g. 'google', 'meta') */
+      integration_key: string;
+      /** Human-readable integration name */
+      display_name: string;
+      /** Total events with any utm_source in the window */
+      events_with_utm_last_7d: number;
+      /** Events whose utm_source matched this integration */
+      events_matched_last_7d: number;
+      /** Events that look like this integration's but don't match exactly */
+      events_unmatched_likely_yours_last_7d: number;
+      /**
+         * Timestamp of the most recent matched event
+         * @nullable
+         */
+      last_event_with_matching_utm_at: string | null;
+      /** Percentage of UTM events matched to this integration */
+      matched_pct: number;
+      /** Sample of likely-yours unmatched utm_source values */
+      sample_unmatched_utm_sources: UnmatchedUtmSample[];
     }
 
     /**
@@ -10422,6 +10456,44 @@ export namespace Schemas {
       issues: UtmIssue[];
     }
 
+    export interface CampaignMappingSuggestion {
+      /** Integration key the campaign values belong to */
+      integration: string;
+      /** Human-readable integration name */
+      integration_display_name: string;
+      /** Proposed canonical campaign name */
+      suggested_clean_name: string;
+      /** Raw campaign values clustered under this clean name */
+      raw_campaign_values: string[];
+      /** Confidence score for the clustering (0-1) */
+      confidence: number;
+      /** Mapping method */
+      method: string;
+      /** Why these campaign values were clustered together */
+      reason: string;
+    }
+
+    export interface CandidateEvent {
+      /** Name of the candidate event */
+      event_name: string;
+      /** Count of this event in the last 30 days */
+      last_30d_count: number;
+      /** Distinct users who triggered the event in 30 days */
+      distinct_users_30d: number;
+      /** Percentage of events that carry a utm_source */
+      pct_with_utm_source: number;
+      /** Percentage of events that carry a utm_campaign */
+      pct_with_utm_campaign: number;
+      /** List of [utm_source, count] pairs */
+      top_utm_sources: [string, number][];
+      /** Whether this event is already configured as a goal */
+      is_already_a_goal: boolean;
+      /** Ranking score (higher is a stronger candidate) */
+      suggestion_score: number;
+      /** Human-readable rationale for the suggestion */
+      suggestion_reason: string;
+    }
+
     /**
      * Supporting evidence
      */
@@ -10463,6 +10535,28 @@ export namespace Schemas {
       reason: string;
       /** Supporting evidence */
       evidence?: CapabilityStateEvidence;
+    }
+
+    export interface CatalogueEntry {
+      /** A raw utm_source value seen in the window */
+      raw_utm_source: string;
+      /** Number of events with this value */
+      event_count: number;
+      /**
+         * Integration this value exactly matches, if any
+         * @nullable
+         */
+      matched_integration: string | null;
+      /**
+         * Human-readable name of the matched integration, if any
+         * @nullable
+         */
+      matched_integration_display_name: string | null;
+      /**
+         * Integration suggested by token match, if any
+         * @nullable
+         */
+      suggested_integration: string | null;
     }
 
     export interface CategoricalScoreOption {
@@ -11549,6 +11643,69 @@ export namespace Schemas {
       readonly slack_workspace_domain: string | null;
     }
 
+    export interface ConversionGoalSummary {
+      /** Unique id of the goal (event name, action id, or DW goal id) */
+      id: string;
+      /** Display name of the conversion goal */
+      name: string;
+      /** Goal type — one of: EventsNode (PostHog event), ActionsNode (PostHog action), DataWarehouseNode (external table) */
+      kind: string;
+      /** Human-readable target the goal matches (event/action name or table) */
+      target_label: string;
+      /** Count of matching conversion events in the last 30 days */
+      last_30d_count: number;
+      /**
+         * Conversions whose utm_source matches a known integration. Null for DataWarehouseNode goals.
+         * @nullable
+         */
+      integrated_count: number | null;
+      /**
+         * Conversions with no utm_source at all (fix by tagging UTMs). Null for DataWarehouseNode goals.
+         * @nullable
+         */
+      events_without_utm_source: number | null;
+      /**
+         * Conversions with a utm_source that matches no integration (fix with custom_source_mappings). Null for DataWarehouseNode goals.
+         * @nullable
+         */
+      events_with_unmatched_utm_source: number | null;
+      /**
+         * Total non-integrated conversions (without + unmatched utm_source). Null for DataWarehouseNode goals.
+         * @nullable
+         */
+      non_integrated_count: number | null;
+      /**
+         * Percentage of conversions that are integrated. Null for DataWarehouseNode goals.
+         * @nullable
+         */
+      integrated_pct: number | null;
+      /** Whether the goal could not be evaluated (e.g. deleted action) */
+      is_misconfigured: boolean;
+      /**
+         * Explanation when is_misconfigured is true
+         * @nullable
+         */
+      misconfig_reason: string | null;
+      /** True when this 30d count may differ from the dashboard's attribution-windowed number */
+      is_approximate: boolean;
+      /**
+         * Explanation when is_approximate is true
+         * @nullable
+         */
+      approximation_reason: string | null;
+    }
+
+    export interface ConversionGoalsListResponse {
+      /** One summary entry per configured conversion goal */
+      goals: ConversionGoalSummary[];
+      /** The team's configured attribution window in days */
+      attribution_window_days: number;
+      /** The team's attribution model (e.g. last_touch, first_touch, linear) */
+      attribution_mode: string;
+      /** True if any goal is misconfigured */
+      has_misconfigured: boolean;
+    }
+
     /**
      * * `0` - Disabled
     * `1` - Stateless
@@ -12133,6 +12290,17 @@ export namespace Schemas {
       access_secret: string;
     }
 
+    export interface CurrentMapping {
+      /** A utm_source value already mapped to an integration */
+      raw_utm_source: string;
+      /** Integration key it maps to */
+      target: string;
+      /** Human-readable name of the target integration */
+      target_display_name: string;
+      /** canonical or team_custom */
+      source: string;
+    }
+
     export interface CustomerJourney {
       readonly id: string;
       insight: number;
@@ -12489,6 +12657,85 @@ export namespace Schemas {
          * @nullable
          */
       readonly rows_expected: number | null;
+    }
+
+    export interface RequiredTableStatus {
+      /** Name of the required source table (e.g. 'campaign', 'campaign_stats') */
+      table_name: string;
+      /** Whether the table exists as a schema on the connected source */
+      present: boolean;
+      /** Whether the table is enabled for sync */
+      should_sync: boolean;
+      /**
+         * ExternalDataSchema status: Completed/Running/Failed/Paused/Cancelled, or null
+         * @nullable
+         */
+      status: string | null;
+      /**
+         * When this table last completed a sync
+         * @nullable
+         */
+      last_synced_at: string | null;
+    }
+
+    export interface DataSourceHealthEntry {
+      /** External data source type key (e.g. 'GoogleAds', 'MetaAds') */
+      source_type: string;
+      /** Whether this is a native marketing integration */
+      is_native: boolean;
+      /** Human-readable integration name (e.g. 'Google Ads') */
+      display_name: string;
+      /** Whether a live source of this type is connected */
+      connected: boolean;
+      /**
+         * When the source last completed a sync
+         * @nullable
+         */
+      last_sync_at: string | null;
+      /** Sync status: ok/error/stale/tables_failed/not_connected/never */
+      last_sync_status: string;
+      /**
+         * Latest unresolved sync error message, if any
+         * @nullable
+         */
+      last_error: string | null;
+      /** Rows synced in the last 24 hours */
+      rows_last_24h: number;
+      /** Rows synced in the last 7 days */
+      rows_last_7d: number;
+      /** Whether a column mapping exists for this source */
+      sources_map_present: boolean;
+      /** Schema columns currently mapped for this source */
+      schema_columns_mapped: string[];
+      /** Required schema columns that are not yet mapped */
+      schema_columns_required_missing: string[];
+      /** Per-required-table sync status for this integration */
+      required_tables: RequiredTableStatus[];
+      /** URL to the Marketing analytics global settings page */
+      settings_url: string;
+      /**
+         * URL to the per-source Schemas tab, or null if not connected
+         * @nullable
+         */
+      schemas_url: string | null;
+      /** Human-readable diagnosis of this source's health */
+      diagnosis: string;
+      /**
+         * Suggested fix when the source is unhealthy
+         * @nullable
+         */
+      fix_suggestion: string | null;
+    }
+
+    export interface DataSourceHealthResponse {
+      /** One health entry per native integration */
+      integrations: DataSourceHealthEntry[];
+      /** True if any integration synced rows in the last 7 days */
+      has_any_data: boolean;
+      /** Overall: healthy/degraded/broken/no_sources */
+      overall_status: string;
+      /** Short human-readable summary of detected issues */
+      issues_summary: string[];
     }
 
     export interface DataWarehouseModelPath {
@@ -16345,6 +16592,15 @@ export namespace Schemas {
       readonly updated_at: string;
     }
 
+    export interface EventSuggestionsResponse {
+      /** Ranked candidate events for conversion goals */
+      candidates: CandidateEvent[];
+      /** Lookback window in days used for the analysis */
+      lookback_days: number;
+      /** Number of system/autocaptured events excluded */
+      excluded_events_count: number;
+    }
+
     export interface EventTaxonomyItem {
       property: string;
       sample_count: number;
@@ -18598,6 +18854,86 @@ export namespace Schemas {
       conversions: number;
       /** Period-over-period change in conversions, null when not meaningful. */
       change: WoWChange | null;
+    }
+
+    export interface GoalEventSample {
+      /** UUID of the sampled conversion event */
+      event_uuid: string;
+      /** When the event occurred */
+      timestamp: string;
+      /** Distinct id associated with the event */
+      distinct_id: string;
+      /**
+         * utm_source value on the event, if any
+         * @nullable
+         */
+      utm_source: string | null;
+      /**
+         * utm_campaign value on the event, if any
+         * @nullable
+         */
+      utm_campaign: string | null;
+      /**
+         * Integration the utm_source matched, if any
+         * @nullable
+         */
+      matched_integration: string | null;
+    }
+
+    export interface GoalExplanationPeriod {
+      /**
+         * Start of the analyzed period (ISO)
+         * @nullable
+         */
+      date_from: string | null;
+      /**
+         * End of the analyzed period (ISO)
+         * @nullable
+         */
+      date_to: string | null;
+    }
+
+    export interface GoalExplanation {
+      /** Id of the explained conversion goal */
+      goal_id: string;
+      /** Display name of the conversion goal */
+      goal_name: string;
+      /** EventsNode/ActionsNode/DataWarehouseNode */
+      kind: string;
+      /** The period the breakdown was computed over */
+      period: GoalExplanationPeriod;
+      /** Total matching conversion events in the period */
+      total_count: number;
+      /**
+         * Events whose utm_source matched a known integration. Null for DataWarehouseNode.
+         * @nullable
+         */
+      integrated_count: number | null;
+      /**
+         * Events with no utm_source at all. Null for DataWarehouseNode.
+         * @nullable
+         */
+      events_without_utm_source: number | null;
+      /**
+         * Events with a utm_source matching no integration. Null for DataWarehouseNode.
+         * @nullable
+         */
+      events_with_unmatched_utm_source: number | null;
+      /**
+         * Total non-integrated events (without + unmatched). Null for DataWarehouseNode.
+         * @nullable
+         */
+      non_integrated_count: number | null;
+      /** List of [event_name, count] pairs */
+      by_event: [string, number][];
+      /** List of [utm_source, count] pairs */
+      by_utm_source: [string, number][];
+      /** List of [integration, count] pairs */
+      by_matched_integration: [string, number][];
+      /** A small sample of matching events */
+      samples: GoalEventSample[];
+      /** Caveats about the breakdown (sampling, attribution, etc.) */
+      notes: string[];
     }
 
     export interface Group {
@@ -20997,6 +21333,39 @@ export namespace Schemas {
       readonly display_name: string;
     }
 
+    export interface RecommendedAction {
+      /** Short title of the recommended action */
+      title: string;
+      /** Detailed explanation of the action */
+      detail: string;
+      /** Action severity */
+      severity: string;
+      /**
+         * Follow-up tool to call next, if any
+         * @nullable
+         */
+      target_tool: string | null;
+    }
+
+    export interface IntegrationDiagnostic {
+      /** Integration key (e.g. 'google', 'meta') */
+      integration_key: string;
+      /** External data source type key (e.g. 'GoogleAds') */
+      source_type: string;
+      /** Human-readable integration name */
+      display_name: string;
+      /** Per-integration status */
+      overall_status: string;
+      /** Human-readable cross-domain diagnosis */
+      diagnosis: string;
+      /** Data-source (sync) side health, or null if not connected */
+      data_source?: DataSourceHealthEntry | null;
+      /** Attribution (UTM events) side health, or null if no data */
+      attribution?: AttributionHealthEntry | null;
+      /** Recommended next steps for this integration */
+      recommended_actions: RecommendedAction[];
+    }
+
     /**
      * One row in `inventory.integrations`. Sensitive config is intentionally excluded.
      */
@@ -22535,6 +22904,19 @@ export namespace Schemas {
     export interface MarkToleratedInput {
       /** UUID of the changed snapshot to mark as a known tolerated alternate. Future runs that produce the same alternate hash for this identifier will not be flagged as changes. */
       snapshot_id: string;
+    }
+
+    export interface MarketingDiagnosticResponse {
+      /** Per-integration cross-domain diagnostics */
+      integrations: IntegrationDiagnostic[];
+      /** healthy/degraded/broken/no_sources */
+      overall_status: string;
+      /** One-line plain-English summary of the diagnostic */
+      summary: string;
+      /** Conversion goal summary, when requested */
+      conversion_goals?: ConversionGoalsListResponse | null;
+      /** Top global recommended actions across all integrations */
+      recommended_actions: RecommendedAction[];
     }
 
     /**
@@ -27032,7 +27414,7 @@ export namespace Schemas {
       readonly created_at: string;
       /** Optional name for the threshold. */
       name?: string;
-      /** Threshold bounds and type. Includes bounds (lower/upper floats) and type (absolute or percentage). */
+      /** Threshold bounds and type. Includes bounds (lower/upper floats) and type (absolute or percentage). For threshold-based alerts (no detector_config), at least one of lower or upper must be set. */
       configuration: InsightThreshold;
       readonly alerts: readonly Alert[];
     }
@@ -37914,6 +38296,18 @@ export namespace Schemas {
       limited: QuotaLimitsResponseLimited;
     }
 
+    export interface RawUnmatchedSample {
+      /** A raw utm_source value matching no integration */
+      raw_utm_source: string;
+      /** Number of events with this raw value in the window */
+      event_count: number;
+      /**
+         * Integration suggested by token match, if any
+         * @nullable
+         */
+      suggested_integration: string | null;
+    }
+
     /**
      * * `manual` - manual
     * `experiment_launch` - experiment_launch
@@ -39106,6 +39500,17 @@ export namespace Schemas {
       task: SlackThreadContextTask | null;
       /** All runs on the task, oldest first. Empty when no mapping was found. */
       runs: SlackThreadContextRun[];
+    }
+
+    export interface SourceMappingSuggestion {
+      /** The raw utm_source value seen on events */
+      raw_utm_source: string;
+      /** Integration key it maps to */
+      suggested_target: string;
+      /** Human-readable name of the suggested integration */
+      suggested_target_display_name: string;
+      /** Why this mapping is suggested */
+      reason: string;
     }
 
     /**
@@ -41095,6 +41500,27 @@ export namespace Schemas {
       all_utm_events: UtmEvent[];
     }
 
+    export interface UtmMappingSuggestionsResponse {
+      /** Suggested custom_source_mappings entries */
+      source_suggestions: SourceMappingSuggestion[];
+      /** Suggested campaign-name clusters (empty in v1) */
+      campaign_suggestions: CampaignMappingSuggestion[];
+      /** All unmatched raw utm_source values worth reviewing */
+      raw_unmatched_samples: RawUnmatchedSample[];
+      /** Every utm_source value seen in the window, matched or not */
+      full_utm_source_catalogue: CatalogueEntry[];
+      /** Mappings already in effect (canonical + team_custom) */
+      current_mappings: CurrentMapping[];
+      /** Total events with an unmatched utm_source */
+      total_unmatched_events_in_window: number;
+      /** Total events with any utm_source */
+      total_events_with_utm_in_window: number;
+      /** Lookback window in days used for the analysis */
+      lookback_days_used: number;
+      /** Caveats and guidance about the suggestions */
+      notes: string[];
+    }
+
     export interface ViewLinkValidation {
       /** @maxLength 255 */
       joining_table_name: string;
@@ -41845,6 +42271,27 @@ export namespace Schemas {
       query: _TracingAggregationQueryBody;
     }
 
+    export interface _TracingCountBody {
+      /** Date range for the count. Defaults to last hour. */
+      dateRange?: _TracingDateRange;
+      /** Filter by service names. */
+      serviceNames?: string[];
+      /** Filter by HTTP status codes. */
+      statusCodes?: number[];
+      /** Property filters for the count. */
+      filterGroup?: _SpanPropertyFilter[];
+    }
+
+    export interface _TracingCountRequest {
+      /** The span count query to execute. */
+      query: _TracingCountBody;
+    }
+
+    export interface _TracingCountResponse {
+      /** Number of spans matching the filters. */
+      count: number;
+    }
+
     export interface _TracingQueryBody {
       /** Date range for the query. Defaults to last hour. */
       dateRange?: _TracingDateRange;
@@ -41957,6 +42404,14 @@ export namespace Schemas {
 
     export type EnvironmentsAlertsListParams = {
     /**
+     * Optional. Restrict results to alerts created by the user with this UUID.
+     */
+    created_by?: string;
+    /**
+     * Optional. Restrict results to alerts on this insight ID.
+     */
+    insight_id?: number;
+    /**
      * Number of results to return per page.
      */
     limit?: number;
@@ -41964,6 +42419,10 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    /**
+     * Optional. Fuzzy match against alert `name` using Postgres trigram word similarity (handles typos, transpositions, and prefix-as-you-type). Results are ordered by relevance, then creation time. Capped at 200 characters; longer queries return a 400 error.
+     */
+    search?: string;
     };
 
     export type EnvironmentsAlertsRetrieveParams = {
@@ -44945,6 +45404,74 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type EnvironmentsMarketingAnalyticsDataSourcesRetrieveParams = {
+    /**
+     * Optional. Restrict to one integration (e.g. 'GoogleAds').
+     * @nullable
+     */
+    source_type?: string | null;
+    };
+
+    export type EnvironmentsMarketingAnalyticsDiagnoseRetrieveParams = {
+    /**
+     * Lookback window for attribution health (1-365 days); defaults to 7
+     * @minimum 1
+     * @maximum 365
+     */
+    attribution_lookback_days?: number;
+    /**
+     * Whether to include the conversion-goal summary in the diagnostic
+     */
+    include_conversion_goals?: boolean;
+    /**
+     * Optional integration filter
+     * @nullable
+     */
+    source_type?: string | null;
+    };
+
+    export type EnvironmentsMarketingAnalyticsExplainConversionGoalRetrieveParams = {
+    /**
+     * ISO start; defaults to 30 days ago
+     * @nullable
+     */
+    date_from?: string | null;
+    /**
+     * ISO end; defaults to now
+     * @nullable
+     */
+    date_to?: string | null;
+    /**
+     * Id of the conversion goal to explain (from list_conversion_goals).
+     * @minLength 1
+     */
+    goal_id: string;
+    };
+
+    export type EnvironmentsMarketingAnalyticsSuggestConversionGoalsRetrieveParams = {
+    /**
+     * Minimum 30d event count to be a candidate
+     */
+    min_count?: number;
+    /**
+     * Max candidates to return
+     */
+    top_n?: number;
+    };
+
+    export type EnvironmentsMarketingAnalyticsSuggestUtmMappingsRetrieveParams = {
+    /**
+     * Days of history to inspect (1-365); defaults to 90
+     * @minimum 1
+     * @maximum 365
+     */
+    lookback_days?: number;
+    /**
+     * Only suggest for raw values with >= this many events
+     */
+    min_event_count?: number;
+    };
+
     export type EnvironmentsMarketingAnalyticsUtmAuditRetrieveParams = {
     /**
      * Start date for the audit period
@@ -46972,6 +47499,14 @@ export namespace Schemas {
 
     export type AlertsListParams = {
     /**
+     * Optional. Restrict results to alerts created by the user with this UUID.
+     */
+    created_by?: string;
+    /**
+     * Optional. Restrict results to alerts on this insight ID.
+     */
+    insight_id?: number;
+    /**
      * Number of results to return per page.
      */
     limit?: number;
@@ -46979,6 +47514,10 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    /**
+     * Optional. Fuzzy match against alert `name` using Postgres trigram word similarity (handles typos, transpositions, and prefix-as-you-type). Results are ordered by relevance, then creation time. Capped at 200 characters; longer queries return a 400 error.
+     */
+    search?: string;
     };
 
     export type AlertsRetrieveParams = {
@@ -50716,6 +51255,74 @@ export namespace Schemas {
       Paused: 'paused',
       Running: 'running',
     } as const;
+
+    export type MarketingAnalyticsDataSourcesRetrieveParams = {
+    /**
+     * Optional. Restrict to one integration (e.g. 'GoogleAds').
+     * @nullable
+     */
+    source_type?: string | null;
+    };
+
+    export type MarketingAnalyticsDiagnoseRetrieveParams = {
+    /**
+     * Lookback window for attribution health (1-365 days); defaults to 7
+     * @minimum 1
+     * @maximum 365
+     */
+    attribution_lookback_days?: number;
+    /**
+     * Whether to include the conversion-goal summary in the diagnostic
+     */
+    include_conversion_goals?: boolean;
+    /**
+     * Optional integration filter
+     * @nullable
+     */
+    source_type?: string | null;
+    };
+
+    export type MarketingAnalyticsExplainConversionGoalRetrieveParams = {
+    /**
+     * ISO start; defaults to 30 days ago
+     * @nullable
+     */
+    date_from?: string | null;
+    /**
+     * ISO end; defaults to now
+     * @nullable
+     */
+    date_to?: string | null;
+    /**
+     * Id of the conversion goal to explain (from list_conversion_goals).
+     * @minLength 1
+     */
+    goal_id: string;
+    };
+
+    export type MarketingAnalyticsSuggestConversionGoalsRetrieveParams = {
+    /**
+     * Minimum 30d event count to be a candidate
+     */
+    min_count?: number;
+    /**
+     * Max candidates to return
+     */
+    top_n?: number;
+    };
+
+    export type MarketingAnalyticsSuggestUtmMappingsRetrieveParams = {
+    /**
+     * Days of history to inspect (1-365); defaults to 90
+     * @minimum 1
+     * @maximum 365
+     */
+    lookback_days?: number;
+    /**
+     * Only suggest for raw values with >= this many events
+     */
+    min_event_count?: number;
+    };
 
     export type MarketingAnalyticsUtmAuditRetrieveParams = {
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33,8 +33,8 @@ export namespace Schemas {
 
     /**
      * * `read_write` - read_write
-     * * `read` - read
-     * * `none` - none
+    * `read` - read
+    * `none` - none
      */
     export type AccessLevelEnum = typeof AccessLevelEnum[keyof typeof AccessLevelEnum];
 
@@ -47,7 +47,7 @@ export namespace Schemas {
 
     /**
      * * `warehouse` - warehouse
-     * * `direct` - direct
+    * `direct` - direct
      */
     export type AccessMethodEnum = typeof AccessMethodEnum[keyof typeof AccessMethodEnum];
 
@@ -104,7 +104,7 @@ export namespace Schemas {
          */
       name: string;
       /**
-         * Identifier linking this account to its source customer — the analytics group key (the customer's organization id), used to match billing and external records. Optional.
+         * Identifier for the account in an external system (e.g. CRM ID). Optional.
          * @maxLength 400
          * @nullable
          */
@@ -127,13 +127,13 @@ export namespace Schemas {
 
     /**
      * * `engineering` - Engineering
-     * * `data` - Data
-     * * `product` - Product Management
-     * * `founder` - Founder
-     * * `leadership` - Leadership
-     * * `marketing` - Marketing
-     * * `sales` - Sales / Success
-     * * `other` - Other
+    * `data` - Data
+    * `product` - Product Management
+    * `founder` - Founder
+    * `leadership` - Leadership
+    * `marketing` - Marketing
+    * `sales` - Sales / Success
+    * `other` - Other
      */
     export type RoleAtOrganizationEnum = typeof RoleAtOrganizationEnum[keyof typeof RoleAtOrganizationEnum];
 
@@ -537,32 +537,32 @@ export namespace Schemas {
 
     /**
      * * `event` - event
-     * * `event_metadata` - event_metadata
-     * * `feature` - feature
-     * * `person` - person
-     * * `cohort` - cohort
-     * * `element` - element
-     * * `static-cohort` - static-cohort
-     * * `dynamic-cohort` - dynamic-cohort
-     * * `precalculated-cohort` - precalculated-cohort
-     * * `group` - group
-     * * `recording` - recording
-     * * `log_entry` - log_entry
-     * * `behavioral` - behavioral
-     * * `session` - session
-     * * `hogql` - hogql
-     * * `data_warehouse` - data_warehouse
-     * * `data_warehouse_person_property` - data_warehouse_person_property
-     * * `error_tracking_issue` - error_tracking_issue
-     * * `log` - log
-     * * `log_attribute` - log_attribute
-     * * `log_resource_attribute` - log_resource_attribute
-     * * `span` - span
-     * * `span_attribute` - span_attribute
-     * * `span_resource_attribute` - span_resource_attribute
-     * * `revenue_analytics` - revenue_analytics
-     * * `flag` - flag
-     * * `workflow_variable` - workflow_variable
+    * `event_metadata` - event_metadata
+    * `feature` - feature
+    * `person` - person
+    * `cohort` - cohort
+    * `element` - element
+    * `static-cohort` - static-cohort
+    * `dynamic-cohort` - dynamic-cohort
+    * `precalculated-cohort` - precalculated-cohort
+    * `group` - group
+    * `recording` - recording
+    * `log_entry` - log_entry
+    * `behavioral` - behavioral
+    * `session` - session
+    * `hogql` - hogql
+    * `data_warehouse` - data_warehouse
+    * `data_warehouse_person_property` - data_warehouse_person_property
+    * `error_tracking_issue` - error_tracking_issue
+    * `log` - log
+    * `log_attribute` - log_attribute
+    * `log_resource_attribute` - log_resource_attribute
+    * `span` - span
+    * `span_attribute` - span_attribute
+    * `span_resource_attribute` - span_resource_attribute
+    * `revenue_analytics` - revenue_analytics
+    * `flag` - flag
+    * `workflow_variable` - workflow_variable
      */
     export type PropertyFilterTypeEnum = typeof PropertyFilterTypeEnum[keyof typeof PropertyFilterTypeEnum];
 
@@ -599,11 +599,11 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-     * * `is_not` - is_not
-     * * `icontains` - icontains
-     * * `not_icontains` - not_icontains
-     * * `regex` - regex
-     * * `not_regex` - not_regex
+    * `is_not` - is_not
+    * `icontains` - icontains
+    * `not_icontains` - not_icontains
+    * `regex` - regex
+    * `not_regex` - not_regex
      */
     export type StringMatchOperatorEnum = typeof StringMatchOperatorEnum[keyof typeof StringMatchOperatorEnum];
 
@@ -624,55 +624,55 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-       *
-       * * `event` - event
-       * * `event_metadata` - event_metadata
-       * * `feature` - feature
-       * * `person` - person
-       * * `cohort` - cohort
-       * * `element` - element
-       * * `static-cohort` - static-cohort
-       * * `dynamic-cohort` - dynamic-cohort
-       * * `precalculated-cohort` - precalculated-cohort
-       * * `group` - group
-       * * `recording` - recording
-       * * `log_entry` - log_entry
-       * * `behavioral` - behavioral
-       * * `session` - session
-       * * `hogql` - hogql
-       * * `data_warehouse` - data_warehouse
-       * * `data_warehouse_person_property` - data_warehouse_person_property
-       * * `error_tracking_issue` - error_tracking_issue
-       * * `log` - log
-       * * `log_attribute` - log_attribute
-       * * `log_resource_attribute` - log_resource_attribute
-       * * `span` - span
-       * * `span_attribute` - span_attribute
-       * * `span_resource_attribute` - span_resource_attribute
-       * * `revenue_analytics` - revenue_analytics
-       * * `flag` - flag
-       * * `workflow_variable` - workflow_variable */
+
+      * `event` - event
+      * `event_metadata` - event_metadata
+      * `feature` - feature
+      * `person` - person
+      * `cohort` - cohort
+      * `element` - element
+      * `static-cohort` - static-cohort
+      * `dynamic-cohort` - dynamic-cohort
+      * `precalculated-cohort` - precalculated-cohort
+      * `group` - group
+      * `recording` - recording
+      * `log_entry` - log_entry
+      * `behavioral` - behavioral
+      * `session` - session
+      * `hogql` - hogql
+      * `data_warehouse` - data_warehouse
+      * `data_warehouse_person_property` - data_warehouse_person_property
+      * `error_tracking_issue` - error_tracking_issue
+      * `log` - log
+      * `log_attribute` - log_attribute
+      * `log_resource_attribute` - log_resource_attribute
+      * `span` - span
+      * `span_attribute` - span_attribute
+      * `span_resource_attribute` - span_resource_attribute
+      * `revenue_analytics` - revenue_analytics
+      * `flag` - flag
+      * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** String value to match against. */
       value: string;
       /** String comparison operator.
-       *
-       * * `exact` - exact
-       * * `is_not` - is_not
-       * * `icontains` - icontains
-       * * `not_icontains` - not_icontains
-       * * `regex` - regex
-       * * `not_regex` - not_regex */
+
+      * `exact` - exact
+      * `is_not` - is_not
+      * `icontains` - icontains
+      * `not_icontains` - not_icontains
+      * `regex` - regex
+      * `not_regex` - not_regex */
       operator?: StringMatchOperatorEnum;
     }
 
     /**
      * * `exact` - exact
-     * * `is_not` - is_not
-     * * `gt` - gt
-     * * `lt` - lt
-     * * `gte` - gte
-     * * `lte` - lte
+    * `is_not` - is_not
+    * `gt` - gt
+    * `lt` - lt
+    * `gte` - gte
+    * `lte` - lte
      */
     export type NumericPropertyFilterOperatorEnum = typeof NumericPropertyFilterOperatorEnum[keyof typeof NumericPropertyFilterOperatorEnum];
 
@@ -693,53 +693,53 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-       *
-       * * `event` - event
-       * * `event_metadata` - event_metadata
-       * * `feature` - feature
-       * * `person` - person
-       * * `cohort` - cohort
-       * * `element` - element
-       * * `static-cohort` - static-cohort
-       * * `dynamic-cohort` - dynamic-cohort
-       * * `precalculated-cohort` - precalculated-cohort
-       * * `group` - group
-       * * `recording` - recording
-       * * `log_entry` - log_entry
-       * * `behavioral` - behavioral
-       * * `session` - session
-       * * `hogql` - hogql
-       * * `data_warehouse` - data_warehouse
-       * * `data_warehouse_person_property` - data_warehouse_person_property
-       * * `error_tracking_issue` - error_tracking_issue
-       * * `log` - log
-       * * `log_attribute` - log_attribute
-       * * `log_resource_attribute` - log_resource_attribute
-       * * `span` - span
-       * * `span_attribute` - span_attribute
-       * * `span_resource_attribute` - span_resource_attribute
-       * * `revenue_analytics` - revenue_analytics
-       * * `flag` - flag
-       * * `workflow_variable` - workflow_variable */
+
+      * `event` - event
+      * `event_metadata` - event_metadata
+      * `feature` - feature
+      * `person` - person
+      * `cohort` - cohort
+      * `element` - element
+      * `static-cohort` - static-cohort
+      * `dynamic-cohort` - dynamic-cohort
+      * `precalculated-cohort` - precalculated-cohort
+      * `group` - group
+      * `recording` - recording
+      * `log_entry` - log_entry
+      * `behavioral` - behavioral
+      * `session` - session
+      * `hogql` - hogql
+      * `data_warehouse` - data_warehouse
+      * `data_warehouse_person_property` - data_warehouse_person_property
+      * `error_tracking_issue` - error_tracking_issue
+      * `log` - log
+      * `log_attribute` - log_attribute
+      * `log_resource_attribute` - log_resource_attribute
+      * `span` - span
+      * `span_attribute` - span_attribute
+      * `span_resource_attribute` - span_resource_attribute
+      * `revenue_analytics` - revenue_analytics
+      * `flag` - flag
+      * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** Numeric value to compare against. */
       value: number;
       /** Numeric comparison operator.
-       *
-       * * `exact` - exact
-       * * `is_not` - is_not
-       * * `gt` - gt
-       * * `lt` - lt
-       * * `gte` - gte
-       * * `lte` - lte */
+
+      * `exact` - exact
+      * `is_not` - is_not
+      * `gt` - gt
+      * `lt` - lt
+      * `gte` - gte
+      * `lte` - lte */
       operator?: NumericPropertyFilterOperatorEnum;
     }
 
     /**
      * * `exact` - exact
-     * * `is_not` - is_not
-     * * `in` - in
-     * * `not_in` - not_in
+    * `is_not` - is_not
+    * `in` - in
+    * `not_in` - not_in
      */
     export type ArrayPropertyFilterOperatorEnum = typeof ArrayPropertyFilterOperatorEnum[keyof typeof ArrayPropertyFilterOperatorEnum];
 
@@ -758,50 +758,50 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-       *
-       * * `event` - event
-       * * `event_metadata` - event_metadata
-       * * `feature` - feature
-       * * `person` - person
-       * * `cohort` - cohort
-       * * `element` - element
-       * * `static-cohort` - static-cohort
-       * * `dynamic-cohort` - dynamic-cohort
-       * * `precalculated-cohort` - precalculated-cohort
-       * * `group` - group
-       * * `recording` - recording
-       * * `log_entry` - log_entry
-       * * `behavioral` - behavioral
-       * * `session` - session
-       * * `hogql` - hogql
-       * * `data_warehouse` - data_warehouse
-       * * `data_warehouse_person_property` - data_warehouse_person_property
-       * * `error_tracking_issue` - error_tracking_issue
-       * * `log` - log
-       * * `log_attribute` - log_attribute
-       * * `log_resource_attribute` - log_resource_attribute
-       * * `span` - span
-       * * `span_attribute` - span_attribute
-       * * `span_resource_attribute` - span_resource_attribute
-       * * `revenue_analytics` - revenue_analytics
-       * * `flag` - flag
-       * * `workflow_variable` - workflow_variable */
+
+      * `event` - event
+      * `event_metadata` - event_metadata
+      * `feature` - feature
+      * `person` - person
+      * `cohort` - cohort
+      * `element` - element
+      * `static-cohort` - static-cohort
+      * `dynamic-cohort` - dynamic-cohort
+      * `precalculated-cohort` - precalculated-cohort
+      * `group` - group
+      * `recording` - recording
+      * `log_entry` - log_entry
+      * `behavioral` - behavioral
+      * `session` - session
+      * `hogql` - hogql
+      * `data_warehouse` - data_warehouse
+      * `data_warehouse_person_property` - data_warehouse_person_property
+      * `error_tracking_issue` - error_tracking_issue
+      * `log` - log
+      * `log_attribute` - log_attribute
+      * `log_resource_attribute` - log_resource_attribute
+      * `span` - span
+      * `span_attribute` - span_attribute
+      * `span_resource_attribute` - span_resource_attribute
+      * `revenue_analytics` - revenue_analytics
+      * `flag` - flag
+      * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** List of values to match. For example `["test@example.com", "ok@example.com"]`. */
       value: string[];
       /** Array comparison operator.
-       *
-       * * `exact` - exact
-       * * `is_not` - is_not
-       * * `in` - in
-       * * `not_in` - not_in */
+
+      * `exact` - exact
+      * `is_not` - is_not
+      * `in` - in
+      * `not_in` - not_in */
       operator?: ArrayPropertyFilterOperatorEnum;
     }
 
     /**
      * * `is_date_exact` - is_date_exact
-     * * `is_date_before` - is_date_before
-     * * `is_date_after` - is_date_after
+    * `is_date_before` - is_date_before
+    * `is_date_after` - is_date_after
      */
     export type DateOperatorEnum = typeof DateOperatorEnum[keyof typeof DateOperatorEnum];
 
@@ -819,48 +819,48 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-       *
-       * * `event` - event
-       * * `event_metadata` - event_metadata
-       * * `feature` - feature
-       * * `person` - person
-       * * `cohort` - cohort
-       * * `element` - element
-       * * `static-cohort` - static-cohort
-       * * `dynamic-cohort` - dynamic-cohort
-       * * `precalculated-cohort` - precalculated-cohort
-       * * `group` - group
-       * * `recording` - recording
-       * * `log_entry` - log_entry
-       * * `behavioral` - behavioral
-       * * `session` - session
-       * * `hogql` - hogql
-       * * `data_warehouse` - data_warehouse
-       * * `data_warehouse_person_property` - data_warehouse_person_property
-       * * `error_tracking_issue` - error_tracking_issue
-       * * `log` - log
-       * * `log_attribute` - log_attribute
-       * * `log_resource_attribute` - log_resource_attribute
-       * * `span` - span
-       * * `span_attribute` - span_attribute
-       * * `span_resource_attribute` - span_resource_attribute
-       * * `revenue_analytics` - revenue_analytics
-       * * `flag` - flag
-       * * `workflow_variable` - workflow_variable */
+
+      * `event` - event
+      * `event_metadata` - event_metadata
+      * `feature` - feature
+      * `person` - person
+      * `cohort` - cohort
+      * `element` - element
+      * `static-cohort` - static-cohort
+      * `dynamic-cohort` - dynamic-cohort
+      * `precalculated-cohort` - precalculated-cohort
+      * `group` - group
+      * `recording` - recording
+      * `log_entry` - log_entry
+      * `behavioral` - behavioral
+      * `session` - session
+      * `hogql` - hogql
+      * `data_warehouse` - data_warehouse
+      * `data_warehouse_person_property` - data_warehouse_person_property
+      * `error_tracking_issue` - error_tracking_issue
+      * `log` - log
+      * `log_attribute` - log_attribute
+      * `log_resource_attribute` - log_resource_attribute
+      * `span` - span
+      * `span_attribute` - span_attribute
+      * `span_resource_attribute` - span_resource_attribute
+      * `revenue_analytics` - revenue_analytics
+      * `flag` - flag
+      * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** Date or datetime string in ISO 8601 format (e.g. '2024-01-15' or '2024-01-15T10:30:00Z'). */
       value: string;
       /** Date comparison operator.
-       *
-       * * `is_date_exact` - is_date_exact
-       * * `is_date_before` - is_date_before
-       * * `is_date_after` - is_date_after */
+
+      * `is_date_exact` - is_date_exact
+      * `is_date_before` - is_date_before
+      * `is_date_after` - is_date_after */
       operator?: DateOperatorEnum;
     }
 
     /**
      * * `is_set` - is_set
-     * * `is_not_set` - is_not_set
+    * `is_not_set` - is_not_set
      */
     export type ExistenceOperatorEnum = typeof ExistenceOperatorEnum[keyof typeof ExistenceOperatorEnum];
 
@@ -877,39 +877,39 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-       *
-       * * `event` - event
-       * * `event_metadata` - event_metadata
-       * * `feature` - feature
-       * * `person` - person
-       * * `cohort` - cohort
-       * * `element` - element
-       * * `static-cohort` - static-cohort
-       * * `dynamic-cohort` - dynamic-cohort
-       * * `precalculated-cohort` - precalculated-cohort
-       * * `group` - group
-       * * `recording` - recording
-       * * `log_entry` - log_entry
-       * * `behavioral` - behavioral
-       * * `session` - session
-       * * `hogql` - hogql
-       * * `data_warehouse` - data_warehouse
-       * * `data_warehouse_person_property` - data_warehouse_person_property
-       * * `error_tracking_issue` - error_tracking_issue
-       * * `log` - log
-       * * `log_attribute` - log_attribute
-       * * `log_resource_attribute` - log_resource_attribute
-       * * `span` - span
-       * * `span_attribute` - span_attribute
-       * * `span_resource_attribute` - span_resource_attribute
-       * * `revenue_analytics` - revenue_analytics
-       * * `flag` - flag
-       * * `workflow_variable` - workflow_variable */
+
+      * `event` - event
+      * `event_metadata` - event_metadata
+      * `feature` - feature
+      * `person` - person
+      * `cohort` - cohort
+      * `element` - element
+      * `static-cohort` - static-cohort
+      * `dynamic-cohort` - dynamic-cohort
+      * `precalculated-cohort` - precalculated-cohort
+      * `group` - group
+      * `recording` - recording
+      * `log_entry` - log_entry
+      * `behavioral` - behavioral
+      * `session` - session
+      * `hogql` - hogql
+      * `data_warehouse` - data_warehouse
+      * `data_warehouse_person_property` - data_warehouse_person_property
+      * `error_tracking_issue` - error_tracking_issue
+      * `log` - log
+      * `log_attribute` - log_attribute
+      * `log_resource_attribute` - log_resource_attribute
+      * `span` - span
+      * `span_attribute` - span_attribute
+      * `span_resource_attribute` - span_resource_attribute
+      * `revenue_analytics` - revenue_analytics
+      * `flag` - flag
+      * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** Existence check operator.
-       *
-       * * `is_set` - is_set
-       * * `is_not_set` - is_not_set */
+
+      * `is_set` - is_set
+      * `is_not_set` - is_not_set */
       operator: ExistenceOperatorEnum;
     }
 
@@ -917,8 +917,8 @@ export namespace Schemas {
 
     /**
      * * `contains` - contains
-     * * `regex` - regex
-     * * `exact` - exact
+    * `regex` - regex
+    * `exact` - exact
      */
     export type ActionStepMatchingEnum = typeof ActionStepMatchingEnum[keyof typeof ActionStepMatchingEnum];
 
@@ -958,10 +958,10 @@ export namespace Schemas {
          */
       text?: string | null;
       /** How to match the text value. Defaults to exact.
-       *
-       * * `contains` - contains
-       * * `regex` - regex
-       * * `exact` - exact */
+
+      * `contains` - contains
+      * `regex` - regex
+      * `exact` - exact */
       text_matching?: ActionStepMatchingEnum | null;
       /**
          * Link href attribute to match.
@@ -969,10 +969,10 @@ export namespace Schemas {
          */
       href?: string | null;
       /** How to match the href value. Defaults to exact.
-       *
-       * * `contains` - contains
-       * * `regex` - regex
-       * * `exact` - exact */
+
+      * `contains` - contains
+      * `regex` - regex
+      * `exact` - exact */
       href_matching?: ActionStepMatchingEnum | null;
       /**
          * Page URL to match.
@@ -980,10 +980,10 @@ export namespace Schemas {
          */
       url?: string | null;
       /** How to match the URL value. Defaults to contains.
-       *
-       * * `contains` - contains
-       * * `regex` - regex
-       * * `exact` - exact */
+
+      * `contains` - contains
+      * `regex` - regex
+      * `exact` - exact */
       url_matching?: ActionStepMatchingEnum | null;
     }
 
@@ -1040,8 +1040,8 @@ export namespace Schemas {
 
     /**
      * * `add` - add
-     * * `remove` - remove
-     * * `set` - set
+    * `remove` - remove
+    * `set` - set
      */
     export type ActionEnum = typeof ActionEnum[keyof typeof ActionEnum];
 
@@ -1626,8 +1626,8 @@ export namespace Schemas {
 
     /**
      * * `true` - true
-     * * `false` - false
-     * * `STALE` - STALE
+    * `false` - false
+    * `STALE` - STALE
      */
     export type ActiveEnum = typeof ActiveEnum[keyof typeof ActiveEnum];
 
@@ -1880,7 +1880,7 @@ export namespace Schemas {
 
     export interface DateRange {
       /** Start of the date range. Accepts ISO 8601 timestamps (e.g., 2024-01-15T00:00:00Z) or relative formats: -7d (7 days ago), -2w (2 weeks ago), -1m (1 month ago),
-       * -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
+      -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
       date_from?: string | null;
       /** End of the date range. Same format as date_from. Omit or null for "now". */
       date_to?: string | null;
@@ -2152,14 +2152,14 @@ export namespace Schemas {
 
     export interface TrendsFilter {
       /** Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
-       *
-       * - `numeric` (default): raw numbers, e.g. `1,234`.
-       * - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
-       * - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
-       * - `percentage`: values are already in the 0-100 range; appends `%`.
-       * - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
-       * - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
-       * - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
+
+      - `numeric` (default): raw numbers, e.g. `1,234`.
+      - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
+      - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
+      - `percentage`: values are already in the 0-100 range; appends `%`.
+      - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
+      - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
+      - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
       aggregationAxisFormat?: AggregationAxisFormat | null;
       /** Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself. */
       aggregationAxisPostfix?: string | null;
@@ -2390,8 +2390,6 @@ export namespace Schemas {
       resultCustomizations?: FunnelsFilterResultCustomizations;
       /** Whether to render annotations on the chart. Only applies to historical-trends funnels. */
       showAnnotations?: boolean | null;
-      /** Whether to show a legend describing the series. The legend only renders when the funnel has multiple series. Only applies to historical-trends funnels. */
-      showLegend?: boolean | null;
       /** Display linear regression trend lines on the chart (only for historical trends viz) */
       showTrendLines?: boolean | null;
       showValuesOnSeries?: boolean | null;
@@ -2895,8 +2893,6 @@ export namespace Schemas {
 
     export interface LifecycleFilter {
       showLegend?: boolean | null;
-      /** Append per-band percentage to each value label (e.g. `580 (42%)`). Requires `showValuesOnSeries` — on its own it has no visible effect. */
-      showPercentagesOnSeries?: boolean | null;
       showValuesOnSeries?: boolean | null;
       stacked?: boolean | null;
       toggledLifecycles?: LifecycleToggle[] | null;
@@ -3834,41 +3830,17 @@ export namespace Schemas {
       ErrorTrackingList: 'error_tracking_list',
     } as const;
 
-    export type WidgetDateRangeDateFrom = typeof WidgetDateRangeDateFrom[keyof typeof WidgetDateRangeDateFrom] | null;
-
-
-    export const WidgetDateRangeDateFrom = {
-      '1h': '-1h',
-      '3h': '-3h',
-      '24h': '-24h',
-      '7d': '-7d',
-      '14d': '-14d',
-      '30d': '-30d',
-      '90d': '-90d',
-    } as const;
-
-    export interface WidgetDateRange {
-      date_from?: WidgetDateRangeDateFrom;
-    }
-
-    export interface WidgetFilterEntry {
-      /** @minLength 1 */
-      filterId: string;
-      /** @minLength 1 */
-      propertyName: string;
-      /** @minLength 1 */
-      optionId: string;
-      operator: PropertyOperator;
-      value?: string | string[] | null;
-    }
-
     /**
-     * Issue ranking column.
+     * * `last_seen` - last_seen
+    * `first_seen` - first_seen
+    * `occurrences` - occurrences
+    * `users` - users
+    * `sessions` - sessions
      */
-    export type ErrorTrackingListWidgetConfigOrderBy = typeof ErrorTrackingListWidgetConfigOrderBy[keyof typeof ErrorTrackingListWidgetConfigOrderBy];
+    export type ErrorTrackingIssueOrderByEnum = typeof ErrorTrackingIssueOrderByEnum[keyof typeof ErrorTrackingIssueOrderByEnum];
 
 
-    export const ErrorTrackingListWidgetConfigOrderBy = {
+    export const ErrorTrackingIssueOrderByEnum = {
       LastSeen: 'last_seen',
       FirstSeen: 'first_seen',
       Occurrences: 'occurrences',
@@ -3877,23 +3849,29 @@ export namespace Schemas {
     } as const;
 
     /**
-     * Sort direction for orderBy.
+     * * `ASC` - ASC
+    * `DESC` - DESC
      */
-    export type ErrorTrackingListWidgetConfigOrderDirection = typeof ErrorTrackingListWidgetConfigOrderDirection[keyof typeof ErrorTrackingListWidgetConfigOrderDirection];
+    export type OrderDirectionEnum = typeof OrderDirectionEnum[keyof typeof OrderDirectionEnum];
 
 
-    export const ErrorTrackingListWidgetConfigOrderDirection = {
+    export const OrderDirectionEnum = {
       Asc: 'ASC',
       Desc: 'DESC',
     } as const;
 
     /**
-     * Issue status filter.
+     * * `archived` - archived
+    * `active` - active
+    * `resolved` - resolved
+    * `pending_release` - pending_release
+    * `suppressed` - suppressed
+    * `all` - all
      */
-    export type ErrorTrackingListWidgetConfigStatus = typeof ErrorTrackingListWidgetConfigStatus[keyof typeof ErrorTrackingListWidgetConfigStatus];
+    export type ErrorTrackingIssueStatusEnum = typeof ErrorTrackingIssueStatusEnum[keyof typeof ErrorTrackingIssueStatusEnum];
 
 
-    export const ErrorTrackingListWidgetConfigStatus = {
+    export const ErrorTrackingIssueStatusEnum = {
       Archived: 'archived',
       Active: 'active',
       Resolved: 'resolved',
@@ -3902,39 +3880,118 @@ export namespace Schemas {
       All: 'all',
     } as const;
 
-    export type WidgetAssigneeFilterType = typeof WidgetAssigneeFilterType[keyof typeof WidgetAssigneeFilterType];
+    /**
+     * * `user` - user
+    * `role` - role
+     */
+    export type AssigneeTypeEnum = typeof AssigneeTypeEnum[keyof typeof AssigneeTypeEnum];
 
 
-    export const WidgetAssigneeFilterType = {
+    export const AssigneeTypeEnum = {
       User: 'user',
       Role: 'role',
     } as const;
 
-    export interface WidgetAssigneeFilter {
-      id: string | number;
-      type: WidgetAssigneeFilterType;
+    export interface ErrorTrackingAssignee {
+      /** User ID or role UUID to filter by. */
+      id: string | number | null;
+      /** Assignee target type: user or role.
+
+      * `user` - user
+      * `role` - role */
+      type: AssigneeTypeEnum;
     }
 
-    export type ErrorTrackingListWidgetConfigWidgetFilters = {[key: string]: WidgetFilterEntry} | null;
+    export interface WidgetFilterConfigEntry {
+      /** Filter UUID; must match the widgetFilters map key. */
+      filterId: string;
+      /** Event property key (for example $environment). */
+      propertyName: string;
+      /** Selected option id from the filter definition. */
+      optionId: string;
+      /** Property filter operator (for example exact, is_not, icontains). */
+      operator: string;
+      /** Filter value as a string, list of strings, or null. */
+      value?: unknown;
+    }
+
+    /**
+     * * `-14d` - -14d
+    * `-1h` - -1h
+    * `-24h` - -24h
+    * `-30d` - -30d
+    * `-3h` - -3h
+    * `-7d` - -7d
+    * `-90d` - -90d
+     */
+    export type DateFromEnum = typeof DateFromEnum[keyof typeof DateFromEnum];
+
+
+    export const DateFromEnum = {
+      '14d': '-14d',
+      '1h': '-1h',
+      '24h': '-24h',
+      '30d': '-30d',
+      '3h': '-3h',
+      '7d': '-7d',
+      '90d': '-90d',
+    } as const;
+
+    export interface WidgetDateRange {
+      /** Relative lookback window (for example '-7d'). Omit to use the project default range.
+
+      * `-14d` - -14d
+      * `-1h` - -1h
+      * `-24h` - -24h
+      * `-30d` - -30d
+      * `-3h` - -3h
+      * `-7d` - -7d
+      * `-90d` - -90d */
+      date_from?: DateFromEnum | null;
+    }
+
+    /**
+     * Widget filter selections keyed by filter id. Each key must match the entry's filterId. Configure filters in the product UI first, then copy filter id, option id, and property name here.
+     */
+    export type ErrorTrackingListWidgetConfigWidgetFilters = {[key: string]: WidgetFilterConfigEntry};
 
     export interface ErrorTrackingListWidgetConfig {
-      dateRange?: WidgetDateRange | null;
-      filterTestAccounts?: boolean | null;
-      widgetFilters?: ErrorTrackingListWidgetConfigWidgetFilters;
       /**
-         * Maximum number of issues to return.
+         * Maximum number of issues to return (page size).
          * @minimum 1
          * @maximum 25
          */
       limit?: number;
-      /** Issue ranking column. */
-      orderBy?: ErrorTrackingListWidgetConfigOrderBy;
-      /** Sort direction for orderBy. */
-      orderDirection?: ErrorTrackingListWidgetConfigOrderDirection;
-      /** Issue status filter. */
-      status?: ErrorTrackingListWidgetConfigStatus;
+      /** Issue ranking column.
+
+      * `first_seen` - first_seen
+      * `last_seen` - last_seen
+      * `occurrences` - occurrences
+      * `sessions` - sessions
+      * `users` - users */
+      orderBy?: ErrorTrackingIssueOrderByEnum;
+      /** Sort direction for orderBy.
+
+      * `ASC` - ASC
+      * `DESC` - DESC */
+      orderDirection?: OrderDirectionEnum;
+      /** Issue status filter.
+
+      * `archived` - archived
+      * `active` - active
+      * `resolved` - resolved
+      * `pending_release` - pending_release
+      * `suppressed` - suppressed
+      * `all` - all */
+      status?: ErrorTrackingIssueStatusEnum;
       /** Filter by assignee ({type: user|role, id}). Omit for any assignee. */
-      assignee?: WidgetAssigneeFilter | null;
+      assignee?: ErrorTrackingAssignee | null;
+      /** Widget filter selections keyed by filter id. Each key must match the entry's filterId. Configure filters in the product UI first, then copy filter id, option id, and property name here. */
+      widgetFilters?: ErrorTrackingListWidgetConfigWidgetFilters;
+      /** Relative date range for issues (date_from only on widgets). */
+      dateRange?: WidgetDateRange | null;
+      /** When omitted, follows the project default for filtering test accounts. */
+      filterTestAccounts?: boolean;
     }
 
     export interface ErrorTrackingListWidgetAddRequestOpenApi {
@@ -3951,7 +4008,7 @@ export namespace Schemas {
       /** Whether to show the description on the dashboard tile. */
       show_description?: boolean;
       widget_type: ErrorTrackingListWidgetAddRequestOpenApiWidgetType;
-      /** Configuration for the top issues widget. */
+      /** Configuration for the error tracking list widget. */
       config: ErrorTrackingListWidgetConfig;
     }
 
@@ -3963,47 +4020,57 @@ export namespace Schemas {
     } as const;
 
     /**
-     * Recording ranking column.
+     * * `activity_score` - activity_score
+    * `click_count` - click_count
+    * `console_error_count` - console_error_count
+    * `duration` - duration
+    * `recording_duration` - recording_duration
+    * `start_time` - start_time
      */
-    export type SessionReplayListWidgetConfigOrderBy = typeof SessionReplayListWidgetConfigOrderBy[keyof typeof SessionReplayListWidgetConfigOrderBy];
+    export type SessionReplayListWidgetConfigOrderByEnum = typeof SessionReplayListWidgetConfigOrderByEnum[keyof typeof SessionReplayListWidgetConfigOrderByEnum];
 
 
-    export const SessionReplayListWidgetConfigOrderBy = {
-      StartTime: 'start_time',
+    export const SessionReplayListWidgetConfigOrderByEnum = {
       ActivityScore: 'activity_score',
-      RecordingDuration: 'recording_duration',
-      Duration: 'duration',
       ClickCount: 'click_count',
       ConsoleErrorCount: 'console_error_count',
+      Duration: 'duration',
+      RecordingDuration: 'recording_duration',
+      StartTime: 'start_time',
     } as const;
 
     /**
-     * Sort direction for orderBy.
+     * Widget filter selections keyed by filter id. Each key must match the entry's filterId. Configure filters in the product UI first, then copy filter id, option id, and property name here.
      */
-    export type SessionReplayListWidgetConfigOrderDirection = typeof SessionReplayListWidgetConfigOrderDirection[keyof typeof SessionReplayListWidgetConfigOrderDirection];
-
-
-    export const SessionReplayListWidgetConfigOrderDirection = {
-      Asc: 'ASC',
-      Desc: 'DESC',
-    } as const;
-
-    export type SessionReplayListWidgetConfigWidgetFilters = {[key: string]: WidgetFilterEntry} | null;
+    export type SessionReplayListWidgetConfigWidgetFilters = {[key: string]: WidgetFilterConfigEntry};
 
     export interface SessionReplayListWidgetConfig {
-      dateRange?: WidgetDateRange | null;
-      filterTestAccounts?: boolean | null;
-      widgetFilters?: SessionReplayListWidgetConfigWidgetFilters;
       /**
          * Maximum number of recordings to return.
          * @minimum 1
          * @maximum 25
          */
       limit?: number;
-      /** Recording ranking column. */
-      orderBy?: SessionReplayListWidgetConfigOrderBy;
-      /** Sort direction for orderBy. */
-      orderDirection?: SessionReplayListWidgetConfigOrderDirection;
+      /** Recording ranking column.
+
+      * `activity_score` - activity_score
+      * `click_count` - click_count
+      * `console_error_count` - console_error_count
+      * `duration` - duration
+      * `recording_duration` - recording_duration
+      * `start_time` - start_time */
+      orderBy?: SessionReplayListWidgetConfigOrderByEnum;
+      /** Sort direction for orderBy.
+
+      * `ASC` - ASC
+      * `DESC` - DESC */
+      orderDirection?: OrderDirectionEnum;
+      /** Optional relative date range override. */
+      dateRange?: WidgetDateRange | null;
+      /** Widget filter selections keyed by filter id. Each key must match the entry's filterId. Configure filters in the product UI first, then copy filter id, option id, and property name here. */
+      widgetFilters?: SessionReplayListWidgetConfigWidgetFilters;
+      /** When omitted, follows the project default for filtering test accounts. */
+      filterTestAccounts?: boolean;
     }
 
     export interface SessionReplayListWidgetAddRequestOpenApi {
@@ -4020,7 +4087,7 @@ export namespace Schemas {
       /** Whether to show the description on the dashboard tile. */
       show_description?: boolean;
       widget_type: SessionReplayListWidgetAddRequestOpenApiWidgetType;
-      /** Configuration for the recent recordings widget. */
+      /** Configuration for the session replay list widget. */
       config: SessionReplayListWidgetConfig;
     }
 
@@ -4031,7 +4098,7 @@ export namespace Schemas {
      */
     export interface AddDashboardWidgetsBatchRequestOpenApi {
       /**
-         * Widget tiles to add atomically. Supported widget_type values: error_tracking_list, session_replay_list. Use dashboard-widget-catalog-list for per-type config_schema documentation. (1–10 per request).
+         * Widget tiles to add atomically. Supported widget_type values: error_tracking_list, session_replay_list. Use dashboard-widget-catalog-list for config_schema_hints per type. (1–10 per request).
          * @minItems 1
          * @maxItems 10
          */
@@ -6239,7 +6306,7 @@ export namespace Schemas {
       orderBy: ErrorTrackingOrderBy;
       /** Sort direction. */
       orderDirection?: OrderDirection2 | null;
-      /** Pending fingerprint issue state updates UNIONed into the fingerprint issue state subquery. The backend caps the list at 50 entries; extras are dropped silently. */
+      /** Pending fingerprint issue state updates UNIONed into the fingerprint issue state subquery (V3 only). The backend caps the list at 50 entries; extras are dropped silently. */
       pendingFingerprintIssueStateUpdates?: ErrorTrackingPendingFingerprintIssueStateUpdate[] | null;
       personId?: string | null;
       response?: ErrorTrackingQueryResponse | null;
@@ -6248,6 +6315,10 @@ export namespace Schemas {
       /** Filter by issue status. */
       status?: ErrorTrackingIssueStatus | string | null;
       tags?: QueryLogTags | null;
+      /** Use V2 query path (ClickHouse postgres connector join instead of separate Postgres queries) */
+      useQueryV2?: boolean | null;
+      /** Use V3 query path (denormalized ClickHouse table, no Postgres joins) */
+      useQueryV3?: boolean | null;
       /** version of the node, used for schema migrations */
       version?: number | null;
       volumeResolution: number;
@@ -6817,10 +6888,10 @@ export namespace Schemas {
 
     /**
      * The query definition for this insight. The `kind` field determines the query type:
-     * - `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
-     * - `DataVisualizationNode` — SQL insights using HogQL
-     * - `DataTableNode` — raw data tables
-     * - `HogQuery` — Hog language queries
+    - `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
+    - `DataVisualizationNode` — SQL insights using HogQL
+    - `DataTableNode` — raw data tables
+    - `HogQuery` — Hog language queries
      */
     export type _InsightQuerySchema = InsightVizNode | DataTableNode | DataVisualizationNode | HogQuery;
 
@@ -6880,21 +6951,21 @@ export namespace Schemas {
       order?: number | null;
       deleted?: boolean;
       /**
-       *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
-       *         A dashboard ID for each of the dashboards that this insight is displayed on.
-       *          */
+              DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
+              A dashboard ID for each of the dashboards that this insight is displayed on.
+               */
       dashboards?: number[];
       /**
-       *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
-       *      */
+          A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
+           */
       readonly dashboard_tiles: readonly DashboardTileBasic[];
       /**
          *
-       *     The datetime this insight's results were generated.
-       *     If added to one or more dashboards the insight can be refreshed separately on each.
-       *     Returns the appropriate last_refresh datetime for the context the insight is viewed in
-       *     (see from_dashboard query parameter).
-       *
+          The datetime this insight's results were generated.
+          If added to one or more dashboards the insight can be refreshed separately on each.
+          Returns the appropriate last_refresh datetime for the context the insight is viewed in
+          (see from_dashboard query parameter).
+
          * @nullable
          */
       readonly last_refresh: string | null;
@@ -6905,9 +6976,9 @@ export namespace Schemas {
       readonly cache_target_age: string | null;
       /**
          *
-       *     The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
-       *     by querying the database.
-       *
+          The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
+          by querying the database.
+
          * @nullable
          */
       readonly next_allowed_client_refresh: string | null;
@@ -6954,7 +7025,7 @@ export namespace Schemas {
       readonly alerts: readonly unknown[];
       /** @nullable */
       readonly last_viewed_at: string | null;
-      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      /** How this row matched the `search` term: `exact` (the term is a case-insensitive substring of the name, derived_name, description, or a tag name) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
       readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
@@ -6974,7 +7045,7 @@ export namespace Schemas {
 
     /**
      * * `left` - left
-     * * `right` - right
+    * `right` - right
      */
     export type PlacementEnum = typeof PlacementEnum[keyof typeof PlacementEnum];
 
@@ -6986,7 +7057,7 @@ export namespace Schemas {
 
     /**
      * * `primary` - Primary
-     * * `secondary` - Secondary
+    * `secondary` - Secondary
      */
     export type StyleEnum = typeof StyleEnum[keyof typeof StyleEnum];
 
@@ -7105,18 +7176,17 @@ export namespace Schemas {
 
     /**
      * * `product_analytics` - product_analytics
-     * * `sql` - sql
-     * * `session_replay` - session_replay
-     * * `error_tracking` - error_tracking
-     * * `plan` - plan
-     * * `execution` - execution
-     * * `survey` - survey
-     * * `research` - research
-     * * `flags` - flags
-     * * `llm_analytics` - llm_analytics
-     * * `sandbox` - sandbox
-     * * `user_interview` - user_interview
-     * * `customer_analytics` - customer_analytics
+    * `sql` - sql
+    * `session_replay` - session_replay
+    * `error_tracking` - error_tracking
+    * `plan` - plan
+    * `execution` - execution
+    * `survey` - survey
+    * `research` - research
+    * `flags` - flags
+    * `llm_analytics` - llm_analytics
+    * `sandbox` - sandbox
+    * `user_interview` - user_interview
      */
     export type AgentModeEnum = typeof AgentModeEnum[keyof typeof AgentModeEnum];
 
@@ -7134,7 +7204,6 @@ export namespace Schemas {
       LlmAnalytics: 'llm_analytics',
       Sandbox: 'sandbox',
       UserInterview: 'user_interview',
-      CustomerAnalytics: 'customer_analytics',
     } as const;
 
     export interface AggregatedSpanRow {
@@ -7150,9 +7219,9 @@ export namespace Schemas {
 
     /**
      * * `sum` - sum
-     * * `avg` - avg
-     * * `count` - count
-     * * `p95` - p95
+    * `avg` - avg
+    * `count` - count
+    * `p95` - p95
      */
     export type AggregationEnum = typeof AggregationEnum[keyof typeof AggregationEnum];
 
@@ -7190,7 +7259,7 @@ export namespace Schemas {
       readonly created_at: string;
       /** Optional name for the threshold. */
       name?: string;
-      /** Threshold bounds and type. Includes bounds (lower/upper floats) and type (absolute or percentage). For threshold-based alerts (no detector_config), at least one of lower or upper must be set. */
+      /** Threshold bounds and type. Includes bounds (lower/upper floats) and type (absolute or percentage). */
       configuration: InsightThreshold;
     }
 
@@ -7209,9 +7278,9 @@ export namespace Schemas {
 
     /**
      * * `Firing` - Firing
-     * * `Not firing` - Not firing
-     * * `Errored` - Errored
-     * * `Snoozed` - Snoozed
+    * `Not firing` - Not firing
+    * `Errored` - Errored
+    * `Snoozed` - Snoozed
      */
     export type AlertCheckStateEnum = typeof AlertCheckStateEnum[keyof typeof AlertCheckStateEnum];
 
@@ -7225,10 +7294,10 @@ export namespace Schemas {
 
     /**
      * * `pending` - pending
-     * * `running` - running
-     * * `done` - done
-     * * `failed` - failed
-     * * `skipped` - skipped
+    * `running` - running
+    * `done` - done
+    * `failed` - failed
+    * `skipped` - skipped
      */
     export type InvestigationStatusEnum = typeof InvestigationStatusEnum[keyof typeof InvestigationStatusEnum];
 
@@ -7243,8 +7312,8 @@ export namespace Schemas {
 
     /**
      * * `true_positive` - true_positive
-     * * `false_positive` - false_positive
-     * * `inconclusive` - inconclusive
+    * `false_positive` - false_positive
+    * `inconclusive` - inconclusive
      */
     export type InvestigationVerdictEnum = typeof InvestigationVerdictEnum[keyof typeof InvestigationVerdictEnum];
 
@@ -7465,10 +7534,10 @@ export namespace Schemas {
 
     /**
      * * `every_15_minutes` - every_15_minutes
-     * * `hourly` - hourly
-     * * `daily` - daily
-     * * `weekly` - weekly
-     * * `monthly` - monthly
+    * `hourly` - hourly
+    * `daily` - daily
+    * `weekly` - weekly
+    * `monthly` - monthly
      */
     export type CalculationIntervalEnum = typeof CalculationIntervalEnum[keyof typeof CalculationIntervalEnum];
 
@@ -7495,7 +7564,7 @@ export namespace Schemas {
 
     /**
      * * `notify` - Notify
-     * * `suppress` - Suppress
+    * `suppress` - Suppress
      */
     export type InvestigationInconclusiveActionEnum = typeof InvestigationInconclusiveActionEnum[keyof typeof InvestigationInconclusiveActionEnum];
 
@@ -7540,12 +7609,12 @@ export namespace Schemas {
       config?: TrendsAlertConfig | null;
       detector_config?: DetectorConfig | null;
       /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
-       *
-       * * `every_15_minutes` - every_15_minutes
-       * * `hourly` - hourly
-       * * `daily` - daily
-       * * `weekly` - weekly
-       * * `monthly` - monthly */
+
+      * `every_15_minutes` - every_15_minutes
+      * `hourly` - hourly
+      * `daily` - daily
+      * `weekly` - weekly
+      * `monthly` - monthly */
       calculation_interval?: CalculationIntervalEnum;
       /**
          * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
@@ -7569,9 +7638,9 @@ export namespace Schemas {
       /** When enabled (and investigation_agent_enabled is on), notification dispatch is held until the investigation agent produces a verdict. Notifications are suppressed when the verdict is false_positive (and optionally when inconclusive). A safety-net task force-fires after a few minutes if the investigation stalls. */
       investigation_gates_notifications?: boolean;
       /** How to handle an 'inconclusive' verdict when notifications are gated. 'notify' is the safe default — an agent that can't be sure is itself useful signal.
-       *
-       * * `notify` - Notify
-       * * `suppress` - Suppress */
+
+      * `notify` - Notify
+      * `suppress` - Suppress */
       investigation_inconclusive_action?: InvestigationInconclusiveActionEnum;
     }
 
@@ -7642,7 +7711,7 @@ export namespace Schemas {
 
     /**
      * * `USR` - user
-     * * `GIT` - GitHub
+    * `GIT` - GitHub
      */
     export type CreationTypeEnum = typeof CreationTypeEnum[keyof typeof CreationTypeEnum];
 
@@ -7654,10 +7723,10 @@ export namespace Schemas {
 
     /**
      * * `dashboard_item` - insight
-     * * `dashboard` - dashboard
-     * * `project` - project
-     * * `organization` - organization
-     * * `recording` - recording
+    * `dashboard` - dashboard
+    * `project` - project
+    * `organization` - organization
+    * `recording` - recording
      */
     export type AnnotationScopeEnum = typeof AnnotationScopeEnum[keyof typeof AnnotationScopeEnum];
 
@@ -7684,9 +7753,9 @@ export namespace Schemas {
          */
       date_marker?: string | null;
       /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
-       *
-       * * `USR` - user
-       * * `GIT` - GitHub */
+
+      * `USR` - user
+      * `GIT` - GitHub */
       creation_type?: CreationTypeEnum;
       /** @nullable */
       dashboard_item?: number | null;
@@ -7707,12 +7776,12 @@ export namespace Schemas {
       /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
       deleted?: boolean;
       /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
-       *
-       * * `dashboard_item` - insight
-       * * `dashboard` - dashboard
-       * * `project` - project
-       * * `organization` - organization
-       * * `recording` - recording */
+
+      * `dashboard_item` - insight
+      * `dashboard` - dashboard
+      * `project` - project
+      * `organization` - organization
+      * `recording` - recording */
       scope?: AnnotationScopeEnum;
       /**
          * Optional emoji shown in place of the default badge when this annotation is surfaced on a chart.
@@ -7811,18 +7880,6 @@ export namespace Schemas {
       download_url: string | null;
     }
 
-    /**
-     * * `user` - user
-     * * `role` - role
-     */
-    export type AssigneeTypeEnum = typeof AssigneeTypeEnum[keyof typeof AssigneeTypeEnum];
-
-
-    export const AssigneeTypeEnum = {
-      User: 'user',
-      Role: 'role',
-    } as const;
-
     export interface AsyncDeletionStatus {
       /** The UUID of the person whose events are queued for deletion. */
       person_uuid: string;
@@ -7837,46 +7894,12 @@ export namespace Schemas {
       delete_verified_at: string | null;
     }
 
-    export interface UnmatchedUtmSample {
-      /** A raw utm_source value that doesn't match the integration exactly */
-      raw_value: string;
-      /** Number of events with this raw value in the window */
-      event_count: number;
-      /**
-         * Integration suggested by token match, if any
-         * @nullable
-         */
-      suggested_integration: string | null;
-    }
-
-    export interface AttributionHealthEntry {
-      /** Integration key (e.g. 'google', 'meta') */
-      integration_key: string;
-      /** Human-readable integration name */
-      display_name: string;
-      /** Total events with any utm_source in the window */
-      events_with_utm_last_7d: number;
-      /** Events whose utm_source matched this integration */
-      events_matched_last_7d: number;
-      /** Events that look like this integration's but don't match exactly */
-      events_unmatched_likely_yours_last_7d: number;
-      /**
-         * Timestamp of the most recent matched event
-         * @nullable
-         */
-      last_event_with_matching_utm_at: string | null;
-      /** Percentage of UTM events matched to this integration */
-      matched_pct: number;
-      /** Sample of likely-yours unmatched utm_source values */
-      sample_unmatched_utm_sources: UnmatchedUtmSample[];
-    }
-
     /**
      * * `first_touch` - First Touch
-     * * `last_touch` - Last Touch
-     * * `linear` - Linear
-     * * `time_decay` - Time Decay
-     * * `position_based` - Position Based
+    * `last_touch` - Last Touch
+    * `linear` - Linear
+    * `time_decay` - Time Decay
+    * `position_based` - Position Based
      */
     export type AttributionModeEnum = typeof AttributionModeEnum[keyof typeof AttributionModeEnum];
 
@@ -7887,18 +7910,6 @@ export namespace Schemas {
       Linear: 'linear',
       TimeDecay: 'time_decay',
       PositionBased: 'position_based',
-    } as const;
-
-    /**
-     * * `oauth` - oauth
-     * * `credentials` - credentials
-     */
-    export type AuthMethodEnum = typeof AuthMethodEnum[keyof typeof AuthMethodEnum];
-
-
-    export const AuthMethodEnum = {
-      Oauth: 'oauth',
-      Credentials: 'credentials',
     } as const;
 
     export interface Author {
@@ -7961,10 +7972,10 @@ export namespace Schemas {
 
     /**
      * * `P0` - P0
-     * * `P1` - P1
-     * * `P2` - P2
-     * * `P3` - P3
-     * * `P4` - P4
+    * `P1` - P1
+    * `P2` - P2
+    * `P3` - P3
+    * `P4` - P4
      */
     export type AutonomyPriorityEnum = typeof AutonomyPriorityEnum[keyof typeof AutonomyPriorityEnum];
 
@@ -8010,70 +8021,70 @@ export namespace Schemas {
 
     /**
      * * `ingest_first_event` - ingest_first_event
-     * * `set_up_reverse_proxy` - set_up_reverse_proxy
-     * * `create_first_insight` - create_first_insight
-     * * `create_first_dashboard` - create_first_dashboard
-     * * `track_custom_events` - track_custom_events
-     * * `define_actions` - define_actions
-     * * `set_up_cohorts` - set_up_cohorts
-     * * `explore_trends_insight` - explore_trends_insight
-     * * `create_funnel` - create_funnel
-     * * `explore_retention_insight` - explore_retention_insight
-     * * `explore_paths_insight` - explore_paths_insight
-     * * `explore_stickiness_insight` - explore_stickiness_insight
-     * * `explore_lifecycle_insight` - explore_lifecycle_insight
-     * * `add_authorized_domain` - add_authorized_domain
-     * * `set_up_web_vitals` - set_up_web_vitals
-     * * `review_web_analytics_dashboard` - review_web_analytics_dashboard
-     * * `filter_web_analytics` - filter_web_analytics
-     * * `set_up_web_analytics_conversion_goals` - set_up_web_analytics_conversion_goals
-     * * `visit_web_vitals_dashboard` - visit_web_vitals_dashboard
-     * * `setup_session_recordings` - setup_session_recordings
-     * * `watch_session_recording` - watch_session_recording
-     * * `configure_recording_settings` - configure_recording_settings
-     * * `create_recording_playlist` - create_recording_playlist
-     * * `enable_console_logs` - enable_console_logs
-     * * `create_feature_flag` - create_feature_flag
-     * * `implement_flag_in_code` - implement_flag_in_code
-     * * `update_feature_flag_release_conditions` - update_feature_flag_release_conditions
-     * * `create_multivariate_flag` - create_multivariate_flag
-     * * `set_up_flag_payloads` - set_up_flag_payloads
-     * * `set_up_flag_evaluation_runtimes` - set_up_flag_evaluation_runtimes
-     * * `create_experiment` - create_experiment
-     * * `implement_experiment_variants` - implement_experiment_variants
-     * * `launch_experiment` - launch_experiment
-     * * `review_experiment_results` - review_experiment_results
-     * * `create_survey` - create_survey
-     * * `launch_survey` - launch_survey
-     * * `collect_survey_responses` - collect_survey_responses
-     * * `connect_source` - connect_source
-     * * `run_first_query` - run_first_query
-     * * `join_external_data` - join_external_data
-     * * `create_saved_view` - create_saved_view
-     * * `enable_error_tracking` - enable_error_tracking
-     * * `upload_source_maps` - upload_source_maps
-     * * `view_first_error` - view_first_error
-     * * `resolve_first_error` - resolve_first_error
-     * * `ingest_first_llm_event` - ingest_first_llm_event
-     * * `view_first_trace` - view_first_trace
-     * * `track_costs` - track_costs
-     * * `set_up_llm_evaluation` - set_up_llm_evaluation
-     * * `run_ai_playground` - run_ai_playground
-     * * `enable_revenue_analytics_viewset` - enable_revenue_analytics_viewset
-     * * `connect_revenue_source` - connect_revenue_source
-     * * `set_up_revenue_goal` - set_up_revenue_goal
-     * * `enable_log_capture` - enable_log_capture
-     * * `view_first_logs` - view_first_logs
-     * * `create_first_workflow` - create_first_workflow
-     * * `set_up_first_workflow_channel` - set_up_first_workflow_channel
-     * * `configure_workflow_trigger` - configure_workflow_trigger
-     * * `add_workflow_action` - add_workflow_action
-     * * `launch_workflow` - launch_workflow
-     * * `create_first_endpoint` - create_first_endpoint
-     * * `configure_endpoint` - configure_endpoint
-     * * `test_endpoint` - test_endpoint
-     * * `create_early_access_feature` - create_early_access_feature
-     * * `update_feature_stage` - update_feature_stage
+    * `set_up_reverse_proxy` - set_up_reverse_proxy
+    * `create_first_insight` - create_first_insight
+    * `create_first_dashboard` - create_first_dashboard
+    * `track_custom_events` - track_custom_events
+    * `define_actions` - define_actions
+    * `set_up_cohorts` - set_up_cohorts
+    * `explore_trends_insight` - explore_trends_insight
+    * `create_funnel` - create_funnel
+    * `explore_retention_insight` - explore_retention_insight
+    * `explore_paths_insight` - explore_paths_insight
+    * `explore_stickiness_insight` - explore_stickiness_insight
+    * `explore_lifecycle_insight` - explore_lifecycle_insight
+    * `add_authorized_domain` - add_authorized_domain
+    * `set_up_web_vitals` - set_up_web_vitals
+    * `review_web_analytics_dashboard` - review_web_analytics_dashboard
+    * `filter_web_analytics` - filter_web_analytics
+    * `set_up_web_analytics_conversion_goals` - set_up_web_analytics_conversion_goals
+    * `visit_web_vitals_dashboard` - visit_web_vitals_dashboard
+    * `setup_session_recordings` - setup_session_recordings
+    * `watch_session_recording` - watch_session_recording
+    * `configure_recording_settings` - configure_recording_settings
+    * `create_recording_playlist` - create_recording_playlist
+    * `enable_console_logs` - enable_console_logs
+    * `create_feature_flag` - create_feature_flag
+    * `implement_flag_in_code` - implement_flag_in_code
+    * `update_feature_flag_release_conditions` - update_feature_flag_release_conditions
+    * `create_multivariate_flag` - create_multivariate_flag
+    * `set_up_flag_payloads` - set_up_flag_payloads
+    * `set_up_flag_evaluation_runtimes` - set_up_flag_evaluation_runtimes
+    * `create_experiment` - create_experiment
+    * `implement_experiment_variants` - implement_experiment_variants
+    * `launch_experiment` - launch_experiment
+    * `review_experiment_results` - review_experiment_results
+    * `create_survey` - create_survey
+    * `launch_survey` - launch_survey
+    * `collect_survey_responses` - collect_survey_responses
+    * `connect_source` - connect_source
+    * `run_first_query` - run_first_query
+    * `join_external_data` - join_external_data
+    * `create_saved_view` - create_saved_view
+    * `enable_error_tracking` - enable_error_tracking
+    * `upload_source_maps` - upload_source_maps
+    * `view_first_error` - view_first_error
+    * `resolve_first_error` - resolve_first_error
+    * `ingest_first_llm_event` - ingest_first_llm_event
+    * `view_first_trace` - view_first_trace
+    * `track_costs` - track_costs
+    * `set_up_llm_evaluation` - set_up_llm_evaluation
+    * `run_ai_playground` - run_ai_playground
+    * `enable_revenue_analytics_viewset` - enable_revenue_analytics_viewset
+    * `connect_revenue_source` - connect_revenue_source
+    * `set_up_revenue_goal` - set_up_revenue_goal
+    * `enable_log_capture` - enable_log_capture
+    * `view_first_logs` - view_first_logs
+    * `create_first_workflow` - create_first_workflow
+    * `set_up_first_workflow_channel` - set_up_first_workflow_channel
+    * `configure_workflow_trigger` - configure_workflow_trigger
+    * `add_workflow_action` - add_workflow_action
+    * `launch_workflow` - launch_workflow
+    * `create_first_endpoint` - create_first_endpoint
+    * `configure_endpoint` - configure_endpoint
+    * `test_endpoint` - test_endpoint
+    * `create_early_access_feature` - create_early_access_feature
+    * `update_feature_stage` - update_feature_stage
      */
     export type AvailableSetupTaskIdsEnum = typeof AvailableSetupTaskIdsEnum[keyof typeof AvailableSetupTaskIdsEnum];
 
@@ -8155,10 +8166,10 @@ export namespace Schemas {
 
     /**
      * * `brotli` - brotli
-     * * `gzip` - gzip
-     * * `lz4` - lz4
-     * * `snappy` - snappy
-     * * `zstd` - zstd
+    * `gzip` - gzip
+    * `lz4` - lz4
+    * `snappy` - snappy
+    * `zstd` - zstd
      */
     export type CompressionEnum = typeof CompressionEnum[keyof typeof CompressionEnum];
 
@@ -8173,7 +8184,7 @@ export namespace Schemas {
 
     /**
      * * `JSONLines` - JSONLines
-     * * `Parquet` - Parquet
+    * `Parquet` - Parquet
      */
     export type FileFormatEnum = typeof FileFormatEnum[keyof typeof FileFormatEnum];
 
@@ -8185,9 +8196,9 @@ export namespace Schemas {
 
     /**
      * Typed configuration for an Azure Blob Storage batch-export destination.
-     *
-     * Credentials live in the linked Integration, not in this config. Mirrors
-     * `AzureBlobBatchExportInputs` in `products/batch_exports/backend/service.py`.
+
+    Credentials live in the linked Integration, not in this config. Mirrors
+    `AzureBlobBatchExportInputs` in `products/batch_exports/backend/service.py`.
      */
     export interface AzureBlobDestinationConfig {
       /** Azure Blob Storage container name. */
@@ -8195,17 +8206,17 @@ export namespace Schemas {
       /** Object key prefix applied to every exported file. */
       prefix?: string;
       /** Optional compression codec applied to exported files. Valid codecs depend on file_format.
-       *
-       * * `brotli` - brotli
-       * * `gzip` - gzip
-       * * `lz4` - lz4
-       * * `snappy` - snappy
-       * * `zstd` - zstd */
+
+      * `brotli` - brotli
+      * `gzip` - gzip
+      * `lz4` - lz4
+      * `snappy` - snappy
+      * `zstd` - zstd */
       compression?: CompressionEnum | null;
       /** File format used for exported objects.
-       *
-       * * `JSONLines` - JSONLines
-       * * `Parquet` - Parquet */
+
+      * `JSONLines` - JSONLines
+      * `Parquet` - Parquet */
       file_format?: FileFormatEnum;
       /**
          * If set, rolls to a new file once the current file exceeds this size in MB.
@@ -8244,157 +8255,157 @@ export namespace Schemas {
 
     /**
      * * `AED` - AED
-     * * `AFN` - AFN
-     * * `ALL` - ALL
-     * * `AMD` - AMD
-     * * `ANG` - ANG
-     * * `AOA` - AOA
-     * * `ARS` - ARS
-     * * `AUD` - AUD
-     * * `AWG` - AWG
-     * * `AZN` - AZN
-     * * `BAM` - BAM
-     * * `BBD` - BBD
-     * * `BDT` - BDT
-     * * `BGN` - BGN
-     * * `BHD` - BHD
-     * * `BIF` - BIF
-     * * `BMD` - BMD
-     * * `BND` - BND
-     * * `BOB` - BOB
-     * * `BRL` - BRL
-     * * `BSD` - BSD
-     * * `BTC` - BTC
-     * * `BTN` - BTN
-     * * `BWP` - BWP
-     * * `BYN` - BYN
-     * * `BZD` - BZD
-     * * `CAD` - CAD
-     * * `CDF` - CDF
-     * * `CHF` - CHF
-     * * `CLP` - CLP
-     * * `CNY` - CNY
-     * * `COP` - COP
-     * * `CRC` - CRC
-     * * `CVE` - CVE
-     * * `CZK` - CZK
-     * * `DJF` - DJF
-     * * `DKK` - DKK
-     * * `DOP` - DOP
-     * * `DZD` - DZD
-     * * `EGP` - EGP
-     * * `ERN` - ERN
-     * * `ETB` - ETB
-     * * `EUR` - EUR
-     * * `FJD` - FJD
-     * * `GBP` - GBP
-     * * `GEL` - GEL
-     * * `GHS` - GHS
-     * * `GIP` - GIP
-     * * `GMD` - GMD
-     * * `GNF` - GNF
-     * * `GTQ` - GTQ
-     * * `GYD` - GYD
-     * * `HKD` - HKD
-     * * `HNL` - HNL
-     * * `HRK` - HRK
-     * * `HTG` - HTG
-     * * `HUF` - HUF
-     * * `IDR` - IDR
-     * * `ILS` - ILS
-     * * `INR` - INR
-     * * `IQD` - IQD
-     * * `IRR` - IRR
-     * * `ISK` - ISK
-     * * `JMD` - JMD
-     * * `JOD` - JOD
-     * * `JPY` - JPY
-     * * `KES` - KES
-     * * `KGS` - KGS
-     * * `KHR` - KHR
-     * * `KMF` - KMF
-     * * `KRW` - KRW
-     * * `KWD` - KWD
-     * * `KYD` - KYD
-     * * `KZT` - KZT
-     * * `LAK` - LAK
-     * * `LBP` - LBP
-     * * `LKR` - LKR
-     * * `LRD` - LRD
-     * * `LTL` - LTL
-     * * `LVL` - LVL
-     * * `LSL` - LSL
-     * * `LYD` - LYD
-     * * `MAD` - MAD
-     * * `MDL` - MDL
-     * * `MGA` - MGA
-     * * `MKD` - MKD
-     * * `MMK` - MMK
-     * * `MNT` - MNT
-     * * `MOP` - MOP
-     * * `MRU` - MRU
-     * * `MTL` - MTL
-     * * `MUR` - MUR
-     * * `MVR` - MVR
-     * * `MWK` - MWK
-     * * `MXN` - MXN
-     * * `MYR` - MYR
-     * * `MZN` - MZN
-     * * `NAD` - NAD
-     * * `NGN` - NGN
-     * * `NIO` - NIO
-     * * `NOK` - NOK
-     * * `NPR` - NPR
-     * * `NZD` - NZD
-     * * `OMR` - OMR
-     * * `PAB` - PAB
-     * * `PEN` - PEN
-     * * `PGK` - PGK
-     * * `PHP` - PHP
-     * * `PKR` - PKR
-     * * `PLN` - PLN
-     * * `PYG` - PYG
-     * * `QAR` - QAR
-     * * `RON` - RON
-     * * `RSD` - RSD
-     * * `RUB` - RUB
-     * * `RWF` - RWF
-     * * `SAR` - SAR
-     * * `SBD` - SBD
-     * * `SCR` - SCR
-     * * `SDG` - SDG
-     * * `SEK` - SEK
-     * * `SGD` - SGD
-     * * `SRD` - SRD
-     * * `SSP` - SSP
-     * * `STN` - STN
-     * * `SYP` - SYP
-     * * `SZL` - SZL
-     * * `THB` - THB
-     * * `TJS` - TJS
-     * * `TMT` - TMT
-     * * `TND` - TND
-     * * `TOP` - TOP
-     * * `TRY` - TRY
-     * * `TTD` - TTD
-     * * `TWD` - TWD
-     * * `TZS` - TZS
-     * * `UAH` - UAH
-     * * `UGX` - UGX
-     * * `USD` - USD
-     * * `UYU` - UYU
-     * * `UZS` - UZS
-     * * `VES` - VES
-     * * `VND` - VND
-     * * `VUV` - VUV
-     * * `WST` - WST
-     * * `XAF` - XAF
-     * * `XCD` - XCD
-     * * `XOF` - XOF
-     * * `XPF` - XPF
-     * * `YER` - YER
-     * * `ZAR` - ZAR
-     * * `ZMW` - ZMW
+    * `AFN` - AFN
+    * `ALL` - ALL
+    * `AMD` - AMD
+    * `ANG` - ANG
+    * `AOA` - AOA
+    * `ARS` - ARS
+    * `AUD` - AUD
+    * `AWG` - AWG
+    * `AZN` - AZN
+    * `BAM` - BAM
+    * `BBD` - BBD
+    * `BDT` - BDT
+    * `BGN` - BGN
+    * `BHD` - BHD
+    * `BIF` - BIF
+    * `BMD` - BMD
+    * `BND` - BND
+    * `BOB` - BOB
+    * `BRL` - BRL
+    * `BSD` - BSD
+    * `BTC` - BTC
+    * `BTN` - BTN
+    * `BWP` - BWP
+    * `BYN` - BYN
+    * `BZD` - BZD
+    * `CAD` - CAD
+    * `CDF` - CDF
+    * `CHF` - CHF
+    * `CLP` - CLP
+    * `CNY` - CNY
+    * `COP` - COP
+    * `CRC` - CRC
+    * `CVE` - CVE
+    * `CZK` - CZK
+    * `DJF` - DJF
+    * `DKK` - DKK
+    * `DOP` - DOP
+    * `DZD` - DZD
+    * `EGP` - EGP
+    * `ERN` - ERN
+    * `ETB` - ETB
+    * `EUR` - EUR
+    * `FJD` - FJD
+    * `GBP` - GBP
+    * `GEL` - GEL
+    * `GHS` - GHS
+    * `GIP` - GIP
+    * `GMD` - GMD
+    * `GNF` - GNF
+    * `GTQ` - GTQ
+    * `GYD` - GYD
+    * `HKD` - HKD
+    * `HNL` - HNL
+    * `HRK` - HRK
+    * `HTG` - HTG
+    * `HUF` - HUF
+    * `IDR` - IDR
+    * `ILS` - ILS
+    * `INR` - INR
+    * `IQD` - IQD
+    * `IRR` - IRR
+    * `ISK` - ISK
+    * `JMD` - JMD
+    * `JOD` - JOD
+    * `JPY` - JPY
+    * `KES` - KES
+    * `KGS` - KGS
+    * `KHR` - KHR
+    * `KMF` - KMF
+    * `KRW` - KRW
+    * `KWD` - KWD
+    * `KYD` - KYD
+    * `KZT` - KZT
+    * `LAK` - LAK
+    * `LBP` - LBP
+    * `LKR` - LKR
+    * `LRD` - LRD
+    * `LTL` - LTL
+    * `LVL` - LVL
+    * `LSL` - LSL
+    * `LYD` - LYD
+    * `MAD` - MAD
+    * `MDL` - MDL
+    * `MGA` - MGA
+    * `MKD` - MKD
+    * `MMK` - MMK
+    * `MNT` - MNT
+    * `MOP` - MOP
+    * `MRU` - MRU
+    * `MTL` - MTL
+    * `MUR` - MUR
+    * `MVR` - MVR
+    * `MWK` - MWK
+    * `MXN` - MXN
+    * `MYR` - MYR
+    * `MZN` - MZN
+    * `NAD` - NAD
+    * `NGN` - NGN
+    * `NIO` - NIO
+    * `NOK` - NOK
+    * `NPR` - NPR
+    * `NZD` - NZD
+    * `OMR` - OMR
+    * `PAB` - PAB
+    * `PEN` - PEN
+    * `PGK` - PGK
+    * `PHP` - PHP
+    * `PKR` - PKR
+    * `PLN` - PLN
+    * `PYG` - PYG
+    * `QAR` - QAR
+    * `RON` - RON
+    * `RSD` - RSD
+    * `RUB` - RUB
+    * `RWF` - RWF
+    * `SAR` - SAR
+    * `SBD` - SBD
+    * `SCR` - SCR
+    * `SDG` - SDG
+    * `SEK` - SEK
+    * `SGD` - SGD
+    * `SRD` - SRD
+    * `SSP` - SSP
+    * `STN` - STN
+    * `SYP` - SYP
+    * `SZL` - SZL
+    * `THB` - THB
+    * `TJS` - TJS
+    * `TMT` - TMT
+    * `TND` - TND
+    * `TOP` - TOP
+    * `TRY` - TRY
+    * `TTD` - TTD
+    * `TWD` - TWD
+    * `TZS` - TZS
+    * `UAH` - UAH
+    * `UGX` - UGX
+    * `USD` - USD
+    * `UYU` - UYU
+    * `UZS` - UZS
+    * `VES` - VES
+    * `VND` - VND
+    * `VUV` - VUV
+    * `WST` - WST
+    * `XAF` - XAF
+    * `XCD` - XCD
+    * `XOF` - XOF
+    * `XPF` - XPF
+    * `YER` - YER
+    * `ZAR` - ZAR
+    * `ZMW` - ZMW
      */
     export type BaseCurrencyEnum = typeof BaseCurrencyEnum[keyof typeof BaseCurrencyEnum];
 
@@ -8620,7 +8631,7 @@ export namespace Schemas {
 
     /**
      * * `minimal` - minimal
-     * * `detailed` - detailed
+    * `detailed` - detailed
      */
     export type DetailModeValueEnum = typeof DetailModeValueEnum[keyof typeof DetailModeValueEnum];
 
@@ -8637,9 +8648,9 @@ export namespace Schemas {
          */
       trace_ids: string[];
       /** Summary detail level to check for
-       *
-       * * `minimal` - minimal
-       * * `detailed` - detailed */
+
+      * `minimal` - minimal
+      * `detailed` - detailed */
       mode?: DetailModeValueEnum;
       /**
          * LLM model used for cached summaries
@@ -8660,8 +8671,8 @@ export namespace Schemas {
 
     /**
      * * `events` - Events
-     * * `persons` - Persons
-     * * `sessions` - Sessions
+    * `persons` - Persons
+    * `sessions` - Sessions
      */
     export type ModelEnum = typeof ModelEnum[keyof typeof ModelEnum];
 
@@ -8674,18 +8685,18 @@ export namespace Schemas {
 
     /**
      * * `S3` - S3
-     * * `AwsS3` - Aws S3
-     * * `S3Compatible` - S3 Compatible
-     * * `Snowflake` - Snowflake
-     * * `Postgres` - Postgres
-     * * `Redshift` - Redshift
-     * * `BigQuery` - Bigquery
-     * * `Databricks` - Databricks
-     * * `AzureBlob` - Azure Blob
-     * * `Workflows` - Workflows
-     * * `HTTP` - Http
-     * * `NoOp` - Noop
-     * * `FileDownload` - File Download
+    * `AwsS3` - Aws S3
+    * `S3Compatible` - S3 Compatible
+    * `Snowflake` - Snowflake
+    * `Postgres` - Postgres
+    * `Redshift` - Redshift
+    * `BigQuery` - Bigquery
+    * `Databricks` - Databricks
+    * `AzureBlob` - Azure Blob
+    * `Workflows` - Workflows
+    * `HTTP` - Http
+    * `NoOp` - Noop
+    * `FileDownload` - File Download
      */
     export type BatchExportDestinationTypeEnum = typeof BatchExportDestinationTypeEnum[keyof typeof BatchExportDestinationTypeEnum];
 
@@ -8715,9 +8726,9 @@ export namespace Schemas {
 
     /**
      * Typed configuration for a Databricks batch-export destination.
-     *
-     * Credentials live in the linked Integration, not in this config. Mirrors
-     * `DatabricksBatchExportInputs` in `products/batch_exports/backend/service.py`.
+
+    Credentials live in the linked Integration, not in this config. Mirrors
+    `DatabricksBatchExportInputs` in `products/batch_exports/backend/service.py`.
      */
     export interface DatabricksDestinationConfig {
       /** Databricks SQL warehouse HTTP path. */
@@ -8744,10 +8755,10 @@ export namespace Schemas {
 
     /**
      * Typed configuration for a BigQuery batch-export destination.
-     *
-     * Credentials live in the linked Integration, not in this config. Mirrors the
-     * non-credential fields of `BigQueryBatchExportInputs` in
-     * `products/batch_exports/backend/service.py`.
+
+    Credentials live in the linked Integration, not in this config. Mirrors the
+    non-credential fields of `BigQueryBatchExportInputs` in
+    `products/batch_exports/backend/service.py`.
      */
     export interface BigQueryDestinationConfig {
       /** BigQuery dataset ID to write to. */
@@ -8763,28 +8774,28 @@ export namespace Schemas {
 
     /**
      * Serializer for an BatchExportDestination model.
-     *
-     * The `config` field is polymorphic and typed only for destinations that keep
-     * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).
-     * Other destination types accept the same JSON shape but without a typed
-     * OpenAPI schema. Secret fields are stripped from `config` on read.
+
+    The `config` field is polymorphic and typed only for destinations that keep
+    credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).
+    Other destination types accept the same JSON shape but without a typed
+    OpenAPI schema. Secret fields are stripped from `config` on read.
      */
     export interface BatchExportDestination {
       /** A choice of supported BatchExportDestination types.
-       *
-       * * `S3` - S3
-       * * `AwsS3` - Aws S3
-       * * `S3Compatible` - S3 Compatible
-       * * `Snowflake` - Snowflake
-       * * `Postgres` - Postgres
-       * * `Redshift` - Redshift
-       * * `BigQuery` - Bigquery
-       * * `Databricks` - Databricks
-       * * `AzureBlob` - Azure Blob
-       * * `Workflows` - Workflows
-       * * `HTTP` - Http
-       * * `NoOp` - Noop
-       * * `FileDownload` - File Download */
+
+      * `S3` - S3
+      * `AwsS3` - Aws S3
+      * `S3Compatible` - S3 Compatible
+      * `Snowflake` - Snowflake
+      * `Postgres` - Postgres
+      * `Redshift` - Redshift
+      * `BigQuery` - Bigquery
+      * `Databricks` - Databricks
+      * `AzureBlob` - Azure Blob
+      * `Workflows` - Workflows
+      * `HTTP` - Http
+      * `NoOp` - Noop
+      * `FileDownload` - File Download */
       type: BatchExportDestinationTypeEnum;
       /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
       config: BatchExportDestinationConfig;
@@ -8802,10 +8813,10 @@ export namespace Schemas {
 
     /**
      * * `hour` - hour
-     * * `day` - day
-     * * `week` - week
-     * * `every 5 minutes` - every 5 minutes
-     * * `every 15 minutes` - every 15 minutes
+    * `day` - day
+    * `week` - week
+    * `every 5 minutes` - every 5 minutes
+    * `every 15 minutes` - every 15 minutes
      */
     export type IntervalEnum = typeof IntervalEnum[keyof typeof IntervalEnum];
 
@@ -8820,15 +8831,15 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-     * * `Completed` - Completed
-     * * `ContinuedAsNew` - Continued As New
-     * * `Failed` - Failed
-     * * `FailedRetryable` - Failed Retryable
-     * * `FailedBilling` - Failed Billing
-     * * `Terminated` - Terminated
-     * * `TimedOut` - Timedout
-     * * `Running` - Running
-     * * `Starting` - Starting
+    * `Completed` - Completed
+    * `ContinuedAsNew` - Continued As New
+    * `Failed` - Failed
+    * `FailedRetryable` - Failed Retryable
+    * `FailedBilling` - Failed Billing
+    * `Terminated` - Terminated
+    * `TimedOut` - Timedout
+    * `Running` - Running
+    * `Starting` - Starting
      */
     export type BatchExportRunStatusEnum = typeof BatchExportRunStatusEnum[keyof typeof BatchExportRunStatusEnum];
 
@@ -8852,17 +8863,17 @@ export namespace Schemas {
     export interface BatchExportRun {
       readonly id: string;
       /** The status of this run.
-       *
-       * * `Cancelled` - Cancelled
-       * * `Completed` - Completed
-       * * `ContinuedAsNew` - Continued As New
-       * * `Failed` - Failed
-       * * `FailedRetryable` - Failed Retryable
-       * * `FailedBilling` - Failed Billing
-       * * `Terminated` - Terminated
-       * * `TimedOut` - Timedout
-       * * `Running` - Running
-       * * `Starting` - Starting */
+
+      * `Cancelled` - Cancelled
+      * `Completed` - Completed
+      * `ContinuedAsNew` - Continued As New
+      * `Failed` - Failed
+      * `FailedRetryable` - Failed Retryable
+      * `FailedBilling` - Failed Billing
+      * `Terminated` - Terminated
+      * `TimedOut` - Timedout
+      * `Running` - Running
+      * `Starting` - Starting */
       status: BatchExportRunStatusEnum;
       /**
          * The number of records that have been exported.
@@ -8945,20 +8956,20 @@ export namespace Schemas {
       /** A human-readable name for this BatchExport. */
       name: string;
       /** Which model this BatchExport is exporting.
-       *
-       * * `events` - Events
-       * * `persons` - Persons
-       * * `sessions` - Sessions */
+
+      * `events` - Events
+      * `persons` - Persons
+      * `sessions` - Sessions */
       model?: ModelEnum | BlankEnum | null;
       /** Destination configuration (type, config, and optional integration). */
       destination: BatchExportDestination;
       /** How often the batch export should run.
-       *
-       * * `hour` - hour
-       * * `day` - day
-       * * `week` - week
-       * * `every 5 minutes` - every 5 minutes
-       * * `every 15 minutes` - every 15 minutes */
+
+      * `hour` - hour
+      * `day` - day
+      * `week` - week
+      * `every 5 minutes` - every 5 minutes
+      * `every 15 minutes` - every 15 minutes */
       interval: IntervalEnum;
       /** Whether this BatchExport is paused or not. */
       paused?: boolean;
@@ -8989,603 +9000,603 @@ export namespace Schemas {
       readonly schema: unknown;
       filters?: unknown;
       /** IANA timezone name controlling daily and weekly interval boundaries. Defaults to UTC.
-       *
-       * * `Africa/Abidjan` - Africa/Abidjan
-       * * `Africa/Accra` - Africa/Accra
-       * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-       * * `Africa/Algiers` - Africa/Algiers
-       * * `Africa/Asmara` - Africa/Asmara
-       * * `Africa/Asmera` - Africa/Asmera
-       * * `Africa/Bamako` - Africa/Bamako
-       * * `Africa/Bangui` - Africa/Bangui
-       * * `Africa/Banjul` - Africa/Banjul
-       * * `Africa/Bissau` - Africa/Bissau
-       * * `Africa/Blantyre` - Africa/Blantyre
-       * * `Africa/Brazzaville` - Africa/Brazzaville
-       * * `Africa/Bujumbura` - Africa/Bujumbura
-       * * `Africa/Cairo` - Africa/Cairo
-       * * `Africa/Casablanca` - Africa/Casablanca
-       * * `Africa/Ceuta` - Africa/Ceuta
-       * * `Africa/Conakry` - Africa/Conakry
-       * * `Africa/Dakar` - Africa/Dakar
-       * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-       * * `Africa/Djibouti` - Africa/Djibouti
-       * * `Africa/Douala` - Africa/Douala
-       * * `Africa/El_Aaiun` - Africa/El_Aaiun
-       * * `Africa/Freetown` - Africa/Freetown
-       * * `Africa/Gaborone` - Africa/Gaborone
-       * * `Africa/Harare` - Africa/Harare
-       * * `Africa/Johannesburg` - Africa/Johannesburg
-       * * `Africa/Juba` - Africa/Juba
-       * * `Africa/Kampala` - Africa/Kampala
-       * * `Africa/Khartoum` - Africa/Khartoum
-       * * `Africa/Kigali` - Africa/Kigali
-       * * `Africa/Kinshasa` - Africa/Kinshasa
-       * * `Africa/Lagos` - Africa/Lagos
-       * * `Africa/Libreville` - Africa/Libreville
-       * * `Africa/Lome` - Africa/Lome
-       * * `Africa/Luanda` - Africa/Luanda
-       * * `Africa/Lubumbashi` - Africa/Lubumbashi
-       * * `Africa/Lusaka` - Africa/Lusaka
-       * * `Africa/Malabo` - Africa/Malabo
-       * * `Africa/Maputo` - Africa/Maputo
-       * * `Africa/Maseru` - Africa/Maseru
-       * * `Africa/Mbabane` - Africa/Mbabane
-       * * `Africa/Mogadishu` - Africa/Mogadishu
-       * * `Africa/Monrovia` - Africa/Monrovia
-       * * `Africa/Nairobi` - Africa/Nairobi
-       * * `Africa/Ndjamena` - Africa/Ndjamena
-       * * `Africa/Niamey` - Africa/Niamey
-       * * `Africa/Nouakchott` - Africa/Nouakchott
-       * * `Africa/Ouagadougou` - Africa/Ouagadougou
-       * * `Africa/Porto-Novo` - Africa/Porto-Novo
-       * * `Africa/Sao_Tome` - Africa/Sao_Tome
-       * * `Africa/Timbuktu` - Africa/Timbuktu
-       * * `Africa/Tripoli` - Africa/Tripoli
-       * * `Africa/Tunis` - Africa/Tunis
-       * * `Africa/Windhoek` - Africa/Windhoek
-       * * `America/Adak` - America/Adak
-       * * `America/Anchorage` - America/Anchorage
-       * * `America/Anguilla` - America/Anguilla
-       * * `America/Antigua` - America/Antigua
-       * * `America/Araguaina` - America/Araguaina
-       * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-       * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-       * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-       * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-       * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-       * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-       * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-       * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-       * * `America/Argentina/Salta` - America/Argentina/Salta
-       * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-       * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-       * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-       * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-       * * `America/Aruba` - America/Aruba
-       * * `America/Asuncion` - America/Asuncion
-       * * `America/Atikokan` - America/Atikokan
-       * * `America/Atka` - America/Atka
-       * * `America/Bahia` - America/Bahia
-       * * `America/Bahia_Banderas` - America/Bahia_Banderas
-       * * `America/Barbados` - America/Barbados
-       * * `America/Belem` - America/Belem
-       * * `America/Belize` - America/Belize
-       * * `America/Blanc-Sablon` - America/Blanc-Sablon
-       * * `America/Boa_Vista` - America/Boa_Vista
-       * * `America/Bogota` - America/Bogota
-       * * `America/Boise` - America/Boise
-       * * `America/Buenos_Aires` - America/Buenos_Aires
-       * * `America/Cambridge_Bay` - America/Cambridge_Bay
-       * * `America/Campo_Grande` - America/Campo_Grande
-       * * `America/Cancun` - America/Cancun
-       * * `America/Caracas` - America/Caracas
-       * * `America/Catamarca` - America/Catamarca
-       * * `America/Cayenne` - America/Cayenne
-       * * `America/Cayman` - America/Cayman
-       * * `America/Chicago` - America/Chicago
-       * * `America/Chihuahua` - America/Chihuahua
-       * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-       * * `America/Coral_Harbour` - America/Coral_Harbour
-       * * `America/Cordoba` - America/Cordoba
-       * * `America/Costa_Rica` - America/Costa_Rica
-       * * `America/Creston` - America/Creston
-       * * `America/Cuiaba` - America/Cuiaba
-       * * `America/Curacao` - America/Curacao
-       * * `America/Danmarkshavn` - America/Danmarkshavn
-       * * `America/Dawson` - America/Dawson
-       * * `America/Dawson_Creek` - America/Dawson_Creek
-       * * `America/Denver` - America/Denver
-       * * `America/Detroit` - America/Detroit
-       * * `America/Dominica` - America/Dominica
-       * * `America/Edmonton` - America/Edmonton
-       * * `America/Eirunepe` - America/Eirunepe
-       * * `America/El_Salvador` - America/El_Salvador
-       * * `America/Ensenada` - America/Ensenada
-       * * `America/Fort_Nelson` - America/Fort_Nelson
-       * * `America/Fort_Wayne` - America/Fort_Wayne
-       * * `America/Fortaleza` - America/Fortaleza
-       * * `America/Glace_Bay` - America/Glace_Bay
-       * * `America/Godthab` - America/Godthab
-       * * `America/Goose_Bay` - America/Goose_Bay
-       * * `America/Grand_Turk` - America/Grand_Turk
-       * * `America/Grenada` - America/Grenada
-       * * `America/Guadeloupe` - America/Guadeloupe
-       * * `America/Guatemala` - America/Guatemala
-       * * `America/Guayaquil` - America/Guayaquil
-       * * `America/Guyana` - America/Guyana
-       * * `America/Halifax` - America/Halifax
-       * * `America/Havana` - America/Havana
-       * * `America/Hermosillo` - America/Hermosillo
-       * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-       * * `America/Indiana/Knox` - America/Indiana/Knox
-       * * `America/Indiana/Marengo` - America/Indiana/Marengo
-       * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-       * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-       * * `America/Indiana/Vevay` - America/Indiana/Vevay
-       * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-       * * `America/Indiana/Winamac` - America/Indiana/Winamac
-       * * `America/Indianapolis` - America/Indianapolis
-       * * `America/Inuvik` - America/Inuvik
-       * * `America/Iqaluit` - America/Iqaluit
-       * * `America/Jamaica` - America/Jamaica
-       * * `America/Jujuy` - America/Jujuy
-       * * `America/Juneau` - America/Juneau
-       * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-       * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-       * * `America/Knox_IN` - America/Knox_IN
-       * * `America/Kralendijk` - America/Kralendijk
-       * * `America/La_Paz` - America/La_Paz
-       * * `America/Lima` - America/Lima
-       * * `America/Los_Angeles` - America/Los_Angeles
-       * * `America/Louisville` - America/Louisville
-       * * `America/Lower_Princes` - America/Lower_Princes
-       * * `America/Maceio` - America/Maceio
-       * * `America/Managua` - America/Managua
-       * * `America/Manaus` - America/Manaus
-       * * `America/Marigot` - America/Marigot
-       * * `America/Martinique` - America/Martinique
-       * * `America/Matamoros` - America/Matamoros
-       * * `America/Mazatlan` - America/Mazatlan
-       * * `America/Mendoza` - America/Mendoza
-       * * `America/Menominee` - America/Menominee
-       * * `America/Merida` - America/Merida
-       * * `America/Metlakatla` - America/Metlakatla
-       * * `America/Mexico_City` - America/Mexico_City
-       * * `America/Miquelon` - America/Miquelon
-       * * `America/Moncton` - America/Moncton
-       * * `America/Monterrey` - America/Monterrey
-       * * `America/Montevideo` - America/Montevideo
-       * * `America/Montreal` - America/Montreal
-       * * `America/Montserrat` - America/Montserrat
-       * * `America/Nassau` - America/Nassau
-       * * `America/New_York` - America/New_York
-       * * `America/Nipigon` - America/Nipigon
-       * * `America/Nome` - America/Nome
-       * * `America/Noronha` - America/Noronha
-       * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-       * * `America/North_Dakota/Center` - America/North_Dakota/Center
-       * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-       * * `America/Nuuk` - America/Nuuk
-       * * `America/Ojinaga` - America/Ojinaga
-       * * `America/Panama` - America/Panama
-       * * `America/Pangnirtung` - America/Pangnirtung
-       * * `America/Paramaribo` - America/Paramaribo
-       * * `America/Phoenix` - America/Phoenix
-       * * `America/Port-au-Prince` - America/Port-au-Prince
-       * * `America/Port_of_Spain` - America/Port_of_Spain
-       * * `America/Porto_Acre` - America/Porto_Acre
-       * * `America/Porto_Velho` - America/Porto_Velho
-       * * `America/Puerto_Rico` - America/Puerto_Rico
-       * * `America/Punta_Arenas` - America/Punta_Arenas
-       * * `America/Rainy_River` - America/Rainy_River
-       * * `America/Rankin_Inlet` - America/Rankin_Inlet
-       * * `America/Recife` - America/Recife
-       * * `America/Regina` - America/Regina
-       * * `America/Resolute` - America/Resolute
-       * * `America/Rio_Branco` - America/Rio_Branco
-       * * `America/Rosario` - America/Rosario
-       * * `America/Santa_Isabel` - America/Santa_Isabel
-       * * `America/Santarem` - America/Santarem
-       * * `America/Santiago` - America/Santiago
-       * * `America/Santo_Domingo` - America/Santo_Domingo
-       * * `America/Sao_Paulo` - America/Sao_Paulo
-       * * `America/Scoresbysund` - America/Scoresbysund
-       * * `America/Shiprock` - America/Shiprock
-       * * `America/Sitka` - America/Sitka
-       * * `America/St_Barthelemy` - America/St_Barthelemy
-       * * `America/St_Johns` - America/St_Johns
-       * * `America/St_Kitts` - America/St_Kitts
-       * * `America/St_Lucia` - America/St_Lucia
-       * * `America/St_Thomas` - America/St_Thomas
-       * * `America/St_Vincent` - America/St_Vincent
-       * * `America/Swift_Current` - America/Swift_Current
-       * * `America/Tegucigalpa` - America/Tegucigalpa
-       * * `America/Thule` - America/Thule
-       * * `America/Thunder_Bay` - America/Thunder_Bay
-       * * `America/Tijuana` - America/Tijuana
-       * * `America/Toronto` - America/Toronto
-       * * `America/Tortola` - America/Tortola
-       * * `America/Vancouver` - America/Vancouver
-       * * `America/Virgin` - America/Virgin
-       * * `America/Whitehorse` - America/Whitehorse
-       * * `America/Winnipeg` - America/Winnipeg
-       * * `America/Yakutat` - America/Yakutat
-       * * `America/Yellowknife` - America/Yellowknife
-       * * `Antarctica/Casey` - Antarctica/Casey
-       * * `Antarctica/Davis` - Antarctica/Davis
-       * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-       * * `Antarctica/Macquarie` - Antarctica/Macquarie
-       * * `Antarctica/Mawson` - Antarctica/Mawson
-       * * `Antarctica/McMurdo` - Antarctica/McMurdo
-       * * `Antarctica/Palmer` - Antarctica/Palmer
-       * * `Antarctica/Rothera` - Antarctica/Rothera
-       * * `Antarctica/South_Pole` - Antarctica/South_Pole
-       * * `Antarctica/Syowa` - Antarctica/Syowa
-       * * `Antarctica/Troll` - Antarctica/Troll
-       * * `Antarctica/Vostok` - Antarctica/Vostok
-       * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-       * * `Asia/Aden` - Asia/Aden
-       * * `Asia/Almaty` - Asia/Almaty
-       * * `Asia/Amman` - Asia/Amman
-       * * `Asia/Anadyr` - Asia/Anadyr
-       * * `Asia/Aqtau` - Asia/Aqtau
-       * * `Asia/Aqtobe` - Asia/Aqtobe
-       * * `Asia/Ashgabat` - Asia/Ashgabat
-       * * `Asia/Ashkhabad` - Asia/Ashkhabad
-       * * `Asia/Atyrau` - Asia/Atyrau
-       * * `Asia/Baghdad` - Asia/Baghdad
-       * * `Asia/Bahrain` - Asia/Bahrain
-       * * `Asia/Baku` - Asia/Baku
-       * * `Asia/Bangkok` - Asia/Bangkok
-       * * `Asia/Barnaul` - Asia/Barnaul
-       * * `Asia/Beirut` - Asia/Beirut
-       * * `Asia/Bishkek` - Asia/Bishkek
-       * * `Asia/Brunei` - Asia/Brunei
-       * * `Asia/Calcutta` - Asia/Calcutta
-       * * `Asia/Chita` - Asia/Chita
-       * * `Asia/Choibalsan` - Asia/Choibalsan
-       * * `Asia/Chongqing` - Asia/Chongqing
-       * * `Asia/Chungking` - Asia/Chungking
-       * * `Asia/Colombo` - Asia/Colombo
-       * * `Asia/Dacca` - Asia/Dacca
-       * * `Asia/Damascus` - Asia/Damascus
-       * * `Asia/Dhaka` - Asia/Dhaka
-       * * `Asia/Dili` - Asia/Dili
-       * * `Asia/Dubai` - Asia/Dubai
-       * * `Asia/Dushanbe` - Asia/Dushanbe
-       * * `Asia/Famagusta` - Asia/Famagusta
-       * * `Asia/Gaza` - Asia/Gaza
-       * * `Asia/Harbin` - Asia/Harbin
-       * * `Asia/Hebron` - Asia/Hebron
-       * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-       * * `Asia/Hong_Kong` - Asia/Hong_Kong
-       * * `Asia/Hovd` - Asia/Hovd
-       * * `Asia/Irkutsk` - Asia/Irkutsk
-       * * `Asia/Istanbul` - Asia/Istanbul
-       * * `Asia/Jakarta` - Asia/Jakarta
-       * * `Asia/Jayapura` - Asia/Jayapura
-       * * `Asia/Jerusalem` - Asia/Jerusalem
-       * * `Asia/Kabul` - Asia/Kabul
-       * * `Asia/Kamchatka` - Asia/Kamchatka
-       * * `Asia/Karachi` - Asia/Karachi
-       * * `Asia/Kashgar` - Asia/Kashgar
-       * * `Asia/Kathmandu` - Asia/Kathmandu
-       * * `Asia/Katmandu` - Asia/Katmandu
-       * * `Asia/Khandyga` - Asia/Khandyga
-       * * `Asia/Kolkata` - Asia/Kolkata
-       * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-       * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-       * * `Asia/Kuching` - Asia/Kuching
-       * * `Asia/Kuwait` - Asia/Kuwait
-       * * `Asia/Macao` - Asia/Macao
-       * * `Asia/Macau` - Asia/Macau
-       * * `Asia/Magadan` - Asia/Magadan
-       * * `Asia/Makassar` - Asia/Makassar
-       * * `Asia/Manila` - Asia/Manila
-       * * `Asia/Muscat` - Asia/Muscat
-       * * `Asia/Nicosia` - Asia/Nicosia
-       * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-       * * `Asia/Novosibirsk` - Asia/Novosibirsk
-       * * `Asia/Omsk` - Asia/Omsk
-       * * `Asia/Oral` - Asia/Oral
-       * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-       * * `Asia/Pontianak` - Asia/Pontianak
-       * * `Asia/Pyongyang` - Asia/Pyongyang
-       * * `Asia/Qatar` - Asia/Qatar
-       * * `Asia/Qostanay` - Asia/Qostanay
-       * * `Asia/Qyzylorda` - Asia/Qyzylorda
-       * * `Asia/Rangoon` - Asia/Rangoon
-       * * `Asia/Riyadh` - Asia/Riyadh
-       * * `Asia/Saigon` - Asia/Saigon
-       * * `Asia/Sakhalin` - Asia/Sakhalin
-       * * `Asia/Samarkand` - Asia/Samarkand
-       * * `Asia/Seoul` - Asia/Seoul
-       * * `Asia/Shanghai` - Asia/Shanghai
-       * * `Asia/Singapore` - Asia/Singapore
-       * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-       * * `Asia/Taipei` - Asia/Taipei
-       * * `Asia/Tashkent` - Asia/Tashkent
-       * * `Asia/Tbilisi` - Asia/Tbilisi
-       * * `Asia/Tehran` - Asia/Tehran
-       * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-       * * `Asia/Thimbu` - Asia/Thimbu
-       * * `Asia/Thimphu` - Asia/Thimphu
-       * * `Asia/Tokyo` - Asia/Tokyo
-       * * `Asia/Tomsk` - Asia/Tomsk
-       * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-       * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-       * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-       * * `Asia/Urumqi` - Asia/Urumqi
-       * * `Asia/Ust-Nera` - Asia/Ust-Nera
-       * * `Asia/Vientiane` - Asia/Vientiane
-       * * `Asia/Vladivostok` - Asia/Vladivostok
-       * * `Asia/Yakutsk` - Asia/Yakutsk
-       * * `Asia/Yangon` - Asia/Yangon
-       * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-       * * `Asia/Yerevan` - Asia/Yerevan
-       * * `Atlantic/Azores` - Atlantic/Azores
-       * * `Atlantic/Bermuda` - Atlantic/Bermuda
-       * * `Atlantic/Canary` - Atlantic/Canary
-       * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-       * * `Atlantic/Faeroe` - Atlantic/Faeroe
-       * * `Atlantic/Faroe` - Atlantic/Faroe
-       * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-       * * `Atlantic/Madeira` - Atlantic/Madeira
-       * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-       * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-       * * `Atlantic/St_Helena` - Atlantic/St_Helena
-       * * `Atlantic/Stanley` - Atlantic/Stanley
-       * * `Australia/ACT` - Australia/ACT
-       * * `Australia/Adelaide` - Australia/Adelaide
-       * * `Australia/Brisbane` - Australia/Brisbane
-       * * `Australia/Broken_Hill` - Australia/Broken_Hill
-       * * `Australia/Canberra` - Australia/Canberra
-       * * `Australia/Currie` - Australia/Currie
-       * * `Australia/Darwin` - Australia/Darwin
-       * * `Australia/Eucla` - Australia/Eucla
-       * * `Australia/Hobart` - Australia/Hobart
-       * * `Australia/LHI` - Australia/LHI
-       * * `Australia/Lindeman` - Australia/Lindeman
-       * * `Australia/Lord_Howe` - Australia/Lord_Howe
-       * * `Australia/Melbourne` - Australia/Melbourne
-       * * `Australia/NSW` - Australia/NSW
-       * * `Australia/North` - Australia/North
-       * * `Australia/Perth` - Australia/Perth
-       * * `Australia/Queensland` - Australia/Queensland
-       * * `Australia/South` - Australia/South
-       * * `Australia/Sydney` - Australia/Sydney
-       * * `Australia/Tasmania` - Australia/Tasmania
-       * * `Australia/Victoria` - Australia/Victoria
-       * * `Australia/West` - Australia/West
-       * * `Australia/Yancowinna` - Australia/Yancowinna
-       * * `Brazil/Acre` - Brazil/Acre
-       * * `Brazil/DeNoronha` - Brazil/DeNoronha
-       * * `Brazil/East` - Brazil/East
-       * * `Brazil/West` - Brazil/West
-       * * `CET` - CET
-       * * `CST6CDT` - CST6CDT
-       * * `Canada/Atlantic` - Canada/Atlantic
-       * * `Canada/Central` - Canada/Central
-       * * `Canada/Eastern` - Canada/Eastern
-       * * `Canada/Mountain` - Canada/Mountain
-       * * `Canada/Newfoundland` - Canada/Newfoundland
-       * * `Canada/Pacific` - Canada/Pacific
-       * * `Canada/Saskatchewan` - Canada/Saskatchewan
-       * * `Canada/Yukon` - Canada/Yukon
-       * * `Chile/Continental` - Chile/Continental
-       * * `Chile/EasterIsland` - Chile/EasterIsland
-       * * `Cuba` - Cuba
-       * * `EET` - EET
-       * * `EST` - EST
-       * * `EST5EDT` - EST5EDT
-       * * `Egypt` - Egypt
-       * * `Eire` - Eire
-       * * `Etc/GMT` - Etc/GMT
-       * * `Etc/GMT+0` - Etc/GMT+0
-       * * `Etc/GMT+1` - Etc/GMT+1
-       * * `Etc/GMT+10` - Etc/GMT+10
-       * * `Etc/GMT+11` - Etc/GMT+11
-       * * `Etc/GMT+12` - Etc/GMT+12
-       * * `Etc/GMT+2` - Etc/GMT+2
-       * * `Etc/GMT+3` - Etc/GMT+3
-       * * `Etc/GMT+4` - Etc/GMT+4
-       * * `Etc/GMT+5` - Etc/GMT+5
-       * * `Etc/GMT+6` - Etc/GMT+6
-       * * `Etc/GMT+7` - Etc/GMT+7
-       * * `Etc/GMT+8` - Etc/GMT+8
-       * * `Etc/GMT+9` - Etc/GMT+9
-       * * `Etc/GMT-0` - Etc/GMT-0
-       * * `Etc/GMT-1` - Etc/GMT-1
-       * * `Etc/GMT-10` - Etc/GMT-10
-       * * `Etc/GMT-11` - Etc/GMT-11
-       * * `Etc/GMT-12` - Etc/GMT-12
-       * * `Etc/GMT-13` - Etc/GMT-13
-       * * `Etc/GMT-14` - Etc/GMT-14
-       * * `Etc/GMT-2` - Etc/GMT-2
-       * * `Etc/GMT-3` - Etc/GMT-3
-       * * `Etc/GMT-4` - Etc/GMT-4
-       * * `Etc/GMT-5` - Etc/GMT-5
-       * * `Etc/GMT-6` - Etc/GMT-6
-       * * `Etc/GMT-7` - Etc/GMT-7
-       * * `Etc/GMT-8` - Etc/GMT-8
-       * * `Etc/GMT-9` - Etc/GMT-9
-       * * `Etc/GMT0` - Etc/GMT0
-       * * `Etc/Greenwich` - Etc/Greenwich
-       * * `Etc/UCT` - Etc/UCT
-       * * `Etc/UTC` - Etc/UTC
-       * * `Etc/Universal` - Etc/Universal
-       * * `Etc/Zulu` - Etc/Zulu
-       * * `Europe/Amsterdam` - Europe/Amsterdam
-       * * `Europe/Andorra` - Europe/Andorra
-       * * `Europe/Astrakhan` - Europe/Astrakhan
-       * * `Europe/Athens` - Europe/Athens
-       * * `Europe/Belfast` - Europe/Belfast
-       * * `Europe/Belgrade` - Europe/Belgrade
-       * * `Europe/Berlin` - Europe/Berlin
-       * * `Europe/Bratislava` - Europe/Bratislava
-       * * `Europe/Brussels` - Europe/Brussels
-       * * `Europe/Bucharest` - Europe/Bucharest
-       * * `Europe/Budapest` - Europe/Budapest
-       * * `Europe/Busingen` - Europe/Busingen
-       * * `Europe/Chisinau` - Europe/Chisinau
-       * * `Europe/Copenhagen` - Europe/Copenhagen
-       * * `Europe/Dublin` - Europe/Dublin
-       * * `Europe/Gibraltar` - Europe/Gibraltar
-       * * `Europe/Guernsey` - Europe/Guernsey
-       * * `Europe/Helsinki` - Europe/Helsinki
-       * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-       * * `Europe/Istanbul` - Europe/Istanbul
-       * * `Europe/Jersey` - Europe/Jersey
-       * * `Europe/Kaliningrad` - Europe/Kaliningrad
-       * * `Europe/Kiev` - Europe/Kiev
-       * * `Europe/Kirov` - Europe/Kirov
-       * * `Europe/Kyiv` - Europe/Kyiv
-       * * `Europe/Lisbon` - Europe/Lisbon
-       * * `Europe/Ljubljana` - Europe/Ljubljana
-       * * `Europe/London` - Europe/London
-       * * `Europe/Luxembourg` - Europe/Luxembourg
-       * * `Europe/Madrid` - Europe/Madrid
-       * * `Europe/Malta` - Europe/Malta
-       * * `Europe/Mariehamn` - Europe/Mariehamn
-       * * `Europe/Minsk` - Europe/Minsk
-       * * `Europe/Monaco` - Europe/Monaco
-       * * `Europe/Moscow` - Europe/Moscow
-       * * `Europe/Nicosia` - Europe/Nicosia
-       * * `Europe/Oslo` - Europe/Oslo
-       * * `Europe/Paris` - Europe/Paris
-       * * `Europe/Podgorica` - Europe/Podgorica
-       * * `Europe/Prague` - Europe/Prague
-       * * `Europe/Riga` - Europe/Riga
-       * * `Europe/Rome` - Europe/Rome
-       * * `Europe/Samara` - Europe/Samara
-       * * `Europe/San_Marino` - Europe/San_Marino
-       * * `Europe/Sarajevo` - Europe/Sarajevo
-       * * `Europe/Saratov` - Europe/Saratov
-       * * `Europe/Simferopol` - Europe/Simferopol
-       * * `Europe/Skopje` - Europe/Skopje
-       * * `Europe/Sofia` - Europe/Sofia
-       * * `Europe/Stockholm` - Europe/Stockholm
-       * * `Europe/Tallinn` - Europe/Tallinn
-       * * `Europe/Tirane` - Europe/Tirane
-       * * `Europe/Tiraspol` - Europe/Tiraspol
-       * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-       * * `Europe/Uzhgorod` - Europe/Uzhgorod
-       * * `Europe/Vaduz` - Europe/Vaduz
-       * * `Europe/Vatican` - Europe/Vatican
-       * * `Europe/Vienna` - Europe/Vienna
-       * * `Europe/Vilnius` - Europe/Vilnius
-       * * `Europe/Volgograd` - Europe/Volgograd
-       * * `Europe/Warsaw` - Europe/Warsaw
-       * * `Europe/Zagreb` - Europe/Zagreb
-       * * `Europe/Zaporozhye` - Europe/Zaporozhye
-       * * `Europe/Zurich` - Europe/Zurich
-       * * `GB` - GB
-       * * `GB-Eire` - GB-Eire
-       * * `GMT` - GMT
-       * * `GMT+0` - GMT+0
-       * * `GMT-0` - GMT-0
-       * * `GMT0` - GMT0
-       * * `Greenwich` - Greenwich
-       * * `HST` - HST
-       * * `Hongkong` - Hongkong
-       * * `Iceland` - Iceland
-       * * `Indian/Antananarivo` - Indian/Antananarivo
-       * * `Indian/Chagos` - Indian/Chagos
-       * * `Indian/Christmas` - Indian/Christmas
-       * * `Indian/Cocos` - Indian/Cocos
-       * * `Indian/Comoro` - Indian/Comoro
-       * * `Indian/Kerguelen` - Indian/Kerguelen
-       * * `Indian/Mahe` - Indian/Mahe
-       * * `Indian/Maldives` - Indian/Maldives
-       * * `Indian/Mauritius` - Indian/Mauritius
-       * * `Indian/Mayotte` - Indian/Mayotte
-       * * `Indian/Reunion` - Indian/Reunion
-       * * `Iran` - Iran
-       * * `Israel` - Israel
-       * * `Jamaica` - Jamaica
-       * * `Japan` - Japan
-       * * `Kwajalein` - Kwajalein
-       * * `Libya` - Libya
-       * * `MET` - MET
-       * * `MST` - MST
-       * * `MST7MDT` - MST7MDT
-       * * `Mexico/BajaNorte` - Mexico/BajaNorte
-       * * `Mexico/BajaSur` - Mexico/BajaSur
-       * * `Mexico/General` - Mexico/General
-       * * `NZ` - NZ
-       * * `NZ-CHAT` - NZ-CHAT
-       * * `Navajo` - Navajo
-       * * `PRC` - PRC
-       * * `PST8PDT` - PST8PDT
-       * * `Pacific/Apia` - Pacific/Apia
-       * * `Pacific/Auckland` - Pacific/Auckland
-       * * `Pacific/Bougainville` - Pacific/Bougainville
-       * * `Pacific/Chatham` - Pacific/Chatham
-       * * `Pacific/Chuuk` - Pacific/Chuuk
-       * * `Pacific/Easter` - Pacific/Easter
-       * * `Pacific/Efate` - Pacific/Efate
-       * * `Pacific/Enderbury` - Pacific/Enderbury
-       * * `Pacific/Fakaofo` - Pacific/Fakaofo
-       * * `Pacific/Fiji` - Pacific/Fiji
-       * * `Pacific/Funafuti` - Pacific/Funafuti
-       * * `Pacific/Galapagos` - Pacific/Galapagos
-       * * `Pacific/Gambier` - Pacific/Gambier
-       * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-       * * `Pacific/Guam` - Pacific/Guam
-       * * `Pacific/Honolulu` - Pacific/Honolulu
-       * * `Pacific/Johnston` - Pacific/Johnston
-       * * `Pacific/Kanton` - Pacific/Kanton
-       * * `Pacific/Kiritimati` - Pacific/Kiritimati
-       * * `Pacific/Kosrae` - Pacific/Kosrae
-       * * `Pacific/Kwajalein` - Pacific/Kwajalein
-       * * `Pacific/Majuro` - Pacific/Majuro
-       * * `Pacific/Marquesas` - Pacific/Marquesas
-       * * `Pacific/Midway` - Pacific/Midway
-       * * `Pacific/Nauru` - Pacific/Nauru
-       * * `Pacific/Niue` - Pacific/Niue
-       * * `Pacific/Norfolk` - Pacific/Norfolk
-       * * `Pacific/Noumea` - Pacific/Noumea
-       * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-       * * `Pacific/Palau` - Pacific/Palau
-       * * `Pacific/Pitcairn` - Pacific/Pitcairn
-       * * `Pacific/Pohnpei` - Pacific/Pohnpei
-       * * `Pacific/Ponape` - Pacific/Ponape
-       * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-       * * `Pacific/Rarotonga` - Pacific/Rarotonga
-       * * `Pacific/Saipan` - Pacific/Saipan
-       * * `Pacific/Samoa` - Pacific/Samoa
-       * * `Pacific/Tahiti` - Pacific/Tahiti
-       * * `Pacific/Tarawa` - Pacific/Tarawa
-       * * `Pacific/Tongatapu` - Pacific/Tongatapu
-       * * `Pacific/Truk` - Pacific/Truk
-       * * `Pacific/Wake` - Pacific/Wake
-       * * `Pacific/Wallis` - Pacific/Wallis
-       * * `Pacific/Yap` - Pacific/Yap
-       * * `Poland` - Poland
-       * * `Portugal` - Portugal
-       * * `ROC` - ROC
-       * * `ROK` - ROK
-       * * `Singapore` - Singapore
-       * * `Turkey` - Turkey
-       * * `UCT` - UCT
-       * * `US/Alaska` - US/Alaska
-       * * `US/Aleutian` - US/Aleutian
-       * * `US/Arizona` - US/Arizona
-       * * `US/Central` - US/Central
-       * * `US/East-Indiana` - US/East-Indiana
-       * * `US/Eastern` - US/Eastern
-       * * `US/Hawaii` - US/Hawaii
-       * * `US/Indiana-Starke` - US/Indiana-Starke
-       * * `US/Michigan` - US/Michigan
-       * * `US/Mountain` - US/Mountain
-       * * `US/Pacific` - US/Pacific
-       * * `US/Samoa` - US/Samoa
-       * * `UTC` - UTC
-       * * `Universal` - Universal
-       * * `W-SU` - W-SU
-       * * `WET` - WET
-       * * `Zulu` - Zulu */
+
+      * `Africa/Abidjan` - Africa/Abidjan
+      * `Africa/Accra` - Africa/Accra
+      * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+      * `Africa/Algiers` - Africa/Algiers
+      * `Africa/Asmara` - Africa/Asmara
+      * `Africa/Asmera` - Africa/Asmera
+      * `Africa/Bamako` - Africa/Bamako
+      * `Africa/Bangui` - Africa/Bangui
+      * `Africa/Banjul` - Africa/Banjul
+      * `Africa/Bissau` - Africa/Bissau
+      * `Africa/Blantyre` - Africa/Blantyre
+      * `Africa/Brazzaville` - Africa/Brazzaville
+      * `Africa/Bujumbura` - Africa/Bujumbura
+      * `Africa/Cairo` - Africa/Cairo
+      * `Africa/Casablanca` - Africa/Casablanca
+      * `Africa/Ceuta` - Africa/Ceuta
+      * `Africa/Conakry` - Africa/Conakry
+      * `Africa/Dakar` - Africa/Dakar
+      * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+      * `Africa/Djibouti` - Africa/Djibouti
+      * `Africa/Douala` - Africa/Douala
+      * `Africa/El_Aaiun` - Africa/El_Aaiun
+      * `Africa/Freetown` - Africa/Freetown
+      * `Africa/Gaborone` - Africa/Gaborone
+      * `Africa/Harare` - Africa/Harare
+      * `Africa/Johannesburg` - Africa/Johannesburg
+      * `Africa/Juba` - Africa/Juba
+      * `Africa/Kampala` - Africa/Kampala
+      * `Africa/Khartoum` - Africa/Khartoum
+      * `Africa/Kigali` - Africa/Kigali
+      * `Africa/Kinshasa` - Africa/Kinshasa
+      * `Africa/Lagos` - Africa/Lagos
+      * `Africa/Libreville` - Africa/Libreville
+      * `Africa/Lome` - Africa/Lome
+      * `Africa/Luanda` - Africa/Luanda
+      * `Africa/Lubumbashi` - Africa/Lubumbashi
+      * `Africa/Lusaka` - Africa/Lusaka
+      * `Africa/Malabo` - Africa/Malabo
+      * `Africa/Maputo` - Africa/Maputo
+      * `Africa/Maseru` - Africa/Maseru
+      * `Africa/Mbabane` - Africa/Mbabane
+      * `Africa/Mogadishu` - Africa/Mogadishu
+      * `Africa/Monrovia` - Africa/Monrovia
+      * `Africa/Nairobi` - Africa/Nairobi
+      * `Africa/Ndjamena` - Africa/Ndjamena
+      * `Africa/Niamey` - Africa/Niamey
+      * `Africa/Nouakchott` - Africa/Nouakchott
+      * `Africa/Ouagadougou` - Africa/Ouagadougou
+      * `Africa/Porto-Novo` - Africa/Porto-Novo
+      * `Africa/Sao_Tome` - Africa/Sao_Tome
+      * `Africa/Timbuktu` - Africa/Timbuktu
+      * `Africa/Tripoli` - Africa/Tripoli
+      * `Africa/Tunis` - Africa/Tunis
+      * `Africa/Windhoek` - Africa/Windhoek
+      * `America/Adak` - America/Adak
+      * `America/Anchorage` - America/Anchorage
+      * `America/Anguilla` - America/Anguilla
+      * `America/Antigua` - America/Antigua
+      * `America/Araguaina` - America/Araguaina
+      * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+      * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+      * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+      * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+      * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+      * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+      * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+      * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+      * `America/Argentina/Salta` - America/Argentina/Salta
+      * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+      * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+      * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+      * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+      * `America/Aruba` - America/Aruba
+      * `America/Asuncion` - America/Asuncion
+      * `America/Atikokan` - America/Atikokan
+      * `America/Atka` - America/Atka
+      * `America/Bahia` - America/Bahia
+      * `America/Bahia_Banderas` - America/Bahia_Banderas
+      * `America/Barbados` - America/Barbados
+      * `America/Belem` - America/Belem
+      * `America/Belize` - America/Belize
+      * `America/Blanc-Sablon` - America/Blanc-Sablon
+      * `America/Boa_Vista` - America/Boa_Vista
+      * `America/Bogota` - America/Bogota
+      * `America/Boise` - America/Boise
+      * `America/Buenos_Aires` - America/Buenos_Aires
+      * `America/Cambridge_Bay` - America/Cambridge_Bay
+      * `America/Campo_Grande` - America/Campo_Grande
+      * `America/Cancun` - America/Cancun
+      * `America/Caracas` - America/Caracas
+      * `America/Catamarca` - America/Catamarca
+      * `America/Cayenne` - America/Cayenne
+      * `America/Cayman` - America/Cayman
+      * `America/Chicago` - America/Chicago
+      * `America/Chihuahua` - America/Chihuahua
+      * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+      * `America/Coral_Harbour` - America/Coral_Harbour
+      * `America/Cordoba` - America/Cordoba
+      * `America/Costa_Rica` - America/Costa_Rica
+      * `America/Creston` - America/Creston
+      * `America/Cuiaba` - America/Cuiaba
+      * `America/Curacao` - America/Curacao
+      * `America/Danmarkshavn` - America/Danmarkshavn
+      * `America/Dawson` - America/Dawson
+      * `America/Dawson_Creek` - America/Dawson_Creek
+      * `America/Denver` - America/Denver
+      * `America/Detroit` - America/Detroit
+      * `America/Dominica` - America/Dominica
+      * `America/Edmonton` - America/Edmonton
+      * `America/Eirunepe` - America/Eirunepe
+      * `America/El_Salvador` - America/El_Salvador
+      * `America/Ensenada` - America/Ensenada
+      * `America/Fort_Nelson` - America/Fort_Nelson
+      * `America/Fort_Wayne` - America/Fort_Wayne
+      * `America/Fortaleza` - America/Fortaleza
+      * `America/Glace_Bay` - America/Glace_Bay
+      * `America/Godthab` - America/Godthab
+      * `America/Goose_Bay` - America/Goose_Bay
+      * `America/Grand_Turk` - America/Grand_Turk
+      * `America/Grenada` - America/Grenada
+      * `America/Guadeloupe` - America/Guadeloupe
+      * `America/Guatemala` - America/Guatemala
+      * `America/Guayaquil` - America/Guayaquil
+      * `America/Guyana` - America/Guyana
+      * `America/Halifax` - America/Halifax
+      * `America/Havana` - America/Havana
+      * `America/Hermosillo` - America/Hermosillo
+      * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+      * `America/Indiana/Knox` - America/Indiana/Knox
+      * `America/Indiana/Marengo` - America/Indiana/Marengo
+      * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+      * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+      * `America/Indiana/Vevay` - America/Indiana/Vevay
+      * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+      * `America/Indiana/Winamac` - America/Indiana/Winamac
+      * `America/Indianapolis` - America/Indianapolis
+      * `America/Inuvik` - America/Inuvik
+      * `America/Iqaluit` - America/Iqaluit
+      * `America/Jamaica` - America/Jamaica
+      * `America/Jujuy` - America/Jujuy
+      * `America/Juneau` - America/Juneau
+      * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+      * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+      * `America/Knox_IN` - America/Knox_IN
+      * `America/Kralendijk` - America/Kralendijk
+      * `America/La_Paz` - America/La_Paz
+      * `America/Lima` - America/Lima
+      * `America/Los_Angeles` - America/Los_Angeles
+      * `America/Louisville` - America/Louisville
+      * `America/Lower_Princes` - America/Lower_Princes
+      * `America/Maceio` - America/Maceio
+      * `America/Managua` - America/Managua
+      * `America/Manaus` - America/Manaus
+      * `America/Marigot` - America/Marigot
+      * `America/Martinique` - America/Martinique
+      * `America/Matamoros` - America/Matamoros
+      * `America/Mazatlan` - America/Mazatlan
+      * `America/Mendoza` - America/Mendoza
+      * `America/Menominee` - America/Menominee
+      * `America/Merida` - America/Merida
+      * `America/Metlakatla` - America/Metlakatla
+      * `America/Mexico_City` - America/Mexico_City
+      * `America/Miquelon` - America/Miquelon
+      * `America/Moncton` - America/Moncton
+      * `America/Monterrey` - America/Monterrey
+      * `America/Montevideo` - America/Montevideo
+      * `America/Montreal` - America/Montreal
+      * `America/Montserrat` - America/Montserrat
+      * `America/Nassau` - America/Nassau
+      * `America/New_York` - America/New_York
+      * `America/Nipigon` - America/Nipigon
+      * `America/Nome` - America/Nome
+      * `America/Noronha` - America/Noronha
+      * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+      * `America/North_Dakota/Center` - America/North_Dakota/Center
+      * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+      * `America/Nuuk` - America/Nuuk
+      * `America/Ojinaga` - America/Ojinaga
+      * `America/Panama` - America/Panama
+      * `America/Pangnirtung` - America/Pangnirtung
+      * `America/Paramaribo` - America/Paramaribo
+      * `America/Phoenix` - America/Phoenix
+      * `America/Port-au-Prince` - America/Port-au-Prince
+      * `America/Port_of_Spain` - America/Port_of_Spain
+      * `America/Porto_Acre` - America/Porto_Acre
+      * `America/Porto_Velho` - America/Porto_Velho
+      * `America/Puerto_Rico` - America/Puerto_Rico
+      * `America/Punta_Arenas` - America/Punta_Arenas
+      * `America/Rainy_River` - America/Rainy_River
+      * `America/Rankin_Inlet` - America/Rankin_Inlet
+      * `America/Recife` - America/Recife
+      * `America/Regina` - America/Regina
+      * `America/Resolute` - America/Resolute
+      * `America/Rio_Branco` - America/Rio_Branco
+      * `America/Rosario` - America/Rosario
+      * `America/Santa_Isabel` - America/Santa_Isabel
+      * `America/Santarem` - America/Santarem
+      * `America/Santiago` - America/Santiago
+      * `America/Santo_Domingo` - America/Santo_Domingo
+      * `America/Sao_Paulo` - America/Sao_Paulo
+      * `America/Scoresbysund` - America/Scoresbysund
+      * `America/Shiprock` - America/Shiprock
+      * `America/Sitka` - America/Sitka
+      * `America/St_Barthelemy` - America/St_Barthelemy
+      * `America/St_Johns` - America/St_Johns
+      * `America/St_Kitts` - America/St_Kitts
+      * `America/St_Lucia` - America/St_Lucia
+      * `America/St_Thomas` - America/St_Thomas
+      * `America/St_Vincent` - America/St_Vincent
+      * `America/Swift_Current` - America/Swift_Current
+      * `America/Tegucigalpa` - America/Tegucigalpa
+      * `America/Thule` - America/Thule
+      * `America/Thunder_Bay` - America/Thunder_Bay
+      * `America/Tijuana` - America/Tijuana
+      * `America/Toronto` - America/Toronto
+      * `America/Tortola` - America/Tortola
+      * `America/Vancouver` - America/Vancouver
+      * `America/Virgin` - America/Virgin
+      * `America/Whitehorse` - America/Whitehorse
+      * `America/Winnipeg` - America/Winnipeg
+      * `America/Yakutat` - America/Yakutat
+      * `America/Yellowknife` - America/Yellowknife
+      * `Antarctica/Casey` - Antarctica/Casey
+      * `Antarctica/Davis` - Antarctica/Davis
+      * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+      * `Antarctica/Macquarie` - Antarctica/Macquarie
+      * `Antarctica/Mawson` - Antarctica/Mawson
+      * `Antarctica/McMurdo` - Antarctica/McMurdo
+      * `Antarctica/Palmer` - Antarctica/Palmer
+      * `Antarctica/Rothera` - Antarctica/Rothera
+      * `Antarctica/South_Pole` - Antarctica/South_Pole
+      * `Antarctica/Syowa` - Antarctica/Syowa
+      * `Antarctica/Troll` - Antarctica/Troll
+      * `Antarctica/Vostok` - Antarctica/Vostok
+      * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+      * `Asia/Aden` - Asia/Aden
+      * `Asia/Almaty` - Asia/Almaty
+      * `Asia/Amman` - Asia/Amman
+      * `Asia/Anadyr` - Asia/Anadyr
+      * `Asia/Aqtau` - Asia/Aqtau
+      * `Asia/Aqtobe` - Asia/Aqtobe
+      * `Asia/Ashgabat` - Asia/Ashgabat
+      * `Asia/Ashkhabad` - Asia/Ashkhabad
+      * `Asia/Atyrau` - Asia/Atyrau
+      * `Asia/Baghdad` - Asia/Baghdad
+      * `Asia/Bahrain` - Asia/Bahrain
+      * `Asia/Baku` - Asia/Baku
+      * `Asia/Bangkok` - Asia/Bangkok
+      * `Asia/Barnaul` - Asia/Barnaul
+      * `Asia/Beirut` - Asia/Beirut
+      * `Asia/Bishkek` - Asia/Bishkek
+      * `Asia/Brunei` - Asia/Brunei
+      * `Asia/Calcutta` - Asia/Calcutta
+      * `Asia/Chita` - Asia/Chita
+      * `Asia/Choibalsan` - Asia/Choibalsan
+      * `Asia/Chongqing` - Asia/Chongqing
+      * `Asia/Chungking` - Asia/Chungking
+      * `Asia/Colombo` - Asia/Colombo
+      * `Asia/Dacca` - Asia/Dacca
+      * `Asia/Damascus` - Asia/Damascus
+      * `Asia/Dhaka` - Asia/Dhaka
+      * `Asia/Dili` - Asia/Dili
+      * `Asia/Dubai` - Asia/Dubai
+      * `Asia/Dushanbe` - Asia/Dushanbe
+      * `Asia/Famagusta` - Asia/Famagusta
+      * `Asia/Gaza` - Asia/Gaza
+      * `Asia/Harbin` - Asia/Harbin
+      * `Asia/Hebron` - Asia/Hebron
+      * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+      * `Asia/Hong_Kong` - Asia/Hong_Kong
+      * `Asia/Hovd` - Asia/Hovd
+      * `Asia/Irkutsk` - Asia/Irkutsk
+      * `Asia/Istanbul` - Asia/Istanbul
+      * `Asia/Jakarta` - Asia/Jakarta
+      * `Asia/Jayapura` - Asia/Jayapura
+      * `Asia/Jerusalem` - Asia/Jerusalem
+      * `Asia/Kabul` - Asia/Kabul
+      * `Asia/Kamchatka` - Asia/Kamchatka
+      * `Asia/Karachi` - Asia/Karachi
+      * `Asia/Kashgar` - Asia/Kashgar
+      * `Asia/Kathmandu` - Asia/Kathmandu
+      * `Asia/Katmandu` - Asia/Katmandu
+      * `Asia/Khandyga` - Asia/Khandyga
+      * `Asia/Kolkata` - Asia/Kolkata
+      * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+      * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+      * `Asia/Kuching` - Asia/Kuching
+      * `Asia/Kuwait` - Asia/Kuwait
+      * `Asia/Macao` - Asia/Macao
+      * `Asia/Macau` - Asia/Macau
+      * `Asia/Magadan` - Asia/Magadan
+      * `Asia/Makassar` - Asia/Makassar
+      * `Asia/Manila` - Asia/Manila
+      * `Asia/Muscat` - Asia/Muscat
+      * `Asia/Nicosia` - Asia/Nicosia
+      * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+      * `Asia/Novosibirsk` - Asia/Novosibirsk
+      * `Asia/Omsk` - Asia/Omsk
+      * `Asia/Oral` - Asia/Oral
+      * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+      * `Asia/Pontianak` - Asia/Pontianak
+      * `Asia/Pyongyang` - Asia/Pyongyang
+      * `Asia/Qatar` - Asia/Qatar
+      * `Asia/Qostanay` - Asia/Qostanay
+      * `Asia/Qyzylorda` - Asia/Qyzylorda
+      * `Asia/Rangoon` - Asia/Rangoon
+      * `Asia/Riyadh` - Asia/Riyadh
+      * `Asia/Saigon` - Asia/Saigon
+      * `Asia/Sakhalin` - Asia/Sakhalin
+      * `Asia/Samarkand` - Asia/Samarkand
+      * `Asia/Seoul` - Asia/Seoul
+      * `Asia/Shanghai` - Asia/Shanghai
+      * `Asia/Singapore` - Asia/Singapore
+      * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+      * `Asia/Taipei` - Asia/Taipei
+      * `Asia/Tashkent` - Asia/Tashkent
+      * `Asia/Tbilisi` - Asia/Tbilisi
+      * `Asia/Tehran` - Asia/Tehran
+      * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+      * `Asia/Thimbu` - Asia/Thimbu
+      * `Asia/Thimphu` - Asia/Thimphu
+      * `Asia/Tokyo` - Asia/Tokyo
+      * `Asia/Tomsk` - Asia/Tomsk
+      * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+      * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+      * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+      * `Asia/Urumqi` - Asia/Urumqi
+      * `Asia/Ust-Nera` - Asia/Ust-Nera
+      * `Asia/Vientiane` - Asia/Vientiane
+      * `Asia/Vladivostok` - Asia/Vladivostok
+      * `Asia/Yakutsk` - Asia/Yakutsk
+      * `Asia/Yangon` - Asia/Yangon
+      * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+      * `Asia/Yerevan` - Asia/Yerevan
+      * `Atlantic/Azores` - Atlantic/Azores
+      * `Atlantic/Bermuda` - Atlantic/Bermuda
+      * `Atlantic/Canary` - Atlantic/Canary
+      * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+      * `Atlantic/Faeroe` - Atlantic/Faeroe
+      * `Atlantic/Faroe` - Atlantic/Faroe
+      * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+      * `Atlantic/Madeira` - Atlantic/Madeira
+      * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+      * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+      * `Atlantic/St_Helena` - Atlantic/St_Helena
+      * `Atlantic/Stanley` - Atlantic/Stanley
+      * `Australia/ACT` - Australia/ACT
+      * `Australia/Adelaide` - Australia/Adelaide
+      * `Australia/Brisbane` - Australia/Brisbane
+      * `Australia/Broken_Hill` - Australia/Broken_Hill
+      * `Australia/Canberra` - Australia/Canberra
+      * `Australia/Currie` - Australia/Currie
+      * `Australia/Darwin` - Australia/Darwin
+      * `Australia/Eucla` - Australia/Eucla
+      * `Australia/Hobart` - Australia/Hobart
+      * `Australia/LHI` - Australia/LHI
+      * `Australia/Lindeman` - Australia/Lindeman
+      * `Australia/Lord_Howe` - Australia/Lord_Howe
+      * `Australia/Melbourne` - Australia/Melbourne
+      * `Australia/NSW` - Australia/NSW
+      * `Australia/North` - Australia/North
+      * `Australia/Perth` - Australia/Perth
+      * `Australia/Queensland` - Australia/Queensland
+      * `Australia/South` - Australia/South
+      * `Australia/Sydney` - Australia/Sydney
+      * `Australia/Tasmania` - Australia/Tasmania
+      * `Australia/Victoria` - Australia/Victoria
+      * `Australia/West` - Australia/West
+      * `Australia/Yancowinna` - Australia/Yancowinna
+      * `Brazil/Acre` - Brazil/Acre
+      * `Brazil/DeNoronha` - Brazil/DeNoronha
+      * `Brazil/East` - Brazil/East
+      * `Brazil/West` - Brazil/West
+      * `CET` - CET
+      * `CST6CDT` - CST6CDT
+      * `Canada/Atlantic` - Canada/Atlantic
+      * `Canada/Central` - Canada/Central
+      * `Canada/Eastern` - Canada/Eastern
+      * `Canada/Mountain` - Canada/Mountain
+      * `Canada/Newfoundland` - Canada/Newfoundland
+      * `Canada/Pacific` - Canada/Pacific
+      * `Canada/Saskatchewan` - Canada/Saskatchewan
+      * `Canada/Yukon` - Canada/Yukon
+      * `Chile/Continental` - Chile/Continental
+      * `Chile/EasterIsland` - Chile/EasterIsland
+      * `Cuba` - Cuba
+      * `EET` - EET
+      * `EST` - EST
+      * `EST5EDT` - EST5EDT
+      * `Egypt` - Egypt
+      * `Eire` - Eire
+      * `Etc/GMT` - Etc/GMT
+      * `Etc/GMT+0` - Etc/GMT+0
+      * `Etc/GMT+1` - Etc/GMT+1
+      * `Etc/GMT+10` - Etc/GMT+10
+      * `Etc/GMT+11` - Etc/GMT+11
+      * `Etc/GMT+12` - Etc/GMT+12
+      * `Etc/GMT+2` - Etc/GMT+2
+      * `Etc/GMT+3` - Etc/GMT+3
+      * `Etc/GMT+4` - Etc/GMT+4
+      * `Etc/GMT+5` - Etc/GMT+5
+      * `Etc/GMT+6` - Etc/GMT+6
+      * `Etc/GMT+7` - Etc/GMT+7
+      * `Etc/GMT+8` - Etc/GMT+8
+      * `Etc/GMT+9` - Etc/GMT+9
+      * `Etc/GMT-0` - Etc/GMT-0
+      * `Etc/GMT-1` - Etc/GMT-1
+      * `Etc/GMT-10` - Etc/GMT-10
+      * `Etc/GMT-11` - Etc/GMT-11
+      * `Etc/GMT-12` - Etc/GMT-12
+      * `Etc/GMT-13` - Etc/GMT-13
+      * `Etc/GMT-14` - Etc/GMT-14
+      * `Etc/GMT-2` - Etc/GMT-2
+      * `Etc/GMT-3` - Etc/GMT-3
+      * `Etc/GMT-4` - Etc/GMT-4
+      * `Etc/GMT-5` - Etc/GMT-5
+      * `Etc/GMT-6` - Etc/GMT-6
+      * `Etc/GMT-7` - Etc/GMT-7
+      * `Etc/GMT-8` - Etc/GMT-8
+      * `Etc/GMT-9` - Etc/GMT-9
+      * `Etc/GMT0` - Etc/GMT0
+      * `Etc/Greenwich` - Etc/Greenwich
+      * `Etc/UCT` - Etc/UCT
+      * `Etc/UTC` - Etc/UTC
+      * `Etc/Universal` - Etc/Universal
+      * `Etc/Zulu` - Etc/Zulu
+      * `Europe/Amsterdam` - Europe/Amsterdam
+      * `Europe/Andorra` - Europe/Andorra
+      * `Europe/Astrakhan` - Europe/Astrakhan
+      * `Europe/Athens` - Europe/Athens
+      * `Europe/Belfast` - Europe/Belfast
+      * `Europe/Belgrade` - Europe/Belgrade
+      * `Europe/Berlin` - Europe/Berlin
+      * `Europe/Bratislava` - Europe/Bratislava
+      * `Europe/Brussels` - Europe/Brussels
+      * `Europe/Bucharest` - Europe/Bucharest
+      * `Europe/Budapest` - Europe/Budapest
+      * `Europe/Busingen` - Europe/Busingen
+      * `Europe/Chisinau` - Europe/Chisinau
+      * `Europe/Copenhagen` - Europe/Copenhagen
+      * `Europe/Dublin` - Europe/Dublin
+      * `Europe/Gibraltar` - Europe/Gibraltar
+      * `Europe/Guernsey` - Europe/Guernsey
+      * `Europe/Helsinki` - Europe/Helsinki
+      * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+      * `Europe/Istanbul` - Europe/Istanbul
+      * `Europe/Jersey` - Europe/Jersey
+      * `Europe/Kaliningrad` - Europe/Kaliningrad
+      * `Europe/Kiev` - Europe/Kiev
+      * `Europe/Kirov` - Europe/Kirov
+      * `Europe/Kyiv` - Europe/Kyiv
+      * `Europe/Lisbon` - Europe/Lisbon
+      * `Europe/Ljubljana` - Europe/Ljubljana
+      * `Europe/London` - Europe/London
+      * `Europe/Luxembourg` - Europe/Luxembourg
+      * `Europe/Madrid` - Europe/Madrid
+      * `Europe/Malta` - Europe/Malta
+      * `Europe/Mariehamn` - Europe/Mariehamn
+      * `Europe/Minsk` - Europe/Minsk
+      * `Europe/Monaco` - Europe/Monaco
+      * `Europe/Moscow` - Europe/Moscow
+      * `Europe/Nicosia` - Europe/Nicosia
+      * `Europe/Oslo` - Europe/Oslo
+      * `Europe/Paris` - Europe/Paris
+      * `Europe/Podgorica` - Europe/Podgorica
+      * `Europe/Prague` - Europe/Prague
+      * `Europe/Riga` - Europe/Riga
+      * `Europe/Rome` - Europe/Rome
+      * `Europe/Samara` - Europe/Samara
+      * `Europe/San_Marino` - Europe/San_Marino
+      * `Europe/Sarajevo` - Europe/Sarajevo
+      * `Europe/Saratov` - Europe/Saratov
+      * `Europe/Simferopol` - Europe/Simferopol
+      * `Europe/Skopje` - Europe/Skopje
+      * `Europe/Sofia` - Europe/Sofia
+      * `Europe/Stockholm` - Europe/Stockholm
+      * `Europe/Tallinn` - Europe/Tallinn
+      * `Europe/Tirane` - Europe/Tirane
+      * `Europe/Tiraspol` - Europe/Tiraspol
+      * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+      * `Europe/Uzhgorod` - Europe/Uzhgorod
+      * `Europe/Vaduz` - Europe/Vaduz
+      * `Europe/Vatican` - Europe/Vatican
+      * `Europe/Vienna` - Europe/Vienna
+      * `Europe/Vilnius` - Europe/Vilnius
+      * `Europe/Volgograd` - Europe/Volgograd
+      * `Europe/Warsaw` - Europe/Warsaw
+      * `Europe/Zagreb` - Europe/Zagreb
+      * `Europe/Zaporozhye` - Europe/Zaporozhye
+      * `Europe/Zurich` - Europe/Zurich
+      * `GB` - GB
+      * `GB-Eire` - GB-Eire
+      * `GMT` - GMT
+      * `GMT+0` - GMT+0
+      * `GMT-0` - GMT-0
+      * `GMT0` - GMT0
+      * `Greenwich` - Greenwich
+      * `HST` - HST
+      * `Hongkong` - Hongkong
+      * `Iceland` - Iceland
+      * `Indian/Antananarivo` - Indian/Antananarivo
+      * `Indian/Chagos` - Indian/Chagos
+      * `Indian/Christmas` - Indian/Christmas
+      * `Indian/Cocos` - Indian/Cocos
+      * `Indian/Comoro` - Indian/Comoro
+      * `Indian/Kerguelen` - Indian/Kerguelen
+      * `Indian/Mahe` - Indian/Mahe
+      * `Indian/Maldives` - Indian/Maldives
+      * `Indian/Mauritius` - Indian/Mauritius
+      * `Indian/Mayotte` - Indian/Mayotte
+      * `Indian/Reunion` - Indian/Reunion
+      * `Iran` - Iran
+      * `Israel` - Israel
+      * `Jamaica` - Jamaica
+      * `Japan` - Japan
+      * `Kwajalein` - Kwajalein
+      * `Libya` - Libya
+      * `MET` - MET
+      * `MST` - MST
+      * `MST7MDT` - MST7MDT
+      * `Mexico/BajaNorte` - Mexico/BajaNorte
+      * `Mexico/BajaSur` - Mexico/BajaSur
+      * `Mexico/General` - Mexico/General
+      * `NZ` - NZ
+      * `NZ-CHAT` - NZ-CHAT
+      * `Navajo` - Navajo
+      * `PRC` - PRC
+      * `PST8PDT` - PST8PDT
+      * `Pacific/Apia` - Pacific/Apia
+      * `Pacific/Auckland` - Pacific/Auckland
+      * `Pacific/Bougainville` - Pacific/Bougainville
+      * `Pacific/Chatham` - Pacific/Chatham
+      * `Pacific/Chuuk` - Pacific/Chuuk
+      * `Pacific/Easter` - Pacific/Easter
+      * `Pacific/Efate` - Pacific/Efate
+      * `Pacific/Enderbury` - Pacific/Enderbury
+      * `Pacific/Fakaofo` - Pacific/Fakaofo
+      * `Pacific/Fiji` - Pacific/Fiji
+      * `Pacific/Funafuti` - Pacific/Funafuti
+      * `Pacific/Galapagos` - Pacific/Galapagos
+      * `Pacific/Gambier` - Pacific/Gambier
+      * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+      * `Pacific/Guam` - Pacific/Guam
+      * `Pacific/Honolulu` - Pacific/Honolulu
+      * `Pacific/Johnston` - Pacific/Johnston
+      * `Pacific/Kanton` - Pacific/Kanton
+      * `Pacific/Kiritimati` - Pacific/Kiritimati
+      * `Pacific/Kosrae` - Pacific/Kosrae
+      * `Pacific/Kwajalein` - Pacific/Kwajalein
+      * `Pacific/Majuro` - Pacific/Majuro
+      * `Pacific/Marquesas` - Pacific/Marquesas
+      * `Pacific/Midway` - Pacific/Midway
+      * `Pacific/Nauru` - Pacific/Nauru
+      * `Pacific/Niue` - Pacific/Niue
+      * `Pacific/Norfolk` - Pacific/Norfolk
+      * `Pacific/Noumea` - Pacific/Noumea
+      * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+      * `Pacific/Palau` - Pacific/Palau
+      * `Pacific/Pitcairn` - Pacific/Pitcairn
+      * `Pacific/Pohnpei` - Pacific/Pohnpei
+      * `Pacific/Ponape` - Pacific/Ponape
+      * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+      * `Pacific/Rarotonga` - Pacific/Rarotonga
+      * `Pacific/Saipan` - Pacific/Saipan
+      * `Pacific/Samoa` - Pacific/Samoa
+      * `Pacific/Tahiti` - Pacific/Tahiti
+      * `Pacific/Tarawa` - Pacific/Tarawa
+      * `Pacific/Tongatapu` - Pacific/Tongatapu
+      * `Pacific/Truk` - Pacific/Truk
+      * `Pacific/Wake` - Pacific/Wake
+      * `Pacific/Wallis` - Pacific/Wallis
+      * `Pacific/Yap` - Pacific/Yap
+      * `Poland` - Poland
+      * `Portugal` - Portugal
+      * `ROC` - ROC
+      * `ROK` - ROK
+      * `Singapore` - Singapore
+      * `Turkey` - Turkey
+      * `UCT` - UCT
+      * `US/Alaska` - US/Alaska
+      * `US/Aleutian` - US/Aleutian
+      * `US/Arizona` - US/Arizona
+      * `US/Central` - US/Central
+      * `US/East-Indiana` - US/East-Indiana
+      * `US/Eastern` - US/Eastern
+      * `US/Hawaii` - US/Hawaii
+      * `US/Indiana-Starke` - US/Indiana-Starke
+      * `US/Michigan` - US/Michigan
+      * `US/Mountain` - US/Mountain
+      * `US/Pacific` - US/Pacific
+      * `US/Samoa` - US/Samoa
+      * `UTC` - UTC
+      * `Universal` - Universal
+      * `W-SU` - W-SU
+      * `WET` - WET
+      * `Zulu` - Zulu */
       timezone?: string | null;
       /**
          * Day-of-week offset for weekly intervals (0=Sunday, 6=Saturday). Only valid when interval is 'week'.
@@ -9617,14 +9628,14 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-     * * `Completed` - Completed
-     * * `ContinuedAsNew` - Continued As New
-     * * `Failed` - Failed
-     * * `FailedRetryable` - Failed Retryable
-     * * `Terminated` - Terminated
-     * * `TimedOut` - Timedout
-     * * `Running` - Running
-     * * `Starting` - Starting
+    * `Completed` - Completed
+    * `ContinuedAsNew` - Continued As New
+    * `Failed` - Failed
+    * `FailedRetryable` - Failed Retryable
+    * `Terminated` - Terminated
+    * `TimedOut` - Timedout
+    * `Running` - Running
+    * `Starting` - Starting
      */
     export type BatchExportBackfillStatusEnum = typeof BatchExportBackfillStatusEnum[keyof typeof BatchExportBackfillStatusEnum];
 
@@ -9656,16 +9667,16 @@ export namespace Schemas {
          */
       end_at?: string | null;
       /** The status of this backfill.
-       *
-       * * `Cancelled` - Cancelled
-       * * `Completed` - Completed
-       * * `ContinuedAsNew` - Continued As New
-       * * `Failed` - Failed
-       * * `FailedRetryable` - Failed Retryable
-       * * `Terminated` - Terminated
-       * * `TimedOut` - Timedout
-       * * `Running` - Running
-       * * `Starting` - Starting */
+
+      * `Cancelled` - Cancelled
+      * `Completed` - Completed
+      * `ContinuedAsNew` - Continued As New
+      * `Failed` - Failed
+      * `FailedRetryable` - Failed Retryable
+      * `Terminated` - Terminated
+      * `TimedOut` - Timedout
+      * `Running` - Running
+      * `Starting` - Starting */
       status: BatchExportBackfillStatusEnum;
       /** The timestamp at which this BatchExportBackfill was created. */
       readonly created_at: string;
@@ -9732,29 +9743,29 @@ export namespace Schemas {
 
     /**
      * Request body for create/partial_update on BatchExportViewSet.
-     *
-     * Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
-     * `destination` schema so integration_id is marked required on the types that need
-     * it. Responses continue to use `BatchExportSerializer`.
+
+    Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
+    `destination` schema so integration_id is marked required on the types that need
+    it. Responses continue to use `BatchExportSerializer`.
      */
     export interface BatchExportRequest {
       /** Human-readable name for the batch export. */
       name: string;
       /** Which data model to export (events, persons, sessions).
-       *
-       * * `events` - Events
-       * * `persons` - Persons
-       * * `sessions` - Sessions */
+
+      * `events` - Events
+      * `persons` - Persons
+      * `sessions` - Sessions */
       model?: ModelEnum;
       /** Destination configuration. Required integration_id is enforced per destination type. */
       destination: BatchExportDestinationRequest;
       /** How often the batch export should run.
-       *
-       * * `hour` - hour
-       * * `day` - day
-       * * `week` - week
-       * * `every 5 minutes` - every 5 minutes
-       * * `every 15 minutes` - every 15 minutes */
+
+      * `hour` - hour
+      * `day` - day
+      * `week` - week
+      * `every 5 minutes` - every 5 minutes
+      * `every 15 minutes` - every 15 minutes */
       interval: IntervalEnum;
       /** Whether the batch export is paused. */
       paused?: boolean;
@@ -9789,9 +9800,9 @@ export namespace Schemas {
 
     /**
      * * `completed` - Completed
-     * * `failed` - Failed
-     * * `paused` - Paused
-     * * `running` - Running
+    * `failed` - Failed
+    * `paused` - Paused
+    * `running` - Running
      */
     export type BatchImportStatusEnum = typeof BatchImportStatusEnum[keyof typeof BatchImportStatusEnum];
 
@@ -9960,7 +9971,7 @@ export namespace Schemas {
 
     /**
      * * `distinct_id` - User ID (default)
-     * * `device_id` - Device ID
+    * `device_id` - Device ID
      */
     export type BucketingIdentifierEnum = typeof BucketingIdentifierEnum[keyof typeof BucketingIdentifierEnum];
 
@@ -9972,8 +9983,8 @@ export namespace Schemas {
 
     /**
      * * `fully_rolled_out` - fully_rolled_out
-     * * `not_rolled_out` - not_rolled_out
-     * * `partial` - partial
+    * `not_rolled_out` - not_rolled_out
+    * `partial` - partial
      */
     export type RolloutStateEnum = typeof RolloutStateEnum[keyof typeof RolloutStateEnum];
 
@@ -9990,10 +10001,10 @@ export namespace Schemas {
       /** The flag key at the time of deletion. */
       key: string;
       /** Rollout state captured before deletion.
-       *
-       * * `fully_rolled_out` - fully_rolled_out
-       * * `not_rolled_out` - not_rolled_out
-       * * `partial` - partial */
+
+      * `fully_rolled_out` - fully_rolled_out
+      * `not_rolled_out` - not_rolled_out
+      * `partial` - partial */
       rollout_state: RolloutStateEnum;
       /**
          * Variant key when a multivariate flag was fully rolled out to a single variant; otherwise null.
@@ -10013,9 +10024,9 @@ export namespace Schemas {
 
     /**
      * * `boolean` - boolean
-     * * `multivariant` - multivariant
-     * * `experiment` - experiment
-     * * `remote_config` - remote_config
+    * `multivariant` - multivariant
+    * `experiment` - experiment
+    * `remote_config` - remote_config
      */
     export type BulkDeleteFiltersTypeEnum = typeof BulkDeleteFiltersTypeEnum[keyof typeof BulkDeleteFiltersTypeEnum];
 
@@ -10029,8 +10040,8 @@ export namespace Schemas {
 
     /**
      * * `server` - Server
-     * * `client` - Client
-     * * `all` - All
+    * `client` - Client
+    * `all` - All
      */
     export type EvaluationRuntimeEnum = typeof EvaluationRuntimeEnum[keyof typeof EvaluationRuntimeEnum];
 
@@ -10046,27 +10057,27 @@ export namespace Schemas {
      */
     export interface BulkDeleteFilters {
       /** Filter by active state.
-       *
-       * * `true` - true
-       * * `false` - false
-       * * `STALE` - STALE */
+
+      * `true` - true
+      * `false` - false
+      * `STALE` - STALE */
       active?: ActiveEnum;
       /** Filter to flags created by a specific user ID. */
       created_by_id?: number;
       /** Search by feature flag key or name (case-insensitive). */
       search?: string;
       /** Filter by flag type.
-       *
-       * * `boolean` - boolean
-       * * `multivariant` - multivariant
-       * * `experiment` - experiment
-       * * `remote_config` - remote_config */
+
+      * `boolean` - boolean
+      * `multivariant` - multivariant
+      * `experiment` - experiment
+      * `remote_config` - remote_config */
       type?: BulkDeleteFiltersTypeEnum;
       /** Filter by evaluation runtime.
-       *
-       * * `server` - Server
-       * * `client` - Client
-       * * `all` - All */
+
+      * `server` - Server
+      * `client` - Client
+      * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum;
       /** JSON-encoded property filter to exclude. Same shape as the list endpoint. */
       excluded_properties?: string;
@@ -10079,20 +10090,17 @@ export namespace Schemas {
     export interface BulkDeleteRequest {
       /** Filter criteria — same shape as the list endpoint's query params. Mutually exclusive with `ids`. Use this to bulk-delete by search/active/tags/etc. instead of supplying explicit IDs. */
       filters?: BulkDeleteFilters;
-      /**
-         * Explicit feature flag IDs to soft-delete. Mutually exclusive with `filters`.
-         * @items.minimum 1
-         */
+      /** Explicit feature flag IDs to soft-delete. Mutually exclusive with `filters`. */
       ids?: number[];
     }
 
     /**
      * Schema-only — referenced from ``@extend_schema(responses=...)`` to describe the wire format.
-     * Never instantiate this for validation or call ``.is_valid()`` / ``.errors`` on it: the
-     * declared ``errors`` field shadows DRF's inherited ``Serializer.errors`` ReturnDict property,
-     * so accessing ``serializer.errors`` would return this field descriptor instead of validation
-     * errors. The handler builds the response dict directly; this class exists only so drf-spectacular
-     * can render the response in the OpenAPI spec and downstream generated clients.
+    Never instantiate this for validation or call ``.is_valid()`` / ``.errors`` on it: the
+    declared ``errors`` field shadows DRF's inherited ``Serializer.errors`` ReturnDict property,
+    so accessing ``serializer.errors`` would return this field descriptor instead of validation
+    errors. The handler builds the response dict directly; this class exists only so drf-spectacular
+    can render the response in the OpenAPI spec and downstream generated clients.
      */
     export interface BulkDeleteResponse {
       /** Flags successfully soft-deleted. */
@@ -10155,10 +10163,10 @@ export namespace Schemas {
 
     /**
      * * `new` - New
-     * * `open` - Open
-     * * `pending` - Pending
-     * * `on_hold` - On hold
-     * * `resolved` - Resolved
+    * `open` - Open
+    * `pending` - Pending
+    * `on_hold` - On hold
+    * `resolved` - Resolved
      */
     export type TicketStatusEnum = typeof TicketStatusEnum[keyof typeof TicketStatusEnum];
 
@@ -10178,12 +10186,12 @@ export namespace Schemas {
          */
       ids: string[];
       /** New status to apply to all selected tickets: new, open, pending, on_hold, or resolved.
-       *
-       * * `new` - New
-       * * `open` - Open
-       * * `pending` - Pending
-       * * `on_hold` - On hold
-       * * `resolved` - Resolved */
+
+      * `new` - New
+      * `open` - Open
+      * `pending` - Pending
+      * `on_hold` - On hold
+      * `resolved` - Resolved */
       status: TicketStatusEnum;
     }
 
@@ -10211,10 +10219,10 @@ export namespace Schemas {
          */
       ids: number[];
       /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
-       *
-       * * `add` - add
-       * * `remove` - remove
-       * * `set` - set */
+
+      * `add` - add
+      * `remove` - remove
+      * `set` - set */
       action: ActionEnum;
       /** Tag names to add, remove, or set. */
       tags: string[];
@@ -10227,8 +10235,8 @@ export namespace Schemas {
 
     /**
      * * `b2b` - B2B
-     * * `b2c` - B2C
-     * * `other` - Other
+    * `b2c` - B2C
+    * `other` - Other
      */
     export type BusinessModelEnum = typeof BusinessModelEnum[keyof typeof BusinessModelEnum];
 
@@ -10264,9 +10272,9 @@ export namespace Schemas {
 
     /**
      * Create-response variant that includes the plaintext token.
-     *
-     * Only emitted from the create endpoint - storage-side we only persist the
-     * hash, so subsequent reads use the base serializer.
+
+    Only emitted from the create endpoint - storage-side we only persist the
+    hash, so subsequent reads use the base serializer.
      */
     export interface CIMDVerificationTokenWithValue {
       readonly id: string;
@@ -10371,7 +10379,7 @@ export namespace Schemas {
 
     /**
      * * `error` - error
-     * * `warning` - warning
+    * `warning` - warning
      */
     export type UtmIssueSeverityEnum = typeof UtmIssueSeverityEnum[keyof typeof UtmIssueSeverityEnum];
 
@@ -10385,9 +10393,9 @@ export namespace Schemas {
       /** The UTM field with the issue (e.g. utm_campaign, utm_source) */
       field: string;
       /** Issue severity level
-       *
-       * * `error` - error
-       * * `warning` - warning */
+
+      * `error` - error
+      * `warning` - warning */
       severity: UtmIssueSeverityEnum;
       /** Human-readable description of the issue */
       message: string;
@@ -10414,48 +10422,6 @@ export namespace Schemas {
       issues: UtmIssue[];
     }
 
-    export interface CampaignMappingSuggestion {
-      /** Integration key the campaign values belong to */
-      integration: string;
-      /** Human-readable integration name */
-      integration_display_name: string;
-      /** Proposed canonical campaign name */
-      suggested_clean_name: string;
-      /** Raw campaign values clustered under this clean name */
-      raw_campaign_values: string[];
-      /** Confidence score for the clustering (0-1) */
-      confidence: number;
-      /** Mapping method */
-      method: string;
-      /** Why these campaign values were clustered together */
-      reason: string;
-    }
-
-    export interface CandidateEvent {
-      /** Name of the candidate event */
-      event_name: string;
-      /** Count of this event in the last 30 days */
-      last_30d_count: number;
-      /** Distinct users who triggered the event in 30 days */
-      distinct_users_30d: number;
-      /** Percentage of events that carry a utm_source */
-      pct_with_utm_source: number;
-      /** Percentage of events that carry a utm_campaign */
-      pct_with_utm_campaign: number;
-      /**
-         * List of [utm_source, count] pairs
-         * @items.minItems 2
-         * @items.maxItems 2
-         */
-      top_utm_sources: [string, number][];
-      /** Whether this event is already configured as a goal */
-      is_already_a_goal: boolean;
-      /** Ranking score (higher is a stronger candidate) */
-      suggestion_score: number;
-      /** Human-readable rationale for the suggestion */
-      suggestion_reason: string;
-    }
-
     /**
      * Supporting evidence
      */
@@ -10463,11 +10429,11 @@ export namespace Schemas {
 
     /**
      * * `needs_setup` - needs_setup
-     * * `detected` - detected
-     * * `waiting_for_data` - waiting_for_data
-     * * `ready` - ready
-     * * `not_applicable` - not_applicable
-     * * `unknown` - unknown
+    * `detected` - detected
+    * `waiting_for_data` - waiting_for_data
+    * `ready` - ready
+    * `not_applicable` - not_applicable
+    * `unknown` - unknown
      */
     export type CapabilityStateStateEnum = typeof CapabilityStateStateEnum[keyof typeof CapabilityStateStateEnum];
 
@@ -10483,13 +10449,13 @@ export namespace Schemas {
 
     export interface CapabilityState {
       /** Current state of the capability
-       *
-       * * `needs_setup` - needs_setup
-       * * `detected` - detected
-       * * `waiting_for_data` - waiting_for_data
-       * * `ready` - ready
-       * * `not_applicable` - not_applicable
-       * * `unknown` - unknown */
+
+      * `needs_setup` - needs_setup
+      * `detected` - detected
+      * `waiting_for_data` - waiting_for_data
+      * `ready` - ready
+      * `not_applicable` - not_applicable
+      * `unknown` - unknown */
       state: CapabilityStateStateEnum;
       /** Whether the state is estimated from static analysis */
       estimated: boolean;
@@ -10497,28 +10463,6 @@ export namespace Schemas {
       reason: string;
       /** Supporting evidence */
       evidence?: CapabilityStateEvidence;
-    }
-
-    export interface CatalogueEntry {
-      /** A raw utm_source value seen in the window */
-      raw_utm_source: string;
-      /** Number of events with this value */
-      event_count: number;
-      /**
-         * Integration this value exactly matches, if any
-         * @nullable
-         */
-      matched_integration: string | null;
-      /**
-         * Human-readable name of the matched integration, if any
-         * @nullable
-         */
-      matched_integration_display_name: string | null;
-      /**
-         * Integration suggested by token match, if any
-         * @nullable
-         */
-      suggested_integration: string | null;
     }
 
     export interface CategoricalScoreOption {
@@ -10536,7 +10480,7 @@ export namespace Schemas {
 
     /**
      * * `single` - single
-     * * `multiple` - multiple
+    * `multiple` - multiple
      */
     export type SelectionModeEnum = typeof SelectionModeEnum[keyof typeof SelectionModeEnum];
 
@@ -10550,9 +10494,9 @@ export namespace Schemas {
       /** Ordered categorical options available to the scorer. */
       options: CategoricalScoreOption[];
       /** Whether reviewers can select one option or multiple options. Defaults to `single`.
-       *
-       * * `single` - single
-       * * `multiple` - multiple */
+
+      * `single` - single
+      * `multiple` - multiple */
       selection_mode?: SelectionModeEnum;
       /**
          * Optional minimum number of options that can be selected when `selection_mode` is `multiple`.
@@ -10570,7 +10514,7 @@ export namespace Schemas {
 
     /**
      * * `marketing` - Marketing
-     * * `transactional` - Transactional
+    * `transactional` - Transactional
      */
     export type CategoryTypeEnum = typeof CategoryTypeEnum[keyof typeof CategoryTypeEnum];
 
@@ -10582,8 +10526,8 @@ export namespace Schemas {
 
     /**
      * * `consolidated` - consolidated
-     * * `cdc_only` - cdc_only
-     * * `both` - both
+    * `cdc_only` - cdc_only
+    * `both` - both
      */
     export type CdcTableModeEnum = typeof CdcTableModeEnum[keyof typeof CdcTableModeEnum];
 
@@ -10598,9 +10542,9 @@ export namespace Schemas {
 
     /**
      * * `valid` - Valid
-     * * `invalid` - Invalid
-     * * `expired` - Expired
-     * * `stale` - Stale (resource changed)
+    * `invalid` - Invalid
+    * `expired` - Expired
+    * `stale` - Stale (resource changed)
      */
     export type ValidationStatusEnum = typeof ValidationStatusEnum[keyof typeof ValidationStatusEnum];
 
@@ -10614,11 +10558,11 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-     * * `approved` - Approved (awaiting application)
-     * * `applied` - Applied
-     * * `rejected` - Rejected
-     * * `expired` - Expired
-     * * `failed` - Failed to apply
+    * `approved` - Approved (awaiting application)
+    * `applied` - Applied
+    * `rejected` - Rejected
+    * `expired` - Expired
+    * `failed` - Failed to apply
      */
     export type ChangeRequestStateEnum = typeof ChangeRequestStateEnum[keyof typeof ChangeRequestStateEnum];
 
@@ -10672,13 +10616,13 @@ export namespace Schemas {
 
     /**
      * * `slack_channel_message` - Channel message
-     * * `slack_bot_mention` - Bot mention
-     * * `slack_emoji_reaction` - Emoji reaction
-     * * `teams_channel_message` - Teams channel message
-     * * `teams_bot_mention` - Teams bot mention
-     * * `widget_embedded` - Widget
-     * * `widget_api` - API
-     * * `github_issue` - GitHub issue
+    * `slack_bot_mention` - Bot mention
+    * `slack_emoji_reaction` - Emoji reaction
+    * `teams_channel_message` - Teams channel message
+    * `teams_bot_mention` - Teams bot mention
+    * `widget_embedded` - Widget
+    * `widget_api` - API
+    * `github_issue` - GitHub issue
      */
     export type ChannelDetailEnum = typeof ChannelDetailEnum[keyof typeof ChannelDetailEnum];
 
@@ -10696,10 +10640,10 @@ export namespace Schemas {
 
     /**
      * * `widget` - Widget
-     * * `email` - Email
-     * * `slack` - Slack
-     * * `teams` - Microsoft Teams
-     * * `github` - GitHub
+    * `email` - Email
+    * `slack` - Slack
+    * `teams` - Microsoft Teams
+    * `github` - GitHub
      */
     export type ChannelSourceEnum = typeof ChannelSourceEnum[keyof typeof ChannelSourceEnum];
 
@@ -10719,7 +10663,7 @@ export namespace Schemas {
 
     /**
      * * `abandoned` - Abandoned
-     * * `off-topic` - Off-topic
+    * `off-topic` - Off-topic
      */
     export type ClassificationsEnum = typeof ClassificationsEnum[keyof typeof ClassificationsEnum];
 
@@ -10757,7 +10701,7 @@ export namespace Schemas {
 
     /**
      * * `interactive` - interactive
-     * * `background` - background
+    * `background` - background
      */
     export type TaskExecutionModeEnum = typeof TaskExecutionModeEnum[keyof typeof TaskExecutionModeEnum];
 
@@ -10769,7 +10713,7 @@ export namespace Schemas {
 
     /**
      * * `user` - user
-     * * `bot` - bot
+    * `bot` - bot
      */
     export type PrAuthorshipModeEnum = typeof PrAuthorshipModeEnum[keyof typeof PrAuthorshipModeEnum];
 
@@ -10781,7 +10725,7 @@ export namespace Schemas {
 
     /**
      * * `manual` - manual
-     * * `signal_report` - signal_report
+    * `signal_report` - signal_report
      */
     export type RunSourceEnum = typeof RunSourceEnum[keyof typeof RunSourceEnum];
 
@@ -10793,10 +10737,10 @@ export namespace Schemas {
 
     /**
      * * `low` - low
-     * * `medium` - medium
-     * * `high` - high
-     * * `xhigh` - xhigh
-     * * `max` - max
+    * `medium` - medium
+    * `high` - high
+    * `xhigh` - xhigh
+    * `max` - max
      */
     export type ReasoningEffortEnum = typeof ReasoningEffortEnum[keyof typeof ReasoningEffortEnum];
 
@@ -10811,10 +10755,10 @@ export namespace Schemas {
 
     /**
      * * `default` - default
-     * * `acceptEdits` - acceptEdits
-     * * `plan` - plan
-     * * `bypassPermissions` - bypassPermissions
-     * * `auto` - auto
+    * `acceptEdits` - acceptEdits
+    * `plan` - plan
+    * `bypassPermissions` - bypassPermissions
+    * `auto` - auto
      */
     export type ClaudeTaskRunCreateSchemaInitialPermissionModeEnum = typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnum[keyof typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnum];
 
@@ -10832,9 +10776,9 @@ export namespace Schemas {
      */
     export interface ClaudeTaskRunCreateSchema {
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-       *
-       * * `interactive` - interactive
-       * * `background` - background */
+
+      * `interactive` - interactive
+      * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -10846,48 +10790,45 @@ export namespace Schemas {
       resume_from_run_id?: string;
       /** Initial or follow-up user message to include in the run prompt. */
       pending_user_message?: string;
-      /**
-         * Identifiers for staged task artifacts that should be attached to the initial run prompt.
-         * @items.maxLength 128
-         */
+      /** Identifiers for staged task artifacts that should be attached to the initial run prompt. */
       pending_user_artifact_ids?: string[];
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-       *
-       * * `user` - user
-       * * `bot` - bot */
+
+      * `user` - user
+      * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-       *
-       * * `manual` - manual
-       * * `signal_report` - signal_report */
+
+      * `manual` - manual
+      * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
       /** Agent runtime adapter to launch for this run. Must be 'claude' for Claude runtimes.
-       *
-       * * `claude` - claude */
+
+      * `claude` - claude */
       runtime_adapter: ClaudeRuntimeAdapterEnum;
       /** LLM model identifier to run in the Claude runtime. */
       model: string;
       /** Reasoning effort to request for models that expose an effort control.
-       *
-       * * `low` - low
-       * * `medium` - medium
-       * * `high` - high
-       * * `xhigh` - xhigh
-       * * `max` - max */
+
+      * `low` - low
+      * `medium` - medium
+      * `high` - high
+      * `xhigh` - xhigh
+      * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
       github_user_token?: string;
       /** Initial permission mode for Claude runtimes.
-       *
-       * * `default` - default
-       * * `acceptEdits` - acceptEdits
-       * * `plan` - plan
-       * * `bypassPermissions` - bypassPermissions
-       * * `auto` - auto */
+
+      * `default` - default
+      * `acceptEdits` - acceptEdits
+      * `plan` - plan
+      * `bypassPermissions` - bypassPermissions
+      * `auto` - auto */
       initial_permission_mode?: ClaudeTaskRunCreateSchemaInitialPermissionModeEnum;
     }
 
@@ -10910,10 +10851,7 @@ export namespace Schemas {
          * @nullable
          */
       tag_name?: string | null;
-      /**
-         * @nullable
-         * @items.maxLength 200
-         */
+      /** @nullable */
       attr_class?: string[] | null;
       /**
          * @maxLength 10000
@@ -10976,8 +10914,8 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-     * * `generation` - generation
-     * * `evaluation` - evaluation
+    * `generation` - generation
+    * `evaluation` - evaluation
      */
     export type ClusteringJobAnalysisLevelEnum = typeof ClusteringJobAnalysisLevelEnum[keyof typeof ClusteringJobAnalysisLevelEnum];
 
@@ -11001,7 +10939,7 @@ export namespace Schemas {
 
     /**
      * * `hdbscan` - hdbscan
-     * * `kmeans` - kmeans
+    * `kmeans` - kmeans
      */
     export type ClusteringMethodEnum = typeof ClusteringMethodEnum[keyof typeof ClusteringMethodEnum];
 
@@ -11015,7 +10953,7 @@ export namespace Schemas {
 
     /**
      * * `none` - none
-     * * `l2` - l2
+    * `l2` - l2
      */
     export type EmbeddingNormalizationEnum = typeof EmbeddingNormalizationEnum[keyof typeof EmbeddingNormalizationEnum];
 
@@ -11027,8 +10965,8 @@ export namespace Schemas {
 
     /**
      * * `none` - none
-     * * `umap` - umap
-     * * `pca` - pca
+    * `umap` - umap
+    * `pca` - pca
      */
     export type DimensionalityReductionMethodEnum = typeof DimensionalityReductionMethodEnum[keyof typeof DimensionalityReductionMethodEnum];
 
@@ -11041,8 +10979,8 @@ export namespace Schemas {
 
     /**
      * * `umap` - umap
-     * * `pca` - pca
-     * * `tsne` - tsne
+    * `pca` - pca
+    * `tsne` - tsne
      */
     export type VisualizationMethodEnum = typeof VisualizationMethodEnum[keyof typeof VisualizationMethodEnum];
 
@@ -11070,15 +11008,15 @@ export namespace Schemas {
          */
       max_samples?: number;
       /** Embedding normalization method: 'none' (raw embeddings) or 'l2' (L2 normalize before clustering)
-       *
-       * * `none` - none
-       * * `l2` - l2 */
+
+      * `none` - none
+      * `l2` - l2 */
       embedding_normalization?: EmbeddingNormalizationEnum;
       /** Dimensionality reduction method: 'none' (cluster on raw), 'umap', or 'pca'
-       *
-       * * `none` - none
-       * * `umap` - umap
-       * * `pca` - pca */
+
+      * `none` - none
+      * `umap` - umap
+      * `pca` - pca */
       dimensionality_reduction_method?: DimensionalityReductionMethodEnum;
       /**
          * Target dimensions for dimensionality reduction (ignored if method is 'none')
@@ -11087,9 +11025,9 @@ export namespace Schemas {
          */
       dimensionality_reduction_ndims?: number;
       /** Clustering algorithm: 'hdbscan' (density-based, auto-determines k) or 'kmeans' (centroid-based)
-       *
-       * * `hdbscan` - hdbscan
-       * * `kmeans` - kmeans */
+
+      * `hdbscan` - hdbscan
+      * `kmeans` - kmeans */
       clustering_method?: ClusteringMethodEnum;
       /**
          * Minimum cluster size as fraction of total samples (e.g., 0.02 = 2%)
@@ -11121,10 +11059,10 @@ export namespace Schemas {
          */
       run_label?: string;
       /** Method for 2D scatter plot visualization: 'umap', 'pca', or 'tsne'
-       *
-       * * `umap` - umap
-       * * `pca` - pca
-       * * `tsne` - tsne */
+
+      * `umap` - umap
+      * `pca` - pca
+      * `tsne` - tsne */
       visualization_method?: VisualizationMethodEnum;
       /** Property filters to scope which traces are included in clustering (PostHog standard format) */
       event_filters?: ClusteringRunRequestEventFiltersItem[];
@@ -11152,8 +11090,8 @@ export namespace Schemas {
 
     /**
      * * `auto` - auto
-     * * `read-only` - read-only
-     * * `full-access` - full-access
+    * `read-only` - read-only
+    * `full-access` - full-access
      */
     export type CodexTaskRunCreateSchemaInitialPermissionModeEnum = typeof CodexTaskRunCreateSchemaInitialPermissionModeEnum[keyof typeof CodexTaskRunCreateSchemaInitialPermissionModeEnum];
 
@@ -11169,9 +11107,9 @@ export namespace Schemas {
      */
     export interface CodexTaskRunCreateSchema {
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-       *
-       * * `interactive` - interactive
-       * * `background` - background */
+
+      * `interactive` - interactive
+      * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -11183,46 +11121,43 @@ export namespace Schemas {
       resume_from_run_id?: string;
       /** Initial or follow-up user message to include in the run prompt. */
       pending_user_message?: string;
-      /**
-         * Identifiers for staged task artifacts that should be attached to the initial run prompt.
-         * @items.maxLength 128
-         */
+      /** Identifiers for staged task artifacts that should be attached to the initial run prompt. */
       pending_user_artifact_ids?: string[];
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-       *
-       * * `user` - user
-       * * `bot` - bot */
+
+      * `user` - user
+      * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-       *
-       * * `manual` - manual
-       * * `signal_report` - signal_report */
+
+      * `manual` - manual
+      * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
       /** Agent runtime adapter to launch for this run. Must be 'codex' for Codex runtimes.
-       *
-       * * `codex` - codex */
+
+      * `codex` - codex */
       runtime_adapter: CodexRuntimeAdapterEnum;
       /** LLM model identifier to run in the Codex runtime. */
       model: string;
       /** Reasoning effort to request for models that expose an effort control.
-       *
-       * * `low` - low
-       * * `medium` - medium
-       * * `high` - high
-       * * `xhigh` - xhigh
-       * * `max` - max */
+
+      * `low` - low
+      * `medium` - medium
+      * `high` - high
+      * `xhigh` - xhigh
+      * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
       github_user_token?: string;
       /** Initial permission mode for Codex runtimes.
-       *
-       * * `auto` - auto
-       * * `read-only` - read-only
-       * * `full-access` - full-access */
+
+      * `auto` - auto
+      * `read-only` - read-only
+      * `full-access` - full-access */
       initial_permission_mode?: CodexTaskRunCreateSchemaInitialPermissionModeEnum;
     }
 
@@ -11269,10 +11204,10 @@ export namespace Schemas {
 
     /**
      * * `static` - static
-     * * `person_property` - person_property
-     * * `behavioral` - behavioral
-     * * `realtime` - realtime
-     * * `analytical` - analytical
+    * `person_property` - person_property
+    * `behavioral` - behavioral
+    * `realtime` - realtime
+    * `analytical` - analytical
      */
     export type CohortTypeEnum = typeof CohortTypeEnum[keyof typeof CohortTypeEnum];
 
@@ -11317,12 +11252,12 @@ export namespace Schemas {
       readonly count: number | null;
       is_static?: boolean;
       /** Type of cohort based on filter complexity
-       *
-       * * `static` - static
-       * * `person_property` - person_property
-       * * `behavioral` - behavioral
-       * * `realtime` - realtime
-       * * `analytical` - analytical */
+
+      * `static` - static
+      * `person_property` - person_property
+      * `behavioral` - behavioral
+      * `realtime` - realtime
+      * `analytical` - analytical */
       cohort_type?: CohortTypeEnum | BlankEnum | null;
       readonly experiment_set: readonly number[];
       _create_in_folder?: string;
@@ -11369,73 +11304,9 @@ export namespace Schemas {
       previous: string | null;
     }
 
-    export interface CohortUsedInCohort {
-      /** Cohort database ID */
-      id: number;
-      /** Cohort display name; falls back to 'Unnamed' when empty */
-      name: string;
-    }
-
-    export interface CohortUsedInCohortsBlock {
-      /** Cohorts that include this cohort as a criterion, capped at 100 results */
-      results: CohortUsedInCohort[];
-      /** Total number of cohorts referencing this cohort, before truncation */
-      total: number;
-      /** True when more cohorts exist beyond the truncation cap */
-      has_more: boolean;
-    }
-
-    export interface CohortUsedInFlag {
-      /** Feature flag database ID */
-      id: number;
-      /** Feature flag key (URL slug) */
-      key: string;
-      /**
-         * Feature flag display name
-         * @nullable
-         */
-      name: string | null;
-    }
-
-    export interface CohortUsedInFlagsBlock {
-      /** Feature flags referencing this cohort, capped at 100 results */
-      results: CohortUsedInFlag[];
-      /** Total number of feature flags referencing this cohort, before truncation */
-      total: number;
-      /** True when more feature flags exist beyond the truncation cap */
-      has_more: boolean;
-    }
-
-    export interface CohortUsedInInsight {
-      /** Insight database ID */
-      id: number;
-      /** Insight short ID used for routing in the frontend */
-      short_id: string;
-      /** Insight display name; falls back to derived name, then to 'Unnamed' when both are empty */
-      name: string;
-    }
-
-    export interface CohortUsedInInsightsBlock {
-      /** Insights referencing this cohort, capped at 100 results */
-      results: CohortUsedInInsight[];
-      /** Total number of insights referencing this cohort, before truncation */
-      total: number;
-      /** True when more insights exist beyond the truncation cap */
-      has_more: boolean;
-    }
-
-    export interface CohortUsedInResponse {
-      /** Feature flags (active and inactive, excluding soft-deleted) that reference this cohort in their targeting conditions, with truncation metadata */
-      feature_flags: CohortUsedInFlagsBlock;
-      /** Insights referencing this cohort with truncation metadata */
-      insights: CohortUsedInInsightsBlock;
-      /** Other cohorts that include this cohort as a criterion, with truncation metadata */
-      cohorts: CohortUsedInCohortsBlock;
-    }
-
     /**
      * * `private` - Private (only visible to creator)
-     * * `shared` - Shared with team
+    * `shared` - Shared with team
      */
     export type VisibilityEnum = typeof VisibilityEnum[keyof typeof VisibilityEnum];
 
@@ -11536,10 +11407,10 @@ export namespace Schemas {
 
     /**
      * * `won` - won
-     * * `lost` - lost
-     * * `inconclusive` - inconclusive
-     * * `stopped_early` - stopped_early
-     * * `invalid` - invalid
+    * `lost` - lost
+    * `inconclusive` - inconclusive
+    * `stopped_early` - stopped_early
+    * `invalid` - invalid
      */
     export type ConclusionEnum = typeof ConclusionEnum[keyof typeof ConclusionEnum];
 
@@ -11562,7 +11433,7 @@ export namespace Schemas {
 
     /**
      * * `utf-8` - utf-8
-     * * `base64` - base64
+    * `base64` - base64
      */
     export type ContentEncodingEnum = typeof ContentEncodingEnum[keyof typeof ContentEncodingEnum];
 
@@ -11572,30 +11443,14 @@ export namespace Schemas {
       Base64: 'base64',
     } as const;
 
-    export interface ContextGeneration {
-      /**
-         * ID of the Task currently generating this folder's CONTEXT.md, or null if none.
-         * @nullable
-         */
-      task_id: string | null;
-    }
-
-    export interface ContextGenerationSet {
-      /**
-         * ID of the Task generating this folder's CONTEXT.md. Must reference a Task in the same team. Set to null to clear the association.
-         * @nullable
-         */
-      task_id: string | null;
-    }
-
     export type ConversationMessagesItem = { [key: string]: unknown };
 
     export type ConversationPendingApprovalsItem = { [key: string]: unknown };
 
     /**
      * * `idle` - Idle
-     * * `in_progress` - In progress
-     * * `canceling` - Canceling
+    * `in_progress` - In progress
+    * `canceling` - Canceling
      */
     export type ConversationStatus = typeof ConversationStatus[keyof typeof ConversationStatus];
 
@@ -11607,36 +11462,10 @@ export namespace Schemas {
     } as const;
 
     /**
-     * * `web_analytics` - Web analytics
-     * * `product_analytics` - Product analytics
-     * * `session_replay` - Session replay
-     * * `surveys` - Surveys
-     * * `feature_flags` - Feature flags
-     * * `experiments` - Experiments
-     * * `error_tracking` - Error tracking
-     * * `data_warehouse` - Data warehouse
-     * * `other` - Other
-     */
-    export type TopicEnum = typeof TopicEnum[keyof typeof TopicEnum];
-
-
-    export const TopicEnum = {
-      WebAnalytics: 'web_analytics',
-      ProductAnalytics: 'product_analytics',
-      SessionReplay: 'session_replay',
-      Surveys: 'surveys',
-      FeatureFlags: 'feature_flags',
-      Experiments: 'experiments',
-      ErrorTracking: 'error_tracking',
-      DataWarehouse: 'data_warehouse',
-      Other: 'other',
-    } as const;
-
-    /**
      * * `assistant` - Assistant
-     * * `tool_call` - Tool call
-     * * `deep_research` - Deep research
-     * * `slack` - Slack
+    * `tool_call` - Tool call
+    * `deep_research` - Deep research
+    * `slack` - Slack
      */
     export type ConversationType = typeof ConversationType[keyof typeof ConversationType];
 
@@ -11656,18 +11485,6 @@ export namespace Schemas {
          * @nullable
          */
       readonly title: string | null;
-      /** Product domain the conversation is about, classified from the first question.
-       *
-       * * `web_analytics` - Web analytics
-       * * `product_analytics` - Product analytics
-       * * `session_replay` - Session replay
-       * * `surveys` - Surveys
-       * * `feature_flags` - Feature flags
-       * * `experiments` - Experiments
-       * * `error_tracking` - Error tracking
-       * * `data_warehouse` - Data warehouse
-       * * `other` - Other */
-      readonly topic: TopicEnum | null;
       readonly user: UserBasic;
       /** @nullable */
       readonly created_at: string | null;
@@ -11695,9 +11512,9 @@ export namespace Schemas {
       readonly agent_mode: string | null;
       readonly is_sandbox: boolean;
       /** Return pending approval cards as structured data.
-       *
-       * Combines metadata from conversation.approval_decisions with payload from checkpoint
-       * interrupts (single source of truth for payload data). */
+
+      Combines metadata from conversation.approval_decisions with payload from checkpoint
+      interrupts (single source of truth for payload data). */
       readonly pending_approvals: readonly ConversationPendingApprovalsItem[];
     }
 
@@ -11709,18 +11526,6 @@ export namespace Schemas {
          * @nullable
          */
       readonly title: string | null;
-      /** Product domain the conversation is about, classified from the first question.
-       *
-       * * `web_analytics` - Web analytics
-       * * `product_analytics` - Product analytics
-       * * `session_replay` - Session replay
-       * * `surveys` - Surveys
-       * * `feature_flags` - Feature flags
-       * * `experiments` - Experiments
-       * * `error_tracking` - Error tracking
-       * * `data_warehouse` - Data warehouse
-       * * `other` - Other */
-      readonly topic: TopicEnum | null;
       readonly user: UserBasic;
       /** @nullable */
       readonly created_at: string | null;
@@ -11744,73 +11549,10 @@ export namespace Schemas {
       readonly slack_workspace_domain: string | null;
     }
 
-    export interface ConversionGoalSummary {
-      /** Unique id of the goal (event name, action id, or DW goal id) */
-      id: string;
-      /** Display name of the conversion goal */
-      name: string;
-      /** Goal type — one of: EventsNode (PostHog event), ActionsNode (PostHog action), DataWarehouseNode (external table) */
-      kind: string;
-      /** Human-readable target the goal matches (event/action name or table) */
-      target_label: string;
-      /** Count of matching conversion events in the last 30 days */
-      last_30d_count: number;
-      /**
-         * Conversions whose utm_source matches a known integration. Null for DataWarehouseNode goals.
-         * @nullable
-         */
-      integrated_count: number | null;
-      /**
-         * Conversions with no utm_source at all (fix by tagging UTMs). Null for DataWarehouseNode goals.
-         * @nullable
-         */
-      events_without_utm_source: number | null;
-      /**
-         * Conversions with a utm_source that matches no integration (fix with custom_source_mappings). Null for DataWarehouseNode goals.
-         * @nullable
-         */
-      events_with_unmatched_utm_source: number | null;
-      /**
-         * Total non-integrated conversions (without + unmatched utm_source). Null for DataWarehouseNode goals.
-         * @nullable
-         */
-      non_integrated_count: number | null;
-      /**
-         * Percentage of conversions that are integrated. Null for DataWarehouseNode goals.
-         * @nullable
-         */
-      integrated_pct: number | null;
-      /** Whether the goal could not be evaluated (e.g. deleted action) */
-      is_misconfigured: boolean;
-      /**
-         * Explanation when is_misconfigured is true
-         * @nullable
-         */
-      misconfig_reason: string | null;
-      /** True when this 30d count may differ from the dashboard's attribution-windowed number */
-      is_approximate: boolean;
-      /**
-         * Explanation when is_approximate is true
-         * @nullable
-         */
-      approximation_reason: string | null;
-    }
-
-    export interface ConversionGoalsListResponse {
-      /** One summary entry per configured conversion goal */
-      goals: ConversionGoalSummary[];
-      /** The team's configured attribution window in days */
-      attribution_window_days: number;
-      /** The team's attribution model (e.g. last_touch, first_touch, linear) */
-      attribution_mode: string;
-      /** True if any goal is misconfigured */
-      has_misconfigured: boolean;
-    }
-
     /**
      * * `0` - Disabled
-     * * `1` - Stateless
-     * * `2` - Stateful
+    * `1` - Stateless
+    * `2` - Stateful
      */
     export type CookielessServerHashModeEnum = typeof CookielessServerHashModeEnum[keyof typeof CookielessServerHashModeEnum];
 
@@ -11887,13 +11629,13 @@ export namespace Schemas {
 
     /**
      * * `acquisition` - Acquisition
-     * * `activation` - Activation
-     * * `monetization` - Monetization
-     * * `expansion` - Expansion
-     * * `referral` - Referral
-     * * `retention` - Retention
-     * * `churn` - Churn
-     * * `reactivation` - Reactivation
+    * `activation` - Activation
+    * `monetization` - Monetization
+    * `expansion` - Expansion
+    * `referral` - Referral
+    * `retention` - Retention
+    * `churn` - Churn
+    * `reactivation` - Reactivation
      */
     export type CoreEventCategoryEnum = typeof CoreEventCategoryEnum[keyof typeof CoreEventCategoryEnum];
 
@@ -11919,15 +11661,15 @@ export namespace Schemas {
       /** Optional description */
       description?: string;
       /** Lifecycle category for this core event
-       *
-       * * `acquisition` - Acquisition
-       * * `activation` - Activation
-       * * `monetization` - Monetization
-       * * `expansion` - Expansion
-       * * `referral` - Referral
-       * * `retention` - Retention
-       * * `churn` - Churn
-       * * `reactivation` - Reactivation */
+
+      * `acquisition` - Acquisition
+      * `activation` - Activation
+      * `monetization` - Monetization
+      * `expansion` - Expansion
+      * `referral` - Referral
+      * `retention` - Retention
+      * `churn` - Churn
+      * `reactivation` - Reactivation */
       category: CoreEventCategoryEnum;
       /** Filter configuration - event, action, or data warehouse node */
       filter: unknown;
@@ -11946,9 +11688,9 @@ export namespace Schemas {
 
     /**
      * * `single` - Single page
-     * * `sitemap` - Sitemap
-     * * `same_origin` - Same origin crawl
-     * * `github_repo` - GitHub repository
+    * `sitemap` - Sitemap
+    * `same_origin` - Same origin crawl
+    * `github_repo` - GitHub repository
      */
     export type CrawlModeEnum = typeof CrawlModeEnum[keyof typeof CrawlModeEnum];
 
@@ -11965,17 +11707,17 @@ export namespace Schemas {
      */
     export interface FileDownloadDestinationFileConfig {
       /** File format
-       *
-       * * `Parquet` - Parquet
-       * * `JSONLines` - JSONLines */
+
+      * `Parquet` - Parquet
+      * `JSONLines` - JSONLines */
       format?: FileFormatEnum;
       /** Compress the file with a supported compression format
-       *
-       * * `zstd` - zstd
-       * * `gzip` - gzip
-       * * `brotli` - brotli
-       * * `lz4` - lz4
-       * * `snappy` - snappy */
+
+      * `zstd` - zstd
+      * `gzip` - gzip
+      * `brotli` - brotli
+      * `lz4` - lz4
+      * `snappy` - snappy */
       compression?: CompressionEnum | null;
       /**
          * Split download into multiple files of at most this size in MB
@@ -12042,8 +11784,8 @@ export namespace Schemas {
 
     /**
      * * `cost` - cost
-     * * `latency` - latency
-     * * `eval_pass_rate` - eval_pass_rate
+    * `latency` - latency
+    * `eval_pass_rate` - eval_pass_rate
      */
     export type TemplatesEnum = typeof TemplatesEnum[keyof typeof TemplatesEnum];
 
@@ -12061,7 +11803,6 @@ export namespace Schemas {
          * Ordered list of prompt version numbers to assign to experiment variants. The first entry is the control variant. Must contain between 2 and 10 distinct versions.
          * @minItems 2
          * @maxItems 10
-         * @items.minimum 1
          */
       versions: number[];
       /**
@@ -12091,7 +11832,7 @@ export namespace Schemas {
 
     /**
      * * `BAA` - BAA
-     * * `DPA` - DPA
+    * `DPA` - DPA
      */
     export type CreateLegalDocumentDocumentTypeEnum = typeof CreateLegalDocumentDocumentTypeEnum[keyof typeof CreateLegalDocumentDocumentTypeEnum];
 
@@ -12103,14 +11844,14 @@ export namespace Schemas {
 
     /**
      * Input serializer for POST. Mirrors the submittable fields on the model plus
-     * cross-field rules (BAA addon, DPA mode, uniqueness). The view supplies the
-     * organization and submitting user.
+    cross-field rules (BAA addon, DPA mode, uniqueness). The view supplies the
+    organization and submitting user.
      */
     export interface CreateLegalDocument {
       /** Either 'BAA' or 'DPA'.
-       *
-       * * `BAA` - BAA
-       * * `DPA` - DPA */
+
+      * `BAA` - BAA
+      * `DPA` - DPA */
       document_type: CreateLegalDocumentDocumentTypeEnum;
       /**
          * The customer legal entity entering the agreement (PandaDoc's Client.Company).
@@ -12135,10 +11876,10 @@ export namespace Schemas {
 
     /**
      * * `zoom` - zoom
-     * * `teams` - teams
-     * * `meet` - meet
-     * * `desktop_audio` - desktop_audio
-     * * `slack` - slack
+    * `teams` - teams
+    * `meet` - meet
+    * `desktop_audio` - desktop_audio
+    * `slack` - slack
      */
     export type CreateRecordingRequestPlatformEnum = typeof CreateRecordingRequestPlatformEnum[keyof typeof CreateRecordingRequestPlatformEnum];
 
@@ -12156,21 +11897,21 @@ export namespace Schemas {
      */
     export interface CreateRecordingRequest {
       /** Meeting platform being recorded
-       *
-       * * `zoom` - zoom
-       * * `teams` - teams
-       * * `meet` - meet
-       * * `desktop_audio` - desktop_audio
-       * * `slack` - slack */
+
+      * `zoom` - zoom
+      * `teams` - teams
+      * `meet` - meet
+      * `desktop_audio` - desktop_audio
+      * `slack` - slack */
       platform?: CreateRecordingRequestPlatformEnum;
     }
 
     /**
      * * `zoom` - Zoom
-     * * `teams` - Microsoft Teams
-     * * `meet` - Google Meet
-     * * `desktop_audio` - Desktop audio
-     * * `slack` - Slack huddle
+    * `teams` - Microsoft Teams
+    * `meet` - Google Meet
+    * `desktop_audio` - Desktop audio
+    * `slack` - Slack huddle
      */
     export type MeetingPlatformEnum = typeof MeetingPlatformEnum[keyof typeof MeetingPlatformEnum];
 
@@ -12185,10 +11926,10 @@ export namespace Schemas {
 
     /**
      * * `recording` - Recording
-     * * `uploading` - Uploading
-     * * `processing` - Processing
-     * * `ready` - Ready
-     * * `error` - Error
+    * `uploading` - Uploading
+    * `processing` - Processing
+    * `ready` - Ready
+    * `error` - Error
      */
     export type DesktopRecordingStatusEnum = typeof DesktopRecordingStatusEnum[keyof typeof DesktopRecordingStatusEnum];
 
@@ -12354,8 +12095,8 @@ export namespace Schemas {
 
     /**
      * * `web` - web
-     * * `api` - api
-     * * `mcp` - mcp
+    * `api` - api
+    * `mcp` - mcp
      */
     export type CreatedViaEnum = typeof CreatedViaEnum[keyof typeof CreatedViaEnum];
 
@@ -12368,9 +12109,9 @@ export namespace Schemas {
 
     /**
      * * `default` - Default
-     * * `template` - Template
-     * * `duplicate` - Duplicate
-     * * `unlisted` - Unlisted (product-embedded)
+    * `template` - Template
+    * `duplicate` - Duplicate
+    * `unlisted` - Unlisted (product-embedded)
      */
     export type CreationModeEnum = typeof CreationModeEnum[keyof typeof CreationModeEnum];
 
@@ -12392,17 +12133,6 @@ export namespace Schemas {
       access_secret: string;
     }
 
-    export interface CurrentMapping {
-      /** A utm_source value already mapped to an integration */
-      raw_utm_source: string;
-      /** Integration key it maps to */
-      target: string;
-      /** Human-readable name of the target integration */
-      target_display_name: string;
-      /** canonical or team_custom */
-      source: string;
-    }
-
     export interface CustomerJourney {
       readonly id: string;
       insight: number;
@@ -12419,11 +12149,11 @@ export namespace Schemas {
 
     /**
      * * `person` - Person
-     * * `group_0` - Group 0
-     * * `group_1` - Group 1
-     * * `group_2` - Group 2
-     * * `group_3` - Group 3
-     * * `group_4` - Group 4
+    * `group_0` - Group 0
+    * `group_1` - Group 1
+    * `group_2` - Group 2
+    * `group_3` - Group 3
+    * `group_4` - Group 4
      */
     export type CustomerProfileConfigScopeEnum = typeof CustomerProfileConfigScopeEnum[keyof typeof CustomerProfileConfigScopeEnum];
 
@@ -12488,7 +12218,7 @@ export namespace Schemas {
 
     /**
      * * `21` - Everyone in the project can edit
-     * * `37` - Only those invited to this dashboard can edit
+    * `37` - Only those invited to this dashboard can edit
      */
     export type RestrictionLevelEnum = typeof RestrictionLevelEnum[keyof typeof RestrictionLevelEnum];
 
@@ -12590,9 +12320,9 @@ export namespace Schemas {
       readonly creation_mode: CreationModeEnum;
       tags?: unknown[];
       /** Controls who can edit the dashboard.
-       *
-       * * `21` - Everyone in the project can edit
-       * * `37` - Only those invited to this dashboard can edit */
+
+      * `21` - Everyone in the project can edit
+      * `37` - Only those invited to this dashboard can edit */
       readonly restriction_level: RestrictionLevelEnum;
       readonly effective_restriction_level: EffectivePrivilegeLevelEnum;
       readonly effective_privilege_level: EffectivePrivilegeLevelEnum;
@@ -12605,8 +12335,6 @@ export namespace Schemas {
       /** @nullable */
       readonly last_refresh: string | null;
       readonly team_id: number;
-      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
-      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     export interface DashboardCollaborator {
@@ -12628,48 +12356,9 @@ export namespace Schemas {
     }
 
     /**
-     * * `error_tracking_list` - error_tracking_list
-     * * `session_replay_list` - session_replay_list
-     */
-    export type DashboardPatchWidgetOpenApiWidgetTypeEnum = typeof DashboardPatchWidgetOpenApiWidgetTypeEnum[keyof typeof DashboardPatchWidgetOpenApiWidgetTypeEnum];
-
-
-    export const DashboardPatchWidgetOpenApiWidgetTypeEnum = {
-      ErrorTrackingList: 'error_tracking_list',
-      SessionReplayList: 'session_replay_list',
-    } as const;
-
-    export interface DashboardPatchWidgetOpenApi {
-      /** Existing widget row ID when updating a widget tile via dashboard PATCH. */
-      id?: string;
-      /** Widget type identifier (cannot be changed on update).
-       *
-       * * `error_tracking_list` - error_tracking_list
-       * * `session_replay_list` - session_replay_list */
-      widget_type?: DashboardPatchWidgetOpenApiWidgetTypeEnum;
-      /** Widget-specific configuration. Shape depends on the tile's widget_type. */
-      config?: DashboardWidgetConfig;
-      /**
-         * Optional custom display name for the widget tile.
-         * @maxLength 400
-         * @nullable
-         */
-      name?: string | null;
-      /** Optional markdown description shown when show_description is enabled. */
-      description?: string;
-    }
-
-    export interface DashboardPatchTileOpenApi {
-      /** Dashboard tile ID to update. */
-      id?: number;
-      /** Nested widget row updates. */
-      widget?: DashboardPatchWidgetOpenApi;
-    }
-
-    /**
      * * `team` - Only team
-     * * `global` - Global
-     * * `feature_flag` - Feature Flag
+    * `global` - Global
+    * `feature_flag` - Feature Flag
      */
     export type DashboardTemplateScopeEnum = typeof DashboardTemplateScopeEnum[keyof typeof DashboardTemplateScopeEnum];
 
@@ -12693,10 +12382,7 @@ export namespace Schemas {
          */
       dashboard_description?: string | null;
       dashboard_filters?: unknown;
-      /**
-         * @nullable
-         * @items.maxLength 255
-         */
+      /** @nullable */
       tags?: string[] | null;
       tiles?: unknown;
       variables?: unknown;
@@ -12713,10 +12399,7 @@ export namespace Schemas {
       /** @nullable */
       readonly team_id: number | null;
       scope?: DashboardTemplateScopeEnum | BlankEnum | null;
-      /**
-         * @nullable
-         * @items.maxLength 255
-         */
+      /** @nullable */
       availability_contexts?: string[] | null;
       /** Manually curated; used to highlight templates in the UI. */
       is_featured?: boolean;
@@ -12773,9 +12456,9 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-     * * `Completed` - Completed
-     * * `Failed` - Failed
-     * * `Running` - Running
+    * `Completed` - Completed
+    * `Failed` - Failed
+    * `Running` - Running
      */
     export type DataModelingJobStatusEnum = typeof DataModelingJobStatusEnum[keyof typeof DataModelingJobStatusEnum];
 
@@ -12806,85 +12489,6 @@ export namespace Schemas {
          * @nullable
          */
       readonly rows_expected: number | null;
-    }
-
-    export interface RequiredTableStatus {
-      /** Name of the required source table (e.g. 'campaign', 'campaign_stats') */
-      table_name: string;
-      /** Whether the table exists as a schema on the connected source */
-      present: boolean;
-      /** Whether the table is enabled for sync */
-      should_sync: boolean;
-      /**
-         * ExternalDataSchema status: Completed/Running/Failed/Paused/Cancelled, or null
-         * @nullable
-         */
-      status: string | null;
-      /**
-         * When this table last completed a sync
-         * @nullable
-         */
-      last_synced_at: string | null;
-    }
-
-    export interface DataSourceHealthEntry {
-      /** External data source type key (e.g. 'GoogleAds', 'MetaAds') */
-      source_type: string;
-      /** Whether this is a native marketing integration */
-      is_native: boolean;
-      /** Human-readable integration name (e.g. 'Google Ads') */
-      display_name: string;
-      /** Whether a live source of this type is connected */
-      connected: boolean;
-      /**
-         * When the source last completed a sync
-         * @nullable
-         */
-      last_sync_at: string | null;
-      /** Sync status: ok/error/stale/tables_failed/not_connected/never */
-      last_sync_status: string;
-      /**
-         * Latest unresolved sync error message, if any
-         * @nullable
-         */
-      last_error: string | null;
-      /** Rows synced in the last 24 hours */
-      rows_last_24h: number;
-      /** Rows synced in the last 7 days */
-      rows_last_7d: number;
-      /** Whether a column mapping exists for this source */
-      sources_map_present: boolean;
-      /** Schema columns currently mapped for this source */
-      schema_columns_mapped: string[];
-      /** Required schema columns that are not yet mapped */
-      schema_columns_required_missing: string[];
-      /** Per-required-table sync status for this integration */
-      required_tables: RequiredTableStatus[];
-      /** URL to the Marketing analytics global settings page */
-      settings_url: string;
-      /**
-         * URL to the per-source Schemas tab, or null if not connected
-         * @nullable
-         */
-      schemas_url: string | null;
-      /** Human-readable diagnosis of this source's health */
-      diagnosis: string;
-      /**
-         * Suggested fix when the source is unhealthy
-         * @nullable
-         */
-      fix_suggestion: string | null;
-    }
-
-    export interface DataSourceHealthResponse {
-      /** One health entry per native integration */
-      integrations: DataSourceHealthEntry[];
-      /** True if any integration synced rows in the last 7 days */
-      has_any_data: boolean;
-      /** Overall: healthy/degraded/broken/no_sources */
-      overall_status: string;
-      /** Short human-readable summary of detected issues */
-      issues_summary: string[];
     }
 
     export interface DataWarehouseModelPath {
@@ -12920,10 +12524,10 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-     * * `Modified` - Modified
-     * * `Completed` - Completed
-     * * `Failed` - Failed
-     * * `Running` - Running
+    * `Modified` - Modified
+    * `Completed` - Completed
+    * `Failed` - Failed
+    * `Running` - Running
      */
     export type SavedQueryStatusEnum = typeof SavedQueryStatusEnum[keyof typeof SavedQueryStatusEnum];
 
@@ -12938,8 +12542,8 @@ export namespace Schemas {
 
     /**
      * * `data_warehouse` - Data Warehouse
-     * * `endpoint` - Endpoint
-     * * `managed_viewset` - Managed Viewset
+    * `endpoint` - Endpoint
+    * `managed_viewset` - Managed Viewset
      */
     export type OriginEnum = typeof OriginEnum[keyof typeof OriginEnum];
 
@@ -12952,8 +12556,8 @@ export namespace Schemas {
 
     /**
      * Shared methods for DataWarehouseSavedQuery serializers.
-     *
-     * This mixin is intended to be used with serializers.ModelSerializer subclasses.
+
+    This mixin is intended to be used with serializers.ModelSerializer subclasses.
      */
     export interface DataWarehouseSavedQuery {
       readonly id: string;
@@ -12972,12 +12576,12 @@ export namespace Schemas {
       readonly sync_frequency: string | null;
       readonly columns: readonly DataWarehouseSavedQueryColumnsItem[];
       /** The status of when this SavedQuery last ran.
-       *
-       * * `Cancelled` - Cancelled
-       * * `Modified` - Modified
-       * * `Completed` - Completed
-       * * `Failed` - Failed
-       * * `Running` - Running */
+
+      * `Cancelled` - Cancelled
+      * `Modified` - Modified
+      * `Completed` - Completed
+      * `Failed` - Failed
+      * `Running` - Running */
       readonly status: SavedQueryStatusEnum | null;
       /** @nullable */
       readonly last_run_at: string | null;
@@ -13015,10 +12619,10 @@ export namespace Schemas {
       /** @nullable */
       readonly is_materialized: boolean | null;
       /** Where this SavedQuery is created.
-       *
-       * * `data_warehouse` - Data Warehouse
-       * * `endpoint` - Endpoint
-       * * `managed_viewset` - Managed Viewset */
+
+      * `data_warehouse` - Data Warehouse
+      * `endpoint` - Endpoint
+      * `managed_viewset` - Managed Viewset */
       readonly origin: OriginEnum | null;
       /** Whether this view is for testing only and will auto-expire. */
       is_test?: boolean;
@@ -13089,12 +12693,12 @@ export namespace Schemas {
       readonly sync_frequency: string | null;
       readonly columns: readonly DataWarehouseSavedQueryMinimalColumnsItem[];
       /** The status of when this SavedQuery last ran.
-       *
-       * * `Cancelled` - Cancelled
-       * * `Modified` - Modified
-       * * `Completed` - Completed
-       * * `Failed` - Failed
-       * * `Running` - Running */
+
+      * `Cancelled` - Cancelled
+      * `Modified` - Modified
+      * `Completed` - Completed
+      * `Failed` - Failed
+      * `Running` - Running */
       readonly status: SavedQueryStatusEnum | null;
       /** @nullable */
       readonly last_run_at: string | null;
@@ -13109,10 +12713,10 @@ export namespace Schemas {
       /** @nullable */
       readonly is_materialized: boolean | null;
       /** Where this SavedQuery is created.
-       *
-       * * `data_warehouse` - Data Warehouse
-       * * `endpoint` - Endpoint
-       * * `managed_viewset` - Managed Viewset */
+
+      * `data_warehouse` - Data Warehouse
+      * `endpoint` - Endpoint
+      * `managed_viewset` - Managed Viewset */
       readonly origin: OriginEnum | null;
       /** Whether this view is for testing only and will auto-expire. */
       readonly is_test: boolean;
@@ -13386,238 +12990,153 @@ export namespace Schemas {
 
     /**
      * * `Ashby` - Ashby
-     * * `Supabase` - Supabase
-     * * `CustomerIO` - CustomerIO
-     * * `Github` - Github
-     * * `Stripe` - Stripe
-     * * `Hubspot` - Hubspot
-     * * `Postgres` - Postgres
-     * * `Zendesk` - Zendesk
-     * * `Snowflake` - Snowflake
-     * * `Salesforce` - Salesforce
-     * * `MySQL` - MySQL
-     * * `MongoDB` - MongoDB
-     * * `MSSQL` - MSSQL
-     * * `Vitally` - Vitally
-     * * `BigQuery` - BigQuery
-     * * `Chargebee` - Chargebee
-     * * `Clerk` - Clerk
-     * * `GoogleAds` - GoogleAds
-     * * `GoogleSearchConsole` - GoogleSearchConsole
-     * * `TemporalIO` - TemporalIO
-     * * `DoIt` - DoIt
-     * * `GoogleSheets` - GoogleSheets
-     * * `MetaAds` - MetaAds
-     * * `Klaviyo` - Klaviyo
-     * * `Mailchimp` - Mailchimp
-     * * `Braze` - Braze
-     * * `Mailjet` - Mailjet
-     * * `Redshift` - Redshift
-     * * `Polar` - Polar
-     * * `RevenueCat` - RevenueCat
-     * * `LinkedinAds` - LinkedinAds
-     * * `RedditAds` - RedditAds
-     * * `TikTokAds` - TikTokAds
-     * * `BingAds` - BingAds
-     * * `Shopify` - Shopify
-     * * `Attio` - Attio
-     * * `SnapchatAds` - SnapchatAds
-     * * `Linear` - Linear
-     * * `Intercom` - Intercom
-     * * `Amplitude` - Amplitude
-     * * `Mixpanel` - Mixpanel
-     * * `Jira` - Jira
-     * * `ActiveCampaign` - ActiveCampaign
-     * * `Marketo` - Marketo
-     * * `Adjust` - Adjust
-     * * `AppsFlyer` - AppsFlyer
-     * * `Freshdesk` - Freshdesk
-     * * `GoogleAnalytics` - GoogleAnalytics
-     * * `Pipedrive` - Pipedrive
-     * * `SendGrid` - SendGrid
-     * * `Slack` - Slack
-     * * `PagerDuty` - PagerDuty
-     * * `Asana` - Asana
-     * * `Notion` - Notion
-     * * `Airtable` - Airtable
-     * * `Greenhouse` - Greenhouse
-     * * `BambooHR` - BambooHR
-     * * `Lever` - Lever
-     * * `GitLab` - GitLab
-     * * `Datadog` - Datadog
-     * * `Sentry` - Sentry
-     * * `Pendo` - Pendo
-     * * `FullStory` - FullStory
-     * * `AmazonAds` - AmazonAds
-     * * `PinterestAds` - PinterestAds
-     * * `AppleSearchAds` - AppleSearchAds
-     * * `QuickBooks` - QuickBooks
-     * * `Xero` - Xero
-     * * `NetSuite` - NetSuite
-     * * `WooCommerce` - WooCommerce
-     * * `BigCommerce` - BigCommerce
-     * * `PayPal` - PayPal
-     * * `Square` - Square
-     * * `Zoom` - Zoom
-     * * `Trello` - Trello
-     * * `Monday` - Monday
-     * * `ClickUp` - ClickUp
-     * * `Confluence` - Confluence
-     * * `Recurly` - Recurly
-     * * `SalesLoft` - SalesLoft
-     * * `Outreach` - Outreach
-     * * `Gong` - Gong
-     * * `Calendly` - Calendly
-     * * `Typeform` - Typeform
-     * * `Iterable` - Iterable
-     * * `ZohoCRM` - ZohoCRM
-     * * `Close` - Close
-     * * `Oracle` - Oracle
-     * * `DynamoDB` - DynamoDB
-     * * `Elasticsearch` - Elasticsearch
-     * * `Kafka` - Kafka
-     * * `LaunchDarkly` - LaunchDarkly
-     * * `Braintree` - Braintree
-     * * `Recharge` - Recharge
-     * * `HelpScout` - HelpScout
-     * * `Gorgias` - Gorgias
-     * * `Instagram` - Instagram
-     * * `YouTubeAnalytics` - YouTubeAnalytics
-     * * `FacebookPages` - FacebookPages
-     * * `TwitterAds` - TwitterAds
-     * * `Workday` - Workday
-     * * `ServiceNow` - ServiceNow
-     * * `Pardot` - Pardot
-     * * `Copper` - Copper
-     * * `Front` - Front
-     * * `ChartMogul` - ChartMogul
-     * * `Zuora` - Zuora
-     * * `Paddle` - Paddle
-     * * `CircleCI` - CircleCI
-     * * `CockroachDB` - CockroachDB
-     * * `Firebase` - Firebase
-     * * `AzureBlob` - AzureBlob
-     * * `GoogleDrive` - GoogleDrive
-     * * `OneDrive` - OneDrive
-     * * `SharePoint` - SharePoint
-     * * `Box` - Box
-     * * `SFTP` - SFTP
-     * * `MicrosoftTeams` - MicrosoftTeams
-     * * `Aircall` - Aircall
-     * * `Webflow` - Webflow
-     * * `Okta` - Okta
-     * * `Auth0` - Auth0
-     * * `Productboard` - Productboard
-     * * `Smartsheet` - Smartsheet
-     * * `Wrike` - Wrike
-     * * `Plaid` - Plaid
-     * * `SurveyMonkey` - SurveyMonkey
-     * * `Eventbrite` - Eventbrite
-     * * `RingCentral` - RingCentral
-     * * `Twilio` - Twilio
-     * * `Freshsales` - Freshsales
-     * * `Shortcut` - Shortcut
-     * * `ConvertKit` - ConvertKit
-     * * `Drip` - Drip
-     * * `CampaignMonitor` - CampaignMonitor
-     * * `MailerLite` - MailerLite
-     * * `Omnisend` - Omnisend
-     * * `Brevo` - Brevo
-     * * `Postmark` - Postmark
-     * * `Granola` - Granola
-     * * `BuildBetter` - BuildBetter
-     * * `Convex` - Convex
-     * * `ClickHouse` - ClickHouse
-     * * `Plain` - Plain
-     * * `Resend` - Resend
-     * * `PgAnalyze` - PgAnalyze
-     * * `WorkOS` - WorkOS
-     * * `AmazonS3` - AmazonS3
-     * * `GoogleCloudStorage` - GoogleCloudStorage
-     * * `Databricks` - Databricks
-     * * `Dynamics365` - Dynamics365
-     * * `SalesforceMarketingCloud` - SalesforceMarketingCloud
-     * * `Db2` - Db2
-     * * `Heap` - Heap
-     * * `AdobeAnalytics` - AdobeAnalytics
-     * * `Matomo` - Matomo
-     * * `Optimizely` - Optimizely
-     * * `Adyen` - Adyen
-     * * `GoCardless` - GoCardless
-     * * `Mollie` - Mollie
-     * * `CheckoutCom` - CheckoutCom
-     * * `Branch` - Branch
-     * * `Criteo` - Criteo
-     * * `Outbrain` - Outbrain
-     * * `Taboola` - Taboola
-     * * `AdRoll` - AdRoll
-     * * `DisplayVideo360` - DisplayVideo360
-     * * `GoogleAdManager` - GoogleAdManager
-     * * `CampaignManager360` - CampaignManager360
-     * * `SearchAds360` - SearchAds360
-     * * `AdobeCommerce` - AdobeCommerce
-     * * `AmazonSellingPartner` - AmazonSellingPartner
-     * * `Ebay` - Ebay
-     * * `Commercetools` - Commercetools
-     * * `LightspeedRetail` - LightspeedRetail
-     * * `ShipStation` - ShipStation
-     * * `ConstantContact` - ConstantContact
-     * * `Mailgun` - Mailgun
-     * * `Eloqua` - Eloqua
-     * * `Sailthru` - Sailthru
-     * * `Ortto` - Ortto
-     * * `Attentive` - Attentive
-     * * `Kustomer` - Kustomer
-     * * `Dixa` - Dixa
-     * * `Gladly` - Gladly
-     * * `Qualtrics` - Qualtrics
-     * * `Delighted` - Delighted
-     * * `AzureDevOps` - AzureDevOps
-     * * `Rollbar` - Rollbar
-     * * `Opsgenie` - Opsgenie
-     * * `IncidentIo` - IncidentIo
-     * * `Pingdom` - Pingdom
-     * * `Cloudflare` - Cloudflare
-     * * `CosmosDB` - CosmosDB
-     * * `PlanetScale` - PlanetScale
-     * * `SapHana` - SapHana
-     * * `Rippling` - Rippling
-     * * `HiBob` - HiBob
-     * * `Personio` - Personio
-     * * `Deel` - Deel
-     * * `AdpWorkforceNow` - AdpWorkforceNow
-     * * `Paylocity` - Paylocity
-     * * `Gusto` - Gusto
-     * * `CultureAmp` - CultureAmp
-     * * `Lattice` - Lattice
-     * * `SageIntacct` - SageIntacct
-     * * `FreshBooks` - FreshBooks
-     * * `Expensify` - Expensify
-     * * `Ramp` - Ramp
-     * * `Brex` - Brex
-     * * `Coupa` - Coupa
-     * * `SapConcur` - SapConcur
-     * * `Apollo` - Apollo
-     * * `Crunchbase` - Crunchbase
-     * * `ZoomInfo` - ZoomInfo
-     * * `Clari` - Clari
-     * * `Chorus` - Chorus
-     * * `Coda` - Coda
-     * * `Guru` - Guru
-     * * `Dropbox` - Dropbox
-     * * `Docusign` - Docusign
-     * * `PandaDoc` - PandaDoc
-     * * `SapErp` - SapErp
-     * * `SapSuccessFactors` - SapSuccessFactors
-     * * `OracleEbs` - OracleEbs
-     * * `OracleFusion` - OracleFusion
-     * * `AmazonSNS` - AmazonSNS
-     * * `AmazonEventBridge` - AmazonEventBridge
-     * * `AmazonSQS` - AmazonSQS
-     * * `AmazonKinesis` - AmazonKinesis
-     * * `AmazonCloudWatch` - AmazonCloudWatch
-     * * `OpenAIAds` - OpenAIAds
-     * * `Custom` - Custom
+    * `Supabase` - Supabase
+    * `CustomerIO` - CustomerIO
+    * `Github` - Github
+    * `Stripe` - Stripe
+    * `Hubspot` - Hubspot
+    * `Postgres` - Postgres
+    * `Zendesk` - Zendesk
+    * `Snowflake` - Snowflake
+    * `Salesforce` - Salesforce
+    * `MySQL` - MySQL
+    * `MongoDB` - MongoDB
+    * `MSSQL` - MSSQL
+    * `Vitally` - Vitally
+    * `BigQuery` - BigQuery
+    * `Chargebee` - Chargebee
+    * `Clerk` - Clerk
+    * `GoogleAds` - GoogleAds
+    * `GoogleSearchConsole` - GoogleSearchConsole
+    * `TemporalIO` - TemporalIO
+    * `DoIt` - DoIt
+    * `GoogleSheets` - GoogleSheets
+    * `MetaAds` - MetaAds
+    * `Klaviyo` - Klaviyo
+    * `Mailchimp` - Mailchimp
+    * `Braze` - Braze
+    * `Mailjet` - Mailjet
+    * `Redshift` - Redshift
+    * `Polar` - Polar
+    * `RevenueCat` - RevenueCat
+    * `LinkedinAds` - LinkedinAds
+    * `RedditAds` - RedditAds
+    * `TikTokAds` - TikTokAds
+    * `BingAds` - BingAds
+    * `Shopify` - Shopify
+    * `Attio` - Attio
+    * `SnapchatAds` - SnapchatAds
+    * `Linear` - Linear
+    * `Intercom` - Intercom
+    * `Amplitude` - Amplitude
+    * `Mixpanel` - Mixpanel
+    * `Jira` - Jira
+    * `ActiveCampaign` - ActiveCampaign
+    * `Marketo` - Marketo
+    * `Adjust` - Adjust
+    * `AppsFlyer` - AppsFlyer
+    * `Freshdesk` - Freshdesk
+    * `GoogleAnalytics` - GoogleAnalytics
+    * `Pipedrive` - Pipedrive
+    * `SendGrid` - SendGrid
+    * `Slack` - Slack
+    * `PagerDuty` - PagerDuty
+    * `Asana` - Asana
+    * `Notion` - Notion
+    * `Airtable` - Airtable
+    * `Greenhouse` - Greenhouse
+    * `BambooHR` - BambooHR
+    * `Lever` - Lever
+    * `GitLab` - GitLab
+    * `Datadog` - Datadog
+    * `Sentry` - Sentry
+    * `Pendo` - Pendo
+    * `FullStory` - FullStory
+    * `AmazonAds` - AmazonAds
+    * `PinterestAds` - PinterestAds
+    * `AppleSearchAds` - AppleSearchAds
+    * `QuickBooks` - QuickBooks
+    * `Xero` - Xero
+    * `NetSuite` - NetSuite
+    * `WooCommerce` - WooCommerce
+    * `BigCommerce` - BigCommerce
+    * `PayPal` - PayPal
+    * `Square` - Square
+    * `Zoom` - Zoom
+    * `Trello` - Trello
+    * `Monday` - Monday
+    * `ClickUp` - ClickUp
+    * `Confluence` - Confluence
+    * `Recurly` - Recurly
+    * `SalesLoft` - SalesLoft
+    * `Outreach` - Outreach
+    * `Gong` - Gong
+    * `Calendly` - Calendly
+    * `Typeform` - Typeform
+    * `Iterable` - Iterable
+    * `ZohoCRM` - ZohoCRM
+    * `Close` - Close
+    * `Oracle` - Oracle
+    * `DynamoDB` - DynamoDB
+    * `Elasticsearch` - Elasticsearch
+    * `Kafka` - Kafka
+    * `LaunchDarkly` - LaunchDarkly
+    * `Braintree` - Braintree
+    * `Recharge` - Recharge
+    * `HelpScout` - HelpScout
+    * `Gorgias` - Gorgias
+    * `Instagram` - Instagram
+    * `YouTubeAnalytics` - YouTubeAnalytics
+    * `FacebookPages` - FacebookPages
+    * `TwitterAds` - TwitterAds
+    * `Workday` - Workday
+    * `ServiceNow` - ServiceNow
+    * `Pardot` - Pardot
+    * `Copper` - Copper
+    * `Front` - Front
+    * `ChartMogul` - ChartMogul
+    * `Zuora` - Zuora
+    * `Paddle` - Paddle
+    * `CircleCI` - CircleCI
+    * `CockroachDB` - CockroachDB
+    * `Firebase` - Firebase
+    * `AzureBlob` - AzureBlob
+    * `GoogleDrive` - GoogleDrive
+    * `OneDrive` - OneDrive
+    * `SharePoint` - SharePoint
+    * `Box` - Box
+    * `SFTP` - SFTP
+    * `MicrosoftTeams` - MicrosoftTeams
+    * `Aircall` - Aircall
+    * `Webflow` - Webflow
+    * `Okta` - Okta
+    * `Auth0` - Auth0
+    * `Productboard` - Productboard
+    * `Smartsheet` - Smartsheet
+    * `Wrike` - Wrike
+    * `Plaid` - Plaid
+    * `SurveyMonkey` - SurveyMonkey
+    * `Eventbrite` - Eventbrite
+    * `RingCentral` - RingCentral
+    * `Twilio` - Twilio
+    * `Freshsales` - Freshsales
+    * `Shortcut` - Shortcut
+    * `ConvertKit` - ConvertKit
+    * `Drip` - Drip
+    * `CampaignMonitor` - CampaignMonitor
+    * `MailerLite` - MailerLite
+    * `Omnisend` - Omnisend
+    * `Brevo` - Brevo
+    * `Postmark` - Postmark
+    * `Granola` - Granola
+    * `BuildBetter` - BuildBetter
+    * `Convex` - Convex
+    * `ClickHouse` - ClickHouse
+    * `Plain` - Plain
+    * `Resend` - Resend
+    * `PgAnalyze` - PgAnalyze
+    * `WorkOS` - WorkOS
+    * `Custom` - Custom
      */
     export type ExternalDataSourceTypeEnum = typeof ExternalDataSourceTypeEnum[keyof typeof ExternalDataSourceTypeEnum];
 
@@ -13770,337 +13289,167 @@ export namespace Schemas {
       Resend: 'Resend',
       PgAnalyze: 'PgAnalyze',
       WorkOS: 'WorkOS',
-      AmazonS3: 'AmazonS3',
-      GoogleCloudStorage: 'GoogleCloudStorage',
-      Databricks: 'Databricks',
-      Dynamics365: 'Dynamics365',
-      SalesforceMarketingCloud: 'SalesforceMarketingCloud',
-      Db2: 'Db2',
-      Heap: 'Heap',
-      AdobeAnalytics: 'AdobeAnalytics',
-      Matomo: 'Matomo',
-      Optimizely: 'Optimizely',
-      Adyen: 'Adyen',
-      GoCardless: 'GoCardless',
-      Mollie: 'Mollie',
-      CheckoutCom: 'CheckoutCom',
-      Branch: 'Branch',
-      Criteo: 'Criteo',
-      Outbrain: 'Outbrain',
-      Taboola: 'Taboola',
-      AdRoll: 'AdRoll',
-      DisplayVideo360: 'DisplayVideo360',
-      GoogleAdManager: 'GoogleAdManager',
-      CampaignManager360: 'CampaignManager360',
-      SearchAds360: 'SearchAds360',
-      AdobeCommerce: 'AdobeCommerce',
-      AmazonSellingPartner: 'AmazonSellingPartner',
-      Ebay: 'Ebay',
-      Commercetools: 'Commercetools',
-      LightspeedRetail: 'LightspeedRetail',
-      ShipStation: 'ShipStation',
-      ConstantContact: 'ConstantContact',
-      Mailgun: 'Mailgun',
-      Eloqua: 'Eloqua',
-      Sailthru: 'Sailthru',
-      Ortto: 'Ortto',
-      Attentive: 'Attentive',
-      Kustomer: 'Kustomer',
-      Dixa: 'Dixa',
-      Gladly: 'Gladly',
-      Qualtrics: 'Qualtrics',
-      Delighted: 'Delighted',
-      AzureDevOps: 'AzureDevOps',
-      Rollbar: 'Rollbar',
-      Opsgenie: 'Opsgenie',
-      IncidentIo: 'IncidentIo',
-      Pingdom: 'Pingdom',
-      Cloudflare: 'Cloudflare',
-      CosmosDB: 'CosmosDB',
-      PlanetScale: 'PlanetScale',
-      SapHana: 'SapHana',
-      Rippling: 'Rippling',
-      HiBob: 'HiBob',
-      Personio: 'Personio',
-      Deel: 'Deel',
-      AdpWorkforceNow: 'AdpWorkforceNow',
-      Paylocity: 'Paylocity',
-      Gusto: 'Gusto',
-      CultureAmp: 'CultureAmp',
-      Lattice: 'Lattice',
-      SageIntacct: 'SageIntacct',
-      FreshBooks: 'FreshBooks',
-      Expensify: 'Expensify',
-      Ramp: 'Ramp',
-      Brex: 'Brex',
-      Coupa: 'Coupa',
-      SapConcur: 'SapConcur',
-      Apollo: 'Apollo',
-      Crunchbase: 'Crunchbase',
-      ZoomInfo: 'ZoomInfo',
-      Clari: 'Clari',
-      Chorus: 'Chorus',
-      Coda: 'Coda',
-      Guru: 'Guru',
-      Dropbox: 'Dropbox',
-      Docusign: 'Docusign',
-      PandaDoc: 'PandaDoc',
-      SapErp: 'SapErp',
-      SapSuccessFactors: 'SapSuccessFactors',
-      OracleEbs: 'OracleEbs',
-      OracleFusion: 'OracleFusion',
-      AmazonSNS: 'AmazonSNS',
-      AmazonEventBridge: 'AmazonEventBridge',
-      AmazonSQS: 'AmazonSQS',
-      AmazonKinesis: 'AmazonKinesis',
-      AmazonCloudWatch: 'AmazonCloudWatch',
-      OpenAIAds: 'OpenAIAds',
       Custom: 'Custom',
     } as const;
 
     /**
      * Validate credentials and preview available tables from a remote database.
-     *
-     * The request body contains source_type plus flat source-specific credential fields
-     * (e.g. host, port, database, user, password, schema for Postgres). The credential
-     * fields vary per source_type and are validated dynamically by the source registry.
+
+    The request body contains source_type plus flat source-specific credential fields
+    (e.g. host, port, database, user, password, schema for Postgres). The credential
+    fields vary per source_type and are validated dynamically by the source registry.
      */
     export interface DatabaseSchemaRequest {
       /** The source type to validate against.
-       *
-       * * `Ashby` - Ashby
-       * * `Supabase` - Supabase
-       * * `CustomerIO` - CustomerIO
-       * * `Github` - Github
-       * * `Stripe` - Stripe
-       * * `Hubspot` - Hubspot
-       * * `Postgres` - Postgres
-       * * `Zendesk` - Zendesk
-       * * `Snowflake` - Snowflake
-       * * `Salesforce` - Salesforce
-       * * `MySQL` - MySQL
-       * * `MongoDB` - MongoDB
-       * * `MSSQL` - MSSQL
-       * * `Vitally` - Vitally
-       * * `BigQuery` - BigQuery
-       * * `Chargebee` - Chargebee
-       * * `Clerk` - Clerk
-       * * `GoogleAds` - GoogleAds
-       * * `GoogleSearchConsole` - GoogleSearchConsole
-       * * `TemporalIO` - TemporalIO
-       * * `DoIt` - DoIt
-       * * `GoogleSheets` - GoogleSheets
-       * * `MetaAds` - MetaAds
-       * * `Klaviyo` - Klaviyo
-       * * `Mailchimp` - Mailchimp
-       * * `Braze` - Braze
-       * * `Mailjet` - Mailjet
-       * * `Redshift` - Redshift
-       * * `Polar` - Polar
-       * * `RevenueCat` - RevenueCat
-       * * `LinkedinAds` - LinkedinAds
-       * * `RedditAds` - RedditAds
-       * * `TikTokAds` - TikTokAds
-       * * `BingAds` - BingAds
-       * * `Shopify` - Shopify
-       * * `Attio` - Attio
-       * * `SnapchatAds` - SnapchatAds
-       * * `Linear` - Linear
-       * * `Intercom` - Intercom
-       * * `Amplitude` - Amplitude
-       * * `Mixpanel` - Mixpanel
-       * * `Jira` - Jira
-       * * `ActiveCampaign` - ActiveCampaign
-       * * `Marketo` - Marketo
-       * * `Adjust` - Adjust
-       * * `AppsFlyer` - AppsFlyer
-       * * `Freshdesk` - Freshdesk
-       * * `GoogleAnalytics` - GoogleAnalytics
-       * * `Pipedrive` - Pipedrive
-       * * `SendGrid` - SendGrid
-       * * `Slack` - Slack
-       * * `PagerDuty` - PagerDuty
-       * * `Asana` - Asana
-       * * `Notion` - Notion
-       * * `Airtable` - Airtable
-       * * `Greenhouse` - Greenhouse
-       * * `BambooHR` - BambooHR
-       * * `Lever` - Lever
-       * * `GitLab` - GitLab
-       * * `Datadog` - Datadog
-       * * `Sentry` - Sentry
-       * * `Pendo` - Pendo
-       * * `FullStory` - FullStory
-       * * `AmazonAds` - AmazonAds
-       * * `PinterestAds` - PinterestAds
-       * * `AppleSearchAds` - AppleSearchAds
-       * * `QuickBooks` - QuickBooks
-       * * `Xero` - Xero
-       * * `NetSuite` - NetSuite
-       * * `WooCommerce` - WooCommerce
-       * * `BigCommerce` - BigCommerce
-       * * `PayPal` - PayPal
-       * * `Square` - Square
-       * * `Zoom` - Zoom
-       * * `Trello` - Trello
-       * * `Monday` - Monday
-       * * `ClickUp` - ClickUp
-       * * `Confluence` - Confluence
-       * * `Recurly` - Recurly
-       * * `SalesLoft` - SalesLoft
-       * * `Outreach` - Outreach
-       * * `Gong` - Gong
-       * * `Calendly` - Calendly
-       * * `Typeform` - Typeform
-       * * `Iterable` - Iterable
-       * * `ZohoCRM` - ZohoCRM
-       * * `Close` - Close
-       * * `Oracle` - Oracle
-       * * `DynamoDB` - DynamoDB
-       * * `Elasticsearch` - Elasticsearch
-       * * `Kafka` - Kafka
-       * * `LaunchDarkly` - LaunchDarkly
-       * * `Braintree` - Braintree
-       * * `Recharge` - Recharge
-       * * `HelpScout` - HelpScout
-       * * `Gorgias` - Gorgias
-       * * `Instagram` - Instagram
-       * * `YouTubeAnalytics` - YouTubeAnalytics
-       * * `FacebookPages` - FacebookPages
-       * * `TwitterAds` - TwitterAds
-       * * `Workday` - Workday
-       * * `ServiceNow` - ServiceNow
-       * * `Pardot` - Pardot
-       * * `Copper` - Copper
-       * * `Front` - Front
-       * * `ChartMogul` - ChartMogul
-       * * `Zuora` - Zuora
-       * * `Paddle` - Paddle
-       * * `CircleCI` - CircleCI
-       * * `CockroachDB` - CockroachDB
-       * * `Firebase` - Firebase
-       * * `AzureBlob` - AzureBlob
-       * * `GoogleDrive` - GoogleDrive
-       * * `OneDrive` - OneDrive
-       * * `SharePoint` - SharePoint
-       * * `Box` - Box
-       * * `SFTP` - SFTP
-       * * `MicrosoftTeams` - MicrosoftTeams
-       * * `Aircall` - Aircall
-       * * `Webflow` - Webflow
-       * * `Okta` - Okta
-       * * `Auth0` - Auth0
-       * * `Productboard` - Productboard
-       * * `Smartsheet` - Smartsheet
-       * * `Wrike` - Wrike
-       * * `Plaid` - Plaid
-       * * `SurveyMonkey` - SurveyMonkey
-       * * `Eventbrite` - Eventbrite
-       * * `RingCentral` - RingCentral
-       * * `Twilio` - Twilio
-       * * `Freshsales` - Freshsales
-       * * `Shortcut` - Shortcut
-       * * `ConvertKit` - ConvertKit
-       * * `Drip` - Drip
-       * * `CampaignMonitor` - CampaignMonitor
-       * * `MailerLite` - MailerLite
-       * * `Omnisend` - Omnisend
-       * * `Brevo` - Brevo
-       * * `Postmark` - Postmark
-       * * `Granola` - Granola
-       * * `BuildBetter` - BuildBetter
-       * * `Convex` - Convex
-       * * `ClickHouse` - ClickHouse
-       * * `Plain` - Plain
-       * * `Resend` - Resend
-       * * `PgAnalyze` - PgAnalyze
-       * * `WorkOS` - WorkOS
-       * * `AmazonS3` - AmazonS3
-       * * `GoogleCloudStorage` - GoogleCloudStorage
-       * * `Databricks` - Databricks
-       * * `Dynamics365` - Dynamics365
-       * * `SalesforceMarketingCloud` - SalesforceMarketingCloud
-       * * `Db2` - Db2
-       * * `Heap` - Heap
-       * * `AdobeAnalytics` - AdobeAnalytics
-       * * `Matomo` - Matomo
-       * * `Optimizely` - Optimizely
-       * * `Adyen` - Adyen
-       * * `GoCardless` - GoCardless
-       * * `Mollie` - Mollie
-       * * `CheckoutCom` - CheckoutCom
-       * * `Branch` - Branch
-       * * `Criteo` - Criteo
-       * * `Outbrain` - Outbrain
-       * * `Taboola` - Taboola
-       * * `AdRoll` - AdRoll
-       * * `DisplayVideo360` - DisplayVideo360
-       * * `GoogleAdManager` - GoogleAdManager
-       * * `CampaignManager360` - CampaignManager360
-       * * `SearchAds360` - SearchAds360
-       * * `AdobeCommerce` - AdobeCommerce
-       * * `AmazonSellingPartner` - AmazonSellingPartner
-       * * `Ebay` - Ebay
-       * * `Commercetools` - Commercetools
-       * * `LightspeedRetail` - LightspeedRetail
-       * * `ShipStation` - ShipStation
-       * * `ConstantContact` - ConstantContact
-       * * `Mailgun` - Mailgun
-       * * `Eloqua` - Eloqua
-       * * `Sailthru` - Sailthru
-       * * `Ortto` - Ortto
-       * * `Attentive` - Attentive
-       * * `Kustomer` - Kustomer
-       * * `Dixa` - Dixa
-       * * `Gladly` - Gladly
-       * * `Qualtrics` - Qualtrics
-       * * `Delighted` - Delighted
-       * * `AzureDevOps` - AzureDevOps
-       * * `Rollbar` - Rollbar
-       * * `Opsgenie` - Opsgenie
-       * * `IncidentIo` - IncidentIo
-       * * `Pingdom` - Pingdom
-       * * `Cloudflare` - Cloudflare
-       * * `CosmosDB` - CosmosDB
-       * * `PlanetScale` - PlanetScale
-       * * `SapHana` - SapHana
-       * * `Rippling` - Rippling
-       * * `HiBob` - HiBob
-       * * `Personio` - Personio
-       * * `Deel` - Deel
-       * * `AdpWorkforceNow` - AdpWorkforceNow
-       * * `Paylocity` - Paylocity
-       * * `Gusto` - Gusto
-       * * `CultureAmp` - CultureAmp
-       * * `Lattice` - Lattice
-       * * `SageIntacct` - SageIntacct
-       * * `FreshBooks` - FreshBooks
-       * * `Expensify` - Expensify
-       * * `Ramp` - Ramp
-       * * `Brex` - Brex
-       * * `Coupa` - Coupa
-       * * `SapConcur` - SapConcur
-       * * `Apollo` - Apollo
-       * * `Crunchbase` - Crunchbase
-       * * `ZoomInfo` - ZoomInfo
-       * * `Clari` - Clari
-       * * `Chorus` - Chorus
-       * * `Coda` - Coda
-       * * `Guru` - Guru
-       * * `Dropbox` - Dropbox
-       * * `Docusign` - Docusign
-       * * `PandaDoc` - PandaDoc
-       * * `SapErp` - SapErp
-       * * `SapSuccessFactors` - SapSuccessFactors
-       * * `OracleEbs` - OracleEbs
-       * * `OracleFusion` - OracleFusion
-       * * `AmazonSNS` - AmazonSNS
-       * * `AmazonEventBridge` - AmazonEventBridge
-       * * `AmazonSQS` - AmazonSQS
-       * * `AmazonKinesis` - AmazonKinesis
-       * * `AmazonCloudWatch` - AmazonCloudWatch
-       * * `OpenAIAds` - OpenAIAds
-       * * `Custom` - Custom */
+
+      * `Ashby` - Ashby
+      * `Supabase` - Supabase
+      * `CustomerIO` - CustomerIO
+      * `Github` - Github
+      * `Stripe` - Stripe
+      * `Hubspot` - Hubspot
+      * `Postgres` - Postgres
+      * `Zendesk` - Zendesk
+      * `Snowflake` - Snowflake
+      * `Salesforce` - Salesforce
+      * `MySQL` - MySQL
+      * `MongoDB` - MongoDB
+      * `MSSQL` - MSSQL
+      * `Vitally` - Vitally
+      * `BigQuery` - BigQuery
+      * `Chargebee` - Chargebee
+      * `Clerk` - Clerk
+      * `GoogleAds` - GoogleAds
+      * `GoogleSearchConsole` - GoogleSearchConsole
+      * `TemporalIO` - TemporalIO
+      * `DoIt` - DoIt
+      * `GoogleSheets` - GoogleSheets
+      * `MetaAds` - MetaAds
+      * `Klaviyo` - Klaviyo
+      * `Mailchimp` - Mailchimp
+      * `Braze` - Braze
+      * `Mailjet` - Mailjet
+      * `Redshift` - Redshift
+      * `Polar` - Polar
+      * `RevenueCat` - RevenueCat
+      * `LinkedinAds` - LinkedinAds
+      * `RedditAds` - RedditAds
+      * `TikTokAds` - TikTokAds
+      * `BingAds` - BingAds
+      * `Shopify` - Shopify
+      * `Attio` - Attio
+      * `SnapchatAds` - SnapchatAds
+      * `Linear` - Linear
+      * `Intercom` - Intercom
+      * `Amplitude` - Amplitude
+      * `Mixpanel` - Mixpanel
+      * `Jira` - Jira
+      * `ActiveCampaign` - ActiveCampaign
+      * `Marketo` - Marketo
+      * `Adjust` - Adjust
+      * `AppsFlyer` - AppsFlyer
+      * `Freshdesk` - Freshdesk
+      * `GoogleAnalytics` - GoogleAnalytics
+      * `Pipedrive` - Pipedrive
+      * `SendGrid` - SendGrid
+      * `Slack` - Slack
+      * `PagerDuty` - PagerDuty
+      * `Asana` - Asana
+      * `Notion` - Notion
+      * `Airtable` - Airtable
+      * `Greenhouse` - Greenhouse
+      * `BambooHR` - BambooHR
+      * `Lever` - Lever
+      * `GitLab` - GitLab
+      * `Datadog` - Datadog
+      * `Sentry` - Sentry
+      * `Pendo` - Pendo
+      * `FullStory` - FullStory
+      * `AmazonAds` - AmazonAds
+      * `PinterestAds` - PinterestAds
+      * `AppleSearchAds` - AppleSearchAds
+      * `QuickBooks` - QuickBooks
+      * `Xero` - Xero
+      * `NetSuite` - NetSuite
+      * `WooCommerce` - WooCommerce
+      * `BigCommerce` - BigCommerce
+      * `PayPal` - PayPal
+      * `Square` - Square
+      * `Zoom` - Zoom
+      * `Trello` - Trello
+      * `Monday` - Monday
+      * `ClickUp` - ClickUp
+      * `Confluence` - Confluence
+      * `Recurly` - Recurly
+      * `SalesLoft` - SalesLoft
+      * `Outreach` - Outreach
+      * `Gong` - Gong
+      * `Calendly` - Calendly
+      * `Typeform` - Typeform
+      * `Iterable` - Iterable
+      * `ZohoCRM` - ZohoCRM
+      * `Close` - Close
+      * `Oracle` - Oracle
+      * `DynamoDB` - DynamoDB
+      * `Elasticsearch` - Elasticsearch
+      * `Kafka` - Kafka
+      * `LaunchDarkly` - LaunchDarkly
+      * `Braintree` - Braintree
+      * `Recharge` - Recharge
+      * `HelpScout` - HelpScout
+      * `Gorgias` - Gorgias
+      * `Instagram` - Instagram
+      * `YouTubeAnalytics` - YouTubeAnalytics
+      * `FacebookPages` - FacebookPages
+      * `TwitterAds` - TwitterAds
+      * `Workday` - Workday
+      * `ServiceNow` - ServiceNow
+      * `Pardot` - Pardot
+      * `Copper` - Copper
+      * `Front` - Front
+      * `ChartMogul` - ChartMogul
+      * `Zuora` - Zuora
+      * `Paddle` - Paddle
+      * `CircleCI` - CircleCI
+      * `CockroachDB` - CockroachDB
+      * `Firebase` - Firebase
+      * `AzureBlob` - AzureBlob
+      * `GoogleDrive` - GoogleDrive
+      * `OneDrive` - OneDrive
+      * `SharePoint` - SharePoint
+      * `Box` - Box
+      * `SFTP` - SFTP
+      * `MicrosoftTeams` - MicrosoftTeams
+      * `Aircall` - Aircall
+      * `Webflow` - Webflow
+      * `Okta` - Okta
+      * `Auth0` - Auth0
+      * `Productboard` - Productboard
+      * `Smartsheet` - Smartsheet
+      * `Wrike` - Wrike
+      * `Plaid` - Plaid
+      * `SurveyMonkey` - SurveyMonkey
+      * `Eventbrite` - Eventbrite
+      * `RingCentral` - RingCentral
+      * `Twilio` - Twilio
+      * `Freshsales` - Freshsales
+      * `Shortcut` - Shortcut
+      * `ConvertKit` - ConvertKit
+      * `Drip` - Drip
+      * `CampaignMonitor` - CampaignMonitor
+      * `MailerLite` - MailerLite
+      * `Omnisend` - Omnisend
+      * `Brevo` - Brevo
+      * `Postmark` - Postmark
+      * `Granola` - Granola
+      * `BuildBetter` - BuildBetter
+      * `Convex` - Convex
+      * `ClickHouse` - ClickHouse
+      * `Plain` - Plain
+      * `Resend` - Resend
+      * `PgAnalyze` - PgAnalyze
+      * `WorkOS` - WorkOS
+      * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
     }
 
@@ -14164,7 +13513,7 @@ export namespace Schemas {
 
     /**
      * * `bayesian` - Bayesian
-     * * `frequentist` - Frequentist
+    * `frequentist` - Frequentist
      */
     export type DefaultExperimentStatsMethodEnum = typeof DefaultExperimentStatsMethodEnum[keyof typeof DefaultExperimentStatsMethodEnum];
 
@@ -14181,9 +13530,9 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-     * * `delivered` - Delivered
-     * * `partial_failure` - Partial Failure
-     * * `failed` - Failed
+    * `delivered` - Delivered
+    * `partial_failure` - Partial Failure
+    * `failed` - Failed
      */
     export type DeliveryStatusEnum = typeof DeliveryStatusEnum[keyof typeof DeliveryStatusEnum];
 
@@ -14211,7 +13560,7 @@ export namespace Schemas {
 
     /**
      * * `html` - html
-     * * `text` - text
+    * `text` - text
      */
     export type DescriptionContentTypeEnum = typeof DescriptionContentTypeEnum[keyof typeof DescriptionContentTypeEnum];
 
@@ -14284,8 +13633,8 @@ export namespace Schemas {
 
     /**
      * * `Desktop` - Desktop
-     * * `Mobile` - Mobile
-     * * `Tablet` - Tablet
+    * `Mobile` - Mobile
+    * `Tablet` - Tablet
      */
     export type DeviceTypesEnum = typeof DeviceTypesEnum[keyof typeof DeviceTypesEnum];
 
@@ -14298,9 +13647,9 @@ export namespace Schemas {
 
     /**
      * * `passed` - passed
-     * * `warned` - warned
-     * * `failed` - failed
-     * * `skipped` - skipped
+    * `warned` - warned
+    * `failed` - failed
+    * `skipped` - skipped
      */
     export type DiagnosticCheckResultStatusEnum = typeof DiagnosticCheckResultStatusEnum[keyof typeof DiagnosticCheckResultStatusEnum];
 
@@ -14314,9 +13663,9 @@ export namespace Schemas {
 
     /**
      * * `dns` - dns
-     * * `config` - config
-     * * `wait` - wait
-     * * `retry` - retry
+    * `config` - config
+    * `wait` - wait
+    * `retry` - retry
      */
     export type DiagnosticRemediationTypeEnum = typeof DiagnosticRemediationTypeEnum[keyof typeof DiagnosticRemediationTypeEnum];
 
@@ -14339,11 +13688,11 @@ export namespace Schemas {
 
     export interface DiagnosticRemediation {
       /** Category of fix. dns: customer must change DNS records. config: customer must adjust their server config (e.g. allow port 80). wait: no action — the system will resolve on its own. retry: hit Retry.
-       *
-       * * `dns` - dns
-       * * `config` - config
-       * * `wait` - wait
-       * * `retry` - retry */
+
+      * `dns` - dns
+      * `config` - config
+      * `wait` - wait
+      * `retry` - retry */
       type: DiagnosticRemediationTypeEnum;
       /** One-line, action-oriented summary of what to do. */
       summary: string;
@@ -14357,11 +13706,11 @@ export namespace Schemas {
       /** Human-readable check name. */
       name: string;
       /** passed: ok. warned: degraded but not blocking. failed: blocking. skipped: not run for this state.
-       *
-       * * `passed` - passed
-       * * `warned` - warned
-       * * `failed` - failed
-       * * `skipped` - skipped */
+
+      * `passed` - passed
+      * `warned` - warned
+      * `failed` - failed
+      * `skipped` - skipped */
       status: DiagnosticCheckResultStatusEnum;
       /** Customer-facing explanation of the check's outcome. */
       detail: string;
@@ -14371,8 +13720,8 @@ export namespace Schemas {
 
     /**
      * * `healthy` - healthy
-     * * `warn` - warn
-     * * `fail` - fail
+    * `warn` - warn
+    * `fail` - fail
      */
     export type DiagnosticReportSummaryStatusEnum = typeof DiagnosticReportSummaryStatusEnum[keyof typeof DiagnosticReportSummaryStatusEnum];
 
@@ -14385,10 +13734,10 @@ export namespace Schemas {
 
     export interface DiagnosticReportSummary {
       /** Overall outcome: healthy if the proxy is serving requests, warn for non-blocking issues, fail otherwise.
-       *
-       * * `healthy` - healthy
-       * * `warn` - warn
-       * * `fail` - fail */
+
+      * `healthy` - healthy
+      * `warn` - warn
+      * `fail` - fail */
       status: DiagnosticReportSummaryStatusEnum;
       /**
          * Check id of the most actionable failure, if any. Null when status is healthy.
@@ -14413,7 +13762,7 @@ export namespace Schemas {
 
     /**
      * * `Up` - Up
-     * * `Down` - Down
+    * `Down` - Down
      */
     export type DirectionEnum = typeof DirectionEnum[keyof typeof DirectionEnum];
 
@@ -14542,9 +13891,9 @@ export namespace Schemas {
       /** Absolute percentage change, rounded to nearest integer. */
       percent: number;
       /** Direction of the change relative to the prior period.
-       *
-       * * `Up` - Up
-       * * `Down` - Down */
+
+      * `Up` - Up
+      * `Down` - Down */
       direction: DirectionEnum;
       /** Hex color indicating whether the change is a positive or negative signal. */
       color: string;
@@ -14591,26 +13940,26 @@ export namespace Schemas {
          */
       version?: number | null;
       /** Specifies where this feature flag should be evaluated
-       *
-       * * `server` - Server
-       * * `client` - Client
-       * * `all` - All */
+
+      * `server` - Server
+      * `client` - Client
+      * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum | BlankEnum | null;
       /** Identifier used for bucketing users into rollout and variants
-       *
-       * * `distinct_id` - User ID (default)
-       * * `device_id` - Device ID */
+
+      * `distinct_id` - User ID (default)
+      * `device_id` - Device ID */
       bucketing_identifier?: BucketingIdentifierEnum | BlankEnum | null;
       readonly evaluation_contexts: readonly string[];
     }
 
     /**
      * * `draft` - draft
-     * * `concept` - concept
-     * * `alpha` - alpha
-     * * `beta` - beta
-     * * `general-availability` - general availability
-     * * `archived` - archived
+    * `concept` - concept
+    * `alpha` - alpha
+    * `beta` - beta
+    * `general-availability` - general availability
+    * `archived` - archived
      */
     export type StageEnum = typeof StageEnum[keyof typeof StageEnum];
 
@@ -14635,13 +13984,13 @@ export namespace Schemas {
       /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
       description?: string;
       /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-       *
-       * * `draft` - draft
-       * * `concept` - concept
-       * * `alpha` - alpha
-       * * `beta` - beta
-       * * `general-availability` - general availability
-       * * `archived` - archived */
+
+      * `draft` - draft
+      * `concept` - concept
+      * `alpha` - alpha
+      * `beta` - beta
+      * `general-availability` - general availability
+      * `archived` - archived */
       stage: StageEnum;
       /**
          * URL to external documentation for this feature. Shown to users in the opt-in UI.
@@ -14663,13 +14012,13 @@ export namespace Schemas {
       /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
       description?: string;
       /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-       *
-       * * `draft` - draft
-       * * `concept` - concept
-       * * `alpha` - alpha
-       * * `beta` - beta
-       * * `general-availability` - general availability
-       * * `archived` - archived */
+
+      * `draft` - draft
+      * `concept` - concept
+      * `alpha` - alpha
+      * `beta` - beta
+      * `general-availability` - general availability
+      * `archived` - archived */
       stage: StageEnum;
       /**
          * URL to external documentation for this feature. Shown to users in the opt-in UI.
@@ -14717,10 +14066,7 @@ export namespace Schemas {
          * @nullable
          */
       tag_name?: string | null;
-      /**
-         * @nullable
-         * @items.maxLength 200
-         */
+      /** @nullable */
       attr_class?: string[] | null;
       /**
          * @maxLength 10000
@@ -14767,53 +14113,11 @@ export namespace Schemas {
       text?: string | null;
     }
 
-    /**
-     * Highest htmlID suffix per element type, e.g. {"u_row": 1, "u_content_text": 2}.
-     */
-    export type EmailTemplateDesignCounters = { [key: string]: unknown };
-
-    export type EmailTemplateDesignBodyRowsItem = { [key: string]: unknown };
-
-    export type EmailTemplateDesignBodyHeadersItem = { [key: string]: unknown };
-
-    export type EmailTemplateDesignBodyFootersItem = { [key: string]: unknown };
-
-    /**
-     * Body-level settings: backgroundColor, contentWidth ('600px'), fontFamily, textColor.
-     */
-    export type EmailTemplateDesignBodyValues = { [key: string]: unknown };
-
-    export type EmailTemplateDesignBody = {
-      /** Any unique string. */
-      id?: string;
-      /** Rows of {id, cells, columns[{id, contents[{id, type, values}], values}], values}. */
-      rows: EmailTemplateDesignBodyRowsItem[];
-      headers?: EmailTemplateDesignBodyHeadersItem[];
-      footers?: EmailTemplateDesignBodyFootersItem[];
-      /** Body-level settings: backgroundColor, contentWidth ('600px'), fontFamily, textColor. */
-      values?: EmailTemplateDesignBodyValues;
-    };
-
-    /**
-     * Design JSON for PostHog's visual email editor — the authoring surface and source of truth. The server renders the sent email from it, and it opens as editable blocks in the editor. Full schema in the designing-email-templates skill.
-     */
-    export type EmailTemplateDesign = {
-      /** Highest htmlID suffix per element type, e.g. {"u_row": 1, "u_content_text": 2}. */
-      counters?: EmailTemplateDesignCounters;
-      /** Design schema version, e.g. 16. */
-      schemaVersion: number;
-      body: EmailTemplateDesignBody;
-    };
-
     export interface EmailTemplate {
-      /** Email subject line. Supports Liquid templating. Required for email-type templates. */
       subject?: string;
-      /** Plain-text fallback body for clients that can't render the email. */
       text?: string;
-      /** Rendered email body — derived from the design at save time. The visual editor's save path supplies it directly; omit it otherwise. */
       html?: string;
-      /** Design JSON for PostHog's visual email editor — the authoring surface and source of truth. The server renders the sent email from it, and it opens as editable blocks in the editor. Full schema in the designing-email-templates skill. */
-      design?: EmailTemplateDesign;
+      design?: unknown;
     }
 
     export type EmbeddingStatusEnum = typeof EmbeddingStatusEnum[keyof typeof EmbeddingStatusEnum];
@@ -14873,21 +14177,15 @@ export namespace Schemas {
          */
       hypothesis?: string | null;
       /** Optional severity tag — one of P0, P1, P2, P3, P4. Informational only.
-       *
-       * * `P0` - P0
-       * * `P1` - P1
-       * * `P2` - P2
-       * * `P3` - P3
-       * * `P4` - P4 */
+
+      * `P0` - P0
+      * `P1` - P1
+      * `P2` - P2
+      * `P3` - P3
+      * `P4` - P4 */
       severity?: AutonomyPriorityEnum | null;
       /** Optional keys for downstream dedupe (e.g. `error_tracking_issue:<id>`). */
       dedupe_keys?: string[];
-      /**
-         * Optional category tags as lowercase kebab-case slugs (e.g. `cost-spike`, `silent-failure`), max 10. Reuse the vocabulary in your `tags:<domain>:taxonomy` scratchpad entry when a tag fits; coin a new slug when a genuinely new category emerges. Near-miss formats are normalized to slugs; persisted in the signal's `extra.tags` and on the emission row.
-         * @maxItems 10
-         * @items.maxLength 50
-         */
-      tags?: string[];
       /** Optional time window the finding refers to. */
       time_range?: TimeRange | null;
       /**
@@ -14917,12 +14215,12 @@ export namespace Schemas {
 
     export interface EndExperiment {
       /** The conclusion of the experiment.
-       *
-       * * `won` - won
-       * * `lost` - lost
-       * * `inconclusive` - inconclusive
-       * * `stopped_early` - stopped_early
-       * * `invalid` - invalid */
+
+      * `won` - won
+      * `lost` - lost
+      * `inconclusive` - inconclusive
+      * `stopped_early` - stopped_early
+      * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Optional comment about the experiment conclusion.
@@ -15126,14 +14424,14 @@ export namespace Schemas {
 
     /**
      * Variables to parameterize the endpoint query. The key is the variable name and the value is the variable value.
-     *
-     * For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
-     *
-     * For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
-     *
-     * For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
-     *
-     * Unknown variable names will return a 400 error.
+
+    For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
+
+    For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
+
+    For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
+
+    Unknown variable names will return a 400 error.
      */
     export type EndpointRunRequestVariables = { [key: string]: unknown } | null;
 
@@ -15149,14 +14447,14 @@ export namespace Schemas {
       offset?: number | null;
       refresh?: EndpointRefreshMode | null;
       /** Variables to parameterize the endpoint query. The key is the variable name and the value is the variable value.
-       *
-       * For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
-       *
-       * For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
-       *
-       * For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
-       *
-       * Unknown variable names will return a 400 error. */
+
+      For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
+
+      For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
+
+      For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
+
+      Unknown variable names will return a 400 error. */
       variables?: EndpointRunRequestVariables;
       /** Specific endpoint version to execute. If not provided, the latest version is used. */
       version?: number | null;
@@ -15168,8 +14466,6 @@ export namespace Schemas {
     export interface EndpointRunResponse {
       /** URL-safe endpoint name that was executed. */
       name: string;
-      /** Unique identifier for this execution. Use it to find the matching entry in the endpoint's logs. */
-      execution_id?: string;
       /** Query result rows. Each row is a list of values matching the columns order. */
       results?: unknown[];
       /** Column names from the query SELECT clause. */
@@ -15388,7 +14684,7 @@ export namespace Schemas {
 
     /**
      * * `allow` - Allow
-     * * `reject` - Reject
+    * `reject` - Reject
      */
     export type EnforcementModeEnum = typeof EnforcementModeEnum[keyof typeof EnforcementModeEnum];
 
@@ -15400,7 +14696,7 @@ export namespace Schemas {
 
     /**
      * * `duckdb` - duckdb
-     * * `postgres` - postgres
+    * `postgres` - postgres
      */
     export type EngineEnum = typeof EngineEnum[keyof typeof EngineEnum];
 
@@ -15412,8 +14708,8 @@ export namespace Schemas {
 
     /**
      * * `open` - OPEN
-     * * `closed` - CLOSED
-     * * `merged` - MERGED
+    * `closed` - CLOSED
+    * `merged` - MERGED
      */
     export type EngineeringAnalyticsPRStateEnum = typeof EngineeringAnalyticsPRStateEnum[keyof typeof EngineeringAnalyticsPRStateEnum];
 
@@ -15468,10 +14764,10 @@ export namespace Schemas {
 
     /**
      * * `DateTime` - DateTime
-     * * `String` - String
-     * * `Numeric` - Numeric
-     * * `Boolean` - Boolean
-     * * `Duration` - Duration
+    * `String` - String
+    * `Numeric` - Numeric
+    * `Boolean` - Boolean
+    * `Duration` - Duration
      */
     export type PropertyDefinitionTypeEnum = typeof PropertyDefinitionTypeEnum[keyof typeof PropertyDefinitionTypeEnum];
 
@@ -15535,16 +14831,6 @@ export namespace Schemas {
       volume_buckets?: ErrorTrackingVolumeBucket[];
     }
 
-    export interface ErrorTrackingAssignee {
-      /** User ID or role UUID to filter by. */
-      id: string | number | null;
-      /** Assignee target type: user or role.
-       *
-       * * `user` - user
-       * * `role` - role */
-      type: AssigneeTypeEnum;
-    }
-
     export interface ErrorTrackingAssigneeResponse {
       /** Assignee user ID or role UUID. */
       id?: string | number | null;
@@ -15580,9 +14866,9 @@ export namespace Schemas {
 
     export interface ErrorTrackingAssignmentRuleAssigneeRequest {
       /** Assignee type. Use `user` for a user ID or `role` for a role UUID.
-       *
-       * * `user` - user
-       * * `role` - role */
+
+      * `user` - user
+      * `role` - role */
       type: AssigneeTypeEnum;
       /** User ID when `type` is `user`, or role UUID when `type` is `role`. */
       id: number | string;
@@ -15730,9 +15016,9 @@ export namespace Schemas {
 
     export interface ErrorTrackingGroupingRuleAssigneeRequest {
       /** Assignee type. Use `user` for a user ID or `role` for a role UUID.
-       *
-       * * `user` - user
-       * * `role` - role */
+
+      * `user` - user
+      * `role` - role */
       type: AssigneeTypeEnum;
       /** User ID when `type` is `user`, or role UUID when `type` is `role`. */
       id: number | string;
@@ -15857,22 +15143,22 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-     * * `is_not` - is_not
-     * * `icontains` - icontains
-     * * `not_icontains` - not_icontains
-     * * `regex` - regex
-     * * `not_regex` - not_regex
-     * * `gt` - gt
-     * * `lt` - lt
-     * * `gte` - gte
-     * * `lte` - lte
-     * * `is_set` - is_set
-     * * `is_not_set` - is_not_set
-     * * `is_date_exact` - is_date_exact
-     * * `is_date_after` - is_date_after
-     * * `is_date_before` - is_date_before
-     * * `in` - in
-     * * `not_in` - not_in
+    * `is_not` - is_not
+    * `icontains` - icontains
+    * `not_icontains` - not_icontains
+    * `regex` - regex
+    * `not_regex` - not_regex
+    * `gt` - gt
+    * `lt` - lt
+    * `gte` - gte
+    * `lte` - lte
+    * `is_set` - is_set
+    * `is_not_set` - is_not_set
+    * `is_date_exact` - is_date_exact
+    * `is_date_after` - is_date_after
+    * `is_date_before` - is_date_before
+    * `in` - in
+    * `not_in` - not_in
      */
     export type PropertyItemOperatorEnum = typeof PropertyItemOperatorEnum[keyof typeof PropertyItemOperatorEnum];
 
@@ -15908,21 +15194,9 @@ export namespace Schemas {
     }
 
     /**
-     * * `ASC` - ASC
-     * * `DESC` - DESC
-     */
-    export type OrderDirectionEnum = typeof OrderDirectionEnum[keyof typeof OrderDirectionEnum];
-
-
-    export const OrderDirectionEnum = {
-      Asc: 'ASC',
-      Desc: 'DESC',
-    } as const;
-
-    /**
      * * `summary` - summary
-     * * `stack` - stack
-     * * `raw` - raw
+    * `stack` - stack
+    * `raw` - raw
      */
     export type VerbosityEnum = typeof VerbosityEnum[keyof typeof VerbosityEnum];
 
@@ -15948,9 +15222,9 @@ export namespace Schemas {
          */
       searchQuery?: string;
       /** Timestamp sort direction. Defaults to DESC.
-       *
-       * * `ASC` - ASC
-       * * `DESC` - DESC */
+
+      * `ASC` - ASC
+      * `DESC` - DESC */
       orderDirection?: OrderDirectionEnum;
       /**
          * Page size.
@@ -15964,10 +15238,10 @@ export namespace Schemas {
          */
       offset?: number;
       /** Controls exception detail size: summary, stack, or raw. Defaults to summary.
-       *
-       * * `summary` - summary
-       * * `stack` - stack
-       * * `raw` - raw */
+
+      * `summary` - summary
+      * `stack` - stack
+      * `raw` - raw */
       verbosity?: VerbosityEnum;
       /** When true, include only stack frames marked in_app. Defaults to true. */
       onlyAppFrames?: boolean;
@@ -15996,10 +15270,10 @@ export namespace Schemas {
 
     /**
      * * `archived` - Archived
-     * * `active` - Active
-     * * `resolved` - Resolved
-     * * `pending_release` - Pending release
-     * * `suppressed` - Suppressed
+    * `active` - Active
+    * `resolved` - Resolved
+    * `pending_release` - Pending release
+    * `suppressed` - Suppressed
      */
     export type ErrorTrackingIssueFullStatusEnum = typeof ErrorTrackingIssueFullStatusEnum[keyof typeof ErrorTrackingIssueFullStatusEnum];
 
@@ -16077,24 +15351,6 @@ export namespace Schemas {
       success: boolean;
     }
 
-    /**
-     * * `last_seen` - last_seen
-     * * `first_seen` - first_seen
-     * * `occurrences` - occurrences
-     * * `users` - users
-     * * `sessions` - sessions
-     */
-    export type ErrorTrackingIssueOrderByEnum = typeof ErrorTrackingIssueOrderByEnum[keyof typeof ErrorTrackingIssueOrderByEnum];
-
-
-    export const ErrorTrackingIssueOrderByEnum = {
-      LastSeen: 'last_seen',
-      FirstSeen: 'first_seen',
-      Occurrences: 'occurrences',
-      Users: 'users',
-      Sessions: 'sessions',
-    } as const;
-
     export interface ErrorTrackingIssueQueryRequest {
       /** Error tracking issue ID. */
       issueId: string;
@@ -16133,70 +15389,17 @@ export namespace Schemas {
       new_issue_ids: string[];
     }
 
-    /**
-     * * `archived` - archived
-     * * `active` - active
-     * * `resolved` - resolved
-     * * `pending_release` - pending_release
-     * * `suppressed` - suppressed
-     * * `all` - all
-     */
-    export type ErrorTrackingIssueStatusEnum = typeof ErrorTrackingIssueStatusEnum[keyof typeof ErrorTrackingIssueStatusEnum];
-
-
-    export const ErrorTrackingIssueStatusEnum = {
-      Archived: 'archived',
-      Active: 'active',
-      Resolved: 'resolved',
-      PendingRelease: 'pending_release',
-      Suppressed: 'suppressed',
-      All: 'all',
-    } as const;
-
-    /**
-     * * `active` - active
-     * * `resolved` - resolved
-     * * `suppressed` - suppressed
-     */
-    export type ErrorTrackingIssueWriteStatusEnum = typeof ErrorTrackingIssueWriteStatusEnum[keyof typeof ErrorTrackingIssueWriteStatusEnum];
-
-
-    export const ErrorTrackingIssueWriteStatusEnum = {
-      Active: 'active',
-      Resolved: 'resolved',
-      Suppressed: 'suppressed',
-    } as const;
-
-    export interface ErrorTrackingIssueWrite {
-      /** Issue status to set. Deprecated archived and pending_release values are rejected.
-       *
-       * * `active` - active
-       * * `resolved` - resolved
-       * * `suppressed` - suppressed */
-      status?: ErrorTrackingIssueWriteStatusEnum;
-      /**
-         * Optional issue display name.
-         * @nullable
-         */
-      name?: string | null;
-      /**
-         * Optional issue description.
-         * @nullable
-         */
-      description?: string | null;
-    }
-
     export interface ErrorTrackingIssuesListQueryRequest {
       /** Date range for issue aggregates. Defaults to the last 7 days. */
       dateRange?: ErrorTrackingDateRange;
       /** Filter by issue status. Defaults to active.
-       *
-       * * `archived` - archived
-       * * `active` - active
-       * * `resolved` - resolved
-       * * `pending_release` - pending_release
-       * * `suppressed` - suppressed
-       * * `all` - all */
+
+      * `archived` - archived
+      * `active` - active
+      * `resolved` - resolved
+      * `pending_release` - pending_release
+      * `suppressed` - suppressed
+      * `all` - all */
       status?: ErrorTrackingIssueStatusEnum;
       /** Filter by issue assignee. Omit to include all assignees. */
       assignee?: ErrorTrackingAssignee | null;
@@ -16210,17 +15413,17 @@ export namespace Schemas {
       /** Advanced flat AND property filters. Prefer typed shortcut fields when they fit. HogQL filters are rejected. */
       filterGroup?: PropertyItem[];
       /** Field used to sort issues. Defaults to occurrences.
-       *
-       * * `last_seen` - last_seen
-       * * `first_seen` - first_seen
-       * * `occurrences` - occurrences
-       * * `users` - users
-       * * `sessions` - sessions */
+
+      * `last_seen` - last_seen
+      * `first_seen` - first_seen
+      * `occurrences` - occurrences
+      * `users` - users
+      * `sessions` - sessions */
       orderBy?: ErrorTrackingIssueOrderByEnum;
       /** Sort direction. Defaults to DESC.
-       *
-       * * `ASC` - ASC
-       * * `DESC` - DESC */
+
+      * `ASC` - ASC
+      * `DESC` - DESC */
       orderDirection?: OrderDirectionEnum;
       /**
          * Page size.
@@ -16280,32 +15483,13 @@ export namespace Schemas {
       nextOffset?: number;
     }
 
-    export type ErrorTrackingListWidgetCatalogEntryOpenApiWidgetType = typeof ErrorTrackingListWidgetCatalogEntryOpenApiWidgetType[keyof typeof ErrorTrackingListWidgetCatalogEntryOpenApiWidgetType];
-
-
-    export const ErrorTrackingListWidgetCatalogEntryOpenApiWidgetType = {
-      ErrorTrackingList: 'error_tracking_list',
-    } as const;
-
-    export interface ErrorTrackingListWidgetCatalogEntryOpenApi {
-      widget_type: ErrorTrackingListWidgetCatalogEntryOpenApiWidgetType;
-      group_id: string;
-      group_label: string;
-      label: string;
-      description: string;
-      /** OpenAPI config shape for this widget type (documentation; matches batch-add/PATCH schemas). */
-      readonly config_schema: ErrorTrackingListWidgetConfig;
-      /** @nullable */
-      required_product_access?: string | null;
-    }
-
     /**
      * * `error_tracking_list` - error_tracking_list
      */
-    export type ErrorTrackingListWidgetTypeEnum = typeof ErrorTrackingListWidgetTypeEnum[keyof typeof ErrorTrackingListWidgetTypeEnum];
+    export type ErrorTrackingListWidgetAddRequestOpenApiWidgetTypeEnum = typeof ErrorTrackingListWidgetAddRequestOpenApiWidgetTypeEnum[keyof typeof ErrorTrackingListWidgetAddRequestOpenApiWidgetTypeEnum];
 
 
-    export const ErrorTrackingListWidgetTypeEnum = {
+    export const ErrorTrackingListWidgetAddRequestOpenApiWidgetTypeEnum = {
       ErrorTrackingList: 'error_tracking_list',
     } as const;
 
@@ -16316,7 +15500,7 @@ export namespace Schemas {
 
     /**
      * * `ready` - Ready
-     * * `computing` - Computing
+    * `computing` - Computing
      */
     export type ErrorTrackingRecommendationStatusEnum = typeof ErrorTrackingRecommendationStatusEnum[keyof typeof ErrorTrackingRecommendationStatusEnum];
 
@@ -16336,9 +15520,9 @@ export namespace Schemas {
       /** Whether the recommendation's recommended action has been satisfied. */
       readonly completed: boolean;
       /** 'ready' if meta is fresh, 'computing' if a refresh is in progress.
-       *
-       * * `ready` - Ready
-       * * `computing` - Computing */
+
+      * `ready` - Ready
+      * `computing` - Computing */
       readonly status: ErrorTrackingRecommendationStatusEnum;
       /**
          * Timestamp meta was last successfully computed.
@@ -16665,8 +15849,8 @@ export namespace Schemas {
 
     /**
      * * `active` - Active
-     * * `paused` - Paused
-     * * `error` - Error
+    * `paused` - Paused
+    * `error` - Error
      */
     export type EvaluationStatusEnum = typeof EvaluationStatusEnum[keyof typeof EvaluationStatusEnum];
 
@@ -16679,8 +15863,8 @@ export namespace Schemas {
 
     /**
      * * `trial_limit_reached` - Trial evaluation limit reached
-     * * `model_not_allowed` - Model not available on the trial plan
-     * * `provider_key_deleted` - Provider API key was deleted
+    * `model_not_allowed` - Model not available on the trial plan
+    * `provider_key_deleted` - Provider API key was deleted
      */
     export type StatusReasonEnum = typeof StatusReasonEnum[keyof typeof StatusReasonEnum];
 
@@ -16693,7 +15877,7 @@ export namespace Schemas {
 
     /**
      * * `llm_judge` - LLM as a judge
-     * * `hog` - Hog
+    * `hog` - Hog
      */
     export type EvaluationTypeEnum = typeof EvaluationTypeEnum[keyof typeof EvaluationTypeEnum];
 
@@ -16736,12 +15920,12 @@ export namespace Schemas {
 
     /**
      * * `openai` - Openai
-     * * `anthropic` - Anthropic
-     * * `gemini` - Gemini
-     * * `openrouter` - Openrouter
-     * * `fireworks` - Fireworks
-     * * `azure_openai` - Azure OpenAI
-     * * `together_ai` - Together AI
+    * `anthropic` - Anthropic
+    * `gemini` - Gemini
+    * `openrouter` - Openrouter
+    * `fireworks` - Fireworks
+    * `azure_openai` - Azure OpenAI
+    * `together_ai` - Together AI
      */
     export type LLMProviderEnum = typeof LLMProviderEnum[keyof typeof LLMProviderEnum];
 
@@ -16783,15 +15967,15 @@ export namespace Schemas {
       readonly status: EvaluationStatusEnum;
       readonly status_reason: StatusReasonEnum | null;
       /** 'llm_judge' uses an LLM to score outputs against a prompt; 'hog' runs deterministic Hog code.
-       *
-       * * `llm_judge` - LLM as a judge
-       * * `hog` - Hog */
+
+      * `llm_judge` - LLM as a judge
+      * `hog` - Hog */
       evaluation_type: EvaluationTypeEnum;
       /** Configuration dict. For 'llm_judge': {prompt}. For 'hog': {source}. */
       evaluation_config?: EvaluationEvaluationConfig;
       /** Output format. Currently only 'boolean' is supported.
-       *
-       * * `boolean` - Boolean (Pass/Fail) */
+
+      * `boolean` - Boolean (Pass/Fail) */
       output_type: OutputTypeEnum;
       /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
       output_config?: EvaluationOutputConfig;
@@ -16807,9 +15991,9 @@ export namespace Schemas {
 
     /**
      * * `unknown` - Unknown
-     * * `ok` - Ok
-     * * `invalid` - Invalid
-     * * `error` - Error
+    * `ok` - Ok
+    * `invalid` - Invalid
+    * `error` - Error
      */
     export type LLMProviderKeyStateEnum = typeof LLMProviderKeyStateEnum[keyof typeof LLMProviderKeyStateEnum];
 
@@ -16884,7 +16068,7 @@ export namespace Schemas {
 
     /**
      * * `scheduled` - Scheduled
-     * * `every_n` - Every N
+    * `every_n` - Every N
      */
     export type EvaluationReportFrequencyEnum = typeof EvaluationReportFrequencyEnum[keyof typeof EvaluationReportFrequencyEnum];
 
@@ -16899,9 +16083,9 @@ export namespace Schemas {
       /** UUID of the evaluation this report config belongs to. */
       evaluation: string;
       /** How report generation is triggered. 'every_n' fires once N new evaluation results have accumulated (subject to cooldown_minutes and daily_run_cap). 'scheduled' fires on the cadence defined by rrule + starts_at + timezone_name.
-       *
-       * * `scheduled` - Scheduled
-       * * `every_n` - Every N */
+
+      * `scheduled` - Scheduled
+      * `every_n` - Every N */
       frequency?: EvaluationReportFrequencyEnum;
       /** RFC 5545 recurrence rule string (e.g. 'FREQ=WEEKLY;BYDAY=MO'). Must not contain DTSTART — the anchor is set via starts_at. Required when frequency is 'scheduled'; ignored otherwise. */
       rrule?: string;
@@ -16971,11 +16155,11 @@ export namespace Schemas {
       /** End of the evaluation window covered by this report. */
       readonly period_end: string;
       /** 'pending', 'delivered', or 'failed'.
-       *
-       * * `pending` - Pending
-       * * `delivered` - Delivered
-       * * `partial_failure` - Partial Failure
-       * * `failed` - Failed */
+
+      * `pending` - Pending
+      * `delivered` - Delivered
+      * `partial_failure` - Partial Failure
+      * `failed` - Failed */
       readonly delivery_status: DeliveryStatusEnum;
       /** List of delivery error messages if delivery failed. */
       readonly delivery_errors: unknown;
@@ -17000,9 +16184,9 @@ export namespace Schemas {
 
     /**
      * * `all` - all
-     * * `pass` - pass
-     * * `fail` - fail
-     * * `na` - na
+    * `pass` - pass
+    * `fail` - fail
+    * `na` - na
      */
     export type FilterEnum = typeof FilterEnum[keyof typeof FilterEnum];
 
@@ -17021,11 +16205,11 @@ export namespace Schemas {
       /** UUID of the evaluation config to summarize */
       evaluation_id: string;
       /** Filter type to apply ('all', 'pass', 'fail', or 'na')
-       *
-       * * `all` - all
-       * * `pass` - pass
-       * * `fail` - fail
-       * * `na` - na */
+
+      * `all` - all
+      * `pass` - pass
+      * `fail` - fail
+      * `na` - na */
       filter?: FilterEnum;
       /**
          * Optional: specific generation IDs to include in summary (max 250)
@@ -17087,8 +16271,8 @@ export namespace Schemas {
 
     /**
      * * `disabled` - Disabled
-     * * `dry_run` - Dry Run
-     * * `live` - Live
+    * `dry_run` - Dry Run
+    * `live` - Live
      */
     export type EventFilterConfigModeEnum = typeof EventFilterConfigModeEnum[keyof typeof EventFilterConfigModeEnum];
 
@@ -17112,10 +16296,10 @@ export namespace Schemas {
 
     /**
      * * `DateTime` - DateTime
-     * * `String` - String
-     * * `Numeric` - Numeric
-     * * `Boolean` - Boolean
-     * * `Object` - Object
+    * `String` - String
+    * `Numeric` - Numeric
+    * `Boolean` - Boolean
+    * `Object` - Object
      */
     export type SchemaPropertyGroupPropertyPropertyTypeEnum = typeof SchemaPropertyGroupPropertyPropertyTypeEnum[keyof typeof SchemaPropertyGroupPropertyPropertyTypeEnum];
 
@@ -17159,15 +16343,6 @@ export namespace Schemas {
       property_group_id: string;
       readonly created_at: string;
       readonly updated_at: string;
-    }
-
-    export interface EventSuggestionsResponse {
-      /** Ranked candidate events for conversion goals */
-      candidates: CandidateEvent[];
-      /** Lookback window in days used for the analysis */
-      lookback_days: number;
-      /** Number of system/autocaptured events excluded */
-      excluded_events_count: number;
     }
 
     export interface EventTaxonomyItem {
@@ -17243,9 +16418,9 @@ export namespace Schemas {
 
     /**
      * * `$ai_generation` - $ai_generation
-     * * `$ai_span` - $ai_span
-     * * `$ai_embedding` - $ai_embedding
-     * * `$ai_trace` - $ai_trace
+    * `$ai_span` - $ai_span
+    * `$ai_embedding` - $ai_embedding
+    * `$ai_trace` - $ai_trace
      */
     export type EventTypeEnum = typeof EventTypeEnum[keyof typeof EventTypeEnum];
 
@@ -17314,9 +16489,9 @@ export namespace Schemas {
 
     /**
      * * `exit_on_conversion` - Conversion
-     * * `exit_on_trigger_not_matched` - Trigger Not Matched
-     * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
-     * * `exit_only_at_end` - Only At End
+    * `exit_on_trigger_not_matched` - Trigger Not Matched
+    * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+    * `exit_only_at_end` - Only At End
      */
     export type ExitConditionEnum = typeof ExitConditionEnum[keyof typeof ExitConditionEnum];
 
@@ -17376,7 +16551,7 @@ export namespace Schemas {
 
     /**
      * * `web` - web
-     * * `product` - product
+    * `product` - product
      */
     export type ExperimentTypeEnum = typeof ExperimentTypeEnum[keyof typeof ExperimentTypeEnum];
 
@@ -17520,7 +16695,7 @@ export namespace Schemas {
       start_date?: string | null;
       /** @nullable */
       end_date?: string | null;
-      /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flag-get-all tool first — reuse an existing flag when possible. */
+      /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flags-get-all tool first — reuse an existing flag when possible. */
       feature_flag_key: string;
       readonly feature_flag: MinimalFeatureFlag;
       readonly holdout: ExperimentHoldout;
@@ -17549,13 +16724,13 @@ export namespace Schemas {
       readonly created_at: string;
       readonly updated_at: string;
       /** Experiment type: web for frontend UI changes, product for backend/API changes.
-       *
-       * * `web` - web
-       * * `product` - product */
+
+      * `web` - web
+      * `product` - product */
       type?: ExperimentTypeEnum | null;
       /** Exposure configuration including filter test accounts and custom exposure events. */
       exposure_criteria?: ExperimentApiExposureCriteria | null;
-      /** Primary experiment metrics. Each metric must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Use the read-data-schema tool with query kind 'events' to find available events in the project. */
+      /** Primary experiment metrics. Each metric must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Use the event-definitions-list tool to find available events in the project. */
       metrics?: _ExperimentApiMetricsList | null;
       /** Secondary metrics for additional measurements. Same format as primary metrics. */
       metrics_secondary?: _ExperimentApiMetricsList | null;
@@ -17565,12 +16740,12 @@ export namespace Schemas {
       allow_unknown_events?: boolean;
       _create_in_folder?: string;
       /** Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.
-       *
-       * * `won` - won
-       * * `lost` - lost
-       * * `inconclusive` - inconclusive
-       * * `stopped_early` - stopped_early
-       * * `invalid` - invalid */
+
+      * `won` - won
+      * `lost` - lost
+      * `inconclusive` - inconclusive
+      * `stopped_early` - stopped_early
+      * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Comment about the experiment conclusion.
@@ -17664,8 +16839,8 @@ export namespace Schemas {
 
     /**
      * * `categorical` - categorical
-     * * `numeric` - numeric
-     * * `boolean` - boolean
+    * `numeric` - numeric
+    * `boolean` - boolean
      */
     export type ExperimentMetricKindEnum = typeof ExperimentMetricKindEnum[keyof typeof ExperimentMetricKindEnum];
 
@@ -17675,6 +16850,84 @@ export namespace Schemas {
       Numeric: 'numeric',
       Boolean: 'boolean',
     } as const;
+
+    /**
+     * * `pending` - pending
+    * `in_progress` - in_progress
+    * `completed` - completed
+    * `failed` - failed
+     */
+    export type ExperimentMetricsRecalculationStatusEnum = typeof ExperimentMetricsRecalculationStatusEnum[keyof typeof ExperimentMetricsRecalculationStatusEnum];
+
+
+    export const ExperimentMetricsRecalculationStatusEnum = {
+      Pending: 'pending',
+      InProgress: 'in_progress',
+      Completed: 'completed',
+      Failed: 'failed',
+    } as const;
+
+    /**
+     * * `manual` - manual
+    * `experiment_launch` - experiment_launch
+    * `experiment_stop` - experiment_stop
+    * `experiment_update` - experiment_update
+     */
+    export type TriggerEnum = typeof TriggerEnum[keyof typeof TriggerEnum];
+
+
+    export const TriggerEnum = {
+      Manual: 'manual',
+      ExperimentLaunch: 'experiment_launch',
+      ExperimentStop: 'experiment_stop',
+      ExperimentUpdate: 'experiment_update',
+    } as const;
+
+    /**
+     * Serializer for metrics recalculation status responses.
+     */
+    export interface ExperimentMetricsRecalculation {
+      /** Unique identifier for this recalculation job */
+      readonly id: string;
+      /** ID of the experiment being recalculated */
+      readonly experiment_id: number;
+      /** Current status of the recalculation job
+
+      * `pending` - pending
+      * `in_progress` - in_progress
+      * `completed` - completed
+      * `failed` - failed */
+      readonly status: ExperimentMetricsRecalculationStatusEnum;
+      /** Total number of metrics to recalculate */
+      readonly total_metrics: number;
+      /** Number of metrics successfully recalculated */
+      readonly completed_metrics: number;
+      /** Number of metrics that failed to recalculate */
+      readonly failed_metrics: number;
+      /** Map of metric_uuid to error details */
+      readonly metric_errors: unknown;
+      /** What triggered this recalculation
+
+      * `manual` - manual
+      * `experiment_launch` - experiment_launch
+      * `experiment_stop` - experiment_stop
+      * `experiment_update` - experiment_update */
+      readonly trigger: TriggerEnum;
+      /** When the job was created */
+      readonly created_at: string;
+      /**
+         * When processing started
+         * @nullable
+         */
+      readonly started_at: string | null;
+      /**
+         * When processing completed
+         * @nullable
+         */
+      readonly completed_at: string | null;
+      /** True if returning an existing job rather than a newly created one */
+      readonly is_existing: boolean;
+    }
 
     /**
      * Mixin for serializers to add user access control fields
@@ -17716,13 +16969,13 @@ export namespace Schemas {
 
     /**
      * * `image/png` - image/png
-     * * `application/pdf` - application/pdf
-     * * `text/csv` - text/csv
-     * * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
-     * * `video/webm` - video/webm
-     * * `video/mp4` - video/mp4
-     * * `image/gif` - image/gif
-     * * `application/json` - application/json
+    * `application/pdf` - application/pdf
+    * `text/csv` - text/csv
+    * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+    * `video/webm` - video/webm
+    * `video/mp4` - video/mp4
+    * `image/gif` - image/gif
+    * `application/json` - application/json
      */
     export type ExportFormatEnum = typeof ExportFormatEnum[keyof typeof ExportFormatEnum];
 
@@ -17783,10 +17036,10 @@ export namespace Schemas {
 
     /**
      * * `full_refresh` - full_refresh
-     * * `incremental` - incremental
-     * * `append` - append
-     * * `webhook` - webhook
-     * * `cdc` - cdc
+    * `incremental` - incremental
+    * `append` - append
+    * `webhook` - webhook
+    * `cdc` - cdc
      */
     export type SyncTypeEnum = typeof SyncTypeEnum[keyof typeof SyncTypeEnum];
 
@@ -17801,11 +17054,11 @@ export namespace Schemas {
 
     /**
      * * `integer` - integer
-     * * `numeric` - numeric
-     * * `datetime` - datetime
-     * * `date` - date
-     * * `timestamp` - timestamp
-     * * `objectid` - objectid
+    * `numeric` - numeric
+    * `datetime` - datetime
+    * `date` - date
+    * `timestamp` - timestamp
+    * `objectid` - objectid
      */
     export type IncrementalFieldTypeEnum = typeof IncrementalFieldTypeEnum[keyof typeof IncrementalFieldTypeEnum];
 
@@ -17821,16 +17074,16 @@ export namespace Schemas {
 
     /**
      * * `never` - never
-     * * `1min` - 1min
-     * * `5min` - 5min
-     * * `15min` - 15min
-     * * `30min` - 30min
-     * * `1hour` - 1hour
-     * * `6hour` - 6hour
-     * * `12hour` - 12hour
-     * * `24hour` - 24hour
-     * * `7day` - 7day
-     * * `30day` - 30day
+    * `1min` - 1min
+    * `5min` - 5min
+    * `15min` - 15min
+    * `30min` - 30min
+    * `1hour` - 1hour
+    * `6hour` - 6hour
+    * `12hour` - 12hour
+    * `24hour` - 24hour
+    * `7day` - 7day
+    * `30day` - 30day
      */
     export type SyncFrequencyEnum = typeof SyncFrequencyEnum[keyof typeof SyncFrequencyEnum];
 
@@ -17868,12 +17121,12 @@ export namespace Schemas {
       /** @nullable */
       readonly status: string | null;
       /** Sync strategy: incremental, full_refresh, append, or cdc.
-       *
-       * * `full_refresh` - full_refresh
-       * * `incremental` - incremental
-       * * `append` - append
-       * * `webhook` - webhook
-       * * `cdc` - cdc */
+
+      * `full_refresh` - full_refresh
+      * `incremental` - incremental
+      * `append` - append
+      * `webhook` - webhook
+      * `cdc` - cdc */
       sync_type?: SyncTypeEnum | null;
       /**
          * Column name used to track sync progress.
@@ -17881,27 +17134,27 @@ export namespace Schemas {
          */
       incremental_field?: string | null;
       /** Data type of the incremental field.
-       *
-       * * `integer` - integer
-       * * `numeric` - numeric
-       * * `datetime` - datetime
-       * * `date` - date
-       * * `timestamp` - timestamp
-       * * `objectid` - objectid */
+
+      * `integer` - integer
+      * `numeric` - numeric
+      * `datetime` - datetime
+      * `date` - date
+      * `timestamp` - timestamp
+      * `objectid` - objectid */
       incremental_field_type?: IncrementalFieldTypeEnum | null;
       /** How often to sync.
-       *
-       * * `never` - never
-       * * `1min` - 1min
-       * * `5min` - 5min
-       * * `15min` - 15min
-       * * `30min` - 30min
-       * * `1hour` - 1hour
-       * * `6hour` - 6hour
-       * * `12hour` - 12hour
-       * * `24hour` - 24hour
-       * * `7day` - 7day
-       * * `30day` - 30day */
+
+      * `never` - never
+      * `1min` - 1min
+      * `5min` - 5min
+      * `15min` - 15min
+      * `30min` - 30min
+      * `1hour` - 1hour
+      * `6hour` - 6hour
+      * `12hour` - 12hour
+      * `24hour` - 24hour
+      * `7day` - 7day
+      * `30day` - 30day */
       sync_frequency?: SyncFrequencyEnum | null;
       /**
          * UTC time of day to run the sync (HH:MM:SS).
@@ -17916,10 +17169,10 @@ export namespace Schemas {
          */
       primary_key_columns?: string[] | null;
       /** For CDC syncs: consolidated, cdc_only, or both.
-       *
-       * * `consolidated` - consolidated
-       * * `cdc_only` - cdc_only
-       * * `both` - both */
+
+      * `consolidated` - consolidated
+      * `cdc_only` - cdc_only
+      * `both` - both */
       cdc_table_mode?: CdcTableModeEnum | null;
       /**
          * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
@@ -17941,12 +17194,12 @@ export namespace Schemas {
       /** Whether the schema should be queryable/synced. */
       should_sync?: boolean;
       /** Requested sync mode for the schema.
-       *
-       * * `full_refresh` - full_refresh
-       * * `incremental` - incremental
-       * * `append` - append
-       * * `webhook` - webhook
-       * * `cdc` - cdc */
+
+      * `full_refresh` - full_refresh
+      * `incremental` - incremental
+      * `append` - append
+      * `webhook` - webhook
+      * `cdc` - cdc */
       sync_type?: SyncTypeEnum | null;
       /**
          * Incremental cursor field for incremental or append syncs.
@@ -17969,10 +17222,10 @@ export namespace Schemas {
          */
       sync_time_of_day?: string | null;
       /** How CDC-backed tables should be exposed.
-       *
-       * * `consolidated` - consolidated
-       * * `cdc_only` - cdc_only
-       * * `both` - both */
+
+      * `consolidated` - consolidated
+      * `cdc_only` - cdc_only
+      * `both` - both */
       cdc_table_mode?: CdcTableModeEnum | null;
       /**
          * Columns to sync. Null means sync all columns.
@@ -17986,9 +17239,9 @@ export namespace Schemas {
       /** @nullable */
       readonly prefix: string | null;
       /** Backend engine detected for the direct connection.
-       *
-       * * `duckdb` - duckdb
-       * * `postgres` - postgres */
+
+      * `duckdb` - duckdb
+      * `postgres` - postgres */
       readonly engine: EngineEnum | null;
     }
 
@@ -17999,240 +17252,155 @@ export namespace Schemas {
 
     export interface ExternalDataSourceCreate {
       /** The source type (e.g. 'Postgres', 'Stripe').
-       *
-       * * `Ashby` - Ashby
-       * * `Supabase` - Supabase
-       * * `CustomerIO` - CustomerIO
-       * * `Github` - Github
-       * * `Stripe` - Stripe
-       * * `Hubspot` - Hubspot
-       * * `Postgres` - Postgres
-       * * `Zendesk` - Zendesk
-       * * `Snowflake` - Snowflake
-       * * `Salesforce` - Salesforce
-       * * `MySQL` - MySQL
-       * * `MongoDB` - MongoDB
-       * * `MSSQL` - MSSQL
-       * * `Vitally` - Vitally
-       * * `BigQuery` - BigQuery
-       * * `Chargebee` - Chargebee
-       * * `Clerk` - Clerk
-       * * `GoogleAds` - GoogleAds
-       * * `GoogleSearchConsole` - GoogleSearchConsole
-       * * `TemporalIO` - TemporalIO
-       * * `DoIt` - DoIt
-       * * `GoogleSheets` - GoogleSheets
-       * * `MetaAds` - MetaAds
-       * * `Klaviyo` - Klaviyo
-       * * `Mailchimp` - Mailchimp
-       * * `Braze` - Braze
-       * * `Mailjet` - Mailjet
-       * * `Redshift` - Redshift
-       * * `Polar` - Polar
-       * * `RevenueCat` - RevenueCat
-       * * `LinkedinAds` - LinkedinAds
-       * * `RedditAds` - RedditAds
-       * * `TikTokAds` - TikTokAds
-       * * `BingAds` - BingAds
-       * * `Shopify` - Shopify
-       * * `Attio` - Attio
-       * * `SnapchatAds` - SnapchatAds
-       * * `Linear` - Linear
-       * * `Intercom` - Intercom
-       * * `Amplitude` - Amplitude
-       * * `Mixpanel` - Mixpanel
-       * * `Jira` - Jira
-       * * `ActiveCampaign` - ActiveCampaign
-       * * `Marketo` - Marketo
-       * * `Adjust` - Adjust
-       * * `AppsFlyer` - AppsFlyer
-       * * `Freshdesk` - Freshdesk
-       * * `GoogleAnalytics` - GoogleAnalytics
-       * * `Pipedrive` - Pipedrive
-       * * `SendGrid` - SendGrid
-       * * `Slack` - Slack
-       * * `PagerDuty` - PagerDuty
-       * * `Asana` - Asana
-       * * `Notion` - Notion
-       * * `Airtable` - Airtable
-       * * `Greenhouse` - Greenhouse
-       * * `BambooHR` - BambooHR
-       * * `Lever` - Lever
-       * * `GitLab` - GitLab
-       * * `Datadog` - Datadog
-       * * `Sentry` - Sentry
-       * * `Pendo` - Pendo
-       * * `FullStory` - FullStory
-       * * `AmazonAds` - AmazonAds
-       * * `PinterestAds` - PinterestAds
-       * * `AppleSearchAds` - AppleSearchAds
-       * * `QuickBooks` - QuickBooks
-       * * `Xero` - Xero
-       * * `NetSuite` - NetSuite
-       * * `WooCommerce` - WooCommerce
-       * * `BigCommerce` - BigCommerce
-       * * `PayPal` - PayPal
-       * * `Square` - Square
-       * * `Zoom` - Zoom
-       * * `Trello` - Trello
-       * * `Monday` - Monday
-       * * `ClickUp` - ClickUp
-       * * `Confluence` - Confluence
-       * * `Recurly` - Recurly
-       * * `SalesLoft` - SalesLoft
-       * * `Outreach` - Outreach
-       * * `Gong` - Gong
-       * * `Calendly` - Calendly
-       * * `Typeform` - Typeform
-       * * `Iterable` - Iterable
-       * * `ZohoCRM` - ZohoCRM
-       * * `Close` - Close
-       * * `Oracle` - Oracle
-       * * `DynamoDB` - DynamoDB
-       * * `Elasticsearch` - Elasticsearch
-       * * `Kafka` - Kafka
-       * * `LaunchDarkly` - LaunchDarkly
-       * * `Braintree` - Braintree
-       * * `Recharge` - Recharge
-       * * `HelpScout` - HelpScout
-       * * `Gorgias` - Gorgias
-       * * `Instagram` - Instagram
-       * * `YouTubeAnalytics` - YouTubeAnalytics
-       * * `FacebookPages` - FacebookPages
-       * * `TwitterAds` - TwitterAds
-       * * `Workday` - Workday
-       * * `ServiceNow` - ServiceNow
-       * * `Pardot` - Pardot
-       * * `Copper` - Copper
-       * * `Front` - Front
-       * * `ChartMogul` - ChartMogul
-       * * `Zuora` - Zuora
-       * * `Paddle` - Paddle
-       * * `CircleCI` - CircleCI
-       * * `CockroachDB` - CockroachDB
-       * * `Firebase` - Firebase
-       * * `AzureBlob` - AzureBlob
-       * * `GoogleDrive` - GoogleDrive
-       * * `OneDrive` - OneDrive
-       * * `SharePoint` - SharePoint
-       * * `Box` - Box
-       * * `SFTP` - SFTP
-       * * `MicrosoftTeams` - MicrosoftTeams
-       * * `Aircall` - Aircall
-       * * `Webflow` - Webflow
-       * * `Okta` - Okta
-       * * `Auth0` - Auth0
-       * * `Productboard` - Productboard
-       * * `Smartsheet` - Smartsheet
-       * * `Wrike` - Wrike
-       * * `Plaid` - Plaid
-       * * `SurveyMonkey` - SurveyMonkey
-       * * `Eventbrite` - Eventbrite
-       * * `RingCentral` - RingCentral
-       * * `Twilio` - Twilio
-       * * `Freshsales` - Freshsales
-       * * `Shortcut` - Shortcut
-       * * `ConvertKit` - ConvertKit
-       * * `Drip` - Drip
-       * * `CampaignMonitor` - CampaignMonitor
-       * * `MailerLite` - MailerLite
-       * * `Omnisend` - Omnisend
-       * * `Brevo` - Brevo
-       * * `Postmark` - Postmark
-       * * `Granola` - Granola
-       * * `BuildBetter` - BuildBetter
-       * * `Convex` - Convex
-       * * `ClickHouse` - ClickHouse
-       * * `Plain` - Plain
-       * * `Resend` - Resend
-       * * `PgAnalyze` - PgAnalyze
-       * * `WorkOS` - WorkOS
-       * * `AmazonS3` - AmazonS3
-       * * `GoogleCloudStorage` - GoogleCloudStorage
-       * * `Databricks` - Databricks
-       * * `Dynamics365` - Dynamics365
-       * * `SalesforceMarketingCloud` - SalesforceMarketingCloud
-       * * `Db2` - Db2
-       * * `Heap` - Heap
-       * * `AdobeAnalytics` - AdobeAnalytics
-       * * `Matomo` - Matomo
-       * * `Optimizely` - Optimizely
-       * * `Adyen` - Adyen
-       * * `GoCardless` - GoCardless
-       * * `Mollie` - Mollie
-       * * `CheckoutCom` - CheckoutCom
-       * * `Branch` - Branch
-       * * `Criteo` - Criteo
-       * * `Outbrain` - Outbrain
-       * * `Taboola` - Taboola
-       * * `AdRoll` - AdRoll
-       * * `DisplayVideo360` - DisplayVideo360
-       * * `GoogleAdManager` - GoogleAdManager
-       * * `CampaignManager360` - CampaignManager360
-       * * `SearchAds360` - SearchAds360
-       * * `AdobeCommerce` - AdobeCommerce
-       * * `AmazonSellingPartner` - AmazonSellingPartner
-       * * `Ebay` - Ebay
-       * * `Commercetools` - Commercetools
-       * * `LightspeedRetail` - LightspeedRetail
-       * * `ShipStation` - ShipStation
-       * * `ConstantContact` - ConstantContact
-       * * `Mailgun` - Mailgun
-       * * `Eloqua` - Eloqua
-       * * `Sailthru` - Sailthru
-       * * `Ortto` - Ortto
-       * * `Attentive` - Attentive
-       * * `Kustomer` - Kustomer
-       * * `Dixa` - Dixa
-       * * `Gladly` - Gladly
-       * * `Qualtrics` - Qualtrics
-       * * `Delighted` - Delighted
-       * * `AzureDevOps` - AzureDevOps
-       * * `Rollbar` - Rollbar
-       * * `Opsgenie` - Opsgenie
-       * * `IncidentIo` - IncidentIo
-       * * `Pingdom` - Pingdom
-       * * `Cloudflare` - Cloudflare
-       * * `CosmosDB` - CosmosDB
-       * * `PlanetScale` - PlanetScale
-       * * `SapHana` - SapHana
-       * * `Rippling` - Rippling
-       * * `HiBob` - HiBob
-       * * `Personio` - Personio
-       * * `Deel` - Deel
-       * * `AdpWorkforceNow` - AdpWorkforceNow
-       * * `Paylocity` - Paylocity
-       * * `Gusto` - Gusto
-       * * `CultureAmp` - CultureAmp
-       * * `Lattice` - Lattice
-       * * `SageIntacct` - SageIntacct
-       * * `FreshBooks` - FreshBooks
-       * * `Expensify` - Expensify
-       * * `Ramp` - Ramp
-       * * `Brex` - Brex
-       * * `Coupa` - Coupa
-       * * `SapConcur` - SapConcur
-       * * `Apollo` - Apollo
-       * * `Crunchbase` - Crunchbase
-       * * `ZoomInfo` - ZoomInfo
-       * * `Clari` - Clari
-       * * `Chorus` - Chorus
-       * * `Coda` - Coda
-       * * `Guru` - Guru
-       * * `Dropbox` - Dropbox
-       * * `Docusign` - Docusign
-       * * `PandaDoc` - PandaDoc
-       * * `SapErp` - SapErp
-       * * `SapSuccessFactors` - SapSuccessFactors
-       * * `OracleEbs` - OracleEbs
-       * * `OracleFusion` - OracleFusion
-       * * `AmazonSNS` - AmazonSNS
-       * * `AmazonEventBridge` - AmazonEventBridge
-       * * `AmazonSQS` - AmazonSQS
-       * * `AmazonKinesis` - AmazonKinesis
-       * * `AmazonCloudWatch` - AmazonCloudWatch
-       * * `OpenAIAds` - OpenAIAds
-       * * `Custom` - Custom */
+
+      * `Ashby` - Ashby
+      * `Supabase` - Supabase
+      * `CustomerIO` - CustomerIO
+      * `Github` - Github
+      * `Stripe` - Stripe
+      * `Hubspot` - Hubspot
+      * `Postgres` - Postgres
+      * `Zendesk` - Zendesk
+      * `Snowflake` - Snowflake
+      * `Salesforce` - Salesforce
+      * `MySQL` - MySQL
+      * `MongoDB` - MongoDB
+      * `MSSQL` - MSSQL
+      * `Vitally` - Vitally
+      * `BigQuery` - BigQuery
+      * `Chargebee` - Chargebee
+      * `Clerk` - Clerk
+      * `GoogleAds` - GoogleAds
+      * `GoogleSearchConsole` - GoogleSearchConsole
+      * `TemporalIO` - TemporalIO
+      * `DoIt` - DoIt
+      * `GoogleSheets` - GoogleSheets
+      * `MetaAds` - MetaAds
+      * `Klaviyo` - Klaviyo
+      * `Mailchimp` - Mailchimp
+      * `Braze` - Braze
+      * `Mailjet` - Mailjet
+      * `Redshift` - Redshift
+      * `Polar` - Polar
+      * `RevenueCat` - RevenueCat
+      * `LinkedinAds` - LinkedinAds
+      * `RedditAds` - RedditAds
+      * `TikTokAds` - TikTokAds
+      * `BingAds` - BingAds
+      * `Shopify` - Shopify
+      * `Attio` - Attio
+      * `SnapchatAds` - SnapchatAds
+      * `Linear` - Linear
+      * `Intercom` - Intercom
+      * `Amplitude` - Amplitude
+      * `Mixpanel` - Mixpanel
+      * `Jira` - Jira
+      * `ActiveCampaign` - ActiveCampaign
+      * `Marketo` - Marketo
+      * `Adjust` - Adjust
+      * `AppsFlyer` - AppsFlyer
+      * `Freshdesk` - Freshdesk
+      * `GoogleAnalytics` - GoogleAnalytics
+      * `Pipedrive` - Pipedrive
+      * `SendGrid` - SendGrid
+      * `Slack` - Slack
+      * `PagerDuty` - PagerDuty
+      * `Asana` - Asana
+      * `Notion` - Notion
+      * `Airtable` - Airtable
+      * `Greenhouse` - Greenhouse
+      * `BambooHR` - BambooHR
+      * `Lever` - Lever
+      * `GitLab` - GitLab
+      * `Datadog` - Datadog
+      * `Sentry` - Sentry
+      * `Pendo` - Pendo
+      * `FullStory` - FullStory
+      * `AmazonAds` - AmazonAds
+      * `PinterestAds` - PinterestAds
+      * `AppleSearchAds` - AppleSearchAds
+      * `QuickBooks` - QuickBooks
+      * `Xero` - Xero
+      * `NetSuite` - NetSuite
+      * `WooCommerce` - WooCommerce
+      * `BigCommerce` - BigCommerce
+      * `PayPal` - PayPal
+      * `Square` - Square
+      * `Zoom` - Zoom
+      * `Trello` - Trello
+      * `Monday` - Monday
+      * `ClickUp` - ClickUp
+      * `Confluence` - Confluence
+      * `Recurly` - Recurly
+      * `SalesLoft` - SalesLoft
+      * `Outreach` - Outreach
+      * `Gong` - Gong
+      * `Calendly` - Calendly
+      * `Typeform` - Typeform
+      * `Iterable` - Iterable
+      * `ZohoCRM` - ZohoCRM
+      * `Close` - Close
+      * `Oracle` - Oracle
+      * `DynamoDB` - DynamoDB
+      * `Elasticsearch` - Elasticsearch
+      * `Kafka` - Kafka
+      * `LaunchDarkly` - LaunchDarkly
+      * `Braintree` - Braintree
+      * `Recharge` - Recharge
+      * `HelpScout` - HelpScout
+      * `Gorgias` - Gorgias
+      * `Instagram` - Instagram
+      * `YouTubeAnalytics` - YouTubeAnalytics
+      * `FacebookPages` - FacebookPages
+      * `TwitterAds` - TwitterAds
+      * `Workday` - Workday
+      * `ServiceNow` - ServiceNow
+      * `Pardot` - Pardot
+      * `Copper` - Copper
+      * `Front` - Front
+      * `ChartMogul` - ChartMogul
+      * `Zuora` - Zuora
+      * `Paddle` - Paddle
+      * `CircleCI` - CircleCI
+      * `CockroachDB` - CockroachDB
+      * `Firebase` - Firebase
+      * `AzureBlob` - AzureBlob
+      * `GoogleDrive` - GoogleDrive
+      * `OneDrive` - OneDrive
+      * `SharePoint` - SharePoint
+      * `Box` - Box
+      * `SFTP` - SFTP
+      * `MicrosoftTeams` - MicrosoftTeams
+      * `Aircall` - Aircall
+      * `Webflow` - Webflow
+      * `Okta` - Okta
+      * `Auth0` - Auth0
+      * `Productboard` - Productboard
+      * `Smartsheet` - Smartsheet
+      * `Wrike` - Wrike
+      * `Plaid` - Plaid
+      * `SurveyMonkey` - SurveyMonkey
+      * `Eventbrite` - Eventbrite
+      * `RingCentral` - RingCentral
+      * `Twilio` - Twilio
+      * `Freshsales` - Freshsales
+      * `Shortcut` - Shortcut
+      * `ConvertKit` - ConvertKit
+      * `Drip` - Drip
+      * `CampaignMonitor` - CampaignMonitor
+      * `MailerLite` - MailerLite
+      * `Omnisend` - Omnisend
+      * `Brevo` - Brevo
+      * `Postmark` - Postmark
+      * `Granola` - Granola
+      * `BuildBetter` - BuildBetter
+      * `Convex` - Convex
+      * `ClickHouse` - ClickHouse
+      * `Plain` - Plain
+      * `Resend` - Resend
+      * `PgAnalyze` - PgAnalyze
+      * `WorkOS` - WorkOS
+      * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
       /** Connection credentials and a 'schemas' array. Keys depend on source_type. */
       payload: ExternalDataSourceCreatePayload;
@@ -18249,15 +17417,15 @@ export namespace Schemas {
          */
       description?: string | null;
       /** Connection mode: 'warehouse' (import) or 'direct' (live query).
-       *
-       * * `warehouse` - warehouse
-       * * `direct` - direct */
+
+      * `warehouse` - warehouse
+      * `direct` - direct */
       access_method?: AccessMethodEnum;
       /** Where the request came from
-       *
-       * * `web` - web
-       * * `api` - api
-       * * `mcp` - mcp */
+
+      * `web` - web
+      * `api` - api
+      * `mcp` - mcp */
       created_via?: CreatedViaEnum;
     }
 
@@ -18294,10 +17462,10 @@ export namespace Schemas {
       /** @nullable */
       readonly created_by: string | null;
       /** How this source was created. Defaults to `api` on create when omitted. `web` for the in-app UI, `api` for direct API callers, `mcp` for agent/MCP tool calls. Ignored on update.
-       *
-       * * `web` - web
-       * * `api` - api
-       * * `mcp` - mcp */
+
+      * `web` - web
+      * `api` - api
+      * `mcp` - mcp */
       created_via?: CreatedViaEnum | null;
       readonly status: string;
       client_secret: string;
@@ -18317,9 +17485,9 @@ export namespace Schemas {
       description?: string | null;
       readonly access_method: AccessMethodEnum;
       /** Backend engine detected for the direct connection.
-       *
-       * * `duckdb` - duckdb
-       * * `postgres` - postgres */
+
+      * `duckdb` - duckdb
+      * `postgres` - postgres */
       readonly engine: EngineEnum | null;
       /** @nullable */
       readonly last_run_at: string | null;
@@ -18359,26 +17527,19 @@ export namespace Schemas {
 
     export type FeatureFlagFilters = { [key: string]: unknown };
 
+    export type FeatureFlagExperimentSetMetadataItem = { [key: string]: unknown };
+
     export type FeatureFlagSurveys = { [key: string]: unknown };
 
     export type FeatureFlagFeatures = { [key: string]: unknown };
 
-    export interface FeatureFlagExperimentSetMetadata {
-      /** ID of the experiment linked to this flag. */
-      id: number;
-      /** Name of the experiment linked to this flag. */
-      name: string;
-      /** Whether the experiment is currently running (started and not yet stopped). A running experiment blocks deletion of the linked flag. */
-      is_running: boolean;
-    }
-
     /**
      * * `feature_flags` - feature_flags
-     * * `experiments` - experiments
-     * * `surveys` - surveys
-     * * `early_access_features` - early_access_features
-     * * `web_experiments` - web_experiments
-     * * `product_tours` - product_tours
+    * `experiments` - experiments
+    * `surveys` - surveys
+    * `early_access_features` - early_access_features
+    * `web_experiments` - web_experiments
+    * `product_tours` - product_tours
      */
     export type FeatureFlagCreationContextEnum = typeof FeatureFlagCreationContextEnum[keyof typeof FeatureFlagCreationContextEnum];
 
@@ -18413,7 +17574,7 @@ export namespace Schemas {
       /** @nullable */
       ensure_experience_continuity?: boolean | null;
       readonly experiment_set: readonly number[];
-      readonly experiment_set_metadata: readonly FeatureFlagExperimentSetMetadata[];
+      readonly experiment_set_metadata: readonly FeatureFlagExperimentSetMetadataItem[];
       readonly surveys: FeatureFlagSurveys;
       readonly features: FeatureFlagFeatures;
       rollback_conditions?: unknown;
@@ -18432,13 +17593,13 @@ export namespace Schemas {
          */
       readonly user_access_level: string | null;
       /** Indicates the origin product of the feature flag. Choices: 'feature_flags', 'experiments', 'surveys', 'early_access_features', 'web_experiments', 'product_tours'.
-       *
-       * * `feature_flags` - feature_flags
-       * * `experiments` - experiments
-       * * `surveys` - surveys
-       * * `early_access_features` - early_access_features
-       * * `web_experiments` - web_experiments
-       * * `product_tours` - product_tours */
+
+      * `feature_flags` - feature_flags
+      * `experiments` - experiments
+      * `surveys` - surveys
+      * `early_access_features` - early_access_features
+      * `web_experiments` - web_experiments
+      * `product_tours` - product_tours */
       creation_context?: FeatureFlagCreationContextEnum;
       /** @nullable */
       is_remote_configuration?: boolean | null;
@@ -18446,15 +17607,15 @@ export namespace Schemas {
       has_encrypted_payloads?: boolean | null;
       readonly status: string;
       /** Specifies where this feature flag should be evaluated
-       *
-       * * `server` - Server
-       * * `client` - Client
-       * * `all` - All */
+
+      * `server` - Server
+      * `client` - Client
+      * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum | BlankEnum | null;
       /** Identifier used for bucketing users into rollout and variants
-       *
-       * * `distinct_id` - User ID (default)
-       * * `device_id` - Device ID */
+
+      * `distinct_id` - User ID (default)
+      * `device_id` - Device ID */
       bucketing_identifier?: BucketingIdentifierEnum | BlankEnum | null;
       /**
          * Last time this feature flag was called (from $feature_flag_called events)
@@ -18508,8 +17669,8 @@ export namespace Schemas {
 
     /**
      * * `cohort` - cohort
-     * * `person` - person
-     * * `group` - group
+    * `person` - person
+    * `group` - group
      */
     export type PropertyGroupTypeEnum = typeof PropertyGroupTypeEnum[keyof typeof PropertyGroupTypeEnum];
 
@@ -18522,15 +17683,15 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-     * * `is_not` - is_not
-     * * `icontains` - icontains
-     * * `not_icontains` - not_icontains
-     * * `regex` - regex
-     * * `not_regex` - not_regex
-     * * `gt` - gt
-     * * `gte` - gte
-     * * `lt` - lt
-     * * `lte` - lte
+    * `is_not` - is_not
+    * `icontains` - icontains
+    * `not_icontains` - not_icontains
+    * `regex` - regex
+    * `not_regex` - not_regex
+    * `gt` - gt
+    * `gte` - gte
+    * `lt` - lt
+    * `lte` - lte
      */
     export type FeatureFlagFilterPropertyGenericSchemaOperatorEnum = typeof FeatureFlagFilterPropertyGenericSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertyGenericSchemaOperatorEnum];
 
@@ -18552,10 +17713,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-       *
-       * * `cohort` - cohort
-       * * `person` - person
-       * * `group` - group */
+
+      * `cohort` - cohort
+      * `person` - person
+      * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18570,17 +17731,17 @@ export namespace Schemas {
       /** Comparison value for the property filter. Supports strings, numbers, booleans, and arrays. */
       value: unknown;
       /** Operator used to compare the property value.
-       *
-       * * `exact` - exact
-       * * `is_not` - is_not
-       * * `icontains` - icontains
-       * * `not_icontains` - not_icontains
-       * * `regex` - regex
-       * * `not_regex` - not_regex
-       * * `gt` - gt
-       * * `gte` - gte
-       * * `lt` - lt
-       * * `lte` - lte */
+
+      * `exact` - exact
+      * `is_not` - is_not
+      * `icontains` - icontains
+      * `not_icontains` - not_icontains
+      * `regex` - regex
+      * `not_regex` - not_regex
+      * `gt` - gt
+      * `gte` - gte
+      * `lt` - lt
+      * `lte` - lte */
       operator: FeatureFlagFilterPropertyGenericSchemaOperatorEnum;
     }
 
@@ -18588,10 +17749,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-       *
-       * * `cohort` - cohort
-       * * `person` - person
-       * * `group` - group */
+
+      * `cohort` - cohort
+      * `person` - person
+      * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18604,9 +17765,9 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Existence operator.
-       *
-       * * `is_set` - is_set
-       * * `is_not_set` - is_not_set */
+
+      * `is_set` - is_set
+      * `is_not_set` - is_not_set */
       operator: ExistenceOperatorEnum;
       /** Optional value. Runtime behavior determines whether this is ignored. */
       value?: unknown;
@@ -18616,10 +17777,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-       *
-       * * `cohort` - cohort
-       * * `person` - person
-       * * `group` - group */
+
+      * `cohort` - cohort
+      * `person` - person
+      * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18632,10 +17793,10 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Date comparison operator.
-       *
-       * * `is_date_exact` - is_date_exact
-       * * `is_date_after` - is_date_after
-       * * `is_date_before` - is_date_before */
+
+      * `is_date_exact` - is_date_exact
+      * `is_date_after` - is_date_after
+      * `is_date_before` - is_date_before */
       operator: DateOperatorEnum;
       /** Date value in ISO format or relative date expression. */
       value: string;
@@ -18643,14 +17804,14 @@ export namespace Schemas {
 
     /**
      * * `semver_gt` - semver_gt
-     * * `semver_gte` - semver_gte
-     * * `semver_lt` - semver_lt
-     * * `semver_lte` - semver_lte
-     * * `semver_eq` - semver_eq
-     * * `semver_neq` - semver_neq
-     * * `semver_tilde` - semver_tilde
-     * * `semver_caret` - semver_caret
-     * * `semver_wildcard` - semver_wildcard
+    * `semver_gte` - semver_gte
+    * `semver_lt` - semver_lt
+    * `semver_lte` - semver_lte
+    * `semver_eq` - semver_eq
+    * `semver_neq` - semver_neq
+    * `semver_tilde` - semver_tilde
+    * `semver_caret` - semver_caret
+    * `semver_wildcard` - semver_wildcard
      */
     export type FeatureFlagFilterPropertySemverSchemaOperatorEnum = typeof FeatureFlagFilterPropertySemverSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertySemverSchemaOperatorEnum];
 
@@ -18671,10 +17832,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-       *
-       * * `cohort` - cohort
-       * * `person` - person
-       * * `group` - group */
+
+      * `cohort` - cohort
+      * `person` - person
+      * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18687,16 +17848,16 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Semantic version comparison operator.
-       *
-       * * `semver_gt` - semver_gt
-       * * `semver_gte` - semver_gte
-       * * `semver_lt` - semver_lt
-       * * `semver_lte` - semver_lte
-       * * `semver_eq` - semver_eq
-       * * `semver_neq` - semver_neq
-       * * `semver_tilde` - semver_tilde
-       * * `semver_caret` - semver_caret
-       * * `semver_wildcard` - semver_wildcard */
+
+      * `semver_gt` - semver_gt
+      * `semver_gte` - semver_gte
+      * `semver_lt` - semver_lt
+      * `semver_lte` - semver_lte
+      * `semver_eq` - semver_eq
+      * `semver_neq` - semver_neq
+      * `semver_tilde` - semver_tilde
+      * `semver_caret` - semver_caret
+      * `semver_wildcard` - semver_wildcard */
       operator: FeatureFlagFilterPropertySemverSchemaOperatorEnum;
       /** Semantic version string. */
       value: string;
@@ -18704,7 +17865,7 @@ export namespace Schemas {
 
     /**
      * * `icontains_multi` - icontains_multi
-     * * `not_icontains_multi` - not_icontains_multi
+    * `not_icontains_multi` - not_icontains_multi
      */
     export type FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum = typeof FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum];
 
@@ -18718,10 +17879,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-       *
-       * * `cohort` - cohort
-       * * `person` - person
-       * * `group` - group */
+
+      * `cohort` - cohort
+      * `person` - person
+      * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18734,9 +17895,9 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Multi-contains operator.
-       *
-       * * `icontains_multi` - icontains_multi
-       * * `not_icontains_multi` - not_icontains_multi */
+
+      * `icontains_multi` - icontains_multi
+      * `not_icontains_multi` - not_icontains_multi */
       operator: FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum;
       /** List of strings to evaluate against. */
       value: string[];
@@ -18754,7 +17915,7 @@ export namespace Schemas {
 
     /**
      * * `in` - in
-     * * `not_in` - not_in
+    * `not_in` - not_in
      */
     export type FeatureFlagFilterPropertyCohortInSchemaOperatorEnum = typeof FeatureFlagFilterPropertyCohortInSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertyCohortInSchemaOperatorEnum];
 
@@ -18768,8 +17929,8 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Cohort property type required for in/not_in operators.
-       *
-       * * `cohort` - cohort */
+
+      * `cohort` - cohort */
       type: FeatureFlagFilterPropertyCohortInSchemaTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18782,9 +17943,9 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Membership operator for cohort properties.
-       *
-       * * `in` - in
-       * * `not_in` - not_in */
+
+      * `in` - in
+      * `not_in` - not_in */
       operator: FeatureFlagFilterPropertyCohortInSchemaOperatorEnum;
       /** Cohort comparison value (single or list, depending on usage). */
       value: unknown;
@@ -18814,8 +17975,8 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Flag property type required for flag dependency checks.
-       *
-       * * `flag` - flag */
+
+      * `flag` - flag */
       type: FeatureFlagFilterPropertyFlagEvaluatesSchemaTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18828,8 +17989,8 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Operator for feature flag dependency evaluation.
-       *
-       * * `flag_evaluates_to` - flag_evaluates_to */
+
+      * `flag_evaluates_to` - flag_evaluates_to */
       operator: FeatureFlagFilterPropertyFlagEvaluatesSchemaOperatorEnum;
       /** Value to compare flag evaluation against. */
       value: unknown;
@@ -18907,11 +18068,6 @@ export namespace Schemas {
       tags?: string[];
       /** Evaluation contexts that control where this flag evaluates at runtime. */
       evaluation_contexts?: string[];
-      /**
-         * Whether this flag is a remote configuration flag that delivers a payload rather than gating a feature.
-         * @nullable
-         */
-      is_remote_configuration?: boolean | null;
     }
 
     export interface FeatureFlagStatusResponse {
@@ -18996,15 +18152,15 @@ export namespace Schemas {
       /** @nullable */
       has_encrypted_payloads?: boolean | null;
       /** Specifies where this feature flag should be evaluated
-       *
-       * * `server` - Server
-       * * `client` - Client
-       * * `all` - All */
+
+      * `server` - Server
+      * `client` - Client
+      * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum | BlankEnum | null;
       /** Identifier used for bucketing users into rollout and variants
-       *
-       * * `distinct_id` - User ID (default)
-       * * `device_id` - Device ID */
+
+      * `distinct_id` - User ID (default)
+      * `device_id` - Device ID */
       bucketing_identifier?: BucketingIdentifierEnum | BlankEnum | null;
       /**
          * Last time this feature flag was called (from $feature_flag_called events)
@@ -19026,112 +18182,9 @@ export namespace Schemas {
     }
 
     /**
-     * Structured element metadata (inferred selectors, attributes, component hints).
-     */
-    export type FieldNoteElementContext = { [key: string]: unknown };
-
-    /**
-     * Viewport size when the field note was made, as {width, height}.
-     * @nullable
-     */
-    export type FieldNoteViewport = {
-      /** Viewport width in pixels. */
-      width?: number;
-      /** Viewport height in pixels. */
-      height?: number;
-    } | null;
-
-    /**
-     * * `pending` - Pending
-     * * `acknowledged` - Acknowledged
-     * * `resolved` - Resolved
-     * * `dismissed` - Dismissed
-     */
-    export type FieldNoteStatusEnum = typeof FieldNoteStatusEnum[keyof typeof FieldNoteStatusEnum];
-
-
-    export const FieldNoteStatusEnum = {
-      Pending: 'pending',
-      Acknowledged: 'acknowledged',
-      Resolved: 'resolved',
-      Dismissed: 'dismissed',
-    } as const;
-
-    export interface FieldNote {
-      readonly id: string;
-      /**
-         * The note the user wrote about the element.
-         * @maxLength 5000
-         */
-      comment: string;
-      /** Lifecycle of the field note: pending, acknowledged, resolved, or dismissed. Ignored on create.
-       *
-       * * `pending` - Pending
-       * * `acknowledged` - Acknowledged
-       * * `resolved` - Resolved
-       * * `dismissed` - Dismissed */
-      field_note_status?: FieldNoteStatusEnum;
-      /**
-         * Optional note left by the agent when acknowledging, resolving, or dismissing the field note.
-         * @nullable
-         */
-      resolution?: string | null;
-      /**
-         * Full URL of the page the field note was made on.
-         * @maxLength 2048
-         */
-      url: string;
-      /**
-         * Hostname of the page, used to scope field notes to a site.
-         * @maxLength 255
-         */
-      host: string;
-      /**
-         * Path portion of the URL.
-         * @maxLength 2048
-         * @nullable
-         */
-      pathname?: string | null;
-      /**
-         * CSS selector that locates the element on the page.
-         * @maxLength 4096
-         */
-      selector: string;
-      /**
-         * Visible text of the element, if any.
-         * @maxLength 2048
-         * @nullable
-         */
-      element_text?: string | null;
-      /**
-         * Serialized autocapture-style element chain from the element up to the document root.
-         * @maxLength 20000
-         * @nullable
-         */
-      element_chain?: string | null;
-      /** Structured element metadata (inferred selectors, attributes, component hints). */
-      element_context?: FieldNoteElementContext;
-      /**
-         * Viewport size when the field note was made, as {width, height}.
-         * @nullable
-         */
-      viewport?: FieldNoteViewport;
-      /**
-         * URL of an uploaded screenshot captured with the field_note.
-         * @maxLength 2048
-         * @nullable
-         */
-      screenshot_url?: string | null;
-      readonly created_at: string;
-      /** @nullable */
-      readonly updated_at: string | null;
-      readonly created_by: UserBasic;
-    }
-
-    /**
      * * `events` - events
-     * * `persons` - persons
-     * * `sessions` - sessions
+    * `persons` - persons
+    * `sessions` - sessions
      */
     export type FileDownloadBatchExportOnDemandModelEnum = typeof FileDownloadBatchExportOnDemandModelEnum[keyof typeof FileDownloadBatchExportOnDemandModelEnum];
 
@@ -19510,98 +18563,6 @@ export namespace Schemas {
       change: WoWChange | null;
     }
 
-    export interface GoalEventSample {
-      /** UUID of the sampled conversion event */
-      event_uuid: string;
-      /** When the event occurred */
-      timestamp: string;
-      /** Distinct id associated with the event */
-      distinct_id: string;
-      /**
-         * utm_source value on the event, if any
-         * @nullable
-         */
-      utm_source: string | null;
-      /**
-         * utm_campaign value on the event, if any
-         * @nullable
-         */
-      utm_campaign: string | null;
-      /**
-         * Integration the utm_source matched, if any
-         * @nullable
-         */
-      matched_integration: string | null;
-    }
-
-    export interface GoalExplanationPeriod {
-      /**
-         * Start of the analyzed period (ISO)
-         * @nullable
-         */
-      date_from: string | null;
-      /**
-         * End of the analyzed period (ISO)
-         * @nullable
-         */
-      date_to: string | null;
-    }
-
-    export interface GoalExplanation {
-      /** Id of the explained conversion goal */
-      goal_id: string;
-      /** Display name of the conversion goal */
-      goal_name: string;
-      /** EventsNode/ActionsNode/DataWarehouseNode */
-      kind: string;
-      /** The period the breakdown was computed over */
-      period: GoalExplanationPeriod;
-      /** Total matching conversion events in the period */
-      total_count: number;
-      /**
-         * Events whose utm_source matched a known integration. Null for DataWarehouseNode.
-         * @nullable
-         */
-      integrated_count: number | null;
-      /**
-         * Events with no utm_source at all. Null for DataWarehouseNode.
-         * @nullable
-         */
-      events_without_utm_source: number | null;
-      /**
-         * Events with a utm_source matching no integration. Null for DataWarehouseNode.
-         * @nullable
-         */
-      events_with_unmatched_utm_source: number | null;
-      /**
-         * Total non-integrated events (without + unmatched). Null for DataWarehouseNode.
-         * @nullable
-         */
-      non_integrated_count: number | null;
-      /**
-         * List of [event_name, count] pairs
-         * @items.minItems 2
-         * @items.maxItems 2
-         */
-      by_event: [string, number][];
-      /**
-         * List of [utm_source, count] pairs
-         * @items.minItems 2
-         * @items.maxItems 2
-         */
-      by_utm_source: [string, number][];
-      /**
-         * List of [integration, count] pairs
-         * @items.minItems 2
-         * @items.maxItems 2
-         */
-      by_matched_integration: [string, number][];
-      /** A small sample of matching events */
-      samples: GoalEventSample[];
-      /** Caveats about the breakdown (sampling, attribution, etc.) */
-      notes: string[];
-    }
-
     export interface Group {
       /**
          * @minimum -2147483648
@@ -19637,16 +18598,16 @@ export namespace Schemas {
 
     /**
      * Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-     *
-     * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-     *
-     * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
+
+    **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+
+    **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
      */
     export type GroupUsageMetricFilters = { [key: string]: unknown };
 
     /**
      * * `numeric` - numeric
-     * * `currency` - currency
+    * `currency` - currency
      */
     export type GroupUsageMetricFormatEnum = typeof GroupUsageMetricFormatEnum[keyof typeof GroupUsageMetricFormatEnum];
 
@@ -19658,7 +18619,7 @@ export namespace Schemas {
 
     /**
      * * `number` - number
-     * * `sparkline` - sparkline
+    * `sparkline` - sparkline
      */
     export type GroupUsageMetricDisplayEnum = typeof GroupUsageMetricDisplayEnum[keyof typeof GroupUsageMetricDisplayEnum];
 
@@ -19670,7 +18631,7 @@ export namespace Schemas {
 
     /**
      * * `count` - count
-     * * `sum` - sum
+    * `sum` - sum
      */
     export type MathEnum = typeof MathEnum[keyof typeof MathEnum];
 
@@ -19688,27 +18649,27 @@ export namespace Schemas {
          */
       name: string;
       /** How the metric value is formatted in the UI. One of `numeric` or `currency`.
-       *
-       * * `numeric` - numeric
-       * * `currency` - currency */
+
+      * `numeric` - numeric
+      * `currency` - currency */
       format?: GroupUsageMetricFormatEnum;
       /** Rolling time window in days used to compute the metric. Defaults to 7. */
       interval?: number;
       /** Visual representation in the UI. One of `number` or `sparkline`.
-       *
-       * * `number` - number
-       * * `sparkline` - sparkline */
+
+      * `number` - number
+      * `sparkline` - sparkline */
       display?: GroupUsageMetricDisplayEnum;
       /** Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-       *
-       * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-       *
-       * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
+
+      **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+
+      **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
       filters: GroupUsageMetricFilters;
       /** Aggregation function. `count` counts matching events; `sum` sums the value of `math_property` on matching events.
-       *
-       * * `count` - count
-       * * `sum` - sum */
+
+      * `count` - count
+      * `sum` - sum */
       math?: MathEnum;
       /**
          * Required when `math` is `sum`; must be empty when `math` is `count`. For events metrics this is an event property name. For data warehouse metrics this is the column name (or HogQL expression) to sum on the DW table.
@@ -19720,8 +18681,8 @@ export namespace Schemas {
 
     /**
      * * `success` - success
-     * * `warning` - warning
-     * * `danger` - danger
+    * `warning` - warning
+    * `danger` - danger
      */
     export type HealthEnum = typeof HealthEnum[keyof typeof HealthEnum];
 
@@ -19739,8 +18700,8 @@ export namespace Schemas {
 
     /**
      * * `critical` - Critical
-     * * `warning` - Warning
-     * * `info` - Info
+    * `warning` - Warning
+    * `info` - Info
      */
     export type HealthIssueSeverityEnum = typeof HealthIssueSeverityEnum[keyof typeof HealthIssueSeverityEnum];
 
@@ -19753,7 +18714,7 @@ export namespace Schemas {
 
     /**
      * * `active` - Active
-     * * `resolved` - Resolved
+    * `resolved` - Resolved
      */
     export type HealthIssueStatusEnum = typeof HealthIssueStatusEnum[keyof typeof HealthIssueStatusEnum];
 
@@ -19769,15 +18730,15 @@ export namespace Schemas {
       /** Which health check produced this issue (e.g. 'sdk_outdated', 'external_data_failure', 'no_live_events', 'ingestion_warnings'). Stable string key — use it to filter issues by category. */
       readonly kind: string;
       /** How serious the issue is: 'critical', 'warning', or 'info'.
-       *
-       * * `critical` - Critical
-       * * `warning` - Warning
-       * * `info` - Info */
+
+      * `critical` - Critical
+      * `warning` - Warning
+      * `info` - Info */
       readonly severity: HealthIssueSeverityEnum;
       /** 'active' while the underlying problem is still detected; 'resolved' once a later check run no longer finds it.
-       *
-       * * `active` - Active
-       * * `resolved` - Resolved */
+
+      * `active` - Active
+      * `resolved` - Resolved */
       readonly status: HealthIssueStatusEnum;
       /** Whether a user has dismissed this issue from the Health UI. Dismissed issues stay in the list but are hidden by default. */
       dismissed?: boolean;
@@ -19808,11 +18769,11 @@ export namespace Schemas {
 
     /**
      * Single-issue view that adds the rendered, human-readable explanation.
-     *
-     * `render_alert` produces the per-issue title/summary/link; `remediation` is
-     * the static, kind-level fix-it guide (split into a human and an agent half).
-     * Together they let the detail view explain what's wrong and how to fix it
-     * without the caller having to interpret the raw payload.
+
+    `render_alert` produces the per-issue title/summary/link; `remediation` is
+    the static, kind-level fix-it guide (split into a human and an agent half).
+    Together they let the detail view explain what's wrong and how to fix it
+    without the caller having to interpret the raw payload.
      */
     export interface HealthIssueDetail {
       /** Unique identifier for the health issue. */
@@ -19820,15 +18781,15 @@ export namespace Schemas {
       /** Which health check produced this issue (e.g. 'sdk_outdated', 'external_data_failure', 'no_live_events', 'ingestion_warnings'). Stable string key — use it to filter issues by category. */
       readonly kind: string;
       /** How serious the issue is: 'critical', 'warning', or 'info'.
-       *
-       * * `critical` - Critical
-       * * `warning` - Warning
-       * * `info` - Info */
+
+      * `critical` - Critical
+      * `warning` - Warning
+      * `info` - Info */
       readonly severity: HealthIssueSeverityEnum;
       /** 'active' while the underlying problem is still detected; 'resolved' once a later check run no longer finds it.
-       *
-       * * `active` - Active
-       * * `resolved` - Resolved */
+
+      * `active` - Active
+      * `resolved` - Resolved */
       readonly status: HealthIssueStatusEnum;
       /** Whether a user has dismissed this issue from the Health UI. Dismissed issues stay in the list but are hidden by default. */
       dismissed?: boolean;
@@ -19912,8 +18873,8 @@ export namespace Schemas {
 
     /**
      * * `screenshot` - Screenshot
-     * * `iframe` - Iframe
-     * * `recording` - Recording
+    * `iframe` - Iframe
+    * `recording` - Recording
      */
     export type HeatmapType = typeof HeatmapType[keyof typeof HeatmapType];
 
@@ -19926,8 +18887,8 @@ export namespace Schemas {
 
     /**
      * * `processing` - Processing
-     * * `completed` - Completed
-     * * `failed` - Failed
+    * `completed` - Completed
+    * `failed` - Failed
      */
     export type HeatmapScreenshotResponseStatusEnum = typeof HeatmapScreenshotResponseStatusEnum[keyof typeof HeatmapScreenshotResponseStatusEnum];
 
@@ -19969,16 +18930,16 @@ export namespace Schemas {
       /** Viewport widths (CSS pixels) the screenshot is rendered at. */
       target_widths?: unknown;
       /** Render mode: 'screenshot', 'iframe', or 'recording'.
-       *
-       * * `screenshot` - Screenshot
-       * * `iframe` - Iframe
-       * * `recording` - Recording */
+
+      * `screenshot` - Screenshot
+      * `iframe` - Iframe
+      * `recording` - Recording */
       type?: HeatmapType;
       /** Screenshot generation status: 'processing', 'completed', or 'failed'.
-       *
-       * * `processing` - Processing
-       * * `completed` - Completed
-       * * `failed` - Failed */
+
+      * `processing` - Processing
+      * `completed` - Completed
+      * `failed` - Failed */
       readonly status: HeatmapScreenshotResponseStatusEnum;
       /** Whether at least one rendered image is ready to fetch. */
       readonly has_content: boolean;
@@ -20017,8 +18978,8 @@ export namespace Schemas {
 
     /**
      * * `draft` - Draft
-     * * `active` - Active
-     * * `archived` - Archived
+    * `active` - Active
+    * `archived` - Archived
      */
     export type HogFlowStatusEnum = typeof HogFlowStatusEnum[keyof typeof HogFlowStatusEnum];
 
@@ -20031,18 +18992,18 @@ export namespace Schemas {
 
     export interface HogFlowMasking {
       /**
-         * Seconds (60 to ~94M / 3y) to suppress repeat firings of the same hash.
+         * Hash TTL in seconds (60 to ~94M / 3y).
          * @minimum 60
          * @maximum 94608000
          * @nullable
          */
       ttl?: number | null;
       /**
-         * Fire once per N matches of the same hash within ttl — a sampler: N=3 fires on the 1st, 4th, 7th… match. Omit to fire on the first match, then suppress repeats within ttl.
+         * Min matching events before triggering (k-anonymity).
          * @nullable
          */
       threshold?: number | null;
-      /** HogQL template defining the dedup/grouping key, e.g. '{person.id}' (once per person) within ttl. */
+      /** HogQL template, e.g. '{person.properties.email}'. */
       hash: string;
       /** Auto-compiled from hash. Do not set. */
       bytecode?: unknown;
@@ -20050,7 +19011,7 @@ export namespace Schemas {
 
     /**
      * * `continue` - continue
-     * * `branch` - branch
+    * `branch` - branch
      */
     export type HogFlowEdgeTypeEnum = typeof HogFlowEdgeTypeEnum[keyof typeof HogFlowEdgeTypeEnum];
 
@@ -20064,9 +19025,9 @@ export namespace Schemas {
       /** Target action id. */
       to: string;
       /** continue: fall-through (sequential or the no-match path of conditional_branch). branch: requires 'index' matching config.conditions[index].
-       *
-       * * `continue` - continue
-       * * `branch` - branch */
+
+      * `continue` - continue
+      * `branch` - branch */
       type: HogFlowEdgeTypeEnum;
       /** Required for type='branch'. Index into config.conditions on conditional_branch / wait_until_condition. */
       index?: number;
@@ -20076,9 +19037,9 @@ export namespace Schemas {
 
     /**
      * * `continue` - continue
-     * * `abort` - abort
-     * * `complete` - complete
-     * * `branch` - branch
+    * `abort` - abort
+    * `complete` - complete
+    * `branch` - branch
      */
     export type OnErrorEnum = typeof OnErrorEnum[keyof typeof OnErrorEnum];
 
@@ -20092,8 +19053,8 @@ export namespace Schemas {
 
     /**
      * * `events` - events
-     * * `person-updates` - person-updates
-     * * `data-warehouse-table` - data-warehouse-table
+    * `person-updates` - person-updates
+    * `data-warehouse-table` - data-warehouse-table
      */
     export type HogFunctionFiltersSourceEnum = typeof HogFunctionFiltersSourceEnum[keyof typeof HogFunctionFiltersSourceEnum];
 
@@ -20135,11 +19096,11 @@ export namespace Schemas {
       /** Optional description. */
       description?: string;
       /** On failure: continue (skip), abort (stop), complete (mark done), branch (follow error edge).
-       *
-       * * `continue` - continue
-       * * `abort` - abort
-       * * `complete` - complete
-       * * `branch` - branch */
+
+      * `continue` - continue
+      * `abort` - abort
+      * `complete` - complete
+      * `branch` - branch */
       on_error?: OnErrorEnum | null;
       /** Created at (epoch ms). Frontend-managed. */
       created_at?: number;
@@ -20160,8 +19121,8 @@ export namespace Schemas {
 
     /**
      * * `active` - Active
-     * * `paused` - Paused
-     * * `completed` - Completed
+    * `paused` - Paused
+    * `completed` - Completed
      */
     export type HogFlowScheduleStatusEnum = typeof HogFlowScheduleStatusEnum[keyof typeof HogFlowScheduleStatusEnum];
 
@@ -20186,10 +19147,10 @@ export namespace Schemas {
       /** Variable value overrides merged with the workflow defaults on each run. */
       variables?: unknown;
       /** active, paused, or completed (set once the RRULE's COUNT/UNTIL is exhausted).
-       *
-       * * `active` - Active
-       * * `paused` - Paused
-       * * `completed` - Completed */
+
+      * `active` - Active
+      * `paused` - Paused
+      * `completed` - Completed */
       readonly status: HogFlowScheduleStatusEnum;
       /**
          * Next scheduled fire time, computed by the scheduler.
@@ -20212,25 +19173,25 @@ export namespace Schemas {
       description?: string;
       readonly version: number;
       /** draft (no execution), active (live), archived (disabled).
-       *
-       * * `draft` - Draft
-       * * `active` - Active
-       * * `archived` - Archived */
+
+      * `draft` - Draft
+      * `active` - Active
+      * `archived` - Archived */
       status?: HogFlowStatusEnum;
       readonly created_at: string;
       readonly created_by: UserBasic;
       readonly updated_at: string;
       readonly trigger: unknown;
-      /** Optional dedup/throttle on an already-matched trigger: {hash: <HogQL template>, ttl: <seconds, 60-94608000>, threshold?: <int>}. Without threshold: fire once per hash, then suppress repeats within ttl (hash '{person.id}' = once per person per ttl). With threshold N: fire once per N matches of the same hash — a sampler, the 1st then every Nth. Throttles an already-qualifying trigger; it doesn't decide who enters. Server compiles bytecode from hash; omit to disable. */
+      /** Optional dedup: {hash: <HogQL template>, ttl: <seconds, 60-94608000>, threshold?: <int>}. Server compiles bytecode from hash. Omit to disable. */
       trigger_masking?: HogFlowMasking | null;
       /** Conversion goal: {filters: [<cond>, ...], window_minutes}. <cond>: {key, value, operator, type: event|person|group}. Empty filters = any event in window. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
       conversion?: unknown;
       /** exit_only_at_end: only at exit node (default). exit_on_conversion: also on conversion (needs 'conversion'; silent no-op otherwise). exit_on_trigger_not_matched: also when trigger filter stops matching. exit_on_trigger_not_matched_or_conversion: both (needs 'conversion').
-       *
-       * * `exit_on_conversion` - Conversion
-       * * `exit_on_trigger_not_matched` - Trigger Not Matched
-       * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
-       * * `exit_only_at_end` - Only At End */
+
+      * `exit_on_conversion` - Conversion
+      * `exit_on_trigger_not_matched` - Trigger Not Matched
+      * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+      * `exit_only_at_end` - Only At End */
       exit_condition?: ExitConditionEnum;
       /** Graph edges: [{from, to, type: 'continue'|'branch', index?}]. 'continue' = fall-through (sequential, or no-match path of conditional_branch). 'branch' requires 'index': matches config.conditions[index] on conditional_branch / wait_until_condition. Every non-exit action needs a reachable next action ('No next action found' otherwise). */
       edges?: HogFlowEdge[];
@@ -20247,11 +19208,11 @@ export namespace Schemas {
 
     /**
      * * `waiting` - Waiting
-     * * `queued` - Queued
-     * * `active` - Active
-     * * `completed` - Completed
-     * * `cancelled` - Cancelled
-     * * `failed` - Failed
+    * `queued` - Queued
+    * `active` - Active
+    * `completed` - Completed
+    * `cancelled` - Cancelled
+    * `failed` - Failed
      */
     export type HogFlowBatchJobStatusEnum = typeof HogFlowBatchJobStatusEnum[keyof typeof HogFlowBatchJobStatusEnum];
 
@@ -20268,13 +19229,13 @@ export namespace Schemas {
     export interface HogFlowBatchJob {
       readonly id: string;
       /** Not currently tracked — stays at its initial value. Use the workflow logs/metrics endpoints for run outcome.
-       *
-       * * `waiting` - Waiting
-       * * `queued` - Queued
-       * * `active` - Active
-       * * `completed` - Completed
-       * * `cancelled` - Cancelled
-       * * `failed` - Failed */
+
+      * `waiting` - Waiting
+      * `queued` - Queued
+      * `active` - Active
+      * `completed` - Completed
+      * `cancelled` - Cancelled
+      * `failed` - Failed */
       status?: HogFlowBatchJobStatusEnum;
       /** ID of the workflow this batch run belongs to. */
       hog_flow: string;
@@ -20337,8 +19298,8 @@ export namespace Schemas {
 
     /**
      * * `team` - Only team
-     * * `organization` - Organization
-     * * `global` - Global
+    * `organization` - Organization
+    * `global` - Global
      */
     export type HogFlowTemplateScopeEnum = typeof HogFlowTemplateScopeEnum[keyof typeof HogFlowTemplateScopeEnum];
 
@@ -20351,7 +19312,7 @@ export namespace Schemas {
 
     /**
      * Custom action serializer for templates that skips input validation
-     * (since templates should have default/empty values).
+    (since templates should have default/empty values).
      */
     export interface HogFlowTemplateAction {
       id: string;
@@ -20370,7 +19331,7 @@ export namespace Schemas {
 
     /**
      * Serializer for creating hog flow templates.
-     * Validates and sanitizes the workflow before creating it as a template.
+    Validates and sanitizes the workflow before creating it as a template.
      */
     export interface HogFlowTemplate {
       readonly id: string;
@@ -20404,7 +19365,7 @@ export namespace Schemas {
 
     /**
      * * `hog` - hog
-     * * `liquid` - liquid
+    * `liquid` - liquid
      */
     export type HogFunctionTemplatingEnum = typeof HogFunctionTemplatingEnum[keyof typeof HogFunctionTemplatingEnum];
 
@@ -20429,12 +19390,12 @@ export namespace Schemas {
 
     /**
      * * `destination` - Destination
-     * * `site_destination` - Site Destination
-     * * `internal_destination` - Internal Destination
-     * * `source_webhook` - Source Webhook
-     * * `warehouse_source_webhook` - Warehouse Source Webhook
-     * * `site_app` - Site App
-     * * `transformation` - Transformation
+    * `site_destination` - Site Destination
+    * `internal_destination` - Internal Destination
+    * `source_webhook` - Source Webhook
+    * `warehouse_source_webhook` - Warehouse Source Webhook
+    * `site_app` - Site App
+    * `transformation` - Transformation
      */
     export type HogFunctionTypeEnum = typeof HogFunctionTypeEnum[keyof typeof HogFunctionTypeEnum];
 
@@ -20451,19 +19412,19 @@ export namespace Schemas {
 
     /**
      * * `string` - string
-     * * `number` - number
-     * * `boolean` - boolean
-     * * `dictionary` - dictionary
-     * * `choice` - choice
-     * * `json` - json
-     * * `integration` - integration
-     * * `integration_field` - integration_field
-     * * `email` - email
-     * * `native_email` - native_email
-     * * `posthog_assignee` - posthog_assignee
-     * * `posthog_ticket_tags` - posthog_ticket_tags
-     * * `posthog_business_hours` - posthog_business_hours
-     * * `non_failure_status_codes` - non_failure_status_codes
+    * `number` - number
+    * `boolean` - boolean
+    * `dictionary` - dictionary
+    * `choice` - choice
+    * `json` - json
+    * `integration` - integration
+    * `integration_field` - integration_field
+    * `email` - email
+    * `native_email` - native_email
+    * `posthog_assignee` - posthog_assignee
+    * `posthog_ticket_tags` - posthog_ticket_tags
+    * `posthog_business_hours` - posthog_business_hours
+    * `non_failure_status_codes` - non_failure_status_codes
      */
     export type InputsSchemaItemTypeEnum = typeof InputsSchemaItemTypeEnum[keyof typeof InputsSchemaItemTypeEnum];
 
@@ -20608,11 +19569,11 @@ export namespace Schemas {
 
     /**
      * * `0` - 0
-     * * `1` - 1
-     * * `2` - 2
-     * * `3` - 3
-     * * `11` - 11
-     * * `12` - 12
+    * `1` - 1
+    * `2` - 2
+    * `3` - 3
+    * `11` - 11
+    * `12` - 12
      */
     export type HogFunctionStatusStateEnum = typeof HogFunctionStatusStateEnum[keyof typeof HogFunctionStatusStateEnum];
 
@@ -20634,14 +19595,14 @@ export namespace Schemas {
     export interface HogFunction {
       readonly id: string;
       /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
-       *
-       * * `destination` - Destination
-       * * `site_destination` - Site Destination
-       * * `internal_destination` - Internal Destination
-       * * `source_webhook` - Source Webhook
-       * * `warehouse_source_webhook` - Warehouse Source Webhook
-       * * `site_app` - Site App
-       * * `transformation` - Transformation */
+
+      * `destination` - Destination
+      * `site_destination` - Site Destination
+      * `internal_destination` - Internal Destination
+      * `source_webhook` - Source Webhook
+      * `warehouse_source_webhook` - Warehouse Source Webhook
+      * `site_app` - Site App
+      * `transformation` - Transformation */
       type?: HogFunctionTypeEnum | null;
       /**
          * Display name for the function.
@@ -20699,8 +19660,6 @@ export namespace Schemas {
       _create_in_folder?: string;
       /** @nullable */
       readonly batch_export_id: string | null;
-      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
-      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     /**
@@ -20752,8 +19711,6 @@ export namespace Schemas {
       readonly status: HogFunctionStatus | null;
       /** @nullable */
       readonly execution_order: number | null;
-      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
-      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     export interface HogInvocationResult {
@@ -21227,14 +20184,6 @@ export namespace Schemas {
       version?: number | null;
     }
 
-    export type TraceOrderColumn = typeof TraceOrderColumn[keyof typeof TraceOrderColumn];
-
-
-    export const TraceOrderColumn = {
-      Timestamp: 'timestamp',
-      Duration: 'duration',
-    } as const;
-
     export interface TraceSpansQueryResponse {
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
       error?: string | null;
@@ -21272,10 +20221,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
-      /** Column to order by. Defaults to timestamp. `timestamp` paginates via keyset cursor (`after`); other columns via `offset`. */
-      orderBy?: TraceOrderColumn | null;
-      /** Order direction. Defaults to DESC. */
-      orderDirection?: OrderDirection2 | null;
+      orderBy?: LogsOrderBy | null;
       /** Prefetch up to this many spans per trace and include them in results */
       prefetchSpans?: number | null;
       response?: TraceSpansQueryResponse | null;
@@ -21480,14 +20426,12 @@ export namespace Schemas {
       id: string;
       inactive_seconds?: number | null;
       keypress_count?: number | null;
-      /** False when the recording was included in list results via a direct link despite not matching the filters. */
-      matches_filters?: boolean | null;
       /** List of matching events. * */
       matching_events?: MatchedRecording[] | null;
       /** count of all mouse activity in the recording, not just clicks */
       mouse_activity_count?: number | null;
       /** whether we have received data for this recording in the last 5 minutes (assumes the recording was loaded from ClickHouse)
-       * * */
+      * */
       ongoing?: boolean | null;
       person?: PersonType | null;
       /** Length of recording in seconds. */
@@ -21798,9 +20742,9 @@ export namespace Schemas {
 
     /**
      * * `trends` - trends
-     * * `funnel` - funnel
-     * * `retention` - retention
-     * * `sql` - sql
+    * `funnel` - funnel
+    * `retention` - retention
+    * `sql` - sql
      */
     export type InsightTypeEnum = typeof InsightTypeEnum[keyof typeof InsightTypeEnum];
 
@@ -21814,10 +20758,10 @@ export namespace Schemas {
 
     /**
      * * `String` - String
-     * * `Number` - Number
-     * * `Boolean` - Boolean
-     * * `List` - List
-     * * `Date` - Date
+    * `Number` - Number
+    * `Boolean` - Boolean
+    * `List` - List
+    * `Date` - Date
      */
     export type InsightVariableTypeEnum = typeof InsightVariableTypeEnum[keyof typeof InsightVariableTypeEnum];
 
@@ -21839,12 +20783,12 @@ export namespace Schemas {
          */
       name: string;
       /** Variable type. Controls how the value is rendered and substituted in HogQL.
-       *
-       * * `String` - String
-       * * `Number` - Number
-       * * `Boolean` - Boolean
-       * * `List` - List
-       * * `Date` - Date */
+
+      * `String` - String
+      * `Number` - Number
+      * `Boolean` - Boolean
+      * `List` - List
+      * `Date` - Date */
       type: InsightVariableTypeEnum;
       /** Default value used when a query references this variable. */
       default_value?: unknown;
@@ -21880,7 +20824,7 @@ export namespace Schemas {
 
     /**
      * * `api_key` - api_key
-     * * `oauth` - oauth
+    * `oauth` - oauth
      */
     export type InstallCustomAuthTypeEnum = typeof InstallCustomAuthTypeEnum[keyof typeof InstallCustomAuthTypeEnum];
 
@@ -21892,7 +20836,7 @@ export namespace Schemas {
 
     /**
      * * `posthog` - posthog
-     * * `posthog-code` - posthog-code
+    * `posthog-code` - posthog-code
      */
     export type InstallSourceEnum = typeof InstallSourceEnum[keyof typeof InstallSourceEnum];
 
@@ -21925,41 +20869,41 @@ export namespace Schemas {
 
     /**
      * * `anthropic` - Anthropic
-     * * `apns` - Apple Push
-     * * `azure-blob` - Azure Blob
-     * * `bing-ads` - Bing Ads
-     * * `clickup` - Clickup
-     * * `customerio-app` - Customerio App
-     * * `customerio-track` - Customerio Track
-     * * `customerio-webhook` - Customerio Webhook
-     * * `databricks` - Databricks
-     * * `email` - Email
-     * * `firebase` - Firebase
-     * * `github` - Github
-     * * `gitlab` - Gitlab
-     * * `google-ads` - Google Ads
-     * * `google-cloud-service-account` - Google Cloud Service Account
-     * * `google-cloud-storage` - Google Cloud Storage
-     * * `google-pubsub` - Google Pubsub
-     * * `google-search-console` - Google Search Console
-     * * `google-sheets` - Google Sheets
-     * * `hubspot` - Hubspot
-     * * `intercom` - Intercom
-     * * `jira` - Jira
-     * * `linear` - Linear
-     * * `linkedin-ads` - Linkedin Ads
-     * * `meta-ads` - Meta Ads
-     * * `pinterest-ads` - Pinterest Ads
-     * * `postgresql` - Postgresql
-     * * `reddit-ads` - Reddit Ads
-     * * `salesforce` - Salesforce
-     * * `slack` - Slack
-     * * `slack-posthog-code` - Slack Posthog Code
-     * * `snapchat` - Snapchat
-     * * `stripe` - Stripe
-     * * `tiktok-ads` - Tiktok Ads
-     * * `twilio` - Twilio
-     * * `vercel` - Vercel
+    * `apns` - Apple Push
+    * `azure-blob` - Azure Blob
+    * `bing-ads` - Bing Ads
+    * `clickup` - Clickup
+    * `customerio-app` - Customerio App
+    * `customerio-track` - Customerio Track
+    * `customerio-webhook` - Customerio Webhook
+    * `databricks` - Databricks
+    * `email` - Email
+    * `firebase` - Firebase
+    * `github` - Github
+    * `gitlab` - Gitlab
+    * `google-ads` - Google Ads
+    * `google-cloud-service-account` - Google Cloud Service Account
+    * `google-cloud-storage` - Google Cloud Storage
+    * `google-pubsub` - Google Pubsub
+    * `google-search-console` - Google Search Console
+    * `google-sheets` - Google Sheets
+    * `hubspot` - Hubspot
+    * `intercom` - Intercom
+    * `jira` - Jira
+    * `linear` - Linear
+    * `linkedin-ads` - Linkedin Ads
+    * `meta-ads` - Meta Ads
+    * `pinterest-ads` - Pinterest Ads
+    * `postgresql` - Postgresql
+    * `reddit-ads` - Reddit Ads
+    * `salesforce` - Salesforce
+    * `slack` - Slack
+    * `slack-posthog-code` - Slack Posthog Code
+    * `snapchat` - Snapchat
+    * `stripe` - Stripe
+    * `tiktok-ads` - Tiktok Ads
+    * `twilio` - Twilio
+    * `vercel` - Vercel
      */
     export type IntegrationKindEnum = typeof IntegrationKindEnum[keyof typeof IntegrationKindEnum];
 
@@ -22014,39 +20958,6 @@ export namespace Schemas {
       readonly created_by: UserBasic;
       readonly errors: string;
       readonly display_name: string;
-    }
-
-    export interface RecommendedAction {
-      /** Short title of the recommended action */
-      title: string;
-      /** Detailed explanation of the action */
-      detail: string;
-      /** Action severity */
-      severity: string;
-      /**
-         * Follow-up tool to call next, if any
-         * @nullable
-         */
-      target_tool: string | null;
-    }
-
-    export interface IntegrationDiagnostic {
-      /** Integration key (e.g. 'google', 'meta') */
-      integration_key: string;
-      /** External data source type key (e.g. 'GoogleAds') */
-      source_type: string;
-      /** Human-readable integration name */
-      display_name: string;
-      /** Per-integration status */
-      overall_status: string;
-      /** Human-readable cross-domain diagnosis */
-      diagnosis: string;
-      /** Data-source (sync) side health, or null if not connected */
-      data_source?: DataSourceHealthEntry | null;
-      /** Attribution (UTM events) side health, or null if no data */
-      attribution?: AttributionHealthEntry | null;
-      /** Recommended next steps for this integration */
-      recommended_actions: RecommendedAction[];
     }
 
     /**
@@ -22132,58 +21043,9 @@ export namespace Schemas {
     } as const;
 
     /**
-     * One chunk in a drill-down window over a single knowledge document.
-     *
-     * Output-only — the rows come from the `get_document_window` logic helper
-     * (a `KnowledgeSearchResult` dataclass), not the ORM, so this is a plain
-     * read serializer rather than a `ModelSerializer`.
-     */
-    export interface KnowledgeDocumentWindow {
-      /** Stable identifier of this chunk. Same value used in search results. */
-      readonly chunk_id: string;
-      /** Zero-based position of this chunk within its document. Use it as `around_ordinal` to recenter the window. */
-      readonly ordinal: number;
-      /** The chunk's text content. */
-      readonly content: string;
-      /** Breadcrumb of section headings this chunk sits under. Empty when the document has no heading structure. */
-      readonly heading_path: string;
-      /** Human label of the knowledge source this chunk belongs to. */
-      readonly source_name: string;
-      /** Title of the document this chunk belongs to. */
-      readonly document_title: string;
-    }
-
-    /**
-     * One ranked chunk from a business knowledge search.
-     *
-     * Output-only — the rows come from the ``search_knowledge_for_team`` logic
-     * helper (a ``KnowledgeSearchResult`` dataclass), not the ORM.
-     */
-    export interface KnowledgeSearchResult {
-      /** Stable identifier of this chunk. */
-      readonly chunk_id: string;
-      /** ID of the parent document. Pass to the document-window endpoint with `around_ordinal` to drill down. */
-      readonly document_id: string;
-      /** Zero-based position of this chunk within its document. Use as `around_ordinal` in the document-window endpoint. */
-      readonly ordinal: number;
-      /** ID of the knowledge source this chunk belongs to. */
-      readonly source_id: string;
-      /** Human label of the knowledge source this chunk belongs to. */
-      readonly source_name: string;
-      /** Source type (text, url, or file). */
-      readonly source_type: string;
-      /** Title of the document this chunk belongs to. */
-      readonly document_title: string;
-      /** Breadcrumb of section headings this chunk sits under. Empty when the document has no heading structure. */
-      readonly heading_path: string;
-      /** The chunk's text content. */
-      readonly content: string;
-    }
-
-    /**
      * * `text` - Text
-     * * `url` - URL
-     * * `file` - File
+    * `url` - URL
+    * `file` - File
      */
     export type KnowledgeSourceSourceTypeEnum = typeof KnowledgeSourceSourceTypeEnum[keyof typeof KnowledgeSourceSourceTypeEnum];
 
@@ -22196,9 +21058,9 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-     * * `processing` - Processing
-     * * `ready` - Ready
-     * * `error` - Error
+    * `processing` - Processing
+    * `ready` - Ready
+    * `error` - Error
      */
     export type KnowledgeSourceStatusEnum = typeof KnowledgeSourceStatusEnum[keyof typeof KnowledgeSourceStatusEnum];
 
@@ -22212,8 +21074,8 @@ export namespace Schemas {
 
     /**
      * * `success` - Success
-     * * `not_modified` - Not modified
-     * * `error` - Error
+    * `not_modified` - Not modified
+    * `error` - Error
      */
     export type LastRefreshStatusEnum = typeof LastRefreshStatusEnum[keyof typeof LastRefreshStatusEnum];
 
@@ -22226,10 +21088,10 @@ export namespace Schemas {
 
     /**
      * * `manual` - Manual only
-     * * `1h` - Every hour
-     * * `6h` - Every 6 hours
-     * * `24h` - Every day
-     * * `7d` - Every week
+    * `1h` - Every hour
+    * `6h` - Every 6 hours
+    * `24h` - Every day
+    * `7d` - Every week
      */
     export type RefreshIntervalEnum = typeof RefreshIntervalEnum[keyof typeof RefreshIntervalEnum];
 
@@ -22678,9 +21540,9 @@ export namespace Schemas {
 
     /**
      * * `today` - today
-     * * `this_week` - this_week
-     * * `inactive` - inactive
-     * * `never` - never
+    * `this_week` - this_week
+    * `inactive` - inactive
+    * `never` - never
      */
     export type LastActiveEnum = typeof LastActiveEnum[keyof typeof LastActiveEnum];
 
@@ -22703,8 +21565,8 @@ export namespace Schemas {
 
     /**
      * * `preserve` - preserve
-     * * `two_column` - two_column
-     * * `full_width` - full_width
+    * `two_column` - two_column
+    * `full_width` - full_width
      */
     export type LayoutEnum = typeof LayoutEnum[keyof typeof LayoutEnum];
 
@@ -22742,7 +21604,7 @@ export namespace Schemas {
 
     /**
      * * `burst` - burst
-     * * `sustained` - sustained
+    * `sustained` - sustained
      */
     export type LimitTypeEnum = typeof LimitTypeEnum[keyof typeof LimitTypeEnum];
 
@@ -22759,17 +21621,17 @@ export namespace Schemas {
       /** ID of the file download batch export run. */
       id: string;
       /** Current status of the file download batch export run.
-       *
-       * * `Cancelled` - Cancelled
-       * * `Completed` - Completed
-       * * `ContinuedAsNew` - Continued As New
-       * * `Failed` - Failed
-       * * `FailedRetryable` - Failed Retryable
-       * * `FailedBilling` - Failed Billing
-       * * `Terminated` - Terminated
-       * * `TimedOut` - Timedout
-       * * `Running` - Running
-       * * `Starting` - Starting */
+
+      * `Cancelled` - Cancelled
+      * `Completed` - Completed
+      * `ContinuedAsNew` - Continued As New
+      * `Failed` - Failed
+      * `FailedRetryable` - Failed Retryable
+      * `FailedBilling` - Failed Billing
+      * `Terminated` - Terminated
+      * `TimedOut` - Timedout
+      * `Running` - Running
+      * `Starting` - Starting */
       status: BatchExportRunStatusEnum;
     }
 
@@ -22798,7 +21660,7 @@ export namespace Schemas {
 
     /**
      * * `above` - Above
-     * * `below` - Below
+    * `below` - Below
      */
     export type ThresholdOperatorEnum = typeof ThresholdOperatorEnum[keyof typeof ThresholdOperatorEnum];
 
@@ -22810,11 +21672,11 @@ export namespace Schemas {
 
     /**
      * * `not_firing` - Not firing
-     * * `firing` - Firing
-     * * `pending_resolve` - Pending resolve
-     * * `errored` - Errored
-     * * `snoozed` - Snoozed
-     * * `broken` - Broken
+    * `firing` - Firing
+    * `pending_resolve` - Pending resolve
+    * `errored` - Errored
+    * `snoozed` - Snoozed
+    * `broken` - Broken
      */
     export type LogsAlertConfigurationStateEnum = typeof LogsAlertConfigurationStateEnum[keyof typeof LogsAlertConfigurationStateEnum];
 
@@ -22834,13 +21696,13 @@ export namespace Schemas {
       /** Interval end (UTC, exclusive). */
       end: string;
       /** Alert state during this interval.
-       *
-       * * `not_firing` - Not firing
-       * * `firing` - Firing
-       * * `pending_resolve` - Pending resolve
-       * * `errored` - Errored
-       * * `snoozed` - Snoozed
-       * * `broken` - Broken */
+
+      * `not_firing` - Not firing
+      * `firing` - Firing
+      * `pending_resolve` - Pending resolve
+      * `errored` - Errored
+      * `snoozed` - Snoozed
+      * `broken` - Broken */
       state: LogsAlertConfigurationStateEnum;
       /** Whether the alert was enabled during this interval. Disabled alerts keep their state but are inactive. */
       enabled: boolean;
@@ -22848,8 +21710,7 @@ export namespace Schemas {
 
     /**
      * * `slack` - slack
-     * * `webhook` - webhook
-     * * `teams` - teams
+    * `webhook` - webhook
      */
     export type NotificationDestinationTypeEnum = typeof NotificationDestinationTypeEnum[keyof typeof NotificationDestinationTypeEnum];
 
@@ -22857,7 +21718,6 @@ export namespace Schemas {
     export const NotificationDestinationTypeEnum = {
       Slack: 'slack',
       Webhook: 'webhook',
-      Teams: 'teams',
     } as const;
 
     export interface LogsAlertConfiguration {
@@ -22878,22 +21738,22 @@ export namespace Schemas {
          */
       threshold_count?: number;
       /** Whether the alert fires when the count is above or below the threshold.
-       *
-       * * `above` - Above
-       * * `below` - Below */
+
+      * `above` - Above
+      * `below` - Below */
       threshold_operator?: ThresholdOperatorEnum;
       /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
       window_minutes?: number;
       /** How often the alert is evaluated, in minutes. Server-managed. */
       readonly check_interval_minutes: number;
       /** Current alert state: not_firing, firing, pending_resolve, errored, or snoozed. Server-managed.
-       *
-       * * `not_firing` - Not firing
-       * * `firing` - Firing
-       * * `pending_resolve` - Pending resolve
-       * * `errored` - Errored
-       * * `snoozed` - Snoozed
-       * * `broken` - Broken */
+
+      * `not_firing` - Not firing
+      * `firing` - Firing
+      * `pending_resolve` - Pending resolve
+      * `errored` - Errored
+      * `snoozed` - Snoozed
+      * `broken` - Broken */
       readonly state: LogsAlertConfigurationStateEnum;
       /**
          * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
@@ -22959,11 +21819,10 @@ export namespace Schemas {
     }
 
     export interface LogsAlertCreateDestination {
-      /** Destination type — slack, webhook, or teams.
-       *
-       * * `slack` - slack
-       * * `webhook` - webhook
-       * * `teams` - teams */
+      /** Destination type — slack or webhook.
+
+      * `slack` - slack
+      * `webhook` - webhook */
       type: NotificationDestinationTypeEnum;
       /** Integration ID for the Slack workspace. Required when type=slack. */
       slack_workspace_id?: number;
@@ -22971,7 +21830,7 @@ export namespace Schemas {
       slack_channel_id?: string;
       /** Human-readable channel name for display. */
       slack_channel_name?: string;
-      /** HTTPS endpoint to POST to. Required when type=webhook, or the Teams webhook URL when type=teams. */
+      /** HTTPS endpoint to POST to. Required when type=webhook. */
       webhook_url?: string;
     }
 
@@ -22989,13 +21848,13 @@ export namespace Schemas {
 
     /**
      * * `check` - Check
-     * * `reset` - Reset
-     * * `enable` - Enable
-     * * `disable` - Disable
-     * * `snooze` - Snooze
-     * * `unsnooze` - Unsnooze
-     * * `threshold_change` - Threshold change
-     * * `broken_config` - Broken config
+    * `reset` - Reset
+    * `enable` - Enable
+    * `disable` - Disable
+    * `snooze` - Snooze
+    * `unsnooze` - Unsnooze
+    * `threshold_change` - Threshold change
+    * `broken_config` - Broken config
      */
     export type LogsAlertEventKindEnum = typeof LogsAlertEventKindEnum[keyof typeof LogsAlertEventKindEnum];
 
@@ -23050,9 +21909,9 @@ export namespace Schemas {
          */
       threshold_count: number;
       /** Whether the alert fires when the count is above or below the threshold.
-       *
-       * * `above` - Above
-       * * `below` - Below */
+
+      * `above` - Above
+      * `below` - Below */
       threshold_operator: ThresholdOperatorEnum;
       /** Window size in minutes — determines bucket interval. */
       window_minutes: number;
@@ -23102,8 +21961,8 @@ export namespace Schemas {
 
     /**
      * * `severity_sampling` - Severity-based reduction
-     * * `path_drop` - Path exclusion
-     * * `rate_limit` - Rate limit
+    * `path_drop` - Path exclusion
+    * `rate_limit` - Rate limit
      */
     export type RuleTypeEnum = typeof RuleTypeEnum[keyof typeof RuleTypeEnum];
 
@@ -23131,10 +21990,10 @@ export namespace Schemas {
          */
       priority?: number | null;
       /** Rule kind: severity_sampling, path_drop, or rate_limit (caps matching log volume at ingestion).
-       *
-       * * `severity_sampling` - Severity-based reduction
-       * * `path_drop` - Path exclusion
-       * * `rate_limit` - Rate limit */
+
+      * `severity_sampling` - Severity-based reduction
+      * `path_drop` - Path exclusion
+      * `rate_limit` - Rate limit */
       rule_type: RuleTypeEnum;
       /**
          * Optional legacy service-name scope; new rules use `config.filter_group` for matching instead.
@@ -23193,7 +22052,7 @@ export namespace Schemas {
 
     /**
      * * `feedback` - Feedback
-     * * `missing_capability` - Missing capability
+    * `missing_capability` - Missing capability
      */
     export type MCPAnalyticsSubmissionKindEnum = typeof MCPAnalyticsSubmissionKindEnum[keyof typeof MCPAnalyticsSubmissionKindEnum];
 
@@ -23207,9 +22066,9 @@ export namespace Schemas {
       /** Unique identifier for this submission. */
       readonly id: string;
       /** Whether this submission is general feedback or a missing capability report.
-       *
-       * * `feedback` - Feedback
-       * * `missing_capability` - Missing capability */
+
+      * `feedback` - Feedback
+      * `missing_capability` - Missing capability */
       readonly kind: MCPAnalyticsSubmissionKindEnum;
       /** The user's goal in plain language. */
       goal: string;
@@ -23244,7 +22103,7 @@ export namespace Schemas {
 
     /**
      * * `api_key` - API Key
-     * * `oauth` - OAuth
+    * `oauth` - OAuth
      */
     export type MCPAuthTypeEnum = typeof MCPAuthTypeEnum[keyof typeof MCPAuthTypeEnum];
 
@@ -23256,10 +22115,10 @@ export namespace Schemas {
 
     /**
      * * `results` - Results
-     * * `usability` - Usability
-     * * `bug` - Bug
-     * * `docs` - Docs
-     * * `other` - Other
+    * `usability` - Usability
+    * `bug` - Bug
+    * `docs` - Docs
+    * `other` - Other
      */
     export type MCPFeedbackCreateCategoryEnum = typeof MCPFeedbackCreateCategoryEnum[keyof typeof MCPFeedbackCreateCategoryEnum];
 
@@ -23319,12 +22178,12 @@ export namespace Schemas {
          */
       feedback: string;
       /** High-level category for the feedback.
-       *
-       * * `results` - Results
-       * * `usability` - Usability
-       * * `bug` - Bug
-       * * `docs` - Docs
-       * * `other` - Other */
+
+      * `results` - Results
+      * `usability` - Usability
+      * `bug` - Bug
+      * `docs` - Docs
+      * `other` - Other */
       category?: MCPFeedbackCreateCategoryEnum;
     }
 
@@ -23343,7 +22202,7 @@ export namespace Schemas {
 
     /**
      * * `completed` - Completed
-     * * `error` - Error
+    * `error` - Error
      */
     export type OutcomeEnum = typeof OutcomeEnum[keyof typeof OutcomeEnum];
 
@@ -23357,9 +22216,9 @@ export namespace Schemas {
       /** Ordered tool names called during the path. Length is fixed; null entries indicate the session ended before this step. */
       readonly steps: readonly (string | null)[];
       /** Terminal outcome of the sessions following this path.
-       *
-       * * `completed` - Completed
-       * * `error` - Error */
+
+      * `completed` - Completed
+      * `error` - Error */
       readonly outcome: OutcomeEnum;
       /** Number of sessions in this cluster that followed this exact path. */
       readonly count: number;
@@ -23401,8 +22260,8 @@ export namespace Schemas {
 
     /**
      * * `idle` - Idle
-     * * `computing` - Computing
-     * * `error` - Error
+    * `computing` - Computing
+    * `error` - Error
      */
     export type MCPIntentClusterSnapshotStatusEnum = typeof MCPIntentClusterSnapshotStatusEnum[keyof typeof MCPIntentClusterSnapshotStatusEnum];
 
@@ -23426,10 +22285,10 @@ export namespace Schemas {
 
     export interface MCPIntentClusterSnapshot {
       /** Whether a snapshot is current (idle), being recomputed (computing), or failed (error).
-       *
-       * * `idle` - Idle
-       * * `computing` - Computing
-       * * `error` - Error */
+
+      * `idle` - Idle
+      * `computing` - Computing
+      * `error` - Error */
       readonly status: MCPIntentClusterSnapshotStatusEnum;
       /** Error message from the most recent failed run, otherwise empty. */
       readonly error_message: string;
@@ -23522,8 +22381,8 @@ export namespace Schemas {
 
     /**
      * * `approved` - Approved
-     * * `needs_approval` - Needs approval
-     * * `do_not_use` - Do not use
+    * `needs_approval` - Needs approval
+    * `do_not_use` - Do not use
      */
     export type MCPServerInstallationToolApprovalStateEnum = typeof MCPServerInstallationToolApprovalStateEnum[keyof typeof MCPServerInstallationToolApprovalStateEnum];
 
@@ -23551,11 +22410,11 @@ export namespace Schemas {
 
     /**
      * * `business` - Business Operations
-     * * `data` - Data & Analytics
-     * * `design` - Design & Content
-     * * `dev` - Developer Tools & APIs
-     * * `infra` - Infrastructure
-     * * `productivity` - Productivity & Collaboration
+    * `data` - Data & Analytics
+    * `design` - Design & Content
+    * `dev` - Developer Tools & APIs
+    * `infra` - Infrastructure
+    * `productivity` - Productivity & Collaboration
      */
     export type MCPServerTemplateCategoryEnum = typeof MCPServerTemplateCategoryEnum[keyof typeof MCPServerTemplateCategoryEnum];
 
@@ -23641,22 +22500,9 @@ export namespace Schemas {
       snapshot_id: string;
     }
 
-    export interface MarketingDiagnosticResponse {
-      /** Per-integration cross-domain diagnostics */
-      integrations: IntegrationDiagnostic[];
-      /** healthy/degraded/broken/no_sources */
-      overall_status: string;
-      /** One-line plain-English summary of the diagnostic */
-      summary: string;
-      /** Conversion goal summary, when requested */
-      conversion_goals?: ConversionGoalsListResponse | null;
-      /** Top global recommended actions across all integrations */
-      recommended_actions: RecommendedAction[];
-    }
-
     /**
      * * `key` - key
-     * * `value` - value
+    * `value` - value
      */
     export type MatchedOnEnum = typeof MatchedOnEnum[keyof typeof MatchedOnEnum];
 
@@ -23690,9 +22536,9 @@ export namespace Schemas {
 
     /**
      * * `PENDING` - Pending
-     * * `BACKFILL` - Backfill
-     * * `READY` - Ready
-     * * `ERROR` - Error
+    * `BACKFILL` - Backfill
+    * `READY` - Ready
+    * `ERROR` - Error
      */
     export type MaterializedColumnSlotStateEnum = typeof MaterializedColumnSlotStateEnum[keyof typeof MaterializedColumnSlotStateEnum];
 
@@ -23729,8 +22575,8 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-     * * `completed` - Completed
-     * * `skipped` - Skipped
+    * `completed` - Completed
+    * `skipped` - Skipped
      */
     export type ScrapingStatusEnum = typeof ScrapingStatusEnum[keyof typeof ScrapingStatusEnum];
 
@@ -23812,50 +22658,24 @@ export namespace Schemas {
       scores: MessageSentimentScores;
     }
 
-    /**
-     * * `liquid` - liquid
-     */
-    export type MessageTemplateContentTemplatingEnum = typeof MessageTemplateContentTemplatingEnum[keyof typeof MessageTemplateContentTemplatingEnum];
-
-
-    export const MessageTemplateContentTemplatingEnum = {
-      Liquid: 'liquid',
-    } as const;
-
     export interface MessageTemplateContent {
-      /** Templating language for the email content. Always 'liquid' — Liquid tags pass through verbatim.
-       *
-       * * `liquid` - liquid */
-      templating?: MessageTemplateContentTemplatingEnum;
-      /** Email message content. Replaced as a whole on update — send the complete object. */
+      templating?: HogFunctionTemplatingEnum;
       email?: EmailTemplate | null;
     }
 
     export interface MessageTemplate {
       readonly id: string;
-      /**
-         * Human-readable template name shown in the library.
-         * @maxLength 400
-         */
+      /** @maxLength 400 */
       name: string;
-      /** What the template is for and when to use it. */
       description?: string;
       readonly created_at: string;
       readonly updated_at: string;
-      /** Template content keyed by channel. Replaced as a whole on update, not merged. */
       content?: MessageTemplateContent;
       readonly created_by: UserBasic;
-      /**
-         * Message channel of the template. Currently 'email'.
-         * @maxLength 24
-         */
+      /** @maxLength 24 */
       type?: string;
-      /**
-         * Message category ID to file the template under. Must belong to the same project.
-         * @nullable
-         */
+      /** @nullable */
       message_category?: string | null;
-      /** Soft-delete flag. Set true to remove the template from the library. */
       deleted?: boolean;
     }
 
@@ -23876,10 +22696,10 @@ export namespace Schemas {
 
     /**
      * * `user_message` - user_message
-     * * `cancel` - cancel
-     * * `close` - close
-     * * `permission_response` - permission_response
-     * * `set_config_option` - set_config_option
+    * `cancel` - cancel
+    * `close` - close
+    * `permission_response` - permission_response
+    * `set_config_option` - set_config_option
      */
     export type MethodEnum = typeof MethodEnum[keyof typeof MethodEnum];
 
@@ -23894,8 +22714,8 @@ export namespace Schemas {
 
     /**
      * * `precise` - PRECISE
-     * * `coarse` - COARSE
-     * * `partial` - PARTIAL
+    * `coarse` - COARSE
+    * `partial` - PARTIAL
      */
     export type MetricQualityEnum = typeof MetricQualityEnum[keyof typeof MetricQualityEnum];
 
@@ -23963,8 +22783,8 @@ export namespace Schemas {
 
     /**
      * * `trusted` - Trusted
-     * * `full` - Full
-     * * `custom` - Custom
+    * `full` - Full
+    * `custom` - Custom
      */
     export type NetworkAccessLevelEnum = typeof NetworkAccessLevelEnum[keyof typeof NetworkAccessLevelEnum];
 
@@ -23977,9 +22797,9 @@ export namespace Schemas {
 
     /**
      * * `table` - Table
-     * * `view` - View
-     * * `matview` - Mat View
-     * * `endpoint` - Endpoint
+    * `view` - View
+    * `matview` - Mat View
+    * `endpoint` - Endpoint
      */
     export type NodeTypeEnum = typeof NodeTypeEnum[keyof typeof NodeTypeEnum];
 
@@ -24069,44 +22889,6 @@ export namespace Schemas {
       _create_in_folder?: string;
     }
 
-    export interface NotebookCollabCursor {
-      /**
-         * ProseMirror selection head position (rich v1 notebooks).
-         * @minimum 0
-         */
-      head?: number;
-      /**
-         * Index of the caret's block node in the markdown notebook document (markdown notebooks).
-         * @minimum 0
-         */
-      node_index?: number;
-      /**
-         * Caret offset in the plain text of the focused editable element, in UTF-16 code units.
-         * @minimum 0
-         */
-      offset?: number;
-      /**
-         * Index of the focused list item when the caret is inside a list block.
-         * @minimum 0
-         */
-      list_item_index?: number;
-    }
-
-    export interface NotebookCollabPresence {
-      /**
-         * Unique identifier for the client session, used to skip self-echo on the update stream.
-         * @maxLength 200
-         */
-      client_id: string;
-      /**
-         * The notebook version the cursor position is relative to.
-         * @minimum 0
-         */
-      version: number;
-      /** The caller's caret position, broadcast to other clients on this notebook's collab stream. */
-      cursor: NotebookCollabCursor;
-    }
-
     export interface NotebookCollabSave {
       /** Unique identifier for the client session. */
       client_id: string;
@@ -24125,21 +22907,6 @@ export namespace Schemas {
          * @nullable
          */
       cursor_head?: number | null;
-    }
-
-    export interface NotebookMarkdownSave {
-      /** Unique identifier for the client session, used to skip self-echo on the update stream. */
-      client_id: string;
-      /** The notebook version the submitted content is based on (optimistic concurrency baseline). */
-      version: number;
-      /** The full markdown notebook document: a ProseMirror doc wrapping a single markdown node. */
-      content: unknown;
-      /** Plain text for search indexing. */
-      text_content?: string;
-      /** Updated notebook title. */
-      title?: string;
-      /** The author's caret in the saved markdown, broadcast with the update so other clients can move the author's remote caret together with the text change. */
-      cursor?: NotebookCollabCursor;
     }
 
     export interface NotebookMinimal {
@@ -24168,14 +22935,13 @@ export namespace Schemas {
 
     /**
      * * `replay` - REPLAY
-     * * `notebook` - NOTEBOOK
-     * * `insight` - INSIGHT
-     * * `feature_flag` - FEATURE_FLAG
-     * * `dashboard` - DASHBOARD
-     * * `survey` - SURVEY
-     * * `experiment` - EXPERIMENT
-     * * `error_tracking` - ERROR_TRACKING
-     * * `customer_analytics` - CUSTOMER_ANALYTICS
+    * `notebook` - NOTEBOOK
+    * `insight` - INSIGHT
+    * `feature_flag` - FEATURE_FLAG
+    * `dashboard` - DASHBOARD
+    * `survey` - SURVEY
+    * `experiment` - EXPERIMENT
+    * `error_tracking` - ERROR_TRACKING
      */
     export type NotificationEventSourceTypeEnum = typeof NotificationEventSourceTypeEnum[keyof typeof NotificationEventSourceTypeEnum];
 
@@ -24189,7 +22955,6 @@ export namespace Schemas {
       Survey: 'survey',
       Experiment: 'experiment',
       ErrorTracking: 'error_tracking',
-      CustomerAnalytics: 'customer_analytics',
     } as const;
 
     export interface NotificationEvent {
@@ -24332,10 +23097,10 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-     * * `running` - Running
-     * * `succeeded` - Succeeded
-     * * `failed` - Failed
-     * * `ineligible` - Ineligible
+    * `running` - Running
+    * `succeeded` - Succeeded
+    * `failed` - Failed
+    * `ineligible` - Ineligible
      */
     export type ObservationStatusEnum = typeof ObservationStatusEnum[keyof typeof ObservationStatusEnum];
 
@@ -24350,7 +23115,7 @@ export namespace Schemas {
 
     /**
      * * `schedule` - Schedule
-     * * `on_demand` - On demand
+    * `on_demand` - On demand
      */
     export type ObservationTriggerEnum = typeof ObservationTriggerEnum[keyof typeof ObservationTriggerEnum];
 
@@ -24401,7 +23166,7 @@ export namespace Schemas {
 
     /**
      * * `later` - Later
-     * * `other` - Other
+    * `other` - Other
      */
     export type OnboardingSkipRequestReasonEnum = typeof OnboardingSkipRequestReasonEnum[keyof typeof OnboardingSkipRequestReasonEnum];
 
@@ -24413,16 +23178,16 @@ export namespace Schemas {
 
     /**
      * Request body for POST /api/users/{id}/onboarding/skip/.
-     *
-     * Source of truth for OpenAPI / generated TS / zod / MCP — bind this serializer at
-     * runtime so the contract clients believe is enforced (length cap, choice validation,
-     * no extra fields) is actually enforced server-side.
+
+    Source of truth for OpenAPI / generated TS / zod / MCP — bind this serializer at
+    runtime so the contract clients believe is enforced (length cap, choice validation,
+    no extra fields) is actually enforced server-side.
      */
     export interface OnboardingSkipRequest {
       /** Why the user is leaving onboarding. 'later' keeps them able to return; 'other' is a catch-all. 'delegated' is rejected here — use the delegate endpoint so the delegation invite is created atomically.
-       *
-       * * `later` - Later
-       * * `other` - Other */
+
+      * `later` - Later
+      * `other` - Other */
       reason: OnboardingSkipRequestReasonEnum;
       /**
          * Onboarding step key the user was on when skipping, for analytics only.
@@ -24433,8 +23198,8 @@ export namespace Schemas {
 
     /**
      * * `delegated` - Delegated to teammate
-     * * `later` - Skipped for later
-     * * `other` - Other
+    * `later` - Skipped for later
+    * `other` - Other
      */
     export type OnboardingSkippedReasonEnum = typeof OnboardingSkippedReasonEnum[keyof typeof OnboardingSkippedReasonEnum];
 
@@ -24447,7 +23212,7 @@ export namespace Schemas {
 
     /**
      * * `latest` - latest
-     * * `earliest` - earliest
+    * `earliest` - earliest
      */
     export type OrderByEnum = typeof OrderByEnum[keyof typeof OrderByEnum];
 
@@ -24465,9 +23230,9 @@ export namespace Schemas {
 
     /**
      * * `0` - none
-     * * `3` - config
-     * * `6` - install
-     * * `9` - root
+    * `3` - config
+    * `6` - install
+    * `9` - root
      */
     export type PluginsAccessLevelEnum = typeof PluginsAccessLevelEnum[keyof typeof PluginsAccessLevelEnum];
 
@@ -24532,9 +23297,9 @@ export namespace Schemas {
       /** @nullable */
       readonly is_hipaa: boolean | null;
       /** Default statistical method for new experiments in this organization.
-       *
-       * * `bayesian` - Bayesian
-       * * `frequentist` - Frequentist */
+
+      * `bayesian` - Bayesian
+      * `frequentist` - Frequentist */
       default_experiment_stats_method?: DefaultExperimentStatsMethodEnum | BlankEnum | null;
       /** Default setting for 'Discard client IP data' for new projects in this organization. */
       default_anonymize_ips?: boolean;
@@ -24562,7 +23327,7 @@ export namespace Schemas {
 
     /**
      * Serializer for `Organization` model with minimal attributes to speeed up loading and transfer times.
-     * Also used for nested serializers.
+    Also used for nested serializers.
      */
     export interface OrganizationBasic {
       readonly id: string;
@@ -24642,10 +23407,7 @@ export namespace Schemas {
          * @nullable
          */
       id_jag_jwks_url?: string | null;
-      /**
-         * Allowed ID-JAG client IDs. Empty list allows any client_id.
-         * @items.maxLength 256
-         */
+      /** Allowed ID-JAG client IDs. Empty list allows any client_id. */
       id_jag_allowed_clients?: string[];
     }
 
@@ -24675,8 +23437,8 @@ export namespace Schemas {
 
     /**
      * * `1` - member
-     * * `8` - administrator
-     * * `15` - owner
+    * `8` - administrator
+    * `15` - owner
      */
     export type OrganizationMembershipLevelEnum = typeof OrganizationMembershipLevelEnum[keyof typeof OrganizationMembershipLevelEnum];
 
@@ -24732,8 +23494,6 @@ export namespace Schemas {
       readonly is_2fa_enabled: boolean;
       readonly has_social_auth: boolean;
       readonly last_login: string;
-      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
-      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     /**
@@ -24795,14 +23555,14 @@ export namespace Schemas {
 
     /**
      * * `error_tracking` - Error Tracking
-     * * `eval_clusters` - Eval Clusters
-     * * `user_created` - User Created
-     * * `automation` - Automation
-     * * `slack` - Slack
-     * * `support_queue` - Support Queue
-     * * `session_summaries` - Session Summaries
-     * * `signal_report` - Signal Report
-     * * `signals_scout` - Signals Scout
+    * `eval_clusters` - Eval Clusters
+    * `user_created` - User Created
+    * `automation` - Automation
+    * `slack` - Slack
+    * `support_queue` - Support Queue
+    * `session_summaries` - Session Summaries
+    * `signal_report` - Signal Report
+    * `signals_scout` - Signals Scout
      */
     export type OriginProductEnum = typeof OriginProductEnum[keyof typeof OriginProductEnum];
 
@@ -24842,7 +23602,7 @@ export namespace Schemas {
 
     /**
      * * `healthy` - healthy
-     * * `needs_attention` - needs_attention
+    * `needs_attention` - needs_attention
      */
     export type OverallHealthEnum = typeof OverallHealthEnum[keyof typeof OverallHealthEnum];
 
@@ -24873,10 +23633,10 @@ export namespace Schemas {
       /** Pull request title. */
       title: string;
       /** Derived state: 'open', 'closed', or 'merged'.
-       *
-       * * `open` - OPEN
-       * * `closed` - CLOSED
-       * * `merged` - MERGED */
+
+      * `open` - OPEN
+      * `closed` - CLOSED
+      * `merged` - MERGED */
       state: EngineeringAnalyticsPRStateEnum;
       /** True if the pull request is a draft. */
       is_draft: boolean;
@@ -24896,10 +23656,10 @@ export namespace Schemas {
 
     /**
      * * `opened` - OPENED
-     * * `ci_started` - CI_STARTED
-     * * `ci_finished` - CI_FINISHED
-     * * `merged` - MERGED
-     * * `closed` - CLOSED
+    * `ci_started` - CI_STARTED
+    * `ci_finished` - CI_FINISHED
+    * `merged` - MERGED
+    * `closed` - CLOSED
      */
     export type PRLifecycleEventKindEnum = typeof PRLifecycleEventKindEnum[keyof typeof PRLifecycleEventKindEnum];
 
@@ -24914,12 +23674,12 @@ export namespace Schemas {
 
     export interface PRLifecycleEvent {
       /** Event kind: opened, ci_started, ci_finished, merged, or closed.
-       *
-       * * `opened` - OPENED
-       * * `ci_started` - CI_STARTED
-       * * `ci_finished` - CI_FINISHED
-       * * `merged` - MERGED
-       * * `closed` - CLOSED */
+
+      * `opened` - OPENED
+      * `ci_started` - CI_STARTED
+      * `ci_finished` - CI_FINISHED
+      * `merged` - MERGED
+      * `closed` - CLOSED */
       kind: PRLifecycleEventKindEnum;
       /** When the event occurred. */
       at: string;
@@ -24936,10 +23696,10 @@ export namespace Schemas {
       /** Lifecycle events ordered by time. */
       events: PRLifecycleEvent[];
       /** Always 'partial' — CI events only; reviews and comments are not yet available.
-       *
-       * * `precise` - PRECISE
-       * * `coarse` - COARSE
-       * * `partial` - PARTIAL */
+
+      * `precise` - PRECISE
+      * `coarse` - COARSE
+      * `partial` - PARTIAL */
       metric_quality?: MetricQualityEnum;
     }
 
@@ -25503,15 +24263,6 @@ export namespace Schemas {
       results: FeatureFlag[];
     }
 
-    export interface PaginatedFieldNoteList {
-      count: number;
-      /** @nullable */
-      next?: string | null;
-      /** @nullable */
-      previous?: string | null;
-      results: FieldNote[];
-    }
-
     export interface PaginatedFileSystemList {
       count: number;
       /** @nullable */
@@ -25973,8 +24724,8 @@ export namespace Schemas {
 
     /**
      * * `home` - Home
-     * * `pinned` - Pinned
-     * * `custom_products` - Custom Products
+    * `pinned` - Pinned
+    * `custom_products` - Custom Products
      */
     export type PersistedFolderTypeEnum = typeof PersistedFolderTypeEnum[keyof typeof PersistedFolderTypeEnum];
 
@@ -25988,10 +24739,10 @@ export namespace Schemas {
     export interface PersistedFolder {
       readonly id: string;
       /** Which persisted folder this is for the user (home, pinned, custom_products).
-       *
-       * * `home` - Home
-       * * `pinned` - Pinned
-       * * `custom_products` - Custom Products */
+
+      * `home` - Home
+      * `pinned` - Pinned
+      * `custom_products` - Custom Products */
       type: PersistedFolderTypeEnum;
       /**
          * Protocol prefix of the folder location, e.g. 'products://'.
@@ -26043,8 +24794,8 @@ export namespace Schemas {
 
     /**
      * * `SYSTEM` - SYSTEM
-     * * `PLUGIN` - PLUGIN
-     * * `CONSOLE` - CONSOLE
+    * `PLUGIN` - PLUGIN
+    * `CONSOLE` - CONSOLE
      */
     export type PluginLogEntrySourceEnum = typeof PluginLogEntrySourceEnum[keyof typeof PluginLogEntrySourceEnum];
 
@@ -26057,10 +24808,10 @@ export namespace Schemas {
 
     /**
      * * `DEBUG` - DEBUG
-     * * `LOG` - LOG
-     * * `INFO` - INFO
-     * * `WARN` - WARN
-     * * `ERROR` - ERROR
+    * `LOG` - LOG
+    * `INFO` - INFO
+    * `WARN` - WARN
+    * `ERROR` - ERROR
      */
     export type PluginLogEntryTypeEnum = typeof PluginLogEntryTypeEnum[keyof typeof PluginLogEntryTypeEnum];
 
@@ -26127,8 +24878,6 @@ export namespace Schemas {
       readonly created_by: UserBasic;
       readonly updated_at: string;
       archived?: boolean;
-      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
-      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     export interface PaginatedProductTourList {
@@ -26142,16 +24891,14 @@ export namespace Schemas {
 
     /**
      * Like `ProjectBasicSerializer`, but also works as a drop-in replacement for `TeamBasicSerializer` by way of
-     * passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
-     * backward compatibility of the REST API.
-     * Do not use this in greenfield endpoints!
+    passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
+    backward compatibility of the REST API.
+    Do not use this in greenfield endpoints!
      */
     export interface ProjectBackwardCompatBasic {
       readonly id: number;
       readonly uuid: string;
       readonly organization: string;
-      /** ID of the project this environment belongs to. */
-      readonly project_id: number;
       readonly api_token: string;
       readonly name: string;
       readonly completed_snippet_onboarding: boolean;
@@ -26184,7 +24931,6 @@ export namespace Schemas {
       readonly last_used_at: string | null;
       /** @nullable */
       readonly last_rolled_at: string | null;
-      /** Project-wide API scopes granted to this key. Project secret API keys do not honor object-level access controls, so a scope can access resources of that type even when per-resource RBAC would hide them from an individual user. */
       scopes: string[];
     }
 
@@ -26223,11 +24969,11 @@ export namespace Schemas {
     export interface QueryTabState {
       readonly id: string;
       /**
-       *             Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
-       *             and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
-       *             ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
-       *             for a user.
-       *              */
+                  Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
+                  and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
+                  ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
+                  for a user.
+                   */
       state?: unknown;
     }
 
@@ -26242,7 +24988,7 @@ export namespace Schemas {
 
     /**
      * * `manual-options` - manual-options
-     * * `auto-discovery` - auto-discovery
+    * `auto-discovery` - auto-discovery
      */
     export type QuickFilterTypeEnum = typeof QuickFilterTypeEnum[keyof typeof QuickFilterTypeEnum];
 
@@ -26276,9 +25022,9 @@ export namespace Schemas {
 
     /**
      * * `monitor` - Monitor
-     * * `classifier` - Classifier
-     * * `scorer` - Scorer
-     * * `summarizer` - Summarizer
+    * `classifier` - Classifier
+    * `scorer` - Scorer
+    * `summarizer` - Summarizer
      */
     export type ScannerTypeEnum = typeof ScannerTypeEnum[keyof typeof ScannerTypeEnum];
 
@@ -26292,7 +25038,7 @@ export namespace Schemas {
 
     /**
      * * `gemini-3-flash-preview` - Gemini 3 Flash
-     * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
+    * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
      */
     export type ScannerModelEnum = typeof ScannerModelEnum[keyof typeof ScannerModelEnum];
 
@@ -26319,22 +25065,22 @@ export namespace Schemas {
       /** Scanner name at run time. */
       name: string;
       /** Scanner type (monitor, classifier, scorer, summarizer) at run time.
-       *
-       * * `monitor` - Monitor
-       * * `classifier` - Classifier
-       * * `scorer` - Scorer
-       * * `summarizer` - Summarizer */
+
+      * `monitor` - Monitor
+      * `classifier` - Classifier
+      * `scorer` - Scorer
+      * `summarizer` - Summarizer */
       scanner_type: ScannerTypeEnum;
       /** The `ReplayScanner.scanner_version` value at the moment the workflow ran. */
       scanner_version: number;
       /** Concrete model that ran the observation.
-       *
-       * * `gemini-3-flash-preview` - Gemini 3 Flash
-       * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+
+      * `gemini-3-flash-preview` - Gemini 3 Flash
+      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
       model: ScannerModelEnum;
       /** Concrete provider that ran the observation.
-       *
-       * * `google` - Google */
+
+      * `google` - Google */
       provider: ScannerProviderEnum;
       /** Whether the observation was run with Signal emission enabled. */
       emits_signals: boolean;
@@ -26362,12 +25108,12 @@ export namespace Schemas {
       /** Session recording id this scanner was applied to. */
       readonly session_id: string;
       /** Observation status (pending, running, succeeded, failed, ineligible).
-       *
-       * * `pending` - Pending
-       * * `running` - Running
-       * * `succeeded` - Succeeded
-       * * `failed` - Failed
-       * * `ineligible` - Ineligible */
+
+      * `pending` - Pending
+      * `running` - Running
+      * `succeeded` - Succeeded
+      * `failed` - Failed
+      * `ineligible` - Ineligible */
       readonly status: ObservationStatusEnum;
       /** Populated on terminal non-success statuses; formatted as `kind:human-readable message`. For `ineligible`, kind is one of no_recording / too_short / too_inactive / too_long / no_events. For `failed`, kind is one of provider_transient / provider_rejected / rasterization_failed / validation_failed / internal_error. */
       readonly error_reason: string;
@@ -26378,9 +25124,9 @@ export namespace Schemas {
       /** Result data persisted on success; null until the observation succeeds. */
       readonly scanner_result: ScannerResult | null;
       /** Whether this observation came from the schedule or an on-demand request.
-       *
-       * * `schedule` - Schedule
-       * * `on_demand` - On demand */
+
+      * `schedule` - Schedule
+      * `on_demand` - On demand */
       readonly triggered_by: ObservationTriggerEnum;
       /** User who triggered an on-demand observation; null for scheduled observations. */
       readonly triggered_by_user: UserBasic | null;
@@ -26410,11 +25156,11 @@ export namespace Schemas {
       /** Free-form description shown in the scanner management UI. */
       description?: string;
       /** What the scanner does: monitor, classifier, scorer, or summarizer.
-       *
-       * * `monitor` - Monitor
-       * * `classifier` - Classifier
-       * * `scorer` - Scorer
-       * * `summarizer` - Summarizer */
+
+      * `monitor` - Monitor
+      * `classifier` - Classifier
+      * `scorer` - Scorer
+      * `summarizer` - Summarizer */
       scanner_type: ScannerTypeEnum;
       /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
       scanner_config: unknown;
@@ -26427,13 +25173,13 @@ export namespace Schemas {
          */
       sampling_rate?: number;
       /** LLM provider. v1 is Google-only.
-       *
-       * * `google` - Google */
+
+      * `google` - Google */
       provider?: ScannerProviderEnum;
       /** Concrete model to use for this scanner.
-       *
-       * * `gemini-3-flash-preview` - Gemini 3 Flash
-       * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+
+      * `gemini-3-flash-preview` - Gemini 3 Flash
+      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
       model: ScannerModelEnum;
       /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
       enabled?: boolean;
@@ -26441,11 +25187,6 @@ export namespace Schemas {
       emits_signals?: boolean;
       /** Increments on every config-changing save. Observations snapshot this value. */
       readonly scanner_version: number;
-      /**
-         * Latest projected observations/month for this scanner. Null until first computed.
-         * @nullable
-         */
-      readonly estimated_monthly_observations: number | null;
       /** Watermark for the scanner's last scheduled fire. Mirrors Temporal schedule state for recovery. */
       readonly last_swept_at: string;
       readonly created_at: string;
@@ -26630,15 +25371,9 @@ export namespace Schemas {
       /** @maxLength 255 */
       name: string;
       network_access_level?: NetworkAccessLevelEnum;
-      /**
-         * List of allowed domains for custom network access
-         * @items.maxLength 255
-         */
+      /** List of allowed domains for custom network access */
       allowed_domains?: string[];
-      /**
-         * List of repositories this environment applies to (format: org/repo)
-         * @items.maxLength 255
-         */
+      /** List of repositories this environment applies to (format: org/repo) */
       repositories?: string[];
       /** If true, only the creator can see this environment. Otherwise visible to whole team. */
       private?: boolean;
@@ -26660,9 +25395,9 @@ export namespace Schemas {
 
     /**
      * * `daily` - daily
-     * * `weekly` - weekly
-     * * `monthly` - monthly
-     * * `yearly` - yearly
+    * `weekly` - weekly
+    * `monthly` - monthly
+    * `yearly` - yearly
      */
     export type RecurrenceIntervalEnum = typeof RecurrenceIntervalEnum[keyof typeof RecurrenceIntervalEnum];
 
@@ -26683,8 +25418,8 @@ export namespace Schemas {
          */
       record_id: string;
       /** The type of record to modify. Currently only "FeatureFlag" is supported.
-       *
-       * * `FeatureFlag` - feature flag */
+
+      * `FeatureFlag` - feature flag */
       model_name: ModelNameEnum;
       /** The change to apply. Must include an 'operation' key and a 'value' key. Supported operations: 'update_status' (value: true/false to enable/disable the flag), 'add_release_condition' (value: object with 'groups', 'payloads', and 'multivariate' keys), 'update_variants' (value: object with 'variants' and 'payloads' keys). */
       payload: unknown;
@@ -26703,11 +25438,11 @@ export namespace Schemas {
       /** Whether this schedule repeats. Only the 'update_status' operation supports recurring schedules. */
       is_recurring?: boolean;
       /** How often the schedule repeats. Required when is_recurring is true. One of: daily, weekly, monthly, yearly.
-       *
-       * * `daily` - daily
-       * * `weekly` - weekly
-       * * `monthly` - monthly
-       * * `yearly` - yearly */
+
+      * `daily` - daily
+      * `weekly` - weekly
+      * `monthly` - monthly
+      * `yearly` - yearly */
       recurrence_interval?: RecurrenceIntervalEnum | null;
       /**
          * @maxLength 100
@@ -26811,7 +25546,7 @@ export namespace Schemas {
 
     /**
      * Serializer for linking session recordings to external issue trackers.
-     * Reuses error tracking's integration infrastructure
+    Reuses error tracking's integration infrastructure
      */
     export interface SessionRecordingExternalRef {
       readonly id: string;
@@ -26885,8 +25620,6 @@ export namespace Schemas {
       readonly summary_outcome: Outcome | null;
       /** Load external references (linked issues) for this recording */
       readonly external_references: readonly SessionRecordingExternalReferencesItem[];
-      /** Whether this recording matched the filters of the listing query that returned it. False only when a recording requested via session_recording_id was included despite not matching the filters. */
-      readonly matches_filters: boolean;
     }
 
     export interface PaginatedSessionRecordingList {
@@ -26900,7 +25633,7 @@ export namespace Schemas {
 
     /**
      * * `collection` - Collection
-     * * `filters` - Filters
+    * `filters` - Filters
      */
     export type SessionRecordingPlaylistTypeEnum = typeof SessionRecordingPlaylistTypeEnum[keyof typeof SessionRecordingPlaylistTypeEnum];
 
@@ -26940,9 +25673,9 @@ export namespace Schemas {
       readonly last_modified_by: UserBasic;
       readonly recordings_counts: SessionRecordingPlaylistRecordingsCounts;
       /** Playlist type: 'collection' for manually curated recordings, 'filters' for saved filter views. Required on create, cannot be changed after.
-       *
-       * * `collection` - Collection
-       * * `filters` - Filters */
+
+      * `collection` - Collection
+      * `filters` - Filters */
       type?: SessionRecordingPlaylistTypeEnum | null;
       /** Return whether this is a synthetic playlist */
       readonly is_synthetic: boolean;
@@ -26960,14 +25693,14 @@ export namespace Schemas {
 
     /**
      * * `potential` - Potential
-     * * `candidate` - Candidate
-     * * `in_progress` - In Progress
-     * * `pending_input` - Pending Input
-     * * `ready` - Ready
-     * * `resolved` - Resolved
-     * * `failed` - Failed
-     * * `deleted` - Deleted
-     * * `suppressed` - Suppressed
+    * `candidate` - Candidate
+    * `in_progress` - In Progress
+    * `pending_input` - Pending Input
+    * `ready` - Ready
+    * `resolved` - Resolved
+    * `failed` - Failed
+    * `deleted` - Deleted
+    * `suppressed` - Suppressed
      */
     export type SignalReportStatusEnum = typeof SignalReportStatusEnum[keyof typeof SignalReportStatusEnum];
 
@@ -27033,15 +25766,15 @@ export namespace Schemas {
 
     /**
      * * `session_replay` - Session replay
-     * * `llm_analytics` - LLM analytics
-     * * `github` - GitHub
-     * * `linear` - Linear
-     * * `zendesk` - Zendesk
-     * * `conversations` - Conversations
-     * * `error_tracking` - Error tracking
-     * * `pganalyze` - pganalyze
-     * * `signals_scout` - Signals scout
-     * * `logs` - Logs
+    * `llm_analytics` - LLM analytics
+    * `github` - GitHub
+    * `linear` - Linear
+    * `zendesk` - Zendesk
+    * `conversations` - Conversations
+    * `error_tracking` - Error tracking
+    * `pganalyze` - pganalyze
+    * `signals_scout` - Signals scout
+    * `logs` - Logs
      */
     export type SourceProductEnum = typeof SourceProductEnum[keyof typeof SourceProductEnum];
 
@@ -27061,14 +25794,14 @@ export namespace Schemas {
 
     /**
      * * `session_analysis_cluster` - Session analysis cluster
-     * * `evaluation` - Evaluation
-     * * `issue` - Issue
-     * * `ticket` - Ticket
-     * * `issue_created` - Issue created
-     * * `issue_reopened` - Issue reopened
-     * * `issue_spiking` - Issue spiking
-     * * `cross_source_issue` - Cross source issue
-     * * `alert_state_change` - Alert state change
+    * `evaluation` - Evaluation
+    * `issue` - Issue
+    * `ticket` - Ticket
+    * `issue_created` - Issue created
+    * `issue_reopened` - Issue reopened
+    * `issue_spiking` - Issue spiking
+    * `cross_source_issue` - Cross source issue
+    * `alert_state_change` - Alert state change
      */
     export type SignalSourceConfigSourceTypeEnum = typeof SignalSourceConfigSourceTypeEnum[keyof typeof SignalSourceConfigSourceTypeEnum];
 
@@ -27251,9 +25984,9 @@ export namespace Schemas {
 
     /**
      * * `starting` - Starting
-     * * `completed` - Completed
-     * * `failed` - Failed
-     * * `skipped` - Skipped
+    * `completed` - Completed
+    * `failed` - Failed
+    * `skipped` - Skipped
      */
     export type SubscriptionDeliveryStatusEnum = typeof SubscriptionDeliveryStatusEnum[keyof typeof SubscriptionDeliveryStatusEnum];
 
@@ -27285,22 +26018,18 @@ export namespace Schemas {
       readonly target_type: string;
       /** Destination snapshot at send time (emails, channel id, URL). */
       readonly target_value: string;
-      /**
-         * ExportedAsset ids generated for this send.
-         * @items.minimum -2147483648
-         * @items.maximum 2147483647
-         */
+      /** ExportedAsset ids generated for this send. */
       readonly exported_asset_ids: readonly number[];
       /** Snapshot at send time: dashboard metadata, total_insight_count, and per-exported-insight entries (id, short_id, name, query_hash, cache_key, query_results, optional query_error). */
       readonly content_snapshot: unknown;
       /** Per-destination outcomes; items use status success, failed, or partial. */
       readonly recipient_results: unknown;
       /** Overall run status: starting, completed, failed, or skipped.
-       *
-       * * `starting` - Starting
-       * * `completed` - Completed
-       * * `failed` - Failed
-       * * `skipped` - Skipped */
+
+      * `starting` - Starting
+      * `completed` - Completed
+      * `failed` - Failed
+      * `skipped` - Skipped */
       readonly status: SubscriptionDeliveryStatusEnum;
       /** Top-level failure payload when status is failed, if any. */
       readonly error: unknown;
@@ -27330,8 +26059,8 @@ export namespace Schemas {
 
     /**
      * * `insight` - Insight
-     * * `dashboard` - Dashboard
-     * * `ai_prompt` - AI prompt
+    * `dashboard` - Dashboard
+    * `ai_prompt` - AI prompt
      */
     export type ResourceTypeEnum = typeof ResourceTypeEnum[keyof typeof ResourceTypeEnum];
 
@@ -27344,7 +26073,7 @@ export namespace Schemas {
 
     /**
      * * `email` - Email
-     * * `slack` - Slack
+    * `slack` - Slack
      */
     export type TargetTypeEnum = typeof TargetTypeEnum[keyof typeof TargetTypeEnum];
 
@@ -27356,9 +26085,9 @@ export namespace Schemas {
 
     /**
      * * `daily` - Daily
-     * * `weekly` - Weekly
-     * * `monthly` - Monthly
-     * * `yearly` - Yearly
+    * `weekly` - Weekly
+    * `monthly` - Monthly
+    * `yearly` - Yearly
      */
     export type SubscriptionFrequencyEnum = typeof SubscriptionFrequencyEnum[keyof typeof SubscriptionFrequencyEnum];
 
@@ -27372,12 +26101,12 @@ export namespace Schemas {
 
     /**
      * * `monday` - Monday
-     * * `tuesday` - Tuesday
-     * * `wednesday` - Wednesday
-     * * `thursday` - Thursday
-     * * `friday` - Friday
-     * * `saturday` - Saturday
-     * * `sunday` - Sunday
+    * `tuesday` - Tuesday
+    * `wednesday` - Wednesday
+    * `thursday` - Thursday
+    * `friday` - Friday
+    * `saturday` - Saturday
+    * `sunday` - Sunday
      */
     export type SubscriptionByweekdayItem = typeof SubscriptionByweekdayItem[keyof typeof SubscriptionByweekdayItem];
 
@@ -27398,10 +26127,10 @@ export namespace Schemas {
     export interface Subscription {
       readonly id: number;
       /** What the subscription delivers: 'insight' (snapshot of one insight), 'dashboard' (snapshot of one dashboard), or 'ai_prompt' (LLM-generated report). Read-only — derived from the populated target (insight → insight, dashboard → dashboard, prompt → ai_prompt).
-       *
-       * * `insight` - Insight
-       * * `dashboard` - Dashboard
-       * * `ai_prompt` - AI prompt */
+
+      * `insight` - Insight
+      * `dashboard` - Dashboard
+      * `ai_prompt` - AI prompt */
       readonly resource_type: ResourceTypeEnum;
       /**
          * Dashboard ID to subscribe to (mutually exclusive with insight on create).
@@ -27425,18 +26154,18 @@ export namespace Schemas {
          */
       prompt?: string | null;
       /** Delivery channel: email or slack.
-       *
-       * * `email` - Email
-       * * `slack` - Slack */
+
+      * `email` - Email
+      * `slack` - Slack */
       target_type: TargetTypeEnum;
       /** Recipient(s): comma-separated email addresses for email, or Slack channel name/ID for slack. */
       target_value: string;
       /** How often to deliver: daily, weekly, monthly, or yearly.
-       *
-       * * `daily` - Daily
-       * * `weekly` - Weekly
-       * * `monthly` - Monthly
-       * * `yearly` - Yearly */
+
+      * `daily` - Daily
+      * `weekly` - Weekly
+      * `monthly` - Monthly
+      * `yearly` - Yearly */
       frequency: SubscriptionFrequencyEnum;
       /**
          * Interval multiplier (e.g. 2 with weekly frequency means every 2 weeks). Required on create; must be 1 or greater.
@@ -27516,9 +26245,9 @@ export namespace Schemas {
 
     /**
      * * `popover` - popover
-     * * `widget` - widget
-     * * `external_survey` - external survey
-     * * `api` - api
+    * `widget` - widget
+    * `external_survey` - external survey
+    * `api` - api
      */
     export type SurveyType = typeof SurveyType[keyof typeof SurveyType];
 
@@ -27532,8 +26261,8 @@ export namespace Schemas {
 
     /**
      * * `day` - day
-     * * `week` - week
-     * * `month` - month
+    * `week` - week
+    * `month` - month
      */
     export type ResponseSamplingIntervalTypeEnum = typeof ResponseSamplingIntervalTypeEnum[keyof typeof ResponseSamplingIntervalTypeEnum];
 
@@ -27570,117 +26299,117 @@ export namespace Schemas {
       readonly targeting_flag: MinimalFeatureFlag;
       readonly internal_targeting_flag: MinimalFeatureFlag;
       /**
-       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-       *
-       *         Basic (open-ended question)
-       *         - `id`: The question ID
-       *         - `type`: `open`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Link (a question with a link)
-       *         - `id`: The question ID
-       *         - `type`: `link`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `link`: The URL associated with the question.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Rating (a question with a rating scale)
-       *         - `id`: The question ID
-       *         - `type`: `rating`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `display`: Display style of the rating (`number` or `emoji`).
-       *         - `scale`: The scale of the rating (`number`).
-       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
-       *         - `upperBoundLabel`: Label for the upper bound of the scale.
-       *         - `isNpsQuestion`: Whether the question is an NPS rating.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Multiple choice
-       *         - `id`: The question ID
-       *         - `type`: `single_choice` or `multiple_choice`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `choices`: An array of choices for the question.
-       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Branching logic can be one of the following types:
-       *
-       *         Next question: Proceeds to the next question
-       *         ```json
-       *         {
-       *             "type": "next_question"
-       *         }
-       *         ```
-       *
-       *         End: Ends the survey, optionally displaying a confirmation message.
-       *         ```json
-       *         {
-       *             "type": "end"
-       *         }
-       *         ```
-       *
-       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-       *         ```json
-       *         {
-       *             "type": "response_based",
-       *             "responseValues": {
-       *                 "responseKey": "value"
-       *             }
-       *         }
-       *         ```
-       *
-       *         Specific question: Proceeds to a specific question by index.
-       *         ```json
-       *         {
-       *             "type": "specific_question",
-       *             "index": 2
-       *         }
-       *         ```
-       *
-       *         Translations: Each question can include inline translations.
-       *         - `translations`: Object mapping language codes to translated fields.
-       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-       *
-       *         Example with translations:
-       *         ```json
-       *         {
-       *             "id": "uuid",
-       *             "type": "rating",
-       *             "question": "How satisfied are you?",
-       *             "lowerBoundLabel": "Not satisfied",
-       *             "upperBoundLabel": "Very satisfied",
-       *             "translations": {
-       *                 "es": {
-       *                     "question": "¿Qué tan satisfecho estás?",
-       *                     "lowerBoundLabel": "No satisfecho",
-       *                     "upperBoundLabel": "Muy satisfecho"
-       *                 },
-       *                 "fr": {
-       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
-       *                 }
-       *             }
-       *         }
-       *         ```
-       *          */
+              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+
+              Basic (open-ended question)
+              - `id`: The question ID
+              - `type`: `open`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Link (a question with a link)
+              - `id`: The question ID
+              - `type`: `link`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `link`: The URL associated with the question.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Rating (a question with a rating scale)
+              - `id`: The question ID
+              - `type`: `rating`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `display`: Display style of the rating (`number` or `emoji`).
+              - `scale`: The scale of the rating (`number`).
+              - `lowerBoundLabel`: Label for the lower bound of the scale.
+              - `upperBoundLabel`: Label for the upper bound of the scale.
+              - `isNpsQuestion`: Whether the question is an NPS rating.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Multiple choice
+              - `id`: The question ID
+              - `type`: `single_choice` or `multiple_choice`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `choices`: An array of choices for the question.
+              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Branching logic can be one of the following types:
+
+              Next question: Proceeds to the next question
+              ```json
+              {
+                  "type": "next_question"
+              }
+              ```
+
+              End: Ends the survey, optionally displaying a confirmation message.
+              ```json
+              {
+                  "type": "end"
+              }
+              ```
+
+              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+              ```json
+              {
+                  "type": "response_based",
+                  "responseValues": {
+                      "responseKey": "value"
+                  }
+              }
+              ```
+
+              Specific question: Proceeds to a specific question by index.
+              ```json
+              {
+                  "type": "specific_question",
+                  "index": 2
+              }
+              ```
+
+              Translations: Each question can include inline translations.
+              - `translations`: Object mapping language codes to translated fields.
+              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+
+              Example with translations:
+              ```json
+              {
+                  "id": "uuid",
+                  "type": "rating",
+                  "question": "How satisfied are you?",
+                  "lowerBoundLabel": "Not satisfied",
+                  "upperBoundLabel": "Very satisfied",
+                  "translations": {
+                      "es": {
+                          "question": "¿Qué tan satisfecho estás?",
+                          "lowerBoundLabel": "No satisfecho",
+                          "upperBoundLabel": "Muy satisfecho"
+                      },
+                      "fr": {
+                          "question": "Dans quelle mesure êtes-vous satisfait?"
+                      }
+                  }
+              }
+              ```
+               */
       questions?: unknown;
       /** @nullable */
       readonly conditions: SurveyConditions;
@@ -27753,8 +26482,6 @@ export namespace Schemas {
          */
       readonly user_access_level: string | null;
       form_content?: unknown;
-      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
-      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     export interface PaginatedSurveyList {
@@ -27768,11 +26495,11 @@ export namespace Schemas {
 
     /**
      * * `CSV` - CSV
-     * * `CSVWithNames` - CSVWithNames
-     * * `Parquet` - Parquet
-     * * `JSONEachRow` - JSON
-     * * `Delta` - Delta
-     * * `DeltaS3Wrapper` - DeltaS3Wrapper
+    * `CSVWithNames` - CSVWithNames
+    * `Parquet` - Parquet
+    * `JSONEachRow` - JSON
+    * `Delta` - Delta
+    * `DeltaS3Wrapper` - DeltaS3Wrapper
      */
     export type TableFormatEnum = typeof TableFormatEnum[keyof typeof TableFormatEnum];
 
@@ -27855,7 +26582,7 @@ export namespace Schemas {
 
     /**
      * * `llm` - LLM
-     * * `hog` - Hog
+    * `hog` - Hog
      */
     export type TaggerTypeEnum = typeof TaggerTypeEnum[keyof typeof TaggerTypeEnum];
 
@@ -27890,14 +26617,14 @@ export namespace Schemas {
      */
     export interface TaggerModelConfiguration {
       /** LLM provider to use for this tagger.
-       *
-       * * `openai` - Openai
-       * * `anthropic` - Anthropic
-       * * `gemini` - Gemini
-       * * `openrouter` - Openrouter
-       * * `fireworks` - Fireworks
-       * * `azure_openai` - Azure OpenAI
-       * * `together_ai` - Together AI */
+
+      * `openai` - Openai
+      * `anthropic` - Anthropic
+      * `gemini` - Gemini
+      * `openrouter` - Openrouter
+      * `fireworks` - Fireworks
+      * `azure_openai` - Azure OpenAI
+      * `together_ai` - Together AI */
       provider: LLMProviderEnum;
       /**
          * Provider model identifier to use for this tagger.
@@ -28012,16 +26739,16 @@ export namespace Schemas {
       /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
       description?: string;
       /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-       *
-       * * `error_tracking` - Error Tracking
-       * * `eval_clusters` - Eval Clusters
-       * * `user_created` - User Created
-       * * `automation` - Automation
-       * * `slack` - Slack
-       * * `support_queue` - Support Queue
-       * * `session_summaries` - Session Summaries
-       * * `signal_report` - Signal Report
-       * * `signals_scout` - Signals Scout */
+
+      * `error_tracking` - Error Tracking
+      * `eval_clusters` - Eval Clusters
+      * `user_created` - User Created
+      * `automation` - Automation
+      * `slack` - Slack
+      * `support_queue` - Support Queue
+      * `session_summaries` - Session Summaries
+      * `signal_report` - Signal Report
+      * `signals_scout` - Signals Scout */
       origin_product?: OriginProductEnum;
       /**
          * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
@@ -28076,11 +26803,11 @@ export namespace Schemas {
 
     /**
      * * `not_started` - Not Started
-     * * `queued` - Queued
-     * * `in_progress` - In Progress
-     * * `completed` - Completed
-     * * `failed` - Failed
-     * * `cancelled` - Cancelled
+    * `queued` - Queued
+    * `in_progress` - In Progress
+    * `completed` - Completed
+    * `failed` - Failed
+    * `cancelled` - Cancelled
      */
     export type TaskRunStatusEnum = typeof TaskRunStatusEnum[keyof typeof TaskRunStatusEnum];
 
@@ -28096,7 +26823,7 @@ export namespace Schemas {
 
     /**
      * * `local` - Local
-     * * `cloud` - Cloud
+    * `cloud` - Cloud
      */
     export type TaskRunEnvironmentEnum = typeof TaskRunEnvironmentEnum[keyof typeof TaskRunEnvironmentEnum];
 
@@ -28108,7 +26835,7 @@ export namespace Schemas {
 
     /**
      * * `claude` - claude
-     * * `codex` - codex
+    * `codex` - codex
      */
     export type RuntimeAdapterEnum = typeof RuntimeAdapterEnum[keyof typeof RuntimeAdapterEnum];
 
@@ -28162,9 +26889,9 @@ export namespace Schemas {
       branch?: string | null;
       status?: TaskRunStatusEnum;
       /** Execution environment
-       *
-       * * `local` - Local
-       * * `cloud` - Cloud */
+
+      * `local` - Local
+      * `cloud` - Cloud */
       environment?: TaskRunEnvironmentEnum;
       /** Configured runtime adapter for this run, such as 'claude' or 'codex'. */
       readonly runtime_adapter: RuntimeAdapterEnum | null;
@@ -28233,7 +26960,7 @@ export namespace Schemas {
 
     /**
      * Serializer for `Team` model with minimal attributes to speeed up loading and transfer times.
-     * Also used for nested serializers.
+    Also used for nested serializers.
      */
     export interface TeamBasic {
       readonly id: number;
@@ -28268,7 +26995,7 @@ export namespace Schemas {
       readonly created_at: string;
       /** Optional name for the threshold. */
       name?: string;
-      /** Threshold bounds and type. Includes bounds (lower/upper floats) and type (absolute or percentage). For threshold-based alerts (no detector_config), at least one of lower or upper must be set. */
+      /** Threshold bounds and type. Includes bounds (lower/upper floats) and type (absolute or percentage). */
       configuration: InsightThreshold;
       readonly alerts: readonly Alert[];
     }
@@ -28284,8 +27011,8 @@ export namespace Schemas {
 
     /**
      * * `low` - Low
-     * * `medium` - Medium
-     * * `high` - High
+    * `medium` - Medium
+    * `high` - High
      */
     export type PriorityEnum = typeof PriorityEnum[keyof typeof PriorityEnum];
 
@@ -28343,18 +27070,18 @@ export namespace Schemas {
       readonly channel_detail: ChannelDetailEnum | null;
       readonly distinct_id: string;
       /** Ticket status: new, open, pending, on_hold, or resolved
-       *
-       * * `new` - New
-       * * `open` - Open
-       * * `pending` - Pending
-       * * `on_hold` - On hold
-       * * `resolved` - Resolved */
+
+      * `new` - New
+      * `open` - Open
+      * `pending` - Pending
+      * `on_hold` - On hold
+      * `resolved` - Resolved */
       status?: TicketStatusEnum;
       /** Ticket priority: low, medium, or high. Null if unset.
-       *
-       * * `low` - Low
-       * * `medium` - Medium
-       * * `high` - High */
+
+      * `low` - Low
+      * `medium` - Medium
+      * `high` - High */
       priority?: PriorityEnum | BlankEnum | null;
       readonly assignee: TicketAssignment;
       /** Customer-provided traits such as name and email */
@@ -28409,34 +27136,6 @@ export namespace Schemas {
       /** @nullable */
       previous?: string | null;
       results: Ticket[];
-    }
-
-    /**
-     * A single message in a ticket thread (output-only).
-     */
-    export interface TicketMessage {
-      /** Message (comment) UUID. */
-      readonly id: string;
-      /** Plain-text message body. */
-      readonly content: string;
-      /** TipTap rich content JSON, if any. */
-      readonly rich_content: unknown;
-      /** One of: customer, support, AI. */
-      readonly author_type: string;
-      /** Display name of the author. */
-      readonly author_name: string;
-      /** True for internal notes not visible to the customer. */
-      readonly is_private: boolean;
-      readonly created_at: string;
-    }
-
-    export interface PaginatedTicketMessageList {
-      count: number;
-      /** @nullable */
-      next?: string | null;
-      /** @nullable */
-      previous?: string | null;
-      results: TicketMessage[];
     }
 
     /**
@@ -28590,7 +27289,7 @@ export namespace Schemas {
       readonly user_access_level: string | null;
       /** @nullable */
       readonly last_viewed_at: string | null;
-      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      /** How this row matched the `search` term: `exact` (the term is a case-insensitive substring of the name, derived_name, description, or a tag name) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
       readonly search_match_type: SearchMatchTypeEnum | null;
       /** Number of distinct viewers in the time window. Higher values indicate insights that more people in the project actively look at, which is a strong proxy for which insights matter. */
       readonly view_count: number;
@@ -28660,7 +27359,6 @@ export namespace Schemas {
       readonly id: string;
       readonly created_by: UserBasic;
       readonly created_at: string;
-      /** @items.maxLength 254 */
       interviewee_emails?: string[];
       readonly interviewee_identifier: string;
       /** @nullable */
@@ -28685,15 +27383,9 @@ export namespace Schemas {
       readonly id: string;
       readonly created_by: UserBasic;
       readonly created_at: string;
-      /**
-         * Email addresses of people to interview. May be combined with interviewee_distinct_ids.
-         * @items.maxLength 254
-         */
+      /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
       interviewee_emails?: string[];
-      /**
-         * PostHog distinct IDs of people to interview. May be combined with interviewee_emails.
-         * @items.maxLength 400
-         */
+      /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
       interviewee_distinct_ids?: string[];
       /** The product, feature, or idea you want to ask interviewees about. */
       topic: string;
@@ -28724,7 +27416,7 @@ export namespace Schemas {
 
     /**
      * * `disabled` - disabled
-     * * `toolbar` - toolbar
+    * `toolbar` - toolbar
      */
     export type ToolbarModeEnum = typeof ToolbarModeEnum[keyof typeof ToolbarModeEnum];
 
@@ -28743,8 +27435,8 @@ export namespace Schemas {
 
     /**
      * * `light` - Light
-     * * `dark` - Dark
-     * * `system` - System
+    * `dark` - Dark
+    * `system` - System
      */
     export type ThemeModeEnum = typeof ThemeModeEnum[keyof typeof ThemeModeEnum];
 
@@ -28757,8 +27449,8 @@ export namespace Schemas {
 
     /**
      * * `above` - Above
-     * * `below` - Below
-     * * `hidden` - Hidden
+    * `below` - Below
+    * `hidden` - Hidden
      */
     export type ShortcutPositionEnum = typeof ShortcutPositionEnum[keyof typeof ShortcutPositionEnum];
 
@@ -28869,7 +27561,7 @@ export namespace Schemas {
       /** Real-time notification types that currently have a live dispatch site. Drives the in-app notifications settings UI. Read-only. */
       readonly active_realtime_notification_types: readonly string[];
       readonly pending_invites: readonly PendingInvite[];
-      /** True if the user has at least one Personal API Key or passkey and has not yet acknowledged their existing credentials. Used to gate a one-shot review screen on first post-provisioning login. Becomes False once the user POSTs to `/api/users/@me/credentials_review_complete/`. Read-only. */
+      /** True if the user has at least one Personal API Key and has not yet acknowledged their existing credentials. Used to gate a one-shot review screen on first post-provisioning login. Becomes False once the user POSTs to `/api/users/@me/credentials_review_complete/`. Read-only. */
       readonly requires_credential_review: boolean;
     }
 
@@ -28884,13 +27576,13 @@ export namespace Schemas {
 
     /**
      * * `onboarding` - Onboarding
-     * * `product_intent` - Product Intent
-     * * `used_by_colleagues` - Used by Colleagues
-     * * `used_similar_products` - Used Similar Products
-     * * `used_on_separate_team` - Used on Separate Team
-     * * `new_product` - New Product
-     * * `sales_led` - Sales Led
-     * * `onboarding_delegated` - Onboarding Delegated
+    * `product_intent` - Product Intent
+    * `used_by_colleagues` - Used by Colleagues
+    * `used_similar_products` - Used Similar Products
+    * `used_on_separate_team` - Used on Separate Team
+    * `new_product` - New Product
+    * `sales_led` - Sales Led
+    * `onboarding_delegated` - Onboarding Delegated
      */
     export type UserProductListReasonEnum = typeof UserProductListReasonEnum[keyof typeof UserProductListReasonEnum];
 
@@ -28989,20 +27681,20 @@ export namespace Schemas {
       created_at?: string;
       readonly feature_flag_key: string;
       /** Variants for the web experiment. Example:
-       *
-       *         {
-       *             "control": {
-       *                 "transforms": [
-       *                     {
-       *                         "text": "Here comes Superman!",
-       *                         "html": "",
-       *                         "selector": "#page > #body > .header h1"
-       *                     }
-       *                 ],
-       *                 "conditions": "None",
-       *                 "rollout_percentage": 50
-       *             },
-       *         } */
+
+              {
+                  "control": {
+                      "transforms": [
+                          {
+                              "text": "Here comes Superman!",
+                              "html": "",
+                              "selector": "#page > #body > .header h1"
+                          }
+                      ],
+                      "conditions": "None",
+                      "rollout_percentage": 50
+                  },
+              } */
       variants: unknown;
     }
 
@@ -29017,9 +27709,9 @@ export namespace Schemas {
 
     /**
      * * `idle` - IDLE
-     * * `running` - RUNNING
-     * * `completed` - COMPLETED
-     * * `error` - ERROR
+    * `running` - RUNNING
+    * `completed` - COMPLETED
+    * `error` - ERROR
      */
     export type RunPhaseEnum = typeof RunPhaseEnum[keyof typeof RunPhaseEnum];
 
@@ -29033,10 +27725,10 @@ export namespace Schemas {
 
     /**
      * * `pending` - PENDING
-     * * `in_progress` - IN_PROGRESS
-     * * `completed` - COMPLETED
-     * * `failed` - FAILED
-     * * `canceled` - CANCELED
+    * `in_progress` - IN_PROGRESS
+    * `completed` - COMPLETED
+    * `failed` - FAILED
+    * `canceled` - CANCELED
      */
     export type WizardTaskDTOStatusEnum = typeof WizardTaskDTOStatusEnum[keyof typeof WizardTaskDTOStatusEnum];
 
@@ -29141,7 +27833,7 @@ export namespace Schemas {
          */
       name?: string;
       /**
-         * Identifier linking this account to its source customer — the analytics group key (the customer's organization id), used to match billing and external records. Optional.
+         * Identifier for the account in an external system (e.g. CRM ID). Optional.
          * @maxLength 400
          * @nullable
          */
@@ -29249,12 +27941,12 @@ export namespace Schemas {
       config?: TrendsAlertConfig | null;
       detector_config?: DetectorConfig | null;
       /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
-       *
-       * * `every_15_minutes` - every_15_minutes
-       * * `hourly` - hourly
-       * * `daily` - daily
-       * * `weekly` - weekly
-       * * `monthly` - monthly */
+
+      * `every_15_minutes` - every_15_minutes
+      * `hourly` - hourly
+      * `daily` - daily
+      * `weekly` - weekly
+      * `monthly` - monthly */
       calculation_interval?: CalculationIntervalEnum;
       /**
          * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
@@ -29278,9 +27970,9 @@ export namespace Schemas {
       /** When enabled (and investigation_agent_enabled is on), notification dispatch is held until the investigation agent produces a verdict. Notifications are suppressed when the verdict is false_positive (and optionally when inconclusive). A safety-net task force-fires after a few minutes if the investigation stalls. */
       investigation_gates_notifications?: boolean;
       /** How to handle an 'inconclusive' verdict when notifications are gated. 'notify' is the safe default — an agent that can't be sure is itself useful signal.
-       *
-       * * `notify` - Notify
-       * * `suppress` - Suppress */
+
+      * `notify` - Notify
+      * `suppress` - Suppress */
       investigation_inconclusive_action?: InvestigationInconclusiveActionEnum;
     }
 
@@ -29298,9 +27990,9 @@ export namespace Schemas {
          */
       date_marker?: string | null;
       /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
-       *
-       * * `USR` - user
-       * * `GIT` - GitHub */
+
+      * `USR` - user
+      * `GIT` - GitHub */
       creation_type?: CreationTypeEnum;
       /** @nullable */
       dashboard_item?: number | null;
@@ -29321,12 +28013,12 @@ export namespace Schemas {
       /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
       deleted?: boolean;
       /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
-       *
-       * * `dashboard_item` - insight
-       * * `dashboard` - dashboard
-       * * `project` - project
-       * * `organization` - organization
-       * * `recording` - recording */
+
+      * `dashboard_item` - insight
+      * `dashboard` - dashboard
+      * `project` - project
+      * `organization` - organization
+      * `recording` - recording */
       scope?: AnnotationScopeEnum;
       /**
          * Optional emoji shown in place of the default badge when this annotation is surfaced on a chart.
@@ -29356,29 +28048,29 @@ export namespace Schemas {
 
     /**
      * Request body for create/partial_update on BatchExportViewSet.
-     *
-     * Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
-     * `destination` schema so integration_id is marked required on the types that need
-     * it. Responses continue to use `BatchExportSerializer`.
+
+    Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
+    `destination` schema so integration_id is marked required on the types that need
+    it. Responses continue to use `BatchExportSerializer`.
      */
     export interface PatchedBatchExportRequest {
       /** Human-readable name for the batch export. */
       name?: string;
       /** Which data model to export (events, persons, sessions).
-       *
-       * * `events` - Events
-       * * `persons` - Persons
-       * * `sessions` - Sessions */
+
+      * `events` - Events
+      * `persons` - Persons
+      * `sessions` - Sessions */
       model?: ModelEnum;
       /** Destination configuration. Required integration_id is enforced per destination type. */
       destination?: BatchExportDestinationRequest;
       /** How often the batch export should run.
-       *
-       * * `hour` - hour
-       * * `day` - day
-       * * `week` - week
-       * * `every 5 minutes` - every 5 minutes
-       * * `every 15 minutes` - every 15 minutes */
+
+      * `hour` - hour
+      * `day` - day
+      * `week` - week
+      * `every 5 minutes` - every 5 minutes
+      * `every 15 minutes` - every 15 minutes */
       interval?: IntervalEnum;
       /** Whether the batch export is paused. */
       paused?: boolean;
@@ -29471,12 +28163,12 @@ export namespace Schemas {
       readonly count?: number | null;
       is_static?: boolean;
       /** Type of cohort based on filter complexity
-       *
-       * * `static` - static
-       * * `person_property` - person_property
-       * * `behavioral` - behavioral
-       * * `realtime` - realtime
-       * * `analytical` - analytical */
+
+      * `static` - static
+      * `person_property` - person_property
+      * `behavioral` - behavioral
+      * `realtime` - realtime
+      * `analytical` - analytical */
       cohort_type?: CohortTypeEnum | BlankEnum | null;
       readonly experiment_set?: readonly number[];
       _create_in_folder?: string;
@@ -29548,18 +28240,6 @@ export namespace Schemas {
          * @nullable
          */
       readonly title?: string | null;
-      /** Product domain the conversation is about, classified from the first question.
-       *
-       * * `web_analytics` - Web analytics
-       * * `product_analytics` - Product analytics
-       * * `session_replay` - Session replay
-       * * `surveys` - Surveys
-       * * `feature_flags` - Feature flags
-       * * `experiments` - Experiments
-       * * `error_tracking` - Error tracking
-       * * `data_warehouse` - Data warehouse
-       * * `other` - Other */
-      readonly topic?: TopicEnum | null;
       readonly user?: UserBasic;
       /** @nullable */
       readonly created_at?: string | null;
@@ -29587,9 +28267,9 @@ export namespace Schemas {
       readonly agent_mode?: string | null;
       readonly is_sandbox?: boolean;
       /** Return pending approval cards as structured data.
-       *
-       * Combines metadata from conversation.approval_decisions with payload from checkpoint
-       * interrupts (single source of truth for payload data). */
+
+      Combines metadata from conversation.approval_decisions with payload from checkpoint
+      interrupts (single source of truth for payload data). */
       readonly pending_approvals?: readonly PatchedConversationPendingApprovalsItem[];
     }
 
@@ -29603,15 +28283,15 @@ export namespace Schemas {
       /** Optional description */
       description?: string;
       /** Lifecycle category for this core event
-       *
-       * * `acquisition` - Acquisition
-       * * `activation` - Activation
-       * * `monetization` - Monetization
-       * * `expansion` - Expansion
-       * * `referral` - Referral
-       * * `retention` - Retention
-       * * `churn` - Churn
-       * * `reactivation` - Reactivation */
+
+      * `acquisition` - Acquisition
+      * `activation` - Activation
+      * `monetization` - Monetization
+      * `expansion` - Expansion
+      * `referral` - Referral
+      * `retention` - Retention
+      * `churn` - Churn
+      * `reactivation` - Reactivation */
       category?: CoreEventCategoryEnum;
       /** Filter configuration - event, action, or data warehouse node */
       filter?: unknown;
@@ -29663,6 +28343,92 @@ export namespace Schemas {
       readonly updated_at?: string | null;
     }
 
+    export type PatchedDashboardFilters = { [key: string]: unknown };
+
+    /**
+     * @nullable
+     */
+    export type PatchedDashboardVariables = { [key: string]: unknown } | null;
+
+    /**
+     * @nullable
+     */
+    export type PatchedDashboardPersistedFilters = { [key: string]: unknown } | null;
+
+    /**
+     * @nullable
+     */
+    export type PatchedDashboardPersistedVariables = { [key: string]: unknown } | null;
+
+    export type PatchedDashboardTilesItem = { [key: string]: unknown };
+
+    /**
+     * Serializer mixin that handles tags for objects.
+     */
+    export interface PatchedDashboard {
+      readonly id?: number;
+      /**
+         * @maxLength 400
+         * @nullable
+         */
+      name?: string | null;
+      description?: string;
+      pinned?: boolean;
+      readonly created_at?: string;
+      readonly created_by?: UserBasic;
+      /** @nullable */
+      last_accessed_at?: string | null;
+      /** @nullable */
+      readonly last_viewed_at?: string | null;
+      readonly is_shared?: boolean;
+      deleted?: boolean;
+      readonly creation_mode?: CreationModeEnum;
+      readonly filters?: PatchedDashboardFilters;
+      /** @nullable */
+      readonly variables?: PatchedDashboardVariables;
+      /** Custom color mapping for breakdown values. */
+      breakdown_colors?: unknown;
+      /**
+         * ID of the color theme used for chart visualizations.
+         * @nullable
+         */
+      data_color_theme_id?: number | null;
+      tags?: unknown[];
+      restriction_level?: RestrictionLevelEnum;
+      readonly effective_restriction_level?: EffectivePrivilegeLevelEnum;
+      readonly effective_privilege_level?: EffectivePrivilegeLevelEnum;
+      /**
+         * The effective access level the user has for this object
+         * @nullable
+         */
+      readonly user_access_level?: string | null;
+      readonly access_control_version?: string;
+      /** @nullable */
+      last_refresh?: string | null;
+      /** @nullable */
+      readonly persisted_filters?: PatchedDashboardPersistedFilters;
+      /** @nullable */
+      readonly persisted_variables?: PatchedDashboardPersistedVariables;
+      readonly team_id?: number;
+      /**
+         * List of quick filter IDs associated with this dashboard
+         * @nullable
+         */
+      quick_filter_ids?: string[] | null;
+      /** @nullable */
+      readonly tiles?: readonly PatchedDashboardTilesItem[] | null;
+      /** Template key to create the dashboard from a predefined template. */
+      use_template?: string;
+      /**
+         * ID of an existing dashboard to duplicate.
+         * @nullable
+         */
+      use_dashboard?: number | null;
+      /** When deleting, also delete insights that are only on this dashboard. */
+      delete_insights?: boolean;
+      _create_in_folder?: string;
+    }
+
     export interface PatchedDashboardTemplate {
       readonly id?: string;
       /**
@@ -29676,10 +28442,7 @@ export namespace Schemas {
          */
       dashboard_description?: string | null;
       dashboard_filters?: unknown;
-      /**
-         * @nullable
-         * @items.maxLength 255
-         */
+      /** @nullable */
       tags?: string[] | null;
       tiles?: unknown;
       variables?: unknown;
@@ -29696,10 +28459,7 @@ export namespace Schemas {
       /** @nullable */
       readonly team_id?: number | null;
       scope?: DashboardTemplateScopeEnum | BlankEnum | null;
-      /**
-         * @nullable
-         * @items.maxLength 255
-         */
+      /** @nullable */
       availability_contexts?: string[] | null;
       /** Manually curated; used to highlight templates in the UI. */
       is_featured?: boolean;
@@ -29735,8 +28495,8 @@ export namespace Schemas {
 
     /**
      * Shared methods for DataWarehouseSavedQuery serializers.
-     *
-     * This mixin is intended to be used with serializers.ModelSerializer subclasses.
+
+    This mixin is intended to be used with serializers.ModelSerializer subclasses.
      */
     export interface PatchedDataWarehouseSavedQuery {
       readonly id?: string;
@@ -29755,12 +28515,12 @@ export namespace Schemas {
       readonly sync_frequency?: string | null;
       readonly columns?: readonly PatchedDataWarehouseSavedQueryColumnsItem[];
       /** The status of when this SavedQuery last ran.
-       *
-       * * `Cancelled` - Cancelled
-       * * `Modified` - Modified
-       * * `Completed` - Completed
-       * * `Failed` - Failed
-       * * `Running` - Running */
+
+      * `Cancelled` - Cancelled
+      * `Modified` - Modified
+      * `Completed` - Completed
+      * `Failed` - Failed
+      * `Running` - Running */
       readonly status?: SavedQueryStatusEnum | null;
       /** @nullable */
       readonly last_run_at?: string | null;
@@ -29798,10 +28558,10 @@ export namespace Schemas {
       /** @nullable */
       readonly is_materialized?: boolean | null;
       /** Where this SavedQuery is created.
-       *
-       * * `data_warehouse` - Data Warehouse
-       * * `endpoint` - Endpoint
-       * * `managed_viewset` - Managed Viewset */
+
+      * `data_warehouse` - Data Warehouse
+      * `endpoint` - Endpoint
+      * `managed_viewset` - Managed Viewset */
       readonly origin?: OriginEnum | null;
       /** Whether this view is for testing only and will auto-expire. */
       is_test?: boolean;
@@ -29976,13 +28736,13 @@ export namespace Schemas {
       /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
       description?: string;
       /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-       *
-       * * `draft` - draft
-       * * `concept` - concept
-       * * `alpha` - alpha
-       * * `beta` - beta
-       * * `general-availability` - general availability
-       * * `archived` - archived */
+
+      * `draft` - draft
+      * `concept` - concept
+      * `alpha` - alpha
+      * `beta` - beta
+      * `general-availability` - general availability
+      * `archived` - archived */
       stage?: StageEnum;
       /**
          * URL to external documentation for this feature. Shown to users in the opt-in UI.
@@ -30017,10 +28777,7 @@ export namespace Schemas {
          * @nullable
          */
       tag_name?: string | null;
-      /**
-         * @nullable
-         * @items.maxLength 200
-         */
+      /** @nullable */
       attr_class?: string[] | null;
       /**
          * @maxLength 10000
@@ -30275,25 +29032,6 @@ export namespace Schemas {
       readonly cohort?: PatchedErrorTrackingIssueFullCohort;
     }
 
-    export interface PatchedErrorTrackingIssueWrite {
-      /** Issue status to set. Deprecated archived and pending_release values are rejected.
-       *
-       * * `active` - active
-       * * `resolved` - resolved
-       * * `suppressed` - suppressed */
-      status?: ErrorTrackingIssueWriteStatusEnum;
-      /**
-         * Optional issue display name.
-         * @nullable
-         */
-      name?: string | null;
-      /**
-         * Optional issue description.
-         * @nullable
-         */
-      description?: string | null;
-    }
-
     export interface PatchedErrorTrackingRelease {
       readonly id?: string;
       hash_id?: string;
@@ -30413,15 +29151,15 @@ export namespace Schemas {
       readonly status?: EvaluationStatusEnum;
       readonly status_reason?: StatusReasonEnum | null;
       /** 'llm_judge' uses an LLM to score outputs against a prompt; 'hog' runs deterministic Hog code.
-       *
-       * * `llm_judge` - LLM as a judge
-       * * `hog` - Hog */
+
+      * `llm_judge` - LLM as a judge
+      * `hog` - Hog */
       evaluation_type?: EvaluationTypeEnum;
       /** Configuration dict. For 'llm_judge': {prompt}. For 'hog': {source}. */
       evaluation_config?: PatchedEvaluationEvaluationConfig;
       /** Output format. Currently only 'boolean' is supported.
-       *
-       * * `boolean` - Boolean (Pass/Fail) */
+
+      * `boolean` - Boolean (Pass/Fail) */
       output_type?: OutputTypeEnum;
       /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
       output_config?: PatchedEvaluationOutputConfig;
@@ -30440,9 +29178,9 @@ export namespace Schemas {
       /** UUID of the evaluation this report config belongs to. */
       evaluation?: string;
       /** How report generation is triggered. 'every_n' fires once N new evaluation results have accumulated (subject to cooldown_minutes and daily_run_cap). 'scheduled' fires on the cadence defined by rrule + starts_at + timezone_name.
-       *
-       * * `scheduled` - Scheduled
-       * * `every_n` - Every N */
+
+      * `scheduled` - Scheduled
+      * `every_n` - Every N */
       frequency?: EvaluationReportFrequencyEnum;
       /** RFC 5545 recurrence rule string (e.g. 'FREQ=WEEKLY;BYDAY=MO'). Must not contain DTSTART — the anchor is set via starts_at. Required when frequency is 'scheduled'; ignored otherwise. */
       rrule?: string;
@@ -30527,7 +29265,7 @@ export namespace Schemas {
       start_date?: string | null;
       /** @nullable */
       end_date?: string | null;
-      /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flag-get-all tool first — reuse an existing flag when possible. */
+      /** Unique key for the experiment's feature flag. Letters, numbers, hyphens, and underscores only. Search existing flags with the feature-flags-get-all tool first — reuse an existing flag when possible. */
       feature_flag_key?: string;
       readonly feature_flag?: MinimalFeatureFlag;
       readonly holdout?: ExperimentHoldout;
@@ -30556,13 +29294,13 @@ export namespace Schemas {
       readonly created_at?: string;
       readonly updated_at?: string;
       /** Experiment type: web for frontend UI changes, product for backend/API changes.
-       *
-       * * `web` - web
-       * * `product` - product */
+
+      * `web` - web
+      * `product` - product */
       type?: ExperimentTypeEnum | null;
       /** Exposure configuration including filter test accounts and custom exposure events. */
       exposure_criteria?: ExperimentApiExposureCriteria | null;
-      /** Primary experiment metrics. Each metric must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Use the read-data-schema tool with query kind 'events' to find available events in the project. */
+      /** Primary experiment metrics. Each metric must have kind='ExperimentMetric' and a metric_type: 'mean' (set source to an EventsNode with an event name), 'funnel' (set series to an array of EventsNode steps), 'ratio' (set numerator and denominator EventsNode entries), or 'retention' (set start_event and completion_event). Use the event-definitions-list tool to find available events in the project. */
       metrics?: _ExperimentApiMetricsList | null;
       /** Secondary metrics for additional measurements. Same format as primary metrics. */
       metrics_secondary?: _ExperimentApiMetricsList | null;
@@ -30572,12 +29310,12 @@ export namespace Schemas {
       allow_unknown_events?: boolean;
       _create_in_folder?: string;
       /** Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.
-       *
-       * * `won` - won
-       * * `lost` - lost
-       * * `inconclusive` - inconclusive
-       * * `stopped_early` - stopped_early
-       * * `invalid` - invalid */
+
+      * `won` - won
+      * `lost` - lost
+      * `inconclusive` - inconclusive
+      * `stopped_early` - stopped_early
+      * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Comment about the experiment conclusion.
@@ -30684,12 +29422,12 @@ export namespace Schemas {
       /** @nullable */
       readonly status?: string | null;
       /** Sync strategy: incremental, full_refresh, append, or cdc.
-       *
-       * * `full_refresh` - full_refresh
-       * * `incremental` - incremental
-       * * `append` - append
-       * * `webhook` - webhook
-       * * `cdc` - cdc */
+
+      * `full_refresh` - full_refresh
+      * `incremental` - incremental
+      * `append` - append
+      * `webhook` - webhook
+      * `cdc` - cdc */
       sync_type?: SyncTypeEnum | null;
       /**
          * Column name used to track sync progress.
@@ -30697,27 +29435,27 @@ export namespace Schemas {
          */
       incremental_field?: string | null;
       /** Data type of the incremental field.
-       *
-       * * `integer` - integer
-       * * `numeric` - numeric
-       * * `datetime` - datetime
-       * * `date` - date
-       * * `timestamp` - timestamp
-       * * `objectid` - objectid */
+
+      * `integer` - integer
+      * `numeric` - numeric
+      * `datetime` - datetime
+      * `date` - date
+      * `timestamp` - timestamp
+      * `objectid` - objectid */
       incremental_field_type?: IncrementalFieldTypeEnum | null;
       /** How often to sync.
-       *
-       * * `never` - never
-       * * `1min` - 1min
-       * * `5min` - 5min
-       * * `15min` - 15min
-       * * `30min` - 30min
-       * * `1hour` - 1hour
-       * * `6hour` - 6hour
-       * * `12hour` - 12hour
-       * * `24hour` - 24hour
-       * * `7day` - 7day
-       * * `30day` - 30day */
+
+      * `never` - never
+      * `1min` - 1min
+      * `5min` - 5min
+      * `15min` - 15min
+      * `30min` - 30min
+      * `1hour` - 1hour
+      * `6hour` - 6hour
+      * `12hour` - 12hour
+      * `24hour` - 24hour
+      * `7day` - 7day
+      * `30day` - 30day */
       sync_frequency?: SyncFrequencyEnum | null;
       /**
          * UTC time of day to run the sync (HH:MM:SS).
@@ -30732,10 +29470,10 @@ export namespace Schemas {
          */
       primary_key_columns?: string[] | null;
       /** For CDC syncs: consolidated, cdc_only, or both.
-       *
-       * * `consolidated` - consolidated
-       * * `cdc_only` - cdc_only
-       * * `both` - both */
+
+      * `consolidated` - consolidated
+      * `cdc_only` - cdc_only
+      * `both` - both */
       cdc_table_mode?: CdcTableModeEnum | null;
       /**
          * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
@@ -30767,10 +29505,10 @@ export namespace Schemas {
       /** @nullable */
       readonly created_by?: string | null;
       /** How this source was created. Defaults to `api` on create when omitted. `web` for the in-app UI, `api` for direct API callers, `mcp` for agent/MCP tool calls. Ignored on update.
-       *
-       * * `web` - web
-       * * `api` - api
-       * * `mcp` - mcp */
+
+      * `web` - web
+      * `api` - api
+      * `mcp` - mcp */
       created_via?: CreatedViaEnum | null;
       readonly status?: string;
       client_secret?: string;
@@ -30790,9 +29528,9 @@ export namespace Schemas {
       description?: string | null;
       readonly access_method?: AccessMethodEnum;
       /** Backend engine detected for the direct connection.
-       *
-       * * `duckdb` - duckdb
-       * * `postgres` - postgres */
+
+      * `duckdb` - duckdb
+      * `postgres` - postgres */
       readonly engine?: EngineEnum | null;
       /** @nullable */
       readonly last_run_at?: string | null;
@@ -30822,98 +29560,6 @@ export namespace Schemas {
       tags?: string[];
       /** Evaluation contexts that control where this flag evaluates at runtime. */
       evaluation_contexts?: string[];
-      /**
-         * Whether this flag is a remote configuration flag that delivers a payload rather than gating a feature.
-         * @nullable
-         */
-      is_remote_configuration?: boolean | null;
-    }
-
-    /**
-     * Structured element metadata (inferred selectors, attributes, component hints).
-     */
-    export type PatchedFieldNoteElementContext = { [key: string]: unknown };
-
-    /**
-     * Viewport size when the field note was made, as {width, height}.
-     * @nullable
-     */
-    export type PatchedFieldNoteViewport = {
-      /** Viewport width in pixels. */
-      width?: number;
-      /** Viewport height in pixels. */
-      height?: number;
-    } | null;
-
-    export interface PatchedFieldNote {
-      readonly id?: string;
-      /**
-         * The note the user wrote about the element.
-         * @maxLength 5000
-         */
-      comment?: string;
-      /** Lifecycle of the field note: pending, acknowledged, resolved, or dismissed. Ignored on create.
-       *
-       * * `pending` - Pending
-       * * `acknowledged` - Acknowledged
-       * * `resolved` - Resolved
-       * * `dismissed` - Dismissed */
-      field_note_status?: FieldNoteStatusEnum;
-      /**
-         * Optional note left by the agent when acknowledging, resolving, or dismissing the field note.
-         * @nullable
-         */
-      resolution?: string | null;
-      /**
-         * Full URL of the page the field note was made on.
-         * @maxLength 2048
-         */
-      url?: string;
-      /**
-         * Hostname of the page, used to scope field notes to a site.
-         * @maxLength 255
-         */
-      host?: string;
-      /**
-         * Path portion of the URL.
-         * @maxLength 2048
-         * @nullable
-         */
-      pathname?: string | null;
-      /**
-         * CSS selector that locates the element on the page.
-         * @maxLength 4096
-         */
-      selector?: string;
-      /**
-         * Visible text of the element, if any.
-         * @maxLength 2048
-         * @nullable
-         */
-      element_text?: string | null;
-      /**
-         * Serialized autocapture-style element chain from the element up to the document root.
-         * @maxLength 20000
-         * @nullable
-         */
-      element_chain?: string | null;
-      /** Structured element metadata (inferred selectors, attributes, component hints). */
-      element_context?: PatchedFieldNoteElementContext;
-      /**
-         * Viewport size when the field note was made, as {width, height}.
-         * @nullable
-         */
-      viewport?: PatchedFieldNoteViewport;
-      /**
-         * URL of an uploaded screenshot captured with the field_note.
-         * @maxLength 2048
-         * @nullable
-         */
-      screenshot_url?: string | null;
-      readonly created_at?: string;
-      /** @nullable */
-      readonly updated_at?: string | null;
-      readonly created_by?: UserBasic;
     }
 
     export interface PatchedFileSystem {
@@ -31000,10 +29646,10 @@ export namespace Schemas {
 
     /**
      * Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-     *
-     * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-     *
-     * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
+
+    **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+
+    **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
      */
     export type PatchedGroupUsageMetricFilters = { [key: string]: unknown };
 
@@ -31015,27 +29661,27 @@ export namespace Schemas {
          */
       name?: string;
       /** How the metric value is formatted in the UI. One of `numeric` or `currency`.
-       *
-       * * `numeric` - numeric
-       * * `currency` - currency */
+
+      * `numeric` - numeric
+      * `currency` - currency */
       format?: GroupUsageMetricFormatEnum;
       /** Rolling time window in days used to compute the metric. Defaults to 7. */
       interval?: number;
       /** Visual representation in the UI. One of `number` or `sparkline`.
-       *
-       * * `number` - number
-       * * `sparkline` - sparkline */
+
+      * `number` - number
+      * `sparkline` - sparkline */
       display?: GroupUsageMetricDisplayEnum;
       /** Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-       *
-       * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-       *
-       * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
+
+      **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+
+      **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
       filters?: PatchedGroupUsageMetricFilters;
       /** Aggregation function. `count` counts matching events; `sum` sums the value of `math_property` on matching events.
-       *
-       * * `count` - count
-       * * `sum` - sum */
+
+      * `count` - count
+      * `sum` - sum */
       math?: MathEnum;
       /**
          * Required when `math` is `sum`; must be empty when `math` is `count`. For events metrics this is an event property name. For data warehouse metrics this is the column name (or HogQL expression) to sum on the DW table.
@@ -31056,15 +29702,15 @@ export namespace Schemas {
       /** Which health check produced this issue (e.g. 'sdk_outdated', 'external_data_failure', 'no_live_events', 'ingestion_warnings'). Stable string key — use it to filter issues by category. */
       readonly kind?: string;
       /** How serious the issue is: 'critical', 'warning', or 'info'.
-       *
-       * * `critical` - Critical
-       * * `warning` - Warning
-       * * `info` - Info */
+
+      * `critical` - Critical
+      * `warning` - Warning
+      * `info` - Info */
       readonly severity?: HealthIssueSeverityEnum;
       /** 'active' while the underlying problem is still detected; 'resolved' once a later check run no longer finds it.
-       *
-       * * `active` - Active
-       * * `resolved` - Resolved */
+
+      * `active` - Active
+      * `resolved` - Resolved */
       readonly status?: HealthIssueStatusEnum;
       /** Whether a user has dismissed this issue from the Health UI. Dismissed issues stay in the list but are hidden by default. */
       dismissed?: boolean;
@@ -31098,25 +29744,25 @@ export namespace Schemas {
       description?: string;
       readonly version?: number;
       /** draft (no execution), active (live), archived (disabled).
-       *
-       * * `draft` - Draft
-       * * `active` - Active
-       * * `archived` - Archived */
+
+      * `draft` - Draft
+      * `active` - Active
+      * `archived` - Archived */
       status?: HogFlowStatusEnum;
       readonly created_at?: string;
       readonly created_by?: UserBasic;
       readonly updated_at?: string;
       readonly trigger?: unknown;
-      /** Optional dedup/throttle on an already-matched trigger: {hash: <HogQL template>, ttl: <seconds, 60-94608000>, threshold?: <int>}. Without threshold: fire once per hash, then suppress repeats within ttl (hash '{person.id}' = once per person per ttl). With threshold N: fire once per N matches of the same hash — a sampler, the 1st then every Nth. Throttles an already-qualifying trigger; it doesn't decide who enters. Server compiles bytecode from hash; omit to disable. */
+      /** Optional dedup: {hash: <HogQL template>, ttl: <seconds, 60-94608000>, threshold?: <int>}. Server compiles bytecode from hash. Omit to disable. */
       trigger_masking?: HogFlowMasking | null;
       /** Conversion goal: {filters: [<cond>, ...], window_minutes}. <cond>: {key, value, operator, type: event|person|group}. Empty filters = any event in window. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
       conversion?: unknown;
       /** exit_only_at_end: only at exit node (default). exit_on_conversion: also on conversion (needs 'conversion'; silent no-op otherwise). exit_on_trigger_not_matched: also when trigger filter stops matching. exit_on_trigger_not_matched_or_conversion: both (needs 'conversion').
-       *
-       * * `exit_on_conversion` - Conversion
-       * * `exit_on_trigger_not_matched` - Trigger Not Matched
-       * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
-       * * `exit_only_at_end` - Only At End */
+
+      * `exit_on_conversion` - Conversion
+      * `exit_on_trigger_not_matched` - Trigger Not Matched
+      * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+      * `exit_only_at_end` - Only At End */
       exit_condition?: ExitConditionEnum;
       /** Graph edges: [{from, to, type: 'continue'|'branch', index?}]. 'continue' = fall-through (sequential, or no-match path of conditional_branch). 'branch' requires 'index': matches config.conditions[index] on conditional_branch / wait_until_condition. Every non-exit action needs a reachable next action ('No next action found' otherwise). */
       edges?: HogFlowEdge[];
@@ -31145,10 +29791,10 @@ export namespace Schemas {
       /** Variable value overrides merged with the workflow defaults on each run. */
       variables?: unknown;
       /** active, paused, or completed (set once the RRULE's COUNT/UNTIL is exhausted).
-       *
-       * * `active` - Active
-       * * `paused` - Paused
-       * * `completed` - Completed */
+
+      * `active` - Active
+      * `paused` - Paused
+      * `completed` - Completed */
       readonly status?: HogFlowScheduleStatusEnum;
       /**
          * Next scheduled fire time, computed by the scheduler.
@@ -31171,7 +29817,7 @@ export namespace Schemas {
 
     /**
      * Serializer for creating hog flow templates.
-     * Validates and sanitizes the workflow before creating it as a template.
+    Validates and sanitizes the workflow before creating it as a template.
      */
     export interface PatchedHogFlowTemplate {
       readonly id?: string;
@@ -31211,14 +29857,14 @@ export namespace Schemas {
     export interface PatchedHogFunction {
       readonly id?: string;
       /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
-       *
-       * * `destination` - Destination
-       * * `site_destination` - Site Destination
-       * * `internal_destination` - Internal Destination
-       * * `source_webhook` - Source Webhook
-       * * `warehouse_source_webhook` - Warehouse Source Webhook
-       * * `site_app` - Site App
-       * * `transformation` - Transformation */
+
+      * `destination` - Destination
+      * `site_destination` - Site Destination
+      * `internal_destination` - Internal Destination
+      * `source_webhook` - Source Webhook
+      * `warehouse_source_webhook` - Warehouse Source Webhook
+      * `site_app` - Site App
+      * `transformation` - Transformation */
       type?: HogFunctionTypeEnum | null;
       /**
          * Display name for the function.
@@ -31276,8 +29922,6 @@ export namespace Schemas {
       _create_in_folder?: string;
       /** @nullable */
       readonly batch_export_id?: string | null;
-      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
-      readonly search_match_type?: SearchMatchTypeEnum | null;
     }
 
     /**
@@ -31323,21 +29967,21 @@ export namespace Schemas {
       order?: number | null;
       deleted?: boolean;
       /**
-       *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
-       *         A dashboard ID for each of the dashboards that this insight is displayed on.
-       *          */
+              DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
+              A dashboard ID for each of the dashboards that this insight is displayed on.
+               */
       dashboards?: number[];
       /**
-       *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
-       *      */
+          A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
+           */
       readonly dashboard_tiles?: readonly DashboardTileBasic[];
       /**
          *
-       *     The datetime this insight's results were generated.
-       *     If added to one or more dashboards the insight can be refreshed separately on each.
-       *     Returns the appropriate last_refresh datetime for the context the insight is viewed in
-       *     (see from_dashboard query parameter).
-       *
+          The datetime this insight's results were generated.
+          If added to one or more dashboards the insight can be refreshed separately on each.
+          Returns the appropriate last_refresh datetime for the context the insight is viewed in
+          (see from_dashboard query parameter).
+
          * @nullable
          */
       readonly last_refresh?: string | null;
@@ -31348,9 +29992,9 @@ export namespace Schemas {
       readonly cache_target_age?: string | null;
       /**
          *
-       *     The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
-       *     by querying the database.
-       *
+          The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
+          by querying the database.
+
          * @nullable
          */
       readonly next_allowed_client_refresh?: string | null;
@@ -31397,7 +30041,7 @@ export namespace Schemas {
       readonly alerts?: readonly unknown[];
       /** @nullable */
       readonly last_viewed_at?: string | null;
-      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      /** How this row matched the `search` term: `exact` (the term is a case-insensitive substring of the name, derived_name, description, or a tag name) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
       readonly search_match_type?: SearchMatchTypeEnum | null;
     }
 
@@ -31410,12 +30054,12 @@ export namespace Schemas {
          */
       name?: string;
       /** Variable type. Controls how the value is rendered and substituted in HogQL.
-       *
-       * * `String` - String
-       * * `Number` - Number
-       * * `Boolean` - Boolean
-       * * `List` - List
-       * * `Date` - Date */
+
+      * `String` - String
+      * `Number` - Number
+      * `Boolean` - Boolean
+      * `List` - List
+      * `Date` - Date */
       type?: InsightVariableTypeEnum;
       /** Default value used when a query references this variable. */
       default_value?: unknown;
@@ -31594,22 +30238,22 @@ export namespace Schemas {
          */
       threshold_count?: number;
       /** Whether the alert fires when the count is above or below the threshold.
-       *
-       * * `above` - Above
-       * * `below` - Below */
+
+      * `above` - Above
+      * `below` - Below */
       threshold_operator?: ThresholdOperatorEnum;
       /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
       window_minutes?: number;
       /** How often the alert is evaluated, in minutes. Server-managed. */
       readonly check_interval_minutes?: number;
       /** Current alert state: not_firing, firing, pending_resolve, errored, or snoozed. Server-managed.
-       *
-       * * `not_firing` - Not firing
-       * * `firing` - Firing
-       * * `pending_resolve` - Pending resolve
-       * * `errored` - Errored
-       * * `snoozed` - Snoozed
-       * * `broken` - Broken */
+
+      * `not_firing` - Not firing
+      * `firing` - Firing
+      * `pending_resolve` - Pending resolve
+      * `errored` - Errored
+      * `snoozed` - Snoozed
+      * `broken` - Broken */
       readonly state?: LogsAlertConfigurationStateEnum;
       /**
          * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
@@ -31693,10 +30337,10 @@ export namespace Schemas {
          */
       priority?: number | null;
       /** Rule kind: severity_sampling, path_drop, or rate_limit (caps matching log volume at ingestion).
-       *
-       * * `severity_sampling` - Severity-based reduction
-       * * `path_drop` - Path exclusion
-       * * `rate_limit` - Rate limit */
+
+      * `severity_sampling` - Severity-based reduction
+      * `path_drop` - Path exclusion
+      * `rate_limit` - Rate limit */
       rule_type?: RuleTypeEnum;
       /**
          * Optional legacy service-name scope; new rules use `config.filter_group` for matching instead.
@@ -31795,29 +30439,17 @@ export namespace Schemas {
 
     export interface PatchedMessageTemplate {
       readonly id?: string;
-      /**
-         * Human-readable template name shown in the library.
-         * @maxLength 400
-         */
+      /** @maxLength 400 */
       name?: string;
-      /** What the template is for and when to use it. */
       description?: string;
       readonly created_at?: string;
       readonly updated_at?: string;
-      /** Template content keyed by channel. Replaced as a whole on update, not merged. */
       content?: MessageTemplateContent;
       readonly created_by?: UserBasic;
-      /**
-         * Message channel of the template. Currently 'email'.
-         * @maxLength 24
-         */
+      /** @maxLength 24 */
       type?: string;
-      /**
-         * Message category ID to file the template under. Must belong to the same project.
-         * @nullable
-         */
+      /** @nullable */
       message_category?: string | null;
-      /** Soft-delete flag. Set true to remove the template from the library. */
       deleted?: boolean;
     }
 
@@ -31982,9 +30614,9 @@ export namespace Schemas {
       /** @nullable */
       readonly is_hipaa?: boolean | null;
       /** Default statistical method for new experiments in this organization.
-       *
-       * * `bayesian` - Bayesian
-       * * `frequentist` - Frequentist */
+
+      * `bayesian` - Bayesian
+      * `frequentist` - Frequentist */
       default_experiment_stats_method?: DefaultExperimentStatsMethodEnum | BlankEnum | null;
       /** Default setting for 'Discard client IP data' for new projects in this organization. */
       default_anonymize_ips?: boolean;
@@ -32057,10 +30689,7 @@ export namespace Schemas {
          * @nullable
          */
       id_jag_jwks_url?: string | null;
-      /**
-         * Allowed ID-JAG client IDs. Empty list allows any client_id.
-         * @items.maxLength 256
-         */
+      /** Allowed ID-JAG client IDs. Empty list allows any client_id. */
       id_jag_allowed_clients?: string[];
     }
 
@@ -32087,8 +30716,6 @@ export namespace Schemas {
       readonly is_2fa_enabled?: boolean;
       readonly has_social_auth?: boolean;
       readonly last_login?: string;
-      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
-      readonly search_match_type?: SearchMatchTypeEnum | null;
     }
 
     export interface PatchedParserRecipe {
@@ -32107,54 +30734,13 @@ export namespace Schemas {
       readonly updated_at?: string | null;
     }
 
-    /**
-     * OpenAPI-only PATCH body for dashboards (agents/MCP).
-     *
-     * Must be a superset of ``dashboard_patch_runtime_openapi_field_names()`` — ``extend_schema(request=...)``
-     * replaces the inferred schema entirely. Contract: ``test_dashboard_openapi.py``.
-     */
-    export interface PatchedPatchedDashboardOpenApi {
-      /**
-         * @maxLength 400
-         * @nullable
-         */
-      name?: string | null;
-      description?: string;
-      pinned?: boolean;
-      /** Custom color mapping for breakdown values. */
-      breakdown_colors?: unknown;
-      /**
-         * ID of the color theme used for chart visualizations.
-         * @nullable
-         */
-      data_color_theme_id?: number | null;
-      tags?: string[];
-      restriction_level?: EffectivePrivilegeLevelEnum;
-      /**
-         * List of quick filter IDs associated with this dashboard.
-         * @nullable
-         */
-      quick_filter_ids?: string[] | null;
-      /** Dashboard tiles to update. Widget tiles accept nested widget.config patches. */
-      tiles?: DashboardPatchTileOpenApi[];
-      /** Template key to create the dashboard from a predefined template. */
-      use_template?: string;
-      /**
-         * ID of an existing dashboard to duplicate.
-         * @nullable
-         */
-      use_dashboard?: number | null;
-      /** When deleting, also delete insights that are only on this dashboard. */
-      delete_insights?: boolean;
-    }
-
     export interface PatchedPersistedFolder {
       readonly id?: string;
       /** Which persisted folder this is for the user (home, pinned, custom_products).
-       *
-       * * `home` - Home
-       * * `pinned` - Pinned
-       * * `custom_products` - Custom Products */
+
+      * `home` - Home
+      * `pinned` - Pinned
+      * `custom_products` - Custom Products */
       type?: PersistedFolderTypeEnum;
       /**
          * Protocol prefix of the folder location, e.g. 'products://'.
@@ -32229,7 +30815,7 @@ export namespace Schemas {
 
     /**
      * * `app` - app
-     * * `toolbar` - toolbar
+    * `toolbar` - toolbar
      */
     export type ProductTourSerializerCreateUpdateOnlyCreationContextEnum = typeof ProductTourSerializerCreateUpdateOnlyCreationContextEnum[keyof typeof ProductTourSerializerCreateUpdateOnlyCreationContextEnum];
 
@@ -32263,9 +30849,9 @@ export namespace Schemas {
       readonly updated_at?: string;
       archived?: boolean;
       /** Where the tour was created/updated from
-       *
-       * * `app` - app
-       * * `toolbar` - toolbar */
+
+      * `app` - app
+      * `toolbar` - toolbar */
       creation_context?: ProductTourSerializerCreateUpdateOnlyCreationContextEnum;
     }
 
@@ -32281,13 +30867,11 @@ export namespace Schemas {
       updated_at?: string;
     };
 
-    export type PatchedProjectBackwardCompatManagedViewsets = {[key: string]: boolean};
-
     /**
      * * `30d` - 30 Days
-     * * `90d` - 90 Days
-     * * `1y` - 1 Year
-     * * `5y` - 5 Years
+    * `90d` - 90 Days
+    * `1y` - 1 Year
+    * `5y` - 5 Years
      */
     export type SessionRecordingRetentionPeriodEnum = typeof SessionRecordingRetentionPeriodEnum[keyof typeof SessionRecordingRetentionPeriodEnum];
 
@@ -32301,7 +30885,7 @@ export namespace Schemas {
 
     /**
      * * `0` - Sunday
-     * * `1` - Monday
+    * `1` - Monday
      */
     export type WeekStartDayEnum = typeof WeekStartDayEnum[keyof typeof WeekStartDayEnum];
 
@@ -32310,50 +30894,6 @@ export namespace Schemas {
       Number0: 0,
       Number1: 1,
     } as const;
-
-    export interface TeamRevenueAnalyticsConfig {
-      base_currency?: BaseCurrencyEnum;
-      events?: unknown;
-      goals?: unknown;
-      filter_test_accounts?: boolean;
-    }
-
-    export interface TeamMarketingAnalyticsConfig {
-      sources_map?: unknown;
-      conversion_goals?: unknown;
-      /**
-         * @minimum 1
-         * @maximum 90
-         */
-      attribution_window_days?: number;
-      attribution_mode?: AttributionModeEnum;
-      campaign_name_mappings?: unknown;
-      custom_source_mappings?: unknown;
-      campaign_field_preferences?: unknown;
-    }
-
-    export interface TeamCustomerAnalyticsConfig {
-      /** Event used as the activity signal (DAU/WAU/MAU). */
-      activity_event?: unknown;
-      /** Event used to count signup pageviews on dashboards. */
-      signup_pageview_event?: unknown;
-      /** Event used to count signups on dashboards. */
-      signup_event?: unknown;
-      /** Event used to count subscriptions on dashboards. */
-      subscription_event?: unknown;
-      /** Event used to count payments on dashboards. */
-      payment_event?: unknown;
-      /**
-         * Index of the group type to treat as an Account in customer analytics. Must reference an existing group type configured for the project.
-         * @nullable
-         */
-      account_group_type_index?: number | null;
-    }
-
-    export interface TeamWorkflowsConfig {
-      /** When enabled, workflows engagement activity (email sends, opens, clicks, bounces, spam reports, unsubscribes) is captured as standard PostHog events ($workflows_email_*) alongside the existing workflow metrics. */
-      capture_workflows_engagement_events?: boolean;
-    }
 
     /**
      * Mixin for serializers to add user access control fields
@@ -32383,7 +30923,6 @@ export namespace Schemas {
       readonly updated_at?: string | null;
       readonly uuid?: string;
       readonly api_token?: string;
-      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       /** When true, PostHog drops the IP address from every ingested event. */
       anonymize_ips?: boolean;
@@ -32400,610 +30939,609 @@ export namespace Schemas {
       path_cleaning_filters?: unknown;
       is_demo?: boolean;
       /** IANA timezone used for date-based filters and reporting (e.g. `America/Los_Angeles`).
-       *
-       * * `Africa/Abidjan` - Africa/Abidjan
-       * * `Africa/Accra` - Africa/Accra
-       * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-       * * `Africa/Algiers` - Africa/Algiers
-       * * `Africa/Asmara` - Africa/Asmara
-       * * `Africa/Asmera` - Africa/Asmera
-       * * `Africa/Bamako` - Africa/Bamako
-       * * `Africa/Bangui` - Africa/Bangui
-       * * `Africa/Banjul` - Africa/Banjul
-       * * `Africa/Bissau` - Africa/Bissau
-       * * `Africa/Blantyre` - Africa/Blantyre
-       * * `Africa/Brazzaville` - Africa/Brazzaville
-       * * `Africa/Bujumbura` - Africa/Bujumbura
-       * * `Africa/Cairo` - Africa/Cairo
-       * * `Africa/Casablanca` - Africa/Casablanca
-       * * `Africa/Ceuta` - Africa/Ceuta
-       * * `Africa/Conakry` - Africa/Conakry
-       * * `Africa/Dakar` - Africa/Dakar
-       * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-       * * `Africa/Djibouti` - Africa/Djibouti
-       * * `Africa/Douala` - Africa/Douala
-       * * `Africa/El_Aaiun` - Africa/El_Aaiun
-       * * `Africa/Freetown` - Africa/Freetown
-       * * `Africa/Gaborone` - Africa/Gaborone
-       * * `Africa/Harare` - Africa/Harare
-       * * `Africa/Johannesburg` - Africa/Johannesburg
-       * * `Africa/Juba` - Africa/Juba
-       * * `Africa/Kampala` - Africa/Kampala
-       * * `Africa/Khartoum` - Africa/Khartoum
-       * * `Africa/Kigali` - Africa/Kigali
-       * * `Africa/Kinshasa` - Africa/Kinshasa
-       * * `Africa/Lagos` - Africa/Lagos
-       * * `Africa/Libreville` - Africa/Libreville
-       * * `Africa/Lome` - Africa/Lome
-       * * `Africa/Luanda` - Africa/Luanda
-       * * `Africa/Lubumbashi` - Africa/Lubumbashi
-       * * `Africa/Lusaka` - Africa/Lusaka
-       * * `Africa/Malabo` - Africa/Malabo
-       * * `Africa/Maputo` - Africa/Maputo
-       * * `Africa/Maseru` - Africa/Maseru
-       * * `Africa/Mbabane` - Africa/Mbabane
-       * * `Africa/Mogadishu` - Africa/Mogadishu
-       * * `Africa/Monrovia` - Africa/Monrovia
-       * * `Africa/Nairobi` - Africa/Nairobi
-       * * `Africa/Ndjamena` - Africa/Ndjamena
-       * * `Africa/Niamey` - Africa/Niamey
-       * * `Africa/Nouakchott` - Africa/Nouakchott
-       * * `Africa/Ouagadougou` - Africa/Ouagadougou
-       * * `Africa/Porto-Novo` - Africa/Porto-Novo
-       * * `Africa/Sao_Tome` - Africa/Sao_Tome
-       * * `Africa/Timbuktu` - Africa/Timbuktu
-       * * `Africa/Tripoli` - Africa/Tripoli
-       * * `Africa/Tunis` - Africa/Tunis
-       * * `Africa/Windhoek` - Africa/Windhoek
-       * * `America/Adak` - America/Adak
-       * * `America/Anchorage` - America/Anchorage
-       * * `America/Anguilla` - America/Anguilla
-       * * `America/Antigua` - America/Antigua
-       * * `America/Araguaina` - America/Araguaina
-       * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-       * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-       * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-       * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-       * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-       * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-       * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-       * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-       * * `America/Argentina/Salta` - America/Argentina/Salta
-       * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-       * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-       * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-       * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-       * * `America/Aruba` - America/Aruba
-       * * `America/Asuncion` - America/Asuncion
-       * * `America/Atikokan` - America/Atikokan
-       * * `America/Atka` - America/Atka
-       * * `America/Bahia` - America/Bahia
-       * * `America/Bahia_Banderas` - America/Bahia_Banderas
-       * * `America/Barbados` - America/Barbados
-       * * `America/Belem` - America/Belem
-       * * `America/Belize` - America/Belize
-       * * `America/Blanc-Sablon` - America/Blanc-Sablon
-       * * `America/Boa_Vista` - America/Boa_Vista
-       * * `America/Bogota` - America/Bogota
-       * * `America/Boise` - America/Boise
-       * * `America/Buenos_Aires` - America/Buenos_Aires
-       * * `America/Cambridge_Bay` - America/Cambridge_Bay
-       * * `America/Campo_Grande` - America/Campo_Grande
-       * * `America/Cancun` - America/Cancun
-       * * `America/Caracas` - America/Caracas
-       * * `America/Catamarca` - America/Catamarca
-       * * `America/Cayenne` - America/Cayenne
-       * * `America/Cayman` - America/Cayman
-       * * `America/Chicago` - America/Chicago
-       * * `America/Chihuahua` - America/Chihuahua
-       * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-       * * `America/Coral_Harbour` - America/Coral_Harbour
-       * * `America/Cordoba` - America/Cordoba
-       * * `America/Costa_Rica` - America/Costa_Rica
-       * * `America/Creston` - America/Creston
-       * * `America/Cuiaba` - America/Cuiaba
-       * * `America/Curacao` - America/Curacao
-       * * `America/Danmarkshavn` - America/Danmarkshavn
-       * * `America/Dawson` - America/Dawson
-       * * `America/Dawson_Creek` - America/Dawson_Creek
-       * * `America/Denver` - America/Denver
-       * * `America/Detroit` - America/Detroit
-       * * `America/Dominica` - America/Dominica
-       * * `America/Edmonton` - America/Edmonton
-       * * `America/Eirunepe` - America/Eirunepe
-       * * `America/El_Salvador` - America/El_Salvador
-       * * `America/Ensenada` - America/Ensenada
-       * * `America/Fort_Nelson` - America/Fort_Nelson
-       * * `America/Fort_Wayne` - America/Fort_Wayne
-       * * `America/Fortaleza` - America/Fortaleza
-       * * `America/Glace_Bay` - America/Glace_Bay
-       * * `America/Godthab` - America/Godthab
-       * * `America/Goose_Bay` - America/Goose_Bay
-       * * `America/Grand_Turk` - America/Grand_Turk
-       * * `America/Grenada` - America/Grenada
-       * * `America/Guadeloupe` - America/Guadeloupe
-       * * `America/Guatemala` - America/Guatemala
-       * * `America/Guayaquil` - America/Guayaquil
-       * * `America/Guyana` - America/Guyana
-       * * `America/Halifax` - America/Halifax
-       * * `America/Havana` - America/Havana
-       * * `America/Hermosillo` - America/Hermosillo
-       * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-       * * `America/Indiana/Knox` - America/Indiana/Knox
-       * * `America/Indiana/Marengo` - America/Indiana/Marengo
-       * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-       * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-       * * `America/Indiana/Vevay` - America/Indiana/Vevay
-       * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-       * * `America/Indiana/Winamac` - America/Indiana/Winamac
-       * * `America/Indianapolis` - America/Indianapolis
-       * * `America/Inuvik` - America/Inuvik
-       * * `America/Iqaluit` - America/Iqaluit
-       * * `America/Jamaica` - America/Jamaica
-       * * `America/Jujuy` - America/Jujuy
-       * * `America/Juneau` - America/Juneau
-       * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-       * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-       * * `America/Knox_IN` - America/Knox_IN
-       * * `America/Kralendijk` - America/Kralendijk
-       * * `America/La_Paz` - America/La_Paz
-       * * `America/Lima` - America/Lima
-       * * `America/Los_Angeles` - America/Los_Angeles
-       * * `America/Louisville` - America/Louisville
-       * * `America/Lower_Princes` - America/Lower_Princes
-       * * `America/Maceio` - America/Maceio
-       * * `America/Managua` - America/Managua
-       * * `America/Manaus` - America/Manaus
-       * * `America/Marigot` - America/Marigot
-       * * `America/Martinique` - America/Martinique
-       * * `America/Matamoros` - America/Matamoros
-       * * `America/Mazatlan` - America/Mazatlan
-       * * `America/Mendoza` - America/Mendoza
-       * * `America/Menominee` - America/Menominee
-       * * `America/Merida` - America/Merida
-       * * `America/Metlakatla` - America/Metlakatla
-       * * `America/Mexico_City` - America/Mexico_City
-       * * `America/Miquelon` - America/Miquelon
-       * * `America/Moncton` - America/Moncton
-       * * `America/Monterrey` - America/Monterrey
-       * * `America/Montevideo` - America/Montevideo
-       * * `America/Montreal` - America/Montreal
-       * * `America/Montserrat` - America/Montserrat
-       * * `America/Nassau` - America/Nassau
-       * * `America/New_York` - America/New_York
-       * * `America/Nipigon` - America/Nipigon
-       * * `America/Nome` - America/Nome
-       * * `America/Noronha` - America/Noronha
-       * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-       * * `America/North_Dakota/Center` - America/North_Dakota/Center
-       * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-       * * `America/Nuuk` - America/Nuuk
-       * * `America/Ojinaga` - America/Ojinaga
-       * * `America/Panama` - America/Panama
-       * * `America/Pangnirtung` - America/Pangnirtung
-       * * `America/Paramaribo` - America/Paramaribo
-       * * `America/Phoenix` - America/Phoenix
-       * * `America/Port-au-Prince` - America/Port-au-Prince
-       * * `America/Port_of_Spain` - America/Port_of_Spain
-       * * `America/Porto_Acre` - America/Porto_Acre
-       * * `America/Porto_Velho` - America/Porto_Velho
-       * * `America/Puerto_Rico` - America/Puerto_Rico
-       * * `America/Punta_Arenas` - America/Punta_Arenas
-       * * `America/Rainy_River` - America/Rainy_River
-       * * `America/Rankin_Inlet` - America/Rankin_Inlet
-       * * `America/Recife` - America/Recife
-       * * `America/Regina` - America/Regina
-       * * `America/Resolute` - America/Resolute
-       * * `America/Rio_Branco` - America/Rio_Branco
-       * * `America/Rosario` - America/Rosario
-       * * `America/Santa_Isabel` - America/Santa_Isabel
-       * * `America/Santarem` - America/Santarem
-       * * `America/Santiago` - America/Santiago
-       * * `America/Santo_Domingo` - America/Santo_Domingo
-       * * `America/Sao_Paulo` - America/Sao_Paulo
-       * * `America/Scoresbysund` - America/Scoresbysund
-       * * `America/Shiprock` - America/Shiprock
-       * * `America/Sitka` - America/Sitka
-       * * `America/St_Barthelemy` - America/St_Barthelemy
-       * * `America/St_Johns` - America/St_Johns
-       * * `America/St_Kitts` - America/St_Kitts
-       * * `America/St_Lucia` - America/St_Lucia
-       * * `America/St_Thomas` - America/St_Thomas
-       * * `America/St_Vincent` - America/St_Vincent
-       * * `America/Swift_Current` - America/Swift_Current
-       * * `America/Tegucigalpa` - America/Tegucigalpa
-       * * `America/Thule` - America/Thule
-       * * `America/Thunder_Bay` - America/Thunder_Bay
-       * * `America/Tijuana` - America/Tijuana
-       * * `America/Toronto` - America/Toronto
-       * * `America/Tortola` - America/Tortola
-       * * `America/Vancouver` - America/Vancouver
-       * * `America/Virgin` - America/Virgin
-       * * `America/Whitehorse` - America/Whitehorse
-       * * `America/Winnipeg` - America/Winnipeg
-       * * `America/Yakutat` - America/Yakutat
-       * * `America/Yellowknife` - America/Yellowknife
-       * * `Antarctica/Casey` - Antarctica/Casey
-       * * `Antarctica/Davis` - Antarctica/Davis
-       * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-       * * `Antarctica/Macquarie` - Antarctica/Macquarie
-       * * `Antarctica/Mawson` - Antarctica/Mawson
-       * * `Antarctica/McMurdo` - Antarctica/McMurdo
-       * * `Antarctica/Palmer` - Antarctica/Palmer
-       * * `Antarctica/Rothera` - Antarctica/Rothera
-       * * `Antarctica/South_Pole` - Antarctica/South_Pole
-       * * `Antarctica/Syowa` - Antarctica/Syowa
-       * * `Antarctica/Troll` - Antarctica/Troll
-       * * `Antarctica/Vostok` - Antarctica/Vostok
-       * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-       * * `Asia/Aden` - Asia/Aden
-       * * `Asia/Almaty` - Asia/Almaty
-       * * `Asia/Amman` - Asia/Amman
-       * * `Asia/Anadyr` - Asia/Anadyr
-       * * `Asia/Aqtau` - Asia/Aqtau
-       * * `Asia/Aqtobe` - Asia/Aqtobe
-       * * `Asia/Ashgabat` - Asia/Ashgabat
-       * * `Asia/Ashkhabad` - Asia/Ashkhabad
-       * * `Asia/Atyrau` - Asia/Atyrau
-       * * `Asia/Baghdad` - Asia/Baghdad
-       * * `Asia/Bahrain` - Asia/Bahrain
-       * * `Asia/Baku` - Asia/Baku
-       * * `Asia/Bangkok` - Asia/Bangkok
-       * * `Asia/Barnaul` - Asia/Barnaul
-       * * `Asia/Beirut` - Asia/Beirut
-       * * `Asia/Bishkek` - Asia/Bishkek
-       * * `Asia/Brunei` - Asia/Brunei
-       * * `Asia/Calcutta` - Asia/Calcutta
-       * * `Asia/Chita` - Asia/Chita
-       * * `Asia/Choibalsan` - Asia/Choibalsan
-       * * `Asia/Chongqing` - Asia/Chongqing
-       * * `Asia/Chungking` - Asia/Chungking
-       * * `Asia/Colombo` - Asia/Colombo
-       * * `Asia/Dacca` - Asia/Dacca
-       * * `Asia/Damascus` - Asia/Damascus
-       * * `Asia/Dhaka` - Asia/Dhaka
-       * * `Asia/Dili` - Asia/Dili
-       * * `Asia/Dubai` - Asia/Dubai
-       * * `Asia/Dushanbe` - Asia/Dushanbe
-       * * `Asia/Famagusta` - Asia/Famagusta
-       * * `Asia/Gaza` - Asia/Gaza
-       * * `Asia/Harbin` - Asia/Harbin
-       * * `Asia/Hebron` - Asia/Hebron
-       * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-       * * `Asia/Hong_Kong` - Asia/Hong_Kong
-       * * `Asia/Hovd` - Asia/Hovd
-       * * `Asia/Irkutsk` - Asia/Irkutsk
-       * * `Asia/Istanbul` - Asia/Istanbul
-       * * `Asia/Jakarta` - Asia/Jakarta
-       * * `Asia/Jayapura` - Asia/Jayapura
-       * * `Asia/Jerusalem` - Asia/Jerusalem
-       * * `Asia/Kabul` - Asia/Kabul
-       * * `Asia/Kamchatka` - Asia/Kamchatka
-       * * `Asia/Karachi` - Asia/Karachi
-       * * `Asia/Kashgar` - Asia/Kashgar
-       * * `Asia/Kathmandu` - Asia/Kathmandu
-       * * `Asia/Katmandu` - Asia/Katmandu
-       * * `Asia/Khandyga` - Asia/Khandyga
-       * * `Asia/Kolkata` - Asia/Kolkata
-       * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-       * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-       * * `Asia/Kuching` - Asia/Kuching
-       * * `Asia/Kuwait` - Asia/Kuwait
-       * * `Asia/Macao` - Asia/Macao
-       * * `Asia/Macau` - Asia/Macau
-       * * `Asia/Magadan` - Asia/Magadan
-       * * `Asia/Makassar` - Asia/Makassar
-       * * `Asia/Manila` - Asia/Manila
-       * * `Asia/Muscat` - Asia/Muscat
-       * * `Asia/Nicosia` - Asia/Nicosia
-       * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-       * * `Asia/Novosibirsk` - Asia/Novosibirsk
-       * * `Asia/Omsk` - Asia/Omsk
-       * * `Asia/Oral` - Asia/Oral
-       * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-       * * `Asia/Pontianak` - Asia/Pontianak
-       * * `Asia/Pyongyang` - Asia/Pyongyang
-       * * `Asia/Qatar` - Asia/Qatar
-       * * `Asia/Qostanay` - Asia/Qostanay
-       * * `Asia/Qyzylorda` - Asia/Qyzylorda
-       * * `Asia/Rangoon` - Asia/Rangoon
-       * * `Asia/Riyadh` - Asia/Riyadh
-       * * `Asia/Saigon` - Asia/Saigon
-       * * `Asia/Sakhalin` - Asia/Sakhalin
-       * * `Asia/Samarkand` - Asia/Samarkand
-       * * `Asia/Seoul` - Asia/Seoul
-       * * `Asia/Shanghai` - Asia/Shanghai
-       * * `Asia/Singapore` - Asia/Singapore
-       * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-       * * `Asia/Taipei` - Asia/Taipei
-       * * `Asia/Tashkent` - Asia/Tashkent
-       * * `Asia/Tbilisi` - Asia/Tbilisi
-       * * `Asia/Tehran` - Asia/Tehran
-       * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-       * * `Asia/Thimbu` - Asia/Thimbu
-       * * `Asia/Thimphu` - Asia/Thimphu
-       * * `Asia/Tokyo` - Asia/Tokyo
-       * * `Asia/Tomsk` - Asia/Tomsk
-       * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-       * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-       * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-       * * `Asia/Urumqi` - Asia/Urumqi
-       * * `Asia/Ust-Nera` - Asia/Ust-Nera
-       * * `Asia/Vientiane` - Asia/Vientiane
-       * * `Asia/Vladivostok` - Asia/Vladivostok
-       * * `Asia/Yakutsk` - Asia/Yakutsk
-       * * `Asia/Yangon` - Asia/Yangon
-       * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-       * * `Asia/Yerevan` - Asia/Yerevan
-       * * `Atlantic/Azores` - Atlantic/Azores
-       * * `Atlantic/Bermuda` - Atlantic/Bermuda
-       * * `Atlantic/Canary` - Atlantic/Canary
-       * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-       * * `Atlantic/Faeroe` - Atlantic/Faeroe
-       * * `Atlantic/Faroe` - Atlantic/Faroe
-       * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-       * * `Atlantic/Madeira` - Atlantic/Madeira
-       * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-       * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-       * * `Atlantic/St_Helena` - Atlantic/St_Helena
-       * * `Atlantic/Stanley` - Atlantic/Stanley
-       * * `Australia/ACT` - Australia/ACT
-       * * `Australia/Adelaide` - Australia/Adelaide
-       * * `Australia/Brisbane` - Australia/Brisbane
-       * * `Australia/Broken_Hill` - Australia/Broken_Hill
-       * * `Australia/Canberra` - Australia/Canberra
-       * * `Australia/Currie` - Australia/Currie
-       * * `Australia/Darwin` - Australia/Darwin
-       * * `Australia/Eucla` - Australia/Eucla
-       * * `Australia/Hobart` - Australia/Hobart
-       * * `Australia/LHI` - Australia/LHI
-       * * `Australia/Lindeman` - Australia/Lindeman
-       * * `Australia/Lord_Howe` - Australia/Lord_Howe
-       * * `Australia/Melbourne` - Australia/Melbourne
-       * * `Australia/NSW` - Australia/NSW
-       * * `Australia/North` - Australia/North
-       * * `Australia/Perth` - Australia/Perth
-       * * `Australia/Queensland` - Australia/Queensland
-       * * `Australia/South` - Australia/South
-       * * `Australia/Sydney` - Australia/Sydney
-       * * `Australia/Tasmania` - Australia/Tasmania
-       * * `Australia/Victoria` - Australia/Victoria
-       * * `Australia/West` - Australia/West
-       * * `Australia/Yancowinna` - Australia/Yancowinna
-       * * `Brazil/Acre` - Brazil/Acre
-       * * `Brazil/DeNoronha` - Brazil/DeNoronha
-       * * `Brazil/East` - Brazil/East
-       * * `Brazil/West` - Brazil/West
-       * * `CET` - CET
-       * * `CST6CDT` - CST6CDT
-       * * `Canada/Atlantic` - Canada/Atlantic
-       * * `Canada/Central` - Canada/Central
-       * * `Canada/Eastern` - Canada/Eastern
-       * * `Canada/Mountain` - Canada/Mountain
-       * * `Canada/Newfoundland` - Canada/Newfoundland
-       * * `Canada/Pacific` - Canada/Pacific
-       * * `Canada/Saskatchewan` - Canada/Saskatchewan
-       * * `Canada/Yukon` - Canada/Yukon
-       * * `Chile/Continental` - Chile/Continental
-       * * `Chile/EasterIsland` - Chile/EasterIsland
-       * * `Cuba` - Cuba
-       * * `EET` - EET
-       * * `EST` - EST
-       * * `EST5EDT` - EST5EDT
-       * * `Egypt` - Egypt
-       * * `Eire` - Eire
-       * * `Etc/GMT` - Etc/GMT
-       * * `Etc/GMT+0` - Etc/GMT+0
-       * * `Etc/GMT+1` - Etc/GMT+1
-       * * `Etc/GMT+10` - Etc/GMT+10
-       * * `Etc/GMT+11` - Etc/GMT+11
-       * * `Etc/GMT+12` - Etc/GMT+12
-       * * `Etc/GMT+2` - Etc/GMT+2
-       * * `Etc/GMT+3` - Etc/GMT+3
-       * * `Etc/GMT+4` - Etc/GMT+4
-       * * `Etc/GMT+5` - Etc/GMT+5
-       * * `Etc/GMT+6` - Etc/GMT+6
-       * * `Etc/GMT+7` - Etc/GMT+7
-       * * `Etc/GMT+8` - Etc/GMT+8
-       * * `Etc/GMT+9` - Etc/GMT+9
-       * * `Etc/GMT-0` - Etc/GMT-0
-       * * `Etc/GMT-1` - Etc/GMT-1
-       * * `Etc/GMT-10` - Etc/GMT-10
-       * * `Etc/GMT-11` - Etc/GMT-11
-       * * `Etc/GMT-12` - Etc/GMT-12
-       * * `Etc/GMT-13` - Etc/GMT-13
-       * * `Etc/GMT-14` - Etc/GMT-14
-       * * `Etc/GMT-2` - Etc/GMT-2
-       * * `Etc/GMT-3` - Etc/GMT-3
-       * * `Etc/GMT-4` - Etc/GMT-4
-       * * `Etc/GMT-5` - Etc/GMT-5
-       * * `Etc/GMT-6` - Etc/GMT-6
-       * * `Etc/GMT-7` - Etc/GMT-7
-       * * `Etc/GMT-8` - Etc/GMT-8
-       * * `Etc/GMT-9` - Etc/GMT-9
-       * * `Etc/GMT0` - Etc/GMT0
-       * * `Etc/Greenwich` - Etc/Greenwich
-       * * `Etc/UCT` - Etc/UCT
-       * * `Etc/UTC` - Etc/UTC
-       * * `Etc/Universal` - Etc/Universal
-       * * `Etc/Zulu` - Etc/Zulu
-       * * `Europe/Amsterdam` - Europe/Amsterdam
-       * * `Europe/Andorra` - Europe/Andorra
-       * * `Europe/Astrakhan` - Europe/Astrakhan
-       * * `Europe/Athens` - Europe/Athens
-       * * `Europe/Belfast` - Europe/Belfast
-       * * `Europe/Belgrade` - Europe/Belgrade
-       * * `Europe/Berlin` - Europe/Berlin
-       * * `Europe/Bratislava` - Europe/Bratislava
-       * * `Europe/Brussels` - Europe/Brussels
-       * * `Europe/Bucharest` - Europe/Bucharest
-       * * `Europe/Budapest` - Europe/Budapest
-       * * `Europe/Busingen` - Europe/Busingen
-       * * `Europe/Chisinau` - Europe/Chisinau
-       * * `Europe/Copenhagen` - Europe/Copenhagen
-       * * `Europe/Dublin` - Europe/Dublin
-       * * `Europe/Gibraltar` - Europe/Gibraltar
-       * * `Europe/Guernsey` - Europe/Guernsey
-       * * `Europe/Helsinki` - Europe/Helsinki
-       * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-       * * `Europe/Istanbul` - Europe/Istanbul
-       * * `Europe/Jersey` - Europe/Jersey
-       * * `Europe/Kaliningrad` - Europe/Kaliningrad
-       * * `Europe/Kiev` - Europe/Kiev
-       * * `Europe/Kirov` - Europe/Kirov
-       * * `Europe/Kyiv` - Europe/Kyiv
-       * * `Europe/Lisbon` - Europe/Lisbon
-       * * `Europe/Ljubljana` - Europe/Ljubljana
-       * * `Europe/London` - Europe/London
-       * * `Europe/Luxembourg` - Europe/Luxembourg
-       * * `Europe/Madrid` - Europe/Madrid
-       * * `Europe/Malta` - Europe/Malta
-       * * `Europe/Mariehamn` - Europe/Mariehamn
-       * * `Europe/Minsk` - Europe/Minsk
-       * * `Europe/Monaco` - Europe/Monaco
-       * * `Europe/Moscow` - Europe/Moscow
-       * * `Europe/Nicosia` - Europe/Nicosia
-       * * `Europe/Oslo` - Europe/Oslo
-       * * `Europe/Paris` - Europe/Paris
-       * * `Europe/Podgorica` - Europe/Podgorica
-       * * `Europe/Prague` - Europe/Prague
-       * * `Europe/Riga` - Europe/Riga
-       * * `Europe/Rome` - Europe/Rome
-       * * `Europe/Samara` - Europe/Samara
-       * * `Europe/San_Marino` - Europe/San_Marino
-       * * `Europe/Sarajevo` - Europe/Sarajevo
-       * * `Europe/Saratov` - Europe/Saratov
-       * * `Europe/Simferopol` - Europe/Simferopol
-       * * `Europe/Skopje` - Europe/Skopje
-       * * `Europe/Sofia` - Europe/Sofia
-       * * `Europe/Stockholm` - Europe/Stockholm
-       * * `Europe/Tallinn` - Europe/Tallinn
-       * * `Europe/Tirane` - Europe/Tirane
-       * * `Europe/Tiraspol` - Europe/Tiraspol
-       * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-       * * `Europe/Uzhgorod` - Europe/Uzhgorod
-       * * `Europe/Vaduz` - Europe/Vaduz
-       * * `Europe/Vatican` - Europe/Vatican
-       * * `Europe/Vienna` - Europe/Vienna
-       * * `Europe/Vilnius` - Europe/Vilnius
-       * * `Europe/Volgograd` - Europe/Volgograd
-       * * `Europe/Warsaw` - Europe/Warsaw
-       * * `Europe/Zagreb` - Europe/Zagreb
-       * * `Europe/Zaporozhye` - Europe/Zaporozhye
-       * * `Europe/Zurich` - Europe/Zurich
-       * * `GB` - GB
-       * * `GB-Eire` - GB-Eire
-       * * `GMT` - GMT
-       * * `GMT+0` - GMT+0
-       * * `GMT-0` - GMT-0
-       * * `GMT0` - GMT0
-       * * `Greenwich` - Greenwich
-       * * `HST` - HST
-       * * `Hongkong` - Hongkong
-       * * `Iceland` - Iceland
-       * * `Indian/Antananarivo` - Indian/Antananarivo
-       * * `Indian/Chagos` - Indian/Chagos
-       * * `Indian/Christmas` - Indian/Christmas
-       * * `Indian/Cocos` - Indian/Cocos
-       * * `Indian/Comoro` - Indian/Comoro
-       * * `Indian/Kerguelen` - Indian/Kerguelen
-       * * `Indian/Mahe` - Indian/Mahe
-       * * `Indian/Maldives` - Indian/Maldives
-       * * `Indian/Mauritius` - Indian/Mauritius
-       * * `Indian/Mayotte` - Indian/Mayotte
-       * * `Indian/Reunion` - Indian/Reunion
-       * * `Iran` - Iran
-       * * `Israel` - Israel
-       * * `Jamaica` - Jamaica
-       * * `Japan` - Japan
-       * * `Kwajalein` - Kwajalein
-       * * `Libya` - Libya
-       * * `MET` - MET
-       * * `MST` - MST
-       * * `MST7MDT` - MST7MDT
-       * * `Mexico/BajaNorte` - Mexico/BajaNorte
-       * * `Mexico/BajaSur` - Mexico/BajaSur
-       * * `Mexico/General` - Mexico/General
-       * * `NZ` - NZ
-       * * `NZ-CHAT` - NZ-CHAT
-       * * `Navajo` - Navajo
-       * * `PRC` - PRC
-       * * `PST8PDT` - PST8PDT
-       * * `Pacific/Apia` - Pacific/Apia
-       * * `Pacific/Auckland` - Pacific/Auckland
-       * * `Pacific/Bougainville` - Pacific/Bougainville
-       * * `Pacific/Chatham` - Pacific/Chatham
-       * * `Pacific/Chuuk` - Pacific/Chuuk
-       * * `Pacific/Easter` - Pacific/Easter
-       * * `Pacific/Efate` - Pacific/Efate
-       * * `Pacific/Enderbury` - Pacific/Enderbury
-       * * `Pacific/Fakaofo` - Pacific/Fakaofo
-       * * `Pacific/Fiji` - Pacific/Fiji
-       * * `Pacific/Funafuti` - Pacific/Funafuti
-       * * `Pacific/Galapagos` - Pacific/Galapagos
-       * * `Pacific/Gambier` - Pacific/Gambier
-       * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-       * * `Pacific/Guam` - Pacific/Guam
-       * * `Pacific/Honolulu` - Pacific/Honolulu
-       * * `Pacific/Johnston` - Pacific/Johnston
-       * * `Pacific/Kanton` - Pacific/Kanton
-       * * `Pacific/Kiritimati` - Pacific/Kiritimati
-       * * `Pacific/Kosrae` - Pacific/Kosrae
-       * * `Pacific/Kwajalein` - Pacific/Kwajalein
-       * * `Pacific/Majuro` - Pacific/Majuro
-       * * `Pacific/Marquesas` - Pacific/Marquesas
-       * * `Pacific/Midway` - Pacific/Midway
-       * * `Pacific/Nauru` - Pacific/Nauru
-       * * `Pacific/Niue` - Pacific/Niue
-       * * `Pacific/Norfolk` - Pacific/Norfolk
-       * * `Pacific/Noumea` - Pacific/Noumea
-       * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-       * * `Pacific/Palau` - Pacific/Palau
-       * * `Pacific/Pitcairn` - Pacific/Pitcairn
-       * * `Pacific/Pohnpei` - Pacific/Pohnpei
-       * * `Pacific/Ponape` - Pacific/Ponape
-       * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-       * * `Pacific/Rarotonga` - Pacific/Rarotonga
-       * * `Pacific/Saipan` - Pacific/Saipan
-       * * `Pacific/Samoa` - Pacific/Samoa
-       * * `Pacific/Tahiti` - Pacific/Tahiti
-       * * `Pacific/Tarawa` - Pacific/Tarawa
-       * * `Pacific/Tongatapu` - Pacific/Tongatapu
-       * * `Pacific/Truk` - Pacific/Truk
-       * * `Pacific/Wake` - Pacific/Wake
-       * * `Pacific/Wallis` - Pacific/Wallis
-       * * `Pacific/Yap` - Pacific/Yap
-       * * `Poland` - Poland
-       * * `Portugal` - Portugal
-       * * `ROC` - ROC
-       * * `ROK` - ROK
-       * * `Singapore` - Singapore
-       * * `Turkey` - Turkey
-       * * `UCT` - UCT
-       * * `US/Alaska` - US/Alaska
-       * * `US/Aleutian` - US/Aleutian
-       * * `US/Arizona` - US/Arizona
-       * * `US/Central` - US/Central
-       * * `US/East-Indiana` - US/East-Indiana
-       * * `US/Eastern` - US/Eastern
-       * * `US/Hawaii` - US/Hawaii
-       * * `US/Indiana-Starke` - US/Indiana-Starke
-       * * `US/Michigan` - US/Michigan
-       * * `US/Mountain` - US/Mountain
-       * * `US/Pacific` - US/Pacific
-       * * `US/Samoa` - US/Samoa
-       * * `UTC` - UTC
-       * * `Universal` - Universal
-       * * `W-SU` - W-SU
-       * * `WET` - WET
-       * * `Zulu` - Zulu */
+
+      * `Africa/Abidjan` - Africa/Abidjan
+      * `Africa/Accra` - Africa/Accra
+      * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+      * `Africa/Algiers` - Africa/Algiers
+      * `Africa/Asmara` - Africa/Asmara
+      * `Africa/Asmera` - Africa/Asmera
+      * `Africa/Bamako` - Africa/Bamako
+      * `Africa/Bangui` - Africa/Bangui
+      * `Africa/Banjul` - Africa/Banjul
+      * `Africa/Bissau` - Africa/Bissau
+      * `Africa/Blantyre` - Africa/Blantyre
+      * `Africa/Brazzaville` - Africa/Brazzaville
+      * `Africa/Bujumbura` - Africa/Bujumbura
+      * `Africa/Cairo` - Africa/Cairo
+      * `Africa/Casablanca` - Africa/Casablanca
+      * `Africa/Ceuta` - Africa/Ceuta
+      * `Africa/Conakry` - Africa/Conakry
+      * `Africa/Dakar` - Africa/Dakar
+      * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+      * `Africa/Djibouti` - Africa/Djibouti
+      * `Africa/Douala` - Africa/Douala
+      * `Africa/El_Aaiun` - Africa/El_Aaiun
+      * `Africa/Freetown` - Africa/Freetown
+      * `Africa/Gaborone` - Africa/Gaborone
+      * `Africa/Harare` - Africa/Harare
+      * `Africa/Johannesburg` - Africa/Johannesburg
+      * `Africa/Juba` - Africa/Juba
+      * `Africa/Kampala` - Africa/Kampala
+      * `Africa/Khartoum` - Africa/Khartoum
+      * `Africa/Kigali` - Africa/Kigali
+      * `Africa/Kinshasa` - Africa/Kinshasa
+      * `Africa/Lagos` - Africa/Lagos
+      * `Africa/Libreville` - Africa/Libreville
+      * `Africa/Lome` - Africa/Lome
+      * `Africa/Luanda` - Africa/Luanda
+      * `Africa/Lubumbashi` - Africa/Lubumbashi
+      * `Africa/Lusaka` - Africa/Lusaka
+      * `Africa/Malabo` - Africa/Malabo
+      * `Africa/Maputo` - Africa/Maputo
+      * `Africa/Maseru` - Africa/Maseru
+      * `Africa/Mbabane` - Africa/Mbabane
+      * `Africa/Mogadishu` - Africa/Mogadishu
+      * `Africa/Monrovia` - Africa/Monrovia
+      * `Africa/Nairobi` - Africa/Nairobi
+      * `Africa/Ndjamena` - Africa/Ndjamena
+      * `Africa/Niamey` - Africa/Niamey
+      * `Africa/Nouakchott` - Africa/Nouakchott
+      * `Africa/Ouagadougou` - Africa/Ouagadougou
+      * `Africa/Porto-Novo` - Africa/Porto-Novo
+      * `Africa/Sao_Tome` - Africa/Sao_Tome
+      * `Africa/Timbuktu` - Africa/Timbuktu
+      * `Africa/Tripoli` - Africa/Tripoli
+      * `Africa/Tunis` - Africa/Tunis
+      * `Africa/Windhoek` - Africa/Windhoek
+      * `America/Adak` - America/Adak
+      * `America/Anchorage` - America/Anchorage
+      * `America/Anguilla` - America/Anguilla
+      * `America/Antigua` - America/Antigua
+      * `America/Araguaina` - America/Araguaina
+      * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+      * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+      * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+      * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+      * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+      * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+      * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+      * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+      * `America/Argentina/Salta` - America/Argentina/Salta
+      * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+      * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+      * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+      * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+      * `America/Aruba` - America/Aruba
+      * `America/Asuncion` - America/Asuncion
+      * `America/Atikokan` - America/Atikokan
+      * `America/Atka` - America/Atka
+      * `America/Bahia` - America/Bahia
+      * `America/Bahia_Banderas` - America/Bahia_Banderas
+      * `America/Barbados` - America/Barbados
+      * `America/Belem` - America/Belem
+      * `America/Belize` - America/Belize
+      * `America/Blanc-Sablon` - America/Blanc-Sablon
+      * `America/Boa_Vista` - America/Boa_Vista
+      * `America/Bogota` - America/Bogota
+      * `America/Boise` - America/Boise
+      * `America/Buenos_Aires` - America/Buenos_Aires
+      * `America/Cambridge_Bay` - America/Cambridge_Bay
+      * `America/Campo_Grande` - America/Campo_Grande
+      * `America/Cancun` - America/Cancun
+      * `America/Caracas` - America/Caracas
+      * `America/Catamarca` - America/Catamarca
+      * `America/Cayenne` - America/Cayenne
+      * `America/Cayman` - America/Cayman
+      * `America/Chicago` - America/Chicago
+      * `America/Chihuahua` - America/Chihuahua
+      * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+      * `America/Coral_Harbour` - America/Coral_Harbour
+      * `America/Cordoba` - America/Cordoba
+      * `America/Costa_Rica` - America/Costa_Rica
+      * `America/Creston` - America/Creston
+      * `America/Cuiaba` - America/Cuiaba
+      * `America/Curacao` - America/Curacao
+      * `America/Danmarkshavn` - America/Danmarkshavn
+      * `America/Dawson` - America/Dawson
+      * `America/Dawson_Creek` - America/Dawson_Creek
+      * `America/Denver` - America/Denver
+      * `America/Detroit` - America/Detroit
+      * `America/Dominica` - America/Dominica
+      * `America/Edmonton` - America/Edmonton
+      * `America/Eirunepe` - America/Eirunepe
+      * `America/El_Salvador` - America/El_Salvador
+      * `America/Ensenada` - America/Ensenada
+      * `America/Fort_Nelson` - America/Fort_Nelson
+      * `America/Fort_Wayne` - America/Fort_Wayne
+      * `America/Fortaleza` - America/Fortaleza
+      * `America/Glace_Bay` - America/Glace_Bay
+      * `America/Godthab` - America/Godthab
+      * `America/Goose_Bay` - America/Goose_Bay
+      * `America/Grand_Turk` - America/Grand_Turk
+      * `America/Grenada` - America/Grenada
+      * `America/Guadeloupe` - America/Guadeloupe
+      * `America/Guatemala` - America/Guatemala
+      * `America/Guayaquil` - America/Guayaquil
+      * `America/Guyana` - America/Guyana
+      * `America/Halifax` - America/Halifax
+      * `America/Havana` - America/Havana
+      * `America/Hermosillo` - America/Hermosillo
+      * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+      * `America/Indiana/Knox` - America/Indiana/Knox
+      * `America/Indiana/Marengo` - America/Indiana/Marengo
+      * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+      * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+      * `America/Indiana/Vevay` - America/Indiana/Vevay
+      * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+      * `America/Indiana/Winamac` - America/Indiana/Winamac
+      * `America/Indianapolis` - America/Indianapolis
+      * `America/Inuvik` - America/Inuvik
+      * `America/Iqaluit` - America/Iqaluit
+      * `America/Jamaica` - America/Jamaica
+      * `America/Jujuy` - America/Jujuy
+      * `America/Juneau` - America/Juneau
+      * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+      * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+      * `America/Knox_IN` - America/Knox_IN
+      * `America/Kralendijk` - America/Kralendijk
+      * `America/La_Paz` - America/La_Paz
+      * `America/Lima` - America/Lima
+      * `America/Los_Angeles` - America/Los_Angeles
+      * `America/Louisville` - America/Louisville
+      * `America/Lower_Princes` - America/Lower_Princes
+      * `America/Maceio` - America/Maceio
+      * `America/Managua` - America/Managua
+      * `America/Manaus` - America/Manaus
+      * `America/Marigot` - America/Marigot
+      * `America/Martinique` - America/Martinique
+      * `America/Matamoros` - America/Matamoros
+      * `America/Mazatlan` - America/Mazatlan
+      * `America/Mendoza` - America/Mendoza
+      * `America/Menominee` - America/Menominee
+      * `America/Merida` - America/Merida
+      * `America/Metlakatla` - America/Metlakatla
+      * `America/Mexico_City` - America/Mexico_City
+      * `America/Miquelon` - America/Miquelon
+      * `America/Moncton` - America/Moncton
+      * `America/Monterrey` - America/Monterrey
+      * `America/Montevideo` - America/Montevideo
+      * `America/Montreal` - America/Montreal
+      * `America/Montserrat` - America/Montserrat
+      * `America/Nassau` - America/Nassau
+      * `America/New_York` - America/New_York
+      * `America/Nipigon` - America/Nipigon
+      * `America/Nome` - America/Nome
+      * `America/Noronha` - America/Noronha
+      * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+      * `America/North_Dakota/Center` - America/North_Dakota/Center
+      * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+      * `America/Nuuk` - America/Nuuk
+      * `America/Ojinaga` - America/Ojinaga
+      * `America/Panama` - America/Panama
+      * `America/Pangnirtung` - America/Pangnirtung
+      * `America/Paramaribo` - America/Paramaribo
+      * `America/Phoenix` - America/Phoenix
+      * `America/Port-au-Prince` - America/Port-au-Prince
+      * `America/Port_of_Spain` - America/Port_of_Spain
+      * `America/Porto_Acre` - America/Porto_Acre
+      * `America/Porto_Velho` - America/Porto_Velho
+      * `America/Puerto_Rico` - America/Puerto_Rico
+      * `America/Punta_Arenas` - America/Punta_Arenas
+      * `America/Rainy_River` - America/Rainy_River
+      * `America/Rankin_Inlet` - America/Rankin_Inlet
+      * `America/Recife` - America/Recife
+      * `America/Regina` - America/Regina
+      * `America/Resolute` - America/Resolute
+      * `America/Rio_Branco` - America/Rio_Branco
+      * `America/Rosario` - America/Rosario
+      * `America/Santa_Isabel` - America/Santa_Isabel
+      * `America/Santarem` - America/Santarem
+      * `America/Santiago` - America/Santiago
+      * `America/Santo_Domingo` - America/Santo_Domingo
+      * `America/Sao_Paulo` - America/Sao_Paulo
+      * `America/Scoresbysund` - America/Scoresbysund
+      * `America/Shiprock` - America/Shiprock
+      * `America/Sitka` - America/Sitka
+      * `America/St_Barthelemy` - America/St_Barthelemy
+      * `America/St_Johns` - America/St_Johns
+      * `America/St_Kitts` - America/St_Kitts
+      * `America/St_Lucia` - America/St_Lucia
+      * `America/St_Thomas` - America/St_Thomas
+      * `America/St_Vincent` - America/St_Vincent
+      * `America/Swift_Current` - America/Swift_Current
+      * `America/Tegucigalpa` - America/Tegucigalpa
+      * `America/Thule` - America/Thule
+      * `America/Thunder_Bay` - America/Thunder_Bay
+      * `America/Tijuana` - America/Tijuana
+      * `America/Toronto` - America/Toronto
+      * `America/Tortola` - America/Tortola
+      * `America/Vancouver` - America/Vancouver
+      * `America/Virgin` - America/Virgin
+      * `America/Whitehorse` - America/Whitehorse
+      * `America/Winnipeg` - America/Winnipeg
+      * `America/Yakutat` - America/Yakutat
+      * `America/Yellowknife` - America/Yellowknife
+      * `Antarctica/Casey` - Antarctica/Casey
+      * `Antarctica/Davis` - Antarctica/Davis
+      * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+      * `Antarctica/Macquarie` - Antarctica/Macquarie
+      * `Antarctica/Mawson` - Antarctica/Mawson
+      * `Antarctica/McMurdo` - Antarctica/McMurdo
+      * `Antarctica/Palmer` - Antarctica/Palmer
+      * `Antarctica/Rothera` - Antarctica/Rothera
+      * `Antarctica/South_Pole` - Antarctica/South_Pole
+      * `Antarctica/Syowa` - Antarctica/Syowa
+      * `Antarctica/Troll` - Antarctica/Troll
+      * `Antarctica/Vostok` - Antarctica/Vostok
+      * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+      * `Asia/Aden` - Asia/Aden
+      * `Asia/Almaty` - Asia/Almaty
+      * `Asia/Amman` - Asia/Amman
+      * `Asia/Anadyr` - Asia/Anadyr
+      * `Asia/Aqtau` - Asia/Aqtau
+      * `Asia/Aqtobe` - Asia/Aqtobe
+      * `Asia/Ashgabat` - Asia/Ashgabat
+      * `Asia/Ashkhabad` - Asia/Ashkhabad
+      * `Asia/Atyrau` - Asia/Atyrau
+      * `Asia/Baghdad` - Asia/Baghdad
+      * `Asia/Bahrain` - Asia/Bahrain
+      * `Asia/Baku` - Asia/Baku
+      * `Asia/Bangkok` - Asia/Bangkok
+      * `Asia/Barnaul` - Asia/Barnaul
+      * `Asia/Beirut` - Asia/Beirut
+      * `Asia/Bishkek` - Asia/Bishkek
+      * `Asia/Brunei` - Asia/Brunei
+      * `Asia/Calcutta` - Asia/Calcutta
+      * `Asia/Chita` - Asia/Chita
+      * `Asia/Choibalsan` - Asia/Choibalsan
+      * `Asia/Chongqing` - Asia/Chongqing
+      * `Asia/Chungking` - Asia/Chungking
+      * `Asia/Colombo` - Asia/Colombo
+      * `Asia/Dacca` - Asia/Dacca
+      * `Asia/Damascus` - Asia/Damascus
+      * `Asia/Dhaka` - Asia/Dhaka
+      * `Asia/Dili` - Asia/Dili
+      * `Asia/Dubai` - Asia/Dubai
+      * `Asia/Dushanbe` - Asia/Dushanbe
+      * `Asia/Famagusta` - Asia/Famagusta
+      * `Asia/Gaza` - Asia/Gaza
+      * `Asia/Harbin` - Asia/Harbin
+      * `Asia/Hebron` - Asia/Hebron
+      * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+      * `Asia/Hong_Kong` - Asia/Hong_Kong
+      * `Asia/Hovd` - Asia/Hovd
+      * `Asia/Irkutsk` - Asia/Irkutsk
+      * `Asia/Istanbul` - Asia/Istanbul
+      * `Asia/Jakarta` - Asia/Jakarta
+      * `Asia/Jayapura` - Asia/Jayapura
+      * `Asia/Jerusalem` - Asia/Jerusalem
+      * `Asia/Kabul` - Asia/Kabul
+      * `Asia/Kamchatka` - Asia/Kamchatka
+      * `Asia/Karachi` - Asia/Karachi
+      * `Asia/Kashgar` - Asia/Kashgar
+      * `Asia/Kathmandu` - Asia/Kathmandu
+      * `Asia/Katmandu` - Asia/Katmandu
+      * `Asia/Khandyga` - Asia/Khandyga
+      * `Asia/Kolkata` - Asia/Kolkata
+      * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+      * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+      * `Asia/Kuching` - Asia/Kuching
+      * `Asia/Kuwait` - Asia/Kuwait
+      * `Asia/Macao` - Asia/Macao
+      * `Asia/Macau` - Asia/Macau
+      * `Asia/Magadan` - Asia/Magadan
+      * `Asia/Makassar` - Asia/Makassar
+      * `Asia/Manila` - Asia/Manila
+      * `Asia/Muscat` - Asia/Muscat
+      * `Asia/Nicosia` - Asia/Nicosia
+      * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+      * `Asia/Novosibirsk` - Asia/Novosibirsk
+      * `Asia/Omsk` - Asia/Omsk
+      * `Asia/Oral` - Asia/Oral
+      * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+      * `Asia/Pontianak` - Asia/Pontianak
+      * `Asia/Pyongyang` - Asia/Pyongyang
+      * `Asia/Qatar` - Asia/Qatar
+      * `Asia/Qostanay` - Asia/Qostanay
+      * `Asia/Qyzylorda` - Asia/Qyzylorda
+      * `Asia/Rangoon` - Asia/Rangoon
+      * `Asia/Riyadh` - Asia/Riyadh
+      * `Asia/Saigon` - Asia/Saigon
+      * `Asia/Sakhalin` - Asia/Sakhalin
+      * `Asia/Samarkand` - Asia/Samarkand
+      * `Asia/Seoul` - Asia/Seoul
+      * `Asia/Shanghai` - Asia/Shanghai
+      * `Asia/Singapore` - Asia/Singapore
+      * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+      * `Asia/Taipei` - Asia/Taipei
+      * `Asia/Tashkent` - Asia/Tashkent
+      * `Asia/Tbilisi` - Asia/Tbilisi
+      * `Asia/Tehran` - Asia/Tehran
+      * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+      * `Asia/Thimbu` - Asia/Thimbu
+      * `Asia/Thimphu` - Asia/Thimphu
+      * `Asia/Tokyo` - Asia/Tokyo
+      * `Asia/Tomsk` - Asia/Tomsk
+      * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+      * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+      * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+      * `Asia/Urumqi` - Asia/Urumqi
+      * `Asia/Ust-Nera` - Asia/Ust-Nera
+      * `Asia/Vientiane` - Asia/Vientiane
+      * `Asia/Vladivostok` - Asia/Vladivostok
+      * `Asia/Yakutsk` - Asia/Yakutsk
+      * `Asia/Yangon` - Asia/Yangon
+      * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+      * `Asia/Yerevan` - Asia/Yerevan
+      * `Atlantic/Azores` - Atlantic/Azores
+      * `Atlantic/Bermuda` - Atlantic/Bermuda
+      * `Atlantic/Canary` - Atlantic/Canary
+      * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+      * `Atlantic/Faeroe` - Atlantic/Faeroe
+      * `Atlantic/Faroe` - Atlantic/Faroe
+      * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+      * `Atlantic/Madeira` - Atlantic/Madeira
+      * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+      * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+      * `Atlantic/St_Helena` - Atlantic/St_Helena
+      * `Atlantic/Stanley` - Atlantic/Stanley
+      * `Australia/ACT` - Australia/ACT
+      * `Australia/Adelaide` - Australia/Adelaide
+      * `Australia/Brisbane` - Australia/Brisbane
+      * `Australia/Broken_Hill` - Australia/Broken_Hill
+      * `Australia/Canberra` - Australia/Canberra
+      * `Australia/Currie` - Australia/Currie
+      * `Australia/Darwin` - Australia/Darwin
+      * `Australia/Eucla` - Australia/Eucla
+      * `Australia/Hobart` - Australia/Hobart
+      * `Australia/LHI` - Australia/LHI
+      * `Australia/Lindeman` - Australia/Lindeman
+      * `Australia/Lord_Howe` - Australia/Lord_Howe
+      * `Australia/Melbourne` - Australia/Melbourne
+      * `Australia/NSW` - Australia/NSW
+      * `Australia/North` - Australia/North
+      * `Australia/Perth` - Australia/Perth
+      * `Australia/Queensland` - Australia/Queensland
+      * `Australia/South` - Australia/South
+      * `Australia/Sydney` - Australia/Sydney
+      * `Australia/Tasmania` - Australia/Tasmania
+      * `Australia/Victoria` - Australia/Victoria
+      * `Australia/West` - Australia/West
+      * `Australia/Yancowinna` - Australia/Yancowinna
+      * `Brazil/Acre` - Brazil/Acre
+      * `Brazil/DeNoronha` - Brazil/DeNoronha
+      * `Brazil/East` - Brazil/East
+      * `Brazil/West` - Brazil/West
+      * `CET` - CET
+      * `CST6CDT` - CST6CDT
+      * `Canada/Atlantic` - Canada/Atlantic
+      * `Canada/Central` - Canada/Central
+      * `Canada/Eastern` - Canada/Eastern
+      * `Canada/Mountain` - Canada/Mountain
+      * `Canada/Newfoundland` - Canada/Newfoundland
+      * `Canada/Pacific` - Canada/Pacific
+      * `Canada/Saskatchewan` - Canada/Saskatchewan
+      * `Canada/Yukon` - Canada/Yukon
+      * `Chile/Continental` - Chile/Continental
+      * `Chile/EasterIsland` - Chile/EasterIsland
+      * `Cuba` - Cuba
+      * `EET` - EET
+      * `EST` - EST
+      * `EST5EDT` - EST5EDT
+      * `Egypt` - Egypt
+      * `Eire` - Eire
+      * `Etc/GMT` - Etc/GMT
+      * `Etc/GMT+0` - Etc/GMT+0
+      * `Etc/GMT+1` - Etc/GMT+1
+      * `Etc/GMT+10` - Etc/GMT+10
+      * `Etc/GMT+11` - Etc/GMT+11
+      * `Etc/GMT+12` - Etc/GMT+12
+      * `Etc/GMT+2` - Etc/GMT+2
+      * `Etc/GMT+3` - Etc/GMT+3
+      * `Etc/GMT+4` - Etc/GMT+4
+      * `Etc/GMT+5` - Etc/GMT+5
+      * `Etc/GMT+6` - Etc/GMT+6
+      * `Etc/GMT+7` - Etc/GMT+7
+      * `Etc/GMT+8` - Etc/GMT+8
+      * `Etc/GMT+9` - Etc/GMT+9
+      * `Etc/GMT-0` - Etc/GMT-0
+      * `Etc/GMT-1` - Etc/GMT-1
+      * `Etc/GMT-10` - Etc/GMT-10
+      * `Etc/GMT-11` - Etc/GMT-11
+      * `Etc/GMT-12` - Etc/GMT-12
+      * `Etc/GMT-13` - Etc/GMT-13
+      * `Etc/GMT-14` - Etc/GMT-14
+      * `Etc/GMT-2` - Etc/GMT-2
+      * `Etc/GMT-3` - Etc/GMT-3
+      * `Etc/GMT-4` - Etc/GMT-4
+      * `Etc/GMT-5` - Etc/GMT-5
+      * `Etc/GMT-6` - Etc/GMT-6
+      * `Etc/GMT-7` - Etc/GMT-7
+      * `Etc/GMT-8` - Etc/GMT-8
+      * `Etc/GMT-9` - Etc/GMT-9
+      * `Etc/GMT0` - Etc/GMT0
+      * `Etc/Greenwich` - Etc/Greenwich
+      * `Etc/UCT` - Etc/UCT
+      * `Etc/UTC` - Etc/UTC
+      * `Etc/Universal` - Etc/Universal
+      * `Etc/Zulu` - Etc/Zulu
+      * `Europe/Amsterdam` - Europe/Amsterdam
+      * `Europe/Andorra` - Europe/Andorra
+      * `Europe/Astrakhan` - Europe/Astrakhan
+      * `Europe/Athens` - Europe/Athens
+      * `Europe/Belfast` - Europe/Belfast
+      * `Europe/Belgrade` - Europe/Belgrade
+      * `Europe/Berlin` - Europe/Berlin
+      * `Europe/Bratislava` - Europe/Bratislava
+      * `Europe/Brussels` - Europe/Brussels
+      * `Europe/Bucharest` - Europe/Bucharest
+      * `Europe/Budapest` - Europe/Budapest
+      * `Europe/Busingen` - Europe/Busingen
+      * `Europe/Chisinau` - Europe/Chisinau
+      * `Europe/Copenhagen` - Europe/Copenhagen
+      * `Europe/Dublin` - Europe/Dublin
+      * `Europe/Gibraltar` - Europe/Gibraltar
+      * `Europe/Guernsey` - Europe/Guernsey
+      * `Europe/Helsinki` - Europe/Helsinki
+      * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+      * `Europe/Istanbul` - Europe/Istanbul
+      * `Europe/Jersey` - Europe/Jersey
+      * `Europe/Kaliningrad` - Europe/Kaliningrad
+      * `Europe/Kiev` - Europe/Kiev
+      * `Europe/Kirov` - Europe/Kirov
+      * `Europe/Kyiv` - Europe/Kyiv
+      * `Europe/Lisbon` - Europe/Lisbon
+      * `Europe/Ljubljana` - Europe/Ljubljana
+      * `Europe/London` - Europe/London
+      * `Europe/Luxembourg` - Europe/Luxembourg
+      * `Europe/Madrid` - Europe/Madrid
+      * `Europe/Malta` - Europe/Malta
+      * `Europe/Mariehamn` - Europe/Mariehamn
+      * `Europe/Minsk` - Europe/Minsk
+      * `Europe/Monaco` - Europe/Monaco
+      * `Europe/Moscow` - Europe/Moscow
+      * `Europe/Nicosia` - Europe/Nicosia
+      * `Europe/Oslo` - Europe/Oslo
+      * `Europe/Paris` - Europe/Paris
+      * `Europe/Podgorica` - Europe/Podgorica
+      * `Europe/Prague` - Europe/Prague
+      * `Europe/Riga` - Europe/Riga
+      * `Europe/Rome` - Europe/Rome
+      * `Europe/Samara` - Europe/Samara
+      * `Europe/San_Marino` - Europe/San_Marino
+      * `Europe/Sarajevo` - Europe/Sarajevo
+      * `Europe/Saratov` - Europe/Saratov
+      * `Europe/Simferopol` - Europe/Simferopol
+      * `Europe/Skopje` - Europe/Skopje
+      * `Europe/Sofia` - Europe/Sofia
+      * `Europe/Stockholm` - Europe/Stockholm
+      * `Europe/Tallinn` - Europe/Tallinn
+      * `Europe/Tirane` - Europe/Tirane
+      * `Europe/Tiraspol` - Europe/Tiraspol
+      * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+      * `Europe/Uzhgorod` - Europe/Uzhgorod
+      * `Europe/Vaduz` - Europe/Vaduz
+      * `Europe/Vatican` - Europe/Vatican
+      * `Europe/Vienna` - Europe/Vienna
+      * `Europe/Vilnius` - Europe/Vilnius
+      * `Europe/Volgograd` - Europe/Volgograd
+      * `Europe/Warsaw` - Europe/Warsaw
+      * `Europe/Zagreb` - Europe/Zagreb
+      * `Europe/Zaporozhye` - Europe/Zaporozhye
+      * `Europe/Zurich` - Europe/Zurich
+      * `GB` - GB
+      * `GB-Eire` - GB-Eire
+      * `GMT` - GMT
+      * `GMT+0` - GMT+0
+      * `GMT-0` - GMT-0
+      * `GMT0` - GMT0
+      * `Greenwich` - Greenwich
+      * `HST` - HST
+      * `Hongkong` - Hongkong
+      * `Iceland` - Iceland
+      * `Indian/Antananarivo` - Indian/Antananarivo
+      * `Indian/Chagos` - Indian/Chagos
+      * `Indian/Christmas` - Indian/Christmas
+      * `Indian/Cocos` - Indian/Cocos
+      * `Indian/Comoro` - Indian/Comoro
+      * `Indian/Kerguelen` - Indian/Kerguelen
+      * `Indian/Mahe` - Indian/Mahe
+      * `Indian/Maldives` - Indian/Maldives
+      * `Indian/Mauritius` - Indian/Mauritius
+      * `Indian/Mayotte` - Indian/Mayotte
+      * `Indian/Reunion` - Indian/Reunion
+      * `Iran` - Iran
+      * `Israel` - Israel
+      * `Jamaica` - Jamaica
+      * `Japan` - Japan
+      * `Kwajalein` - Kwajalein
+      * `Libya` - Libya
+      * `MET` - MET
+      * `MST` - MST
+      * `MST7MDT` - MST7MDT
+      * `Mexico/BajaNorte` - Mexico/BajaNorte
+      * `Mexico/BajaSur` - Mexico/BajaSur
+      * `Mexico/General` - Mexico/General
+      * `NZ` - NZ
+      * `NZ-CHAT` - NZ-CHAT
+      * `Navajo` - Navajo
+      * `PRC` - PRC
+      * `PST8PDT` - PST8PDT
+      * `Pacific/Apia` - Pacific/Apia
+      * `Pacific/Auckland` - Pacific/Auckland
+      * `Pacific/Bougainville` - Pacific/Bougainville
+      * `Pacific/Chatham` - Pacific/Chatham
+      * `Pacific/Chuuk` - Pacific/Chuuk
+      * `Pacific/Easter` - Pacific/Easter
+      * `Pacific/Efate` - Pacific/Efate
+      * `Pacific/Enderbury` - Pacific/Enderbury
+      * `Pacific/Fakaofo` - Pacific/Fakaofo
+      * `Pacific/Fiji` - Pacific/Fiji
+      * `Pacific/Funafuti` - Pacific/Funafuti
+      * `Pacific/Galapagos` - Pacific/Galapagos
+      * `Pacific/Gambier` - Pacific/Gambier
+      * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+      * `Pacific/Guam` - Pacific/Guam
+      * `Pacific/Honolulu` - Pacific/Honolulu
+      * `Pacific/Johnston` - Pacific/Johnston
+      * `Pacific/Kanton` - Pacific/Kanton
+      * `Pacific/Kiritimati` - Pacific/Kiritimati
+      * `Pacific/Kosrae` - Pacific/Kosrae
+      * `Pacific/Kwajalein` - Pacific/Kwajalein
+      * `Pacific/Majuro` - Pacific/Majuro
+      * `Pacific/Marquesas` - Pacific/Marquesas
+      * `Pacific/Midway` - Pacific/Midway
+      * `Pacific/Nauru` - Pacific/Nauru
+      * `Pacific/Niue` - Pacific/Niue
+      * `Pacific/Norfolk` - Pacific/Norfolk
+      * `Pacific/Noumea` - Pacific/Noumea
+      * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+      * `Pacific/Palau` - Pacific/Palau
+      * `Pacific/Pitcairn` - Pacific/Pitcairn
+      * `Pacific/Pohnpei` - Pacific/Pohnpei
+      * `Pacific/Ponape` - Pacific/Ponape
+      * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+      * `Pacific/Rarotonga` - Pacific/Rarotonga
+      * `Pacific/Saipan` - Pacific/Saipan
+      * `Pacific/Samoa` - Pacific/Samoa
+      * `Pacific/Tahiti` - Pacific/Tahiti
+      * `Pacific/Tarawa` - Pacific/Tarawa
+      * `Pacific/Tongatapu` - Pacific/Tongatapu
+      * `Pacific/Truk` - Pacific/Truk
+      * `Pacific/Wake` - Pacific/Wake
+      * `Pacific/Wallis` - Pacific/Wallis
+      * `Pacific/Yap` - Pacific/Yap
+      * `Poland` - Poland
+      * `Portugal` - Portugal
+      * `ROC` - ROC
+      * `ROK` - ROK
+      * `Singapore` - Singapore
+      * `Turkey` - Turkey
+      * `UCT` - UCT
+      * `US/Alaska` - US/Alaska
+      * `US/Aleutian` - US/Aleutian
+      * `US/Arizona` - US/Arizona
+      * `US/Central` - US/Central
+      * `US/East-Indiana` - US/East-Indiana
+      * `US/Eastern` - US/Eastern
+      * `US/Hawaii` - US/Hawaii
+      * `US/Indiana-Starke` - US/Indiana-Starke
+      * `US/Michigan` - US/Michigan
+      * `US/Mountain` - US/Mountain
+      * `US/Pacific` - US/Pacific
+      * `US/Samoa` - US/Samoa
+      * `UTC` - UTC
+      * `Universal` - Universal
+      * `W-SU` - W-SU
+      * `WET` - WET
+      * `Zulu` - Zulu */
       timezone?: string;
       /** Element attributes that posthog-js should capture as action identifiers (e.g. `['data-attr']`). */
       data_attributes?: unknown;
       /**
          * Ordered list of person properties used to render a human-friendly display name in the UI.
          * @nullable
-         * @items.maxLength 400
          */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
@@ -33066,19 +31604,19 @@ export namespace Schemas {
       /** V2 trigger groups configuration for session recording. If present, takes precedence over legacy trigger fields. */
       session_recording_trigger_groups?: unknown;
       /** How long to retain new session recordings. One of `30d`, `90d`, `1y`, or `5y` (availability depends on plan).
-       *
-       * * `30d` - 30 Days
-       * * `90d` - 90 Days
-       * * `1y` - 1 Year
-       * * `5y` - 5 Years */
+
+      * `30d` - 30 Days
+      * `90d` - 90 Days
+      * `1y` - 1 Year
+      * `5y` - 5 Years */
       session_recording_retention_period?: SessionRecordingRetentionPeriodEnum;
       session_replay_config?: unknown;
       survey_config?: unknown;
       access_control?: boolean;
       /** First day of the week for date range filters. 0 = Sunday, 1 = Monday.
-       *
-       * * `0` - Sunday
-       * * `1` - Monday */
+
+      * `0` - Sunday
+      * `1` - Monday */
       week_start_day?: WeekStartDayEnum | null;
       /**
          * ID of the dashboard shown as the project's default landing dashboard.
@@ -33090,7 +31628,6 @@ export namespace Schemas {
       /**
          * Origins permitted to record session replays and heatmaps. Empty list allows all origins.
          * @nullable
-         * @items.maxLength 200
          */
       recording_domains?: (string | null)[] | null;
       readonly person_on_events_querying_enabled?: boolean;
@@ -33123,10 +31660,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts.
-       *
-       * * `b2b` - B2B
-       * * `b2c` - B2C
-       * * `other` - Other */
+
+      * `b2b` - B2B
+      * `b2c` - B2C
+      * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /**
          * Enables the customer conversations / live chat product for this project.
@@ -33143,50 +31680,6 @@ export namespace Schemas {
          * @nullable
          */
       readonly is_pending_deletion?: boolean | null;
-      /** ID of the project this environment belongs to. */
-      readonly project_id?: number;
-      /**
-         * The effective access level the user has for this object
-         * @nullable
-         */
-      readonly user_access_level?: string | null;
-      readonly managed_viewsets?: PatchedProjectBackwardCompatManagedViewsets;
-      revenue_analytics_config?: TeamRevenueAnalyticsConfig;
-      marketing_analytics_config?: TeamMarketingAnalyticsConfig;
-      customer_analytics_config?: TeamCustomerAnalyticsConfig;
-      workflows_config?: TeamWorkflowsConfig;
-      base_currency?: BaseCurrencyEnum;
-      /**
-         * Enables capturing clicks that had no effect (rage-click detection).
-         * @nullable
-         */
-      capture_dead_clicks?: boolean | null;
-      cookieless_server_hash_mode?: CookielessServerHashModeEnum | null;
-      /** @nullable */
-      human_friendly_comparison_periods?: boolean | null;
-      /** @nullable */
-      feature_flag_confirmation_enabled?: boolean | null;
-      /** @nullable */
-      feature_flag_confirmation_message?: string | null;
-      /**
-         * Whether to automatically apply default evaluation contexts to new feature flags
-         * @nullable
-         */
-      default_evaluation_contexts_enabled?: boolean | null;
-      /**
-         * Whether to require at least one evaluation context tag when creating new feature flags
-         * @nullable
-         */
-      require_evaluation_contexts?: boolean | null;
-      /**
-         * @minimum -2147483648
-         * @maximum 2147483647
-         * @nullable
-         */
-      default_data_theme?: number | null;
-      onboarding_tasks?: unknown;
-      /** @nullable */
-      web_analytics_pre_aggregated_tables_enabled?: boolean | null;
     }
 
     export interface PatchedProjectSecretAPIKey {
@@ -33202,18 +31695,17 @@ export namespace Schemas {
       readonly last_used_at?: string | null;
       /** @nullable */
       readonly last_rolled_at?: string | null;
-      /** Project-wide API scopes granted to this key. Project secret API keys do not honor object-level access controls, so a scope can access resources of that type even when per-resource RBAC would hide them from an individual user. */
       scopes?: string[];
     }
 
     export interface PatchedQueryTabState {
       readonly id?: string;
       /**
-       *             Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
-       *             and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
-       *             ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
-       *             for a user.
-       *              */
+                  Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
+                  and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
+                  ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
+                  for a user.
+                   */
       state?: unknown;
     }
 
@@ -33245,11 +31737,11 @@ export namespace Schemas {
       /** Free-form description shown in the scanner management UI. */
       description?: string;
       /** What the scanner does: monitor, classifier, scorer, or summarizer.
-       *
-       * * `monitor` - Monitor
-       * * `classifier` - Classifier
-       * * `scorer` - Scorer
-       * * `summarizer` - Summarizer */
+
+      * `monitor` - Monitor
+      * `classifier` - Classifier
+      * `scorer` - Scorer
+      * `summarizer` - Summarizer */
       scanner_type?: ScannerTypeEnum;
       /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
       scanner_config?: unknown;
@@ -33262,13 +31754,13 @@ export namespace Schemas {
          */
       sampling_rate?: number;
       /** LLM provider. v1 is Google-only.
-       *
-       * * `google` - Google */
+
+      * `google` - Google */
       provider?: ScannerProviderEnum;
       /** Concrete model to use for this scanner.
-       *
-       * * `gemini-3-flash-preview` - Gemini 3 Flash
-       * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+
+      * `gemini-3-flash-preview` - Gemini 3 Flash
+      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
       model?: ScannerModelEnum;
       /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
       enabled?: boolean;
@@ -33276,11 +31768,6 @@ export namespace Schemas {
       emits_signals?: boolean;
       /** Increments on every config-changing save. Observations snapshot this value. */
       readonly scanner_version?: number;
-      /**
-         * Latest projected observations/month for this scanner. Null until first computed.
-         * @nullable
-         */
-      readonly estimated_monthly_observations?: number | null;
       /** Watermark for the scanner's last scheduled fire. Mirrors Temporal schedule state for recovery. */
       readonly last_swept_at?: string;
       readonly created_at?: string;
@@ -33320,17 +31807,11 @@ export namespace Schemas {
       /** @maxLength 255 */
       name?: string;
       network_access_level?: NetworkAccessLevelEnum;
-      /**
-         * List of allowed domains for custom network access
-         * @items.maxLength 255
-         */
+      /** List of allowed domains for custom network access */
       allowed_domains?: string[];
       /** Whether to include default trusted domains (GitHub, npm, PyPI) */
       include_default_domains?: boolean;
-      /**
-         * List of repositories this environment applies to (format: org/repo)
-         * @items.maxLength 255
-         */
+      /** List of repositories this environment applies to (format: org/repo) */
       repositories?: string[];
       /** Encrypted environment variables (write-only, never returned in responses) */
       environment_variables?: unknown;
@@ -33368,15 +31849,13 @@ export namespace Schemas {
       /**
          * Viewport widths (px, 100-3000) to render the heatmap screenshot at — one render per width. Defaults to [320, 375, 425, 768, 1024, 1440, 1920] when omitted. At most 16 widths.
          * @maxItems 16
-         * @items.minimum 100
-         * @items.maximum 3000
          */
       widths?: number[];
       /** Render mode: 'screenshot' (renders the page headlessly, default), 'iframe', or 'recording'. Only 'screenshot' generates image bytes.
-       *
-       * * `screenshot` - Screenshot
-       * * `iframe` - Iframe
-       * * `recording` - Recording */
+
+      * `screenshot` - Screenshot
+      * `iframe` - Iframe
+      * `recording` - Recording */
       type?: HeatmapType;
       /** Set true to soft-delete the saved heatmap. */
       deleted?: boolean;
@@ -33391,8 +31870,8 @@ export namespace Schemas {
          */
       record_id?: string;
       /** The type of record to modify. Currently only "FeatureFlag" is supported.
-       *
-       * * `FeatureFlag` - feature flag */
+
+      * `FeatureFlag` - feature flag */
       model_name?: ModelNameEnum;
       /** The change to apply. Must include an 'operation' key and a 'value' key. Supported operations: 'update_status' (value: true/false to enable/disable the flag), 'add_release_condition' (value: object with 'groups', 'payloads', and 'multivariate' keys), 'update_variants' (value: object with 'variants' and 'payloads' keys). */
       payload?: unknown;
@@ -33411,11 +31890,11 @@ export namespace Schemas {
       /** Whether this schedule repeats. Only the 'update_status' operation supports recurring schedules. */
       is_recurring?: boolean;
       /** How often the schedule repeats. Required when is_recurring is true. One of: daily, weekly, monthly, yearly.
-       *
-       * * `daily` - daily
-       * * `weekly` - weekly
-       * * `monthly` - monthly
-       * * `yearly` - yearly */
+
+      * `daily` - daily
+      * `weekly` - weekly
+      * `monthly` - monthly
+      * `yearly` - yearly */
       recurrence_interval?: RecurrenceIntervalEnum | null;
       /**
          * @maxLength 100
@@ -33464,10 +31943,7 @@ export namespace Schemas {
       readonly id?: string;
       /** Title of the group session summary */
       readonly title?: string;
-      /**
-         * List of session replay IDs included in this group summary
-         * @items.maxLength 200
-         */
+      /** List of session replay IDs included in this group summary */
       readonly session_ids?: readonly string[];
       /** Group summary in JSON format (EnrichedSessionGroupSummaryPatternsList schema) */
       readonly summary?: unknown;
@@ -33529,8 +32005,6 @@ export namespace Schemas {
       readonly summary_outcome?: Outcome | null;
       /** Load external references (linked issues) for this recording */
       readonly external_references?: readonly PatchedSessionRecordingExternalReferencesItem[];
-      /** Whether this recording matched the filters of the listing query that returned it. False only when a recording requested via session_recording_id was included despite not matching the filters. */
-      readonly matches_filters?: boolean;
     }
 
     /**
@@ -33540,7 +32014,7 @@ export namespace Schemas {
 
     /**
      * Serializer for linking session recordings to external issue trackers.
-     * Reuses error tracking's integration infrastructure
+    Reuses error tracking's integration infrastructure
      */
     export interface PatchedSessionRecordingExternalRef {
       readonly id?: string;
@@ -33586,9 +32060,9 @@ export namespace Schemas {
       readonly last_modified_by?: UserBasic;
       readonly recordings_counts?: PatchedSessionRecordingPlaylistRecordingsCounts;
       /** Playlist type: 'collection' for manually curated recordings, 'filters' for saved filter views. Required on create, cannot be changed after.
-       *
-       * * `collection` - Collection
-       * * `filters` - Filters */
+
+      * `collection` - Collection
+      * `filters` - Filters */
       type?: SessionRecordingPlaylistTypeEnum | null;
       /** Return whether this is a synthetic playlist */
       readonly is_synthetic?: boolean;
@@ -33612,16 +32086,14 @@ export namespace Schemas {
 
     /**
      * Per-(team, skill) scout config: schedule, enablement, and emit posture.
-     *
-     * One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
-     * when it discovers a scout skill; this serializer lets agents tune the row.
+
+    One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
+    when it discovers a scout skill; this serializer lets agents tune the row.
      */
     export interface PatchedSignalScoutConfig {
       readonly id?: string;
       /** The `signals-scout-*` skill this config controls. Set at creation, not editable. */
       readonly skill_name?: string;
-      /** Human-readable summary of what this scout investigates, sourced from the scout skill's `description` metadata. Use it for a quick steer on the scout's focus without loading the full skill body. Empty if the skill is not currently present on the team or carries no description. */
-      readonly description?: string;
       /** Whether this scout runs on its schedule. Disabled scouts are skipped by the coordinator. */
       enabled?: boolean;
       /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. */
@@ -33654,12 +32126,12 @@ export namespace Schemas {
 
     /**
      * * `monday` - Monday
-     * * `tuesday` - Tuesday
-     * * `wednesday` - Wednesday
-     * * `thursday` - Thursday
-     * * `friday` - Friday
-     * * `saturday` - Saturday
-     * * `sunday` - Sunday
+    * `tuesday` - Tuesday
+    * `wednesday` - Wednesday
+    * `thursday` - Thursday
+    * `friday` - Friday
+    * `saturday` - Saturday
+    * `sunday` - Sunday
      */
     export type PatchedSubscriptionByweekdayItem = typeof PatchedSubscriptionByweekdayItem[keyof typeof PatchedSubscriptionByweekdayItem];
 
@@ -33680,10 +32152,10 @@ export namespace Schemas {
     export interface PatchedSubscription {
       readonly id?: number;
       /** What the subscription delivers: 'insight' (snapshot of one insight), 'dashboard' (snapshot of one dashboard), or 'ai_prompt' (LLM-generated report). Read-only — derived from the populated target (insight → insight, dashboard → dashboard, prompt → ai_prompt).
-       *
-       * * `insight` - Insight
-       * * `dashboard` - Dashboard
-       * * `ai_prompt` - AI prompt */
+
+      * `insight` - Insight
+      * `dashboard` - Dashboard
+      * `ai_prompt` - AI prompt */
       readonly resource_type?: ResourceTypeEnum;
       /**
          * Dashboard ID to subscribe to (mutually exclusive with insight on create).
@@ -33707,18 +32179,18 @@ export namespace Schemas {
          */
       prompt?: string | null;
       /** Delivery channel: email or slack.
-       *
-       * * `email` - Email
-       * * `slack` - Slack */
+
+      * `email` - Email
+      * `slack` - Slack */
       target_type?: TargetTypeEnum;
       /** Recipient(s): comma-separated email addresses for email, or Slack channel name/ID for slack. */
       target_value?: string;
       /** How often to deliver: daily, weekly, monthly, or yearly.
-       *
-       * * `daily` - Daily
-       * * `weekly` - Weekly
-       * * `monthly` - Monthly
-       * * `yearly` - Yearly */
+
+      * `daily` - Daily
+      * `weekly` - Weekly
+      * `monthly` - Monthly
+      * `yearly` - Yearly */
       frequency?: SubscriptionFrequencyEnum;
       /**
          * Interval multiplier (e.g. 2 with weekly frequency means every 2 weeks). Required on create; must be 1 or greater.
@@ -33789,8 +32261,8 @@ export namespace Schemas {
 
     /**
      * * `once` - once
-     * * `recurring` - recurring
-     * * `always` - always
+    * `recurring` - recurring
+    * `always` - always
      */
     export type ScheduleEnum = typeof ScheduleEnum[keyof typeof ScheduleEnum];
 
@@ -33818,9 +32290,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-       *
-       * * `text` - text
-       * * `html` - html */
+
+      * `text` - text
+      * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -33845,9 +32317,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-       *
-       * * `text` - text
-       * * `html` - html */
+
+      * `text` - text
+      * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -33869,7 +32341,7 @@ export namespace Schemas {
 
     /**
      * * `number` - number
-     * * `emoji` - emoji
+    * `emoji` - emoji
      */
     export type SurveyRatingQuestionSchemaDisplayEnum = typeof SurveyRatingQuestionSchemaDisplayEnum[keyof typeof SurveyRatingQuestionSchemaDisplayEnum];
 
@@ -33891,8 +32363,8 @@ export namespace Schemas {
 
     export interface SurveyNextQuestionBranching {
       /** Continue to the next question in sequence.
-       *
-       * * `next_question` - next_question */
+
+      * `next_question` - next_question */
       type: SurveyNextQuestionBranchingTypeEnum;
     }
 
@@ -33908,8 +32380,8 @@ export namespace Schemas {
 
     export interface SurveyEndBranching {
       /** End the survey.
-       *
-       * * `end` - end */
+
+      * `end` - end */
       type: SurveyEndBranchingTypeEnum;
     }
 
@@ -33925,8 +32397,8 @@ export namespace Schemas {
 
     export interface SurveySpecificQuestionBranching {
       /** Jump to a specific question index.
-       *
-       * * `specific_question` - specific_question */
+
+      * `specific_question` - specific_question */
       type: SurveySpecificQuestionBranchingTypeEnum;
       /**
          * 0-based index of the next question.
@@ -33952,8 +32424,8 @@ export namespace Schemas {
 
     export interface SurveyResponseBasedBranching {
       /** Branch based on the selected or entered response.
-       *
-       * * `response_based` - response_based */
+
+      * `response_based` - response_based */
       type: SurveyResponseBasedBranchingTypeEnum;
       /** Response-based branching map. Values can be a question index or 'end'. */
       responseValues: SurveyResponseBasedBranchingResponseValues;
@@ -33968,18 +32440,18 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-       *
-       * * `text` - text
-       * * `html` - html */
+
+      * `text` - text
+      * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
       /** Custom button label. */
       buttonText?: string;
       /** Display format: 'number' shows numeric scale, 'emoji' shows emoji scale.
-       *
-       * * `number` - number
-       * * `emoji` - emoji */
+
+      * `number` - number
+      * `emoji` - emoji */
       display?: SurveyRatingQuestionSchemaDisplayEnum;
       /**
          * Rating scale can be one of 3, 5, or 7
@@ -34010,9 +32482,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-       *
-       * * `text` - text
-       * * `html` - html */
+
+      * `text` - text
+      * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -34048,9 +32520,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-       *
-       * * `text` - text
-       * * `html` - html */
+
+      * `text` - text
+      * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -34091,25 +32563,25 @@ export namespace Schemas {
          */
       seenSurveyWaitPeriodInDays?: number;
       /** URL/device matching types: 'regex' (matches regex pattern), 'not_regex' (does not match regex pattern), 'exact' (exact string match), 'is_not' (not exact match), 'icontains' (case-insensitive contains), 'not_icontains' (case-insensitive does not contain).
-       *
-       * * `regex` - regex
-       * * `not_regex` - not_regex
-       * * `exact` - exact
-       * * `is_not` - is_not
-       * * `icontains` - icontains
-       * * `not_icontains` - not_icontains */
+
+      * `regex` - regex
+      * `not_regex` - not_regex
+      * `exact` - exact
+      * `is_not` - is_not
+      * `icontains` - icontains
+      * `not_icontains` - not_icontains */
       urlMatchType?: StringMatchOperatorEnum;
       events?: SurveyEventsConditionSchema;
       /** Device types that should match for this survey to be shown. */
       deviceTypes?: DeviceTypesEnum[];
       /** URL/device matching types: 'regex' (matches regex pattern), 'not_regex' (does not match regex pattern), 'exact' (exact string match), 'is_not' (not exact match), 'icontains' (case-insensitive contains), 'not_icontains' (case-insensitive does not contain).
-       *
-       * * `regex` - regex
-       * * `not_regex` - not_regex
-       * * `exact` - exact
-       * * `is_not` - is_not
-       * * `icontains` - icontains
-       * * `not_icontains` - not_icontains */
+
+      * `regex` - regex
+      * `not_regex` - not_regex
+      * `exact` - exact
+      * `is_not` - is_not
+      * `icontains` - icontains
+      * `not_icontains` - not_icontains */
       deviceTypesMatchType?: StringMatchOperatorEnum;
       /** The variant of the feature flag linked to this survey. */
       linkedFlagVariant?: string;
@@ -34117,8 +32589,8 @@ export namespace Schemas {
 
     /**
      * * `button` - button
-     * * `tab` - tab
-     * * `selector` - selector
+    * `tab` - tab
+    * `selector` - selector
      */
     export type WidgetTypeEnum = typeof WidgetTypeEnum[keyof typeof WidgetTypeEnum];
 
@@ -34176,17 +32648,17 @@ export namespace Schemas {
       /** Survey description. */
       description?: string;
       /** Survey type.
-       *
-       * * `popover` - popover
-       * * `widget` - widget
-       * * `external_survey` - external survey
-       * * `api` - api */
+
+      * `popover` - popover
+      * `widget` - widget
+      * `external_survey` - external survey
+      * `api` - api */
       type?: SurveyType;
       /** Survey scheduling behavior: 'once' = show once per user (default), 'recurring' = repeat based on iteration_count and iteration_frequency_days settings, 'always' = show every time conditions are met (mainly for widget surveys)
-       *
-       * * `once` - once
-       * * `recurring` - recurring
-       * * `always` - always */
+
+      * `once` - once
+      * `recurring` - recurring
+      * `always` - always */
       schedule?: ScheduleEnum | null;
       readonly linked_flag?: MinimalFeatureFlag;
       /**
@@ -34209,117 +32681,117 @@ export namespace Schemas {
       remove_targeting_flag?: boolean | null;
       /**
          *
-       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-       *
-       *         Basic (open-ended question)
-       *         - `id`: The question ID
-       *         - `type`: `open`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Link (a question with a link)
-       *         - `id`: The question ID
-       *         - `type`: `link`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `link`: The URL associated with the question.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Rating (a question with a rating scale)
-       *         - `id`: The question ID
-       *         - `type`: `rating`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `display`: Display style of the rating (`number` or `emoji`).
-       *         - `scale`: The scale of the rating (`number`).
-       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
-       *         - `upperBoundLabel`: Label for the upper bound of the scale.
-       *         - `isNpsQuestion`: Whether the question is an NPS rating.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Multiple choice
-       *         - `id`: The question ID
-       *         - `type`: `single_choice` or `multiple_choice`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `choices`: An array of choices for the question.
-       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Branching logic can be one of the following types:
-       *
-       *         Next question: Proceeds to the next question
-       *         ```json
-       *         {
-       *             "type": "next_question"
-       *         }
-       *         ```
-       *
-       *         End: Ends the survey, optionally displaying a confirmation message.
-       *         ```json
-       *         {
-       *             "type": "end"
-       *         }
-       *         ```
-       *
-       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-       *         ```json
-       *         {
-       *             "type": "response_based",
-       *             "responseValues": {
-       *                 "responseKey": "value"
-       *             }
-       *         }
-       *         ```
-       *
-       *         Specific question: Proceeds to a specific question by index.
-       *         ```json
-       *         {
-       *             "type": "specific_question",
-       *             "index": 2
-       *         }
-       *         ```
-       *
-       *         Translations: Each question can include inline translations.
-       *         - `translations`: Object mapping language codes to translated fields.
-       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-       *
-       *         Example with translations:
-       *         ```json
-       *         {
-       *             "id": "uuid",
-       *             "type": "rating",
-       *             "question": "How satisfied are you?",
-       *             "lowerBoundLabel": "Not satisfied",
-       *             "upperBoundLabel": "Very satisfied",
-       *             "translations": {
-       *                 "es": {
-       *                     "question": "¿Qué tan satisfecho estás?",
-       *                     "lowerBoundLabel": "No satisfecho",
-       *                     "upperBoundLabel": "Muy satisfecho"
-       *                 },
-       *                 "fr": {
-       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
-       *                 }
-       *             }
-       *         }
-       *         ```
-       *
+              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+
+              Basic (open-ended question)
+              - `id`: The question ID
+              - `type`: `open`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Link (a question with a link)
+              - `id`: The question ID
+              - `type`: `link`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `link`: The URL associated with the question.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Rating (a question with a rating scale)
+              - `id`: The question ID
+              - `type`: `rating`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `display`: Display style of the rating (`number` or `emoji`).
+              - `scale`: The scale of the rating (`number`).
+              - `lowerBoundLabel`: Label for the lower bound of the scale.
+              - `upperBoundLabel`: Label for the upper bound of the scale.
+              - `isNpsQuestion`: Whether the question is an NPS rating.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Multiple choice
+              - `id`: The question ID
+              - `type`: `single_choice` or `multiple_choice`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `choices`: An array of choices for the question.
+              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Branching logic can be one of the following types:
+
+              Next question: Proceeds to the next question
+              ```json
+              {
+                  "type": "next_question"
+              }
+              ```
+
+              End: Ends the survey, optionally displaying a confirmation message.
+              ```json
+              {
+                  "type": "end"
+              }
+              ```
+
+              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+              ```json
+              {
+                  "type": "response_based",
+                  "responseValues": {
+                      "responseKey": "value"
+                  }
+              }
+              ```
+
+              Specific question: Proceeds to a specific question by index.
+              ```json
+              {
+                  "type": "specific_question",
+                  "index": 2
+              }
+              ```
+
+              Translations: Each question can include inline translations.
+              - `translations`: Object mapping language codes to translated fields.
+              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+
+              Example with translations:
+              ```json
+              {
+                  "id": "uuid",
+                  "type": "rating",
+                  "question": "How satisfied are you?",
+                  "lowerBoundLabel": "Not satisfied",
+                  "upperBoundLabel": "Very satisfied",
+                  "translations": {
+                      "es": {
+                          "question": "¿Qué tan satisfecho estás?",
+                          "lowerBoundLabel": "No satisfecho",
+                          "upperBoundLabel": "Muy satisfecho"
+                      },
+                      "fr": {
+                          "question": "Dans quelle mesure êtes-vous satisfait?"
+                      }
+                  }
+              }
+              ```
+
          * @nullable
          */
       questions?: SurveyQuestionInputSchema[] | null;
@@ -34441,14 +32913,14 @@ export namespace Schemas {
 
     export interface TaggerModelConfigurationWrite {
       /** LLM provider to use for this tagger.
-       *
-       * * `openai` - Openai
-       * * `anthropic` - Anthropic
-       * * `gemini` - Gemini
-       * * `openrouter` - Openrouter
-       * * `fireworks` - Fireworks
-       * * `azure_openai` - Azure OpenAI
-       * * `together_ai` - Together AI */
+
+      * `openai` - Openai
+      * `anthropic` - Anthropic
+      * `gemini` - Gemini
+      * `openrouter` - Openrouter
+      * `fireworks` - Fireworks
+      * `azure_openai` - Azure OpenAI
+      * `together_ai` - Together AI */
       provider: LLMProviderEnum;
       /**
          * Provider model identifier to use for this tagger.
@@ -34496,16 +32968,16 @@ export namespace Schemas {
       /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
       description?: string;
       /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-       *
-       * * `error_tracking` - Error Tracking
-       * * `eval_clusters` - Eval Clusters
-       * * `user_created` - User Created
-       * * `automation` - Automation
-       * * `slack` - Slack
-       * * `support_queue` - Support Queue
-       * * `session_summaries` - Session Summaries
-       * * `signal_report` - Signal Report
-       * * `signals_scout` - Signals Scout */
+
+      * `error_tracking` - Error Tracking
+      * `eval_clusters` - Eval Clusters
+      * `user_created` - User Created
+      * `automation` - Automation
+      * `slack` - Slack
+      * `support_queue` - Support Queue
+      * `session_summaries` - Session Summaries
+      * `signal_report` - Signal Report
+      * `signals_scout` - Signals Scout */
       origin_product?: OriginProductEnum;
       /**
          * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
@@ -34589,11 +33061,11 @@ export namespace Schemas {
 
     /**
      * * `not_started` - not_started
-     * * `queued` - queued
-     * * `in_progress` - in_progress
-     * * `completed` - completed
-     * * `failed` - failed
-     * * `cancelled` - cancelled
+    * `queued` - queued
+    * `in_progress` - in_progress
+    * `completed` - completed
+    * `failed` - failed
+    * `cancelled` - cancelled
      */
     export type TaskRunUpdateStatusEnum = typeof TaskRunUpdateStatusEnum[keyof typeof TaskRunUpdateStatusEnum];
 
@@ -34619,13 +33091,13 @@ export namespace Schemas {
 
     export interface PatchedTaskRunUpdate {
       /** Current execution status
-       *
-       * * `not_started` - not_started
-       * * `queued` - queued
-       * * `in_progress` - in_progress
-       * * `completed` - completed
-       * * `failed` - failed
-       * * `cancelled` - cancelled */
+
+      * `not_started` - not_started
+      * `queued` - queued
+      * `in_progress` - in_progress
+      * `completed` - completed
+      * `failed` - failed
+      * `cancelled` - cancelled */
       status?: TaskRunUpdateStatusEnum;
       /**
          * Git branch name to associate with the task
@@ -34649,8 +33121,8 @@ export namespace Schemas {
          */
       error_message?: string | null;
       /** Transition a cloud run to local. Use the resume_in_cloud action to move a run into cloud.
-       *
-       * * `local` - local */
+
+      * `local` - local */
       environment?: TaskRunUpdateEnvironmentEnum;
     }
 
@@ -34661,6 +33133,50 @@ export namespace Schemas {
     export type PatchedTeamProductIntentsItem = { [key: string]: unknown };
 
     export type PatchedTeamManagedViewsets = {[key: string]: boolean};
+
+    export interface TeamRevenueAnalyticsConfig {
+      base_currency?: BaseCurrencyEnum;
+      events?: unknown;
+      goals?: unknown;
+      filter_test_accounts?: boolean;
+    }
+
+    export interface TeamMarketingAnalyticsConfig {
+      sources_map?: unknown;
+      conversion_goals?: unknown;
+      /**
+         * @minimum 1
+         * @maximum 90
+         */
+      attribution_window_days?: number;
+      attribution_mode?: AttributionModeEnum;
+      campaign_name_mappings?: unknown;
+      custom_source_mappings?: unknown;
+      campaign_field_preferences?: unknown;
+    }
+
+    export interface TeamCustomerAnalyticsConfig {
+      /** Event used as the activity signal (DAU/WAU/MAU). */
+      activity_event?: unknown;
+      /** Event used to count signup pageviews on dashboards. */
+      signup_pageview_event?: unknown;
+      /** Event used to count signups on dashboards. */
+      signup_event?: unknown;
+      /** Event used to count subscriptions on dashboards. */
+      subscription_event?: unknown;
+      /** Event used to count payments on dashboards. */
+      payment_event?: unknown;
+      /**
+         * Index of the group type to treat as an Account in customer analytics. Must reference an existing group type configured for the project.
+         * @nullable
+         */
+      account_group_type_index?: number | null;
+    }
+
+    export interface TeamWorkflowsConfig {
+      /** When enabled, workflows engagement activity (email sends, opens, clicks, bounces, spam reports, unsubscribes) is captured as standard PostHog events ($workflows_email_*) alongside the existing workflow metrics. */
+      capture_workflows_engagement_events?: boolean;
+    }
 
     export interface PatchedTeam {
       readonly id?: number;
@@ -34692,29 +33208,28 @@ export namespace Schemas {
          * @nullable
          */
       readonly user_access_level?: string | null;
-      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       anonymize_ips?: boolean;
       completed_snippet_onboarding?: boolean;
       /** Filters used to identify internal/test users. Each entry is a property filter.
-       *
-       *             Supported entry types and the exact shape each accepts:
-       *
-       *             # Person property — match (or exclude) by a person property
-       *             {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
-       *
-       *             # Event property — match by an event property
-       *             {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
-       *
-       *             # Cohort membership — match (or exclude) members of a cohort.
-       *             # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
-       *             # `negation` field here — `negation` is specific to cohort *definitions*
-       *             # (the inner sub-filters that build a cohort) and is rejected by the
-       *             # property-filter schema.
-       *             {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
-       *
-       *             Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
-       *             "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
+
+                  Supported entry types and the exact shape each accepts:
+
+                  # Person property — match (or exclude) by a person property
+                  {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
+
+                  # Event property — match by an event property
+                  {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
+
+                  # Cohort membership — match (or exclude) members of a cohort.
+                  # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
+                  # `negation` field here — `negation` is specific to cohort *definitions*
+                  # (the inner sub-filters that build a cohort) and is rejected by the
+                  # property-filter schema.
+                  {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
+
+                  Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
+                  "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
       test_account_filters?: unknown;
       /** @nullable */
       test_account_filters_default_checked?: boolean | null;
@@ -34722,10 +33237,7 @@ export namespace Schemas {
       is_demo?: boolean;
       timezone?: string;
       data_attributes?: unknown;
-      /**
-         * @nullable
-         * @items.maxLength 400
-         */
+      /** @nullable */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
       /** @nullable */
@@ -34777,10 +33289,7 @@ export namespace Schemas {
       primary_dashboard?: number | null;
       /** @nullable */
       live_events_columns?: string[] | null;
-      /**
-         * @nullable
-         * @items.maxLength 200
-         */
+      /** @nullable */
       recording_domains?: (string | null)[] | null;
       cookieless_server_hash_mode?: CookielessServerHashModeEnum | null;
       /** @nullable */
@@ -34828,10 +33337,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers, used to optimize the UI layout.
-       *
-       * * `b2b` - B2B
-       * * `b2c` - B2C
-       * * `other` - Other */
+
+      * `b2b` - B2B
+      * `b2c` - B2C
+      * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /** @nullable */
       conversations_enabled?: boolean | null;
@@ -34859,18 +33368,18 @@ export namespace Schemas {
       readonly channel_detail?: ChannelDetailEnum | null;
       readonly distinct_id?: string;
       /** Ticket status: new, open, pending, on_hold, or resolved
-       *
-       * * `new` - New
-       * * `open` - Open
-       * * `pending` - Pending
-       * * `on_hold` - On hold
-       * * `resolved` - Resolved */
+
+      * `new` - New
+      * `open` - Open
+      * `pending` - Pending
+      * `on_hold` - On hold
+      * `resolved` - Resolved */
       status?: TicketStatusEnum;
       /** Ticket priority: low, medium, or high. Null if unset.
-       *
-       * * `low` - Low
-       * * `medium` - Medium
-       * * `high` - High */
+
+      * `low` - Low
+      * `medium` - Medium
+      * `high` - High */
       priority?: PriorityEnum | BlankEnum | null;
       readonly assignee?: TicketAssignment;
       /** Customer-provided traits such as name and email */
@@ -34920,8 +33429,8 @@ export namespace Schemas {
 
     /**
      * * `approved` - approved
-     * * `needs_approval` - needs_approval
-     * * `do_not_use` - do_not_use
+    * `needs_approval` - needs_approval
+    * `do_not_use` - do_not_use
      */
     export type ToolApprovalUpdateApprovalStateEnum = typeof ToolApprovalUpdateApprovalStateEnum[keyof typeof ToolApprovalUpdateApprovalStateEnum];
 
@@ -34948,7 +33457,6 @@ export namespace Schemas {
          * Categorical option keys selected for this score.
          * @minItems 1
          * @nullable
-         * @items.maxLength 128
          */
       categorical_values?: string[] | null;
       /**
@@ -34998,7 +33506,7 @@ export namespace Schemas {
 
     /**
      * PATCH payload for text sources. Both fields optional, at least one
-     * required. `text` triggers a re-chunk; `name` alone does not.
+    required. `text` triggers a re-chunk; `name` alone does not.
      */
     export interface PatchedUpdateTextSource {
       /**
@@ -35099,7 +33607,7 @@ export namespace Schemas {
       /** Real-time notification types that currently have a live dispatch site. Drives the in-app notifications settings UI. Read-only. */
       readonly active_realtime_notification_types?: readonly string[];
       readonly pending_invites?: readonly PendingInvite[];
-      /** True if the user has at least one Personal API Key or passkey and has not yet acknowledged their existing credentials. Used to gate a one-shot review screen on first post-provisioning login. Becomes False once the user POSTs to `/api/users/@me/credentials_review_complete/`. Read-only. */
+      /** True if the user has at least one Personal API Key and has not yet acknowledged their existing credentials. Used to gate a one-shot review screen on first post-provisioning login. Becomes False once the user POSTs to `/api/users/@me/credentials_review_complete/`. Read-only. */
       readonly requires_credential_review?: boolean;
     }
 
@@ -35107,7 +33615,6 @@ export namespace Schemas {
       readonly id?: string;
       readonly created_by?: UserBasic;
       readonly created_at?: string;
-      /** @items.maxLength 254 */
       interviewee_emails?: string[];
       readonly interviewee_identifier?: string;
       /** @nullable */
@@ -35123,15 +33630,9 @@ export namespace Schemas {
       readonly id?: string;
       readonly created_by?: UserBasic;
       readonly created_at?: string;
-      /**
-         * Email addresses of people to interview. May be combined with interviewee_distinct_ids.
-         * @items.maxLength 254
-         */
+      /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
       interviewee_emails?: string[];
-      /**
-         * PostHog distinct IDs of people to interview. May be combined with interviewee_emails.
-         * @items.maxLength 400
-         */
+      /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
       interviewee_distinct_ids?: string[];
       /** The product, feature, or idea you want to ask interviewees about. */
       topic?: string;
@@ -35207,20 +33708,20 @@ export namespace Schemas {
       created_at?: string;
       readonly feature_flag_key?: string;
       /** Variants for the web experiment. Example:
-       *
-       *         {
-       *             "control": {
-       *                 "transforms": [
-       *                     {
-       *                         "text": "Here comes Superman!",
-       *                         "html": "",
-       *                         "selector": "#page > #body > .header h1"
-       *                     }
-       *                 ],
-       *                 "conditions": "None",
-       *                 "rollout_percentage": 50
-       *             },
-       *         } */
+
+              {
+                  "control": {
+                      "transforms": [
+                          {
+                              "text": "Here comes Superman!",
+                              "html": "",
+                              "selector": "#page > #body > .header h1"
+                          }
+                      ],
+                      "conditions": "None",
+                      "rollout_percentage": 50
+                  },
+              } */
       variants?: unknown;
     }
 
@@ -35561,9 +34062,9 @@ export namespace Schemas {
       readonly updated_at: string;
       archived?: boolean;
       /** Where the tour was created/updated from
-       *
-       * * `app` - app
-       * * `toolbar` - toolbar */
+
+      * `app` - app
+      * `toolbar` - toolbar */
       creation_context?: ProductTourSerializerCreateUpdateOnlyCreationContextEnum;
     }
 
@@ -35578,8 +34079,6 @@ export namespace Schemas {
       onboarding_completed_at?: string | null;
       updated_at?: string;
     };
-
-    export type ProjectBackwardCompatManagedViewsets = {[key: string]: boolean};
 
     /**
      * Mixin for serializers to add user access control fields
@@ -35609,7 +34108,6 @@ export namespace Schemas {
       readonly updated_at: string | null;
       readonly uuid: string;
       readonly api_token: string;
-      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       /** When true, PostHog drops the IP address from every ingested event. */
       anonymize_ips?: boolean;
@@ -35626,610 +34124,609 @@ export namespace Schemas {
       path_cleaning_filters?: unknown;
       is_demo?: boolean;
       /** IANA timezone used for date-based filters and reporting (e.g. `America/Los_Angeles`).
-       *
-       * * `Africa/Abidjan` - Africa/Abidjan
-       * * `Africa/Accra` - Africa/Accra
-       * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-       * * `Africa/Algiers` - Africa/Algiers
-       * * `Africa/Asmara` - Africa/Asmara
-       * * `Africa/Asmera` - Africa/Asmera
-       * * `Africa/Bamako` - Africa/Bamako
-       * * `Africa/Bangui` - Africa/Bangui
-       * * `Africa/Banjul` - Africa/Banjul
-       * * `Africa/Bissau` - Africa/Bissau
-       * * `Africa/Blantyre` - Africa/Blantyre
-       * * `Africa/Brazzaville` - Africa/Brazzaville
-       * * `Africa/Bujumbura` - Africa/Bujumbura
-       * * `Africa/Cairo` - Africa/Cairo
-       * * `Africa/Casablanca` - Africa/Casablanca
-       * * `Africa/Ceuta` - Africa/Ceuta
-       * * `Africa/Conakry` - Africa/Conakry
-       * * `Africa/Dakar` - Africa/Dakar
-       * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-       * * `Africa/Djibouti` - Africa/Djibouti
-       * * `Africa/Douala` - Africa/Douala
-       * * `Africa/El_Aaiun` - Africa/El_Aaiun
-       * * `Africa/Freetown` - Africa/Freetown
-       * * `Africa/Gaborone` - Africa/Gaborone
-       * * `Africa/Harare` - Africa/Harare
-       * * `Africa/Johannesburg` - Africa/Johannesburg
-       * * `Africa/Juba` - Africa/Juba
-       * * `Africa/Kampala` - Africa/Kampala
-       * * `Africa/Khartoum` - Africa/Khartoum
-       * * `Africa/Kigali` - Africa/Kigali
-       * * `Africa/Kinshasa` - Africa/Kinshasa
-       * * `Africa/Lagos` - Africa/Lagos
-       * * `Africa/Libreville` - Africa/Libreville
-       * * `Africa/Lome` - Africa/Lome
-       * * `Africa/Luanda` - Africa/Luanda
-       * * `Africa/Lubumbashi` - Africa/Lubumbashi
-       * * `Africa/Lusaka` - Africa/Lusaka
-       * * `Africa/Malabo` - Africa/Malabo
-       * * `Africa/Maputo` - Africa/Maputo
-       * * `Africa/Maseru` - Africa/Maseru
-       * * `Africa/Mbabane` - Africa/Mbabane
-       * * `Africa/Mogadishu` - Africa/Mogadishu
-       * * `Africa/Monrovia` - Africa/Monrovia
-       * * `Africa/Nairobi` - Africa/Nairobi
-       * * `Africa/Ndjamena` - Africa/Ndjamena
-       * * `Africa/Niamey` - Africa/Niamey
-       * * `Africa/Nouakchott` - Africa/Nouakchott
-       * * `Africa/Ouagadougou` - Africa/Ouagadougou
-       * * `Africa/Porto-Novo` - Africa/Porto-Novo
-       * * `Africa/Sao_Tome` - Africa/Sao_Tome
-       * * `Africa/Timbuktu` - Africa/Timbuktu
-       * * `Africa/Tripoli` - Africa/Tripoli
-       * * `Africa/Tunis` - Africa/Tunis
-       * * `Africa/Windhoek` - Africa/Windhoek
-       * * `America/Adak` - America/Adak
-       * * `America/Anchorage` - America/Anchorage
-       * * `America/Anguilla` - America/Anguilla
-       * * `America/Antigua` - America/Antigua
-       * * `America/Araguaina` - America/Araguaina
-       * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-       * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-       * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-       * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-       * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-       * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-       * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-       * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-       * * `America/Argentina/Salta` - America/Argentina/Salta
-       * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-       * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-       * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-       * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-       * * `America/Aruba` - America/Aruba
-       * * `America/Asuncion` - America/Asuncion
-       * * `America/Atikokan` - America/Atikokan
-       * * `America/Atka` - America/Atka
-       * * `America/Bahia` - America/Bahia
-       * * `America/Bahia_Banderas` - America/Bahia_Banderas
-       * * `America/Barbados` - America/Barbados
-       * * `America/Belem` - America/Belem
-       * * `America/Belize` - America/Belize
-       * * `America/Blanc-Sablon` - America/Blanc-Sablon
-       * * `America/Boa_Vista` - America/Boa_Vista
-       * * `America/Bogota` - America/Bogota
-       * * `America/Boise` - America/Boise
-       * * `America/Buenos_Aires` - America/Buenos_Aires
-       * * `America/Cambridge_Bay` - America/Cambridge_Bay
-       * * `America/Campo_Grande` - America/Campo_Grande
-       * * `America/Cancun` - America/Cancun
-       * * `America/Caracas` - America/Caracas
-       * * `America/Catamarca` - America/Catamarca
-       * * `America/Cayenne` - America/Cayenne
-       * * `America/Cayman` - America/Cayman
-       * * `America/Chicago` - America/Chicago
-       * * `America/Chihuahua` - America/Chihuahua
-       * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-       * * `America/Coral_Harbour` - America/Coral_Harbour
-       * * `America/Cordoba` - America/Cordoba
-       * * `America/Costa_Rica` - America/Costa_Rica
-       * * `America/Creston` - America/Creston
-       * * `America/Cuiaba` - America/Cuiaba
-       * * `America/Curacao` - America/Curacao
-       * * `America/Danmarkshavn` - America/Danmarkshavn
-       * * `America/Dawson` - America/Dawson
-       * * `America/Dawson_Creek` - America/Dawson_Creek
-       * * `America/Denver` - America/Denver
-       * * `America/Detroit` - America/Detroit
-       * * `America/Dominica` - America/Dominica
-       * * `America/Edmonton` - America/Edmonton
-       * * `America/Eirunepe` - America/Eirunepe
-       * * `America/El_Salvador` - America/El_Salvador
-       * * `America/Ensenada` - America/Ensenada
-       * * `America/Fort_Nelson` - America/Fort_Nelson
-       * * `America/Fort_Wayne` - America/Fort_Wayne
-       * * `America/Fortaleza` - America/Fortaleza
-       * * `America/Glace_Bay` - America/Glace_Bay
-       * * `America/Godthab` - America/Godthab
-       * * `America/Goose_Bay` - America/Goose_Bay
-       * * `America/Grand_Turk` - America/Grand_Turk
-       * * `America/Grenada` - America/Grenada
-       * * `America/Guadeloupe` - America/Guadeloupe
-       * * `America/Guatemala` - America/Guatemala
-       * * `America/Guayaquil` - America/Guayaquil
-       * * `America/Guyana` - America/Guyana
-       * * `America/Halifax` - America/Halifax
-       * * `America/Havana` - America/Havana
-       * * `America/Hermosillo` - America/Hermosillo
-       * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-       * * `America/Indiana/Knox` - America/Indiana/Knox
-       * * `America/Indiana/Marengo` - America/Indiana/Marengo
-       * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-       * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-       * * `America/Indiana/Vevay` - America/Indiana/Vevay
-       * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-       * * `America/Indiana/Winamac` - America/Indiana/Winamac
-       * * `America/Indianapolis` - America/Indianapolis
-       * * `America/Inuvik` - America/Inuvik
-       * * `America/Iqaluit` - America/Iqaluit
-       * * `America/Jamaica` - America/Jamaica
-       * * `America/Jujuy` - America/Jujuy
-       * * `America/Juneau` - America/Juneau
-       * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-       * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-       * * `America/Knox_IN` - America/Knox_IN
-       * * `America/Kralendijk` - America/Kralendijk
-       * * `America/La_Paz` - America/La_Paz
-       * * `America/Lima` - America/Lima
-       * * `America/Los_Angeles` - America/Los_Angeles
-       * * `America/Louisville` - America/Louisville
-       * * `America/Lower_Princes` - America/Lower_Princes
-       * * `America/Maceio` - America/Maceio
-       * * `America/Managua` - America/Managua
-       * * `America/Manaus` - America/Manaus
-       * * `America/Marigot` - America/Marigot
-       * * `America/Martinique` - America/Martinique
-       * * `America/Matamoros` - America/Matamoros
-       * * `America/Mazatlan` - America/Mazatlan
-       * * `America/Mendoza` - America/Mendoza
-       * * `America/Menominee` - America/Menominee
-       * * `America/Merida` - America/Merida
-       * * `America/Metlakatla` - America/Metlakatla
-       * * `America/Mexico_City` - America/Mexico_City
-       * * `America/Miquelon` - America/Miquelon
-       * * `America/Moncton` - America/Moncton
-       * * `America/Monterrey` - America/Monterrey
-       * * `America/Montevideo` - America/Montevideo
-       * * `America/Montreal` - America/Montreal
-       * * `America/Montserrat` - America/Montserrat
-       * * `America/Nassau` - America/Nassau
-       * * `America/New_York` - America/New_York
-       * * `America/Nipigon` - America/Nipigon
-       * * `America/Nome` - America/Nome
-       * * `America/Noronha` - America/Noronha
-       * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-       * * `America/North_Dakota/Center` - America/North_Dakota/Center
-       * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-       * * `America/Nuuk` - America/Nuuk
-       * * `America/Ojinaga` - America/Ojinaga
-       * * `America/Panama` - America/Panama
-       * * `America/Pangnirtung` - America/Pangnirtung
-       * * `America/Paramaribo` - America/Paramaribo
-       * * `America/Phoenix` - America/Phoenix
-       * * `America/Port-au-Prince` - America/Port-au-Prince
-       * * `America/Port_of_Spain` - America/Port_of_Spain
-       * * `America/Porto_Acre` - America/Porto_Acre
-       * * `America/Porto_Velho` - America/Porto_Velho
-       * * `America/Puerto_Rico` - America/Puerto_Rico
-       * * `America/Punta_Arenas` - America/Punta_Arenas
-       * * `America/Rainy_River` - America/Rainy_River
-       * * `America/Rankin_Inlet` - America/Rankin_Inlet
-       * * `America/Recife` - America/Recife
-       * * `America/Regina` - America/Regina
-       * * `America/Resolute` - America/Resolute
-       * * `America/Rio_Branco` - America/Rio_Branco
-       * * `America/Rosario` - America/Rosario
-       * * `America/Santa_Isabel` - America/Santa_Isabel
-       * * `America/Santarem` - America/Santarem
-       * * `America/Santiago` - America/Santiago
-       * * `America/Santo_Domingo` - America/Santo_Domingo
-       * * `America/Sao_Paulo` - America/Sao_Paulo
-       * * `America/Scoresbysund` - America/Scoresbysund
-       * * `America/Shiprock` - America/Shiprock
-       * * `America/Sitka` - America/Sitka
-       * * `America/St_Barthelemy` - America/St_Barthelemy
-       * * `America/St_Johns` - America/St_Johns
-       * * `America/St_Kitts` - America/St_Kitts
-       * * `America/St_Lucia` - America/St_Lucia
-       * * `America/St_Thomas` - America/St_Thomas
-       * * `America/St_Vincent` - America/St_Vincent
-       * * `America/Swift_Current` - America/Swift_Current
-       * * `America/Tegucigalpa` - America/Tegucigalpa
-       * * `America/Thule` - America/Thule
-       * * `America/Thunder_Bay` - America/Thunder_Bay
-       * * `America/Tijuana` - America/Tijuana
-       * * `America/Toronto` - America/Toronto
-       * * `America/Tortola` - America/Tortola
-       * * `America/Vancouver` - America/Vancouver
-       * * `America/Virgin` - America/Virgin
-       * * `America/Whitehorse` - America/Whitehorse
-       * * `America/Winnipeg` - America/Winnipeg
-       * * `America/Yakutat` - America/Yakutat
-       * * `America/Yellowknife` - America/Yellowknife
-       * * `Antarctica/Casey` - Antarctica/Casey
-       * * `Antarctica/Davis` - Antarctica/Davis
-       * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-       * * `Antarctica/Macquarie` - Antarctica/Macquarie
-       * * `Antarctica/Mawson` - Antarctica/Mawson
-       * * `Antarctica/McMurdo` - Antarctica/McMurdo
-       * * `Antarctica/Palmer` - Antarctica/Palmer
-       * * `Antarctica/Rothera` - Antarctica/Rothera
-       * * `Antarctica/South_Pole` - Antarctica/South_Pole
-       * * `Antarctica/Syowa` - Antarctica/Syowa
-       * * `Antarctica/Troll` - Antarctica/Troll
-       * * `Antarctica/Vostok` - Antarctica/Vostok
-       * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-       * * `Asia/Aden` - Asia/Aden
-       * * `Asia/Almaty` - Asia/Almaty
-       * * `Asia/Amman` - Asia/Amman
-       * * `Asia/Anadyr` - Asia/Anadyr
-       * * `Asia/Aqtau` - Asia/Aqtau
-       * * `Asia/Aqtobe` - Asia/Aqtobe
-       * * `Asia/Ashgabat` - Asia/Ashgabat
-       * * `Asia/Ashkhabad` - Asia/Ashkhabad
-       * * `Asia/Atyrau` - Asia/Atyrau
-       * * `Asia/Baghdad` - Asia/Baghdad
-       * * `Asia/Bahrain` - Asia/Bahrain
-       * * `Asia/Baku` - Asia/Baku
-       * * `Asia/Bangkok` - Asia/Bangkok
-       * * `Asia/Barnaul` - Asia/Barnaul
-       * * `Asia/Beirut` - Asia/Beirut
-       * * `Asia/Bishkek` - Asia/Bishkek
-       * * `Asia/Brunei` - Asia/Brunei
-       * * `Asia/Calcutta` - Asia/Calcutta
-       * * `Asia/Chita` - Asia/Chita
-       * * `Asia/Choibalsan` - Asia/Choibalsan
-       * * `Asia/Chongqing` - Asia/Chongqing
-       * * `Asia/Chungking` - Asia/Chungking
-       * * `Asia/Colombo` - Asia/Colombo
-       * * `Asia/Dacca` - Asia/Dacca
-       * * `Asia/Damascus` - Asia/Damascus
-       * * `Asia/Dhaka` - Asia/Dhaka
-       * * `Asia/Dili` - Asia/Dili
-       * * `Asia/Dubai` - Asia/Dubai
-       * * `Asia/Dushanbe` - Asia/Dushanbe
-       * * `Asia/Famagusta` - Asia/Famagusta
-       * * `Asia/Gaza` - Asia/Gaza
-       * * `Asia/Harbin` - Asia/Harbin
-       * * `Asia/Hebron` - Asia/Hebron
-       * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-       * * `Asia/Hong_Kong` - Asia/Hong_Kong
-       * * `Asia/Hovd` - Asia/Hovd
-       * * `Asia/Irkutsk` - Asia/Irkutsk
-       * * `Asia/Istanbul` - Asia/Istanbul
-       * * `Asia/Jakarta` - Asia/Jakarta
-       * * `Asia/Jayapura` - Asia/Jayapura
-       * * `Asia/Jerusalem` - Asia/Jerusalem
-       * * `Asia/Kabul` - Asia/Kabul
-       * * `Asia/Kamchatka` - Asia/Kamchatka
-       * * `Asia/Karachi` - Asia/Karachi
-       * * `Asia/Kashgar` - Asia/Kashgar
-       * * `Asia/Kathmandu` - Asia/Kathmandu
-       * * `Asia/Katmandu` - Asia/Katmandu
-       * * `Asia/Khandyga` - Asia/Khandyga
-       * * `Asia/Kolkata` - Asia/Kolkata
-       * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-       * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-       * * `Asia/Kuching` - Asia/Kuching
-       * * `Asia/Kuwait` - Asia/Kuwait
-       * * `Asia/Macao` - Asia/Macao
-       * * `Asia/Macau` - Asia/Macau
-       * * `Asia/Magadan` - Asia/Magadan
-       * * `Asia/Makassar` - Asia/Makassar
-       * * `Asia/Manila` - Asia/Manila
-       * * `Asia/Muscat` - Asia/Muscat
-       * * `Asia/Nicosia` - Asia/Nicosia
-       * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-       * * `Asia/Novosibirsk` - Asia/Novosibirsk
-       * * `Asia/Omsk` - Asia/Omsk
-       * * `Asia/Oral` - Asia/Oral
-       * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-       * * `Asia/Pontianak` - Asia/Pontianak
-       * * `Asia/Pyongyang` - Asia/Pyongyang
-       * * `Asia/Qatar` - Asia/Qatar
-       * * `Asia/Qostanay` - Asia/Qostanay
-       * * `Asia/Qyzylorda` - Asia/Qyzylorda
-       * * `Asia/Rangoon` - Asia/Rangoon
-       * * `Asia/Riyadh` - Asia/Riyadh
-       * * `Asia/Saigon` - Asia/Saigon
-       * * `Asia/Sakhalin` - Asia/Sakhalin
-       * * `Asia/Samarkand` - Asia/Samarkand
-       * * `Asia/Seoul` - Asia/Seoul
-       * * `Asia/Shanghai` - Asia/Shanghai
-       * * `Asia/Singapore` - Asia/Singapore
-       * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-       * * `Asia/Taipei` - Asia/Taipei
-       * * `Asia/Tashkent` - Asia/Tashkent
-       * * `Asia/Tbilisi` - Asia/Tbilisi
-       * * `Asia/Tehran` - Asia/Tehran
-       * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-       * * `Asia/Thimbu` - Asia/Thimbu
-       * * `Asia/Thimphu` - Asia/Thimphu
-       * * `Asia/Tokyo` - Asia/Tokyo
-       * * `Asia/Tomsk` - Asia/Tomsk
-       * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-       * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-       * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-       * * `Asia/Urumqi` - Asia/Urumqi
-       * * `Asia/Ust-Nera` - Asia/Ust-Nera
-       * * `Asia/Vientiane` - Asia/Vientiane
-       * * `Asia/Vladivostok` - Asia/Vladivostok
-       * * `Asia/Yakutsk` - Asia/Yakutsk
-       * * `Asia/Yangon` - Asia/Yangon
-       * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-       * * `Asia/Yerevan` - Asia/Yerevan
-       * * `Atlantic/Azores` - Atlantic/Azores
-       * * `Atlantic/Bermuda` - Atlantic/Bermuda
-       * * `Atlantic/Canary` - Atlantic/Canary
-       * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-       * * `Atlantic/Faeroe` - Atlantic/Faeroe
-       * * `Atlantic/Faroe` - Atlantic/Faroe
-       * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-       * * `Atlantic/Madeira` - Atlantic/Madeira
-       * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-       * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-       * * `Atlantic/St_Helena` - Atlantic/St_Helena
-       * * `Atlantic/Stanley` - Atlantic/Stanley
-       * * `Australia/ACT` - Australia/ACT
-       * * `Australia/Adelaide` - Australia/Adelaide
-       * * `Australia/Brisbane` - Australia/Brisbane
-       * * `Australia/Broken_Hill` - Australia/Broken_Hill
-       * * `Australia/Canberra` - Australia/Canberra
-       * * `Australia/Currie` - Australia/Currie
-       * * `Australia/Darwin` - Australia/Darwin
-       * * `Australia/Eucla` - Australia/Eucla
-       * * `Australia/Hobart` - Australia/Hobart
-       * * `Australia/LHI` - Australia/LHI
-       * * `Australia/Lindeman` - Australia/Lindeman
-       * * `Australia/Lord_Howe` - Australia/Lord_Howe
-       * * `Australia/Melbourne` - Australia/Melbourne
-       * * `Australia/NSW` - Australia/NSW
-       * * `Australia/North` - Australia/North
-       * * `Australia/Perth` - Australia/Perth
-       * * `Australia/Queensland` - Australia/Queensland
-       * * `Australia/South` - Australia/South
-       * * `Australia/Sydney` - Australia/Sydney
-       * * `Australia/Tasmania` - Australia/Tasmania
-       * * `Australia/Victoria` - Australia/Victoria
-       * * `Australia/West` - Australia/West
-       * * `Australia/Yancowinna` - Australia/Yancowinna
-       * * `Brazil/Acre` - Brazil/Acre
-       * * `Brazil/DeNoronha` - Brazil/DeNoronha
-       * * `Brazil/East` - Brazil/East
-       * * `Brazil/West` - Brazil/West
-       * * `CET` - CET
-       * * `CST6CDT` - CST6CDT
-       * * `Canada/Atlantic` - Canada/Atlantic
-       * * `Canada/Central` - Canada/Central
-       * * `Canada/Eastern` - Canada/Eastern
-       * * `Canada/Mountain` - Canada/Mountain
-       * * `Canada/Newfoundland` - Canada/Newfoundland
-       * * `Canada/Pacific` - Canada/Pacific
-       * * `Canada/Saskatchewan` - Canada/Saskatchewan
-       * * `Canada/Yukon` - Canada/Yukon
-       * * `Chile/Continental` - Chile/Continental
-       * * `Chile/EasterIsland` - Chile/EasterIsland
-       * * `Cuba` - Cuba
-       * * `EET` - EET
-       * * `EST` - EST
-       * * `EST5EDT` - EST5EDT
-       * * `Egypt` - Egypt
-       * * `Eire` - Eire
-       * * `Etc/GMT` - Etc/GMT
-       * * `Etc/GMT+0` - Etc/GMT+0
-       * * `Etc/GMT+1` - Etc/GMT+1
-       * * `Etc/GMT+10` - Etc/GMT+10
-       * * `Etc/GMT+11` - Etc/GMT+11
-       * * `Etc/GMT+12` - Etc/GMT+12
-       * * `Etc/GMT+2` - Etc/GMT+2
-       * * `Etc/GMT+3` - Etc/GMT+3
-       * * `Etc/GMT+4` - Etc/GMT+4
-       * * `Etc/GMT+5` - Etc/GMT+5
-       * * `Etc/GMT+6` - Etc/GMT+6
-       * * `Etc/GMT+7` - Etc/GMT+7
-       * * `Etc/GMT+8` - Etc/GMT+8
-       * * `Etc/GMT+9` - Etc/GMT+9
-       * * `Etc/GMT-0` - Etc/GMT-0
-       * * `Etc/GMT-1` - Etc/GMT-1
-       * * `Etc/GMT-10` - Etc/GMT-10
-       * * `Etc/GMT-11` - Etc/GMT-11
-       * * `Etc/GMT-12` - Etc/GMT-12
-       * * `Etc/GMT-13` - Etc/GMT-13
-       * * `Etc/GMT-14` - Etc/GMT-14
-       * * `Etc/GMT-2` - Etc/GMT-2
-       * * `Etc/GMT-3` - Etc/GMT-3
-       * * `Etc/GMT-4` - Etc/GMT-4
-       * * `Etc/GMT-5` - Etc/GMT-5
-       * * `Etc/GMT-6` - Etc/GMT-6
-       * * `Etc/GMT-7` - Etc/GMT-7
-       * * `Etc/GMT-8` - Etc/GMT-8
-       * * `Etc/GMT-9` - Etc/GMT-9
-       * * `Etc/GMT0` - Etc/GMT0
-       * * `Etc/Greenwich` - Etc/Greenwich
-       * * `Etc/UCT` - Etc/UCT
-       * * `Etc/UTC` - Etc/UTC
-       * * `Etc/Universal` - Etc/Universal
-       * * `Etc/Zulu` - Etc/Zulu
-       * * `Europe/Amsterdam` - Europe/Amsterdam
-       * * `Europe/Andorra` - Europe/Andorra
-       * * `Europe/Astrakhan` - Europe/Astrakhan
-       * * `Europe/Athens` - Europe/Athens
-       * * `Europe/Belfast` - Europe/Belfast
-       * * `Europe/Belgrade` - Europe/Belgrade
-       * * `Europe/Berlin` - Europe/Berlin
-       * * `Europe/Bratislava` - Europe/Bratislava
-       * * `Europe/Brussels` - Europe/Brussels
-       * * `Europe/Bucharest` - Europe/Bucharest
-       * * `Europe/Budapest` - Europe/Budapest
-       * * `Europe/Busingen` - Europe/Busingen
-       * * `Europe/Chisinau` - Europe/Chisinau
-       * * `Europe/Copenhagen` - Europe/Copenhagen
-       * * `Europe/Dublin` - Europe/Dublin
-       * * `Europe/Gibraltar` - Europe/Gibraltar
-       * * `Europe/Guernsey` - Europe/Guernsey
-       * * `Europe/Helsinki` - Europe/Helsinki
-       * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-       * * `Europe/Istanbul` - Europe/Istanbul
-       * * `Europe/Jersey` - Europe/Jersey
-       * * `Europe/Kaliningrad` - Europe/Kaliningrad
-       * * `Europe/Kiev` - Europe/Kiev
-       * * `Europe/Kirov` - Europe/Kirov
-       * * `Europe/Kyiv` - Europe/Kyiv
-       * * `Europe/Lisbon` - Europe/Lisbon
-       * * `Europe/Ljubljana` - Europe/Ljubljana
-       * * `Europe/London` - Europe/London
-       * * `Europe/Luxembourg` - Europe/Luxembourg
-       * * `Europe/Madrid` - Europe/Madrid
-       * * `Europe/Malta` - Europe/Malta
-       * * `Europe/Mariehamn` - Europe/Mariehamn
-       * * `Europe/Minsk` - Europe/Minsk
-       * * `Europe/Monaco` - Europe/Monaco
-       * * `Europe/Moscow` - Europe/Moscow
-       * * `Europe/Nicosia` - Europe/Nicosia
-       * * `Europe/Oslo` - Europe/Oslo
-       * * `Europe/Paris` - Europe/Paris
-       * * `Europe/Podgorica` - Europe/Podgorica
-       * * `Europe/Prague` - Europe/Prague
-       * * `Europe/Riga` - Europe/Riga
-       * * `Europe/Rome` - Europe/Rome
-       * * `Europe/Samara` - Europe/Samara
-       * * `Europe/San_Marino` - Europe/San_Marino
-       * * `Europe/Sarajevo` - Europe/Sarajevo
-       * * `Europe/Saratov` - Europe/Saratov
-       * * `Europe/Simferopol` - Europe/Simferopol
-       * * `Europe/Skopje` - Europe/Skopje
-       * * `Europe/Sofia` - Europe/Sofia
-       * * `Europe/Stockholm` - Europe/Stockholm
-       * * `Europe/Tallinn` - Europe/Tallinn
-       * * `Europe/Tirane` - Europe/Tirane
-       * * `Europe/Tiraspol` - Europe/Tiraspol
-       * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-       * * `Europe/Uzhgorod` - Europe/Uzhgorod
-       * * `Europe/Vaduz` - Europe/Vaduz
-       * * `Europe/Vatican` - Europe/Vatican
-       * * `Europe/Vienna` - Europe/Vienna
-       * * `Europe/Vilnius` - Europe/Vilnius
-       * * `Europe/Volgograd` - Europe/Volgograd
-       * * `Europe/Warsaw` - Europe/Warsaw
-       * * `Europe/Zagreb` - Europe/Zagreb
-       * * `Europe/Zaporozhye` - Europe/Zaporozhye
-       * * `Europe/Zurich` - Europe/Zurich
-       * * `GB` - GB
-       * * `GB-Eire` - GB-Eire
-       * * `GMT` - GMT
-       * * `GMT+0` - GMT+0
-       * * `GMT-0` - GMT-0
-       * * `GMT0` - GMT0
-       * * `Greenwich` - Greenwich
-       * * `HST` - HST
-       * * `Hongkong` - Hongkong
-       * * `Iceland` - Iceland
-       * * `Indian/Antananarivo` - Indian/Antananarivo
-       * * `Indian/Chagos` - Indian/Chagos
-       * * `Indian/Christmas` - Indian/Christmas
-       * * `Indian/Cocos` - Indian/Cocos
-       * * `Indian/Comoro` - Indian/Comoro
-       * * `Indian/Kerguelen` - Indian/Kerguelen
-       * * `Indian/Mahe` - Indian/Mahe
-       * * `Indian/Maldives` - Indian/Maldives
-       * * `Indian/Mauritius` - Indian/Mauritius
-       * * `Indian/Mayotte` - Indian/Mayotte
-       * * `Indian/Reunion` - Indian/Reunion
-       * * `Iran` - Iran
-       * * `Israel` - Israel
-       * * `Jamaica` - Jamaica
-       * * `Japan` - Japan
-       * * `Kwajalein` - Kwajalein
-       * * `Libya` - Libya
-       * * `MET` - MET
-       * * `MST` - MST
-       * * `MST7MDT` - MST7MDT
-       * * `Mexico/BajaNorte` - Mexico/BajaNorte
-       * * `Mexico/BajaSur` - Mexico/BajaSur
-       * * `Mexico/General` - Mexico/General
-       * * `NZ` - NZ
-       * * `NZ-CHAT` - NZ-CHAT
-       * * `Navajo` - Navajo
-       * * `PRC` - PRC
-       * * `PST8PDT` - PST8PDT
-       * * `Pacific/Apia` - Pacific/Apia
-       * * `Pacific/Auckland` - Pacific/Auckland
-       * * `Pacific/Bougainville` - Pacific/Bougainville
-       * * `Pacific/Chatham` - Pacific/Chatham
-       * * `Pacific/Chuuk` - Pacific/Chuuk
-       * * `Pacific/Easter` - Pacific/Easter
-       * * `Pacific/Efate` - Pacific/Efate
-       * * `Pacific/Enderbury` - Pacific/Enderbury
-       * * `Pacific/Fakaofo` - Pacific/Fakaofo
-       * * `Pacific/Fiji` - Pacific/Fiji
-       * * `Pacific/Funafuti` - Pacific/Funafuti
-       * * `Pacific/Galapagos` - Pacific/Galapagos
-       * * `Pacific/Gambier` - Pacific/Gambier
-       * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-       * * `Pacific/Guam` - Pacific/Guam
-       * * `Pacific/Honolulu` - Pacific/Honolulu
-       * * `Pacific/Johnston` - Pacific/Johnston
-       * * `Pacific/Kanton` - Pacific/Kanton
-       * * `Pacific/Kiritimati` - Pacific/Kiritimati
-       * * `Pacific/Kosrae` - Pacific/Kosrae
-       * * `Pacific/Kwajalein` - Pacific/Kwajalein
-       * * `Pacific/Majuro` - Pacific/Majuro
-       * * `Pacific/Marquesas` - Pacific/Marquesas
-       * * `Pacific/Midway` - Pacific/Midway
-       * * `Pacific/Nauru` - Pacific/Nauru
-       * * `Pacific/Niue` - Pacific/Niue
-       * * `Pacific/Norfolk` - Pacific/Norfolk
-       * * `Pacific/Noumea` - Pacific/Noumea
-       * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-       * * `Pacific/Palau` - Pacific/Palau
-       * * `Pacific/Pitcairn` - Pacific/Pitcairn
-       * * `Pacific/Pohnpei` - Pacific/Pohnpei
-       * * `Pacific/Ponape` - Pacific/Ponape
-       * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-       * * `Pacific/Rarotonga` - Pacific/Rarotonga
-       * * `Pacific/Saipan` - Pacific/Saipan
-       * * `Pacific/Samoa` - Pacific/Samoa
-       * * `Pacific/Tahiti` - Pacific/Tahiti
-       * * `Pacific/Tarawa` - Pacific/Tarawa
-       * * `Pacific/Tongatapu` - Pacific/Tongatapu
-       * * `Pacific/Truk` - Pacific/Truk
-       * * `Pacific/Wake` - Pacific/Wake
-       * * `Pacific/Wallis` - Pacific/Wallis
-       * * `Pacific/Yap` - Pacific/Yap
-       * * `Poland` - Poland
-       * * `Portugal` - Portugal
-       * * `ROC` - ROC
-       * * `ROK` - ROK
-       * * `Singapore` - Singapore
-       * * `Turkey` - Turkey
-       * * `UCT` - UCT
-       * * `US/Alaska` - US/Alaska
-       * * `US/Aleutian` - US/Aleutian
-       * * `US/Arizona` - US/Arizona
-       * * `US/Central` - US/Central
-       * * `US/East-Indiana` - US/East-Indiana
-       * * `US/Eastern` - US/Eastern
-       * * `US/Hawaii` - US/Hawaii
-       * * `US/Indiana-Starke` - US/Indiana-Starke
-       * * `US/Michigan` - US/Michigan
-       * * `US/Mountain` - US/Mountain
-       * * `US/Pacific` - US/Pacific
-       * * `US/Samoa` - US/Samoa
-       * * `UTC` - UTC
-       * * `Universal` - Universal
-       * * `W-SU` - W-SU
-       * * `WET` - WET
-       * * `Zulu` - Zulu */
+
+      * `Africa/Abidjan` - Africa/Abidjan
+      * `Africa/Accra` - Africa/Accra
+      * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+      * `Africa/Algiers` - Africa/Algiers
+      * `Africa/Asmara` - Africa/Asmara
+      * `Africa/Asmera` - Africa/Asmera
+      * `Africa/Bamako` - Africa/Bamako
+      * `Africa/Bangui` - Africa/Bangui
+      * `Africa/Banjul` - Africa/Banjul
+      * `Africa/Bissau` - Africa/Bissau
+      * `Africa/Blantyre` - Africa/Blantyre
+      * `Africa/Brazzaville` - Africa/Brazzaville
+      * `Africa/Bujumbura` - Africa/Bujumbura
+      * `Africa/Cairo` - Africa/Cairo
+      * `Africa/Casablanca` - Africa/Casablanca
+      * `Africa/Ceuta` - Africa/Ceuta
+      * `Africa/Conakry` - Africa/Conakry
+      * `Africa/Dakar` - Africa/Dakar
+      * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+      * `Africa/Djibouti` - Africa/Djibouti
+      * `Africa/Douala` - Africa/Douala
+      * `Africa/El_Aaiun` - Africa/El_Aaiun
+      * `Africa/Freetown` - Africa/Freetown
+      * `Africa/Gaborone` - Africa/Gaborone
+      * `Africa/Harare` - Africa/Harare
+      * `Africa/Johannesburg` - Africa/Johannesburg
+      * `Africa/Juba` - Africa/Juba
+      * `Africa/Kampala` - Africa/Kampala
+      * `Africa/Khartoum` - Africa/Khartoum
+      * `Africa/Kigali` - Africa/Kigali
+      * `Africa/Kinshasa` - Africa/Kinshasa
+      * `Africa/Lagos` - Africa/Lagos
+      * `Africa/Libreville` - Africa/Libreville
+      * `Africa/Lome` - Africa/Lome
+      * `Africa/Luanda` - Africa/Luanda
+      * `Africa/Lubumbashi` - Africa/Lubumbashi
+      * `Africa/Lusaka` - Africa/Lusaka
+      * `Africa/Malabo` - Africa/Malabo
+      * `Africa/Maputo` - Africa/Maputo
+      * `Africa/Maseru` - Africa/Maseru
+      * `Africa/Mbabane` - Africa/Mbabane
+      * `Africa/Mogadishu` - Africa/Mogadishu
+      * `Africa/Monrovia` - Africa/Monrovia
+      * `Africa/Nairobi` - Africa/Nairobi
+      * `Africa/Ndjamena` - Africa/Ndjamena
+      * `Africa/Niamey` - Africa/Niamey
+      * `Africa/Nouakchott` - Africa/Nouakchott
+      * `Africa/Ouagadougou` - Africa/Ouagadougou
+      * `Africa/Porto-Novo` - Africa/Porto-Novo
+      * `Africa/Sao_Tome` - Africa/Sao_Tome
+      * `Africa/Timbuktu` - Africa/Timbuktu
+      * `Africa/Tripoli` - Africa/Tripoli
+      * `Africa/Tunis` - Africa/Tunis
+      * `Africa/Windhoek` - Africa/Windhoek
+      * `America/Adak` - America/Adak
+      * `America/Anchorage` - America/Anchorage
+      * `America/Anguilla` - America/Anguilla
+      * `America/Antigua` - America/Antigua
+      * `America/Araguaina` - America/Araguaina
+      * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+      * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+      * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+      * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+      * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+      * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+      * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+      * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+      * `America/Argentina/Salta` - America/Argentina/Salta
+      * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+      * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+      * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+      * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+      * `America/Aruba` - America/Aruba
+      * `America/Asuncion` - America/Asuncion
+      * `America/Atikokan` - America/Atikokan
+      * `America/Atka` - America/Atka
+      * `America/Bahia` - America/Bahia
+      * `America/Bahia_Banderas` - America/Bahia_Banderas
+      * `America/Barbados` - America/Barbados
+      * `America/Belem` - America/Belem
+      * `America/Belize` - America/Belize
+      * `America/Blanc-Sablon` - America/Blanc-Sablon
+      * `America/Boa_Vista` - America/Boa_Vista
+      * `America/Bogota` - America/Bogota
+      * `America/Boise` - America/Boise
+      * `America/Buenos_Aires` - America/Buenos_Aires
+      * `America/Cambridge_Bay` - America/Cambridge_Bay
+      * `America/Campo_Grande` - America/Campo_Grande
+      * `America/Cancun` - America/Cancun
+      * `America/Caracas` - America/Caracas
+      * `America/Catamarca` - America/Catamarca
+      * `America/Cayenne` - America/Cayenne
+      * `America/Cayman` - America/Cayman
+      * `America/Chicago` - America/Chicago
+      * `America/Chihuahua` - America/Chihuahua
+      * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+      * `America/Coral_Harbour` - America/Coral_Harbour
+      * `America/Cordoba` - America/Cordoba
+      * `America/Costa_Rica` - America/Costa_Rica
+      * `America/Creston` - America/Creston
+      * `America/Cuiaba` - America/Cuiaba
+      * `America/Curacao` - America/Curacao
+      * `America/Danmarkshavn` - America/Danmarkshavn
+      * `America/Dawson` - America/Dawson
+      * `America/Dawson_Creek` - America/Dawson_Creek
+      * `America/Denver` - America/Denver
+      * `America/Detroit` - America/Detroit
+      * `America/Dominica` - America/Dominica
+      * `America/Edmonton` - America/Edmonton
+      * `America/Eirunepe` - America/Eirunepe
+      * `America/El_Salvador` - America/El_Salvador
+      * `America/Ensenada` - America/Ensenada
+      * `America/Fort_Nelson` - America/Fort_Nelson
+      * `America/Fort_Wayne` - America/Fort_Wayne
+      * `America/Fortaleza` - America/Fortaleza
+      * `America/Glace_Bay` - America/Glace_Bay
+      * `America/Godthab` - America/Godthab
+      * `America/Goose_Bay` - America/Goose_Bay
+      * `America/Grand_Turk` - America/Grand_Turk
+      * `America/Grenada` - America/Grenada
+      * `America/Guadeloupe` - America/Guadeloupe
+      * `America/Guatemala` - America/Guatemala
+      * `America/Guayaquil` - America/Guayaquil
+      * `America/Guyana` - America/Guyana
+      * `America/Halifax` - America/Halifax
+      * `America/Havana` - America/Havana
+      * `America/Hermosillo` - America/Hermosillo
+      * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+      * `America/Indiana/Knox` - America/Indiana/Knox
+      * `America/Indiana/Marengo` - America/Indiana/Marengo
+      * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+      * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+      * `America/Indiana/Vevay` - America/Indiana/Vevay
+      * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+      * `America/Indiana/Winamac` - America/Indiana/Winamac
+      * `America/Indianapolis` - America/Indianapolis
+      * `America/Inuvik` - America/Inuvik
+      * `America/Iqaluit` - America/Iqaluit
+      * `America/Jamaica` - America/Jamaica
+      * `America/Jujuy` - America/Jujuy
+      * `America/Juneau` - America/Juneau
+      * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+      * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+      * `America/Knox_IN` - America/Knox_IN
+      * `America/Kralendijk` - America/Kralendijk
+      * `America/La_Paz` - America/La_Paz
+      * `America/Lima` - America/Lima
+      * `America/Los_Angeles` - America/Los_Angeles
+      * `America/Louisville` - America/Louisville
+      * `America/Lower_Princes` - America/Lower_Princes
+      * `America/Maceio` - America/Maceio
+      * `America/Managua` - America/Managua
+      * `America/Manaus` - America/Manaus
+      * `America/Marigot` - America/Marigot
+      * `America/Martinique` - America/Martinique
+      * `America/Matamoros` - America/Matamoros
+      * `America/Mazatlan` - America/Mazatlan
+      * `America/Mendoza` - America/Mendoza
+      * `America/Menominee` - America/Menominee
+      * `America/Merida` - America/Merida
+      * `America/Metlakatla` - America/Metlakatla
+      * `America/Mexico_City` - America/Mexico_City
+      * `America/Miquelon` - America/Miquelon
+      * `America/Moncton` - America/Moncton
+      * `America/Monterrey` - America/Monterrey
+      * `America/Montevideo` - America/Montevideo
+      * `America/Montreal` - America/Montreal
+      * `America/Montserrat` - America/Montserrat
+      * `America/Nassau` - America/Nassau
+      * `America/New_York` - America/New_York
+      * `America/Nipigon` - America/Nipigon
+      * `America/Nome` - America/Nome
+      * `America/Noronha` - America/Noronha
+      * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+      * `America/North_Dakota/Center` - America/North_Dakota/Center
+      * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+      * `America/Nuuk` - America/Nuuk
+      * `America/Ojinaga` - America/Ojinaga
+      * `America/Panama` - America/Panama
+      * `America/Pangnirtung` - America/Pangnirtung
+      * `America/Paramaribo` - America/Paramaribo
+      * `America/Phoenix` - America/Phoenix
+      * `America/Port-au-Prince` - America/Port-au-Prince
+      * `America/Port_of_Spain` - America/Port_of_Spain
+      * `America/Porto_Acre` - America/Porto_Acre
+      * `America/Porto_Velho` - America/Porto_Velho
+      * `America/Puerto_Rico` - America/Puerto_Rico
+      * `America/Punta_Arenas` - America/Punta_Arenas
+      * `America/Rainy_River` - America/Rainy_River
+      * `America/Rankin_Inlet` - America/Rankin_Inlet
+      * `America/Recife` - America/Recife
+      * `America/Regina` - America/Regina
+      * `America/Resolute` - America/Resolute
+      * `America/Rio_Branco` - America/Rio_Branco
+      * `America/Rosario` - America/Rosario
+      * `America/Santa_Isabel` - America/Santa_Isabel
+      * `America/Santarem` - America/Santarem
+      * `America/Santiago` - America/Santiago
+      * `America/Santo_Domingo` - America/Santo_Domingo
+      * `America/Sao_Paulo` - America/Sao_Paulo
+      * `America/Scoresbysund` - America/Scoresbysund
+      * `America/Shiprock` - America/Shiprock
+      * `America/Sitka` - America/Sitka
+      * `America/St_Barthelemy` - America/St_Barthelemy
+      * `America/St_Johns` - America/St_Johns
+      * `America/St_Kitts` - America/St_Kitts
+      * `America/St_Lucia` - America/St_Lucia
+      * `America/St_Thomas` - America/St_Thomas
+      * `America/St_Vincent` - America/St_Vincent
+      * `America/Swift_Current` - America/Swift_Current
+      * `America/Tegucigalpa` - America/Tegucigalpa
+      * `America/Thule` - America/Thule
+      * `America/Thunder_Bay` - America/Thunder_Bay
+      * `America/Tijuana` - America/Tijuana
+      * `America/Toronto` - America/Toronto
+      * `America/Tortola` - America/Tortola
+      * `America/Vancouver` - America/Vancouver
+      * `America/Virgin` - America/Virgin
+      * `America/Whitehorse` - America/Whitehorse
+      * `America/Winnipeg` - America/Winnipeg
+      * `America/Yakutat` - America/Yakutat
+      * `America/Yellowknife` - America/Yellowknife
+      * `Antarctica/Casey` - Antarctica/Casey
+      * `Antarctica/Davis` - Antarctica/Davis
+      * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+      * `Antarctica/Macquarie` - Antarctica/Macquarie
+      * `Antarctica/Mawson` - Antarctica/Mawson
+      * `Antarctica/McMurdo` - Antarctica/McMurdo
+      * `Antarctica/Palmer` - Antarctica/Palmer
+      * `Antarctica/Rothera` - Antarctica/Rothera
+      * `Antarctica/South_Pole` - Antarctica/South_Pole
+      * `Antarctica/Syowa` - Antarctica/Syowa
+      * `Antarctica/Troll` - Antarctica/Troll
+      * `Antarctica/Vostok` - Antarctica/Vostok
+      * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+      * `Asia/Aden` - Asia/Aden
+      * `Asia/Almaty` - Asia/Almaty
+      * `Asia/Amman` - Asia/Amman
+      * `Asia/Anadyr` - Asia/Anadyr
+      * `Asia/Aqtau` - Asia/Aqtau
+      * `Asia/Aqtobe` - Asia/Aqtobe
+      * `Asia/Ashgabat` - Asia/Ashgabat
+      * `Asia/Ashkhabad` - Asia/Ashkhabad
+      * `Asia/Atyrau` - Asia/Atyrau
+      * `Asia/Baghdad` - Asia/Baghdad
+      * `Asia/Bahrain` - Asia/Bahrain
+      * `Asia/Baku` - Asia/Baku
+      * `Asia/Bangkok` - Asia/Bangkok
+      * `Asia/Barnaul` - Asia/Barnaul
+      * `Asia/Beirut` - Asia/Beirut
+      * `Asia/Bishkek` - Asia/Bishkek
+      * `Asia/Brunei` - Asia/Brunei
+      * `Asia/Calcutta` - Asia/Calcutta
+      * `Asia/Chita` - Asia/Chita
+      * `Asia/Choibalsan` - Asia/Choibalsan
+      * `Asia/Chongqing` - Asia/Chongqing
+      * `Asia/Chungking` - Asia/Chungking
+      * `Asia/Colombo` - Asia/Colombo
+      * `Asia/Dacca` - Asia/Dacca
+      * `Asia/Damascus` - Asia/Damascus
+      * `Asia/Dhaka` - Asia/Dhaka
+      * `Asia/Dili` - Asia/Dili
+      * `Asia/Dubai` - Asia/Dubai
+      * `Asia/Dushanbe` - Asia/Dushanbe
+      * `Asia/Famagusta` - Asia/Famagusta
+      * `Asia/Gaza` - Asia/Gaza
+      * `Asia/Harbin` - Asia/Harbin
+      * `Asia/Hebron` - Asia/Hebron
+      * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+      * `Asia/Hong_Kong` - Asia/Hong_Kong
+      * `Asia/Hovd` - Asia/Hovd
+      * `Asia/Irkutsk` - Asia/Irkutsk
+      * `Asia/Istanbul` - Asia/Istanbul
+      * `Asia/Jakarta` - Asia/Jakarta
+      * `Asia/Jayapura` - Asia/Jayapura
+      * `Asia/Jerusalem` - Asia/Jerusalem
+      * `Asia/Kabul` - Asia/Kabul
+      * `Asia/Kamchatka` - Asia/Kamchatka
+      * `Asia/Karachi` - Asia/Karachi
+      * `Asia/Kashgar` - Asia/Kashgar
+      * `Asia/Kathmandu` - Asia/Kathmandu
+      * `Asia/Katmandu` - Asia/Katmandu
+      * `Asia/Khandyga` - Asia/Khandyga
+      * `Asia/Kolkata` - Asia/Kolkata
+      * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+      * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+      * `Asia/Kuching` - Asia/Kuching
+      * `Asia/Kuwait` - Asia/Kuwait
+      * `Asia/Macao` - Asia/Macao
+      * `Asia/Macau` - Asia/Macau
+      * `Asia/Magadan` - Asia/Magadan
+      * `Asia/Makassar` - Asia/Makassar
+      * `Asia/Manila` - Asia/Manila
+      * `Asia/Muscat` - Asia/Muscat
+      * `Asia/Nicosia` - Asia/Nicosia
+      * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+      * `Asia/Novosibirsk` - Asia/Novosibirsk
+      * `Asia/Omsk` - Asia/Omsk
+      * `Asia/Oral` - Asia/Oral
+      * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+      * `Asia/Pontianak` - Asia/Pontianak
+      * `Asia/Pyongyang` - Asia/Pyongyang
+      * `Asia/Qatar` - Asia/Qatar
+      * `Asia/Qostanay` - Asia/Qostanay
+      * `Asia/Qyzylorda` - Asia/Qyzylorda
+      * `Asia/Rangoon` - Asia/Rangoon
+      * `Asia/Riyadh` - Asia/Riyadh
+      * `Asia/Saigon` - Asia/Saigon
+      * `Asia/Sakhalin` - Asia/Sakhalin
+      * `Asia/Samarkand` - Asia/Samarkand
+      * `Asia/Seoul` - Asia/Seoul
+      * `Asia/Shanghai` - Asia/Shanghai
+      * `Asia/Singapore` - Asia/Singapore
+      * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+      * `Asia/Taipei` - Asia/Taipei
+      * `Asia/Tashkent` - Asia/Tashkent
+      * `Asia/Tbilisi` - Asia/Tbilisi
+      * `Asia/Tehran` - Asia/Tehran
+      * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+      * `Asia/Thimbu` - Asia/Thimbu
+      * `Asia/Thimphu` - Asia/Thimphu
+      * `Asia/Tokyo` - Asia/Tokyo
+      * `Asia/Tomsk` - Asia/Tomsk
+      * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+      * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+      * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+      * `Asia/Urumqi` - Asia/Urumqi
+      * `Asia/Ust-Nera` - Asia/Ust-Nera
+      * `Asia/Vientiane` - Asia/Vientiane
+      * `Asia/Vladivostok` - Asia/Vladivostok
+      * `Asia/Yakutsk` - Asia/Yakutsk
+      * `Asia/Yangon` - Asia/Yangon
+      * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+      * `Asia/Yerevan` - Asia/Yerevan
+      * `Atlantic/Azores` - Atlantic/Azores
+      * `Atlantic/Bermuda` - Atlantic/Bermuda
+      * `Atlantic/Canary` - Atlantic/Canary
+      * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+      * `Atlantic/Faeroe` - Atlantic/Faeroe
+      * `Atlantic/Faroe` - Atlantic/Faroe
+      * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+      * `Atlantic/Madeira` - Atlantic/Madeira
+      * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+      * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+      * `Atlantic/St_Helena` - Atlantic/St_Helena
+      * `Atlantic/Stanley` - Atlantic/Stanley
+      * `Australia/ACT` - Australia/ACT
+      * `Australia/Adelaide` - Australia/Adelaide
+      * `Australia/Brisbane` - Australia/Brisbane
+      * `Australia/Broken_Hill` - Australia/Broken_Hill
+      * `Australia/Canberra` - Australia/Canberra
+      * `Australia/Currie` - Australia/Currie
+      * `Australia/Darwin` - Australia/Darwin
+      * `Australia/Eucla` - Australia/Eucla
+      * `Australia/Hobart` - Australia/Hobart
+      * `Australia/LHI` - Australia/LHI
+      * `Australia/Lindeman` - Australia/Lindeman
+      * `Australia/Lord_Howe` - Australia/Lord_Howe
+      * `Australia/Melbourne` - Australia/Melbourne
+      * `Australia/NSW` - Australia/NSW
+      * `Australia/North` - Australia/North
+      * `Australia/Perth` - Australia/Perth
+      * `Australia/Queensland` - Australia/Queensland
+      * `Australia/South` - Australia/South
+      * `Australia/Sydney` - Australia/Sydney
+      * `Australia/Tasmania` - Australia/Tasmania
+      * `Australia/Victoria` - Australia/Victoria
+      * `Australia/West` - Australia/West
+      * `Australia/Yancowinna` - Australia/Yancowinna
+      * `Brazil/Acre` - Brazil/Acre
+      * `Brazil/DeNoronha` - Brazil/DeNoronha
+      * `Brazil/East` - Brazil/East
+      * `Brazil/West` - Brazil/West
+      * `CET` - CET
+      * `CST6CDT` - CST6CDT
+      * `Canada/Atlantic` - Canada/Atlantic
+      * `Canada/Central` - Canada/Central
+      * `Canada/Eastern` - Canada/Eastern
+      * `Canada/Mountain` - Canada/Mountain
+      * `Canada/Newfoundland` - Canada/Newfoundland
+      * `Canada/Pacific` - Canada/Pacific
+      * `Canada/Saskatchewan` - Canada/Saskatchewan
+      * `Canada/Yukon` - Canada/Yukon
+      * `Chile/Continental` - Chile/Continental
+      * `Chile/EasterIsland` - Chile/EasterIsland
+      * `Cuba` - Cuba
+      * `EET` - EET
+      * `EST` - EST
+      * `EST5EDT` - EST5EDT
+      * `Egypt` - Egypt
+      * `Eire` - Eire
+      * `Etc/GMT` - Etc/GMT
+      * `Etc/GMT+0` - Etc/GMT+0
+      * `Etc/GMT+1` - Etc/GMT+1
+      * `Etc/GMT+10` - Etc/GMT+10
+      * `Etc/GMT+11` - Etc/GMT+11
+      * `Etc/GMT+12` - Etc/GMT+12
+      * `Etc/GMT+2` - Etc/GMT+2
+      * `Etc/GMT+3` - Etc/GMT+3
+      * `Etc/GMT+4` - Etc/GMT+4
+      * `Etc/GMT+5` - Etc/GMT+5
+      * `Etc/GMT+6` - Etc/GMT+6
+      * `Etc/GMT+7` - Etc/GMT+7
+      * `Etc/GMT+8` - Etc/GMT+8
+      * `Etc/GMT+9` - Etc/GMT+9
+      * `Etc/GMT-0` - Etc/GMT-0
+      * `Etc/GMT-1` - Etc/GMT-1
+      * `Etc/GMT-10` - Etc/GMT-10
+      * `Etc/GMT-11` - Etc/GMT-11
+      * `Etc/GMT-12` - Etc/GMT-12
+      * `Etc/GMT-13` - Etc/GMT-13
+      * `Etc/GMT-14` - Etc/GMT-14
+      * `Etc/GMT-2` - Etc/GMT-2
+      * `Etc/GMT-3` - Etc/GMT-3
+      * `Etc/GMT-4` - Etc/GMT-4
+      * `Etc/GMT-5` - Etc/GMT-5
+      * `Etc/GMT-6` - Etc/GMT-6
+      * `Etc/GMT-7` - Etc/GMT-7
+      * `Etc/GMT-8` - Etc/GMT-8
+      * `Etc/GMT-9` - Etc/GMT-9
+      * `Etc/GMT0` - Etc/GMT0
+      * `Etc/Greenwich` - Etc/Greenwich
+      * `Etc/UCT` - Etc/UCT
+      * `Etc/UTC` - Etc/UTC
+      * `Etc/Universal` - Etc/Universal
+      * `Etc/Zulu` - Etc/Zulu
+      * `Europe/Amsterdam` - Europe/Amsterdam
+      * `Europe/Andorra` - Europe/Andorra
+      * `Europe/Astrakhan` - Europe/Astrakhan
+      * `Europe/Athens` - Europe/Athens
+      * `Europe/Belfast` - Europe/Belfast
+      * `Europe/Belgrade` - Europe/Belgrade
+      * `Europe/Berlin` - Europe/Berlin
+      * `Europe/Bratislava` - Europe/Bratislava
+      * `Europe/Brussels` - Europe/Brussels
+      * `Europe/Bucharest` - Europe/Bucharest
+      * `Europe/Budapest` - Europe/Budapest
+      * `Europe/Busingen` - Europe/Busingen
+      * `Europe/Chisinau` - Europe/Chisinau
+      * `Europe/Copenhagen` - Europe/Copenhagen
+      * `Europe/Dublin` - Europe/Dublin
+      * `Europe/Gibraltar` - Europe/Gibraltar
+      * `Europe/Guernsey` - Europe/Guernsey
+      * `Europe/Helsinki` - Europe/Helsinki
+      * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+      * `Europe/Istanbul` - Europe/Istanbul
+      * `Europe/Jersey` - Europe/Jersey
+      * `Europe/Kaliningrad` - Europe/Kaliningrad
+      * `Europe/Kiev` - Europe/Kiev
+      * `Europe/Kirov` - Europe/Kirov
+      * `Europe/Kyiv` - Europe/Kyiv
+      * `Europe/Lisbon` - Europe/Lisbon
+      * `Europe/Ljubljana` - Europe/Ljubljana
+      * `Europe/London` - Europe/London
+      * `Europe/Luxembourg` - Europe/Luxembourg
+      * `Europe/Madrid` - Europe/Madrid
+      * `Europe/Malta` - Europe/Malta
+      * `Europe/Mariehamn` - Europe/Mariehamn
+      * `Europe/Minsk` - Europe/Minsk
+      * `Europe/Monaco` - Europe/Monaco
+      * `Europe/Moscow` - Europe/Moscow
+      * `Europe/Nicosia` - Europe/Nicosia
+      * `Europe/Oslo` - Europe/Oslo
+      * `Europe/Paris` - Europe/Paris
+      * `Europe/Podgorica` - Europe/Podgorica
+      * `Europe/Prague` - Europe/Prague
+      * `Europe/Riga` - Europe/Riga
+      * `Europe/Rome` - Europe/Rome
+      * `Europe/Samara` - Europe/Samara
+      * `Europe/San_Marino` - Europe/San_Marino
+      * `Europe/Sarajevo` - Europe/Sarajevo
+      * `Europe/Saratov` - Europe/Saratov
+      * `Europe/Simferopol` - Europe/Simferopol
+      * `Europe/Skopje` - Europe/Skopje
+      * `Europe/Sofia` - Europe/Sofia
+      * `Europe/Stockholm` - Europe/Stockholm
+      * `Europe/Tallinn` - Europe/Tallinn
+      * `Europe/Tirane` - Europe/Tirane
+      * `Europe/Tiraspol` - Europe/Tiraspol
+      * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+      * `Europe/Uzhgorod` - Europe/Uzhgorod
+      * `Europe/Vaduz` - Europe/Vaduz
+      * `Europe/Vatican` - Europe/Vatican
+      * `Europe/Vienna` - Europe/Vienna
+      * `Europe/Vilnius` - Europe/Vilnius
+      * `Europe/Volgograd` - Europe/Volgograd
+      * `Europe/Warsaw` - Europe/Warsaw
+      * `Europe/Zagreb` - Europe/Zagreb
+      * `Europe/Zaporozhye` - Europe/Zaporozhye
+      * `Europe/Zurich` - Europe/Zurich
+      * `GB` - GB
+      * `GB-Eire` - GB-Eire
+      * `GMT` - GMT
+      * `GMT+0` - GMT+0
+      * `GMT-0` - GMT-0
+      * `GMT0` - GMT0
+      * `Greenwich` - Greenwich
+      * `HST` - HST
+      * `Hongkong` - Hongkong
+      * `Iceland` - Iceland
+      * `Indian/Antananarivo` - Indian/Antananarivo
+      * `Indian/Chagos` - Indian/Chagos
+      * `Indian/Christmas` - Indian/Christmas
+      * `Indian/Cocos` - Indian/Cocos
+      * `Indian/Comoro` - Indian/Comoro
+      * `Indian/Kerguelen` - Indian/Kerguelen
+      * `Indian/Mahe` - Indian/Mahe
+      * `Indian/Maldives` - Indian/Maldives
+      * `Indian/Mauritius` - Indian/Mauritius
+      * `Indian/Mayotte` - Indian/Mayotte
+      * `Indian/Reunion` - Indian/Reunion
+      * `Iran` - Iran
+      * `Israel` - Israel
+      * `Jamaica` - Jamaica
+      * `Japan` - Japan
+      * `Kwajalein` - Kwajalein
+      * `Libya` - Libya
+      * `MET` - MET
+      * `MST` - MST
+      * `MST7MDT` - MST7MDT
+      * `Mexico/BajaNorte` - Mexico/BajaNorte
+      * `Mexico/BajaSur` - Mexico/BajaSur
+      * `Mexico/General` - Mexico/General
+      * `NZ` - NZ
+      * `NZ-CHAT` - NZ-CHAT
+      * `Navajo` - Navajo
+      * `PRC` - PRC
+      * `PST8PDT` - PST8PDT
+      * `Pacific/Apia` - Pacific/Apia
+      * `Pacific/Auckland` - Pacific/Auckland
+      * `Pacific/Bougainville` - Pacific/Bougainville
+      * `Pacific/Chatham` - Pacific/Chatham
+      * `Pacific/Chuuk` - Pacific/Chuuk
+      * `Pacific/Easter` - Pacific/Easter
+      * `Pacific/Efate` - Pacific/Efate
+      * `Pacific/Enderbury` - Pacific/Enderbury
+      * `Pacific/Fakaofo` - Pacific/Fakaofo
+      * `Pacific/Fiji` - Pacific/Fiji
+      * `Pacific/Funafuti` - Pacific/Funafuti
+      * `Pacific/Galapagos` - Pacific/Galapagos
+      * `Pacific/Gambier` - Pacific/Gambier
+      * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+      * `Pacific/Guam` - Pacific/Guam
+      * `Pacific/Honolulu` - Pacific/Honolulu
+      * `Pacific/Johnston` - Pacific/Johnston
+      * `Pacific/Kanton` - Pacific/Kanton
+      * `Pacific/Kiritimati` - Pacific/Kiritimati
+      * `Pacific/Kosrae` - Pacific/Kosrae
+      * `Pacific/Kwajalein` - Pacific/Kwajalein
+      * `Pacific/Majuro` - Pacific/Majuro
+      * `Pacific/Marquesas` - Pacific/Marquesas
+      * `Pacific/Midway` - Pacific/Midway
+      * `Pacific/Nauru` - Pacific/Nauru
+      * `Pacific/Niue` - Pacific/Niue
+      * `Pacific/Norfolk` - Pacific/Norfolk
+      * `Pacific/Noumea` - Pacific/Noumea
+      * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+      * `Pacific/Palau` - Pacific/Palau
+      * `Pacific/Pitcairn` - Pacific/Pitcairn
+      * `Pacific/Pohnpei` - Pacific/Pohnpei
+      * `Pacific/Ponape` - Pacific/Ponape
+      * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+      * `Pacific/Rarotonga` - Pacific/Rarotonga
+      * `Pacific/Saipan` - Pacific/Saipan
+      * `Pacific/Samoa` - Pacific/Samoa
+      * `Pacific/Tahiti` - Pacific/Tahiti
+      * `Pacific/Tarawa` - Pacific/Tarawa
+      * `Pacific/Tongatapu` - Pacific/Tongatapu
+      * `Pacific/Truk` - Pacific/Truk
+      * `Pacific/Wake` - Pacific/Wake
+      * `Pacific/Wallis` - Pacific/Wallis
+      * `Pacific/Yap` - Pacific/Yap
+      * `Poland` - Poland
+      * `Portugal` - Portugal
+      * `ROC` - ROC
+      * `ROK` - ROK
+      * `Singapore` - Singapore
+      * `Turkey` - Turkey
+      * `UCT` - UCT
+      * `US/Alaska` - US/Alaska
+      * `US/Aleutian` - US/Aleutian
+      * `US/Arizona` - US/Arizona
+      * `US/Central` - US/Central
+      * `US/East-Indiana` - US/East-Indiana
+      * `US/Eastern` - US/Eastern
+      * `US/Hawaii` - US/Hawaii
+      * `US/Indiana-Starke` - US/Indiana-Starke
+      * `US/Michigan` - US/Michigan
+      * `US/Mountain` - US/Mountain
+      * `US/Pacific` - US/Pacific
+      * `US/Samoa` - US/Samoa
+      * `UTC` - UTC
+      * `Universal` - Universal
+      * `W-SU` - W-SU
+      * `WET` - WET
+      * `Zulu` - Zulu */
       timezone?: string;
       /** Element attributes that posthog-js should capture as action identifiers (e.g. `['data-attr']`). */
       data_attributes?: unknown;
       /**
          * Ordered list of person properties used to render a human-friendly display name in the UI.
          * @nullable
-         * @items.maxLength 400
          */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
@@ -36292,19 +34789,19 @@ export namespace Schemas {
       /** V2 trigger groups configuration for session recording. If present, takes precedence over legacy trigger fields. */
       session_recording_trigger_groups?: unknown;
       /** How long to retain new session recordings. One of `30d`, `90d`, `1y`, or `5y` (availability depends on plan).
-       *
-       * * `30d` - 30 Days
-       * * `90d` - 90 Days
-       * * `1y` - 1 Year
-       * * `5y` - 5 Years */
+
+      * `30d` - 30 Days
+      * `90d` - 90 Days
+      * `1y` - 1 Year
+      * `5y` - 5 Years */
       session_recording_retention_period?: SessionRecordingRetentionPeriodEnum;
       session_replay_config?: unknown;
       survey_config?: unknown;
       access_control?: boolean;
       /** First day of the week for date range filters. 0 = Sunday, 1 = Monday.
-       *
-       * * `0` - Sunday
-       * * `1` - Monday */
+
+      * `0` - Sunday
+      * `1` - Monday */
       week_start_day?: WeekStartDayEnum | null;
       /**
          * ID of the dashboard shown as the project's default landing dashboard.
@@ -36316,7 +34813,6 @@ export namespace Schemas {
       /**
          * Origins permitted to record session replays and heatmaps. Empty list allows all origins.
          * @nullable
-         * @items.maxLength 200
          */
       recording_domains?: (string | null)[] | null;
       readonly person_on_events_querying_enabled: boolean;
@@ -36349,10 +34845,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts.
-       *
-       * * `b2b` - B2B
-       * * `b2c` - B2C
-       * * `other` - Other */
+
+      * `b2b` - B2B
+      * `b2c` - B2C
+      * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /**
          * Enables the customer conversations / live chat product for this project.
@@ -36369,50 +34865,6 @@ export namespace Schemas {
          * @nullable
          */
       readonly is_pending_deletion: boolean | null;
-      /** ID of the project this environment belongs to. */
-      readonly project_id: number;
-      /**
-         * The effective access level the user has for this object
-         * @nullable
-         */
-      readonly user_access_level: string | null;
-      readonly managed_viewsets: ProjectBackwardCompatManagedViewsets;
-      revenue_analytics_config?: TeamRevenueAnalyticsConfig;
-      marketing_analytics_config?: TeamMarketingAnalyticsConfig;
-      customer_analytics_config?: TeamCustomerAnalyticsConfig;
-      workflows_config?: TeamWorkflowsConfig;
-      base_currency?: BaseCurrencyEnum;
-      /**
-         * Enables capturing clicks that had no effect (rage-click detection).
-         * @nullable
-         */
-      capture_dead_clicks?: boolean | null;
-      cookieless_server_hash_mode?: CookielessServerHashModeEnum | null;
-      /** @nullable */
-      human_friendly_comparison_periods?: boolean | null;
-      /** @nullable */
-      feature_flag_confirmation_enabled?: boolean | null;
-      /** @nullable */
-      feature_flag_confirmation_message?: string | null;
-      /**
-         * Whether to automatically apply default evaluation contexts to new feature flags
-         * @nullable
-         */
-      default_evaluation_contexts_enabled?: boolean | null;
-      /**
-         * Whether to require at least one evaluation context tag when creating new feature flags
-         * @nullable
-         */
-      require_evaluation_contexts?: boolean | null;
-      /**
-         * @minimum -2147483648
-         * @maximum 2147483647
-         * @nullable
-         */
-      default_data_theme?: number | null;
-      onboarding_tasks?: unknown;
-      /** @nullable */
-      web_analytics_pre_aggregated_tables_enabled?: boolean | null;
     }
 
     /**
@@ -36815,10 +35267,10 @@ export namespace Schemas {
 
     /**
      * The deterministic inventory layer of a project profile.
-     *
-     * Read this to orient on the team's product mix, integrations, warehouse sources, signal
-     * coverage, and existing inbox surface in one tool call. Distinct from `SignalScratchpad`:
-     * profile is ground truth from authoritative tables; memory is agent inference.
+
+    Read this to orient on the team's product mix, integrations, warehouse sources, signal
+    coverage, and existing inbox surface in one tool call. Distinct from `SignalScratchpad`:
+    profile is ground truth from authoritative tables; memory is agent inference.
      */
     export interface ProjectProfileInventory {
       /** Free-form orientation: human-set product description + registered app URLs. */
@@ -36866,9 +35318,9 @@ export namespace Schemas {
 
     /**
      * Top-level `payload` shape on a `SignalProjectProfile` row.
-     *
-     * v1 carries `inventory` only. Phase 7 will add `deltas`, `activity_notes`, and
-     * `narrative` slots — they're absent (not null) in v1 responses.
+
+    v1 carries `inventory` only. Phase 7 will add `deltas`, `activity_notes`, and
+    `narrative` slots — they're absent (not null) in v1 responses.
      */
     export interface ProjectProfilePayload {
       /** Deterministic snapshot of what's true about the project. */
@@ -36877,11 +35329,11 @@ export namespace Schemas {
 
     /**
      * Wire shape for the project profile returned by `signals-scout-harness-project-profile-list`.
-     *
-     * Read this once at the start of a run (after `skill-get`) to orient on the team. Cache
-     * is per-team with a soft TTL (`PROFILE_TTL`); the response always reflects either the
-     * latest cached profile or a freshly-built one if the cache was stale or the caller passed
-     * `force_refresh=true`.
+
+    Read this once at the start of a run (after `skill-get`) to orient on the team. Cache
+    is per-team with a soft TTL (`PROFILE_TTL`); the response always reflects either the
+    latest cached profile or a freshly-built one if the cache was stale or the caller passed
+    `force_refresh=true`.
      */
     export interface ProjectProfile {
       /** UUID of the `SignalProjectProfile` row. */
@@ -36906,48 +35358,48 @@ export namespace Schemas {
 
     export interface Property {
       /**
-       *  You can use a simplified version:
-       * ```json
-       * {
-       *     "properties": [
-       *         {
-       *             "key": "email",
-       *             "value": "x@y.com",
-       *             "operator": "exact",
-       *             "type": "event"
-       *         }
-       *     ]
-       * }
-       * ```
-       *
-       * Or you can create more complicated queries with AND and OR:
-       * ```json
-       * {
-       *     "properties": {
-       *         "type": "AND",
-       *         "values": [
-       *             {
-       *                 "type": "OR",
-       *                 "values": [
-       *                     {"key": "email", ...},
-       *                     {"key": "email", ...}
-       *                 ]
-       *             },
-       *             {
-       *                 "type": "AND",
-       *                 "values": [
-       *                     {"key": "email", ...},
-       *                     {"key": "email", ...}
-       *                 ]
-       *             }
-       *         ]
-       *     ]
-       * }
-       * ```
-       *
-       *
-       * * `AND` - AND
-       * * `OR` - OR */
+       You can use a simplified version:
+      ```json
+      {
+          "properties": [
+              {
+                  "key": "email",
+                  "value": "x@y.com",
+                  "operator": "exact",
+                  "type": "event"
+              }
+          ]
+      }
+      ```
+
+      Or you can create more complicated queries with AND and OR:
+      ```json
+      {
+          "properties": {
+              "type": "AND",
+              "values": [
+                  {
+                      "type": "OR",
+                      "values": [
+                          {"key": "email", ...},
+                          {"key": "email", ...}
+                      ]
+                  },
+                  {
+                      "type": "AND",
+                      "values": [
+                          {"key": "email", ...},
+                          {"key": "email", ...}
+                      ]
+                  }
+              ]
+          ]
+      }
+      ```
+
+
+      * `AND` - AND
+      * `OR` - OR */
       type?: PropertyGroupOperator;
       values: PropertyItem[];
     }
@@ -36958,10 +35410,10 @@ export namespace Schemas {
     export interface PropertyAccessControlRule {
       readonly id: string;
       /** The access level for this rule.
-       *
-       * * `read_write` - read_write
-       * * `read` - read
-       * * `none` - none */
+
+      * `read_write` - read_write
+      * `read` - read
+      * `none` - none */
       access_level: AccessLevelEnum;
       /**
          * The organization member UUID this rule applies to, if any.
@@ -36981,9 +35433,9 @@ export namespace Schemas {
 
     /**
      * Serializes the aggregate state for a property definition.
-     *
-     * Preserves the existing API shape: ``access_controls`` is the list
-     * of rules, plus the available levels and the computed default.
+
+    Preserves the existing API shape: ``access_controls`` is the list
+    of rules, plus the available levels and the computed default.
      */
     export interface PropertyAccessControlState {
       /** List of all access control rules for this property definition. */
@@ -37001,10 +35453,10 @@ export namespace Schemas {
       /** The property definition ID this rule applies to. */
       property_definition_id: string;
       /** The access level to set for this rule.
-       *
-       * * `read_write` - read_write
-       * * `read` - read
-       * * `none` - none */
+
+      * `read_write` - read_write
+      * `read` - read
+      * `none` - none */
       access_level: AccessLevelEnum;
       /**
          * The organization member UUID to set an override for.
@@ -37078,12 +35530,12 @@ export namespace Schemas {
 
     /**
      * * `waiting` - Waiting
-     * * `issuing` - Issuing
-     * * `valid` - Valid
-     * * `warning` - Warning
-     * * `erroring` - Erroring
-     * * `deleting` - Deleting
-     * * `timed_out` - Timed Out
+    * `issuing` - Issuing
+    * `valid` - Valid
+    * `warning` - Warning
+    * `erroring` - Erroring
+    * `deleting` - Deleting
+    * `timed_out` - Timed Out
      */
     export type ProxyRecordStatusEnum = typeof ProxyRecordStatusEnum[keyof typeof ProxyRecordStatusEnum];
 
@@ -37106,14 +35558,14 @@ export namespace Schemas {
       /** The CNAME target to add as a DNS record for your domain. Point your domain's CNAME to this value. */
       readonly target_cname: string;
       /** Current provisioning status. Values: waiting (DNS verification pending), issuing (SSL certificate being issued), valid (proxy is live and working), warning (proxy has issues but is operational), erroring (proxy setup failed), deleting (removal in progress), timed_out (DNS verification timed out).
-       *
-       * * `waiting` - Waiting
-       * * `issuing` - Issuing
-       * * `valid` - Valid
-       * * `warning` - Warning
-       * * `erroring` - Erroring
-       * * `deleting` - Deleting
-       * * `timed_out` - Timed Out */
+
+      * `waiting` - Waiting
+      * `issuing` - Issuing
+      * `valid` - Valid
+      * `warning` - Warning
+      * `erroring` - Erroring
+      * `deleting` - Deleting
+      * `timed_out` - Timed Out */
       readonly status: ProxyRecordStatusEnum;
       /**
          * Human-readable status message with details about errors or warnings, if any.
@@ -37146,10 +35598,10 @@ export namespace Schemas {
       /** Pull request title. */
       title: string;
       /** Derived state: 'open', 'closed', or 'merged'.
-       *
-       * * `open` - OPEN
-       * * `closed` - CLOSED
-       * * `merged` - MERGED */
+
+      * `open` - OPEN
+      * `closed` - CLOSED
+      * `merged` - MERGED */
       state: EngineeringAnalyticsPRStateEnum;
       /** True if the pull request is a draft. */
       is_draft: boolean;
@@ -37180,8 +35632,8 @@ export namespace Schemas {
 
     /**
      * * `ios` - iOS
-     * * `android` - Android
-     * * `web` - Web
+    * `android` - Android
+    * `web` - Web
      */
     export type PushTokenPlatformEnum = typeof PushTokenPlatformEnum[keyof typeof PushTokenPlatformEnum];
 
@@ -37375,24 +35827,24 @@ export namespace Schemas {
       /** Name given to a query. It's used to identify the query in the UI. Up to 128 characters for a name. */
       name?: string | null;
       /** Submit a JSON string representing a query for PostHog data analysis, for example a HogQL query.
-       *
-       * Example payload:
-       *
-       * ```
-       *
-       * {"query": {"kind": "HogQLQuery", "query": "select * from events limit 100"}}
-       *
-       * ```
-       *
-       * For more details on HogQL queries, see the [PostHog HogQL documentation](/docs/hogql#api-access). */
+
+      Example payload:
+
+      ```
+
+      {"query": {"kind": "HogQLQuery", "query": "select * from events limit 100"}}
+
+      ```
+
+      For more details on HogQL queries, see the [PostHog HogQL documentation](/docs/hogql#api-access). */
       query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | PropertyValuesQuery;
       /** Whether results should be calculated sync or async, and how much to rely on the cache:
-       * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-       * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-       * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-       * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-       * - `'force_async'` - kick off background calculation, even if fresh results are already cached
-       * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates Background calculation can be tracked using the `query_status` response field. */
+      - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+      - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+      - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+      - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+      - `'force_async'` - kick off background calculation, even if fresh results are already cached
+      - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates Background calculation can be tracked using the `query_status` response field. */
       refresh?: RefreshType | null;
       variables_override?: QueryRequestVariablesOverride;
     }
@@ -39425,16 +37877,17 @@ export namespace Schemas {
       limited: QuotaLimitsResponseLimited;
     }
 
-    export interface RawUnmatchedSample {
-      /** A raw utm_source value matching no integration */
-      raw_utm_source: string;
-      /** Number of events with this raw value in the window */
-      event_count: number;
-      /**
-         * Integration suggested by token match, if any
-         * @nullable
-         */
-      suggested_integration: string | null;
+    /**
+     * Request body for triggering a metrics recalculation.
+     */
+    export interface RecalculateMetricsRequest {
+      /** What triggered this recalculation (manual is the default for user-initiated runs)
+
+      * `manual` - manual
+      * `experiment_launch` - experiment_launch
+      * `experiment_stop` - experiment_stop
+      * `experiment_update` - experiment_update */
+      trigger?: TriggerEnum;
     }
 
     export interface RecomputeResult {
@@ -39474,10 +37927,10 @@ export namespace Schemas {
          */
       tile_order: number[];
       /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.
-       *
-       * * `preserve` - preserve
-       * * `two_column` - two_column
-       * * `full_width` - full_width */
+
+      * `preserve` - preserve
+      * `two_column` - two_column
+      * `full_width` - full_width */
       layout?: LayoutEnum;
     }
 
@@ -39546,8 +37999,8 @@ export namespace Schemas {
 
     /**
      * * `Starting` - Starting
-     * * `Running` - Running
-     * * `Cancelled` - Cancelled
+    * `Running` - Running
+    * `Cancelled` - Cancelled
      */
     export type RetrieveBasicOutputStatusEnum = typeof RetrieveBasicOutputStatusEnum[keyof typeof RetrieveBasicOutputStatusEnum];
 
@@ -39604,10 +38057,10 @@ export namespace Schemas {
 
     /**
      * * `Failed` - Failed
-     * * `FailedRetryable` - FailedRetryable
-     * * `FailedBilling` - FailedBilling
-     * * `Terminated` - Terminated
-     * * `TimedOut` - TimedOut
+    * `FailedRetryable` - FailedRetryable
+    * `FailedBilling` - FailedBilling
+    * `Terminated` - Terminated
+    * `TimedOut` - TimedOut
      */
     export type RetrieveFailedOutputStatusEnum = typeof RetrieveFailedOutputStatusEnum[keyof typeof RetrieveFailedOutputStatusEnum];
 
@@ -39679,17 +38132,11 @@ export namespace Schemas {
       /** @maxLength 255 */
       name: string;
       network_access_level?: NetworkAccessLevelEnum;
-      /**
-         * List of allowed domains for custom network access
-         * @items.maxLength 255
-         */
+      /** List of allowed domains for custom network access */
       allowed_domains?: string[];
       /** Whether to include default trusted domains (GitHub, npm, PyPI) */
       include_default_domains?: boolean;
-      /**
-         * List of repositories this environment applies to (format: org/repo)
-         * @items.maxLength 255
-         */
+      /** List of repositories this environment applies to (format: org/repo) */
       repositories?: string[];
       /** Encrypted environment variables (write-only, never returned in responses) */
       environment_variables?: unknown;
@@ -39733,15 +38180,13 @@ export namespace Schemas {
       /**
          * Viewport widths (px, 100-3000) to render the heatmap screenshot at — one render per width. Defaults to [320, 375, 425, 768, 1024, 1440, 1920] when omitted. At most 16 widths.
          * @maxItems 16
-         * @items.minimum 100
-         * @items.maximum 3000
          */
       widths?: number[];
       /** Render mode: 'screenshot' (renders the page headlessly, default), 'iframe', or 'recording'. Only 'screenshot' generates image bytes.
-       *
-       * * `screenshot` - Screenshot
-       * * `iframe` - Iframe
-       * * `recording` - Recording */
+
+      * `screenshot` - Screenshot
+      * `iframe` - Iframe
+      * `recording` - Recording */
       type?: HeatmapType;
       /** Set true to soft-delete the saved heatmap. */
       deleted?: boolean;
@@ -39799,10 +38244,10 @@ export namespace Schemas {
          */
       description?: string | null;
       /** Scorer kind. This cannot be changed after creation.
-       *
-       * * `categorical` - categorical
-       * * `numeric` - numeric
-       * * `boolean` - boolean */
+
+      * `categorical` - categorical
+      * `numeric` - numeric
+      * `boolean` - boolean */
       kind: ExperimentMetricKindEnum;
       /** New scorers are always created as active. */
       archived?: boolean;
@@ -39826,7 +38271,7 @@ export namespace Schemas {
     export interface ScratchpadEntry {
       /** Agent-chosen semantic key, unique per team. */
       key: string;
-      /** Prose content for prompt injection. Blank when the search projected it out (`keys_only=true`); truncated to a preview when `content_max_chars` was set. */
+      /** Prose content for prompt injection. */
       content: string;
       /**
          * ISO-8601 creation timestamp.
@@ -39847,8 +38292,8 @@ export namespace Schemas {
 
     /**
      * * `none` - none
-     * * `warning` - warning
-     * * `danger` - danger
+    * `warning` - warning
+    * `danger` - danger
      */
     export type SdkAssessmentSeverityEnum = typeof SdkAssessmentSeverityEnum[keyof typeof SdkAssessmentSeverityEnum];
 
@@ -39911,10 +38356,10 @@ export namespace Schemas {
       /** True if the primary in-use version is flagged as old by age alone. */
       is_old: boolean;
       /** UI severity badge — 'none' when healthy, 'warning' when outdated, 'danger' when the majority of team SDKs are outdated.
-       *
-       * * `none` - none
-       * * `warning` - warning
-       * * `danger` - danger */
+
+      * `none` - none
+      * `warning` - warning
+      * `danger` - danger */
       severity: SdkAssessmentSeverityEnum;
       /** Per-SDK programmatic summary (used for ranking/filtering). For user-facing copy, prefer releases[].status_reason (badge tooltip) and banners (top-level alert text) — those match the UI exactly. */
       reason: string;
@@ -39928,15 +38373,15 @@ export namespace Schemas {
 
     export interface SdkHealthReport {
       /** 'healthy' when no SDKs need updating, 'needs_attention' otherwise.
-       *
-       * * `healthy` - healthy
-       * * `needs_attention` - needs_attention */
+
+      * `healthy` - healthy
+      * `needs_attention` - needs_attention */
       overall_health: OverallHealthEnum;
       /** UI-level status — 'success' when healthy, 'warning' when some SDKs are outdated, 'danger' when the majority are outdated.
-       *
-       * * `success` - success
-       * * `warning` - warning
-       * * `danger` - danger */
+
+      * `success` - success
+      * `warning` - warning
+      * `danger` - danger */
       health: HealthEnum;
       /** Number of SDKs that need updating. */
       needs_updating_count: number;
@@ -39978,10 +38423,10 @@ export namespace Schemas {
 
     /**
      * Filter shape mirrors the previous frontend `api.query({filters: ...})` payload.
-     *
-     * `filters` accepts the same `HogQLFilters` schema that the legacy frontend HogQL
-     * path used (dateRange, filterTestAccounts, properties), so the migration is
-     * behaviour-preserving for callers that pass a request unchanged.
+
+    `filters` accepts the same `HogQLFilters` schema that the legacy frontend HogQL
+    path used (dateRange, filterTestAccounts, properties), so the migration is
+    behaviour-preserving for callers that pass a request unchanged.
      */
     export interface SentimentGenerationsRequest {
       filters?: unknown;
@@ -39993,7 +38438,7 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-     * * `generation` - generation
+    * `generation` - generation
      */
     export type SentimentRequestAnalysisLevelEnum = typeof SentimentRequestAnalysisLevelEnum[keyof typeof SentimentRequestAnalysisLevelEnum];
 
@@ -40011,9 +38456,9 @@ export namespace Schemas {
          */
       ids: string[];
       /** Whether the IDs are 'trace' IDs or 'generation' IDs.
-       *
-       * * `trace` - trace
-       * * `generation` - generation */
+
+      * `trace` - trace
+      * `generation` - generation */
       analysis_level?: SentimentRequestAnalysisLevelEnum;
       /** If true, bypass cache and reclassify. */
       force_refresh?: boolean;
@@ -40033,10 +38478,7 @@ export namespace Schemas {
       readonly id: string;
       /** Title of the group session summary */
       readonly title: string;
-      /**
-         * List of session replay IDs included in this group summary
-         * @items.maxLength 200
-         */
+      /** List of session replay IDs included in this group summary */
       readonly session_ids: readonly string[];
       /** Group summary in JSON format (EnrichedSessionGroupSummaryPatternsList schema) */
       readonly summary: unknown;
@@ -40049,32 +38491,13 @@ export namespace Schemas {
       readonly team: number;
     }
 
-    export type SessionReplayListWidgetCatalogEntryOpenApiWidgetType = typeof SessionReplayListWidgetCatalogEntryOpenApiWidgetType[keyof typeof SessionReplayListWidgetCatalogEntryOpenApiWidgetType];
-
-
-    export const SessionReplayListWidgetCatalogEntryOpenApiWidgetType = {
-      SessionReplayList: 'session_replay_list',
-    } as const;
-
-    export interface SessionReplayListWidgetCatalogEntryOpenApi {
-      widget_type: SessionReplayListWidgetCatalogEntryOpenApiWidgetType;
-      group_id: string;
-      group_label: string;
-      label: string;
-      description: string;
-      /** OpenAPI config shape for this widget type (documentation; matches batch-add/PATCH schemas). */
-      readonly config_schema: SessionReplayListWidgetConfig;
-      /** @nullable */
-      required_product_access?: string | null;
-    }
-
     /**
      * * `session_replay_list` - session_replay_list
      */
-    export type SessionReplayListWidgetTypeEnum = typeof SessionReplayListWidgetTypeEnum[keyof typeof SessionReplayListWidgetTypeEnum];
+    export type SessionReplayListWidgetAddRequestOpenApiWidgetTypeEnum = typeof SessionReplayListWidgetAddRequestOpenApiWidgetTypeEnum[keyof typeof SessionReplayListWidgetAddRequestOpenApiWidgetTypeEnum];
 
 
-    export const SessionReplayListWidgetTypeEnum = {
+    export const SessionReplayListWidgetAddRequestOpenApiWidgetTypeEnum = {
       SessionReplayList: 'session_replay_list',
     } as const;
 
@@ -40109,11 +38532,11 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-     * * `debug` - debug
-     * * `info` - info
-     * * `warn` - warn
-     * * `error` - error
-     * * `fatal` - fatal
+    * `debug` - debug
+    * `info` - info
+    * `warn` - warn
+    * `error` - error
+    * `fatal` - fatal
      */
     export type SeverityLevelsEnum = typeof SeverityLevelsEnum[keyof typeof SeverityLevelsEnum];
 
@@ -40151,12 +38574,12 @@ export namespace Schemas {
 
     export interface ShipVariant {
       /** The conclusion of the experiment.
-       *
-       * * `won` - won
-       * * `lost` - lost
-       * * `inconclusive` - inconclusive
-       * * `stopped_early` - stopped_early
-       * * `invalid` - invalid */
+
+      * `won` - won
+      * `lost` - lost
+      * `inconclusive` - inconclusive
+      * `stopped_early` - stopped_early
+      * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Optional comment about the experiment conclusion.
@@ -40171,7 +38594,7 @@ export namespace Schemas {
 
     /**
      * * `suppressed` - suppressed
-     * * `potential` - potential
+    * `potential` - potential
      */
     export type SignalReportStateRequestStateEnum = typeof SignalReportStateRequestStateEnum[keyof typeof SignalReportStateRequestStateEnum];
 
@@ -40183,9 +38606,9 @@ export namespace Schemas {
 
     export interface SignalReportStateRequest {
       /** Target state for the report. Use 'suppressed' to dismiss the report from the inbox, or 'potential' to snooze/reopen it for later review.
-       *
-       * * `suppressed` - suppressed
-       * * `potential` - potential */
+
+      * `suppressed` - suppressed
+      * `potential` - potential */
       state: SignalReportStateRequestStateEnum;
       /** Optional short reason code for the dismissal (e.g. 'not_a_bug', 'wont_fix', 'duplicate'). The set of reason codes is owned by the caller and is not validated server-side. */
       dismissal_reason?: string;
@@ -40204,16 +38627,14 @@ export namespace Schemas {
 
     /**
      * Per-(team, skill) scout config: schedule, enablement, and emit posture.
-     *
-     * One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
-     * when it discovers a scout skill; this serializer lets agents tune the row.
+
+    One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
+    when it discovers a scout skill; this serializer lets agents tune the row.
      */
     export interface SignalScoutConfig {
       readonly id: string;
       /** The `signals-scout-*` skill this config controls. Set at creation, not editable. */
       readonly skill_name: string;
-      /** Human-readable summary of what this scout investigates, sourced from the scout skill's `description` metadata. Use it for a quick steer on the scout's focus without loading the full skill body. Empty if the skill is not currently present on the team or carries no description. */
-      readonly description: string;
       /** Whether this scout runs on its schedule. Disabled scouts are skipped by the coordinator. */
       enabled?: boolean;
       /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. */
@@ -40233,34 +38654,10 @@ export namespace Schemas {
     }
 
     /**
-     * Request body for registering a scout config without waiting for the coordinator tick.
-     *
-     * Upsert keyed on `skill_name`: if the coordinator (or a concurrent caller) already
-     * registered the row, the provided tunables are applied to it instead.
-     */
-    export interface SignalScoutConfigCreate {
-      /**
-         * The `signals-scout-*` skill to register a config for. The skill must already exist on this project — author it via the skills store first.
-         * @maxLength 200
-         */
-      skill_name: string;
-      /** Whether this scout runs on its schedule. Defaults to true. */
-      enabled?: boolean;
-      /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. Defaults to true. */
-      emit?: boolean;
-      /**
-         * Minutes between runs (10–43200). Defaults to 60 (hourly).
-         * @minimum 10
-         * @maximum 43200
-         */
-      run_interval_minutes?: number;
-    }
-
-    /**
      * One finding a scout run emitted to the inbox — the persisted, queryable record of
-     * *what* the run surfaced, returned by `signals-scout-runs-emissions-list`. The emitted text
-     * lives in `description`; `source_id` is the join key (`run:<run_id>:finding:<finding_id>`)
-     * back into the underlying signal store.
+    *what* the run surfaced, returned by `signals-scout-runs-emissions-list`. The emitted text
+    lives in `description`; `source_id` is the join key (`run:<run_id>:finding:<finding_id>`)
+    back into the underlying signal store.
      */
     export interface SignalScoutEmission {
       readonly id: string;
@@ -40283,15 +38680,13 @@ export namespace Schemas {
          */
       confidence: number;
       /** Optional severity tag — one of P0, P1, P2, P3, P4 — or null if the run didn't set one.
-       *
-       * * `P0` - P0
-       * * `P1` - P1
-       * * `P2` - P2
-       * * `P3` - P3
-       * * `P4` - P4 */
+
+      * `P0` - P0
+      * `P1` - P1
+      * `P2` - P2
+      * `P3` - P3
+      * `P4` - P4 */
       severity: AutonomyPriorityEnum | null;
-      /** Slug tags the scout attached to this finding (lowercase kebab-case, e.g. `cost-spike`). Empty list when the run set none. */
-      tags: string[];
       /** Deterministic `run:<run_id>:finding:<finding_id>` — the join key into the underlying signal store. */
       source_id: string;
       /** ISO-8601 timestamp the finding was emitted. */
@@ -40300,8 +38695,8 @@ export namespace Schemas {
 
     /**
      * Full `SignalScoutRun` projection used by `get-run`. Same shape as the summary
-     * today; kept distinct so future detail-only extensions (linked Signal rows,
-     * LLMA token-cost join) can land here without bloating the list response.
+    today; kept distinct so future detail-only extensions (linked Signal rows,
+    LLMA token-cost join) can land here without bloating the list response.
      */
     export interface SignalScoutRunDetail {
       /** UUID of the bridge row. */
@@ -40336,16 +38731,6 @@ export namespace Schemas {
       task_url?: string | null;
       /** One-paragraph close-out the scout wrote at end-of-run. Empty string for runs that errored before close-out. The dedupe key for non-emitting runs. */
       summary: string;
-      /**
-         * Full `error_message` from the linked TaskRun, surfaced only for failed/cancelled runs (null otherwise, including on success). Use `failure_reason` for a concise scan-friendly summary.
-         * @nullable
-         */
-      error?: string | null;
-      /**
-         * Concise derived reason the run didn't complete cleanly — the first line of `error` (bounded), or a status-derived fallback. Null unless the run terminated failed/cancelled. Read this to see at a glance *why* a run emitted nothing without pulling full stack traces.
-         * @nullable
-         */
-      failure_reason?: string | null;
       /** Number of findings this run actually emitted to the inbox. 0 for runs that investigated but surfaced nothing, or ran dry-run / before AI approval. `> 0` means the run produced at least one `Signal`. */
       emitted_count: number;
       /** The `finding_id`s behind `emitted_count`, in emit order. Each maps to a `Signal` with `source_id = run:<run_id>:finding:<finding_id>`. Empty for non-emitting runs. */
@@ -40354,8 +38739,8 @@ export namespace Schemas {
 
     /**
      * Lightweight projection of a `SignalScoutRun` row used by `search-recent-runs`.
-     *
-     * Status and timestamps flow from the linked `tasks.TaskRun`.
+
+    Status and timestamps flow from the linked `tasks.TaskRun`.
      */
     export interface SignalScoutRunSummary {
       /** UUID of the bridge row. */
@@ -40390,16 +38775,6 @@ export namespace Schemas {
       task_url?: string | null;
       /** One-paragraph close-out the scout wrote at end-of-run. Empty string for runs that errored before close-out. The dedupe key for non-emitting runs. */
       summary: string;
-      /**
-         * Full `error_message` from the linked TaskRun, surfaced only for failed/cancelled runs (null otherwise, including on success). Use `failure_reason` for a concise scan-friendly summary.
-         * @nullable
-         */
-      error?: string | null;
-      /**
-         * Concise derived reason the run didn't complete cleanly — the first line of `error` (bounded), or a status-derived fallback. Null unless the run terminated failed/cancelled. Read this to see at a glance *why* a run emitted nothing without pulling full stack traces.
-         * @nullable
-         */
-      failure_reason?: string | null;
       /** Number of findings this run actually emitted to the inbox. 0 for runs that investigated but surfaced nothing, or ran dry-run / before AI approval. `> 0` means the run produced at least one `Signal`. */
       emitted_count: number;
       /** The `finding_id`s behind `emitted_count`, in emit order. Each maps to a `Signal` with `source_id = run:<run_id>:finding:<finding_id>`. Empty for non-emitting runs. */
@@ -40430,12 +38805,12 @@ export namespace Schemas {
          */
       slack_notification_channel?: string | null;
       /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority (and reports without a priority judgment).
-       *
-       * * `P0` - P0
-       * * `P1` - P1
-       * * `P2` - P2
-       * * `P3` - P3
-       * * `P4` - P4 */
+
+      * `P0` - P0
+      * `P1` - P1
+      * `P2` - P2
+      * `P3` - P3
+      * `P4` - P4 */
       slack_notification_min_priority?: AutonomyPriorityEnum | BlankEnum | null;
       readonly created_at: string;
       readonly updated_at: string;
@@ -40529,10 +38904,10 @@ export namespace Schemas {
 
     /**
      * The internal sandbox run the discovery agent used to pick this run's repo.
-     *
-     * Only present when the originating mention was ambiguous (multiple candidate
-     * repos, no explicit mention) — that's the only path that spins up a research
-     * sandbox. Null otherwise.
+
+    Only present when the originating mention was ambiguous (multiple candidate
+    repos, no explicit mention) — that's the only path that spins up a research
+    sandbox. Null otherwise.
      */
     export interface SlackThreadContextRepoResearch {
       /** UUID of the internal repo-research Task. */
@@ -40680,292 +39055,10 @@ export namespace Schemas {
       runs: SlackThreadContextRun[];
     }
 
-    export interface SourceConnectLink {
-      /** The source type the link is for. */
-      source_type: string;
-      /** What the user will do on the connect page: 'oauth' = authorize an account in their browser; 'credentials' = enter connection details (or pick OAuth where the source offers both). Either way secrets never pass through the agent, and the result is always a stored credential id.
-       *
-       * * `oauth` - oauth
-       * * `credentials` - credentials */
-      auth_method: AuthMethodEnum;
-      /** Full URL to share with the user. It opens the source's connection form in PostHog — credentials never pass through the agent or the chat. */
-      connect_url: string;
-      /** Next steps for the agent to relay to the user. */
-      instructions: string;
-    }
-
-    export interface SourceCredential {
-      /** Stored credential id. Pass to the setup endpoint as {'credential_id': <id>} to create the source. */
-      credential_id: string;
-      /** The source type the stored credentials are for. */
-      source_type: string;
-      /** When the credentials were stored. */
-      created_at: string;
-      /** When the stored credentials expire. Unconsumed credentials are unusable past this time. */
-      expires_at: string;
-    }
-
-    /**
-     * Connection details as flat keys for the source_type — the same fields the create flow accepts (host, port, password, API key, …). Checked against a live connection before being stored.
-     */
-    export type SourceCredentialCreatePayload = { [key: string]: unknown };
-
-    export interface SourceCredentialCreate {
-      /** The source type these credentials are for (e.g. 'Stripe', 'Postgres').
-       *
-       * * `Ashby` - Ashby
-       * * `Supabase` - Supabase
-       * * `CustomerIO` - CustomerIO
-       * * `Github` - Github
-       * * `Stripe` - Stripe
-       * * `Hubspot` - Hubspot
-       * * `Postgres` - Postgres
-       * * `Zendesk` - Zendesk
-       * * `Snowflake` - Snowflake
-       * * `Salesforce` - Salesforce
-       * * `MySQL` - MySQL
-       * * `MongoDB` - MongoDB
-       * * `MSSQL` - MSSQL
-       * * `Vitally` - Vitally
-       * * `BigQuery` - BigQuery
-       * * `Chargebee` - Chargebee
-       * * `Clerk` - Clerk
-       * * `GoogleAds` - GoogleAds
-       * * `GoogleSearchConsole` - GoogleSearchConsole
-       * * `TemporalIO` - TemporalIO
-       * * `DoIt` - DoIt
-       * * `GoogleSheets` - GoogleSheets
-       * * `MetaAds` - MetaAds
-       * * `Klaviyo` - Klaviyo
-       * * `Mailchimp` - Mailchimp
-       * * `Braze` - Braze
-       * * `Mailjet` - Mailjet
-       * * `Redshift` - Redshift
-       * * `Polar` - Polar
-       * * `RevenueCat` - RevenueCat
-       * * `LinkedinAds` - LinkedinAds
-       * * `RedditAds` - RedditAds
-       * * `TikTokAds` - TikTokAds
-       * * `BingAds` - BingAds
-       * * `Shopify` - Shopify
-       * * `Attio` - Attio
-       * * `SnapchatAds` - SnapchatAds
-       * * `Linear` - Linear
-       * * `Intercom` - Intercom
-       * * `Amplitude` - Amplitude
-       * * `Mixpanel` - Mixpanel
-       * * `Jira` - Jira
-       * * `ActiveCampaign` - ActiveCampaign
-       * * `Marketo` - Marketo
-       * * `Adjust` - Adjust
-       * * `AppsFlyer` - AppsFlyer
-       * * `Freshdesk` - Freshdesk
-       * * `GoogleAnalytics` - GoogleAnalytics
-       * * `Pipedrive` - Pipedrive
-       * * `SendGrid` - SendGrid
-       * * `Slack` - Slack
-       * * `PagerDuty` - PagerDuty
-       * * `Asana` - Asana
-       * * `Notion` - Notion
-       * * `Airtable` - Airtable
-       * * `Greenhouse` - Greenhouse
-       * * `BambooHR` - BambooHR
-       * * `Lever` - Lever
-       * * `GitLab` - GitLab
-       * * `Datadog` - Datadog
-       * * `Sentry` - Sentry
-       * * `Pendo` - Pendo
-       * * `FullStory` - FullStory
-       * * `AmazonAds` - AmazonAds
-       * * `PinterestAds` - PinterestAds
-       * * `AppleSearchAds` - AppleSearchAds
-       * * `QuickBooks` - QuickBooks
-       * * `Xero` - Xero
-       * * `NetSuite` - NetSuite
-       * * `WooCommerce` - WooCommerce
-       * * `BigCommerce` - BigCommerce
-       * * `PayPal` - PayPal
-       * * `Square` - Square
-       * * `Zoom` - Zoom
-       * * `Trello` - Trello
-       * * `Monday` - Monday
-       * * `ClickUp` - ClickUp
-       * * `Confluence` - Confluence
-       * * `Recurly` - Recurly
-       * * `SalesLoft` - SalesLoft
-       * * `Outreach` - Outreach
-       * * `Gong` - Gong
-       * * `Calendly` - Calendly
-       * * `Typeform` - Typeform
-       * * `Iterable` - Iterable
-       * * `ZohoCRM` - ZohoCRM
-       * * `Close` - Close
-       * * `Oracle` - Oracle
-       * * `DynamoDB` - DynamoDB
-       * * `Elasticsearch` - Elasticsearch
-       * * `Kafka` - Kafka
-       * * `LaunchDarkly` - LaunchDarkly
-       * * `Braintree` - Braintree
-       * * `Recharge` - Recharge
-       * * `HelpScout` - HelpScout
-       * * `Gorgias` - Gorgias
-       * * `Instagram` - Instagram
-       * * `YouTubeAnalytics` - YouTubeAnalytics
-       * * `FacebookPages` - FacebookPages
-       * * `TwitterAds` - TwitterAds
-       * * `Workday` - Workday
-       * * `ServiceNow` - ServiceNow
-       * * `Pardot` - Pardot
-       * * `Copper` - Copper
-       * * `Front` - Front
-       * * `ChartMogul` - ChartMogul
-       * * `Zuora` - Zuora
-       * * `Paddle` - Paddle
-       * * `CircleCI` - CircleCI
-       * * `CockroachDB` - CockroachDB
-       * * `Firebase` - Firebase
-       * * `AzureBlob` - AzureBlob
-       * * `GoogleDrive` - GoogleDrive
-       * * `OneDrive` - OneDrive
-       * * `SharePoint` - SharePoint
-       * * `Box` - Box
-       * * `SFTP` - SFTP
-       * * `MicrosoftTeams` - MicrosoftTeams
-       * * `Aircall` - Aircall
-       * * `Webflow` - Webflow
-       * * `Okta` - Okta
-       * * `Auth0` - Auth0
-       * * `Productboard` - Productboard
-       * * `Smartsheet` - Smartsheet
-       * * `Wrike` - Wrike
-       * * `Plaid` - Plaid
-       * * `SurveyMonkey` - SurveyMonkey
-       * * `Eventbrite` - Eventbrite
-       * * `RingCentral` - RingCentral
-       * * `Twilio` - Twilio
-       * * `Freshsales` - Freshsales
-       * * `Shortcut` - Shortcut
-       * * `ConvertKit` - ConvertKit
-       * * `Drip` - Drip
-       * * `CampaignMonitor` - CampaignMonitor
-       * * `MailerLite` - MailerLite
-       * * `Omnisend` - Omnisend
-       * * `Brevo` - Brevo
-       * * `Postmark` - Postmark
-       * * `Granola` - Granola
-       * * `BuildBetter` - BuildBetter
-       * * `Convex` - Convex
-       * * `ClickHouse` - ClickHouse
-       * * `Plain` - Plain
-       * * `Resend` - Resend
-       * * `PgAnalyze` - PgAnalyze
-       * * `WorkOS` - WorkOS
-       * * `AmazonS3` - AmazonS3
-       * * `GoogleCloudStorage` - GoogleCloudStorage
-       * * `Databricks` - Databricks
-       * * `Dynamics365` - Dynamics365
-       * * `SalesforceMarketingCloud` - SalesforceMarketingCloud
-       * * `Db2` - Db2
-       * * `Heap` - Heap
-       * * `AdobeAnalytics` - AdobeAnalytics
-       * * `Matomo` - Matomo
-       * * `Optimizely` - Optimizely
-       * * `Adyen` - Adyen
-       * * `GoCardless` - GoCardless
-       * * `Mollie` - Mollie
-       * * `CheckoutCom` - CheckoutCom
-       * * `Branch` - Branch
-       * * `Criteo` - Criteo
-       * * `Outbrain` - Outbrain
-       * * `Taboola` - Taboola
-       * * `AdRoll` - AdRoll
-       * * `DisplayVideo360` - DisplayVideo360
-       * * `GoogleAdManager` - GoogleAdManager
-       * * `CampaignManager360` - CampaignManager360
-       * * `SearchAds360` - SearchAds360
-       * * `AdobeCommerce` - AdobeCommerce
-       * * `AmazonSellingPartner` - AmazonSellingPartner
-       * * `Ebay` - Ebay
-       * * `Commercetools` - Commercetools
-       * * `LightspeedRetail` - LightspeedRetail
-       * * `ShipStation` - ShipStation
-       * * `ConstantContact` - ConstantContact
-       * * `Mailgun` - Mailgun
-       * * `Eloqua` - Eloqua
-       * * `Sailthru` - Sailthru
-       * * `Ortto` - Ortto
-       * * `Attentive` - Attentive
-       * * `Kustomer` - Kustomer
-       * * `Dixa` - Dixa
-       * * `Gladly` - Gladly
-       * * `Qualtrics` - Qualtrics
-       * * `Delighted` - Delighted
-       * * `AzureDevOps` - AzureDevOps
-       * * `Rollbar` - Rollbar
-       * * `Opsgenie` - Opsgenie
-       * * `IncidentIo` - IncidentIo
-       * * `Pingdom` - Pingdom
-       * * `Cloudflare` - Cloudflare
-       * * `CosmosDB` - CosmosDB
-       * * `PlanetScale` - PlanetScale
-       * * `SapHana` - SapHana
-       * * `Rippling` - Rippling
-       * * `HiBob` - HiBob
-       * * `Personio` - Personio
-       * * `Deel` - Deel
-       * * `AdpWorkforceNow` - AdpWorkforceNow
-       * * `Paylocity` - Paylocity
-       * * `Gusto` - Gusto
-       * * `CultureAmp` - CultureAmp
-       * * `Lattice` - Lattice
-       * * `SageIntacct` - SageIntacct
-       * * `FreshBooks` - FreshBooks
-       * * `Expensify` - Expensify
-       * * `Ramp` - Ramp
-       * * `Brex` - Brex
-       * * `Coupa` - Coupa
-       * * `SapConcur` - SapConcur
-       * * `Apollo` - Apollo
-       * * `Crunchbase` - Crunchbase
-       * * `ZoomInfo` - ZoomInfo
-       * * `Clari` - Clari
-       * * `Chorus` - Chorus
-       * * `Coda` - Coda
-       * * `Guru` - Guru
-       * * `Dropbox` - Dropbox
-       * * `Docusign` - Docusign
-       * * `PandaDoc` - PandaDoc
-       * * `SapErp` - SapErp
-       * * `SapSuccessFactors` - SapSuccessFactors
-       * * `OracleEbs` - OracleEbs
-       * * `OracleFusion` - OracleFusion
-       * * `AmazonSNS` - AmazonSNS
-       * * `AmazonEventBridge` - AmazonEventBridge
-       * * `AmazonSQS` - AmazonSQS
-       * * `AmazonKinesis` - AmazonKinesis
-       * * `AmazonCloudWatch` - AmazonCloudWatch
-       * * `OpenAIAds` - OpenAIAds
-       * * `Custom` - Custom */
-      source_type: ExternalDataSourceTypeEnum;
-      /** Connection details as flat keys for the source_type — the same fields the create flow accepts (host, port, password, API key, …). Checked against a live connection before being stored. */
-      payload: SourceCredentialCreatePayload;
-    }
-
-    export interface SourceMappingSuggestion {
-      /** The raw utm_source value seen on events */
-      raw_utm_source: string;
-      /** Integration key it maps to */
-      suggested_target: string;
-      /** Human-readable name of the suggested integration */
-      suggested_target_display_name: string;
-      /** Why this mapping is suggested */
-      reason: string;
-    }
-
     /**
      * * `none` - none
-     * * `auto` - auto
-     * * `mapped` - mapped
+    * `auto` - auto
+    * `mapped` - mapped
      */
     export type SourceMatchEnum = typeof SourceMatchEnum[keyof typeof SourceMatchEnum];
 
@@ -40977,290 +39070,8 @@ export namespace Schemas {
     } as const;
 
     /**
-     * Connection details as flat keys for the source_type (discover required fields with the wizard tool). Prefer references over raw secrets: pass {'credential_id': <id>} referencing the connection details the user stored via the connect-link page (discover ids with the stored_credentials endpoint) — they are merged in server-side and deleted once consumed. An already-connected OAuth integration can be passed via its id key instead (e.g. {'hubspot_integration_id': 123}). A 'schemas' array is NOT required — all discovered tables are enabled automatically with sensible sync defaults.
-     */
-    export type SourceSetupPayload = { [key: string]: unknown };
-
-    export interface SourceSetup {
-      /** The source type to set up (e.g. 'Stripe', 'Postgres', 'Hubspot').
-       *
-       * * `Ashby` - Ashby
-       * * `Supabase` - Supabase
-       * * `CustomerIO` - CustomerIO
-       * * `Github` - Github
-       * * `Stripe` - Stripe
-       * * `Hubspot` - Hubspot
-       * * `Postgres` - Postgres
-       * * `Zendesk` - Zendesk
-       * * `Snowflake` - Snowflake
-       * * `Salesforce` - Salesforce
-       * * `MySQL` - MySQL
-       * * `MongoDB` - MongoDB
-       * * `MSSQL` - MSSQL
-       * * `Vitally` - Vitally
-       * * `BigQuery` - BigQuery
-       * * `Chargebee` - Chargebee
-       * * `Clerk` - Clerk
-       * * `GoogleAds` - GoogleAds
-       * * `GoogleSearchConsole` - GoogleSearchConsole
-       * * `TemporalIO` - TemporalIO
-       * * `DoIt` - DoIt
-       * * `GoogleSheets` - GoogleSheets
-       * * `MetaAds` - MetaAds
-       * * `Klaviyo` - Klaviyo
-       * * `Mailchimp` - Mailchimp
-       * * `Braze` - Braze
-       * * `Mailjet` - Mailjet
-       * * `Redshift` - Redshift
-       * * `Polar` - Polar
-       * * `RevenueCat` - RevenueCat
-       * * `LinkedinAds` - LinkedinAds
-       * * `RedditAds` - RedditAds
-       * * `TikTokAds` - TikTokAds
-       * * `BingAds` - BingAds
-       * * `Shopify` - Shopify
-       * * `Attio` - Attio
-       * * `SnapchatAds` - SnapchatAds
-       * * `Linear` - Linear
-       * * `Intercom` - Intercom
-       * * `Amplitude` - Amplitude
-       * * `Mixpanel` - Mixpanel
-       * * `Jira` - Jira
-       * * `ActiveCampaign` - ActiveCampaign
-       * * `Marketo` - Marketo
-       * * `Adjust` - Adjust
-       * * `AppsFlyer` - AppsFlyer
-       * * `Freshdesk` - Freshdesk
-       * * `GoogleAnalytics` - GoogleAnalytics
-       * * `Pipedrive` - Pipedrive
-       * * `SendGrid` - SendGrid
-       * * `Slack` - Slack
-       * * `PagerDuty` - PagerDuty
-       * * `Asana` - Asana
-       * * `Notion` - Notion
-       * * `Airtable` - Airtable
-       * * `Greenhouse` - Greenhouse
-       * * `BambooHR` - BambooHR
-       * * `Lever` - Lever
-       * * `GitLab` - GitLab
-       * * `Datadog` - Datadog
-       * * `Sentry` - Sentry
-       * * `Pendo` - Pendo
-       * * `FullStory` - FullStory
-       * * `AmazonAds` - AmazonAds
-       * * `PinterestAds` - PinterestAds
-       * * `AppleSearchAds` - AppleSearchAds
-       * * `QuickBooks` - QuickBooks
-       * * `Xero` - Xero
-       * * `NetSuite` - NetSuite
-       * * `WooCommerce` - WooCommerce
-       * * `BigCommerce` - BigCommerce
-       * * `PayPal` - PayPal
-       * * `Square` - Square
-       * * `Zoom` - Zoom
-       * * `Trello` - Trello
-       * * `Monday` - Monday
-       * * `ClickUp` - ClickUp
-       * * `Confluence` - Confluence
-       * * `Recurly` - Recurly
-       * * `SalesLoft` - SalesLoft
-       * * `Outreach` - Outreach
-       * * `Gong` - Gong
-       * * `Calendly` - Calendly
-       * * `Typeform` - Typeform
-       * * `Iterable` - Iterable
-       * * `ZohoCRM` - ZohoCRM
-       * * `Close` - Close
-       * * `Oracle` - Oracle
-       * * `DynamoDB` - DynamoDB
-       * * `Elasticsearch` - Elasticsearch
-       * * `Kafka` - Kafka
-       * * `LaunchDarkly` - LaunchDarkly
-       * * `Braintree` - Braintree
-       * * `Recharge` - Recharge
-       * * `HelpScout` - HelpScout
-       * * `Gorgias` - Gorgias
-       * * `Instagram` - Instagram
-       * * `YouTubeAnalytics` - YouTubeAnalytics
-       * * `FacebookPages` - FacebookPages
-       * * `TwitterAds` - TwitterAds
-       * * `Workday` - Workday
-       * * `ServiceNow` - ServiceNow
-       * * `Pardot` - Pardot
-       * * `Copper` - Copper
-       * * `Front` - Front
-       * * `ChartMogul` - ChartMogul
-       * * `Zuora` - Zuora
-       * * `Paddle` - Paddle
-       * * `CircleCI` - CircleCI
-       * * `CockroachDB` - CockroachDB
-       * * `Firebase` - Firebase
-       * * `AzureBlob` - AzureBlob
-       * * `GoogleDrive` - GoogleDrive
-       * * `OneDrive` - OneDrive
-       * * `SharePoint` - SharePoint
-       * * `Box` - Box
-       * * `SFTP` - SFTP
-       * * `MicrosoftTeams` - MicrosoftTeams
-       * * `Aircall` - Aircall
-       * * `Webflow` - Webflow
-       * * `Okta` - Okta
-       * * `Auth0` - Auth0
-       * * `Productboard` - Productboard
-       * * `Smartsheet` - Smartsheet
-       * * `Wrike` - Wrike
-       * * `Plaid` - Plaid
-       * * `SurveyMonkey` - SurveyMonkey
-       * * `Eventbrite` - Eventbrite
-       * * `RingCentral` - RingCentral
-       * * `Twilio` - Twilio
-       * * `Freshsales` - Freshsales
-       * * `Shortcut` - Shortcut
-       * * `ConvertKit` - ConvertKit
-       * * `Drip` - Drip
-       * * `CampaignMonitor` - CampaignMonitor
-       * * `MailerLite` - MailerLite
-       * * `Omnisend` - Omnisend
-       * * `Brevo` - Brevo
-       * * `Postmark` - Postmark
-       * * `Granola` - Granola
-       * * `BuildBetter` - BuildBetter
-       * * `Convex` - Convex
-       * * `ClickHouse` - ClickHouse
-       * * `Plain` - Plain
-       * * `Resend` - Resend
-       * * `PgAnalyze` - PgAnalyze
-       * * `WorkOS` - WorkOS
-       * * `AmazonS3` - AmazonS3
-       * * `GoogleCloudStorage` - GoogleCloudStorage
-       * * `Databricks` - Databricks
-       * * `Dynamics365` - Dynamics365
-       * * `SalesforceMarketingCloud` - SalesforceMarketingCloud
-       * * `Db2` - Db2
-       * * `Heap` - Heap
-       * * `AdobeAnalytics` - AdobeAnalytics
-       * * `Matomo` - Matomo
-       * * `Optimizely` - Optimizely
-       * * `Adyen` - Adyen
-       * * `GoCardless` - GoCardless
-       * * `Mollie` - Mollie
-       * * `CheckoutCom` - CheckoutCom
-       * * `Branch` - Branch
-       * * `Criteo` - Criteo
-       * * `Outbrain` - Outbrain
-       * * `Taboola` - Taboola
-       * * `AdRoll` - AdRoll
-       * * `DisplayVideo360` - DisplayVideo360
-       * * `GoogleAdManager` - GoogleAdManager
-       * * `CampaignManager360` - CampaignManager360
-       * * `SearchAds360` - SearchAds360
-       * * `AdobeCommerce` - AdobeCommerce
-       * * `AmazonSellingPartner` - AmazonSellingPartner
-       * * `Ebay` - Ebay
-       * * `Commercetools` - Commercetools
-       * * `LightspeedRetail` - LightspeedRetail
-       * * `ShipStation` - ShipStation
-       * * `ConstantContact` - ConstantContact
-       * * `Mailgun` - Mailgun
-       * * `Eloqua` - Eloqua
-       * * `Sailthru` - Sailthru
-       * * `Ortto` - Ortto
-       * * `Attentive` - Attentive
-       * * `Kustomer` - Kustomer
-       * * `Dixa` - Dixa
-       * * `Gladly` - Gladly
-       * * `Qualtrics` - Qualtrics
-       * * `Delighted` - Delighted
-       * * `AzureDevOps` - AzureDevOps
-       * * `Rollbar` - Rollbar
-       * * `Opsgenie` - Opsgenie
-       * * `IncidentIo` - IncidentIo
-       * * `Pingdom` - Pingdom
-       * * `Cloudflare` - Cloudflare
-       * * `CosmosDB` - CosmosDB
-       * * `PlanetScale` - PlanetScale
-       * * `SapHana` - SapHana
-       * * `Rippling` - Rippling
-       * * `HiBob` - HiBob
-       * * `Personio` - Personio
-       * * `Deel` - Deel
-       * * `AdpWorkforceNow` - AdpWorkforceNow
-       * * `Paylocity` - Paylocity
-       * * `Gusto` - Gusto
-       * * `CultureAmp` - CultureAmp
-       * * `Lattice` - Lattice
-       * * `SageIntacct` - SageIntacct
-       * * `FreshBooks` - FreshBooks
-       * * `Expensify` - Expensify
-       * * `Ramp` - Ramp
-       * * `Brex` - Brex
-       * * `Coupa` - Coupa
-       * * `SapConcur` - SapConcur
-       * * `Apollo` - Apollo
-       * * `Crunchbase` - Crunchbase
-       * * `ZoomInfo` - ZoomInfo
-       * * `Clari` - Clari
-       * * `Chorus` - Chorus
-       * * `Coda` - Coda
-       * * `Guru` - Guru
-       * * `Dropbox` - Dropbox
-       * * `Docusign` - Docusign
-       * * `PandaDoc` - PandaDoc
-       * * `SapErp` - SapErp
-       * * `SapSuccessFactors` - SapSuccessFactors
-       * * `OracleEbs` - OracleEbs
-       * * `OracleFusion` - OracleFusion
-       * * `AmazonSNS` - AmazonSNS
-       * * `AmazonEventBridge` - AmazonEventBridge
-       * * `AmazonSQS` - AmazonSQS
-       * * `AmazonKinesis` - AmazonKinesis
-       * * `AmazonCloudWatch` - AmazonCloudWatch
-       * * `OpenAIAds` - OpenAIAds
-       * * `Custom` - Custom */
-      source_type: ExternalDataSourceTypeEnum;
-      /** Connection details as flat keys for the source_type (discover required fields with the wizard tool). Prefer references over raw secrets: pass {'credential_id': <id>} referencing the connection details the user stored via the connect-link page (discover ids with the stored_credentials endpoint) — they are merged in server-side and deleted once consumed. An already-connected OAuth integration can be passed via its id key instead (e.g. {'hubspot_integration_id': 123}). A 'schemas' array is NOT required — all discovered tables are enabled automatically with sensible sync defaults. */
-      payload?: SourceSetupPayload;
-      /**
-         * Table name prefix in HogQL, e.g. 'stripe' produces stripe_charges. Defaults to the source type.
-         * @maxLength 100
-         * @nullable
-         */
-      prefix?: string | null;
-      /**
-         * Human-readable description.
-         * @maxLength 400
-         * @nullable
-         */
-      description?: string | null;
-    }
-
-    export interface SourceSetupWebhook {
-      /** Whether the webhook was registered with the external service. When true, webhook-capable tables (including webhook-only ones) sync via real-time webhooks; when false, tables fall back to the polling sync defaults and webhook-only tables stay disabled. */
-      success: boolean;
-      /**
-         * The PostHog endpoint the external service delivers events to.
-         * @nullable
-         */
-      webhook_url: string | null;
-      /**
-         * Why webhook registration failed (e.g. the credentials lack webhook permissions).
-         * @nullable
-         */
-      error: string | null;
-      /** Webhook input names the user still needs to provide (e.g. a signing secret the external API did not return on create). Submit them via the update_webhook_inputs endpoint. */
-      pending_inputs: string[];
-    }
-
-    export interface SourceSetupResponse {
-      /** ID of the created external data source. */
-      id: string;
-      /** Outcome of automatic webhook registration. Only present for sources that support webhooks (e.g. Stripe) and have webhook-capable tables. */
-      webhook?: SourceSetupWebhook;
-    }
-
-    /**
      * * `severity` - severity
-     * * `service` - service
+    * `service` - service
      */
     export type SparklineBreakdownByEnum = typeof SparklineBreakdownByEnum[keyof typeof SparklineBreakdownByEnum];
 
@@ -41297,7 +39108,7 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-     * * `event` - event
+    * `event` - event
      */
     export type SummarizeTypeEnum = typeof SummarizeTypeEnum[keyof typeof SummarizeTypeEnum];
 
@@ -41309,14 +39120,14 @@ export namespace Schemas {
 
     export interface SummarizeRequest {
       /** Type of entity to summarize. Inferred automatically when using trace_id or generation_id.
-       *
-       * * `trace` - trace
-       * * `event` - event */
+
+      * `trace` - trace
+      * `event` - event */
       summarize_type?: SummarizeTypeEnum;
       /** Summary detail level: 'minimal' for 3-5 points, 'detailed' for 5-10 points
-       *
-       * * `minimal` - minimal
-       * * `detailed` - detailed */
+
+      * `minimal` - minimal
+      * `detailed` - detailed */
       mode?: DetailModeValueEnum;
       /** Data to summarize. For traces: {trace, hierarchy}. For events: {event}. Not required when using trace_id or generation_id. */
       data?: unknown;
@@ -41492,117 +39303,117 @@ export namespace Schemas {
       /** @nullable */
       remove_targeting_flag?: boolean | null;
       /**
-       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-       *
-       *         Basic (open-ended question)
-       *         - `id`: The question ID
-       *         - `type`: `open`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Link (a question with a link)
-       *         - `id`: The question ID
-       *         - `type`: `link`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `link`: The URL associated with the question.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Rating (a question with a rating scale)
-       *         - `id`: The question ID
-       *         - `type`: `rating`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `display`: Display style of the rating (`number` or `emoji`).
-       *         - `scale`: The scale of the rating (`number`).
-       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
-       *         - `upperBoundLabel`: Label for the upper bound of the scale.
-       *         - `isNpsQuestion`: Whether the question is an NPS rating.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Multiple choice
-       *         - `id`: The question ID
-       *         - `type`: `single_choice` or `multiple_choice`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `choices`: An array of choices for the question.
-       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Branching logic can be one of the following types:
-       *
-       *         Next question: Proceeds to the next question
-       *         ```json
-       *         {
-       *             "type": "next_question"
-       *         }
-       *         ```
-       *
-       *         End: Ends the survey, optionally displaying a confirmation message.
-       *         ```json
-       *         {
-       *             "type": "end"
-       *         }
-       *         ```
-       *
-       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-       *         ```json
-       *         {
-       *             "type": "response_based",
-       *             "responseValues": {
-       *                 "responseKey": "value"
-       *             }
-       *         }
-       *         ```
-       *
-       *         Specific question: Proceeds to a specific question by index.
-       *         ```json
-       *         {
-       *             "type": "specific_question",
-       *             "index": 2
-       *         }
-       *         ```
-       *
-       *         Translations: Each question can include inline translations.
-       *         - `translations`: Object mapping language codes to translated fields.
-       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-       *
-       *         Example with translations:
-       *         ```json
-       *         {
-       *             "id": "uuid",
-       *             "type": "rating",
-       *             "question": "How satisfied are you?",
-       *             "lowerBoundLabel": "Not satisfied",
-       *             "upperBoundLabel": "Very satisfied",
-       *             "translations": {
-       *                 "es": {
-       *                     "question": "¿Qué tan satisfecho estás?",
-       *                     "lowerBoundLabel": "No satisfecho",
-       *                     "upperBoundLabel": "Muy satisfecho"
-       *                 },
-       *                 "fr": {
-       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
-       *                 }
-       *             }
-       *         }
-       *         ```
-       *          */
+              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+
+              Basic (open-ended question)
+              - `id`: The question ID
+              - `type`: `open`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Link (a question with a link)
+              - `id`: The question ID
+              - `type`: `link`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `link`: The URL associated with the question.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Rating (a question with a rating scale)
+              - `id`: The question ID
+              - `type`: `rating`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `display`: Display style of the rating (`number` or `emoji`).
+              - `scale`: The scale of the rating (`number`).
+              - `lowerBoundLabel`: Label for the lower bound of the scale.
+              - `upperBoundLabel`: Label for the upper bound of the scale.
+              - `isNpsQuestion`: Whether the question is an NPS rating.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Multiple choice
+              - `id`: The question ID
+              - `type`: `single_choice` or `multiple_choice`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `choices`: An array of choices for the question.
+              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Branching logic can be one of the following types:
+
+              Next question: Proceeds to the next question
+              ```json
+              {
+                  "type": "next_question"
+              }
+              ```
+
+              End: Ends the survey, optionally displaying a confirmation message.
+              ```json
+              {
+                  "type": "end"
+              }
+              ```
+
+              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+              ```json
+              {
+                  "type": "response_based",
+                  "responseValues": {
+                      "responseKey": "value"
+                  }
+              }
+              ```
+
+              Specific question: Proceeds to a specific question by index.
+              ```json
+              {
+                  "type": "specific_question",
+                  "index": 2
+              }
+              ```
+
+              Translations: Each question can include inline translations.
+              - `translations`: Object mapping language codes to translated fields.
+              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+
+              Example with translations:
+              ```json
+              {
+                  "id": "uuid",
+                  "type": "rating",
+                  "question": "How satisfied are you?",
+                  "lowerBoundLabel": "Not satisfied",
+                  "upperBoundLabel": "Very satisfied",
+                  "translations": {
+                      "es": {
+                          "question": "¿Qué tan satisfecho estás?",
+                          "lowerBoundLabel": "No satisfecho",
+                          "upperBoundLabel": "Muy satisfecho"
+                      },
+                      "fr": {
+                          "question": "Dans quelle mesure êtes-vous satisfait?"
+                      }
+                  }
+              }
+              ```
+               */
       questions?: unknown;
       conditions?: unknown;
       appearance?: unknown;
@@ -41682,17 +39493,17 @@ export namespace Schemas {
       /** Survey description. */
       description?: string;
       /** Survey type.
-       *
-       * * `popover` - popover
-       * * `widget` - widget
-       * * `external_survey` - external survey
-       * * `api` - api */
+
+      * `popover` - popover
+      * `widget` - widget
+      * `external_survey` - external survey
+      * `api` - api */
       type: SurveyType;
       /** Survey scheduling behavior: 'once' = show once per user (default), 'recurring' = repeat based on iteration_count and iteration_frequency_days settings, 'always' = show every time conditions are met (mainly for widget surveys)
-       *
-       * * `once` - once
-       * * `recurring` - recurring
-       * * `always` - always */
+
+      * `once` - once
+      * `recurring` - recurring
+      * `always` - always */
       schedule?: ScheduleEnum | null;
       readonly linked_flag: MinimalFeatureFlag;
       /**
@@ -41715,117 +39526,117 @@ export namespace Schemas {
       remove_targeting_flag?: boolean | null;
       /**
          *
-       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-       *
-       *         Basic (open-ended question)
-       *         - `id`: The question ID
-       *         - `type`: `open`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Link (a question with a link)
-       *         - `id`: The question ID
-       *         - `type`: `link`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `link`: The URL associated with the question.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Rating (a question with a rating scale)
-       *         - `id`: The question ID
-       *         - `type`: `rating`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `display`: Display style of the rating (`number` or `emoji`).
-       *         - `scale`: The scale of the rating (`number`).
-       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
-       *         - `upperBoundLabel`: Label for the upper bound of the scale.
-       *         - `isNpsQuestion`: Whether the question is an NPS rating.
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Multiple choice
-       *         - `id`: The question ID
-       *         - `type`: `single_choice` or `multiple_choice`
-       *         - `question`: The text of the question.
-       *         - `description`: Optional description of the question.
-       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
-       *         - `optional`: Whether the question is optional (`boolean`).
-       *         - `buttonText`: Text displayed on the submit button.
-       *         - `choices`: An array of choices for the question.
-       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-       *         - `branching`: Branching logic for the question. See branching types below for details.
-       *
-       *         Branching logic can be one of the following types:
-       *
-       *         Next question: Proceeds to the next question
-       *         ```json
-       *         {
-       *             "type": "next_question"
-       *         }
-       *         ```
-       *
-       *         End: Ends the survey, optionally displaying a confirmation message.
-       *         ```json
-       *         {
-       *             "type": "end"
-       *         }
-       *         ```
-       *
-       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-       *         ```json
-       *         {
-       *             "type": "response_based",
-       *             "responseValues": {
-       *                 "responseKey": "value"
-       *             }
-       *         }
-       *         ```
-       *
-       *         Specific question: Proceeds to a specific question by index.
-       *         ```json
-       *         {
-       *             "type": "specific_question",
-       *             "index": 2
-       *         }
-       *         ```
-       *
-       *         Translations: Each question can include inline translations.
-       *         - `translations`: Object mapping language codes to translated fields.
-       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-       *
-       *         Example with translations:
-       *         ```json
-       *         {
-       *             "id": "uuid",
-       *             "type": "rating",
-       *             "question": "How satisfied are you?",
-       *             "lowerBoundLabel": "Not satisfied",
-       *             "upperBoundLabel": "Very satisfied",
-       *             "translations": {
-       *                 "es": {
-       *                     "question": "¿Qué tan satisfecho estás?",
-       *                     "lowerBoundLabel": "No satisfecho",
-       *                     "upperBoundLabel": "Muy satisfecho"
-       *                 },
-       *                 "fr": {
-       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
-       *                 }
-       *             }
-       *         }
-       *         ```
-       *
+              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+
+              Basic (open-ended question)
+              - `id`: The question ID
+              - `type`: `open`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Link (a question with a link)
+              - `id`: The question ID
+              - `type`: `link`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `link`: The URL associated with the question.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Rating (a question with a rating scale)
+              - `id`: The question ID
+              - `type`: `rating`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `display`: Display style of the rating (`number` or `emoji`).
+              - `scale`: The scale of the rating (`number`).
+              - `lowerBoundLabel`: Label for the lower bound of the scale.
+              - `upperBoundLabel`: Label for the upper bound of the scale.
+              - `isNpsQuestion`: Whether the question is an NPS rating.
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Multiple choice
+              - `id`: The question ID
+              - `type`: `single_choice` or `multiple_choice`
+              - `question`: The text of the question.
+              - `description`: Optional description of the question.
+              - `descriptionContentType`: Content type of the description (`html` or `text`).
+              - `optional`: Whether the question is optional (`boolean`).
+              - `buttonText`: Text displayed on the submit button.
+              - `choices`: An array of choices for the question.
+              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+              - `branching`: Branching logic for the question. See branching types below for details.
+
+              Branching logic can be one of the following types:
+
+              Next question: Proceeds to the next question
+              ```json
+              {
+                  "type": "next_question"
+              }
+              ```
+
+              End: Ends the survey, optionally displaying a confirmation message.
+              ```json
+              {
+                  "type": "end"
+              }
+              ```
+
+              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+              ```json
+              {
+                  "type": "response_based",
+                  "responseValues": {
+                      "responseKey": "value"
+                  }
+              }
+              ```
+
+              Specific question: Proceeds to a specific question by index.
+              ```json
+              {
+                  "type": "specific_question",
+                  "index": 2
+              }
+              ```
+
+              Translations: Each question can include inline translations.
+              - `translations`: Object mapping language codes to translated fields.
+              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+
+              Example with translations:
+              ```json
+              {
+                  "id": "uuid",
+                  "type": "rating",
+                  "question": "How satisfied are you?",
+                  "lowerBoundLabel": "Not satisfied",
+                  "upperBoundLabel": "Very satisfied",
+                  "translations": {
+                      "es": {
+                          "question": "¿Qué tan satisfecho estás?",
+                          "lowerBoundLabel": "No satisfecho",
+                          "upperBoundLabel": "Muy satisfecho"
+                      },
+                      "fr": {
+                          "question": "Dans quelle mesure êtes-vous satisfait?"
+                      }
+                  }
+              }
+              ```
+
          * @nullable
          */
       questions?: SurveyQuestionInputSchema[] | null;
@@ -41980,15 +39791,33 @@ export namespace Schemas {
       deleted?: boolean;
     }
 
+    export interface TaskFileRequest {
+      /** Destination folder path in the project tree (e.g. 'Tasks/Bugs'). Defaults to 'Tasks'. */
+      folder?: string;
+    }
+
+    export interface TaskFileResponse {
+      /** Identifier of the project-tree entry for this task. */
+      id: string;
+      /** Full slash-separated path of the filed task in the project tree. */
+      path: string;
+      /** File system entry type. Always 'task'. */
+      type: string;
+      /** Identifier of the task this entry points to. */
+      ref: string;
+      /** In-app link to the task. */
+      href: string;
+    }
+
     /**
      * Request body for the presence beacon and beacon-leave endpoints.
-     *
-     * `device_id` is the UUID of the caller's `UserPushToken` row, which the
-     * client received when it registered for push via `/api/users/@me/push_tokens/`.
-     * The client is expected to use the same identifier on the beacon and leave
-     * calls; if the user has unregistered the underlying push token, the value
-     * won't resolve and the call returns 404 — at which point pushes were
-     * already not going there anyway.
+
+    `device_id` is the UUID of the caller's `UserPushToken` row, which the
+    client received when it registered for push via `/api/users/@me/push_tokens/`.
+    The client is expected to use the same identifier on the beacon and leave
+    calls; if the user has unregistered the underlying push token, the value
+    won't resolve and the call returns 404 — at which point pushes were
+    already not going there anyway.
      */
     export interface TaskPresenceBeaconRequest {
       /** UUID of the caller's UserPushToken (returned by `/api/users/@me/push_tokens/` on register). */
@@ -42009,12 +39838,12 @@ export namespace Schemas {
 
     /**
      * * `plan` - plan
-     * * `context` - context
-     * * `reference` - reference
-     * * `output` - output
-     * * `artifact` - artifact
-     * * `tree_snapshot` - tree_snapshot
-     * * `user_attachment` - user_attachment
+    * `context` - context
+    * `reference` - reference
+    * `output` - output
+    * `artifact` - artifact
+    * `tree_snapshot` - tree_snapshot
+    * `user_attachment` - user_attachment
      */
     export type TaskRunArtifactTypeEnum = typeof TaskRunArtifactTypeEnum[keyof typeof TaskRunArtifactTypeEnum];
 
@@ -42038,14 +39867,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-       *
-       * * `plan` - plan
-       * * `context` - context
-       * * `reference` - reference
-       * * `output` - output
-       * * `artifact` - artifact
-       * * `tree_snapshot` - tree_snapshot
-       * * `user_attachment` - user_attachment */
+
+      * `plan` - plan
+      * `context` - context
+      * `reference` - reference
+      * `output` - output
+      * `artifact` - artifact
+      * `tree_snapshot` - tree_snapshot
+      * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -42071,14 +39900,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-       *
-       * * `plan` - plan
-       * * `context` - context
-       * * `reference` - reference
-       * * `output` - output
-       * * `artifact` - artifact
-       * * `tree_snapshot` - tree_snapshot
-       * * `user_attachment` - user_attachment */
+
+      * `plan` - plan
+      * `context` - context
+      * `reference` - reference
+      * `output` - output
+      * `artifact` - artifact
+      * `tree_snapshot` - tree_snapshot
+      * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -42141,14 +39970,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-       *
-       * * `plan` - plan
-       * * `context` - context
-       * * `reference` - reference
-       * * `output` - output
-       * * `artifact` - artifact
-       * * `tree_snapshot` - tree_snapshot
-       * * `user_attachment` - user_attachment */
+
+      * `plan` - plan
+      * `context` - context
+      * `reference` - reference
+      * `output` - output
+      * `artifact` - artifact
+      * `tree_snapshot` - tree_snapshot
+      * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -42158,9 +39987,9 @@ export namespace Schemas {
       /** Artifact contents encoded according to content_encoding */
       content: string;
       /** Encoding used for content. Use base64 for binary files and utf-8 for text payloads.
-       *
-       * * `utf-8` - utf-8
-       * * `base64` - base64 */
+
+      * `utf-8` - utf-8
+      * `base64` - base64 */
       content_encoding?: ContentEncodingEnum;
       /**
          * Optional MIME type for the artifact
@@ -42201,7 +40030,7 @@ export namespace Schemas {
 
     /**
      * * `local` - local
-     * * `cloud` - cloud
+    * `cloud` - cloud
      */
     export type TaskRunBootstrapCreateRequestEnvironmentEnum = typeof TaskRunBootstrapCreateRequestEnvironmentEnum[keyof typeof TaskRunBootstrapCreateRequestEnvironmentEnum];
 
@@ -42213,12 +40042,12 @@ export namespace Schemas {
 
     /**
      * * `default` - default
-     * * `acceptEdits` - acceptEdits
-     * * `plan` - plan
-     * * `bypassPermissions` - bypassPermissions
-     * * `auto` - auto
-     * * `read-only` - read-only
-     * * `full-access` - full-access
+    * `acceptEdits` - acceptEdits
+    * `plan` - plan
+    * `bypassPermissions` - bypassPermissions
+    * `auto` - auto
+    * `read-only` - read-only
+    * `full-access` - full-access
      */
     export type TaskRunBootstrapCreateRequestInitialPermissionModeEnum = typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnum[keyof typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnum];
 
@@ -42238,14 +40067,14 @@ export namespace Schemas {
      */
     export interface TaskRunBootstrapCreateRequest {
       /** Execution environment for the new run. Use 'cloud' for remote sandbox runs and 'local' for desktop sessions.
-       *
-       * * `local` - local
-       * * `cloud` - cloud */
+
+      * `local` - local
+      * `cloud` - cloud */
       environment?: TaskRunBootstrapCreateRequestEnvironmentEnum;
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-       *
-       * * `interactive` - interactive
-       * * `background` - background */
+
+      * `interactive` - interactive
+      * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -42256,43 +40085,43 @@ export namespace Schemas {
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-       *
-       * * `user` - user
-       * * `bot` - bot */
+
+      * `user` - user
+      * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-       *
-       * * `manual` - manual
-       * * `signal_report` - signal_report */
+
+      * `manual` - manual
+      * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
       /** Agent runtime adapter to launch for this run. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime.
-       *
-       * * `claude` - claude
-       * * `codex` - codex */
+
+      * `claude` - claude
+      * `codex` - codex */
       runtime_adapter?: RuntimeAdapterEnum;
       /** LLM model identifier to run in the selected runtime. */
       model?: string;
       /** Reasoning effort to request for models that expose an effort control.
-       *
-       * * `low` - low
-       * * `medium` - medium
-       * * `high` - high
-       * * `xhigh` - xhigh
-       * * `max` - max */
+
+      * `low` - low
+      * `medium` - medium
+      * `high` - high
+      * `xhigh` - xhigh
+      * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
       github_user_token?: string;
       /** Initial permission mode for the agent session. Claude runtimes accept PostHog permission presets like 'plan'. Codex runtimes accept native Codex modes like 'auto' and 'read-only'.
-       *
-       * * `default` - default
-       * * `acceptEdits` - acceptEdits
-       * * `plan` - plan
-       * * `bypassPermissions` - bypassPermissions
-       * * `auto` - auto
-       * * `read-only` - read-only
-       * * `full-access` - full-access */
+
+      * `default` - default
+      * `acceptEdits` - acceptEdits
+      * `plan` - plan
+      * `bypassPermissions` - bypassPermissions
+      * `auto` - auto
+      * `read-only` - read-only
+      * `full-access` - full-access */
       initial_permission_mode?: TaskRunBootstrapCreateRequestInitialPermissionModeEnum;
     }
 
@@ -42306,16 +40135,16 @@ export namespace Schemas {
      */
     export interface TaskRunCommandRequest {
       /** JSON-RPC version, must be '2.0'
-       *
-       * * `2.0` - 2.0 */
+
+      * `2.0` - 2.0 */
       jsonrpc: JsonrpcEnum;
       /** Command method to execute on the agent server
-       *
-       * * `user_message` - user_message
-       * * `cancel` - cancel
-       * * `close` - close
-       * * `permission_response` - permission_response
-       * * `set_config_option` - set_config_option */
+
+      * `user_message` - user_message
+      * `cancel` - cancel
+      * `close` - close
+      * `permission_response` - permission_response
+      * `set_config_option` - set_config_option */
       method: MethodEnum;
       /** Parameters for the command */
       params?: TaskRunCommandRequestParams;
@@ -42349,9 +40178,9 @@ export namespace Schemas {
 
     export interface TaskRunResumeRequestSchema {
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-       *
-       * * `interactive` - interactive
-       * * `background` - background */
+
+      * `interactive` - interactive
+      * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -42366,14 +40195,14 @@ export namespace Schemas {
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-       *
-       * * `user` - user
-       * * `bot` - bot */
+
+      * `user` - user
+      * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-       *
-       * * `manual` - manual
-       * * `signal_report` - signal_report */
+
+      * `manual` - manual
+      * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
@@ -42397,9 +40226,9 @@ export namespace Schemas {
       /** Artifact ids that could not be resolved for the run */
       missing_artifact_ids?: string[];
       /** Which usage limit was hit on a rate_limited error: 'burst' (daily) or 'sustained' (monthly)
-       *
-       * * `burst` - burst
-       * * `sustained` - sustained */
+
+      * `burst` - burst
+      * `sustained` - sustained */
       limit_type?: LimitTypeEnum;
       /** ISO 8601 timestamp when the hit usage limit resets, when known */
       reset_at?: string;
@@ -42422,10 +40251,7 @@ export namespace Schemas {
     export interface TaskRunStartRequest {
       /** Initial or follow-up user message to include in the run prompt. */
       pending_user_message?: string;
-      /**
-         * Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox.
-         * @items.maxLength 128
-         */
+      /** Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox. */
       pending_user_artifact_ids?: string[];
     }
 
@@ -42438,14 +40264,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-       *
-       * * `plan` - plan
-       * * `context` - context
-       * * `reference` - reference
-       * * `output` - output
-       * * `artifact` - artifact
-       * * `tree_snapshot` - tree_snapshot
-       * * `user_attachment` - user_attachment */
+
+      * `plan` - plan
+      * `context` - context
+      * `reference` - reference
+      * `output` - output
+      * `artifact` - artifact
+      * `tree_snapshot` - tree_snapshot
+      * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -42471,14 +40297,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-       *
-       * * `plan` - plan
-       * * `context` - context
-       * * `reference` - reference
-       * * `output` - output
-       * * `artifact` - artifact
-       * * `tree_snapshot` - tree_snapshot
-       * * `user_attachment` - user_attachment */
+
+      * `plan` - plan
+      * `context` - context
+      * `reference` - reference
+      * `output` - output
+      * `artifact` - artifact
+      * `tree_snapshot` - tree_snapshot
+      * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -42585,29 +40411,28 @@ export namespace Schemas {
          * @nullable
          */
       readonly user_access_level: string | null;
-      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       anonymize_ips?: boolean;
       completed_snippet_onboarding?: boolean;
       /** Filters used to identify internal/test users. Each entry is a property filter.
-       *
-       *             Supported entry types and the exact shape each accepts:
-       *
-       *             # Person property — match (or exclude) by a person property
-       *             {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
-       *
-       *             # Event property — match by an event property
-       *             {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
-       *
-       *             # Cohort membership — match (or exclude) members of a cohort.
-       *             # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
-       *             # `negation` field here — `negation` is specific to cohort *definitions*
-       *             # (the inner sub-filters that build a cohort) and is rejected by the
-       *             # property-filter schema.
-       *             {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
-       *
-       *             Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
-       *             "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
+
+                  Supported entry types and the exact shape each accepts:
+
+                  # Person property — match (or exclude) by a person property
+                  {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
+
+                  # Event property — match by an event property
+                  {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
+
+                  # Cohort membership — match (or exclude) members of a cohort.
+                  # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
+                  # `negation` field here — `negation` is specific to cohort *definitions*
+                  # (the inner sub-filters that build a cohort) and is rejected by the
+                  # property-filter schema.
+                  {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
+
+                  Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
+                  "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
       test_account_filters?: unknown;
       /** @nullable */
       test_account_filters_default_checked?: boolean | null;
@@ -42615,10 +40440,7 @@ export namespace Schemas {
       is_demo?: boolean;
       timezone?: string;
       data_attributes?: unknown;
-      /**
-         * @nullable
-         * @items.maxLength 400
-         */
+      /** @nullable */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
       /** @nullable */
@@ -42670,10 +40492,7 @@ export namespace Schemas {
       primary_dashboard?: number | null;
       /** @nullable */
       live_events_columns?: string[] | null;
-      /**
-         * @nullable
-         * @items.maxLength 200
-         */
+      /** @nullable */
       recording_domains?: (string | null)[] | null;
       cookieless_server_hash_mode?: CookielessServerHashModeEnum | null;
       /** @nullable */
@@ -42721,10 +40540,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers, used to optimize the UI layout.
-       *
-       * * `b2b` - B2B
-       * * `b2c` - B2C
-       * * `other` - Other */
+
+      * `b2b` - B2B
+      * `b2c` - B2C
+      * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /** @nullable */
       conversations_enabled?: boolean | null;
@@ -42898,11 +40717,11 @@ export namespace Schemas {
 
     export interface TextReprRequest {
       /** Type of LLM event to stringify
-       *
-       * * `$ai_generation` - $ai_generation
-       * * `$ai_span` - $ai_span
-       * * `$ai_embedding` - $ai_embedding
-       * * `$ai_trace` - $ai_trace */
+
+      * `$ai_generation` - $ai_generation
+      * `$ai_span` - $ai_span
+      * `$ai_embedding` - $ai_embedding
+      * `$ai_trace` - $ai_trace */
       event_type: EventTypeEnum;
       /** Event data to stringify. For traces, should include 'trace' and 'hierarchy' fields. */
       data: unknown;
@@ -42915,21 +40734,6 @@ export namespace Schemas {
       text: string;
       /** Metadata about the text representation */
       metadata: TextReprMetadata;
-    }
-
-    /**
-     * Payload for posting a reply or internal note to a ticket.
-     */
-    export interface TicketReplyRequest {
-      /**
-         * Reply content in markdown.
-         * @maxLength 5000
-         */
-      message: string;
-      /** If true, store as an internal note (not sent to the customer). If false, the reply is delivered to the customer over the ticket's channel. */
-      is_private?: boolean;
-      /** Optional TipTap rich content JSON for formatted messages. */
-      rich_content?: unknown;
     }
 
     export interface TopPage {
@@ -43038,11 +40842,11 @@ export namespace Schemas {
       /** UTC timestamp when the wizard started this run. Matches the timestamp encoded in session_id. */
       started_at: string;
       /** Lifecycle stage of the wizard run.
-       *
-       * * `idle` - IDLE
-       * * `running` - RUNNING
-       * * `completed` - COMPLETED
-       * * `error` - ERROR */
+
+      * `idle` - IDLE
+      * `running` - RUNNING
+      * `completed` - COMPLETED
+      * `error` - ERROR */
       run_phase: RunPhaseEnum;
       tasks: WizardTaskDTO[];
       /**
@@ -43098,7 +40902,7 @@ export namespace Schemas {
 
     /**
      * * `transcript` - transcript
-     * * `summary` - summary
+    * `summary` - summary
      */
     export type UserInterviewSearchDocumentTypeEnum = typeof UserInterviewSearchDocumentTypeEnum[keyof typeof UserInterviewSearchDocumentTypeEnum];
 
@@ -43141,9 +40945,9 @@ export namespace Schemas {
       /** ID of the matched UserInterview. */
       interview_id: string;
       /** Which document type matched — `transcript` is the raw conversation, `summary` is the AI-generated abstract.
-       *
-       * * `transcript` - transcript
-       * * `summary` - summary */
+
+      * `transcript` - transcript
+      * `summary` - summary */
       document_type: UserInterviewSearchDocumentTypeEnum;
       /** Cosine similarity in [0, 1]; higher is closer to the query. Computed as `1 - cosineDistance`. */
       similarity: number;
@@ -43164,10 +40968,10 @@ export namespace Schemas {
       /** PostHog UserPushToken row id. */
       id: string;
       /** Device platform the token was issued for.
-       *
-       * * `ios` - iOS
-       * * `android` - Android
-       * * `web` - Web */
+
+      * `ios` - iOS
+      * `android` - Android
+      * `web` - Web */
       platform: PushTokenPlatformEnum;
       /** When this token was first registered. */
       created_at: string;
@@ -43182,10 +40986,10 @@ export namespace Schemas {
          */
       token: string;
       /** Device platform the token was issued for. One of `ios`, `android`, or `web`.
-       *
-       * * `ios` - iOS
-       * * `android` - Android
-       * * `web` - Web */
+
+      * `ios` - iOS
+      * `android` - Android
+      * `web` - Web */
       platform: PushTokenPlatformEnum;
     }
 
@@ -43205,16 +41009,16 @@ export namespace Schemas {
       /** Number of pageview events with this UTM combination */
       event_count: number;
       /** How utm_campaign matched: none, auto (direct name/id), or mapped (manual mapping)
-       *
-       * * `none` - none
-       * * `auto` - auto
-       * * `mapped` - mapped */
+
+      * `none` - none
+      * `auto` - auto
+      * `mapped` - mapped */
       campaign_match: SourceMatchEnum;
       /** How utm_source matched: none, auto (default source), or mapped (custom mapping)
-       *
-       * * `none` - none
-       * * `auto` - auto
-       * * `mapped` - mapped */
+
+      * `none` - none
+      * `auto` - auto
+      * `mapped` - mapped */
       source_match: SourceMatchEnum;
       /**
          * Name of the matched campaign, if any
@@ -43236,27 +41040,6 @@ export namespace Schemas {
       results: CampaignAuditResult[];
       /** All UTM events with match status */
       all_utm_events: UtmEvent[];
-    }
-
-    export interface UtmMappingSuggestionsResponse {
-      /** Suggested custom_source_mappings entries */
-      source_suggestions: SourceMappingSuggestion[];
-      /** Suggested campaign-name clusters (empty in v1) */
-      campaign_suggestions: CampaignMappingSuggestion[];
-      /** All unmatched raw utm_source values worth reviewing */
-      raw_unmatched_samples: RawUnmatchedSample[];
-      /** Every utm_source value seen in the window, matched or not */
-      full_utm_source_catalogue: CatalogueEntry[];
-      /** Mappings already in effect (canonical + team_custom) */
-      current_mappings: CurrentMapping[];
-      /** Total events with an unmatched utm_source */
-      total_unmatched_events_in_window: number;
-      /** Total events with any utm_source */
-      total_events_with_utm_in_window: number;
-      /** Lookback window in days used for the analysis */
-      lookback_days_used: number;
-      /** Caveats and guidance about the suggestions */
-      notes: string[];
     }
 
     export interface ViewLinkValidation {
@@ -43283,17 +41066,15 @@ export namespace Schemas {
       readonly period_start: string;
       /** First moment of the next quota period (UTC); the current period's exclusive upper bound. */
       readonly period_end: string;
-      /** Sum of enabled scanners' projected observations/month across the organization. Scanners without a computed estimate contribute 0. */
-      readonly projected_monthly_observations: number;
     }
 
     /**
      * * `pending` - pending
-     * * `provisioning` - provisioning
-     * * `ready` - ready
-     * * `failed` - failed
-     * * `deleting` - deleting
-     * * `deleted` - deleted
+    * `provisioning` - provisioning
+    * `ready` - ready
+    * `failed` - failed
+    * `deleting` - deleting
+    * `deleted` - deleted
      */
     export type WarehouseStatusResponseStateEnum = typeof WarehouseStatusResponseStateEnum[keyof typeof WarehouseStatusResponseStateEnum];
 
@@ -43389,7 +41170,25 @@ export namespace Schemas {
       is_organization_first_user: boolean;
     }
 
-    export type WidgetCatalogEntry = ErrorTrackingListWidgetCatalogEntryOpenApi | SessionReplayListWidgetCatalogEntryOpenApi;
+    export interface WidgetCatalogEntry {
+      /** Stable widget type identifier used in API requests. */
+      widget_type: string;
+      /** Product area key for grouping related widget variants. */
+      group_id: string;
+      /** Human-readable product area label. */
+      group_label: string;
+      /** Widget variant label within the product area. */
+      label: string;
+      /** Short description of what the widget shows. */
+      description: string;
+      /** JSON schema hints for config fields (types, choices, bounds). Not a strict validator. */
+      config_schema_hints: unknown;
+      /**
+         * Product access resource required to view or run this widget, if any.
+         * @nullable
+         */
+      required_product_access?: string | null;
+    }
 
     export interface WidgetCatalogResponse {
       /** Registered dashboard widget types available when dashboard-widgets is enabled. */
@@ -43473,9 +41272,9 @@ export namespace Schemas {
       /** Property filter type: "log_attribute" or "log_resource_attribute". Use this as the `type` field when filtering. */
       propertyFilterType: string;
       /** How the search query matched this row: "key" if the attribute key matched, "value" if a value matched.
-       *
-       * * `key` - key
-       * * `value` - value */
+
+      * `key` - key
+      * `value` - value */
       matchedOn: MatchedOnEnum;
       /**
          * Sample matching value — only set when matchedOn is "value".
@@ -43530,8 +41329,8 @@ export namespace Schemas {
 
     /**
      * * `log` - log
-     * * `log_attribute` - log_attribute
-     * * `log_resource_attribute` - log_resource_attribute
+    * `log_attribute` - log_attribute
+    * `log_resource_attribute` - log_resource_attribute
      */
     export type _LogPropertyFilterTypeEnum = typeof _LogPropertyFilterTypeEnum[keyof typeof _LogPropertyFilterTypeEnum];
 
@@ -43544,18 +41343,18 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-     * * `is_not` - is_not
-     * * `icontains` - icontains
-     * * `not_icontains` - not_icontains
-     * * `regex` - regex
-     * * `not_regex` - not_regex
-     * * `gt` - gt
-     * * `lt` - lt
-     * * `is_date_exact` - is_date_exact
-     * * `is_date_before` - is_date_before
-     * * `is_date_after` - is_date_after
-     * * `is_set` - is_set
-     * * `is_not_set` - is_not_set
+    * `is_not` - is_not
+    * `icontains` - icontains
+    * `not_icontains` - not_icontains
+    * `regex` - regex
+    * `not_regex` - not_regex
+    * `gt` - gt
+    * `lt` - lt
+    * `is_date_exact` - is_date_exact
+    * `is_date_before` - is_date_before
+    * `is_date_after` - is_date_after
+    * `is_set` - is_set
+    * `is_not_set` - is_not_set
      */
     export type _LogPropertyFilterOperatorEnum = typeof _LogPropertyFilterOperatorEnum[keyof typeof _LogPropertyFilterOperatorEnum];
 
@@ -43580,26 +41379,26 @@ export namespace Schemas {
       /** Attribute key. For type "log", use "message". For "log_attribute"/"log_resource_attribute", use the attribute key (e.g. "k8s.container.name"). */
       key: string;
       /** "log" filters the log body/message. "log_attribute" filters log-level attributes. "log_resource_attribute" filters resource-level attributes.
-       *
-       * * `log` - log
-       * * `log_attribute` - log_attribute
-       * * `log_resource_attribute` - log_resource_attribute */
+
+      * `log` - log
+      * `log_attribute` - log_attribute
+      * `log_resource_attribute` - log_resource_attribute */
       type: _LogPropertyFilterTypeEnum;
       /** Comparison operator.
-       *
-       * * `exact` - exact
-       * * `is_not` - is_not
-       * * `icontains` - icontains
-       * * `not_icontains` - not_icontains
-       * * `regex` - regex
-       * * `not_regex` - not_regex
-       * * `gt` - gt
-       * * `lt` - lt
-       * * `is_date_exact` - is_date_exact
-       * * `is_date_before` - is_date_before
-       * * `is_date_after` - is_date_after
-       * * `is_set` - is_set
-       * * `is_not_set` - is_not_set */
+
+      * `exact` - exact
+      * `is_not` - is_not
+      * `icontains` - icontains
+      * `not_icontains` - not_icontains
+      * `regex` - regex
+      * `not_regex` - not_regex
+      * `gt` - gt
+      * `lt` - lt
+      * `is_date_exact` - is_date_exact
+      * `is_date_before` - is_date_before
+      * `is_date_after` - is_date_after
+      * `is_set` - is_set
+      * `is_not_set` - is_not_set */
       operator: _LogPropertyFilterOperatorEnum;
       /** Value to compare against. String, number, or array of strings. Omit for is_set/is_not_set operators. */
       value?: unknown;
@@ -43683,9 +41482,9 @@ export namespace Schemas {
       /** Filter by service names. */
       serviceNames?: string[];
       /** Order results by timestamp.
-       *
-       * * `latest` - latest
-       * * `earliest` - earliest */
+
+      * `latest` - latest
+      * `earliest` - earliest */
       orderBy?: OrderByEnum;
       /** Full-text search term to filter log bodies. */
       searchTerm?: string;
@@ -43808,9 +41607,9 @@ export namespace Schemas {
       /** Property filters for the query. */
       filterGroup?: _LogPropertyFilter[];
       /** Break down sparkline by "severity" (default) or "service".
-       *
-       * * `severity` - severity
-       * * `service` - service */
+
+      * `severity` - severity
+      * `service` - service */
       sparklineBreakdownBy?: SparklineBreakdownByEnum;
     }
 
@@ -43862,11 +41661,11 @@ export namespace Schemas {
          */
       metricName: string;
       /** Aggregation applied per time bucket.
-       *
-       * * `sum` - sum
-       * * `avg` - avg
-       * * `count` - count
-       * * `p95` - p95 */
+
+      * `sum` - sum
+      * `avg` - avg
+      * `count` - count
+      * `p95` - p95 */
       aggregation?: AggregationEnum;
       /** Lower bound (inclusive) for the query range. ISO 8601. */
       dateFrom: string;
@@ -43893,8 +41692,8 @@ export namespace Schemas {
 
     /**
      * * `span` - span
-     * * `span_attribute` - span_attribute
-     * * `span_resource_attribute` - span_resource_attribute
+    * `span_attribute` - span_attribute
+    * `span_resource_attribute` - span_resource_attribute
      */
     export type _SpanPropertyFilterTypeEnum = typeof _SpanPropertyFilterTypeEnum[keyof typeof _SpanPropertyFilterTypeEnum];
 
@@ -43907,15 +41706,15 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-     * * `is_not` - is_not
-     * * `icontains` - icontains
-     * * `not_icontains` - not_icontains
-     * * `regex` - regex
-     * * `not_regex` - not_regex
-     * * `gt` - gt
-     * * `lt` - lt
-     * * `is_set` - is_set
-     * * `is_not_set` - is_not_set
+    * `is_not` - is_not
+    * `icontains` - icontains
+    * `not_icontains` - not_icontains
+    * `regex` - regex
+    * `not_regex` - not_regex
+    * `gt` - gt
+    * `lt` - lt
+    * `is_set` - is_set
+    * `is_not_set` - is_not_set
      */
     export type _SpanPropertyFilterOperatorEnum = typeof _SpanPropertyFilterOperatorEnum[keyof typeof _SpanPropertyFilterOperatorEnum];
 
@@ -43937,23 +41736,23 @@ export namespace Schemas {
       /** Attribute key. For type "span", use built-in fields (trace_id, span_id, duration, name, kind, status_code, is_root_span). For "span_attribute"/"span_resource_attribute", use the attribute key (e.g. "http.method"). */
       key: string;
       /** "span" filters built-in span fields. "span_attribute" filters span-level attributes. "span_resource_attribute" filters resource-level attributes.
-       *
-       * * `span` - span
-       * * `span_attribute` - span_attribute
-       * * `span_resource_attribute` - span_resource_attribute */
+
+      * `span` - span
+      * `span_attribute` - span_attribute
+      * `span_resource_attribute` - span_resource_attribute */
       type: _SpanPropertyFilterTypeEnum;
       /** Comparison operator.
-       *
-       * * `exact` - exact
-       * * `is_not` - is_not
-       * * `icontains` - icontains
-       * * `not_icontains` - not_icontains
-       * * `regex` - regex
-       * * `not_regex` - not_regex
-       * * `gt` - gt
-       * * `lt` - lt
-       * * `is_set` - is_set
-       * * `is_not_set` - is_not_set */
+
+      * `exact` - exact
+      * `is_not` - is_not
+      * `icontains` - icontains
+      * `not_icontains` - not_icontains
+      * `regex` - regex
+      * `not_regex` - not_regex
+      * `gt` - gt
+      * `lt` - lt
+      * `is_set` - is_set
+      * `is_not_set` - is_not_set */
       operator: _SpanPropertyFilterOperatorEnum;
       /** Value to compare against. String, number, or array of strings. Omit for is_set/is_not_set operators. */
       value?: unknown;
@@ -43993,39 +41792,6 @@ export namespace Schemas {
       query: _TracingAggregationQueryBody;
     }
 
-    export interface _TracingCountBody {
-      /** Date range for the count. Defaults to last hour. */
-      dateRange?: _TracingDateRange;
-      /** Filter by service names. */
-      serviceNames?: string[];
-      /** Filter by HTTP status codes. */
-      statusCodes?: number[];
-      /** Property filters for the count. */
-      filterGroup?: _SpanPropertyFilter[];
-    }
-
-    export interface _TracingCountRequest {
-      /** The span count query to execute. */
-      query: _TracingCountBody;
-    }
-
-    export interface _TracingCountResponse {
-      /** Number of spans matching the filters. */
-      count: number;
-    }
-
-    /**
-     * * `timestamp` - timestamp
-     * * `duration` - duration
-     */
-    export type _TracingQueryBodyOrderByEnum = typeof _TracingQueryBodyOrderByEnum[keyof typeof _TracingQueryBodyOrderByEnum];
-
-
-    export const _TracingQueryBodyOrderByEnum = {
-      Timestamp: 'timestamp',
-      Duration: 'duration',
-    } as const;
-
     export interface _TracingQueryBody {
       /** Date range for the query. Defaults to last hour. */
       dateRange?: _TracingDateRange;
@@ -44033,34 +41799,24 @@ export namespace Schemas {
       serviceNames?: string[];
       /** Filter by HTTP status codes. */
       statusCodes?: number[];
-      /** Column to order by. Defaults to timestamp. Ordering by timestamp paginates via the keyset cursor ('after'); ordering by duration paginates via 'offset'.
-       *
-       * * `timestamp` - timestamp
-       * * `duration` - duration */
-      orderBy?: _TracingQueryBodyOrderByEnum;
-      /** Order direction. Defaults to DESC (e.g. timestamp+DESC = newest first, duration+DESC = slowest first).
-       *
-       * * `ASC` - ASC
-       * * `DESC` - DESC */
-      orderDirection?: OrderDirectionEnum;
+      /** Order results by timestamp. Defaults to latest.
+
+      * `latest` - latest
+      * `earliest` - earliest */
+      orderBy?: OrderByEnum;
       /** Property filters for the query. */
       filterGroup?: _SpanPropertyFilter[];
       /** Filter to a specific trace ID (hex string). */
       traceId?: string;
       /** Max results (1-1000). Defaults to 100. */
       limit?: number;
-      /** Keyset pagination cursor from a previous timestamp-ordered response. */
+      /** Pagination cursor from previous response. */
       after?: string;
-      /**
-         * Pagination offset, used when ordering by a column (e.g. duration). Defaults to 0.
-         * @minimum 0
-         */
-      offset?: number;
       /** Filter to root spans only. Defaults to true. */
       rootSpans?: boolean;
       /** Number of child spans to prefetch per trace (1-100). */
       prefetchSpans?: number;
-      /** Omit the per-span attributes and resource attributes maps from results to keep payloads compact. Defaults to false. */
+      /** Omit the per-span attributes map from results to keep payloads compact. Defaults to false. */
       excludeAttributes?: boolean;
     }
 
@@ -44072,7 +41828,7 @@ export namespace Schemas {
     export interface _TracingTraceRequest {
       /** Date range for the query. Defaults to last 24 hours. */
       dateRange?: _TracingDateRange;
-      /** Omit the per-span attributes and resource attributes maps from results to keep payloads compact. Defaults to false. */
+      /** Omit the per-span attributes map from results to keep payloads compact. Defaults to false. */
       excludeAttributes?: boolean;
     }
 
@@ -44148,14 +41904,6 @@ export namespace Schemas {
 
     export type EnvironmentsAlertsListParams = {
     /**
-     * Optional. Restrict results to alerts created by the user with this UUID.
-     */
-    created_by?: string;
-    /**
-     * Optional. Restrict results to alerts on this insight ID.
-     */
-    insight_id?: number;
-    /**
      * Number of results to return per page.
      */
     limit?: number;
@@ -44163,10 +41911,6 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
-    /**
-     * Optional. Fuzzy match against alert `name` using Postgres trigram word similarity (handles typos, transpositions, and prefix-as-you-type). Results are ordered by relevance, then creation time. Capped at 200 characters; longer queries return a 400 error.
-     */
-    search?: string;
     };
 
     export type EnvironmentsAlertsRetrieveParams = {
@@ -44381,7 +42125,7 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Optional. Match against dashboard `name`, `description`, and tag names. Returns case-insensitive substring matches and fuzzy trigram matches (typos, transpositions, prefix-as-you-type) together, ordered exact-first, then pinned status, then name; each result's `search_match_type` is `exact` or `similar`. When omitted, dashboards are ordered by pinned status then alphabetical name. Capped at 200 characters; longer queries return a 400 error.
+     * Optional. Fuzzy match against dashboard `name` and `description` using Postgres trigram word similarity (handles typos, transpositions, and prefix-as-you-type). `name` matches rank above `description` matches. Results are ordered by relevance, then pinned status, then name. When omitted, dashboards are ordered by pinned status then alphabetical name. Capped at 200 characters; longer queries return a 400 error.
      */
     search?: string;
     };
@@ -44793,11 +42537,11 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-     *
-     * * `created_at` - Created At
-     * * `-created_at` - Created At (descending)
-     * * `updated_at` - Updated At
-     * * `-updated_at` - Updated At (descending)
+
+    * `created_at` - Created At
+    * `-created_at` - Created At (descending)
+    * `updated_at` - Updated At
+    * `-updated_at` - Updated At (descending)
      */
     order_by?: string[];
     /**
@@ -44839,38 +42583,6 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
-    };
-
-    export type EnvironmentsEndpointsLogsRetrieveParams = {
-    /**
-     * Only return entries after this ISO 8601 timestamp.
-     */
-    after?: string;
-    /**
-     * Only return entries before this ISO 8601 timestamp.
-     */
-    before?: string;
-    /**
-     * Filter logs to a specific execution instance.
-     * @minLength 1
-     */
-    instance_id?: string;
-    /**
-     * Comma-separated log levels to include, e.g. 'WARN,ERROR'. Valid levels: DEBUG, LOG, INFO, WARN, ERROR.
-     * @minLength 1
-     */
-    level?: string;
-    /**
-     * Maximum number of log entries to return (1-500, default 50).
-     * @minimum 1
-     * @maximum 500
-     */
-    limit?: number;
-    /**
-     * Case-insensitive substring search across log messages.
-     * @minLength 1
-     */
-    search?: string;
     };
 
     export type EnvironmentsEndpointsOpenapiSpecRetrieveParams = {
@@ -45049,13 +42761,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort order for symbol sets. Prefix with `-` for descending order.
-     *
-     * * `created_at` - created_at
-     * * `-created_at` - -created_at
-     * * `ref` - ref
-     * * `-ref` - -ref
-     * * `last_used` - last_used
-     * * `-last_used` - -last_used
+
+    * `created_at` - created_at
+    * `-created_at` - -created_at
+    * `ref` - ref
+    * `-ref` - -ref
+    * `last_used` - last_used
+    * `-last_used` - -last_used
      * @minLength 1
      */
     order_by?: string;
@@ -45071,10 +42783,10 @@ export namespace Schemas {
     search?: string;
     /**
      * Upload status filter: `valid` has an uploaded file, `invalid` is missing a file, `all` returns both.
-     *
-     * * `all` - all
-     * * `valid` - valid
-     * * `invalid` - invalid
+
+    * `all` - all
+    * `valid` - valid
+    * `invalid` - invalid
      * @minLength 1
      */
     status?: EnvironmentsErrorTrackingSymbolSetsListStatus;
@@ -45110,13 +42822,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-     *
-     * * `created_at` - Created At
-     * * `-created_at` - Created At (descending)
-     * * `updated_at` - Updated At
-     * * `-updated_at` - Updated At (descending)
-     * * `name` - Name
-     * * `-name` - Name (descending)
+
+    * `created_at` - Created At
+    * `-created_at` - Created At (descending)
+    * `updated_at` - Updated At
+    * `-updated_at` - Updated At (descending)
+    * `name` - Name
+    * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -45274,13 +42986,6 @@ export namespace Schemas {
       errors?: string[];
     };
 
-    export type EnvironmentsExternalDataSourcesConnectLinkRetrieveParams = {
-    /**
-     * The source type to generate a connect link for (e.g. 'Stripe', 'Postgres', 'Hubspot').
-     */
-    source_type: string;
-    };
-
     export type EnvironmentsExternalDataSourcesConnectionsListParams = {
     /**
      * Number of results to return per page.
@@ -45294,17 +42999,6 @@ export namespace Schemas {
      * A search term.
      */
     search?: string;
-    };
-
-    export type EnvironmentsExternalDataSourcesStoredCredentialsListParams = {
-    /**
-     * A search term.
-     */
-    search?: string;
-    /**
-     * Only return stored credentials for this source type (e.g. 'Stripe', 'Postgres').
-     */
-    source_type?: string;
     };
 
     export type EnvironmentsFileDownloadBatchExportsListParams = {
@@ -45502,9 +43196,9 @@ export namespace Schemas {
     export type EnvironmentsHeatmapsListParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-     *
-     * * `unique_visitors` - unique_visitors
-     * * `total_count` - total_count
+
+    * `unique_visitors` - unique_visitors
+    * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: EnvironmentsHeatmapsListAggregation;
@@ -45568,9 +43262,9 @@ export namespace Schemas {
     export type EnvironmentsHeatmapsEventsRetrieveParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-     *
-     * * `unique_visitors` - unique_visitors
-     * * `total_count` - total_count
+
+    * `unique_visitors` - unique_visitors
+    * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: EnvironmentsHeatmapsEventsRetrieveAggregation;
@@ -45704,8 +43398,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * * `draft` - Draft
-     * * `active` - Active
-     * * `archived` - Archived
+    * `active` - Active
+    * `archived` - Archived
      */
     status?: EnvironmentsHogFlowsListStatus;
     updated_at?: string;
@@ -45794,9 +43488,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-     *
-     * * `name` - name
-     * * `kind` - kind
+
+    * `name` - name
+    * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFlowsMetricsRetrieveBreakdownBy;
@@ -45807,10 +43501,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-     *
-     * * `hour` - hour
-     * * `day` - day
-     * * `week` - week
+
+    * `hour` - hour
+    * `day` - day
+    * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFlowsMetricsRetrieveInterval;
@@ -45856,9 +43550,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-     *
-     * * `name` - name
-     * * `kind` - kind
+
+    * `name` - name
+    * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFlowsMetricsTotalsRetrieveBreakdownBy;
@@ -45869,10 +43563,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-     *
-     * * `hour` - hour
-     * * `day` - day
-     * * `week` - week
+
+    * `hour` - hour
+    * `day` - day
+    * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFlowsMetricsTotalsRetrieveInterval;
@@ -45983,9 +43677,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-     *
-     * * `name` - name
-     * * `kind` - kind
+
+    * `name` - name
+    * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFunctionsMetricsRetrieveBreakdownBy;
@@ -45996,10 +43690,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-     *
-     * * `hour` - hour
-     * * `day` - day
-     * * `week` - week
+
+    * `hour` - hour
+    * `day` - day
+    * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFunctionsMetricsRetrieveInterval;
@@ -46045,9 +43739,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-     *
-     * * `name` - name
-     * * `kind` - kind
+
+    * `name` - name
+    * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFunctionsMetricsTotalsRetrieveBreakdownBy;
@@ -46058,10 +43752,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-     *
-     * * `hour` - hour
-     * * `day` - day
-     * * `week` - week
+
+    * `hour` - hour
+    * `day` - day
+    * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFunctionsMetricsTotalsRetrieveInterval;
@@ -46157,14 +43851,14 @@ export namespace Schemas {
     offset?: number;
     /**
      *
-     * Whether to refresh the retrieved insights, how aggressively, and if sync or async:
-     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
-     * Background calculation can be tracked using the `query_status` response field.
+    Whether to refresh the retrieved insights, how aggressively, and if sync or async:
+    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+    - `'force_async'` - kick off background calculation, even if fresh results are already cached
+    Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: EnvironmentsInsightsListRefresh;
     /**
@@ -46252,20 +43946,20 @@ export namespace Schemas {
     format?: EnvironmentsInsightsRetrieveFormat;
     /**
      *
-     * Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
-     * When set, the specified dashboard's filters and date range override will be applied.
+    Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
+    When set, the specified dashboard's filters and date range override will be applied.
      */
     from_dashboard?: number;
     /**
      *
-     * Whether to refresh the insight, how aggresively, and if sync or async:
-     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
-     * Background calculation can be tracked using the `query_status` response field.
+    Whether to refresh the insight, how aggresively, and if sync or async:
+    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+    - `'force_async'` - kick off background calculation, even if fresh results are already cached
+    Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: EnvironmentsInsightsRetrieveRefresh;
     /**
@@ -46494,41 +44188,41 @@ export namespace Schemas {
     export type EnvironmentsIntegrationsListParams = {
     /**
      * * `anthropic` - Anthropic
-     * * `apns` - Apple Push
-     * * `azure-blob` - Azure Blob
-     * * `bing-ads` - Bing Ads
-     * * `clickup` - Clickup
-     * * `customerio-app` - Customerio App
-     * * `customerio-track` - Customerio Track
-     * * `customerio-webhook` - Customerio Webhook
-     * * `databricks` - Databricks
-     * * `email` - Email
-     * * `firebase` - Firebase
-     * * `github` - Github
-     * * `gitlab` - Gitlab
-     * * `google-ads` - Google Ads
-     * * `google-cloud-service-account` - Google Cloud Service Account
-     * * `google-cloud-storage` - Google Cloud Storage
-     * * `google-pubsub` - Google Pubsub
-     * * `google-search-console` - Google Search Console
-     * * `google-sheets` - Google Sheets
-     * * `hubspot` - Hubspot
-     * * `intercom` - Intercom
-     * * `jira` - Jira
-     * * `linear` - Linear
-     * * `linkedin-ads` - Linkedin Ads
-     * * `meta-ads` - Meta Ads
-     * * `pinterest-ads` - Pinterest Ads
-     * * `postgresql` - Postgresql
-     * * `reddit-ads` - Reddit Ads
-     * * `salesforce` - Salesforce
-     * * `slack` - Slack
-     * * `slack-posthog-code` - Slack Posthog Code
-     * * `snapchat` - Snapchat
-     * * `stripe` - Stripe
-     * * `tiktok-ads` - Tiktok Ads
-     * * `twilio` - Twilio
-     * * `vercel` - Vercel
+    * `apns` - Apple Push
+    * `azure-blob` - Azure Blob
+    * `bing-ads` - Bing Ads
+    * `clickup` - Clickup
+    * `customerio-app` - Customerio App
+    * `customerio-track` - Customerio Track
+    * `customerio-webhook` - Customerio Webhook
+    * `databricks` - Databricks
+    * `email` - Email
+    * `firebase` - Firebase
+    * `github` - Github
+    * `gitlab` - Gitlab
+    * `google-ads` - Google Ads
+    * `google-cloud-service-account` - Google Cloud Service Account
+    * `google-cloud-storage` - Google Cloud Storage
+    * `google-pubsub` - Google Pubsub
+    * `google-search-console` - Google Search Console
+    * `google-sheets` - Google Sheets
+    * `hubspot` - Hubspot
+    * `intercom` - Intercom
+    * `jira` - Jira
+    * `linear` - Linear
+    * `linkedin-ads` - Linkedin Ads
+    * `meta-ads` - Meta Ads
+    * `pinterest-ads` - Pinterest Ads
+    * `postgresql` - Postgresql
+    * `reddit-ads` - Reddit Ads
+    * `salesforce` - Salesforce
+    * `slack` - Slack
+    * `slack-posthog-code` - Slack Posthog Code
+    * `snapchat` - Snapchat
+    * `stripe` - Stripe
+    * `tiktok-ads` - Tiktok Ads
+    * `twilio` - Twilio
+    * `vercel` - Vercel
      */
     kind?: EnvironmentsIntegrationsListKind;
     /**
@@ -46888,10 +44582,10 @@ export namespace Schemas {
     export type EnvironmentsLlmPromptsListParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-     *
-     * * `full` - full
-     * * `preview` - preview
-     * * `none` - none
+
+    * `full` - full
+    * `preview` - preview
+    * `none` - none
      * @minLength 1
      */
     content?: EnvironmentsLlmPromptsListContent;
@@ -46925,10 +44619,10 @@ export namespace Schemas {
     export type EnvironmentsLlmPromptsNameRetrieveParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-     *
-     * * `full` - full
-     * * `preview` - preview
-     * * `none` - none
+
+    * `full` - full
+    * `preview` - preview
+    * `none` - none
      * @minLength 1
      */
     content?: EnvironmentsLlmPromptsNameRetrieveContent;
@@ -47072,9 +44766,9 @@ export namespace Schemas {
     export type EnvironmentsLogsAttributesRetrieveParams = {
     /**
      * Type of attributes: "log" for log attributes, "resource" for resource attributes. Defaults to "log".
-     *
-     * * `log` - log
-     * * `resource` - resource
+
+    * `log` - log
+    * `resource` - resource
      * @minLength 1
      */
     attribute_type?: EnvironmentsLogsAttributesRetrieveAttributeType;
@@ -47149,9 +44843,9 @@ export namespace Schemas {
     export type EnvironmentsLogsValuesRetrieveParams = {
     /**
      * Type of attribute: "log" or "resource". Defaults to "log".
-     *
-     * * `log` - log
-     * * `resource` - resource
+
+    * `log` - log
+    * `resource` - resource
      * @minLength 1
      */
     attribute_type?: EnvironmentsLogsValuesRetrieveAttributeType;
@@ -47198,74 +44892,6 @@ export namespace Schemas {
     offset?: number;
     };
 
-    export type EnvironmentsMarketingAnalyticsDataSourcesRetrieveParams = {
-    /**
-     * Optional. Restrict to one integration (e.g. 'GoogleAds').
-     * @nullable
-     */
-    source_type?: string | null;
-    };
-
-    export type EnvironmentsMarketingAnalyticsDiagnoseRetrieveParams = {
-    /**
-     * Lookback window for attribution health (1-365 days); defaults to 7
-     * @minimum 1
-     * @maximum 365
-     */
-    attribution_lookback_days?: number;
-    /**
-     * Whether to include the conversion-goal summary in the diagnostic
-     */
-    include_conversion_goals?: boolean;
-    /**
-     * Optional integration filter
-     * @nullable
-     */
-    source_type?: string | null;
-    };
-
-    export type EnvironmentsMarketingAnalyticsExplainConversionGoalRetrieveParams = {
-    /**
-     * ISO start; defaults to 30 days ago
-     * @nullable
-     */
-    date_from?: string | null;
-    /**
-     * ISO end; defaults to now
-     * @nullable
-     */
-    date_to?: string | null;
-    /**
-     * Id of the conversion goal to explain (from list_conversion_goals).
-     * @minLength 1
-     */
-    goal_id: string;
-    };
-
-    export type EnvironmentsMarketingAnalyticsSuggestConversionGoalsRetrieveParams = {
-    /**
-     * Minimum 30d event count to be a candidate
-     */
-    min_count?: number;
-    /**
-     * Max candidates to return
-     */
-    top_n?: number;
-    };
-
-    export type EnvironmentsMarketingAnalyticsSuggestUtmMappingsRetrieveParams = {
-    /**
-     * Days of history to inspect (1-365); defaults to 90
-     * @minimum 1
-     * @maximum 365
-     */
-    lookback_days?: number;
-    /**
-     * Only suggest for raw values with >= this many events
-     */
-    min_event_count?: number;
-    };
-
     export type EnvironmentsMarketingAnalyticsUtmAuditRetrieveParams = {
     /**
      * Start date for the audit period
@@ -47304,7 +44930,7 @@ export namespace Schemas {
     export type EnvironmentsMcpServerInstallationsAuthorizeRetrieveParams = {
     /**
      * * `posthog` - posthog
-     * * `posthog-code` - posthog-code
+    * `posthog-code` - posthog-code
      * @minLength 1
      */
     install_source?: EnvironmentsMcpServerInstallationsAuthorizeRetrieveInstallSource;
@@ -47951,13 +45577,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-     *
-     * * `created_at` - Created At
-     * * `-created_at` - Created At (descending)
-     * * `updated_at` - Updated At
-     * * `-updated_at` - Updated At (descending)
-     * * `name` - Name
-     * * `-name` - Name (descending)
+
+    * `created_at` - Created At
+    * `-created_at` - Created At (descending)
+    * `updated_at` - Updated At
+    * `-updated_at` - Updated At (descending)
+    * `name` - Name
+    * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -47969,9 +45595,9 @@ export namespace Schemas {
     export type EnvironmentsTracingSpansAttributesRetrieveParams = {
     /**
      * Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-     *
-     * * `span_attribute` - span_attribute
-     * * `span_resource_attribute` - span_resource_attribute
+
+    * `span_attribute` - span_attribute
+    * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: EnvironmentsTracingSpansAttributesRetrieveAttributeType;
@@ -48017,10 +45643,10 @@ export namespace Schemas {
     export type EnvironmentsTracingSpansValuesRetrieveParams = {
     /**
      * Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-     *
-     * * `span` - span
-     * * `span_attribute` - span_attribute
-     * * `span_resource_attribute` - span_resource_attribute
+
+    * `span` - span
+    * `span_attribute` - span_attribute
+    * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: EnvironmentsTracingSpansValuesRetrieveAttributeType;
@@ -48199,10 +45825,6 @@ export namespace Schemas {
     };
 
     export type EnvironmentsVisionScannersObservationsStatsRetrieveParams = {
-    /**
-     * Window size in days for the coverage `recent_sessions` count. Clamped to [1, 365]. Defaults to 14 when omitted.
-     */
-    recent_days?: number;
     /**
      * Filter to observations of a specific session recording.
      */
@@ -48672,7 +46294,7 @@ export namespace Schemas {
      */
     order?: string;
     /**
-     * Match against member `first_name`, `last_name`, and `email`. Returns case-insensitive substring matches and fuzzy trigram matches (typos, prefix-as-you-type) together, ordered exact-first; each result's `search_match_type` is `exact` or `similar`. Capped at 200 characters.
+     * Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.
      */
     search?: string;
     };
@@ -48947,70 +46569,69 @@ export namespace Schemas {
     page_size?: number;
     /**
      * Filter by a single activity scope, e.g. "FeatureFlag", "Insight", "Dashboard", "Experiment".
-     *
-     * * `Cohort` - Cohort
-     * * `FeatureFlag` - FeatureFlag
-     * * `Person` - Person
-     * * `Group` - Group
-     * * `Insight` - Insight
-     * * `Plugin` - Plugin
-     * * `PluginConfig` - PluginConfig
-     * * `HogFunction` - HogFunction
-     * * `HogFlow` - HogFlow
-     * * `DataManagement` - DataManagement
-     * * `EventDefinition` - EventDefinition
-     * * `PropertyDefinition` - PropertyDefinition
-     * * `Notebook` - Notebook
-     * * `Endpoint` - Endpoint
-     * * `EndpointVersion` - EndpointVersion
-     * * `Dashboard` - Dashboard
-     * * `Replay` - Replay
-     * * `Experiment` - Experiment
-     * * `ExperimentHoldout` - ExperimentHoldout
-     * * `ExperimentSavedMetric` - ExperimentSavedMetric
-     * * `Survey` - Survey
-     * * `EarlyAccessFeature` - EarlyAccessFeature
-     * * `SessionRecordingPlaylist` - SessionRecordingPlaylist
-     * * `Comment` - Comment
-     * * `Team` - Team
-     * * `Project` - Project
-     * * `ErrorTrackingIssue` - ErrorTrackingIssue
-     * * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
-     * * `LegalDocument` - LegalDocument
-     * * `Organization` - Organization
-     * * `OrganizationDomain` - OrganizationDomain
-     * * `OrganizationMembership` - OrganizationMembership
-     * * `Role` - Role
-     * * `UserGroup` - UserGroup
-     * * `BatchExport` - BatchExport
-     * * `BatchImport` - BatchImport
-     * * `Integration` - Integration
-     * * `Annotation` - Annotation
-     * * `Tag` - Tag
-     * * `TaggedItem` - TaggedItem
-     * * `Subscription` - Subscription
-     * * `PersonalAPIKey` - PersonalAPIKey
-     * * `ProjectSecretAPIKey` - ProjectSecretAPIKey
-     * * `OAuthApplication` - OAuthApplication
-     * * `User` - User
-     * * `Action` - Action
-     * * `AlertConfiguration` - AlertConfiguration
-     * * `Threshold` - Threshold
-     * * `AlertSubscription` - AlertSubscription
-     * * `ExternalDataSource` - ExternalDataSource
-     * * `ExternalDataSchema` - ExternalDataSchema
-     * * `Evaluation` - Evaluation
-     * * `LLMTrace` - LLMTrace
-     * * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
-     * * `CustomerProfileConfig` - CustomerProfileConfig
-     * * `Log` - Log
-     * * `LogsAlertConfiguration` - LogsAlertConfiguration
-     * * `LogsExclusionRule` - LogsExclusionRule
-     * * `DashboardWidget` - DashboardWidget
-     * * `ProductTour` - ProductTour
-     * * `Ticket` - Ticket
-     * * `InstanceSetting` - InstanceSetting
-     * * `SignalScoutConfig` - SignalScoutConfig
+
+    * `Cohort` - Cohort
+    * `FeatureFlag` - FeatureFlag
+    * `Person` - Person
+    * `Group` - Group
+    * `Insight` - Insight
+    * `Plugin` - Plugin
+    * `PluginConfig` - PluginConfig
+    * `HogFunction` - HogFunction
+    * `HogFlow` - HogFlow
+    * `DataManagement` - DataManagement
+    * `EventDefinition` - EventDefinition
+    * `PropertyDefinition` - PropertyDefinition
+    * `Notebook` - Notebook
+    * `Endpoint` - Endpoint
+    * `EndpointVersion` - EndpointVersion
+    * `Dashboard` - Dashboard
+    * `Replay` - Replay
+    * `Experiment` - Experiment
+    * `ExperimentHoldout` - ExperimentHoldout
+    * `ExperimentSavedMetric` - ExperimentSavedMetric
+    * `Survey` - Survey
+    * `EarlyAccessFeature` - EarlyAccessFeature
+    * `SessionRecordingPlaylist` - SessionRecordingPlaylist
+    * `Comment` - Comment
+    * `Team` - Team
+    * `Project` - Project
+    * `ErrorTrackingIssue` - ErrorTrackingIssue
+    * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
+    * `LegalDocument` - LegalDocument
+    * `Organization` - Organization
+    * `OrganizationDomain` - OrganizationDomain
+    * `OrganizationMembership` - OrganizationMembership
+    * `Role` - Role
+    * `UserGroup` - UserGroup
+    * `BatchExport` - BatchExport
+    * `BatchImport` - BatchImport
+    * `Integration` - Integration
+    * `Annotation` - Annotation
+    * `Tag` - Tag
+    * `TaggedItem` - TaggedItem
+    * `Subscription` - Subscription
+    * `PersonalAPIKey` - PersonalAPIKey
+    * `ProjectSecretAPIKey` - ProjectSecretAPIKey
+    * `User` - User
+    * `Action` - Action
+    * `AlertConfiguration` - AlertConfiguration
+    * `Threshold` - Threshold
+    * `AlertSubscription` - AlertSubscription
+    * `ExternalDataSource` - ExternalDataSource
+    * `ExternalDataSchema` - ExternalDataSchema
+    * `Evaluation` - Evaluation
+    * `LLMTrace` - LLMTrace
+    * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
+    * `CustomerProfileConfig` - CustomerProfileConfig
+    * `Log` - Log
+    * `LogsAlertConfiguration` - LogsAlertConfiguration
+    * `LogsExclusionRule` - LogsExclusionRule
+    * `DashboardWidget` - DashboardWidget
+    * `ProductTour` - ProductTour
+    * `Ticket` - Ticket
+    * `InstanceSetting` - InstanceSetting
+    * `SignalScoutConfig` - SignalScoutConfig
      * @minLength 1
      */
     scope?: ActivityLogListScope;
@@ -49071,7 +46692,6 @@ export namespace Schemas {
       Subscription: 'Subscription',
       PersonalAPIKey: 'PersonalAPIKey',
       ProjectSecretAPIKey: 'ProjectSecretAPIKey',
-      OAuthApplication: 'OAuthApplication',
       User: 'User',
       Action: 'Action',
       AlertConfiguration: 'AlertConfiguration',
@@ -49095,68 +46715,67 @@ export namespace Schemas {
 
     /**
      * * `Cohort` - Cohort
-     * * `FeatureFlag` - FeatureFlag
-     * * `Person` - Person
-     * * `Group` - Group
-     * * `Insight` - Insight
-     * * `Plugin` - Plugin
-     * * `PluginConfig` - PluginConfig
-     * * `HogFunction` - HogFunction
-     * * `HogFlow` - HogFlow
-     * * `DataManagement` - DataManagement
-     * * `EventDefinition` - EventDefinition
-     * * `PropertyDefinition` - PropertyDefinition
-     * * `Notebook` - Notebook
-     * * `Endpoint` - Endpoint
-     * * `EndpointVersion` - EndpointVersion
-     * * `Dashboard` - Dashboard
-     * * `Replay` - Replay
-     * * `Experiment` - Experiment
-     * * `ExperimentHoldout` - ExperimentHoldout
-     * * `ExperimentSavedMetric` - ExperimentSavedMetric
-     * * `Survey` - Survey
-     * * `EarlyAccessFeature` - EarlyAccessFeature
-     * * `SessionRecordingPlaylist` - SessionRecordingPlaylist
-     * * `Comment` - Comment
-     * * `Team` - Team
-     * * `Project` - Project
-     * * `ErrorTrackingIssue` - ErrorTrackingIssue
-     * * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
-     * * `LegalDocument` - LegalDocument
-     * * `Organization` - Organization
-     * * `OrganizationDomain` - OrganizationDomain
-     * * `OrganizationMembership` - OrganizationMembership
-     * * `Role` - Role
-     * * `UserGroup` - UserGroup
-     * * `BatchExport` - BatchExport
-     * * `BatchImport` - BatchImport
-     * * `Integration` - Integration
-     * * `Annotation` - Annotation
-     * * `Tag` - Tag
-     * * `TaggedItem` - TaggedItem
-     * * `Subscription` - Subscription
-     * * `PersonalAPIKey` - PersonalAPIKey
-     * * `ProjectSecretAPIKey` - ProjectSecretAPIKey
-     * * `OAuthApplication` - OAuthApplication
-     * * `User` - User
-     * * `Action` - Action
-     * * `AlertConfiguration` - AlertConfiguration
-     * * `Threshold` - Threshold
-     * * `AlertSubscription` - AlertSubscription
-     * * `ExternalDataSource` - ExternalDataSource
-     * * `ExternalDataSchema` - ExternalDataSchema
-     * * `Evaluation` - Evaluation
-     * * `LLMTrace` - LLMTrace
-     * * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
-     * * `CustomerProfileConfig` - CustomerProfileConfig
-     * * `Log` - Log
-     * * `LogsAlertConfiguration` - LogsAlertConfiguration
-     * * `LogsExclusionRule` - LogsExclusionRule
-     * * `DashboardWidget` - DashboardWidget
-     * * `ProductTour` - ProductTour
-     * * `Ticket` - Ticket
-     * * `InstanceSetting` - InstanceSetting
-     * * `SignalScoutConfig` - SignalScoutConfig
+    * `FeatureFlag` - FeatureFlag
+    * `Person` - Person
+    * `Group` - Group
+    * `Insight` - Insight
+    * `Plugin` - Plugin
+    * `PluginConfig` - PluginConfig
+    * `HogFunction` - HogFunction
+    * `HogFlow` - HogFlow
+    * `DataManagement` - DataManagement
+    * `EventDefinition` - EventDefinition
+    * `PropertyDefinition` - PropertyDefinition
+    * `Notebook` - Notebook
+    * `Endpoint` - Endpoint
+    * `EndpointVersion` - EndpointVersion
+    * `Dashboard` - Dashboard
+    * `Replay` - Replay
+    * `Experiment` - Experiment
+    * `ExperimentHoldout` - ExperimentHoldout
+    * `ExperimentSavedMetric` - ExperimentSavedMetric
+    * `Survey` - Survey
+    * `EarlyAccessFeature` - EarlyAccessFeature
+    * `SessionRecordingPlaylist` - SessionRecordingPlaylist
+    * `Comment` - Comment
+    * `Team` - Team
+    * `Project` - Project
+    * `ErrorTrackingIssue` - ErrorTrackingIssue
+    * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
+    * `LegalDocument` - LegalDocument
+    * `Organization` - Organization
+    * `OrganizationDomain` - OrganizationDomain
+    * `OrganizationMembership` - OrganizationMembership
+    * `Role` - Role
+    * `UserGroup` - UserGroup
+    * `BatchExport` - BatchExport
+    * `BatchImport` - BatchImport
+    * `Integration` - Integration
+    * `Annotation` - Annotation
+    * `Tag` - Tag
+    * `TaggedItem` - TaggedItem
+    * `Subscription` - Subscription
+    * `PersonalAPIKey` - PersonalAPIKey
+    * `ProjectSecretAPIKey` - ProjectSecretAPIKey
+    * `User` - User
+    * `Action` - Action
+    * `AlertConfiguration` - AlertConfiguration
+    * `Threshold` - Threshold
+    * `AlertSubscription` - AlertSubscription
+    * `ExternalDataSource` - ExternalDataSource
+    * `ExternalDataSchema` - ExternalDataSchema
+    * `Evaluation` - Evaluation
+    * `LLMTrace` - LLMTrace
+    * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
+    * `CustomerProfileConfig` - CustomerProfileConfig
+    * `Log` - Log
+    * `LogsAlertConfiguration` - LogsAlertConfiguration
+    * `LogsExclusionRule` - LogsExclusionRule
+    * `DashboardWidget` - DashboardWidget
+    * `ProductTour` - ProductTour
+    * `Ticket` - Ticket
+    * `InstanceSetting` - InstanceSetting
+    * `SignalScoutConfig` - SignalScoutConfig
      */
     export type ActivityLogListScopesItem = typeof ActivityLogListScopesItem[keyof typeof ActivityLogListScopesItem];
 
@@ -49205,7 +46824,6 @@ export namespace Schemas {
       Subscription: 'Subscription',
       PersonalAPIKey: 'PersonalAPIKey',
       ProjectSecretAPIKey: 'ProjectSecretAPIKey',
-      OAuthApplication: 'OAuthApplication',
       User: 'User',
       Action: 'Action',
       AlertConfiguration: 'AlertConfiguration',
@@ -49301,14 +46919,6 @@ export namespace Schemas {
 
     export type AlertsListParams = {
     /**
-     * Optional. Restrict results to alerts created by the user with this UUID.
-     */
-    created_by?: string;
-    /**
-     * Optional. Restrict results to alerts on this insight ID.
-     */
-    insight_id?: number;
-    /**
      * Number of results to return per page.
      */
     limit?: number;
@@ -49316,10 +46926,6 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
-    /**
-     * Optional. Fuzzy match against alert `name` using Postgres trigram word similarity (handles typos, transpositions, and prefix-as-you-type). Results are ordered by relevance, then creation time. Capped at 200 characters; longer queries return a 400 error.
-     */
-    search?: string;
     };
 
     export type AlertsRetrieveParams = {
@@ -49464,28 +47070,6 @@ export namespace Schemas {
     search?: string;
     };
 
-    export type BusinessKnowledgeDocumentsWindowListParams = {
-    /**
-     * Zero-based chunk ordinal to center the window on (from a search result).
-     */
-    around_ordinal: number;
-    /**
-     * Number of chunks before and after the center to include. Defaults to 5, clamped to [0, 15].
-     */
-    radius?: number;
-    };
-
-    export type BusinessKnowledgeDocumentsSearchListParams = {
-    /**
-     * Maximum number of ranked chunks to return. Defaults to 10, capped at 20.
-     */
-    limit?: number;
-    /**
-     * Natural-language search query. Runs hybrid (semantic + full-text) retrieval over all SAFE, READY knowledge chunks in this project.
-     */
-    query: string;
-    };
-
     export type BusinessKnowledgeSourcesListParams = {
     /**
      * Number of results to return per page.
@@ -49573,10 +47157,10 @@ export namespace Schemas {
     export type CommentsListParams = {
     /**
      * When kind=task, restrict to open (incomplete) or completed tasks. Ignored when kind is not 'task'. Defaults to 'any' (no filter).
-     *
-     * * `any` - any
-     * * `open` - open
-     * * `completed` - completed
+
+    * `any` - any
+    * `open` - open
+    * `completed` - completed
      * @minLength 1
      */
     completed?: CommentsListCompleted;
@@ -49591,10 +47175,10 @@ export namespace Schemas {
     item_id?: string;
     /**
      * Filter by comment kind. 'task' returns only items intentionally created as actionable. 'comment' excludes tasks. Defaults to 'any' (no filter).
-     *
-     * * `any` - any
-     * * `comment` - comment
-     * * `task` - task
+
+    * `any` - any
+    * `comment` - comment
+    * `task` - task
      * @minLength 1
      */
     kind?: CommentsListKind;
@@ -49687,17 +47271,9 @@ export namespace Schemas {
      */
     status?: string;
     /**
-     * JSON-encoded array of tag names; returns tickets with ANY of them (OR), e.g. `["billing","urgent"]`.
+     * JSON-encoded array of tag names to filter by, e.g. `["billing","urgent"]`.
      */
     tags?: string;
-    /**
-     * JSON-encoded array of tag names; returns tickets that have ALL of them (AND), e.g. `["billing","urgent"]`.
-     */
-    tags_all?: string;
-    /**
-     * JSON-encoded array of tag names; returns tickets that have NONE of them (NOT), e.g. `["escalated"]`.
-     */
-    tags_exclude?: string;
     };
 
     export type ConversationsTicketsListChannelDetail = typeof ConversationsTicketsListChannelDetail[keyof typeof ConversationsTicketsListChannelDetail];
@@ -49733,17 +47309,6 @@ export namespace Schemas {
       Breached: 'breached',
       OnTrack: 'on-track',
     } as const;
-
-    export type ConversationsTicketsMessagesListParams = {
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number;
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number;
-    };
 
     export type ConversationsViewsListParams = {
     /**
@@ -49832,7 +47397,7 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Optional. Match against dashboard `name`, `description`, and tag names. Returns case-insensitive substring matches and fuzzy trigram matches (typos, transpositions, prefix-as-you-type) together, ordered exact-first, then pinned status, then name; each result's `search_match_type` is `exact` or `similar`. When omitted, dashboards are ordered by pinned status then alphabetical name. Capped at 200 characters; longer queries return a 400 error.
+     * Optional. Fuzzy match against dashboard `name` and `description` using Postgres trigram word similarity (handles typos, transpositions, and prefix-as-you-type). `name` matches rank above `description` matches. Results are ordered by relevance, then pinned status, then name. When omitted, dashboards are ordered by pinned status then alphabetical name. Capped at 200 characters; longer queries return a 400 error.
      */
     search?: string;
     };
@@ -50244,11 +47809,11 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-     *
-     * * `created_at` - Created At
-     * * `-created_at` - Created At (descending)
-     * * `updated_at` - Updated At
-     * * `-updated_at` - Updated At (descending)
+
+    * `created_at` - Created At
+    * `-created_at` - Created At (descending)
+    * `updated_at` - Updated At
+    * `-updated_at` - Updated At (descending)
      */
     order_by?: string[];
     /**
@@ -50353,38 +47918,6 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
-    };
-
-    export type EndpointsLogsRetrieveParams = {
-    /**
-     * Only return entries after this ISO 8601 timestamp.
-     */
-    after?: string;
-    /**
-     * Only return entries before this ISO 8601 timestamp.
-     */
-    before?: string;
-    /**
-     * Filter logs to a specific execution instance.
-     * @minLength 1
-     */
-    instance_id?: string;
-    /**
-     * Comma-separated log levels to include, e.g. 'WARN,ERROR'. Valid levels: DEBUG, LOG, INFO, WARN, ERROR.
-     * @minLength 1
-     */
-    level?: string;
-    /**
-     * Maximum number of log entries to return (1-500, default 50).
-     * @minimum 1
-     * @maximum 500
-     */
-    limit?: number;
-    /**
-     * Case-insensitive substring search across log messages.
-     * @minLength 1
-     */
-    search?: string;
     };
 
     export type EndpointsOpenapiSpecRetrieveParams = {
@@ -50603,13 +48136,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort order for symbol sets. Prefix with `-` for descending order.
-     *
-     * * `created_at` - created_at
-     * * `-created_at` - -created_at
-     * * `ref` - ref
-     * * `-ref` - -ref
-     * * `last_used` - last_used
-     * * `-last_used` - -last_used
+
+    * `created_at` - created_at
+    * `-created_at` - -created_at
+    * `ref` - ref
+    * `-ref` - -ref
+    * `last_used` - last_used
+    * `-last_used` - -last_used
      * @minLength 1
      */
     order_by?: string;
@@ -50625,10 +48158,10 @@ export namespace Schemas {
     search?: string;
     /**
      * Upload status filter: `valid` has an uploaded file, `invalid` is missing a file, `all` returns both.
-     *
-     * * `all` - all
-     * * `valid` - valid
-     * * `invalid` - invalid
+
+    * `all` - all
+    * `valid` - valid
+    * `invalid` - invalid
      * @minLength 1
      */
     status?: ErrorTrackingSymbolSetsListStatus;
@@ -50664,13 +48197,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-     *
-     * * `created_at` - Created At
-     * * `-created_at` - Created At (descending)
-     * * `updated_at` - Updated At
-     * * `-updated_at` - Updated At (descending)
-     * * `name` - Name
-     * * `-name` - Name (descending)
+
+    * `created_at` - Created At
+    * `-created_at` - Created At (descending)
+    * `updated_at` - Updated At
+    * `-updated_at` - Updated At (descending)
+    * `name` - Name
+    * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -50970,13 +48503,6 @@ export namespace Schemas {
       errors?: string[];
     };
 
-    export type ExternalDataSourcesConnectLinkRetrieveParams = {
-    /**
-     * The source type to generate a connect link for (e.g. 'Stripe', 'Postgres', 'Hubspot').
-     */
-    source_type: string;
-    };
-
     export type ExternalDataSourcesConnectionsListParams = {
     /**
      * Number of results to return per page.
@@ -50990,17 +48516,6 @@ export namespace Schemas {
      * A search term.
      */
     search?: string;
-    };
-
-    export type ExternalDataSourcesStoredCredentialsListParams = {
-    /**
-     * A search term.
-     */
-    search?: string;
-    /**
-     * Only return stored credentials for this source type (e.g. 'Stripe', 'Postgres').
-     */
-    source_type?: string;
     };
 
     export type FeatureFlagsListParams = {
@@ -51120,35 +48635,6 @@ export namespace Schemas {
      */
     groups?: string;
     };
-
-    export type FieldNotesListParams = {
-    /**
-     * Filter to field notes in this lifecycle state (e.g. `pending` for unaddressed feedback).
-     */
-    field_note_status?: FieldNotesListFieldNoteStatus;
-    /**
-     * Filter to field notes made on this hostname (e.g. `app.example.com`).
-     */
-    host?: string;
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number;
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number;
-    };
-
-    export type FieldNotesListFieldNoteStatus = typeof FieldNotesListFieldNoteStatus[keyof typeof FieldNotesListFieldNoteStatus];
-
-
-    export const FieldNotesListFieldNoteStatus = {
-      Acknowledged: 'acknowledged',
-      Dismissed: 'dismissed',
-      Pending: 'pending',
-      Resolved: 'resolved',
-    } as const;
 
     export type FileDownloadBatchExportsListParams = {
     /**
@@ -51363,9 +48849,9 @@ export namespace Schemas {
     export type HeatmapsListParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-     *
-     * * `unique_visitors` - unique_visitors
-     * * `total_count` - total_count
+
+    * `unique_visitors` - unique_visitors
+    * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: HeatmapsListAggregation;
@@ -51429,9 +48915,9 @@ export namespace Schemas {
     export type HeatmapsEventsRetrieveParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-     *
-     * * `unique_visitors` - unique_visitors
-     * * `total_count` - total_count
+
+    * `unique_visitors` - unique_visitors
+    * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: HeatmapsEventsRetrieveAggregation;
@@ -51565,8 +49051,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * * `draft` - Draft
-     * * `active` - Active
-     * * `archived` - Archived
+    * `active` - Active
+    * `archived` - Archived
      */
     status?: HogFlowsListStatus;
     updated_at?: string;
@@ -51655,9 +49141,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-     *
-     * * `name` - name
-     * * `kind` - kind
+
+    * `name` - name
+    * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFlowsMetricsRetrieveBreakdownBy;
@@ -51668,10 +49154,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-     *
-     * * `hour` - hour
-     * * `day` - day
-     * * `week` - week
+
+    * `hour` - hour
+    * `day` - day
+    * `week` - week
      * @minLength 1
      */
     interval?: HogFlowsMetricsRetrieveInterval;
@@ -51717,9 +49203,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-     *
-     * * `name` - name
-     * * `kind` - kind
+
+    * `name` - name
+    * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFlowsMetricsTotalsRetrieveBreakdownBy;
@@ -51730,10 +49216,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-     *
-     * * `hour` - hour
-     * * `day` - day
-     * * `week` - week
+
+    * `hour` - hour
+    * `day` - day
+    * `week` - week
      * @minLength 1
      */
     interval?: HogFlowsMetricsTotalsRetrieveInterval;
@@ -51867,9 +49353,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-     *
-     * * `name` - name
-     * * `kind` - kind
+
+    * `name` - name
+    * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFunctionsMetricsRetrieveBreakdownBy;
@@ -51880,10 +49366,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-     *
-     * * `hour` - hour
-     * * `day` - day
-     * * `week` - week
+
+    * `hour` - hour
+    * `day` - day
+    * `week` - week
      * @minLength 1
      */
     interval?: HogFunctionsMetricsRetrieveInterval;
@@ -51929,9 +49415,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-     *
-     * * `name` - name
-     * * `kind` - kind
+
+    * `name` - name
+    * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFunctionsMetricsTotalsRetrieveBreakdownBy;
@@ -51942,10 +49428,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-     *
-     * * `hour` - hour
-     * * `day` - day
-     * * `week` - week
+
+    * `hour` - hour
+    * `day` - day
+    * `week` - week
      * @minLength 1
      */
     interval?: HogFunctionsMetricsTotalsRetrieveInterval;
@@ -52041,14 +49527,14 @@ export namespace Schemas {
     offset?: number;
     /**
      *
-     * Whether to refresh the retrieved insights, how aggressively, and if sync or async:
-     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
-     * Background calculation can be tracked using the `query_status` response field.
+    Whether to refresh the retrieved insights, how aggressively, and if sync or async:
+    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+    - `'force_async'` - kick off background calculation, even if fresh results are already cached
+    Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: InsightsListRefresh;
     /**
@@ -52136,20 +49622,20 @@ export namespace Schemas {
     format?: InsightsRetrieveFormat;
     /**
      *
-     * Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
-     * When set, the specified dashboard's filters and date range override will be applied.
+    Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
+    When set, the specified dashboard's filters and date range override will be applied.
      */
     from_dashboard?: number;
     /**
      *
-     * Whether to refresh the insight, how aggresively, and if sync or async:
-     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
-     * Background calculation can be tracked using the `query_status` response field.
+    Whether to refresh the insight, how aggresively, and if sync or async:
+    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+    - `'force_async'` - kick off background calculation, even if fresh results are already cached
+    Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: InsightsRetrieveRefresh;
     /**
@@ -52378,41 +49864,41 @@ export namespace Schemas {
     export type IntegrationsListParams = {
     /**
      * * `anthropic` - Anthropic
-     * * `apns` - Apple Push
-     * * `azure-blob` - Azure Blob
-     * * `bing-ads` - Bing Ads
-     * * `clickup` - Clickup
-     * * `customerio-app` - Customerio App
-     * * `customerio-track` - Customerio Track
-     * * `customerio-webhook` - Customerio Webhook
-     * * `databricks` - Databricks
-     * * `email` - Email
-     * * `firebase` - Firebase
-     * * `github` - Github
-     * * `gitlab` - Gitlab
-     * * `google-ads` - Google Ads
-     * * `google-cloud-service-account` - Google Cloud Service Account
-     * * `google-cloud-storage` - Google Cloud Storage
-     * * `google-pubsub` - Google Pubsub
-     * * `google-search-console` - Google Search Console
-     * * `google-sheets` - Google Sheets
-     * * `hubspot` - Hubspot
-     * * `intercom` - Intercom
-     * * `jira` - Jira
-     * * `linear` - Linear
-     * * `linkedin-ads` - Linkedin Ads
-     * * `meta-ads` - Meta Ads
-     * * `pinterest-ads` - Pinterest Ads
-     * * `postgresql` - Postgresql
-     * * `reddit-ads` - Reddit Ads
-     * * `salesforce` - Salesforce
-     * * `slack` - Slack
-     * * `slack-posthog-code` - Slack Posthog Code
-     * * `snapchat` - Snapchat
-     * * `stripe` - Stripe
-     * * `tiktok-ads` - Tiktok Ads
-     * * `twilio` - Twilio
-     * * `vercel` - Vercel
+    * `apns` - Apple Push
+    * `azure-blob` - Azure Blob
+    * `bing-ads` - Bing Ads
+    * `clickup` - Clickup
+    * `customerio-app` - Customerio App
+    * `customerio-track` - Customerio Track
+    * `customerio-webhook` - Customerio Webhook
+    * `databricks` - Databricks
+    * `email` - Email
+    * `firebase` - Firebase
+    * `github` - Github
+    * `gitlab` - Gitlab
+    * `google-ads` - Google Ads
+    * `google-cloud-service-account` - Google Cloud Service Account
+    * `google-cloud-storage` - Google Cloud Storage
+    * `google-pubsub` - Google Pubsub
+    * `google-search-console` - Google Search Console
+    * `google-sheets` - Google Sheets
+    * `hubspot` - Hubspot
+    * `intercom` - Intercom
+    * `jira` - Jira
+    * `linear` - Linear
+    * `linkedin-ads` - Linkedin Ads
+    * `meta-ads` - Meta Ads
+    * `pinterest-ads` - Pinterest Ads
+    * `postgresql` - Postgresql
+    * `reddit-ads` - Reddit Ads
+    * `salesforce` - Salesforce
+    * `slack` - Slack
+    * `slack-posthog-code` - Slack Posthog Code
+    * `snapchat` - Snapchat
+    * `stripe` - Stripe
+    * `tiktok-ads` - Tiktok Ads
+    * `twilio` - Twilio
+    * `vercel` - Vercel
      */
     kind?: IntegrationsListKind;
     /**
@@ -52832,10 +50318,10 @@ export namespace Schemas {
     export type LlmPromptsListParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-     *
-     * * `full` - full
-     * * `preview` - preview
-     * * `none` - none
+
+    * `full` - full
+    * `preview` - preview
+    * `none` - none
      * @minLength 1
      */
     content?: LlmPromptsListContent;
@@ -52869,10 +50355,10 @@ export namespace Schemas {
     export type LlmPromptsNameRetrieveParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-     *
-     * * `full` - full
-     * * `preview` - preview
-     * * `none` - none
+
+    * `full` - full
+    * `preview` - preview
+    * `none` - none
      * @minLength 1
      */
     content?: LlmPromptsNameRetrieveContent;
@@ -53016,9 +50502,9 @@ export namespace Schemas {
     export type LogsAttributesRetrieveParams = {
     /**
      * Type of attributes: "log" for log attributes, "resource" for resource attributes. Defaults to "log".
-     *
-     * * `log` - log
-     * * `resource` - resource
+
+    * `log` - log
+    * `resource` - resource
      * @minLength 1
      */
     attribute_type?: LogsAttributesRetrieveAttributeType;
@@ -53093,9 +50579,9 @@ export namespace Schemas {
     export type LogsValuesRetrieveParams = {
     /**
      * Type of attribute: "log" or "resource". Defaults to "log".
-     *
-     * * `log` - log
-     * * `resource` - resource
+
+    * `log` - log
+    * `resource` - resource
      * @minLength 1
      */
     attribute_type?: LogsValuesRetrieveAttributeType;
@@ -53161,9 +50647,9 @@ export namespace Schemas {
     search?: string;
     /**
      * * `completed` - Completed
-     * * `failed` - Failed
-     * * `paused` - Paused
-     * * `running` - Running
+    * `failed` - Failed
+    * `paused` - Paused
+    * `running` - Running
      */
     status?: ManagedMigrationsListStatus;
     };
@@ -53177,74 +50663,6 @@ export namespace Schemas {
       Paused: 'paused',
       Running: 'running',
     } as const;
-
-    export type MarketingAnalyticsDataSourcesRetrieveParams = {
-    /**
-     * Optional. Restrict to one integration (e.g. 'GoogleAds').
-     * @nullable
-     */
-    source_type?: string | null;
-    };
-
-    export type MarketingAnalyticsDiagnoseRetrieveParams = {
-    /**
-     * Lookback window for attribution health (1-365 days); defaults to 7
-     * @minimum 1
-     * @maximum 365
-     */
-    attribution_lookback_days?: number;
-    /**
-     * Whether to include the conversion-goal summary in the diagnostic
-     */
-    include_conversion_goals?: boolean;
-    /**
-     * Optional integration filter
-     * @nullable
-     */
-    source_type?: string | null;
-    };
-
-    export type MarketingAnalyticsExplainConversionGoalRetrieveParams = {
-    /**
-     * ISO start; defaults to 30 days ago
-     * @nullable
-     */
-    date_from?: string | null;
-    /**
-     * ISO end; defaults to now
-     * @nullable
-     */
-    date_to?: string | null;
-    /**
-     * Id of the conversion goal to explain (from list_conversion_goals).
-     * @minLength 1
-     */
-    goal_id: string;
-    };
-
-    export type MarketingAnalyticsSuggestConversionGoalsRetrieveParams = {
-    /**
-     * Minimum 30d event count to be a candidate
-     */
-    min_count?: number;
-    /**
-     * Max candidates to return
-     */
-    top_n?: number;
-    };
-
-    export type MarketingAnalyticsSuggestUtmMappingsRetrieveParams = {
-    /**
-     * Days of history to inspect (1-365); defaults to 90
-     * @minimum 1
-     * @maximum 365
-     */
-    lookback_days?: number;
-    /**
-     * Only suggest for raw values with >= this many events
-     */
-    min_event_count?: number;
-    };
 
     export type MarketingAnalyticsUtmAuditRetrieveParams = {
     /**
@@ -53284,7 +50702,7 @@ export namespace Schemas {
     export type McpServerInstallationsAuthorizeRetrieveParams = {
     /**
      * * `posthog` - posthog
-     * * `posthog-code` - posthog-code
+    * `posthog-code` - posthog-code
      * @minLength 1
      */
     install_source?: McpServerInstallationsAuthorizeRetrieveInstallSource;
@@ -53352,8 +50770,8 @@ export namespace Schemas {
     export type NotebooksListParams = {
     /**
      * Filter for notebooks that match a provided filter.
-     *                 Each match pair is separated by a colon,
-     *                 multiple match pairs can be sent separated by a space or a comma
+                    Each match pair is separated by a colon,
+                    multiple match pairs can be sent separated by a space or a comma
      */
     contains?: string;
     /**
@@ -53882,11 +51300,11 @@ export namespace Schemas {
     search?: string;
     /**
      * What property definitions to return
-     *
-     * * `event` - event
-     * * `person` - person
-     * * `group` - group
-     * * `session` - session
+
+    * `event` - event
+    * `person` - person
+    * `group` - group
+    * `session` - session
      * @minLength 1
      */
     type?: PropertyDefinitionsListType;
@@ -54138,16 +51556,6 @@ export namespace Schemas {
      */
     limit?: number;
     /**
-     * Exact-match filter on the scout skill (e.g. `signals-scout-errors`). Narrows the run dump to a single scout — the primary scoping path when a specialist dedupes against its own past runs. Omit to span every scout on the team.
-     * @minLength 1
-     */
-    skill_name?: string;
-    /**
-     * Exact-match filter on the skill version. Pair with `skill_name` to pin one version; omit for all.
-     * @minimum 1
-     */
-    skill_version?: number;
-    /**
      * Case-insensitive substring match on the scout's end-of-run `summary`. Omit to skip the filter.
      * @minLength 1
      */
@@ -54155,15 +51563,6 @@ export namespace Schemas {
     };
 
     export type SignalsScoutScratchpadSearchParams = {
-    /**
-     * Truncate each entry's `content` to the first N characters (a preview). Omit for the full body. Ignored when `keys_only=true`.
-     * @minimum 0
-     */
-    content_max_chars?: number;
-    /**
-     * When true, blank each entry's `content` and return only keys + metadata. Use to scan which memories exist without pulling their (potentially large) bodies, then re-query the ones worth a full read. Takes precedence over `content_max_chars`.
-     */
-    keys_only?: boolean;
     /**
      * Max rows to return (default 20, hard cap 100).
      * @minimum 1
@@ -54322,9 +51721,9 @@ export namespace Schemas {
     search?: string;
     /**
      * * `popover` - popover
-     * * `widget` - widget
-     * * `external_survey` - external survey
-     * * `api` - api
+    * `widget` - widget
+    * `external_survey` - external survey
+    * `api` - api
      */
     type?: SurveysListType;
     };
@@ -54434,13 +51833,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-     *
-     * * `created_at` - Created At
-     * * `-created_at` - Created At (descending)
-     * * `updated_at` - Updated At
-     * * `-updated_at` - Updated At (descending)
-     * * `name` - Name
-     * * `-name` - Name (descending)
+
+    * `created_at` - Created At
+    * `-created_at` - Created At (descending)
+    * `updated_at` - Updated At
+    * `-updated_at` - Updated At (descending)
+    * `name` - Name
+    * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -54474,10 +51873,10 @@ export namespace Schemas {
     export type TasksListParams = {
     /**
      * Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.
-     *
-     * * `true` - true
-     * * `false` - false
-     * * `all` - all
+
+    * `true` - true
+    * `false` - false
+    * `all` - all
      * @minLength 1
      */
     archived?: TasksListArchived;
@@ -54526,13 +51925,13 @@ export namespace Schemas {
     stage?: string;
     /**
      * Filter tasks by the status of their most recent run.
-     *
-     * * `not_started` - not_started
-     * * `queued` - queued
-     * * `in_progress` - in_progress
-     * * `completed` - completed
-     * * `failed` - failed
-     * * `cancelled` - cancelled
+
+    * `not_started` - not_started
+    * `queued` - queued
+    * `in_progress` - in_progress
+    * `completed` - completed
+    * `failed` - failed
+    * `cancelled` - cancelled
      * @minLength 1
      */
     status?: TasksListStatus;
@@ -54637,9 +52036,9 @@ export namespace Schemas {
     export type TracingSpansAttributesRetrieveParams = {
     /**
      * Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-     *
-     * * `span_attribute` - span_attribute
-     * * `span_resource_attribute` - span_resource_attribute
+
+    * `span_attribute` - span_attribute
+    * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: TracingSpansAttributesRetrieveAttributeType;
@@ -54685,10 +52084,10 @@ export namespace Schemas {
     export type TracingSpansValuesRetrieveParams = {
     /**
      * Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-     *
-     * * `span` - span
-     * * `span_attribute` - span_attribute
-     * * `span_resource_attribute` - span_resource_attribute
+
+    * `span` - span
+    * `span_attribute` - span_attribute
+    * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: TracingSpansValuesRetrieveAttributeType;
@@ -54869,10 +52268,6 @@ export namespace Schemas {
     };
 
     export type VisionScannersObservationsStatsRetrieveParams = {
-    /**
-     * Window size in days for the coverage `recent_sessions` count. Clamped to [1, 365]. Defaults to 14 when omitted.
-     */
-    recent_days?: number;
     /**
      * Filter to observations of a specific session recording.
      */
@@ -55162,17 +52557,6 @@ export namespace Schemas {
      * Filter to a single workflow (e.g. 'onboarding').
      */
     workflow_id?: string;
-    };
-
-    export type WizardSessionsLatestRetrieveParams = {
-    /**
-     * Filter to a single skill within the workflow (e.g. 'nextjs').
-     */
-    skill_id?: string;
-    /**
-     * Filter to a single workflow (e.g. 'posthog-integration').
-     */
-    workflow_id: string;
     };
 
     export type WizardSessionsStreamRetrieveParams = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -104,7 +104,7 @@ export namespace Schemas {
          */
       name: string;
       /**
-         * Identifier for the account in an external system (e.g. CRM ID). Optional.
+         * Identifier linking this account to its source customer — the analytics group key (the customer's organization id), used to match billing and external records. Optional.
          * @maxLength 400
          * @nullable
          */
@@ -2390,6 +2390,8 @@ export namespace Schemas {
       resultCustomizations?: FunnelsFilterResultCustomizations;
       /** Whether to render annotations on the chart. Only applies to historical-trends funnels. */
       showAnnotations?: boolean | null;
+      /** Whether to show a legend describing the series. The legend only renders when the funnel has multiple series. Only applies to historical-trends funnels. */
+      showLegend?: boolean | null;
       /** Display linear regression trend lines on the chart (only for historical trends viz) */
       showTrendLines?: boolean | null;
       showValuesOnSeries?: boolean | null;
@@ -6237,7 +6239,7 @@ export namespace Schemas {
       orderBy: ErrorTrackingOrderBy;
       /** Sort direction. */
       orderDirection?: OrderDirection2 | null;
-      /** Pending fingerprint issue state updates UNIONed into the fingerprint issue state subquery (V3 only). The backend caps the list at 50 entries; extras are dropped silently. */
+      /** Pending fingerprint issue state updates UNIONed into the fingerprint issue state subquery. The backend caps the list at 50 entries; extras are dropped silently. */
       pendingFingerprintIssueStateUpdates?: ErrorTrackingPendingFingerprintIssueStateUpdate[] | null;
       personId?: string | null;
       response?: ErrorTrackingQueryResponse | null;
@@ -6246,10 +6248,6 @@ export namespace Schemas {
       /** Filter by issue status. */
       status?: ErrorTrackingIssueStatus | string | null;
       tags?: QueryLogTags | null;
-      /** Use V2 query path (ClickHouse postgres connector join instead of separate Postgres queries) */
-      useQueryV2?: boolean | null;
-      /** Use V3 query path (denormalized ClickHouse table, no Postgres joins) */
-      useQueryV3?: boolean | null;
       /** version of the node, used for schema migrations */
       version?: number | null;
       volumeResolution: number;
@@ -7889,6 +7887,18 @@ export namespace Schemas {
       Linear: 'linear',
       TimeDecay: 'time_decay',
       PositionBased: 'position_based',
+    } as const;
+
+    /**
+     * * `oauth` - oauth
+     * * `credentials` - credentials
+     */
+    export type AuthMethodEnum = typeof AuthMethodEnum[keyof typeof AuthMethodEnum];
+
+
+    export const AuthMethodEnum = {
+      Oauth: 'oauth',
+      Credentials: 'credentials',
     } as const;
 
     export interface Author {
@@ -13585,6 +13595,11 @@ export namespace Schemas {
      * * `SapSuccessFactors` - SapSuccessFactors
      * * `OracleEbs` - OracleEbs
      * * `OracleFusion` - OracleFusion
+     * * `AmazonSNS` - AmazonSNS
+     * * `AmazonEventBridge` - AmazonEventBridge
+     * * `AmazonSQS` - AmazonSQS
+     * * `AmazonKinesis` - AmazonKinesis
+     * * `AmazonCloudWatch` - AmazonCloudWatch
      * * `Custom` - Custom
      */
     export type ExternalDataSourceTypeEnum = typeof ExternalDataSourceTypeEnum[keyof typeof ExternalDataSourceTypeEnum];
@@ -13817,6 +13832,11 @@ export namespace Schemas {
       SapSuccessFactors: 'SapSuccessFactors',
       OracleEbs: 'OracleEbs',
       OracleFusion: 'OracleFusion',
+      AmazonSNS: 'AmazonSNS',
+      AmazonEventBridge: 'AmazonEventBridge',
+      AmazonSQS: 'AmazonSQS',
+      AmazonKinesis: 'AmazonKinesis',
+      AmazonCloudWatch: 'AmazonCloudWatch',
       Custom: 'Custom',
     } as const;
 
@@ -14056,6 +14076,11 @@ export namespace Schemas {
        * * `SapSuccessFactors` - SapSuccessFactors
        * * `OracleEbs` - OracleEbs
        * * `OracleFusion` - OracleFusion
+       * * `AmazonSNS` - AmazonSNS
+       * * `AmazonEventBridge` - AmazonEventBridge
+       * * `AmazonSQS` - AmazonSQS
+       * * `AmazonKinesis` - AmazonKinesis
+       * * `AmazonCloudWatch` - AmazonCloudWatch
        * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
     }
@@ -14723,11 +14748,53 @@ export namespace Schemas {
       text?: string | null;
     }
 
+    /**
+     * Highest htmlID suffix per element type, e.g. {"u_row": 1, "u_content_text": 2}.
+     */
+    export type EmailTemplateDesignCounters = { [key: string]: unknown };
+
+    export type EmailTemplateDesignBodyRowsItem = { [key: string]: unknown };
+
+    export type EmailTemplateDesignBodyHeadersItem = { [key: string]: unknown };
+
+    export type EmailTemplateDesignBodyFootersItem = { [key: string]: unknown };
+
+    /**
+     * Body-level settings: backgroundColor, contentWidth ('600px'), fontFamily, textColor.
+     */
+    export type EmailTemplateDesignBodyValues = { [key: string]: unknown };
+
+    export type EmailTemplateDesignBody = {
+      /** Any unique string. */
+      id?: string;
+      /** Rows of {id, cells, columns[{id, contents[{id, type, values}], values}], values}. */
+      rows: EmailTemplateDesignBodyRowsItem[];
+      headers?: EmailTemplateDesignBodyHeadersItem[];
+      footers?: EmailTemplateDesignBodyFootersItem[];
+      /** Body-level settings: backgroundColor, contentWidth ('600px'), fontFamily, textColor. */
+      values?: EmailTemplateDesignBodyValues;
+    };
+
+    /**
+     * Design JSON for PostHog's visual email editor — the authoring surface and source of truth. The server renders the sent email from it, and it opens as editable blocks in the editor. Full schema in the designing-email-templates skill.
+     */
+    export type EmailTemplateDesign = {
+      /** Highest htmlID suffix per element type, e.g. {"u_row": 1, "u_content_text": 2}. */
+      counters?: EmailTemplateDesignCounters;
+      /** Design schema version, e.g. 16. */
+      schemaVersion: number;
+      body: EmailTemplateDesignBody;
+    };
+
     export interface EmailTemplate {
+      /** Email subject line. Supports Liquid templating. Required for email-type templates. */
       subject?: string;
+      /** Plain-text fallback body for clients that can't render the email. */
       text?: string;
+      /** Rendered email body — derived from the design at save time. The visual editor's save path supplies it directly; omit it otherwise. */
       html?: string;
-      design?: unknown;
+      /** Design JSON for PostHog's visual email editor — the authoring surface and source of truth. The server renders the sent email from it, and it opens as editable blocks in the editor. Full schema in the designing-email-templates skill. */
+      design?: EmailTemplateDesign;
     }
 
     export type EmbeddingStatusEnum = typeof EmbeddingStatusEnum[keyof typeof EmbeddingStatusEnum];
@@ -18255,6 +18322,11 @@ export namespace Schemas {
        * * `SapSuccessFactors` - SapSuccessFactors
        * * `OracleEbs` - OracleEbs
        * * `OracleFusion` - OracleFusion
+       * * `AmazonSNS` - AmazonSNS
+       * * `AmazonEventBridge` - AmazonEventBridge
+       * * `AmazonSQS` - AmazonSQS
+       * * `AmazonKinesis` - AmazonKinesis
+       * * `AmazonCloudWatch` - AmazonCloudWatch
        * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
       /** Connection credentials and a 'schemas' array. Keys depend on source_type. */
@@ -19046,6 +19118,109 @@ export namespace Schemas {
          * @nullable
          */
       readonly modified_by: number | null;
+    }
+
+    /**
+     * Structured element metadata (inferred selectors, attributes, component hints).
+     */
+    export type FieldNoteElementContext = { [key: string]: unknown };
+
+    /**
+     * Viewport size when the field note was made, as {width, height}.
+     * @nullable
+     */
+    export type FieldNoteViewport = {
+      /** Viewport width in pixels. */
+      width?: number;
+      /** Viewport height in pixels. */
+      height?: number;
+    } | null;
+
+    /**
+     * * `pending` - Pending
+     * * `acknowledged` - Acknowledged
+     * * `resolved` - Resolved
+     * * `dismissed` - Dismissed
+     */
+    export type FieldNoteStatusEnum = typeof FieldNoteStatusEnum[keyof typeof FieldNoteStatusEnum];
+
+
+    export const FieldNoteStatusEnum = {
+      Pending: 'pending',
+      Acknowledged: 'acknowledged',
+      Resolved: 'resolved',
+      Dismissed: 'dismissed',
+    } as const;
+
+    export interface FieldNote {
+      readonly id: string;
+      /**
+         * The note the user wrote about the element.
+         * @maxLength 5000
+         */
+      comment: string;
+      /** Lifecycle of the field note: pending, acknowledged, resolved, or dismissed. Ignored on create.
+       *
+       * * `pending` - Pending
+       * * `acknowledged` - Acknowledged
+       * * `resolved` - Resolved
+       * * `dismissed` - Dismissed */
+      field_note_status?: FieldNoteStatusEnum;
+      /**
+         * Optional note left by the agent when acknowledging, resolving, or dismissing the field note.
+         * @nullable
+         */
+      resolution?: string | null;
+      /**
+         * Full URL of the page the field note was made on.
+         * @maxLength 2048
+         */
+      url: string;
+      /**
+         * Hostname of the page, used to scope field notes to a site.
+         * @maxLength 255
+         */
+      host: string;
+      /**
+         * Path portion of the URL.
+         * @maxLength 2048
+         * @nullable
+         */
+      pathname?: string | null;
+      /**
+         * CSS selector that locates the element on the page.
+         * @maxLength 4096
+         */
+      selector: string;
+      /**
+         * Visible text of the element, if any.
+         * @maxLength 2048
+         * @nullable
+         */
+      element_text?: string | null;
+      /**
+         * Serialized autocapture-style element chain from the element up to the document root.
+         * @maxLength 20000
+         * @nullable
+         */
+      element_chain?: string | null;
+      /** Structured element metadata (inferred selectors, attributes, component hints). */
+      element_context?: FieldNoteElementContext;
+      /**
+         * Viewport size when the field note was made, as {width, height}.
+         * @nullable
+         */
+      viewport?: FieldNoteViewport;
+      /**
+         * URL of an uploaded screenshot captured with the field_note.
+         * @maxLength 2048
+         * @nullable
+         */
+      screenshot_url?: string | null;
+      readonly created_at: string;
+      /** @nullable */
+      readonly updated_at: string | null;
+      readonly created_by: UserBasic;
     }
 
     /**
@@ -23732,24 +23907,50 @@ export namespace Schemas {
       scores: MessageSentimentScores;
     }
 
+    /**
+     * * `liquid` - liquid
+     */
+    export type MessageTemplateContentTemplatingEnum = typeof MessageTemplateContentTemplatingEnum[keyof typeof MessageTemplateContentTemplatingEnum];
+
+
+    export const MessageTemplateContentTemplatingEnum = {
+      Liquid: 'liquid',
+    } as const;
+
     export interface MessageTemplateContent {
-      templating?: HogFunctionTemplatingEnum;
+      /** Templating language for the email content. Always 'liquid' — Liquid tags pass through verbatim.
+       *
+       * * `liquid` - liquid */
+      templating?: MessageTemplateContentTemplatingEnum;
+      /** Email message content. Replaced as a whole on update — send the complete object. */
       email?: EmailTemplate | null;
     }
 
     export interface MessageTemplate {
       readonly id: string;
-      /** @maxLength 400 */
+      /**
+         * Human-readable template name shown in the library.
+         * @maxLength 400
+         */
       name: string;
+      /** What the template is for and when to use it. */
       description?: string;
       readonly created_at: string;
       readonly updated_at: string;
+      /** Template content keyed by channel. Replaced as a whole on update, not merged. */
       content?: MessageTemplateContent;
       readonly created_by: UserBasic;
-      /** @maxLength 24 */
+      /**
+         * Message channel of the template. Currently 'email'.
+         * @maxLength 24
+         */
       type?: string;
-      /** @nullable */
+      /**
+         * Message category ID to file the template under. Must belong to the same project.
+         * @nullable
+         */
       message_category?: string | null;
+      /** Soft-delete flag. Set true to remove the template from the library. */
       deleted?: boolean;
     }
 
@@ -23963,6 +24164,44 @@ export namespace Schemas {
       _create_in_folder?: string;
     }
 
+    export interface NotebookCollabCursor {
+      /**
+         * ProseMirror selection head position (rich v1 notebooks).
+         * @minimum 0
+         */
+      head?: number;
+      /**
+         * Index of the caret's block node in the markdown notebook document (markdown notebooks).
+         * @minimum 0
+         */
+      node_index?: number;
+      /**
+         * Caret offset in the plain text of the focused editable element, in UTF-16 code units.
+         * @minimum 0
+         */
+      offset?: number;
+      /**
+         * Index of the focused list item when the caret is inside a list block.
+         * @minimum 0
+         */
+      list_item_index?: number;
+    }
+
+    export interface NotebookCollabPresence {
+      /**
+         * Unique identifier for the client session, used to skip self-echo on the update stream.
+         * @maxLength 200
+         */
+      client_id: string;
+      /**
+         * The notebook version the cursor position is relative to.
+         * @minimum 0
+         */
+      version: number;
+      /** The caller's caret position, broadcast to other clients on this notebook's collab stream. */
+      cursor: NotebookCollabCursor;
+    }
+
     export interface NotebookCollabSave {
       /** Unique identifier for the client session. */
       client_id: string;
@@ -23981,6 +24220,21 @@ export namespace Schemas {
          * @nullable
          */
       cursor_head?: number | null;
+    }
+
+    export interface NotebookMarkdownSave {
+      /** Unique identifier for the client session, used to skip self-echo on the update stream. */
+      client_id: string;
+      /** The notebook version the submitted content is based on (optimistic concurrency baseline). */
+      version: number;
+      /** The full markdown notebook document: a ProseMirror doc wrapping a single markdown node. */
+      content: unknown;
+      /** Plain text for search indexing. */
+      text_content?: string;
+      /** Updated notebook title. */
+      title?: string;
+      /** The author's caret in the saved markdown, broadcast with the update so other clients can move the author's remote caret together with the text change. */
+      cursor?: NotebookCollabCursor;
     }
 
     export interface NotebookMinimal {
@@ -24016,6 +24270,7 @@ export namespace Schemas {
      * * `survey` - SURVEY
      * * `experiment` - EXPERIMENT
      * * `error_tracking` - ERROR_TRACKING
+     * * `customer_analytics` - CUSTOMER_ANALYTICS
      */
     export type NotificationEventSourceTypeEnum = typeof NotificationEventSourceTypeEnum[keyof typeof NotificationEventSourceTypeEnum];
 
@@ -24029,6 +24284,7 @@ export namespace Schemas {
       Survey: 'survey',
       Experiment: 'experiment',
       ErrorTracking: 'error_tracking',
+      CustomerAnalytics: 'customer_analytics',
     } as const;
 
     export interface NotificationEvent {
@@ -25340,6 +25596,15 @@ export namespace Schemas {
       /** @nullable */
       previous?: string | null;
       results: FeatureFlag[];
+    }
+
+    export interface PaginatedFieldNoteList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: FieldNote[];
     }
 
     export interface PaginatedFileSystemList {
@@ -28967,7 +29232,7 @@ export namespace Schemas {
          */
       name?: string;
       /**
-         * Identifier for the account in an external system (e.g. CRM ID). Optional.
+         * Identifier linking this account to its source customer — the analytics group key (the customer's organization id), used to match billing and external records. Optional.
          * @maxLength 400
          * @nullable
          */
@@ -30655,6 +30920,93 @@ export namespace Schemas {
       is_remote_configuration?: boolean | null;
     }
 
+    /**
+     * Structured element metadata (inferred selectors, attributes, component hints).
+     */
+    export type PatchedFieldNoteElementContext = { [key: string]: unknown };
+
+    /**
+     * Viewport size when the field note was made, as {width, height}.
+     * @nullable
+     */
+    export type PatchedFieldNoteViewport = {
+      /** Viewport width in pixels. */
+      width?: number;
+      /** Viewport height in pixels. */
+      height?: number;
+    } | null;
+
+    export interface PatchedFieldNote {
+      readonly id?: string;
+      /**
+         * The note the user wrote about the element.
+         * @maxLength 5000
+         */
+      comment?: string;
+      /** Lifecycle of the field note: pending, acknowledged, resolved, or dismissed. Ignored on create.
+       *
+       * * `pending` - Pending
+       * * `acknowledged` - Acknowledged
+       * * `resolved` - Resolved
+       * * `dismissed` - Dismissed */
+      field_note_status?: FieldNoteStatusEnum;
+      /**
+         * Optional note left by the agent when acknowledging, resolving, or dismissing the field note.
+         * @nullable
+         */
+      resolution?: string | null;
+      /**
+         * Full URL of the page the field note was made on.
+         * @maxLength 2048
+         */
+      url?: string;
+      /**
+         * Hostname of the page, used to scope field notes to a site.
+         * @maxLength 255
+         */
+      host?: string;
+      /**
+         * Path portion of the URL.
+         * @maxLength 2048
+         * @nullable
+         */
+      pathname?: string | null;
+      /**
+         * CSS selector that locates the element on the page.
+         * @maxLength 4096
+         */
+      selector?: string;
+      /**
+         * Visible text of the element, if any.
+         * @maxLength 2048
+         * @nullable
+         */
+      element_text?: string | null;
+      /**
+         * Serialized autocapture-style element chain from the element up to the document root.
+         * @maxLength 20000
+         * @nullable
+         */
+      element_chain?: string | null;
+      /** Structured element metadata (inferred selectors, attributes, component hints). */
+      element_context?: PatchedFieldNoteElementContext;
+      /**
+         * Viewport size when the field note was made, as {width, height}.
+         * @nullable
+         */
+      viewport?: PatchedFieldNoteViewport;
+      /**
+         * URL of an uploaded screenshot captured with the field_note.
+         * @maxLength 2048
+         * @nullable
+         */
+      screenshot_url?: string | null;
+      readonly created_at?: string;
+      /** @nullable */
+      readonly updated_at?: string | null;
+      readonly created_by?: UserBasic;
+    }
+
     export interface PatchedFileSystem {
       readonly id?: string;
       path?: string;
@@ -31534,17 +31886,29 @@ export namespace Schemas {
 
     export interface PatchedMessageTemplate {
       readonly id?: string;
-      /** @maxLength 400 */
+      /**
+         * Human-readable template name shown in the library.
+         * @maxLength 400
+         */
       name?: string;
+      /** What the template is for and when to use it. */
       description?: string;
       readonly created_at?: string;
       readonly updated_at?: string;
+      /** Template content keyed by channel. Replaced as a whole on update, not merged. */
       content?: MessageTemplateContent;
       readonly created_by?: UserBasic;
-      /** @maxLength 24 */
+      /**
+         * Message channel of the template. Currently 'email'.
+         * @maxLength 24
+         */
       type?: string;
-      /** @nullable */
+      /**
+         * Message category ID to file the template under. Must belong to the same project.
+         * @nullable
+         */
       message_category?: string | null;
+      /** Soft-delete flag. Set true to remove the template from the library. */
       deleted?: boolean;
     }
 
@@ -40436,6 +40800,276 @@ export namespace Schemas {
       runs: SlackThreadContextRun[];
     }
 
+    export interface SourceConnectLink {
+      /** The source type the link is for. */
+      source_type: string;
+      /** What the user will do on the connect page: 'oauth' = authorize an account in their browser; 'credentials' = enter connection details (or pick OAuth where the source offers both). Either way secrets never pass through the agent, and the result is always a stored credential id.
+       *
+       * * `oauth` - oauth
+       * * `credentials` - credentials */
+      auth_method: AuthMethodEnum;
+      /** Full URL to share with the user. It opens the source's connection form in PostHog — credentials never pass through the agent or the chat. */
+      connect_url: string;
+      /** Next steps for the agent to relay to the user. */
+      instructions: string;
+    }
+
+    export interface SourceCredential {
+      /** Stored credential id. Pass to the setup endpoint as {'credential_id': <id>} to create the source. */
+      credential_id: string;
+      /** The source type the stored credentials are for. */
+      source_type: string;
+      /** When the credentials were stored. */
+      created_at: string;
+      /** When the stored credentials expire. Unconsumed credentials are unusable past this time. */
+      expires_at: string;
+    }
+
+    /**
+     * Connection details as flat keys for the source_type — the same fields the create flow accepts (host, port, password, API key, …). Checked against a live connection before being stored.
+     */
+    export type SourceCredentialCreatePayload = { [key: string]: unknown };
+
+    export interface SourceCredentialCreate {
+      /** The source type these credentials are for (e.g. 'Stripe', 'Postgres').
+       *
+       * * `Ashby` - Ashby
+       * * `Supabase` - Supabase
+       * * `CustomerIO` - CustomerIO
+       * * `Github` - Github
+       * * `Stripe` - Stripe
+       * * `Hubspot` - Hubspot
+       * * `Postgres` - Postgres
+       * * `Zendesk` - Zendesk
+       * * `Snowflake` - Snowflake
+       * * `Salesforce` - Salesforce
+       * * `MySQL` - MySQL
+       * * `MongoDB` - MongoDB
+       * * `MSSQL` - MSSQL
+       * * `Vitally` - Vitally
+       * * `BigQuery` - BigQuery
+       * * `Chargebee` - Chargebee
+       * * `Clerk` - Clerk
+       * * `GoogleAds` - GoogleAds
+       * * `GoogleSearchConsole` - GoogleSearchConsole
+       * * `TemporalIO` - TemporalIO
+       * * `DoIt` - DoIt
+       * * `GoogleSheets` - GoogleSheets
+       * * `MetaAds` - MetaAds
+       * * `Klaviyo` - Klaviyo
+       * * `Mailchimp` - Mailchimp
+       * * `Braze` - Braze
+       * * `Mailjet` - Mailjet
+       * * `Redshift` - Redshift
+       * * `Polar` - Polar
+       * * `RevenueCat` - RevenueCat
+       * * `LinkedinAds` - LinkedinAds
+       * * `RedditAds` - RedditAds
+       * * `TikTokAds` - TikTokAds
+       * * `BingAds` - BingAds
+       * * `Shopify` - Shopify
+       * * `Attio` - Attio
+       * * `SnapchatAds` - SnapchatAds
+       * * `Linear` - Linear
+       * * `Intercom` - Intercom
+       * * `Amplitude` - Amplitude
+       * * `Mixpanel` - Mixpanel
+       * * `Jira` - Jira
+       * * `ActiveCampaign` - ActiveCampaign
+       * * `Marketo` - Marketo
+       * * `Adjust` - Adjust
+       * * `AppsFlyer` - AppsFlyer
+       * * `Freshdesk` - Freshdesk
+       * * `GoogleAnalytics` - GoogleAnalytics
+       * * `Pipedrive` - Pipedrive
+       * * `SendGrid` - SendGrid
+       * * `Slack` - Slack
+       * * `PagerDuty` - PagerDuty
+       * * `Asana` - Asana
+       * * `Notion` - Notion
+       * * `Airtable` - Airtable
+       * * `Greenhouse` - Greenhouse
+       * * `BambooHR` - BambooHR
+       * * `Lever` - Lever
+       * * `GitLab` - GitLab
+       * * `Datadog` - Datadog
+       * * `Sentry` - Sentry
+       * * `Pendo` - Pendo
+       * * `FullStory` - FullStory
+       * * `AmazonAds` - AmazonAds
+       * * `PinterestAds` - PinterestAds
+       * * `AppleSearchAds` - AppleSearchAds
+       * * `QuickBooks` - QuickBooks
+       * * `Xero` - Xero
+       * * `NetSuite` - NetSuite
+       * * `WooCommerce` - WooCommerce
+       * * `BigCommerce` - BigCommerce
+       * * `PayPal` - PayPal
+       * * `Square` - Square
+       * * `Zoom` - Zoom
+       * * `Trello` - Trello
+       * * `Monday` - Monday
+       * * `ClickUp` - ClickUp
+       * * `Confluence` - Confluence
+       * * `Recurly` - Recurly
+       * * `SalesLoft` - SalesLoft
+       * * `Outreach` - Outreach
+       * * `Gong` - Gong
+       * * `Calendly` - Calendly
+       * * `Typeform` - Typeform
+       * * `Iterable` - Iterable
+       * * `ZohoCRM` - ZohoCRM
+       * * `Close` - Close
+       * * `Oracle` - Oracle
+       * * `DynamoDB` - DynamoDB
+       * * `Elasticsearch` - Elasticsearch
+       * * `Kafka` - Kafka
+       * * `LaunchDarkly` - LaunchDarkly
+       * * `Braintree` - Braintree
+       * * `Recharge` - Recharge
+       * * `HelpScout` - HelpScout
+       * * `Gorgias` - Gorgias
+       * * `Instagram` - Instagram
+       * * `YouTubeAnalytics` - YouTubeAnalytics
+       * * `FacebookPages` - FacebookPages
+       * * `TwitterAds` - TwitterAds
+       * * `Workday` - Workday
+       * * `ServiceNow` - ServiceNow
+       * * `Pardot` - Pardot
+       * * `Copper` - Copper
+       * * `Front` - Front
+       * * `ChartMogul` - ChartMogul
+       * * `Zuora` - Zuora
+       * * `Paddle` - Paddle
+       * * `CircleCI` - CircleCI
+       * * `CockroachDB` - CockroachDB
+       * * `Firebase` - Firebase
+       * * `AzureBlob` - AzureBlob
+       * * `GoogleDrive` - GoogleDrive
+       * * `OneDrive` - OneDrive
+       * * `SharePoint` - SharePoint
+       * * `Box` - Box
+       * * `SFTP` - SFTP
+       * * `MicrosoftTeams` - MicrosoftTeams
+       * * `Aircall` - Aircall
+       * * `Webflow` - Webflow
+       * * `Okta` - Okta
+       * * `Auth0` - Auth0
+       * * `Productboard` - Productboard
+       * * `Smartsheet` - Smartsheet
+       * * `Wrike` - Wrike
+       * * `Plaid` - Plaid
+       * * `SurveyMonkey` - SurveyMonkey
+       * * `Eventbrite` - Eventbrite
+       * * `RingCentral` - RingCentral
+       * * `Twilio` - Twilio
+       * * `Freshsales` - Freshsales
+       * * `Shortcut` - Shortcut
+       * * `ConvertKit` - ConvertKit
+       * * `Drip` - Drip
+       * * `CampaignMonitor` - CampaignMonitor
+       * * `MailerLite` - MailerLite
+       * * `Omnisend` - Omnisend
+       * * `Brevo` - Brevo
+       * * `Postmark` - Postmark
+       * * `Granola` - Granola
+       * * `BuildBetter` - BuildBetter
+       * * `Convex` - Convex
+       * * `ClickHouse` - ClickHouse
+       * * `Plain` - Plain
+       * * `Resend` - Resend
+       * * `PgAnalyze` - PgAnalyze
+       * * `WorkOS` - WorkOS
+       * * `AmazonS3` - AmazonS3
+       * * `GoogleCloudStorage` - GoogleCloudStorage
+       * * `Databricks` - Databricks
+       * * `Dynamics365` - Dynamics365
+       * * `SalesforceMarketingCloud` - SalesforceMarketingCloud
+       * * `Db2` - Db2
+       * * `Heap` - Heap
+       * * `AdobeAnalytics` - AdobeAnalytics
+       * * `Matomo` - Matomo
+       * * `Optimizely` - Optimizely
+       * * `Adyen` - Adyen
+       * * `GoCardless` - GoCardless
+       * * `Mollie` - Mollie
+       * * `CheckoutCom` - CheckoutCom
+       * * `Branch` - Branch
+       * * `Criteo` - Criteo
+       * * `Outbrain` - Outbrain
+       * * `Taboola` - Taboola
+       * * `AdRoll` - AdRoll
+       * * `DisplayVideo360` - DisplayVideo360
+       * * `GoogleAdManager` - GoogleAdManager
+       * * `CampaignManager360` - CampaignManager360
+       * * `SearchAds360` - SearchAds360
+       * * `AdobeCommerce` - AdobeCommerce
+       * * `AmazonSellingPartner` - AmazonSellingPartner
+       * * `Ebay` - Ebay
+       * * `Commercetools` - Commercetools
+       * * `LightspeedRetail` - LightspeedRetail
+       * * `ShipStation` - ShipStation
+       * * `ConstantContact` - ConstantContact
+       * * `Mailgun` - Mailgun
+       * * `Eloqua` - Eloqua
+       * * `Sailthru` - Sailthru
+       * * `Ortto` - Ortto
+       * * `Attentive` - Attentive
+       * * `Kustomer` - Kustomer
+       * * `Dixa` - Dixa
+       * * `Gladly` - Gladly
+       * * `Qualtrics` - Qualtrics
+       * * `Delighted` - Delighted
+       * * `AzureDevOps` - AzureDevOps
+       * * `Rollbar` - Rollbar
+       * * `Opsgenie` - Opsgenie
+       * * `IncidentIo` - IncidentIo
+       * * `Pingdom` - Pingdom
+       * * `Cloudflare` - Cloudflare
+       * * `CosmosDB` - CosmosDB
+       * * `PlanetScale` - PlanetScale
+       * * `SapHana` - SapHana
+       * * `Rippling` - Rippling
+       * * `HiBob` - HiBob
+       * * `Personio` - Personio
+       * * `Deel` - Deel
+       * * `AdpWorkforceNow` - AdpWorkforceNow
+       * * `Paylocity` - Paylocity
+       * * `Gusto` - Gusto
+       * * `CultureAmp` - CultureAmp
+       * * `Lattice` - Lattice
+       * * `SageIntacct` - SageIntacct
+       * * `FreshBooks` - FreshBooks
+       * * `Expensify` - Expensify
+       * * `Ramp` - Ramp
+       * * `Brex` - Brex
+       * * `Coupa` - Coupa
+       * * `SapConcur` - SapConcur
+       * * `Apollo` - Apollo
+       * * `Crunchbase` - Crunchbase
+       * * `ZoomInfo` - ZoomInfo
+       * * `Clari` - Clari
+       * * `Chorus` - Chorus
+       * * `Coda` - Coda
+       * * `Guru` - Guru
+       * * `Dropbox` - Dropbox
+       * * `Docusign` - Docusign
+       * * `PandaDoc` - PandaDoc
+       * * `SapErp` - SapErp
+       * * `SapSuccessFactors` - SapSuccessFactors
+       * * `OracleEbs` - OracleEbs
+       * * `OracleFusion` - OracleFusion
+       * * `AmazonSNS` - AmazonSNS
+       * * `AmazonEventBridge` - AmazonEventBridge
+       * * `AmazonSQS` - AmazonSQS
+       * * `AmazonKinesis` - AmazonKinesis
+       * * `AmazonCloudWatch` - AmazonCloudWatch
+       * * `Custom` - Custom */
+      source_type: ExternalDataSourceTypeEnum;
+      /** Connection details as flat keys for the source_type — the same fields the create flow accepts (host, port, password, API key, …). Checked against a live connection before being stored. */
+      payload: SourceCredentialCreatePayload;
+    }
+
     export interface SourceMappingSuggestion {
       /** The raw utm_source value seen on events */
       raw_utm_source: string;
@@ -40460,6 +41094,287 @@ export namespace Schemas {
       Auto: 'auto',
       Mapped: 'mapped',
     } as const;
+
+    /**
+     * Connection details as flat keys for the source_type (discover required fields with the wizard tool). Prefer references over raw secrets: pass {'credential_id': <id>} referencing the connection details the user stored via the connect-link page (discover ids with the stored_credentials endpoint) — they are merged in server-side and deleted once consumed. An already-connected OAuth integration can be passed via its id key instead (e.g. {'hubspot_integration_id': 123}). A 'schemas' array is NOT required — all discovered tables are enabled automatically with sensible sync defaults.
+     */
+    export type SourceSetupPayload = { [key: string]: unknown };
+
+    export interface SourceSetup {
+      /** The source type to set up (e.g. 'Stripe', 'Postgres', 'Hubspot').
+       *
+       * * `Ashby` - Ashby
+       * * `Supabase` - Supabase
+       * * `CustomerIO` - CustomerIO
+       * * `Github` - Github
+       * * `Stripe` - Stripe
+       * * `Hubspot` - Hubspot
+       * * `Postgres` - Postgres
+       * * `Zendesk` - Zendesk
+       * * `Snowflake` - Snowflake
+       * * `Salesforce` - Salesforce
+       * * `MySQL` - MySQL
+       * * `MongoDB` - MongoDB
+       * * `MSSQL` - MSSQL
+       * * `Vitally` - Vitally
+       * * `BigQuery` - BigQuery
+       * * `Chargebee` - Chargebee
+       * * `Clerk` - Clerk
+       * * `GoogleAds` - GoogleAds
+       * * `GoogleSearchConsole` - GoogleSearchConsole
+       * * `TemporalIO` - TemporalIO
+       * * `DoIt` - DoIt
+       * * `GoogleSheets` - GoogleSheets
+       * * `MetaAds` - MetaAds
+       * * `Klaviyo` - Klaviyo
+       * * `Mailchimp` - Mailchimp
+       * * `Braze` - Braze
+       * * `Mailjet` - Mailjet
+       * * `Redshift` - Redshift
+       * * `Polar` - Polar
+       * * `RevenueCat` - RevenueCat
+       * * `LinkedinAds` - LinkedinAds
+       * * `RedditAds` - RedditAds
+       * * `TikTokAds` - TikTokAds
+       * * `BingAds` - BingAds
+       * * `Shopify` - Shopify
+       * * `Attio` - Attio
+       * * `SnapchatAds` - SnapchatAds
+       * * `Linear` - Linear
+       * * `Intercom` - Intercom
+       * * `Amplitude` - Amplitude
+       * * `Mixpanel` - Mixpanel
+       * * `Jira` - Jira
+       * * `ActiveCampaign` - ActiveCampaign
+       * * `Marketo` - Marketo
+       * * `Adjust` - Adjust
+       * * `AppsFlyer` - AppsFlyer
+       * * `Freshdesk` - Freshdesk
+       * * `GoogleAnalytics` - GoogleAnalytics
+       * * `Pipedrive` - Pipedrive
+       * * `SendGrid` - SendGrid
+       * * `Slack` - Slack
+       * * `PagerDuty` - PagerDuty
+       * * `Asana` - Asana
+       * * `Notion` - Notion
+       * * `Airtable` - Airtable
+       * * `Greenhouse` - Greenhouse
+       * * `BambooHR` - BambooHR
+       * * `Lever` - Lever
+       * * `GitLab` - GitLab
+       * * `Datadog` - Datadog
+       * * `Sentry` - Sentry
+       * * `Pendo` - Pendo
+       * * `FullStory` - FullStory
+       * * `AmazonAds` - AmazonAds
+       * * `PinterestAds` - PinterestAds
+       * * `AppleSearchAds` - AppleSearchAds
+       * * `QuickBooks` - QuickBooks
+       * * `Xero` - Xero
+       * * `NetSuite` - NetSuite
+       * * `WooCommerce` - WooCommerce
+       * * `BigCommerce` - BigCommerce
+       * * `PayPal` - PayPal
+       * * `Square` - Square
+       * * `Zoom` - Zoom
+       * * `Trello` - Trello
+       * * `Monday` - Monday
+       * * `ClickUp` - ClickUp
+       * * `Confluence` - Confluence
+       * * `Recurly` - Recurly
+       * * `SalesLoft` - SalesLoft
+       * * `Outreach` - Outreach
+       * * `Gong` - Gong
+       * * `Calendly` - Calendly
+       * * `Typeform` - Typeform
+       * * `Iterable` - Iterable
+       * * `ZohoCRM` - ZohoCRM
+       * * `Close` - Close
+       * * `Oracle` - Oracle
+       * * `DynamoDB` - DynamoDB
+       * * `Elasticsearch` - Elasticsearch
+       * * `Kafka` - Kafka
+       * * `LaunchDarkly` - LaunchDarkly
+       * * `Braintree` - Braintree
+       * * `Recharge` - Recharge
+       * * `HelpScout` - HelpScout
+       * * `Gorgias` - Gorgias
+       * * `Instagram` - Instagram
+       * * `YouTubeAnalytics` - YouTubeAnalytics
+       * * `FacebookPages` - FacebookPages
+       * * `TwitterAds` - TwitterAds
+       * * `Workday` - Workday
+       * * `ServiceNow` - ServiceNow
+       * * `Pardot` - Pardot
+       * * `Copper` - Copper
+       * * `Front` - Front
+       * * `ChartMogul` - ChartMogul
+       * * `Zuora` - Zuora
+       * * `Paddle` - Paddle
+       * * `CircleCI` - CircleCI
+       * * `CockroachDB` - CockroachDB
+       * * `Firebase` - Firebase
+       * * `AzureBlob` - AzureBlob
+       * * `GoogleDrive` - GoogleDrive
+       * * `OneDrive` - OneDrive
+       * * `SharePoint` - SharePoint
+       * * `Box` - Box
+       * * `SFTP` - SFTP
+       * * `MicrosoftTeams` - MicrosoftTeams
+       * * `Aircall` - Aircall
+       * * `Webflow` - Webflow
+       * * `Okta` - Okta
+       * * `Auth0` - Auth0
+       * * `Productboard` - Productboard
+       * * `Smartsheet` - Smartsheet
+       * * `Wrike` - Wrike
+       * * `Plaid` - Plaid
+       * * `SurveyMonkey` - SurveyMonkey
+       * * `Eventbrite` - Eventbrite
+       * * `RingCentral` - RingCentral
+       * * `Twilio` - Twilio
+       * * `Freshsales` - Freshsales
+       * * `Shortcut` - Shortcut
+       * * `ConvertKit` - ConvertKit
+       * * `Drip` - Drip
+       * * `CampaignMonitor` - CampaignMonitor
+       * * `MailerLite` - MailerLite
+       * * `Omnisend` - Omnisend
+       * * `Brevo` - Brevo
+       * * `Postmark` - Postmark
+       * * `Granola` - Granola
+       * * `BuildBetter` - BuildBetter
+       * * `Convex` - Convex
+       * * `ClickHouse` - ClickHouse
+       * * `Plain` - Plain
+       * * `Resend` - Resend
+       * * `PgAnalyze` - PgAnalyze
+       * * `WorkOS` - WorkOS
+       * * `AmazonS3` - AmazonS3
+       * * `GoogleCloudStorage` - GoogleCloudStorage
+       * * `Databricks` - Databricks
+       * * `Dynamics365` - Dynamics365
+       * * `SalesforceMarketingCloud` - SalesforceMarketingCloud
+       * * `Db2` - Db2
+       * * `Heap` - Heap
+       * * `AdobeAnalytics` - AdobeAnalytics
+       * * `Matomo` - Matomo
+       * * `Optimizely` - Optimizely
+       * * `Adyen` - Adyen
+       * * `GoCardless` - GoCardless
+       * * `Mollie` - Mollie
+       * * `CheckoutCom` - CheckoutCom
+       * * `Branch` - Branch
+       * * `Criteo` - Criteo
+       * * `Outbrain` - Outbrain
+       * * `Taboola` - Taboola
+       * * `AdRoll` - AdRoll
+       * * `DisplayVideo360` - DisplayVideo360
+       * * `GoogleAdManager` - GoogleAdManager
+       * * `CampaignManager360` - CampaignManager360
+       * * `SearchAds360` - SearchAds360
+       * * `AdobeCommerce` - AdobeCommerce
+       * * `AmazonSellingPartner` - AmazonSellingPartner
+       * * `Ebay` - Ebay
+       * * `Commercetools` - Commercetools
+       * * `LightspeedRetail` - LightspeedRetail
+       * * `ShipStation` - ShipStation
+       * * `ConstantContact` - ConstantContact
+       * * `Mailgun` - Mailgun
+       * * `Eloqua` - Eloqua
+       * * `Sailthru` - Sailthru
+       * * `Ortto` - Ortto
+       * * `Attentive` - Attentive
+       * * `Kustomer` - Kustomer
+       * * `Dixa` - Dixa
+       * * `Gladly` - Gladly
+       * * `Qualtrics` - Qualtrics
+       * * `Delighted` - Delighted
+       * * `AzureDevOps` - AzureDevOps
+       * * `Rollbar` - Rollbar
+       * * `Opsgenie` - Opsgenie
+       * * `IncidentIo` - IncidentIo
+       * * `Pingdom` - Pingdom
+       * * `Cloudflare` - Cloudflare
+       * * `CosmosDB` - CosmosDB
+       * * `PlanetScale` - PlanetScale
+       * * `SapHana` - SapHana
+       * * `Rippling` - Rippling
+       * * `HiBob` - HiBob
+       * * `Personio` - Personio
+       * * `Deel` - Deel
+       * * `AdpWorkforceNow` - AdpWorkforceNow
+       * * `Paylocity` - Paylocity
+       * * `Gusto` - Gusto
+       * * `CultureAmp` - CultureAmp
+       * * `Lattice` - Lattice
+       * * `SageIntacct` - SageIntacct
+       * * `FreshBooks` - FreshBooks
+       * * `Expensify` - Expensify
+       * * `Ramp` - Ramp
+       * * `Brex` - Brex
+       * * `Coupa` - Coupa
+       * * `SapConcur` - SapConcur
+       * * `Apollo` - Apollo
+       * * `Crunchbase` - Crunchbase
+       * * `ZoomInfo` - ZoomInfo
+       * * `Clari` - Clari
+       * * `Chorus` - Chorus
+       * * `Coda` - Coda
+       * * `Guru` - Guru
+       * * `Dropbox` - Dropbox
+       * * `Docusign` - Docusign
+       * * `PandaDoc` - PandaDoc
+       * * `SapErp` - SapErp
+       * * `SapSuccessFactors` - SapSuccessFactors
+       * * `OracleEbs` - OracleEbs
+       * * `OracleFusion` - OracleFusion
+       * * `AmazonSNS` - AmazonSNS
+       * * `AmazonEventBridge` - AmazonEventBridge
+       * * `AmazonSQS` - AmazonSQS
+       * * `AmazonKinesis` - AmazonKinesis
+       * * `AmazonCloudWatch` - AmazonCloudWatch
+       * * `Custom` - Custom */
+      source_type: ExternalDataSourceTypeEnum;
+      /** Connection details as flat keys for the source_type (discover required fields with the wizard tool). Prefer references over raw secrets: pass {'credential_id': <id>} referencing the connection details the user stored via the connect-link page (discover ids with the stored_credentials endpoint) — they are merged in server-side and deleted once consumed. An already-connected OAuth integration can be passed via its id key instead (e.g. {'hubspot_integration_id': 123}). A 'schemas' array is NOT required — all discovered tables are enabled automatically with sensible sync defaults. */
+      payload?: SourceSetupPayload;
+      /**
+         * Table name prefix in HogQL, e.g. 'stripe' produces stripe_charges. Defaults to the source type.
+         * @maxLength 100
+         * @nullable
+         */
+      prefix?: string | null;
+      /**
+         * Human-readable description.
+         * @maxLength 400
+         * @nullable
+         */
+      description?: string | null;
+    }
+
+    export interface SourceSetupWebhook {
+      /** Whether the webhook was registered with the external service. When true, webhook-capable tables (including webhook-only ones) sync via real-time webhooks; when false, tables fall back to the polling sync defaults and webhook-only tables stay disabled. */
+      success: boolean;
+      /**
+         * The PostHog endpoint the external service delivers events to.
+         * @nullable
+         */
+      webhook_url: string | null;
+      /**
+         * Why webhook registration failed (e.g. the credentials lack webhook permissions).
+         * @nullable
+         */
+      error: string | null;
+      /** Webhook input names the user still needs to provide (e.g. a signing secret the external API did not return on create). Submit them via the update_webhook_inputs endpoint. */
+      pending_inputs: string[];
+    }
+
+    export interface SourceSetupResponse {
+      /** ID of the created external data source. */
+      id: string;
+      /** Outcome of automatic webhook registration. Only present for sources that support webhooks (e.g. Stripe) and have webhook-capable tables. */
+      webhook?: SourceSetupWebhook;
+    }
 
     /**
      * * `severity` - severity
@@ -43263,7 +44178,7 @@ export namespace Schemas {
       rootSpans?: boolean;
       /** Number of child spans to prefetch per trace (1-100). */
       prefetchSpans?: number;
-      /** Omit the per-span attributes map from results to keep payloads compact. Defaults to false. */
+      /** Omit the per-span attributes and resource attributes maps from results to keep payloads compact. Defaults to false. */
       excludeAttributes?: boolean;
     }
 
@@ -43275,7 +44190,7 @@ export namespace Schemas {
     export interface _TracingTraceRequest {
       /** Date range for the query. Defaults to last 24 hours. */
       dateRange?: _TracingDateRange;
-      /** Omit the per-span attributes map from results to keep payloads compact. Defaults to false. */
+      /** Omit the per-span attributes and resource attributes maps from results to keep payloads compact. Defaults to false. */
       excludeAttributes?: boolean;
     }
 
@@ -44477,6 +45392,13 @@ export namespace Schemas {
       errors?: string[];
     };
 
+    export type EnvironmentsExternalDataSourcesConnectLinkRetrieveParams = {
+    /**
+     * The source type to generate a connect link for (e.g. 'Stripe', 'Postgres', 'Hubspot').
+     */
+    source_type: string;
+    };
+
     export type EnvironmentsExternalDataSourcesConnectionsListParams = {
     /**
      * Number of results to return per page.
@@ -44490,6 +45412,17 @@ export namespace Schemas {
      * A search term.
      */
     search?: string;
+    };
+
+    export type EnvironmentsExternalDataSourcesStoredCredentialsListParams = {
+    /**
+     * A search term.
+     */
+    search?: string;
+    /**
+     * Only return stored credentials for this source type (e.g. 'Stripe', 'Postgres').
+     */
+    source_type?: string;
     };
 
     export type EnvironmentsFileDownloadBatchExportsListParams = {
@@ -50151,6 +51084,13 @@ export namespace Schemas {
       errors?: string[];
     };
 
+    export type ExternalDataSourcesConnectLinkRetrieveParams = {
+    /**
+     * The source type to generate a connect link for (e.g. 'Stripe', 'Postgres', 'Hubspot').
+     */
+    source_type: string;
+    };
+
     export type ExternalDataSourcesConnectionsListParams = {
     /**
      * Number of results to return per page.
@@ -50164,6 +51104,17 @@ export namespace Schemas {
      * A search term.
      */
     search?: string;
+    };
+
+    export type ExternalDataSourcesStoredCredentialsListParams = {
+    /**
+     * A search term.
+     */
+    search?: string;
+    /**
+     * Only return stored credentials for this source type (e.g. 'Stripe', 'Postgres').
+     */
+    source_type?: string;
     };
 
     export type FeatureFlagsListParams = {
@@ -50283,6 +51234,35 @@ export namespace Schemas {
      */
     groups?: string;
     };
+
+    export type FieldNotesListParams = {
+    /**
+     * Filter to field notes in this lifecycle state (e.g. `pending` for unaddressed feedback).
+     */
+    field_note_status?: FieldNotesListFieldNoteStatus;
+    /**
+     * Filter to field notes made on this hostname (e.g. `app.example.com`).
+     */
+    host?: string;
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type FieldNotesListFieldNoteStatus = typeof FieldNotesListFieldNoteStatus[keyof typeof FieldNotesListFieldNoteStatus];
+
+
+    export const FieldNotesListFieldNoteStatus = {
+      Acknowledged: 'acknowledged',
+      Dismissed: 'dismissed',
+      Pending: 'pending',
+      Resolved: 'resolved',
+    } as const;
 
     export type FileDownloadBatchExportsListParams = {
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16884,6 +16884,41 @@ export namespace Schemas {
     } as const;
 
     /**
+     * * `pending` - pending
+    * `completed` - completed
+    * `failed` - failed
+     */
+    export type MetricRecalculationResultStatusEnum = typeof MetricRecalculationResultStatusEnum[keyof typeof MetricRecalculationResultStatusEnum];
+
+
+    export const MetricRecalculationResultStatusEnum = {
+      Pending: 'pending',
+      Completed: 'completed',
+      Failed: 'failed',
+    } as const;
+
+    /**
+     * One metric's recalculated result row, read back from ExperimentMetricResult.
+     */
+    export interface MetricRecalculationResult {
+      /** UUID of the metric this result belongs to */
+      readonly metric_uuid: string;
+      /** Status of this metric's calculation in the run
+
+      * `pending` - pending
+      * `completed` - completed
+      * `failed` - failed */
+      readonly status: MetricRecalculationResultStatusEnum;
+      /** The computed metric result (ExperimentQueryResponse shape); null when status is pending or failed */
+      readonly result: unknown;
+      /**
+         * Error message when status is failed; otherwise null
+         * @nullable
+         */
+      readonly error_message: string | null;
+    }
+
+    /**
      * Serializer for metrics recalculation status responses.
      */
     export interface ExperimentMetricsRecalculation {
@@ -16927,6 +16962,8 @@ export namespace Schemas {
       readonly completed_at: string | null;
       /** True if returning an existing job rather than a newly created one */
       readonly is_existing: boolean;
+      /** Per-metric results computed by this run, scoped by the run's recalc fingerprint */
+      readonly results: readonly MetricRecalculationResult[];
     }
 
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33,8 +33,8 @@ export namespace Schemas {
 
     /**
      * * `read_write` - read_write
-    * `read` - read
-    * `none` - none
+     * * `read` - read
+     * * `none` - none
      */
     export type AccessLevelEnum = typeof AccessLevelEnum[keyof typeof AccessLevelEnum];
 
@@ -47,7 +47,7 @@ export namespace Schemas {
 
     /**
      * * `warehouse` - warehouse
-    * `direct` - direct
+     * * `direct` - direct
      */
     export type AccessMethodEnum = typeof AccessMethodEnum[keyof typeof AccessMethodEnum];
 
@@ -127,13 +127,13 @@ export namespace Schemas {
 
     /**
      * * `engineering` - Engineering
-    * `data` - Data
-    * `product` - Product Management
-    * `founder` - Founder
-    * `leadership` - Leadership
-    * `marketing` - Marketing
-    * `sales` - Sales / Success
-    * `other` - Other
+     * * `data` - Data
+     * * `product` - Product Management
+     * * `founder` - Founder
+     * * `leadership` - Leadership
+     * * `marketing` - Marketing
+     * * `sales` - Sales / Success
+     * * `other` - Other
      */
     export type RoleAtOrganizationEnum = typeof RoleAtOrganizationEnum[keyof typeof RoleAtOrganizationEnum];
 
@@ -537,32 +537,32 @@ export namespace Schemas {
 
     /**
      * * `event` - event
-    * `event_metadata` - event_metadata
-    * `feature` - feature
-    * `person` - person
-    * `cohort` - cohort
-    * `element` - element
-    * `static-cohort` - static-cohort
-    * `dynamic-cohort` - dynamic-cohort
-    * `precalculated-cohort` - precalculated-cohort
-    * `group` - group
-    * `recording` - recording
-    * `log_entry` - log_entry
-    * `behavioral` - behavioral
-    * `session` - session
-    * `hogql` - hogql
-    * `data_warehouse` - data_warehouse
-    * `data_warehouse_person_property` - data_warehouse_person_property
-    * `error_tracking_issue` - error_tracking_issue
-    * `log` - log
-    * `log_attribute` - log_attribute
-    * `log_resource_attribute` - log_resource_attribute
-    * `span` - span
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
-    * `revenue_analytics` - revenue_analytics
-    * `flag` - flag
-    * `workflow_variable` - workflow_variable
+     * * `event_metadata` - event_metadata
+     * * `feature` - feature
+     * * `person` - person
+     * * `cohort` - cohort
+     * * `element` - element
+     * * `static-cohort` - static-cohort
+     * * `dynamic-cohort` - dynamic-cohort
+     * * `precalculated-cohort` - precalculated-cohort
+     * * `group` - group
+     * * `recording` - recording
+     * * `log_entry` - log_entry
+     * * `behavioral` - behavioral
+     * * `session` - session
+     * * `hogql` - hogql
+     * * `data_warehouse` - data_warehouse
+     * * `data_warehouse_person_property` - data_warehouse_person_property
+     * * `error_tracking_issue` - error_tracking_issue
+     * * `log` - log
+     * * `log_attribute` - log_attribute
+     * * `log_resource_attribute` - log_resource_attribute
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
+     * * `revenue_analytics` - revenue_analytics
+     * * `flag` - flag
+     * * `workflow_variable` - workflow_variable
      */
     export type PropertyFilterTypeEnum = typeof PropertyFilterTypeEnum[keyof typeof PropertyFilterTypeEnum];
 
@@ -599,11 +599,11 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `icontains` - icontains
-    * `not_icontains` - not_icontains
-    * `regex` - regex
-    * `not_regex` - not_regex
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
      */
     export type StringMatchOperatorEnum = typeof StringMatchOperatorEnum[keyof typeof StringMatchOperatorEnum];
 
@@ -624,55 +624,55 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-
-      * `event` - event
-      * `event_metadata` - event_metadata
-      * `feature` - feature
-      * `person` - person
-      * `cohort` - cohort
-      * `element` - element
-      * `static-cohort` - static-cohort
-      * `dynamic-cohort` - dynamic-cohort
-      * `precalculated-cohort` - precalculated-cohort
-      * `group` - group
-      * `recording` - recording
-      * `log_entry` - log_entry
-      * `behavioral` - behavioral
-      * `session` - session
-      * `hogql` - hogql
-      * `data_warehouse` - data_warehouse
-      * `data_warehouse_person_property` - data_warehouse_person_property
-      * `error_tracking_issue` - error_tracking_issue
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute
-      * `revenue_analytics` - revenue_analytics
-      * `flag` - flag
-      * `workflow_variable` - workflow_variable */
+       *
+       * * `event` - event
+       * * `event_metadata` - event_metadata
+       * * `feature` - feature
+       * * `person` - person
+       * * `cohort` - cohort
+       * * `element` - element
+       * * `static-cohort` - static-cohort
+       * * `dynamic-cohort` - dynamic-cohort
+       * * `precalculated-cohort` - precalculated-cohort
+       * * `group` - group
+       * * `recording` - recording
+       * * `log_entry` - log_entry
+       * * `behavioral` - behavioral
+       * * `session` - session
+       * * `hogql` - hogql
+       * * `data_warehouse` - data_warehouse
+       * * `data_warehouse_person_property` - data_warehouse_person_property
+       * * `error_tracking_issue` - error_tracking_issue
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute
+       * * `revenue_analytics` - revenue_analytics
+       * * `flag` - flag
+       * * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** String value to match against. */
       value: string;
       /** String comparison operator.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains
-      * `regex` - regex
-      * `not_regex` - not_regex */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains
+       * * `regex` - regex
+       * * `not_regex` - not_regex */
       operator?: StringMatchOperatorEnum;
     }
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `gt` - gt
-    * `lt` - lt
-    * `gte` - gte
-    * `lte` - lte
+     * * `is_not` - is_not
+     * * `gt` - gt
+     * * `lt` - lt
+     * * `gte` - gte
+     * * `lte` - lte
      */
     export type NumericPropertyFilterOperatorEnum = typeof NumericPropertyFilterOperatorEnum[keyof typeof NumericPropertyFilterOperatorEnum];
 
@@ -693,53 +693,53 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-
-      * `event` - event
-      * `event_metadata` - event_metadata
-      * `feature` - feature
-      * `person` - person
-      * `cohort` - cohort
-      * `element` - element
-      * `static-cohort` - static-cohort
-      * `dynamic-cohort` - dynamic-cohort
-      * `precalculated-cohort` - precalculated-cohort
-      * `group` - group
-      * `recording` - recording
-      * `log_entry` - log_entry
-      * `behavioral` - behavioral
-      * `session` - session
-      * `hogql` - hogql
-      * `data_warehouse` - data_warehouse
-      * `data_warehouse_person_property` - data_warehouse_person_property
-      * `error_tracking_issue` - error_tracking_issue
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute
-      * `revenue_analytics` - revenue_analytics
-      * `flag` - flag
-      * `workflow_variable` - workflow_variable */
+       *
+       * * `event` - event
+       * * `event_metadata` - event_metadata
+       * * `feature` - feature
+       * * `person` - person
+       * * `cohort` - cohort
+       * * `element` - element
+       * * `static-cohort` - static-cohort
+       * * `dynamic-cohort` - dynamic-cohort
+       * * `precalculated-cohort` - precalculated-cohort
+       * * `group` - group
+       * * `recording` - recording
+       * * `log_entry` - log_entry
+       * * `behavioral` - behavioral
+       * * `session` - session
+       * * `hogql` - hogql
+       * * `data_warehouse` - data_warehouse
+       * * `data_warehouse_person_property` - data_warehouse_person_property
+       * * `error_tracking_issue` - error_tracking_issue
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute
+       * * `revenue_analytics` - revenue_analytics
+       * * `flag` - flag
+       * * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** Numeric value to compare against. */
       value: number;
       /** Numeric comparison operator.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `gt` - gt
-      * `lt` - lt
-      * `gte` - gte
-      * `lte` - lte */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `gt` - gt
+       * * `lt` - lt
+       * * `gte` - gte
+       * * `lte` - lte */
       operator?: NumericPropertyFilterOperatorEnum;
     }
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `in` - in
-    * `not_in` - not_in
+     * * `is_not` - is_not
+     * * `in` - in
+     * * `not_in` - not_in
      */
     export type ArrayPropertyFilterOperatorEnum = typeof ArrayPropertyFilterOperatorEnum[keyof typeof ArrayPropertyFilterOperatorEnum];
 
@@ -758,50 +758,50 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-
-      * `event` - event
-      * `event_metadata` - event_metadata
-      * `feature` - feature
-      * `person` - person
-      * `cohort` - cohort
-      * `element` - element
-      * `static-cohort` - static-cohort
-      * `dynamic-cohort` - dynamic-cohort
-      * `precalculated-cohort` - precalculated-cohort
-      * `group` - group
-      * `recording` - recording
-      * `log_entry` - log_entry
-      * `behavioral` - behavioral
-      * `session` - session
-      * `hogql` - hogql
-      * `data_warehouse` - data_warehouse
-      * `data_warehouse_person_property` - data_warehouse_person_property
-      * `error_tracking_issue` - error_tracking_issue
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute
-      * `revenue_analytics` - revenue_analytics
-      * `flag` - flag
-      * `workflow_variable` - workflow_variable */
+       *
+       * * `event` - event
+       * * `event_metadata` - event_metadata
+       * * `feature` - feature
+       * * `person` - person
+       * * `cohort` - cohort
+       * * `element` - element
+       * * `static-cohort` - static-cohort
+       * * `dynamic-cohort` - dynamic-cohort
+       * * `precalculated-cohort` - precalculated-cohort
+       * * `group` - group
+       * * `recording` - recording
+       * * `log_entry` - log_entry
+       * * `behavioral` - behavioral
+       * * `session` - session
+       * * `hogql` - hogql
+       * * `data_warehouse` - data_warehouse
+       * * `data_warehouse_person_property` - data_warehouse_person_property
+       * * `error_tracking_issue` - error_tracking_issue
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute
+       * * `revenue_analytics` - revenue_analytics
+       * * `flag` - flag
+       * * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** List of values to match. For example `["test@example.com", "ok@example.com"]`. */
       value: string[];
       /** Array comparison operator.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `in` - in
-      * `not_in` - not_in */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `in` - in
+       * * `not_in` - not_in */
       operator?: ArrayPropertyFilterOperatorEnum;
     }
 
     /**
      * * `is_date_exact` - is_date_exact
-    * `is_date_before` - is_date_before
-    * `is_date_after` - is_date_after
+     * * `is_date_before` - is_date_before
+     * * `is_date_after` - is_date_after
      */
     export type DateOperatorEnum = typeof DateOperatorEnum[keyof typeof DateOperatorEnum];
 
@@ -819,48 +819,48 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-
-      * `event` - event
-      * `event_metadata` - event_metadata
-      * `feature` - feature
-      * `person` - person
-      * `cohort` - cohort
-      * `element` - element
-      * `static-cohort` - static-cohort
-      * `dynamic-cohort` - dynamic-cohort
-      * `precalculated-cohort` - precalculated-cohort
-      * `group` - group
-      * `recording` - recording
-      * `log_entry` - log_entry
-      * `behavioral` - behavioral
-      * `session` - session
-      * `hogql` - hogql
-      * `data_warehouse` - data_warehouse
-      * `data_warehouse_person_property` - data_warehouse_person_property
-      * `error_tracking_issue` - error_tracking_issue
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute
-      * `revenue_analytics` - revenue_analytics
-      * `flag` - flag
-      * `workflow_variable` - workflow_variable */
+       *
+       * * `event` - event
+       * * `event_metadata` - event_metadata
+       * * `feature` - feature
+       * * `person` - person
+       * * `cohort` - cohort
+       * * `element` - element
+       * * `static-cohort` - static-cohort
+       * * `dynamic-cohort` - dynamic-cohort
+       * * `precalculated-cohort` - precalculated-cohort
+       * * `group` - group
+       * * `recording` - recording
+       * * `log_entry` - log_entry
+       * * `behavioral` - behavioral
+       * * `session` - session
+       * * `hogql` - hogql
+       * * `data_warehouse` - data_warehouse
+       * * `data_warehouse_person_property` - data_warehouse_person_property
+       * * `error_tracking_issue` - error_tracking_issue
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute
+       * * `revenue_analytics` - revenue_analytics
+       * * `flag` - flag
+       * * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** Date or datetime string in ISO 8601 format (e.g. '2024-01-15' or '2024-01-15T10:30:00Z'). */
       value: string;
       /** Date comparison operator.
-
-      * `is_date_exact` - is_date_exact
-      * `is_date_before` - is_date_before
-      * `is_date_after` - is_date_after */
+       *
+       * * `is_date_exact` - is_date_exact
+       * * `is_date_before` - is_date_before
+       * * `is_date_after` - is_date_after */
       operator?: DateOperatorEnum;
     }
 
     /**
      * * `is_set` - is_set
-    * `is_not_set` - is_not_set
+     * * `is_not_set` - is_not_set
      */
     export type ExistenceOperatorEnum = typeof ExistenceOperatorEnum[keyof typeof ExistenceOperatorEnum];
 
@@ -877,39 +877,39 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-
-      * `event` - event
-      * `event_metadata` - event_metadata
-      * `feature` - feature
-      * `person` - person
-      * `cohort` - cohort
-      * `element` - element
-      * `static-cohort` - static-cohort
-      * `dynamic-cohort` - dynamic-cohort
-      * `precalculated-cohort` - precalculated-cohort
-      * `group` - group
-      * `recording` - recording
-      * `log_entry` - log_entry
-      * `behavioral` - behavioral
-      * `session` - session
-      * `hogql` - hogql
-      * `data_warehouse` - data_warehouse
-      * `data_warehouse_person_property` - data_warehouse_person_property
-      * `error_tracking_issue` - error_tracking_issue
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute
-      * `revenue_analytics` - revenue_analytics
-      * `flag` - flag
-      * `workflow_variable` - workflow_variable */
+       *
+       * * `event` - event
+       * * `event_metadata` - event_metadata
+       * * `feature` - feature
+       * * `person` - person
+       * * `cohort` - cohort
+       * * `element` - element
+       * * `static-cohort` - static-cohort
+       * * `dynamic-cohort` - dynamic-cohort
+       * * `precalculated-cohort` - precalculated-cohort
+       * * `group` - group
+       * * `recording` - recording
+       * * `log_entry` - log_entry
+       * * `behavioral` - behavioral
+       * * `session` - session
+       * * `hogql` - hogql
+       * * `data_warehouse` - data_warehouse
+       * * `data_warehouse_person_property` - data_warehouse_person_property
+       * * `error_tracking_issue` - error_tracking_issue
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute
+       * * `revenue_analytics` - revenue_analytics
+       * * `flag` - flag
+       * * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** Existence check operator.
-
-      * `is_set` - is_set
-      * `is_not_set` - is_not_set */
+       *
+       * * `is_set` - is_set
+       * * `is_not_set` - is_not_set */
       operator: ExistenceOperatorEnum;
     }
 
@@ -917,8 +917,8 @@ export namespace Schemas {
 
     /**
      * * `contains` - contains
-    * `regex` - regex
-    * `exact` - exact
+     * * `regex` - regex
+     * * `exact` - exact
      */
     export type ActionStepMatchingEnum = typeof ActionStepMatchingEnum[keyof typeof ActionStepMatchingEnum];
 
@@ -958,10 +958,10 @@ export namespace Schemas {
          */
       text?: string | null;
       /** How to match the text value. Defaults to exact.
-
-      * `contains` - contains
-      * `regex` - regex
-      * `exact` - exact */
+       *
+       * * `contains` - contains
+       * * `regex` - regex
+       * * `exact` - exact */
       text_matching?: ActionStepMatchingEnum | null;
       /**
          * Link href attribute to match.
@@ -969,10 +969,10 @@ export namespace Schemas {
          */
       href?: string | null;
       /** How to match the href value. Defaults to exact.
-
-      * `contains` - contains
-      * `regex` - regex
-      * `exact` - exact */
+       *
+       * * `contains` - contains
+       * * `regex` - regex
+       * * `exact` - exact */
       href_matching?: ActionStepMatchingEnum | null;
       /**
          * Page URL to match.
@@ -980,10 +980,10 @@ export namespace Schemas {
          */
       url?: string | null;
       /** How to match the URL value. Defaults to contains.
-
-      * `contains` - contains
-      * `regex` - regex
-      * `exact` - exact */
+       *
+       * * `contains` - contains
+       * * `regex` - regex
+       * * `exact` - exact */
       url_matching?: ActionStepMatchingEnum | null;
     }
 
@@ -1040,8 +1040,8 @@ export namespace Schemas {
 
     /**
      * * `add` - add
-    * `remove` - remove
-    * `set` - set
+     * * `remove` - remove
+     * * `set` - set
      */
     export type ActionEnum = typeof ActionEnum[keyof typeof ActionEnum];
 
@@ -1626,8 +1626,8 @@ export namespace Schemas {
 
     /**
      * * `true` - true
-    * `false` - false
-    * `STALE` - STALE
+     * * `false` - false
+     * * `STALE` - STALE
      */
     export type ActiveEnum = typeof ActiveEnum[keyof typeof ActiveEnum];
 
@@ -1880,7 +1880,7 @@ export namespace Schemas {
 
     export interface DateRange {
       /** Start of the date range. Accepts ISO 8601 timestamps (e.g., 2024-01-15T00:00:00Z) or relative formats: -7d (7 days ago), -2w (2 weeks ago), -1m (1 month ago),
-      -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
+       * -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
       date_from?: string | null;
       /** End of the date range. Same format as date_from. Omit or null for "now". */
       date_to?: string | null;
@@ -2152,14 +2152,14 @@ export namespace Schemas {
 
     export interface TrendsFilter {
       /** Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
-
-      - `numeric` (default): raw numbers, e.g. `1,234`.
-      - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
-      - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
-      - `percentage`: values are already in the 0-100 range; appends `%`.
-      - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
-      - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
-      - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
+       *
+       * - `numeric` (default): raw numbers, e.g. `1,234`.
+       * - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
+       * - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
+       * - `percentage`: values are already in the 0-100 range; appends `%`.
+       * - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
+       * - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
+       * - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
       aggregationAxisFormat?: AggregationAxisFormat | null;
       /** Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself. */
       aggregationAxisPostfix?: string | null;
@@ -3832,10 +3832,10 @@ export namespace Schemas {
 
     /**
      * * `last_seen` - last_seen
-    * `first_seen` - first_seen
-    * `occurrences` - occurrences
-    * `users` - users
-    * `sessions` - sessions
+     * * `first_seen` - first_seen
+     * * `occurrences` - occurrences
+     * * `users` - users
+     * * `sessions` - sessions
      */
     export type ErrorTrackingIssueOrderByEnum = typeof ErrorTrackingIssueOrderByEnum[keyof typeof ErrorTrackingIssueOrderByEnum];
 
@@ -3850,7 +3850,7 @@ export namespace Schemas {
 
     /**
      * * `ASC` - ASC
-    * `DESC` - DESC
+     * * `DESC` - DESC
      */
     export type OrderDirectionEnum = typeof OrderDirectionEnum[keyof typeof OrderDirectionEnum];
 
@@ -3862,11 +3862,11 @@ export namespace Schemas {
 
     /**
      * * `archived` - archived
-    * `active` - active
-    * `resolved` - resolved
-    * `pending_release` - pending_release
-    * `suppressed` - suppressed
-    * `all` - all
+     * * `active` - active
+     * * `resolved` - resolved
+     * * `pending_release` - pending_release
+     * * `suppressed` - suppressed
+     * * `all` - all
      */
     export type ErrorTrackingIssueStatusEnum = typeof ErrorTrackingIssueStatusEnum[keyof typeof ErrorTrackingIssueStatusEnum];
 
@@ -3882,7 +3882,7 @@ export namespace Schemas {
 
     /**
      * * `user` - user
-    * `role` - role
+     * * `role` - role
      */
     export type AssigneeTypeEnum = typeof AssigneeTypeEnum[keyof typeof AssigneeTypeEnum];
 
@@ -3896,9 +3896,9 @@ export namespace Schemas {
       /** User ID or role UUID to filter by. */
       id: string | number | null;
       /** Assignee target type: user or role.
-
-      * `user` - user
-      * `role` - role */
+       *
+       * * `user` - user
+       * * `role` - role */
       type: AssigneeTypeEnum;
     }
 
@@ -3917,12 +3917,12 @@ export namespace Schemas {
 
     /**
      * * `-14d` - -14d
-    * `-1h` - -1h
-    * `-24h` - -24h
-    * `-30d` - -30d
-    * `-3h` - -3h
-    * `-7d` - -7d
-    * `-90d` - -90d
+     * * `-1h` - -1h
+     * * `-24h` - -24h
+     * * `-30d` - -30d
+     * * `-3h` - -3h
+     * * `-7d` - -7d
+     * * `-90d` - -90d
      */
     export type DateFromEnum = typeof DateFromEnum[keyof typeof DateFromEnum];
 
@@ -3939,14 +3939,14 @@ export namespace Schemas {
 
     export interface WidgetDateRange {
       /** Relative lookback window (for example '-7d'). Omit to use the project default range.
-
-      * `-14d` - -14d
-      * `-1h` - -1h
-      * `-24h` - -24h
-      * `-30d` - -30d
-      * `-3h` - -3h
-      * `-7d` - -7d
-      * `-90d` - -90d */
+       *
+       * * `-14d` - -14d
+       * * `-1h` - -1h
+       * * `-24h` - -24h
+       * * `-30d` - -30d
+       * * `-3h` - -3h
+       * * `-7d` - -7d
+       * * `-90d` - -90d */
       date_from?: DateFromEnum | null;
     }
 
@@ -3963,26 +3963,26 @@ export namespace Schemas {
          */
       limit?: number;
       /** Issue ranking column.
-
-      * `first_seen` - first_seen
-      * `last_seen` - last_seen
-      * `occurrences` - occurrences
-      * `sessions` - sessions
-      * `users` - users */
+       *
+       * * `first_seen` - first_seen
+       * * `last_seen` - last_seen
+       * * `occurrences` - occurrences
+       * * `sessions` - sessions
+       * * `users` - users */
       orderBy?: ErrorTrackingIssueOrderByEnum;
       /** Sort direction for orderBy.
-
-      * `ASC` - ASC
-      * `DESC` - DESC */
+       *
+       * * `ASC` - ASC
+       * * `DESC` - DESC */
       orderDirection?: OrderDirectionEnum;
       /** Issue status filter.
-
-      * `archived` - archived
-      * `active` - active
-      * `resolved` - resolved
-      * `pending_release` - pending_release
-      * `suppressed` - suppressed
-      * `all` - all */
+       *
+       * * `archived` - archived
+       * * `active` - active
+       * * `resolved` - resolved
+       * * `pending_release` - pending_release
+       * * `suppressed` - suppressed
+       * * `all` - all */
       status?: ErrorTrackingIssueStatusEnum;
       /** Filter by assignee ({type: user|role, id}). Omit for any assignee. */
       assignee?: ErrorTrackingAssignee | null;
@@ -4021,11 +4021,11 @@ export namespace Schemas {
 
     /**
      * * `activity_score` - activity_score
-    * `click_count` - click_count
-    * `console_error_count` - console_error_count
-    * `duration` - duration
-    * `recording_duration` - recording_duration
-    * `start_time` - start_time
+     * * `click_count` - click_count
+     * * `console_error_count` - console_error_count
+     * * `duration` - duration
+     * * `recording_duration` - recording_duration
+     * * `start_time` - start_time
      */
     export type SessionReplayListWidgetConfigOrderByEnum = typeof SessionReplayListWidgetConfigOrderByEnum[keyof typeof SessionReplayListWidgetConfigOrderByEnum];
 
@@ -4052,18 +4052,18 @@ export namespace Schemas {
          */
       limit?: number;
       /** Recording ranking column.
-
-      * `activity_score` - activity_score
-      * `click_count` - click_count
-      * `console_error_count` - console_error_count
-      * `duration` - duration
-      * `recording_duration` - recording_duration
-      * `start_time` - start_time */
+       *
+       * * `activity_score` - activity_score
+       * * `click_count` - click_count
+       * * `console_error_count` - console_error_count
+       * * `duration` - duration
+       * * `recording_duration` - recording_duration
+       * * `start_time` - start_time */
       orderBy?: SessionReplayListWidgetConfigOrderByEnum;
       /** Sort direction for orderBy.
-
-      * `ASC` - ASC
-      * `DESC` - DESC */
+       *
+       * * `ASC` - ASC
+       * * `DESC` - DESC */
       orderDirection?: OrderDirectionEnum;
       /** Optional relative date range override. */
       dateRange?: WidgetDateRange | null;
@@ -6888,10 +6888,10 @@ export namespace Schemas {
 
     /**
      * The query definition for this insight. The `kind` field determines the query type:
-    - `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
-    - `DataVisualizationNode` — SQL insights using HogQL
-    - `DataTableNode` — raw data tables
-    - `HogQuery` — Hog language queries
+     * - `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
+     * - `DataVisualizationNode` — SQL insights using HogQL
+     * - `DataTableNode` — raw data tables
+     * - `HogQuery` — Hog language queries
      */
     export type _InsightQuerySchema = InsightVizNode | DataTableNode | DataVisualizationNode | HogQuery;
 
@@ -6951,21 +6951,21 @@ export namespace Schemas {
       order?: number | null;
       deleted?: boolean;
       /**
-              DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
-              A dashboard ID for each of the dashboards that this insight is displayed on.
-               */
+       *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
+       *         A dashboard ID for each of the dashboards that this insight is displayed on.
+       *          */
       dashboards?: number[];
       /**
-          A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
-           */
+       *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
+       *      */
       readonly dashboard_tiles: readonly DashboardTileBasic[];
       /**
          *
-          The datetime this insight's results were generated.
-          If added to one or more dashboards the insight can be refreshed separately on each.
-          Returns the appropriate last_refresh datetime for the context the insight is viewed in
-          (see from_dashboard query parameter).
-
+       *     The datetime this insight's results were generated.
+       *     If added to one or more dashboards the insight can be refreshed separately on each.
+       *     Returns the appropriate last_refresh datetime for the context the insight is viewed in
+       *     (see from_dashboard query parameter).
+       *
          * @nullable
          */
       readonly last_refresh: string | null;
@@ -6976,9 +6976,9 @@ export namespace Schemas {
       readonly cache_target_age: string | null;
       /**
          *
-          The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
-          by querying the database.
-
+       *     The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
+       *     by querying the database.
+       *
          * @nullable
          */
       readonly next_allowed_client_refresh: string | null;
@@ -7025,7 +7025,7 @@ export namespace Schemas {
       readonly alerts: readonly unknown[];
       /** @nullable */
       readonly last_viewed_at: string | null;
-      /** How this row matched the `search` term: `exact` (the term is a case-insensitive substring of the name, derived_name, description, or a tag name) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
       readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
@@ -7045,7 +7045,7 @@ export namespace Schemas {
 
     /**
      * * `left` - left
-    * `right` - right
+     * * `right` - right
      */
     export type PlacementEnum = typeof PlacementEnum[keyof typeof PlacementEnum];
 
@@ -7057,7 +7057,7 @@ export namespace Schemas {
 
     /**
      * * `primary` - Primary
-    * `secondary` - Secondary
+     * * `secondary` - Secondary
      */
     export type StyleEnum = typeof StyleEnum[keyof typeof StyleEnum];
 
@@ -7176,17 +7176,17 @@ export namespace Schemas {
 
     /**
      * * `product_analytics` - product_analytics
-    * `sql` - sql
-    * `session_replay` - session_replay
-    * `error_tracking` - error_tracking
-    * `plan` - plan
-    * `execution` - execution
-    * `survey` - survey
-    * `research` - research
-    * `flags` - flags
-    * `llm_analytics` - llm_analytics
-    * `sandbox` - sandbox
-    * `user_interview` - user_interview
+     * * `sql` - sql
+     * * `session_replay` - session_replay
+     * * `error_tracking` - error_tracking
+     * * `plan` - plan
+     * * `execution` - execution
+     * * `survey` - survey
+     * * `research` - research
+     * * `flags` - flags
+     * * `llm_analytics` - llm_analytics
+     * * `sandbox` - sandbox
+     * * `user_interview` - user_interview
      */
     export type AgentModeEnum = typeof AgentModeEnum[keyof typeof AgentModeEnum];
 
@@ -7219,9 +7219,9 @@ export namespace Schemas {
 
     /**
      * * `sum` - sum
-    * `avg` - avg
-    * `count` - count
-    * `p95` - p95
+     * * `avg` - avg
+     * * `count` - count
+     * * `p95` - p95
      */
     export type AggregationEnum = typeof AggregationEnum[keyof typeof AggregationEnum];
 
@@ -7278,9 +7278,9 @@ export namespace Schemas {
 
     /**
      * * `Firing` - Firing
-    * `Not firing` - Not firing
-    * `Errored` - Errored
-    * `Snoozed` - Snoozed
+     * * `Not firing` - Not firing
+     * * `Errored` - Errored
+     * * `Snoozed` - Snoozed
      */
     export type AlertCheckStateEnum = typeof AlertCheckStateEnum[keyof typeof AlertCheckStateEnum];
 
@@ -7294,10 +7294,10 @@ export namespace Schemas {
 
     /**
      * * `pending` - pending
-    * `running` - running
-    * `done` - done
-    * `failed` - failed
-    * `skipped` - skipped
+     * * `running` - running
+     * * `done` - done
+     * * `failed` - failed
+     * * `skipped` - skipped
      */
     export type InvestigationStatusEnum = typeof InvestigationStatusEnum[keyof typeof InvestigationStatusEnum];
 
@@ -7312,8 +7312,8 @@ export namespace Schemas {
 
     /**
      * * `true_positive` - true_positive
-    * `false_positive` - false_positive
-    * `inconclusive` - inconclusive
+     * * `false_positive` - false_positive
+     * * `inconclusive` - inconclusive
      */
     export type InvestigationVerdictEnum = typeof InvestigationVerdictEnum[keyof typeof InvestigationVerdictEnum];
 
@@ -7534,10 +7534,10 @@ export namespace Schemas {
 
     /**
      * * `every_15_minutes` - every_15_minutes
-    * `hourly` - hourly
-    * `daily` - daily
-    * `weekly` - weekly
-    * `monthly` - monthly
+     * * `hourly` - hourly
+     * * `daily` - daily
+     * * `weekly` - weekly
+     * * `monthly` - monthly
      */
     export type CalculationIntervalEnum = typeof CalculationIntervalEnum[keyof typeof CalculationIntervalEnum];
 
@@ -7564,7 +7564,7 @@ export namespace Schemas {
 
     /**
      * * `notify` - Notify
-    * `suppress` - Suppress
+     * * `suppress` - Suppress
      */
     export type InvestigationInconclusiveActionEnum = typeof InvestigationInconclusiveActionEnum[keyof typeof InvestigationInconclusiveActionEnum];
 
@@ -7609,12 +7609,12 @@ export namespace Schemas {
       config?: TrendsAlertConfig | null;
       detector_config?: DetectorConfig | null;
       /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
-
-      * `every_15_minutes` - every_15_minutes
-      * `hourly` - hourly
-      * `daily` - daily
-      * `weekly` - weekly
-      * `monthly` - monthly */
+       *
+       * * `every_15_minutes` - every_15_minutes
+       * * `hourly` - hourly
+       * * `daily` - daily
+       * * `weekly` - weekly
+       * * `monthly` - monthly */
       calculation_interval?: CalculationIntervalEnum;
       /**
          * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
@@ -7638,9 +7638,9 @@ export namespace Schemas {
       /** When enabled (and investigation_agent_enabled is on), notification dispatch is held until the investigation agent produces a verdict. Notifications are suppressed when the verdict is false_positive (and optionally when inconclusive). A safety-net task force-fires after a few minutes if the investigation stalls. */
       investigation_gates_notifications?: boolean;
       /** How to handle an 'inconclusive' verdict when notifications are gated. 'notify' is the safe default — an agent that can't be sure is itself useful signal.
-
-      * `notify` - Notify
-      * `suppress` - Suppress */
+       *
+       * * `notify` - Notify
+       * * `suppress` - Suppress */
       investigation_inconclusive_action?: InvestigationInconclusiveActionEnum;
     }
 
@@ -7711,7 +7711,7 @@ export namespace Schemas {
 
     /**
      * * `USR` - user
-    * `GIT` - GitHub
+     * * `GIT` - GitHub
      */
     export type CreationTypeEnum = typeof CreationTypeEnum[keyof typeof CreationTypeEnum];
 
@@ -7723,10 +7723,10 @@ export namespace Schemas {
 
     /**
      * * `dashboard_item` - insight
-    * `dashboard` - dashboard
-    * `project` - project
-    * `organization` - organization
-    * `recording` - recording
+     * * `dashboard` - dashboard
+     * * `project` - project
+     * * `organization` - organization
+     * * `recording` - recording
      */
     export type AnnotationScopeEnum = typeof AnnotationScopeEnum[keyof typeof AnnotationScopeEnum];
 
@@ -7753,9 +7753,9 @@ export namespace Schemas {
          */
       date_marker?: string | null;
       /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
-
-      * `USR` - user
-      * `GIT` - GitHub */
+       *
+       * * `USR` - user
+       * * `GIT` - GitHub */
       creation_type?: CreationTypeEnum;
       /** @nullable */
       dashboard_item?: number | null;
@@ -7776,12 +7776,12 @@ export namespace Schemas {
       /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
       deleted?: boolean;
       /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
-
-      * `dashboard_item` - insight
-      * `dashboard` - dashboard
-      * `project` - project
-      * `organization` - organization
-      * `recording` - recording */
+       *
+       * * `dashboard_item` - insight
+       * * `dashboard` - dashboard
+       * * `project` - project
+       * * `organization` - organization
+       * * `recording` - recording */
       scope?: AnnotationScopeEnum;
       /**
          * Optional emoji shown in place of the default badge when this annotation is surfaced on a chart.
@@ -7930,10 +7930,10 @@ export namespace Schemas {
 
     /**
      * * `first_touch` - First Touch
-    * `last_touch` - Last Touch
-    * `linear` - Linear
-    * `time_decay` - Time Decay
-    * `position_based` - Position Based
+     * * `last_touch` - Last Touch
+     * * `linear` - Linear
+     * * `time_decay` - Time Decay
+     * * `position_based` - Position Based
      */
     export type AttributionModeEnum = typeof AttributionModeEnum[keyof typeof AttributionModeEnum];
 
@@ -8006,10 +8006,10 @@ export namespace Schemas {
 
     /**
      * * `P0` - P0
-    * `P1` - P1
-    * `P2` - P2
-    * `P3` - P3
-    * `P4` - P4
+     * * `P1` - P1
+     * * `P2` - P2
+     * * `P3` - P3
+     * * `P4` - P4
      */
     export type AutonomyPriorityEnum = typeof AutonomyPriorityEnum[keyof typeof AutonomyPriorityEnum];
 
@@ -8055,70 +8055,70 @@ export namespace Schemas {
 
     /**
      * * `ingest_first_event` - ingest_first_event
-    * `set_up_reverse_proxy` - set_up_reverse_proxy
-    * `create_first_insight` - create_first_insight
-    * `create_first_dashboard` - create_first_dashboard
-    * `track_custom_events` - track_custom_events
-    * `define_actions` - define_actions
-    * `set_up_cohorts` - set_up_cohorts
-    * `explore_trends_insight` - explore_trends_insight
-    * `create_funnel` - create_funnel
-    * `explore_retention_insight` - explore_retention_insight
-    * `explore_paths_insight` - explore_paths_insight
-    * `explore_stickiness_insight` - explore_stickiness_insight
-    * `explore_lifecycle_insight` - explore_lifecycle_insight
-    * `add_authorized_domain` - add_authorized_domain
-    * `set_up_web_vitals` - set_up_web_vitals
-    * `review_web_analytics_dashboard` - review_web_analytics_dashboard
-    * `filter_web_analytics` - filter_web_analytics
-    * `set_up_web_analytics_conversion_goals` - set_up_web_analytics_conversion_goals
-    * `visit_web_vitals_dashboard` - visit_web_vitals_dashboard
-    * `setup_session_recordings` - setup_session_recordings
-    * `watch_session_recording` - watch_session_recording
-    * `configure_recording_settings` - configure_recording_settings
-    * `create_recording_playlist` - create_recording_playlist
-    * `enable_console_logs` - enable_console_logs
-    * `create_feature_flag` - create_feature_flag
-    * `implement_flag_in_code` - implement_flag_in_code
-    * `update_feature_flag_release_conditions` - update_feature_flag_release_conditions
-    * `create_multivariate_flag` - create_multivariate_flag
-    * `set_up_flag_payloads` - set_up_flag_payloads
-    * `set_up_flag_evaluation_runtimes` - set_up_flag_evaluation_runtimes
-    * `create_experiment` - create_experiment
-    * `implement_experiment_variants` - implement_experiment_variants
-    * `launch_experiment` - launch_experiment
-    * `review_experiment_results` - review_experiment_results
-    * `create_survey` - create_survey
-    * `launch_survey` - launch_survey
-    * `collect_survey_responses` - collect_survey_responses
-    * `connect_source` - connect_source
-    * `run_first_query` - run_first_query
-    * `join_external_data` - join_external_data
-    * `create_saved_view` - create_saved_view
-    * `enable_error_tracking` - enable_error_tracking
-    * `upload_source_maps` - upload_source_maps
-    * `view_first_error` - view_first_error
-    * `resolve_first_error` - resolve_first_error
-    * `ingest_first_llm_event` - ingest_first_llm_event
-    * `view_first_trace` - view_first_trace
-    * `track_costs` - track_costs
-    * `set_up_llm_evaluation` - set_up_llm_evaluation
-    * `run_ai_playground` - run_ai_playground
-    * `enable_revenue_analytics_viewset` - enable_revenue_analytics_viewset
-    * `connect_revenue_source` - connect_revenue_source
-    * `set_up_revenue_goal` - set_up_revenue_goal
-    * `enable_log_capture` - enable_log_capture
-    * `view_first_logs` - view_first_logs
-    * `create_first_workflow` - create_first_workflow
-    * `set_up_first_workflow_channel` - set_up_first_workflow_channel
-    * `configure_workflow_trigger` - configure_workflow_trigger
-    * `add_workflow_action` - add_workflow_action
-    * `launch_workflow` - launch_workflow
-    * `create_first_endpoint` - create_first_endpoint
-    * `configure_endpoint` - configure_endpoint
-    * `test_endpoint` - test_endpoint
-    * `create_early_access_feature` - create_early_access_feature
-    * `update_feature_stage` - update_feature_stage
+     * * `set_up_reverse_proxy` - set_up_reverse_proxy
+     * * `create_first_insight` - create_first_insight
+     * * `create_first_dashboard` - create_first_dashboard
+     * * `track_custom_events` - track_custom_events
+     * * `define_actions` - define_actions
+     * * `set_up_cohorts` - set_up_cohorts
+     * * `explore_trends_insight` - explore_trends_insight
+     * * `create_funnel` - create_funnel
+     * * `explore_retention_insight` - explore_retention_insight
+     * * `explore_paths_insight` - explore_paths_insight
+     * * `explore_stickiness_insight` - explore_stickiness_insight
+     * * `explore_lifecycle_insight` - explore_lifecycle_insight
+     * * `add_authorized_domain` - add_authorized_domain
+     * * `set_up_web_vitals` - set_up_web_vitals
+     * * `review_web_analytics_dashboard` - review_web_analytics_dashboard
+     * * `filter_web_analytics` - filter_web_analytics
+     * * `set_up_web_analytics_conversion_goals` - set_up_web_analytics_conversion_goals
+     * * `visit_web_vitals_dashboard` - visit_web_vitals_dashboard
+     * * `setup_session_recordings` - setup_session_recordings
+     * * `watch_session_recording` - watch_session_recording
+     * * `configure_recording_settings` - configure_recording_settings
+     * * `create_recording_playlist` - create_recording_playlist
+     * * `enable_console_logs` - enable_console_logs
+     * * `create_feature_flag` - create_feature_flag
+     * * `implement_flag_in_code` - implement_flag_in_code
+     * * `update_feature_flag_release_conditions` - update_feature_flag_release_conditions
+     * * `create_multivariate_flag` - create_multivariate_flag
+     * * `set_up_flag_payloads` - set_up_flag_payloads
+     * * `set_up_flag_evaluation_runtimes` - set_up_flag_evaluation_runtimes
+     * * `create_experiment` - create_experiment
+     * * `implement_experiment_variants` - implement_experiment_variants
+     * * `launch_experiment` - launch_experiment
+     * * `review_experiment_results` - review_experiment_results
+     * * `create_survey` - create_survey
+     * * `launch_survey` - launch_survey
+     * * `collect_survey_responses` - collect_survey_responses
+     * * `connect_source` - connect_source
+     * * `run_first_query` - run_first_query
+     * * `join_external_data` - join_external_data
+     * * `create_saved_view` - create_saved_view
+     * * `enable_error_tracking` - enable_error_tracking
+     * * `upload_source_maps` - upload_source_maps
+     * * `view_first_error` - view_first_error
+     * * `resolve_first_error` - resolve_first_error
+     * * `ingest_first_llm_event` - ingest_first_llm_event
+     * * `view_first_trace` - view_first_trace
+     * * `track_costs` - track_costs
+     * * `set_up_llm_evaluation` - set_up_llm_evaluation
+     * * `run_ai_playground` - run_ai_playground
+     * * `enable_revenue_analytics_viewset` - enable_revenue_analytics_viewset
+     * * `connect_revenue_source` - connect_revenue_source
+     * * `set_up_revenue_goal` - set_up_revenue_goal
+     * * `enable_log_capture` - enable_log_capture
+     * * `view_first_logs` - view_first_logs
+     * * `create_first_workflow` - create_first_workflow
+     * * `set_up_first_workflow_channel` - set_up_first_workflow_channel
+     * * `configure_workflow_trigger` - configure_workflow_trigger
+     * * `add_workflow_action` - add_workflow_action
+     * * `launch_workflow` - launch_workflow
+     * * `create_first_endpoint` - create_first_endpoint
+     * * `configure_endpoint` - configure_endpoint
+     * * `test_endpoint` - test_endpoint
+     * * `create_early_access_feature` - create_early_access_feature
+     * * `update_feature_stage` - update_feature_stage
      */
     export type AvailableSetupTaskIdsEnum = typeof AvailableSetupTaskIdsEnum[keyof typeof AvailableSetupTaskIdsEnum];
 
@@ -8200,10 +8200,10 @@ export namespace Schemas {
 
     /**
      * * `brotli` - brotli
-    * `gzip` - gzip
-    * `lz4` - lz4
-    * `snappy` - snappy
-    * `zstd` - zstd
+     * * `gzip` - gzip
+     * * `lz4` - lz4
+     * * `snappy` - snappy
+     * * `zstd` - zstd
      */
     export type CompressionEnum = typeof CompressionEnum[keyof typeof CompressionEnum];
 
@@ -8218,7 +8218,7 @@ export namespace Schemas {
 
     /**
      * * `JSONLines` - JSONLines
-    * `Parquet` - Parquet
+     * * `Parquet` - Parquet
      */
     export type FileFormatEnum = typeof FileFormatEnum[keyof typeof FileFormatEnum];
 
@@ -8230,9 +8230,9 @@ export namespace Schemas {
 
     /**
      * Typed configuration for an Azure Blob Storage batch-export destination.
-
-    Credentials live in the linked Integration, not in this config. Mirrors
-    `AzureBlobBatchExportInputs` in `products/batch_exports/backend/service.py`.
+     *
+     * Credentials live in the linked Integration, not in this config. Mirrors
+     * `AzureBlobBatchExportInputs` in `products/batch_exports/backend/service.py`.
      */
     export interface AzureBlobDestinationConfig {
       /** Azure Blob Storage container name. */
@@ -8240,17 +8240,17 @@ export namespace Schemas {
       /** Object key prefix applied to every exported file. */
       prefix?: string;
       /** Optional compression codec applied to exported files. Valid codecs depend on file_format.
-
-      * `brotli` - brotli
-      * `gzip` - gzip
-      * `lz4` - lz4
-      * `snappy` - snappy
-      * `zstd` - zstd */
+       *
+       * * `brotli` - brotli
+       * * `gzip` - gzip
+       * * `lz4` - lz4
+       * * `snappy` - snappy
+       * * `zstd` - zstd */
       compression?: CompressionEnum | null;
       /** File format used for exported objects.
-
-      * `JSONLines` - JSONLines
-      * `Parquet` - Parquet */
+       *
+       * * `JSONLines` - JSONLines
+       * * `Parquet` - Parquet */
       file_format?: FileFormatEnum;
       /**
          * If set, rolls to a new file once the current file exceeds this size in MB.
@@ -8289,157 +8289,157 @@ export namespace Schemas {
 
     /**
      * * `AED` - AED
-    * `AFN` - AFN
-    * `ALL` - ALL
-    * `AMD` - AMD
-    * `ANG` - ANG
-    * `AOA` - AOA
-    * `ARS` - ARS
-    * `AUD` - AUD
-    * `AWG` - AWG
-    * `AZN` - AZN
-    * `BAM` - BAM
-    * `BBD` - BBD
-    * `BDT` - BDT
-    * `BGN` - BGN
-    * `BHD` - BHD
-    * `BIF` - BIF
-    * `BMD` - BMD
-    * `BND` - BND
-    * `BOB` - BOB
-    * `BRL` - BRL
-    * `BSD` - BSD
-    * `BTC` - BTC
-    * `BTN` - BTN
-    * `BWP` - BWP
-    * `BYN` - BYN
-    * `BZD` - BZD
-    * `CAD` - CAD
-    * `CDF` - CDF
-    * `CHF` - CHF
-    * `CLP` - CLP
-    * `CNY` - CNY
-    * `COP` - COP
-    * `CRC` - CRC
-    * `CVE` - CVE
-    * `CZK` - CZK
-    * `DJF` - DJF
-    * `DKK` - DKK
-    * `DOP` - DOP
-    * `DZD` - DZD
-    * `EGP` - EGP
-    * `ERN` - ERN
-    * `ETB` - ETB
-    * `EUR` - EUR
-    * `FJD` - FJD
-    * `GBP` - GBP
-    * `GEL` - GEL
-    * `GHS` - GHS
-    * `GIP` - GIP
-    * `GMD` - GMD
-    * `GNF` - GNF
-    * `GTQ` - GTQ
-    * `GYD` - GYD
-    * `HKD` - HKD
-    * `HNL` - HNL
-    * `HRK` - HRK
-    * `HTG` - HTG
-    * `HUF` - HUF
-    * `IDR` - IDR
-    * `ILS` - ILS
-    * `INR` - INR
-    * `IQD` - IQD
-    * `IRR` - IRR
-    * `ISK` - ISK
-    * `JMD` - JMD
-    * `JOD` - JOD
-    * `JPY` - JPY
-    * `KES` - KES
-    * `KGS` - KGS
-    * `KHR` - KHR
-    * `KMF` - KMF
-    * `KRW` - KRW
-    * `KWD` - KWD
-    * `KYD` - KYD
-    * `KZT` - KZT
-    * `LAK` - LAK
-    * `LBP` - LBP
-    * `LKR` - LKR
-    * `LRD` - LRD
-    * `LTL` - LTL
-    * `LVL` - LVL
-    * `LSL` - LSL
-    * `LYD` - LYD
-    * `MAD` - MAD
-    * `MDL` - MDL
-    * `MGA` - MGA
-    * `MKD` - MKD
-    * `MMK` - MMK
-    * `MNT` - MNT
-    * `MOP` - MOP
-    * `MRU` - MRU
-    * `MTL` - MTL
-    * `MUR` - MUR
-    * `MVR` - MVR
-    * `MWK` - MWK
-    * `MXN` - MXN
-    * `MYR` - MYR
-    * `MZN` - MZN
-    * `NAD` - NAD
-    * `NGN` - NGN
-    * `NIO` - NIO
-    * `NOK` - NOK
-    * `NPR` - NPR
-    * `NZD` - NZD
-    * `OMR` - OMR
-    * `PAB` - PAB
-    * `PEN` - PEN
-    * `PGK` - PGK
-    * `PHP` - PHP
-    * `PKR` - PKR
-    * `PLN` - PLN
-    * `PYG` - PYG
-    * `QAR` - QAR
-    * `RON` - RON
-    * `RSD` - RSD
-    * `RUB` - RUB
-    * `RWF` - RWF
-    * `SAR` - SAR
-    * `SBD` - SBD
-    * `SCR` - SCR
-    * `SDG` - SDG
-    * `SEK` - SEK
-    * `SGD` - SGD
-    * `SRD` - SRD
-    * `SSP` - SSP
-    * `STN` - STN
-    * `SYP` - SYP
-    * `SZL` - SZL
-    * `THB` - THB
-    * `TJS` - TJS
-    * `TMT` - TMT
-    * `TND` - TND
-    * `TOP` - TOP
-    * `TRY` - TRY
-    * `TTD` - TTD
-    * `TWD` - TWD
-    * `TZS` - TZS
-    * `UAH` - UAH
-    * `UGX` - UGX
-    * `USD` - USD
-    * `UYU` - UYU
-    * `UZS` - UZS
-    * `VES` - VES
-    * `VND` - VND
-    * `VUV` - VUV
-    * `WST` - WST
-    * `XAF` - XAF
-    * `XCD` - XCD
-    * `XOF` - XOF
-    * `XPF` - XPF
-    * `YER` - YER
-    * `ZAR` - ZAR
-    * `ZMW` - ZMW
+     * * `AFN` - AFN
+     * * `ALL` - ALL
+     * * `AMD` - AMD
+     * * `ANG` - ANG
+     * * `AOA` - AOA
+     * * `ARS` - ARS
+     * * `AUD` - AUD
+     * * `AWG` - AWG
+     * * `AZN` - AZN
+     * * `BAM` - BAM
+     * * `BBD` - BBD
+     * * `BDT` - BDT
+     * * `BGN` - BGN
+     * * `BHD` - BHD
+     * * `BIF` - BIF
+     * * `BMD` - BMD
+     * * `BND` - BND
+     * * `BOB` - BOB
+     * * `BRL` - BRL
+     * * `BSD` - BSD
+     * * `BTC` - BTC
+     * * `BTN` - BTN
+     * * `BWP` - BWP
+     * * `BYN` - BYN
+     * * `BZD` - BZD
+     * * `CAD` - CAD
+     * * `CDF` - CDF
+     * * `CHF` - CHF
+     * * `CLP` - CLP
+     * * `CNY` - CNY
+     * * `COP` - COP
+     * * `CRC` - CRC
+     * * `CVE` - CVE
+     * * `CZK` - CZK
+     * * `DJF` - DJF
+     * * `DKK` - DKK
+     * * `DOP` - DOP
+     * * `DZD` - DZD
+     * * `EGP` - EGP
+     * * `ERN` - ERN
+     * * `ETB` - ETB
+     * * `EUR` - EUR
+     * * `FJD` - FJD
+     * * `GBP` - GBP
+     * * `GEL` - GEL
+     * * `GHS` - GHS
+     * * `GIP` - GIP
+     * * `GMD` - GMD
+     * * `GNF` - GNF
+     * * `GTQ` - GTQ
+     * * `GYD` - GYD
+     * * `HKD` - HKD
+     * * `HNL` - HNL
+     * * `HRK` - HRK
+     * * `HTG` - HTG
+     * * `HUF` - HUF
+     * * `IDR` - IDR
+     * * `ILS` - ILS
+     * * `INR` - INR
+     * * `IQD` - IQD
+     * * `IRR` - IRR
+     * * `ISK` - ISK
+     * * `JMD` - JMD
+     * * `JOD` - JOD
+     * * `JPY` - JPY
+     * * `KES` - KES
+     * * `KGS` - KGS
+     * * `KHR` - KHR
+     * * `KMF` - KMF
+     * * `KRW` - KRW
+     * * `KWD` - KWD
+     * * `KYD` - KYD
+     * * `KZT` - KZT
+     * * `LAK` - LAK
+     * * `LBP` - LBP
+     * * `LKR` - LKR
+     * * `LRD` - LRD
+     * * `LTL` - LTL
+     * * `LVL` - LVL
+     * * `LSL` - LSL
+     * * `LYD` - LYD
+     * * `MAD` - MAD
+     * * `MDL` - MDL
+     * * `MGA` - MGA
+     * * `MKD` - MKD
+     * * `MMK` - MMK
+     * * `MNT` - MNT
+     * * `MOP` - MOP
+     * * `MRU` - MRU
+     * * `MTL` - MTL
+     * * `MUR` - MUR
+     * * `MVR` - MVR
+     * * `MWK` - MWK
+     * * `MXN` - MXN
+     * * `MYR` - MYR
+     * * `MZN` - MZN
+     * * `NAD` - NAD
+     * * `NGN` - NGN
+     * * `NIO` - NIO
+     * * `NOK` - NOK
+     * * `NPR` - NPR
+     * * `NZD` - NZD
+     * * `OMR` - OMR
+     * * `PAB` - PAB
+     * * `PEN` - PEN
+     * * `PGK` - PGK
+     * * `PHP` - PHP
+     * * `PKR` - PKR
+     * * `PLN` - PLN
+     * * `PYG` - PYG
+     * * `QAR` - QAR
+     * * `RON` - RON
+     * * `RSD` - RSD
+     * * `RUB` - RUB
+     * * `RWF` - RWF
+     * * `SAR` - SAR
+     * * `SBD` - SBD
+     * * `SCR` - SCR
+     * * `SDG` - SDG
+     * * `SEK` - SEK
+     * * `SGD` - SGD
+     * * `SRD` - SRD
+     * * `SSP` - SSP
+     * * `STN` - STN
+     * * `SYP` - SYP
+     * * `SZL` - SZL
+     * * `THB` - THB
+     * * `TJS` - TJS
+     * * `TMT` - TMT
+     * * `TND` - TND
+     * * `TOP` - TOP
+     * * `TRY` - TRY
+     * * `TTD` - TTD
+     * * `TWD` - TWD
+     * * `TZS` - TZS
+     * * `UAH` - UAH
+     * * `UGX` - UGX
+     * * `USD` - USD
+     * * `UYU` - UYU
+     * * `UZS` - UZS
+     * * `VES` - VES
+     * * `VND` - VND
+     * * `VUV` - VUV
+     * * `WST` - WST
+     * * `XAF` - XAF
+     * * `XCD` - XCD
+     * * `XOF` - XOF
+     * * `XPF` - XPF
+     * * `YER` - YER
+     * * `ZAR` - ZAR
+     * * `ZMW` - ZMW
      */
     export type BaseCurrencyEnum = typeof BaseCurrencyEnum[keyof typeof BaseCurrencyEnum];
 
@@ -8665,7 +8665,7 @@ export namespace Schemas {
 
     /**
      * * `minimal` - minimal
-    * `detailed` - detailed
+     * * `detailed` - detailed
      */
     export type DetailModeValueEnum = typeof DetailModeValueEnum[keyof typeof DetailModeValueEnum];
 
@@ -8682,9 +8682,9 @@ export namespace Schemas {
          */
       trace_ids: string[];
       /** Summary detail level to check for
-
-      * `minimal` - minimal
-      * `detailed` - detailed */
+       *
+       * * `minimal` - minimal
+       * * `detailed` - detailed */
       mode?: DetailModeValueEnum;
       /**
          * LLM model used for cached summaries
@@ -8705,8 +8705,8 @@ export namespace Schemas {
 
     /**
      * * `events` - Events
-    * `persons` - Persons
-    * `sessions` - Sessions
+     * * `persons` - Persons
+     * * `sessions` - Sessions
      */
     export type ModelEnum = typeof ModelEnum[keyof typeof ModelEnum];
 
@@ -8719,18 +8719,18 @@ export namespace Schemas {
 
     /**
      * * `S3` - S3
-    * `AwsS3` - Aws S3
-    * `S3Compatible` - S3 Compatible
-    * `Snowflake` - Snowflake
-    * `Postgres` - Postgres
-    * `Redshift` - Redshift
-    * `BigQuery` - Bigquery
-    * `Databricks` - Databricks
-    * `AzureBlob` - Azure Blob
-    * `Workflows` - Workflows
-    * `HTTP` - Http
-    * `NoOp` - Noop
-    * `FileDownload` - File Download
+     * * `AwsS3` - Aws S3
+     * * `S3Compatible` - S3 Compatible
+     * * `Snowflake` - Snowflake
+     * * `Postgres` - Postgres
+     * * `Redshift` - Redshift
+     * * `BigQuery` - Bigquery
+     * * `Databricks` - Databricks
+     * * `AzureBlob` - Azure Blob
+     * * `Workflows` - Workflows
+     * * `HTTP` - Http
+     * * `NoOp` - Noop
+     * * `FileDownload` - File Download
      */
     export type BatchExportDestinationTypeEnum = typeof BatchExportDestinationTypeEnum[keyof typeof BatchExportDestinationTypeEnum];
 
@@ -8760,9 +8760,9 @@ export namespace Schemas {
 
     /**
      * Typed configuration for a Databricks batch-export destination.
-
-    Credentials live in the linked Integration, not in this config. Mirrors
-    `DatabricksBatchExportInputs` in `products/batch_exports/backend/service.py`.
+     *
+     * Credentials live in the linked Integration, not in this config. Mirrors
+     * `DatabricksBatchExportInputs` in `products/batch_exports/backend/service.py`.
      */
     export interface DatabricksDestinationConfig {
       /** Databricks SQL warehouse HTTP path. */
@@ -8789,10 +8789,10 @@ export namespace Schemas {
 
     /**
      * Typed configuration for a BigQuery batch-export destination.
-
-    Credentials live in the linked Integration, not in this config. Mirrors the
-    non-credential fields of `BigQueryBatchExportInputs` in
-    `products/batch_exports/backend/service.py`.
+     *
+     * Credentials live in the linked Integration, not in this config. Mirrors the
+     * non-credential fields of `BigQueryBatchExportInputs` in
+     * `products/batch_exports/backend/service.py`.
      */
     export interface BigQueryDestinationConfig {
       /** BigQuery dataset ID to write to. */
@@ -8808,28 +8808,28 @@ export namespace Schemas {
 
     /**
      * Serializer for an BatchExportDestination model.
-
-    The `config` field is polymorphic and typed only for destinations that keep
-    credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).
-    Other destination types accept the same JSON shape but without a typed
-    OpenAPI schema. Secret fields are stripped from `config` on read.
+     *
+     * The `config` field is polymorphic and typed only for destinations that keep
+     * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).
+     * Other destination types accept the same JSON shape but without a typed
+     * OpenAPI schema. Secret fields are stripped from `config` on read.
      */
     export interface BatchExportDestination {
       /** A choice of supported BatchExportDestination types.
-
-      * `S3` - S3
-      * `AwsS3` - Aws S3
-      * `S3Compatible` - S3 Compatible
-      * `Snowflake` - Snowflake
-      * `Postgres` - Postgres
-      * `Redshift` - Redshift
-      * `BigQuery` - Bigquery
-      * `Databricks` - Databricks
-      * `AzureBlob` - Azure Blob
-      * `Workflows` - Workflows
-      * `HTTP` - Http
-      * `NoOp` - Noop
-      * `FileDownload` - File Download */
+       *
+       * * `S3` - S3
+       * * `AwsS3` - Aws S3
+       * * `S3Compatible` - S3 Compatible
+       * * `Snowflake` - Snowflake
+       * * `Postgres` - Postgres
+       * * `Redshift` - Redshift
+       * * `BigQuery` - Bigquery
+       * * `Databricks` - Databricks
+       * * `AzureBlob` - Azure Blob
+       * * `Workflows` - Workflows
+       * * `HTTP` - Http
+       * * `NoOp` - Noop
+       * * `FileDownload` - File Download */
       type: BatchExportDestinationTypeEnum;
       /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
       config: BatchExportDestinationConfig;
@@ -8847,10 +8847,10 @@ export namespace Schemas {
 
     /**
      * * `hour` - hour
-    * `day` - day
-    * `week` - week
-    * `every 5 minutes` - every 5 minutes
-    * `every 15 minutes` - every 15 minutes
+     * * `day` - day
+     * * `week` - week
+     * * `every 5 minutes` - every 5 minutes
+     * * `every 15 minutes` - every 15 minutes
      */
     export type IntervalEnum = typeof IntervalEnum[keyof typeof IntervalEnum];
 
@@ -8865,15 +8865,15 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-    * `Completed` - Completed
-    * `ContinuedAsNew` - Continued As New
-    * `Failed` - Failed
-    * `FailedRetryable` - Failed Retryable
-    * `FailedBilling` - Failed Billing
-    * `Terminated` - Terminated
-    * `TimedOut` - Timedout
-    * `Running` - Running
-    * `Starting` - Starting
+     * * `Completed` - Completed
+     * * `ContinuedAsNew` - Continued As New
+     * * `Failed` - Failed
+     * * `FailedRetryable` - Failed Retryable
+     * * `FailedBilling` - Failed Billing
+     * * `Terminated` - Terminated
+     * * `TimedOut` - Timedout
+     * * `Running` - Running
+     * * `Starting` - Starting
      */
     export type BatchExportRunStatusEnum = typeof BatchExportRunStatusEnum[keyof typeof BatchExportRunStatusEnum];
 
@@ -8897,17 +8897,17 @@ export namespace Schemas {
     export interface BatchExportRun {
       readonly id: string;
       /** The status of this run.
-
-      * `Cancelled` - Cancelled
-      * `Completed` - Completed
-      * `ContinuedAsNew` - Continued As New
-      * `Failed` - Failed
-      * `FailedRetryable` - Failed Retryable
-      * `FailedBilling` - Failed Billing
-      * `Terminated` - Terminated
-      * `TimedOut` - Timedout
-      * `Running` - Running
-      * `Starting` - Starting */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Completed` - Completed
+       * * `ContinuedAsNew` - Continued As New
+       * * `Failed` - Failed
+       * * `FailedRetryable` - Failed Retryable
+       * * `FailedBilling` - Failed Billing
+       * * `Terminated` - Terminated
+       * * `TimedOut` - Timedout
+       * * `Running` - Running
+       * * `Starting` - Starting */
       status: BatchExportRunStatusEnum;
       /**
          * The number of records that have been exported.
@@ -8990,20 +8990,20 @@ export namespace Schemas {
       /** A human-readable name for this BatchExport. */
       name: string;
       /** Which model this BatchExport is exporting.
-
-      * `events` - Events
-      * `persons` - Persons
-      * `sessions` - Sessions */
+       *
+       * * `events` - Events
+       * * `persons` - Persons
+       * * `sessions` - Sessions */
       model?: ModelEnum | BlankEnum | null;
       /** Destination configuration (type, config, and optional integration). */
       destination: BatchExportDestination;
       /** How often the batch export should run.
-
-      * `hour` - hour
-      * `day` - day
-      * `week` - week
-      * `every 5 minutes` - every 5 minutes
-      * `every 15 minutes` - every 15 minutes */
+       *
+       * * `hour` - hour
+       * * `day` - day
+       * * `week` - week
+       * * `every 5 minutes` - every 5 minutes
+       * * `every 15 minutes` - every 15 minutes */
       interval: IntervalEnum;
       /** Whether this BatchExport is paused or not. */
       paused?: boolean;
@@ -9034,603 +9034,603 @@ export namespace Schemas {
       readonly schema: unknown;
       filters?: unknown;
       /** IANA timezone name controlling daily and weekly interval boundaries. Defaults to UTC.
-
-      * `Africa/Abidjan` - Africa/Abidjan
-      * `Africa/Accra` - Africa/Accra
-      * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-      * `Africa/Algiers` - Africa/Algiers
-      * `Africa/Asmara` - Africa/Asmara
-      * `Africa/Asmera` - Africa/Asmera
-      * `Africa/Bamako` - Africa/Bamako
-      * `Africa/Bangui` - Africa/Bangui
-      * `Africa/Banjul` - Africa/Banjul
-      * `Africa/Bissau` - Africa/Bissau
-      * `Africa/Blantyre` - Africa/Blantyre
-      * `Africa/Brazzaville` - Africa/Brazzaville
-      * `Africa/Bujumbura` - Africa/Bujumbura
-      * `Africa/Cairo` - Africa/Cairo
-      * `Africa/Casablanca` - Africa/Casablanca
-      * `Africa/Ceuta` - Africa/Ceuta
-      * `Africa/Conakry` - Africa/Conakry
-      * `Africa/Dakar` - Africa/Dakar
-      * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-      * `Africa/Djibouti` - Africa/Djibouti
-      * `Africa/Douala` - Africa/Douala
-      * `Africa/El_Aaiun` - Africa/El_Aaiun
-      * `Africa/Freetown` - Africa/Freetown
-      * `Africa/Gaborone` - Africa/Gaborone
-      * `Africa/Harare` - Africa/Harare
-      * `Africa/Johannesburg` - Africa/Johannesburg
-      * `Africa/Juba` - Africa/Juba
-      * `Africa/Kampala` - Africa/Kampala
-      * `Africa/Khartoum` - Africa/Khartoum
-      * `Africa/Kigali` - Africa/Kigali
-      * `Africa/Kinshasa` - Africa/Kinshasa
-      * `Africa/Lagos` - Africa/Lagos
-      * `Africa/Libreville` - Africa/Libreville
-      * `Africa/Lome` - Africa/Lome
-      * `Africa/Luanda` - Africa/Luanda
-      * `Africa/Lubumbashi` - Africa/Lubumbashi
-      * `Africa/Lusaka` - Africa/Lusaka
-      * `Africa/Malabo` - Africa/Malabo
-      * `Africa/Maputo` - Africa/Maputo
-      * `Africa/Maseru` - Africa/Maseru
-      * `Africa/Mbabane` - Africa/Mbabane
-      * `Africa/Mogadishu` - Africa/Mogadishu
-      * `Africa/Monrovia` - Africa/Monrovia
-      * `Africa/Nairobi` - Africa/Nairobi
-      * `Africa/Ndjamena` - Africa/Ndjamena
-      * `Africa/Niamey` - Africa/Niamey
-      * `Africa/Nouakchott` - Africa/Nouakchott
-      * `Africa/Ouagadougou` - Africa/Ouagadougou
-      * `Africa/Porto-Novo` - Africa/Porto-Novo
-      * `Africa/Sao_Tome` - Africa/Sao_Tome
-      * `Africa/Timbuktu` - Africa/Timbuktu
-      * `Africa/Tripoli` - Africa/Tripoli
-      * `Africa/Tunis` - Africa/Tunis
-      * `Africa/Windhoek` - Africa/Windhoek
-      * `America/Adak` - America/Adak
-      * `America/Anchorage` - America/Anchorage
-      * `America/Anguilla` - America/Anguilla
-      * `America/Antigua` - America/Antigua
-      * `America/Araguaina` - America/Araguaina
-      * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-      * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-      * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-      * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-      * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-      * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-      * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-      * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-      * `America/Argentina/Salta` - America/Argentina/Salta
-      * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-      * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-      * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-      * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-      * `America/Aruba` - America/Aruba
-      * `America/Asuncion` - America/Asuncion
-      * `America/Atikokan` - America/Atikokan
-      * `America/Atka` - America/Atka
-      * `America/Bahia` - America/Bahia
-      * `America/Bahia_Banderas` - America/Bahia_Banderas
-      * `America/Barbados` - America/Barbados
-      * `America/Belem` - America/Belem
-      * `America/Belize` - America/Belize
-      * `America/Blanc-Sablon` - America/Blanc-Sablon
-      * `America/Boa_Vista` - America/Boa_Vista
-      * `America/Bogota` - America/Bogota
-      * `America/Boise` - America/Boise
-      * `America/Buenos_Aires` - America/Buenos_Aires
-      * `America/Cambridge_Bay` - America/Cambridge_Bay
-      * `America/Campo_Grande` - America/Campo_Grande
-      * `America/Cancun` - America/Cancun
-      * `America/Caracas` - America/Caracas
-      * `America/Catamarca` - America/Catamarca
-      * `America/Cayenne` - America/Cayenne
-      * `America/Cayman` - America/Cayman
-      * `America/Chicago` - America/Chicago
-      * `America/Chihuahua` - America/Chihuahua
-      * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-      * `America/Coral_Harbour` - America/Coral_Harbour
-      * `America/Cordoba` - America/Cordoba
-      * `America/Costa_Rica` - America/Costa_Rica
-      * `America/Creston` - America/Creston
-      * `America/Cuiaba` - America/Cuiaba
-      * `America/Curacao` - America/Curacao
-      * `America/Danmarkshavn` - America/Danmarkshavn
-      * `America/Dawson` - America/Dawson
-      * `America/Dawson_Creek` - America/Dawson_Creek
-      * `America/Denver` - America/Denver
-      * `America/Detroit` - America/Detroit
-      * `America/Dominica` - America/Dominica
-      * `America/Edmonton` - America/Edmonton
-      * `America/Eirunepe` - America/Eirunepe
-      * `America/El_Salvador` - America/El_Salvador
-      * `America/Ensenada` - America/Ensenada
-      * `America/Fort_Nelson` - America/Fort_Nelson
-      * `America/Fort_Wayne` - America/Fort_Wayne
-      * `America/Fortaleza` - America/Fortaleza
-      * `America/Glace_Bay` - America/Glace_Bay
-      * `America/Godthab` - America/Godthab
-      * `America/Goose_Bay` - America/Goose_Bay
-      * `America/Grand_Turk` - America/Grand_Turk
-      * `America/Grenada` - America/Grenada
-      * `America/Guadeloupe` - America/Guadeloupe
-      * `America/Guatemala` - America/Guatemala
-      * `America/Guayaquil` - America/Guayaquil
-      * `America/Guyana` - America/Guyana
-      * `America/Halifax` - America/Halifax
-      * `America/Havana` - America/Havana
-      * `America/Hermosillo` - America/Hermosillo
-      * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-      * `America/Indiana/Knox` - America/Indiana/Knox
-      * `America/Indiana/Marengo` - America/Indiana/Marengo
-      * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-      * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-      * `America/Indiana/Vevay` - America/Indiana/Vevay
-      * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-      * `America/Indiana/Winamac` - America/Indiana/Winamac
-      * `America/Indianapolis` - America/Indianapolis
-      * `America/Inuvik` - America/Inuvik
-      * `America/Iqaluit` - America/Iqaluit
-      * `America/Jamaica` - America/Jamaica
-      * `America/Jujuy` - America/Jujuy
-      * `America/Juneau` - America/Juneau
-      * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-      * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-      * `America/Knox_IN` - America/Knox_IN
-      * `America/Kralendijk` - America/Kralendijk
-      * `America/La_Paz` - America/La_Paz
-      * `America/Lima` - America/Lima
-      * `America/Los_Angeles` - America/Los_Angeles
-      * `America/Louisville` - America/Louisville
-      * `America/Lower_Princes` - America/Lower_Princes
-      * `America/Maceio` - America/Maceio
-      * `America/Managua` - America/Managua
-      * `America/Manaus` - America/Manaus
-      * `America/Marigot` - America/Marigot
-      * `America/Martinique` - America/Martinique
-      * `America/Matamoros` - America/Matamoros
-      * `America/Mazatlan` - America/Mazatlan
-      * `America/Mendoza` - America/Mendoza
-      * `America/Menominee` - America/Menominee
-      * `America/Merida` - America/Merida
-      * `America/Metlakatla` - America/Metlakatla
-      * `America/Mexico_City` - America/Mexico_City
-      * `America/Miquelon` - America/Miquelon
-      * `America/Moncton` - America/Moncton
-      * `America/Monterrey` - America/Monterrey
-      * `America/Montevideo` - America/Montevideo
-      * `America/Montreal` - America/Montreal
-      * `America/Montserrat` - America/Montserrat
-      * `America/Nassau` - America/Nassau
-      * `America/New_York` - America/New_York
-      * `America/Nipigon` - America/Nipigon
-      * `America/Nome` - America/Nome
-      * `America/Noronha` - America/Noronha
-      * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-      * `America/North_Dakota/Center` - America/North_Dakota/Center
-      * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-      * `America/Nuuk` - America/Nuuk
-      * `America/Ojinaga` - America/Ojinaga
-      * `America/Panama` - America/Panama
-      * `America/Pangnirtung` - America/Pangnirtung
-      * `America/Paramaribo` - America/Paramaribo
-      * `America/Phoenix` - America/Phoenix
-      * `America/Port-au-Prince` - America/Port-au-Prince
-      * `America/Port_of_Spain` - America/Port_of_Spain
-      * `America/Porto_Acre` - America/Porto_Acre
-      * `America/Porto_Velho` - America/Porto_Velho
-      * `America/Puerto_Rico` - America/Puerto_Rico
-      * `America/Punta_Arenas` - America/Punta_Arenas
-      * `America/Rainy_River` - America/Rainy_River
-      * `America/Rankin_Inlet` - America/Rankin_Inlet
-      * `America/Recife` - America/Recife
-      * `America/Regina` - America/Regina
-      * `America/Resolute` - America/Resolute
-      * `America/Rio_Branco` - America/Rio_Branco
-      * `America/Rosario` - America/Rosario
-      * `America/Santa_Isabel` - America/Santa_Isabel
-      * `America/Santarem` - America/Santarem
-      * `America/Santiago` - America/Santiago
-      * `America/Santo_Domingo` - America/Santo_Domingo
-      * `America/Sao_Paulo` - America/Sao_Paulo
-      * `America/Scoresbysund` - America/Scoresbysund
-      * `America/Shiprock` - America/Shiprock
-      * `America/Sitka` - America/Sitka
-      * `America/St_Barthelemy` - America/St_Barthelemy
-      * `America/St_Johns` - America/St_Johns
-      * `America/St_Kitts` - America/St_Kitts
-      * `America/St_Lucia` - America/St_Lucia
-      * `America/St_Thomas` - America/St_Thomas
-      * `America/St_Vincent` - America/St_Vincent
-      * `America/Swift_Current` - America/Swift_Current
-      * `America/Tegucigalpa` - America/Tegucigalpa
-      * `America/Thule` - America/Thule
-      * `America/Thunder_Bay` - America/Thunder_Bay
-      * `America/Tijuana` - America/Tijuana
-      * `America/Toronto` - America/Toronto
-      * `America/Tortola` - America/Tortola
-      * `America/Vancouver` - America/Vancouver
-      * `America/Virgin` - America/Virgin
-      * `America/Whitehorse` - America/Whitehorse
-      * `America/Winnipeg` - America/Winnipeg
-      * `America/Yakutat` - America/Yakutat
-      * `America/Yellowknife` - America/Yellowknife
-      * `Antarctica/Casey` - Antarctica/Casey
-      * `Antarctica/Davis` - Antarctica/Davis
-      * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-      * `Antarctica/Macquarie` - Antarctica/Macquarie
-      * `Antarctica/Mawson` - Antarctica/Mawson
-      * `Antarctica/McMurdo` - Antarctica/McMurdo
-      * `Antarctica/Palmer` - Antarctica/Palmer
-      * `Antarctica/Rothera` - Antarctica/Rothera
-      * `Antarctica/South_Pole` - Antarctica/South_Pole
-      * `Antarctica/Syowa` - Antarctica/Syowa
-      * `Antarctica/Troll` - Antarctica/Troll
-      * `Antarctica/Vostok` - Antarctica/Vostok
-      * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-      * `Asia/Aden` - Asia/Aden
-      * `Asia/Almaty` - Asia/Almaty
-      * `Asia/Amman` - Asia/Amman
-      * `Asia/Anadyr` - Asia/Anadyr
-      * `Asia/Aqtau` - Asia/Aqtau
-      * `Asia/Aqtobe` - Asia/Aqtobe
-      * `Asia/Ashgabat` - Asia/Ashgabat
-      * `Asia/Ashkhabad` - Asia/Ashkhabad
-      * `Asia/Atyrau` - Asia/Atyrau
-      * `Asia/Baghdad` - Asia/Baghdad
-      * `Asia/Bahrain` - Asia/Bahrain
-      * `Asia/Baku` - Asia/Baku
-      * `Asia/Bangkok` - Asia/Bangkok
-      * `Asia/Barnaul` - Asia/Barnaul
-      * `Asia/Beirut` - Asia/Beirut
-      * `Asia/Bishkek` - Asia/Bishkek
-      * `Asia/Brunei` - Asia/Brunei
-      * `Asia/Calcutta` - Asia/Calcutta
-      * `Asia/Chita` - Asia/Chita
-      * `Asia/Choibalsan` - Asia/Choibalsan
-      * `Asia/Chongqing` - Asia/Chongqing
-      * `Asia/Chungking` - Asia/Chungking
-      * `Asia/Colombo` - Asia/Colombo
-      * `Asia/Dacca` - Asia/Dacca
-      * `Asia/Damascus` - Asia/Damascus
-      * `Asia/Dhaka` - Asia/Dhaka
-      * `Asia/Dili` - Asia/Dili
-      * `Asia/Dubai` - Asia/Dubai
-      * `Asia/Dushanbe` - Asia/Dushanbe
-      * `Asia/Famagusta` - Asia/Famagusta
-      * `Asia/Gaza` - Asia/Gaza
-      * `Asia/Harbin` - Asia/Harbin
-      * `Asia/Hebron` - Asia/Hebron
-      * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-      * `Asia/Hong_Kong` - Asia/Hong_Kong
-      * `Asia/Hovd` - Asia/Hovd
-      * `Asia/Irkutsk` - Asia/Irkutsk
-      * `Asia/Istanbul` - Asia/Istanbul
-      * `Asia/Jakarta` - Asia/Jakarta
-      * `Asia/Jayapura` - Asia/Jayapura
-      * `Asia/Jerusalem` - Asia/Jerusalem
-      * `Asia/Kabul` - Asia/Kabul
-      * `Asia/Kamchatka` - Asia/Kamchatka
-      * `Asia/Karachi` - Asia/Karachi
-      * `Asia/Kashgar` - Asia/Kashgar
-      * `Asia/Kathmandu` - Asia/Kathmandu
-      * `Asia/Katmandu` - Asia/Katmandu
-      * `Asia/Khandyga` - Asia/Khandyga
-      * `Asia/Kolkata` - Asia/Kolkata
-      * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-      * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-      * `Asia/Kuching` - Asia/Kuching
-      * `Asia/Kuwait` - Asia/Kuwait
-      * `Asia/Macao` - Asia/Macao
-      * `Asia/Macau` - Asia/Macau
-      * `Asia/Magadan` - Asia/Magadan
-      * `Asia/Makassar` - Asia/Makassar
-      * `Asia/Manila` - Asia/Manila
-      * `Asia/Muscat` - Asia/Muscat
-      * `Asia/Nicosia` - Asia/Nicosia
-      * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-      * `Asia/Novosibirsk` - Asia/Novosibirsk
-      * `Asia/Omsk` - Asia/Omsk
-      * `Asia/Oral` - Asia/Oral
-      * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-      * `Asia/Pontianak` - Asia/Pontianak
-      * `Asia/Pyongyang` - Asia/Pyongyang
-      * `Asia/Qatar` - Asia/Qatar
-      * `Asia/Qostanay` - Asia/Qostanay
-      * `Asia/Qyzylorda` - Asia/Qyzylorda
-      * `Asia/Rangoon` - Asia/Rangoon
-      * `Asia/Riyadh` - Asia/Riyadh
-      * `Asia/Saigon` - Asia/Saigon
-      * `Asia/Sakhalin` - Asia/Sakhalin
-      * `Asia/Samarkand` - Asia/Samarkand
-      * `Asia/Seoul` - Asia/Seoul
-      * `Asia/Shanghai` - Asia/Shanghai
-      * `Asia/Singapore` - Asia/Singapore
-      * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-      * `Asia/Taipei` - Asia/Taipei
-      * `Asia/Tashkent` - Asia/Tashkent
-      * `Asia/Tbilisi` - Asia/Tbilisi
-      * `Asia/Tehran` - Asia/Tehran
-      * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-      * `Asia/Thimbu` - Asia/Thimbu
-      * `Asia/Thimphu` - Asia/Thimphu
-      * `Asia/Tokyo` - Asia/Tokyo
-      * `Asia/Tomsk` - Asia/Tomsk
-      * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-      * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-      * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-      * `Asia/Urumqi` - Asia/Urumqi
-      * `Asia/Ust-Nera` - Asia/Ust-Nera
-      * `Asia/Vientiane` - Asia/Vientiane
-      * `Asia/Vladivostok` - Asia/Vladivostok
-      * `Asia/Yakutsk` - Asia/Yakutsk
-      * `Asia/Yangon` - Asia/Yangon
-      * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-      * `Asia/Yerevan` - Asia/Yerevan
-      * `Atlantic/Azores` - Atlantic/Azores
-      * `Atlantic/Bermuda` - Atlantic/Bermuda
-      * `Atlantic/Canary` - Atlantic/Canary
-      * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-      * `Atlantic/Faeroe` - Atlantic/Faeroe
-      * `Atlantic/Faroe` - Atlantic/Faroe
-      * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-      * `Atlantic/Madeira` - Atlantic/Madeira
-      * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-      * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-      * `Atlantic/St_Helena` - Atlantic/St_Helena
-      * `Atlantic/Stanley` - Atlantic/Stanley
-      * `Australia/ACT` - Australia/ACT
-      * `Australia/Adelaide` - Australia/Adelaide
-      * `Australia/Brisbane` - Australia/Brisbane
-      * `Australia/Broken_Hill` - Australia/Broken_Hill
-      * `Australia/Canberra` - Australia/Canberra
-      * `Australia/Currie` - Australia/Currie
-      * `Australia/Darwin` - Australia/Darwin
-      * `Australia/Eucla` - Australia/Eucla
-      * `Australia/Hobart` - Australia/Hobart
-      * `Australia/LHI` - Australia/LHI
-      * `Australia/Lindeman` - Australia/Lindeman
-      * `Australia/Lord_Howe` - Australia/Lord_Howe
-      * `Australia/Melbourne` - Australia/Melbourne
-      * `Australia/NSW` - Australia/NSW
-      * `Australia/North` - Australia/North
-      * `Australia/Perth` - Australia/Perth
-      * `Australia/Queensland` - Australia/Queensland
-      * `Australia/South` - Australia/South
-      * `Australia/Sydney` - Australia/Sydney
-      * `Australia/Tasmania` - Australia/Tasmania
-      * `Australia/Victoria` - Australia/Victoria
-      * `Australia/West` - Australia/West
-      * `Australia/Yancowinna` - Australia/Yancowinna
-      * `Brazil/Acre` - Brazil/Acre
-      * `Brazil/DeNoronha` - Brazil/DeNoronha
-      * `Brazil/East` - Brazil/East
-      * `Brazil/West` - Brazil/West
-      * `CET` - CET
-      * `CST6CDT` - CST6CDT
-      * `Canada/Atlantic` - Canada/Atlantic
-      * `Canada/Central` - Canada/Central
-      * `Canada/Eastern` - Canada/Eastern
-      * `Canada/Mountain` - Canada/Mountain
-      * `Canada/Newfoundland` - Canada/Newfoundland
-      * `Canada/Pacific` - Canada/Pacific
-      * `Canada/Saskatchewan` - Canada/Saskatchewan
-      * `Canada/Yukon` - Canada/Yukon
-      * `Chile/Continental` - Chile/Continental
-      * `Chile/EasterIsland` - Chile/EasterIsland
-      * `Cuba` - Cuba
-      * `EET` - EET
-      * `EST` - EST
-      * `EST5EDT` - EST5EDT
-      * `Egypt` - Egypt
-      * `Eire` - Eire
-      * `Etc/GMT` - Etc/GMT
-      * `Etc/GMT+0` - Etc/GMT+0
-      * `Etc/GMT+1` - Etc/GMT+1
-      * `Etc/GMT+10` - Etc/GMT+10
-      * `Etc/GMT+11` - Etc/GMT+11
-      * `Etc/GMT+12` - Etc/GMT+12
-      * `Etc/GMT+2` - Etc/GMT+2
-      * `Etc/GMT+3` - Etc/GMT+3
-      * `Etc/GMT+4` - Etc/GMT+4
-      * `Etc/GMT+5` - Etc/GMT+5
-      * `Etc/GMT+6` - Etc/GMT+6
-      * `Etc/GMT+7` - Etc/GMT+7
-      * `Etc/GMT+8` - Etc/GMT+8
-      * `Etc/GMT+9` - Etc/GMT+9
-      * `Etc/GMT-0` - Etc/GMT-0
-      * `Etc/GMT-1` - Etc/GMT-1
-      * `Etc/GMT-10` - Etc/GMT-10
-      * `Etc/GMT-11` - Etc/GMT-11
-      * `Etc/GMT-12` - Etc/GMT-12
-      * `Etc/GMT-13` - Etc/GMT-13
-      * `Etc/GMT-14` - Etc/GMT-14
-      * `Etc/GMT-2` - Etc/GMT-2
-      * `Etc/GMT-3` - Etc/GMT-3
-      * `Etc/GMT-4` - Etc/GMT-4
-      * `Etc/GMT-5` - Etc/GMT-5
-      * `Etc/GMT-6` - Etc/GMT-6
-      * `Etc/GMT-7` - Etc/GMT-7
-      * `Etc/GMT-8` - Etc/GMT-8
-      * `Etc/GMT-9` - Etc/GMT-9
-      * `Etc/GMT0` - Etc/GMT0
-      * `Etc/Greenwich` - Etc/Greenwich
-      * `Etc/UCT` - Etc/UCT
-      * `Etc/UTC` - Etc/UTC
-      * `Etc/Universal` - Etc/Universal
-      * `Etc/Zulu` - Etc/Zulu
-      * `Europe/Amsterdam` - Europe/Amsterdam
-      * `Europe/Andorra` - Europe/Andorra
-      * `Europe/Astrakhan` - Europe/Astrakhan
-      * `Europe/Athens` - Europe/Athens
-      * `Europe/Belfast` - Europe/Belfast
-      * `Europe/Belgrade` - Europe/Belgrade
-      * `Europe/Berlin` - Europe/Berlin
-      * `Europe/Bratislava` - Europe/Bratislava
-      * `Europe/Brussels` - Europe/Brussels
-      * `Europe/Bucharest` - Europe/Bucharest
-      * `Europe/Budapest` - Europe/Budapest
-      * `Europe/Busingen` - Europe/Busingen
-      * `Europe/Chisinau` - Europe/Chisinau
-      * `Europe/Copenhagen` - Europe/Copenhagen
-      * `Europe/Dublin` - Europe/Dublin
-      * `Europe/Gibraltar` - Europe/Gibraltar
-      * `Europe/Guernsey` - Europe/Guernsey
-      * `Europe/Helsinki` - Europe/Helsinki
-      * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-      * `Europe/Istanbul` - Europe/Istanbul
-      * `Europe/Jersey` - Europe/Jersey
-      * `Europe/Kaliningrad` - Europe/Kaliningrad
-      * `Europe/Kiev` - Europe/Kiev
-      * `Europe/Kirov` - Europe/Kirov
-      * `Europe/Kyiv` - Europe/Kyiv
-      * `Europe/Lisbon` - Europe/Lisbon
-      * `Europe/Ljubljana` - Europe/Ljubljana
-      * `Europe/London` - Europe/London
-      * `Europe/Luxembourg` - Europe/Luxembourg
-      * `Europe/Madrid` - Europe/Madrid
-      * `Europe/Malta` - Europe/Malta
-      * `Europe/Mariehamn` - Europe/Mariehamn
-      * `Europe/Minsk` - Europe/Minsk
-      * `Europe/Monaco` - Europe/Monaco
-      * `Europe/Moscow` - Europe/Moscow
-      * `Europe/Nicosia` - Europe/Nicosia
-      * `Europe/Oslo` - Europe/Oslo
-      * `Europe/Paris` - Europe/Paris
-      * `Europe/Podgorica` - Europe/Podgorica
-      * `Europe/Prague` - Europe/Prague
-      * `Europe/Riga` - Europe/Riga
-      * `Europe/Rome` - Europe/Rome
-      * `Europe/Samara` - Europe/Samara
-      * `Europe/San_Marino` - Europe/San_Marino
-      * `Europe/Sarajevo` - Europe/Sarajevo
-      * `Europe/Saratov` - Europe/Saratov
-      * `Europe/Simferopol` - Europe/Simferopol
-      * `Europe/Skopje` - Europe/Skopje
-      * `Europe/Sofia` - Europe/Sofia
-      * `Europe/Stockholm` - Europe/Stockholm
-      * `Europe/Tallinn` - Europe/Tallinn
-      * `Europe/Tirane` - Europe/Tirane
-      * `Europe/Tiraspol` - Europe/Tiraspol
-      * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-      * `Europe/Uzhgorod` - Europe/Uzhgorod
-      * `Europe/Vaduz` - Europe/Vaduz
-      * `Europe/Vatican` - Europe/Vatican
-      * `Europe/Vienna` - Europe/Vienna
-      * `Europe/Vilnius` - Europe/Vilnius
-      * `Europe/Volgograd` - Europe/Volgograd
-      * `Europe/Warsaw` - Europe/Warsaw
-      * `Europe/Zagreb` - Europe/Zagreb
-      * `Europe/Zaporozhye` - Europe/Zaporozhye
-      * `Europe/Zurich` - Europe/Zurich
-      * `GB` - GB
-      * `GB-Eire` - GB-Eire
-      * `GMT` - GMT
-      * `GMT+0` - GMT+0
-      * `GMT-0` - GMT-0
-      * `GMT0` - GMT0
-      * `Greenwich` - Greenwich
-      * `HST` - HST
-      * `Hongkong` - Hongkong
-      * `Iceland` - Iceland
-      * `Indian/Antananarivo` - Indian/Antananarivo
-      * `Indian/Chagos` - Indian/Chagos
-      * `Indian/Christmas` - Indian/Christmas
-      * `Indian/Cocos` - Indian/Cocos
-      * `Indian/Comoro` - Indian/Comoro
-      * `Indian/Kerguelen` - Indian/Kerguelen
-      * `Indian/Mahe` - Indian/Mahe
-      * `Indian/Maldives` - Indian/Maldives
-      * `Indian/Mauritius` - Indian/Mauritius
-      * `Indian/Mayotte` - Indian/Mayotte
-      * `Indian/Reunion` - Indian/Reunion
-      * `Iran` - Iran
-      * `Israel` - Israel
-      * `Jamaica` - Jamaica
-      * `Japan` - Japan
-      * `Kwajalein` - Kwajalein
-      * `Libya` - Libya
-      * `MET` - MET
-      * `MST` - MST
-      * `MST7MDT` - MST7MDT
-      * `Mexico/BajaNorte` - Mexico/BajaNorte
-      * `Mexico/BajaSur` - Mexico/BajaSur
-      * `Mexico/General` - Mexico/General
-      * `NZ` - NZ
-      * `NZ-CHAT` - NZ-CHAT
-      * `Navajo` - Navajo
-      * `PRC` - PRC
-      * `PST8PDT` - PST8PDT
-      * `Pacific/Apia` - Pacific/Apia
-      * `Pacific/Auckland` - Pacific/Auckland
-      * `Pacific/Bougainville` - Pacific/Bougainville
-      * `Pacific/Chatham` - Pacific/Chatham
-      * `Pacific/Chuuk` - Pacific/Chuuk
-      * `Pacific/Easter` - Pacific/Easter
-      * `Pacific/Efate` - Pacific/Efate
-      * `Pacific/Enderbury` - Pacific/Enderbury
-      * `Pacific/Fakaofo` - Pacific/Fakaofo
-      * `Pacific/Fiji` - Pacific/Fiji
-      * `Pacific/Funafuti` - Pacific/Funafuti
-      * `Pacific/Galapagos` - Pacific/Galapagos
-      * `Pacific/Gambier` - Pacific/Gambier
-      * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-      * `Pacific/Guam` - Pacific/Guam
-      * `Pacific/Honolulu` - Pacific/Honolulu
-      * `Pacific/Johnston` - Pacific/Johnston
-      * `Pacific/Kanton` - Pacific/Kanton
-      * `Pacific/Kiritimati` - Pacific/Kiritimati
-      * `Pacific/Kosrae` - Pacific/Kosrae
-      * `Pacific/Kwajalein` - Pacific/Kwajalein
-      * `Pacific/Majuro` - Pacific/Majuro
-      * `Pacific/Marquesas` - Pacific/Marquesas
-      * `Pacific/Midway` - Pacific/Midway
-      * `Pacific/Nauru` - Pacific/Nauru
-      * `Pacific/Niue` - Pacific/Niue
-      * `Pacific/Norfolk` - Pacific/Norfolk
-      * `Pacific/Noumea` - Pacific/Noumea
-      * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-      * `Pacific/Palau` - Pacific/Palau
-      * `Pacific/Pitcairn` - Pacific/Pitcairn
-      * `Pacific/Pohnpei` - Pacific/Pohnpei
-      * `Pacific/Ponape` - Pacific/Ponape
-      * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-      * `Pacific/Rarotonga` - Pacific/Rarotonga
-      * `Pacific/Saipan` - Pacific/Saipan
-      * `Pacific/Samoa` - Pacific/Samoa
-      * `Pacific/Tahiti` - Pacific/Tahiti
-      * `Pacific/Tarawa` - Pacific/Tarawa
-      * `Pacific/Tongatapu` - Pacific/Tongatapu
-      * `Pacific/Truk` - Pacific/Truk
-      * `Pacific/Wake` - Pacific/Wake
-      * `Pacific/Wallis` - Pacific/Wallis
-      * `Pacific/Yap` - Pacific/Yap
-      * `Poland` - Poland
-      * `Portugal` - Portugal
-      * `ROC` - ROC
-      * `ROK` - ROK
-      * `Singapore` - Singapore
-      * `Turkey` - Turkey
-      * `UCT` - UCT
-      * `US/Alaska` - US/Alaska
-      * `US/Aleutian` - US/Aleutian
-      * `US/Arizona` - US/Arizona
-      * `US/Central` - US/Central
-      * `US/East-Indiana` - US/East-Indiana
-      * `US/Eastern` - US/Eastern
-      * `US/Hawaii` - US/Hawaii
-      * `US/Indiana-Starke` - US/Indiana-Starke
-      * `US/Michigan` - US/Michigan
-      * `US/Mountain` - US/Mountain
-      * `US/Pacific` - US/Pacific
-      * `US/Samoa` - US/Samoa
-      * `UTC` - UTC
-      * `Universal` - Universal
-      * `W-SU` - W-SU
-      * `WET` - WET
-      * `Zulu` - Zulu */
+       *
+       * * `Africa/Abidjan` - Africa/Abidjan
+       * * `Africa/Accra` - Africa/Accra
+       * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+       * * `Africa/Algiers` - Africa/Algiers
+       * * `Africa/Asmara` - Africa/Asmara
+       * * `Africa/Asmera` - Africa/Asmera
+       * * `Africa/Bamako` - Africa/Bamako
+       * * `Africa/Bangui` - Africa/Bangui
+       * * `Africa/Banjul` - Africa/Banjul
+       * * `Africa/Bissau` - Africa/Bissau
+       * * `Africa/Blantyre` - Africa/Blantyre
+       * * `Africa/Brazzaville` - Africa/Brazzaville
+       * * `Africa/Bujumbura` - Africa/Bujumbura
+       * * `Africa/Cairo` - Africa/Cairo
+       * * `Africa/Casablanca` - Africa/Casablanca
+       * * `Africa/Ceuta` - Africa/Ceuta
+       * * `Africa/Conakry` - Africa/Conakry
+       * * `Africa/Dakar` - Africa/Dakar
+       * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+       * * `Africa/Djibouti` - Africa/Djibouti
+       * * `Africa/Douala` - Africa/Douala
+       * * `Africa/El_Aaiun` - Africa/El_Aaiun
+       * * `Africa/Freetown` - Africa/Freetown
+       * * `Africa/Gaborone` - Africa/Gaborone
+       * * `Africa/Harare` - Africa/Harare
+       * * `Africa/Johannesburg` - Africa/Johannesburg
+       * * `Africa/Juba` - Africa/Juba
+       * * `Africa/Kampala` - Africa/Kampala
+       * * `Africa/Khartoum` - Africa/Khartoum
+       * * `Africa/Kigali` - Africa/Kigali
+       * * `Africa/Kinshasa` - Africa/Kinshasa
+       * * `Africa/Lagos` - Africa/Lagos
+       * * `Africa/Libreville` - Africa/Libreville
+       * * `Africa/Lome` - Africa/Lome
+       * * `Africa/Luanda` - Africa/Luanda
+       * * `Africa/Lubumbashi` - Africa/Lubumbashi
+       * * `Africa/Lusaka` - Africa/Lusaka
+       * * `Africa/Malabo` - Africa/Malabo
+       * * `Africa/Maputo` - Africa/Maputo
+       * * `Africa/Maseru` - Africa/Maseru
+       * * `Africa/Mbabane` - Africa/Mbabane
+       * * `Africa/Mogadishu` - Africa/Mogadishu
+       * * `Africa/Monrovia` - Africa/Monrovia
+       * * `Africa/Nairobi` - Africa/Nairobi
+       * * `Africa/Ndjamena` - Africa/Ndjamena
+       * * `Africa/Niamey` - Africa/Niamey
+       * * `Africa/Nouakchott` - Africa/Nouakchott
+       * * `Africa/Ouagadougou` - Africa/Ouagadougou
+       * * `Africa/Porto-Novo` - Africa/Porto-Novo
+       * * `Africa/Sao_Tome` - Africa/Sao_Tome
+       * * `Africa/Timbuktu` - Africa/Timbuktu
+       * * `Africa/Tripoli` - Africa/Tripoli
+       * * `Africa/Tunis` - Africa/Tunis
+       * * `Africa/Windhoek` - Africa/Windhoek
+       * * `America/Adak` - America/Adak
+       * * `America/Anchorage` - America/Anchorage
+       * * `America/Anguilla` - America/Anguilla
+       * * `America/Antigua` - America/Antigua
+       * * `America/Araguaina` - America/Araguaina
+       * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+       * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+       * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+       * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+       * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+       * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+       * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+       * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+       * * `America/Argentina/Salta` - America/Argentina/Salta
+       * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+       * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+       * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+       * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+       * * `America/Aruba` - America/Aruba
+       * * `America/Asuncion` - America/Asuncion
+       * * `America/Atikokan` - America/Atikokan
+       * * `America/Atka` - America/Atka
+       * * `America/Bahia` - America/Bahia
+       * * `America/Bahia_Banderas` - America/Bahia_Banderas
+       * * `America/Barbados` - America/Barbados
+       * * `America/Belem` - America/Belem
+       * * `America/Belize` - America/Belize
+       * * `America/Blanc-Sablon` - America/Blanc-Sablon
+       * * `America/Boa_Vista` - America/Boa_Vista
+       * * `America/Bogota` - America/Bogota
+       * * `America/Boise` - America/Boise
+       * * `America/Buenos_Aires` - America/Buenos_Aires
+       * * `America/Cambridge_Bay` - America/Cambridge_Bay
+       * * `America/Campo_Grande` - America/Campo_Grande
+       * * `America/Cancun` - America/Cancun
+       * * `America/Caracas` - America/Caracas
+       * * `America/Catamarca` - America/Catamarca
+       * * `America/Cayenne` - America/Cayenne
+       * * `America/Cayman` - America/Cayman
+       * * `America/Chicago` - America/Chicago
+       * * `America/Chihuahua` - America/Chihuahua
+       * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+       * * `America/Coral_Harbour` - America/Coral_Harbour
+       * * `America/Cordoba` - America/Cordoba
+       * * `America/Costa_Rica` - America/Costa_Rica
+       * * `America/Creston` - America/Creston
+       * * `America/Cuiaba` - America/Cuiaba
+       * * `America/Curacao` - America/Curacao
+       * * `America/Danmarkshavn` - America/Danmarkshavn
+       * * `America/Dawson` - America/Dawson
+       * * `America/Dawson_Creek` - America/Dawson_Creek
+       * * `America/Denver` - America/Denver
+       * * `America/Detroit` - America/Detroit
+       * * `America/Dominica` - America/Dominica
+       * * `America/Edmonton` - America/Edmonton
+       * * `America/Eirunepe` - America/Eirunepe
+       * * `America/El_Salvador` - America/El_Salvador
+       * * `America/Ensenada` - America/Ensenada
+       * * `America/Fort_Nelson` - America/Fort_Nelson
+       * * `America/Fort_Wayne` - America/Fort_Wayne
+       * * `America/Fortaleza` - America/Fortaleza
+       * * `America/Glace_Bay` - America/Glace_Bay
+       * * `America/Godthab` - America/Godthab
+       * * `America/Goose_Bay` - America/Goose_Bay
+       * * `America/Grand_Turk` - America/Grand_Turk
+       * * `America/Grenada` - America/Grenada
+       * * `America/Guadeloupe` - America/Guadeloupe
+       * * `America/Guatemala` - America/Guatemala
+       * * `America/Guayaquil` - America/Guayaquil
+       * * `America/Guyana` - America/Guyana
+       * * `America/Halifax` - America/Halifax
+       * * `America/Havana` - America/Havana
+       * * `America/Hermosillo` - America/Hermosillo
+       * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+       * * `America/Indiana/Knox` - America/Indiana/Knox
+       * * `America/Indiana/Marengo` - America/Indiana/Marengo
+       * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+       * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+       * * `America/Indiana/Vevay` - America/Indiana/Vevay
+       * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+       * * `America/Indiana/Winamac` - America/Indiana/Winamac
+       * * `America/Indianapolis` - America/Indianapolis
+       * * `America/Inuvik` - America/Inuvik
+       * * `America/Iqaluit` - America/Iqaluit
+       * * `America/Jamaica` - America/Jamaica
+       * * `America/Jujuy` - America/Jujuy
+       * * `America/Juneau` - America/Juneau
+       * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+       * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+       * * `America/Knox_IN` - America/Knox_IN
+       * * `America/Kralendijk` - America/Kralendijk
+       * * `America/La_Paz` - America/La_Paz
+       * * `America/Lima` - America/Lima
+       * * `America/Los_Angeles` - America/Los_Angeles
+       * * `America/Louisville` - America/Louisville
+       * * `America/Lower_Princes` - America/Lower_Princes
+       * * `America/Maceio` - America/Maceio
+       * * `America/Managua` - America/Managua
+       * * `America/Manaus` - America/Manaus
+       * * `America/Marigot` - America/Marigot
+       * * `America/Martinique` - America/Martinique
+       * * `America/Matamoros` - America/Matamoros
+       * * `America/Mazatlan` - America/Mazatlan
+       * * `America/Mendoza` - America/Mendoza
+       * * `America/Menominee` - America/Menominee
+       * * `America/Merida` - America/Merida
+       * * `America/Metlakatla` - America/Metlakatla
+       * * `America/Mexico_City` - America/Mexico_City
+       * * `America/Miquelon` - America/Miquelon
+       * * `America/Moncton` - America/Moncton
+       * * `America/Monterrey` - America/Monterrey
+       * * `America/Montevideo` - America/Montevideo
+       * * `America/Montreal` - America/Montreal
+       * * `America/Montserrat` - America/Montserrat
+       * * `America/Nassau` - America/Nassau
+       * * `America/New_York` - America/New_York
+       * * `America/Nipigon` - America/Nipigon
+       * * `America/Nome` - America/Nome
+       * * `America/Noronha` - America/Noronha
+       * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+       * * `America/North_Dakota/Center` - America/North_Dakota/Center
+       * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+       * * `America/Nuuk` - America/Nuuk
+       * * `America/Ojinaga` - America/Ojinaga
+       * * `America/Panama` - America/Panama
+       * * `America/Pangnirtung` - America/Pangnirtung
+       * * `America/Paramaribo` - America/Paramaribo
+       * * `America/Phoenix` - America/Phoenix
+       * * `America/Port-au-Prince` - America/Port-au-Prince
+       * * `America/Port_of_Spain` - America/Port_of_Spain
+       * * `America/Porto_Acre` - America/Porto_Acre
+       * * `America/Porto_Velho` - America/Porto_Velho
+       * * `America/Puerto_Rico` - America/Puerto_Rico
+       * * `America/Punta_Arenas` - America/Punta_Arenas
+       * * `America/Rainy_River` - America/Rainy_River
+       * * `America/Rankin_Inlet` - America/Rankin_Inlet
+       * * `America/Recife` - America/Recife
+       * * `America/Regina` - America/Regina
+       * * `America/Resolute` - America/Resolute
+       * * `America/Rio_Branco` - America/Rio_Branco
+       * * `America/Rosario` - America/Rosario
+       * * `America/Santa_Isabel` - America/Santa_Isabel
+       * * `America/Santarem` - America/Santarem
+       * * `America/Santiago` - America/Santiago
+       * * `America/Santo_Domingo` - America/Santo_Domingo
+       * * `America/Sao_Paulo` - America/Sao_Paulo
+       * * `America/Scoresbysund` - America/Scoresbysund
+       * * `America/Shiprock` - America/Shiprock
+       * * `America/Sitka` - America/Sitka
+       * * `America/St_Barthelemy` - America/St_Barthelemy
+       * * `America/St_Johns` - America/St_Johns
+       * * `America/St_Kitts` - America/St_Kitts
+       * * `America/St_Lucia` - America/St_Lucia
+       * * `America/St_Thomas` - America/St_Thomas
+       * * `America/St_Vincent` - America/St_Vincent
+       * * `America/Swift_Current` - America/Swift_Current
+       * * `America/Tegucigalpa` - America/Tegucigalpa
+       * * `America/Thule` - America/Thule
+       * * `America/Thunder_Bay` - America/Thunder_Bay
+       * * `America/Tijuana` - America/Tijuana
+       * * `America/Toronto` - America/Toronto
+       * * `America/Tortola` - America/Tortola
+       * * `America/Vancouver` - America/Vancouver
+       * * `America/Virgin` - America/Virgin
+       * * `America/Whitehorse` - America/Whitehorse
+       * * `America/Winnipeg` - America/Winnipeg
+       * * `America/Yakutat` - America/Yakutat
+       * * `America/Yellowknife` - America/Yellowknife
+       * * `Antarctica/Casey` - Antarctica/Casey
+       * * `Antarctica/Davis` - Antarctica/Davis
+       * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+       * * `Antarctica/Macquarie` - Antarctica/Macquarie
+       * * `Antarctica/Mawson` - Antarctica/Mawson
+       * * `Antarctica/McMurdo` - Antarctica/McMurdo
+       * * `Antarctica/Palmer` - Antarctica/Palmer
+       * * `Antarctica/Rothera` - Antarctica/Rothera
+       * * `Antarctica/South_Pole` - Antarctica/South_Pole
+       * * `Antarctica/Syowa` - Antarctica/Syowa
+       * * `Antarctica/Troll` - Antarctica/Troll
+       * * `Antarctica/Vostok` - Antarctica/Vostok
+       * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+       * * `Asia/Aden` - Asia/Aden
+       * * `Asia/Almaty` - Asia/Almaty
+       * * `Asia/Amman` - Asia/Amman
+       * * `Asia/Anadyr` - Asia/Anadyr
+       * * `Asia/Aqtau` - Asia/Aqtau
+       * * `Asia/Aqtobe` - Asia/Aqtobe
+       * * `Asia/Ashgabat` - Asia/Ashgabat
+       * * `Asia/Ashkhabad` - Asia/Ashkhabad
+       * * `Asia/Atyrau` - Asia/Atyrau
+       * * `Asia/Baghdad` - Asia/Baghdad
+       * * `Asia/Bahrain` - Asia/Bahrain
+       * * `Asia/Baku` - Asia/Baku
+       * * `Asia/Bangkok` - Asia/Bangkok
+       * * `Asia/Barnaul` - Asia/Barnaul
+       * * `Asia/Beirut` - Asia/Beirut
+       * * `Asia/Bishkek` - Asia/Bishkek
+       * * `Asia/Brunei` - Asia/Brunei
+       * * `Asia/Calcutta` - Asia/Calcutta
+       * * `Asia/Chita` - Asia/Chita
+       * * `Asia/Choibalsan` - Asia/Choibalsan
+       * * `Asia/Chongqing` - Asia/Chongqing
+       * * `Asia/Chungking` - Asia/Chungking
+       * * `Asia/Colombo` - Asia/Colombo
+       * * `Asia/Dacca` - Asia/Dacca
+       * * `Asia/Damascus` - Asia/Damascus
+       * * `Asia/Dhaka` - Asia/Dhaka
+       * * `Asia/Dili` - Asia/Dili
+       * * `Asia/Dubai` - Asia/Dubai
+       * * `Asia/Dushanbe` - Asia/Dushanbe
+       * * `Asia/Famagusta` - Asia/Famagusta
+       * * `Asia/Gaza` - Asia/Gaza
+       * * `Asia/Harbin` - Asia/Harbin
+       * * `Asia/Hebron` - Asia/Hebron
+       * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+       * * `Asia/Hong_Kong` - Asia/Hong_Kong
+       * * `Asia/Hovd` - Asia/Hovd
+       * * `Asia/Irkutsk` - Asia/Irkutsk
+       * * `Asia/Istanbul` - Asia/Istanbul
+       * * `Asia/Jakarta` - Asia/Jakarta
+       * * `Asia/Jayapura` - Asia/Jayapura
+       * * `Asia/Jerusalem` - Asia/Jerusalem
+       * * `Asia/Kabul` - Asia/Kabul
+       * * `Asia/Kamchatka` - Asia/Kamchatka
+       * * `Asia/Karachi` - Asia/Karachi
+       * * `Asia/Kashgar` - Asia/Kashgar
+       * * `Asia/Kathmandu` - Asia/Kathmandu
+       * * `Asia/Katmandu` - Asia/Katmandu
+       * * `Asia/Khandyga` - Asia/Khandyga
+       * * `Asia/Kolkata` - Asia/Kolkata
+       * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+       * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+       * * `Asia/Kuching` - Asia/Kuching
+       * * `Asia/Kuwait` - Asia/Kuwait
+       * * `Asia/Macao` - Asia/Macao
+       * * `Asia/Macau` - Asia/Macau
+       * * `Asia/Magadan` - Asia/Magadan
+       * * `Asia/Makassar` - Asia/Makassar
+       * * `Asia/Manila` - Asia/Manila
+       * * `Asia/Muscat` - Asia/Muscat
+       * * `Asia/Nicosia` - Asia/Nicosia
+       * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+       * * `Asia/Novosibirsk` - Asia/Novosibirsk
+       * * `Asia/Omsk` - Asia/Omsk
+       * * `Asia/Oral` - Asia/Oral
+       * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+       * * `Asia/Pontianak` - Asia/Pontianak
+       * * `Asia/Pyongyang` - Asia/Pyongyang
+       * * `Asia/Qatar` - Asia/Qatar
+       * * `Asia/Qostanay` - Asia/Qostanay
+       * * `Asia/Qyzylorda` - Asia/Qyzylorda
+       * * `Asia/Rangoon` - Asia/Rangoon
+       * * `Asia/Riyadh` - Asia/Riyadh
+       * * `Asia/Saigon` - Asia/Saigon
+       * * `Asia/Sakhalin` - Asia/Sakhalin
+       * * `Asia/Samarkand` - Asia/Samarkand
+       * * `Asia/Seoul` - Asia/Seoul
+       * * `Asia/Shanghai` - Asia/Shanghai
+       * * `Asia/Singapore` - Asia/Singapore
+       * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+       * * `Asia/Taipei` - Asia/Taipei
+       * * `Asia/Tashkent` - Asia/Tashkent
+       * * `Asia/Tbilisi` - Asia/Tbilisi
+       * * `Asia/Tehran` - Asia/Tehran
+       * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+       * * `Asia/Thimbu` - Asia/Thimbu
+       * * `Asia/Thimphu` - Asia/Thimphu
+       * * `Asia/Tokyo` - Asia/Tokyo
+       * * `Asia/Tomsk` - Asia/Tomsk
+       * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+       * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+       * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+       * * `Asia/Urumqi` - Asia/Urumqi
+       * * `Asia/Ust-Nera` - Asia/Ust-Nera
+       * * `Asia/Vientiane` - Asia/Vientiane
+       * * `Asia/Vladivostok` - Asia/Vladivostok
+       * * `Asia/Yakutsk` - Asia/Yakutsk
+       * * `Asia/Yangon` - Asia/Yangon
+       * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+       * * `Asia/Yerevan` - Asia/Yerevan
+       * * `Atlantic/Azores` - Atlantic/Azores
+       * * `Atlantic/Bermuda` - Atlantic/Bermuda
+       * * `Atlantic/Canary` - Atlantic/Canary
+       * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+       * * `Atlantic/Faeroe` - Atlantic/Faeroe
+       * * `Atlantic/Faroe` - Atlantic/Faroe
+       * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+       * * `Atlantic/Madeira` - Atlantic/Madeira
+       * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+       * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+       * * `Atlantic/St_Helena` - Atlantic/St_Helena
+       * * `Atlantic/Stanley` - Atlantic/Stanley
+       * * `Australia/ACT` - Australia/ACT
+       * * `Australia/Adelaide` - Australia/Adelaide
+       * * `Australia/Brisbane` - Australia/Brisbane
+       * * `Australia/Broken_Hill` - Australia/Broken_Hill
+       * * `Australia/Canberra` - Australia/Canberra
+       * * `Australia/Currie` - Australia/Currie
+       * * `Australia/Darwin` - Australia/Darwin
+       * * `Australia/Eucla` - Australia/Eucla
+       * * `Australia/Hobart` - Australia/Hobart
+       * * `Australia/LHI` - Australia/LHI
+       * * `Australia/Lindeman` - Australia/Lindeman
+       * * `Australia/Lord_Howe` - Australia/Lord_Howe
+       * * `Australia/Melbourne` - Australia/Melbourne
+       * * `Australia/NSW` - Australia/NSW
+       * * `Australia/North` - Australia/North
+       * * `Australia/Perth` - Australia/Perth
+       * * `Australia/Queensland` - Australia/Queensland
+       * * `Australia/South` - Australia/South
+       * * `Australia/Sydney` - Australia/Sydney
+       * * `Australia/Tasmania` - Australia/Tasmania
+       * * `Australia/Victoria` - Australia/Victoria
+       * * `Australia/West` - Australia/West
+       * * `Australia/Yancowinna` - Australia/Yancowinna
+       * * `Brazil/Acre` - Brazil/Acre
+       * * `Brazil/DeNoronha` - Brazil/DeNoronha
+       * * `Brazil/East` - Brazil/East
+       * * `Brazil/West` - Brazil/West
+       * * `CET` - CET
+       * * `CST6CDT` - CST6CDT
+       * * `Canada/Atlantic` - Canada/Atlantic
+       * * `Canada/Central` - Canada/Central
+       * * `Canada/Eastern` - Canada/Eastern
+       * * `Canada/Mountain` - Canada/Mountain
+       * * `Canada/Newfoundland` - Canada/Newfoundland
+       * * `Canada/Pacific` - Canada/Pacific
+       * * `Canada/Saskatchewan` - Canada/Saskatchewan
+       * * `Canada/Yukon` - Canada/Yukon
+       * * `Chile/Continental` - Chile/Continental
+       * * `Chile/EasterIsland` - Chile/EasterIsland
+       * * `Cuba` - Cuba
+       * * `EET` - EET
+       * * `EST` - EST
+       * * `EST5EDT` - EST5EDT
+       * * `Egypt` - Egypt
+       * * `Eire` - Eire
+       * * `Etc/GMT` - Etc/GMT
+       * * `Etc/GMT+0` - Etc/GMT+0
+       * * `Etc/GMT+1` - Etc/GMT+1
+       * * `Etc/GMT+10` - Etc/GMT+10
+       * * `Etc/GMT+11` - Etc/GMT+11
+       * * `Etc/GMT+12` - Etc/GMT+12
+       * * `Etc/GMT+2` - Etc/GMT+2
+       * * `Etc/GMT+3` - Etc/GMT+3
+       * * `Etc/GMT+4` - Etc/GMT+4
+       * * `Etc/GMT+5` - Etc/GMT+5
+       * * `Etc/GMT+6` - Etc/GMT+6
+       * * `Etc/GMT+7` - Etc/GMT+7
+       * * `Etc/GMT+8` - Etc/GMT+8
+       * * `Etc/GMT+9` - Etc/GMT+9
+       * * `Etc/GMT-0` - Etc/GMT-0
+       * * `Etc/GMT-1` - Etc/GMT-1
+       * * `Etc/GMT-10` - Etc/GMT-10
+       * * `Etc/GMT-11` - Etc/GMT-11
+       * * `Etc/GMT-12` - Etc/GMT-12
+       * * `Etc/GMT-13` - Etc/GMT-13
+       * * `Etc/GMT-14` - Etc/GMT-14
+       * * `Etc/GMT-2` - Etc/GMT-2
+       * * `Etc/GMT-3` - Etc/GMT-3
+       * * `Etc/GMT-4` - Etc/GMT-4
+       * * `Etc/GMT-5` - Etc/GMT-5
+       * * `Etc/GMT-6` - Etc/GMT-6
+       * * `Etc/GMT-7` - Etc/GMT-7
+       * * `Etc/GMT-8` - Etc/GMT-8
+       * * `Etc/GMT-9` - Etc/GMT-9
+       * * `Etc/GMT0` - Etc/GMT0
+       * * `Etc/Greenwich` - Etc/Greenwich
+       * * `Etc/UCT` - Etc/UCT
+       * * `Etc/UTC` - Etc/UTC
+       * * `Etc/Universal` - Etc/Universal
+       * * `Etc/Zulu` - Etc/Zulu
+       * * `Europe/Amsterdam` - Europe/Amsterdam
+       * * `Europe/Andorra` - Europe/Andorra
+       * * `Europe/Astrakhan` - Europe/Astrakhan
+       * * `Europe/Athens` - Europe/Athens
+       * * `Europe/Belfast` - Europe/Belfast
+       * * `Europe/Belgrade` - Europe/Belgrade
+       * * `Europe/Berlin` - Europe/Berlin
+       * * `Europe/Bratislava` - Europe/Bratislava
+       * * `Europe/Brussels` - Europe/Brussels
+       * * `Europe/Bucharest` - Europe/Bucharest
+       * * `Europe/Budapest` - Europe/Budapest
+       * * `Europe/Busingen` - Europe/Busingen
+       * * `Europe/Chisinau` - Europe/Chisinau
+       * * `Europe/Copenhagen` - Europe/Copenhagen
+       * * `Europe/Dublin` - Europe/Dublin
+       * * `Europe/Gibraltar` - Europe/Gibraltar
+       * * `Europe/Guernsey` - Europe/Guernsey
+       * * `Europe/Helsinki` - Europe/Helsinki
+       * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+       * * `Europe/Istanbul` - Europe/Istanbul
+       * * `Europe/Jersey` - Europe/Jersey
+       * * `Europe/Kaliningrad` - Europe/Kaliningrad
+       * * `Europe/Kiev` - Europe/Kiev
+       * * `Europe/Kirov` - Europe/Kirov
+       * * `Europe/Kyiv` - Europe/Kyiv
+       * * `Europe/Lisbon` - Europe/Lisbon
+       * * `Europe/Ljubljana` - Europe/Ljubljana
+       * * `Europe/London` - Europe/London
+       * * `Europe/Luxembourg` - Europe/Luxembourg
+       * * `Europe/Madrid` - Europe/Madrid
+       * * `Europe/Malta` - Europe/Malta
+       * * `Europe/Mariehamn` - Europe/Mariehamn
+       * * `Europe/Minsk` - Europe/Minsk
+       * * `Europe/Monaco` - Europe/Monaco
+       * * `Europe/Moscow` - Europe/Moscow
+       * * `Europe/Nicosia` - Europe/Nicosia
+       * * `Europe/Oslo` - Europe/Oslo
+       * * `Europe/Paris` - Europe/Paris
+       * * `Europe/Podgorica` - Europe/Podgorica
+       * * `Europe/Prague` - Europe/Prague
+       * * `Europe/Riga` - Europe/Riga
+       * * `Europe/Rome` - Europe/Rome
+       * * `Europe/Samara` - Europe/Samara
+       * * `Europe/San_Marino` - Europe/San_Marino
+       * * `Europe/Sarajevo` - Europe/Sarajevo
+       * * `Europe/Saratov` - Europe/Saratov
+       * * `Europe/Simferopol` - Europe/Simferopol
+       * * `Europe/Skopje` - Europe/Skopje
+       * * `Europe/Sofia` - Europe/Sofia
+       * * `Europe/Stockholm` - Europe/Stockholm
+       * * `Europe/Tallinn` - Europe/Tallinn
+       * * `Europe/Tirane` - Europe/Tirane
+       * * `Europe/Tiraspol` - Europe/Tiraspol
+       * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+       * * `Europe/Uzhgorod` - Europe/Uzhgorod
+       * * `Europe/Vaduz` - Europe/Vaduz
+       * * `Europe/Vatican` - Europe/Vatican
+       * * `Europe/Vienna` - Europe/Vienna
+       * * `Europe/Vilnius` - Europe/Vilnius
+       * * `Europe/Volgograd` - Europe/Volgograd
+       * * `Europe/Warsaw` - Europe/Warsaw
+       * * `Europe/Zagreb` - Europe/Zagreb
+       * * `Europe/Zaporozhye` - Europe/Zaporozhye
+       * * `Europe/Zurich` - Europe/Zurich
+       * * `GB` - GB
+       * * `GB-Eire` - GB-Eire
+       * * `GMT` - GMT
+       * * `GMT+0` - GMT+0
+       * * `GMT-0` - GMT-0
+       * * `GMT0` - GMT0
+       * * `Greenwich` - Greenwich
+       * * `HST` - HST
+       * * `Hongkong` - Hongkong
+       * * `Iceland` - Iceland
+       * * `Indian/Antananarivo` - Indian/Antananarivo
+       * * `Indian/Chagos` - Indian/Chagos
+       * * `Indian/Christmas` - Indian/Christmas
+       * * `Indian/Cocos` - Indian/Cocos
+       * * `Indian/Comoro` - Indian/Comoro
+       * * `Indian/Kerguelen` - Indian/Kerguelen
+       * * `Indian/Mahe` - Indian/Mahe
+       * * `Indian/Maldives` - Indian/Maldives
+       * * `Indian/Mauritius` - Indian/Mauritius
+       * * `Indian/Mayotte` - Indian/Mayotte
+       * * `Indian/Reunion` - Indian/Reunion
+       * * `Iran` - Iran
+       * * `Israel` - Israel
+       * * `Jamaica` - Jamaica
+       * * `Japan` - Japan
+       * * `Kwajalein` - Kwajalein
+       * * `Libya` - Libya
+       * * `MET` - MET
+       * * `MST` - MST
+       * * `MST7MDT` - MST7MDT
+       * * `Mexico/BajaNorte` - Mexico/BajaNorte
+       * * `Mexico/BajaSur` - Mexico/BajaSur
+       * * `Mexico/General` - Mexico/General
+       * * `NZ` - NZ
+       * * `NZ-CHAT` - NZ-CHAT
+       * * `Navajo` - Navajo
+       * * `PRC` - PRC
+       * * `PST8PDT` - PST8PDT
+       * * `Pacific/Apia` - Pacific/Apia
+       * * `Pacific/Auckland` - Pacific/Auckland
+       * * `Pacific/Bougainville` - Pacific/Bougainville
+       * * `Pacific/Chatham` - Pacific/Chatham
+       * * `Pacific/Chuuk` - Pacific/Chuuk
+       * * `Pacific/Easter` - Pacific/Easter
+       * * `Pacific/Efate` - Pacific/Efate
+       * * `Pacific/Enderbury` - Pacific/Enderbury
+       * * `Pacific/Fakaofo` - Pacific/Fakaofo
+       * * `Pacific/Fiji` - Pacific/Fiji
+       * * `Pacific/Funafuti` - Pacific/Funafuti
+       * * `Pacific/Galapagos` - Pacific/Galapagos
+       * * `Pacific/Gambier` - Pacific/Gambier
+       * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+       * * `Pacific/Guam` - Pacific/Guam
+       * * `Pacific/Honolulu` - Pacific/Honolulu
+       * * `Pacific/Johnston` - Pacific/Johnston
+       * * `Pacific/Kanton` - Pacific/Kanton
+       * * `Pacific/Kiritimati` - Pacific/Kiritimati
+       * * `Pacific/Kosrae` - Pacific/Kosrae
+       * * `Pacific/Kwajalein` - Pacific/Kwajalein
+       * * `Pacific/Majuro` - Pacific/Majuro
+       * * `Pacific/Marquesas` - Pacific/Marquesas
+       * * `Pacific/Midway` - Pacific/Midway
+       * * `Pacific/Nauru` - Pacific/Nauru
+       * * `Pacific/Niue` - Pacific/Niue
+       * * `Pacific/Norfolk` - Pacific/Norfolk
+       * * `Pacific/Noumea` - Pacific/Noumea
+       * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+       * * `Pacific/Palau` - Pacific/Palau
+       * * `Pacific/Pitcairn` - Pacific/Pitcairn
+       * * `Pacific/Pohnpei` - Pacific/Pohnpei
+       * * `Pacific/Ponape` - Pacific/Ponape
+       * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+       * * `Pacific/Rarotonga` - Pacific/Rarotonga
+       * * `Pacific/Saipan` - Pacific/Saipan
+       * * `Pacific/Samoa` - Pacific/Samoa
+       * * `Pacific/Tahiti` - Pacific/Tahiti
+       * * `Pacific/Tarawa` - Pacific/Tarawa
+       * * `Pacific/Tongatapu` - Pacific/Tongatapu
+       * * `Pacific/Truk` - Pacific/Truk
+       * * `Pacific/Wake` - Pacific/Wake
+       * * `Pacific/Wallis` - Pacific/Wallis
+       * * `Pacific/Yap` - Pacific/Yap
+       * * `Poland` - Poland
+       * * `Portugal` - Portugal
+       * * `ROC` - ROC
+       * * `ROK` - ROK
+       * * `Singapore` - Singapore
+       * * `Turkey` - Turkey
+       * * `UCT` - UCT
+       * * `US/Alaska` - US/Alaska
+       * * `US/Aleutian` - US/Aleutian
+       * * `US/Arizona` - US/Arizona
+       * * `US/Central` - US/Central
+       * * `US/East-Indiana` - US/East-Indiana
+       * * `US/Eastern` - US/Eastern
+       * * `US/Hawaii` - US/Hawaii
+       * * `US/Indiana-Starke` - US/Indiana-Starke
+       * * `US/Michigan` - US/Michigan
+       * * `US/Mountain` - US/Mountain
+       * * `US/Pacific` - US/Pacific
+       * * `US/Samoa` - US/Samoa
+       * * `UTC` - UTC
+       * * `Universal` - Universal
+       * * `W-SU` - W-SU
+       * * `WET` - WET
+       * * `Zulu` - Zulu */
       timezone?: string | null;
       /**
          * Day-of-week offset for weekly intervals (0=Sunday, 6=Saturday). Only valid when interval is 'week'.
@@ -9662,14 +9662,14 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-    * `Completed` - Completed
-    * `ContinuedAsNew` - Continued As New
-    * `Failed` - Failed
-    * `FailedRetryable` - Failed Retryable
-    * `Terminated` - Terminated
-    * `TimedOut` - Timedout
-    * `Running` - Running
-    * `Starting` - Starting
+     * * `Completed` - Completed
+     * * `ContinuedAsNew` - Continued As New
+     * * `Failed` - Failed
+     * * `FailedRetryable` - Failed Retryable
+     * * `Terminated` - Terminated
+     * * `TimedOut` - Timedout
+     * * `Running` - Running
+     * * `Starting` - Starting
      */
     export type BatchExportBackfillStatusEnum = typeof BatchExportBackfillStatusEnum[keyof typeof BatchExportBackfillStatusEnum];
 
@@ -9701,16 +9701,16 @@ export namespace Schemas {
          */
       end_at?: string | null;
       /** The status of this backfill.
-
-      * `Cancelled` - Cancelled
-      * `Completed` - Completed
-      * `ContinuedAsNew` - Continued As New
-      * `Failed` - Failed
-      * `FailedRetryable` - Failed Retryable
-      * `Terminated` - Terminated
-      * `TimedOut` - Timedout
-      * `Running` - Running
-      * `Starting` - Starting */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Completed` - Completed
+       * * `ContinuedAsNew` - Continued As New
+       * * `Failed` - Failed
+       * * `FailedRetryable` - Failed Retryable
+       * * `Terminated` - Terminated
+       * * `TimedOut` - Timedout
+       * * `Running` - Running
+       * * `Starting` - Starting */
       status: BatchExportBackfillStatusEnum;
       /** The timestamp at which this BatchExportBackfill was created. */
       readonly created_at: string;
@@ -9777,29 +9777,29 @@ export namespace Schemas {
 
     /**
      * Request body for create/partial_update on BatchExportViewSet.
-
-    Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
-    `destination` schema so integration_id is marked required on the types that need
-    it. Responses continue to use `BatchExportSerializer`.
+     *
+     * Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
+     * `destination` schema so integration_id is marked required on the types that need
+     * it. Responses continue to use `BatchExportSerializer`.
      */
     export interface BatchExportRequest {
       /** Human-readable name for the batch export. */
       name: string;
       /** Which data model to export (events, persons, sessions).
-
-      * `events` - Events
-      * `persons` - Persons
-      * `sessions` - Sessions */
+       *
+       * * `events` - Events
+       * * `persons` - Persons
+       * * `sessions` - Sessions */
       model?: ModelEnum;
       /** Destination configuration. Required integration_id is enforced per destination type. */
       destination: BatchExportDestinationRequest;
       /** How often the batch export should run.
-
-      * `hour` - hour
-      * `day` - day
-      * `week` - week
-      * `every 5 minutes` - every 5 minutes
-      * `every 15 minutes` - every 15 minutes */
+       *
+       * * `hour` - hour
+       * * `day` - day
+       * * `week` - week
+       * * `every 5 minutes` - every 5 minutes
+       * * `every 15 minutes` - every 15 minutes */
       interval: IntervalEnum;
       /** Whether the batch export is paused. */
       paused?: boolean;
@@ -9834,9 +9834,9 @@ export namespace Schemas {
 
     /**
      * * `completed` - Completed
-    * `failed` - Failed
-    * `paused` - Paused
-    * `running` - Running
+     * * `failed` - Failed
+     * * `paused` - Paused
+     * * `running` - Running
      */
     export type BatchImportStatusEnum = typeof BatchImportStatusEnum[keyof typeof BatchImportStatusEnum];
 
@@ -10005,7 +10005,7 @@ export namespace Schemas {
 
     /**
      * * `distinct_id` - User ID (default)
-    * `device_id` - Device ID
+     * * `device_id` - Device ID
      */
     export type BucketingIdentifierEnum = typeof BucketingIdentifierEnum[keyof typeof BucketingIdentifierEnum];
 
@@ -10017,8 +10017,8 @@ export namespace Schemas {
 
     /**
      * * `fully_rolled_out` - fully_rolled_out
-    * `not_rolled_out` - not_rolled_out
-    * `partial` - partial
+     * * `not_rolled_out` - not_rolled_out
+     * * `partial` - partial
      */
     export type RolloutStateEnum = typeof RolloutStateEnum[keyof typeof RolloutStateEnum];
 
@@ -10035,10 +10035,10 @@ export namespace Schemas {
       /** The flag key at the time of deletion. */
       key: string;
       /** Rollout state captured before deletion.
-
-      * `fully_rolled_out` - fully_rolled_out
-      * `not_rolled_out` - not_rolled_out
-      * `partial` - partial */
+       *
+       * * `fully_rolled_out` - fully_rolled_out
+       * * `not_rolled_out` - not_rolled_out
+       * * `partial` - partial */
       rollout_state: RolloutStateEnum;
       /**
          * Variant key when a multivariate flag was fully rolled out to a single variant; otherwise null.
@@ -10058,9 +10058,9 @@ export namespace Schemas {
 
     /**
      * * `boolean` - boolean
-    * `multivariant` - multivariant
-    * `experiment` - experiment
-    * `remote_config` - remote_config
+     * * `multivariant` - multivariant
+     * * `experiment` - experiment
+     * * `remote_config` - remote_config
      */
     export type BulkDeleteFiltersTypeEnum = typeof BulkDeleteFiltersTypeEnum[keyof typeof BulkDeleteFiltersTypeEnum];
 
@@ -10074,8 +10074,8 @@ export namespace Schemas {
 
     /**
      * * `server` - Server
-    * `client` - Client
-    * `all` - All
+     * * `client` - Client
+     * * `all` - All
      */
     export type EvaluationRuntimeEnum = typeof EvaluationRuntimeEnum[keyof typeof EvaluationRuntimeEnum];
 
@@ -10091,27 +10091,27 @@ export namespace Schemas {
      */
     export interface BulkDeleteFilters {
       /** Filter by active state.
-
-      * `true` - true
-      * `false` - false
-      * `STALE` - STALE */
+       *
+       * * `true` - true
+       * * `false` - false
+       * * `STALE` - STALE */
       active?: ActiveEnum;
       /** Filter to flags created by a specific user ID. */
       created_by_id?: number;
       /** Search by feature flag key or name (case-insensitive). */
       search?: string;
       /** Filter by flag type.
-
-      * `boolean` - boolean
-      * `multivariant` - multivariant
-      * `experiment` - experiment
-      * `remote_config` - remote_config */
+       *
+       * * `boolean` - boolean
+       * * `multivariant` - multivariant
+       * * `experiment` - experiment
+       * * `remote_config` - remote_config */
       type?: BulkDeleteFiltersTypeEnum;
       /** Filter by evaluation runtime.
-
-      * `server` - Server
-      * `client` - Client
-      * `all` - All */
+       *
+       * * `server` - Server
+       * * `client` - Client
+       * * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum;
       /** JSON-encoded property filter to exclude. Same shape as the list endpoint. */
       excluded_properties?: string;
@@ -10124,17 +10124,20 @@ export namespace Schemas {
     export interface BulkDeleteRequest {
       /** Filter criteria — same shape as the list endpoint's query params. Mutually exclusive with `ids`. Use this to bulk-delete by search/active/tags/etc. instead of supplying explicit IDs. */
       filters?: BulkDeleteFilters;
-      /** Explicit feature flag IDs to soft-delete. Mutually exclusive with `filters`. */
+      /**
+         * Explicit feature flag IDs to soft-delete. Mutually exclusive with `filters`.
+         * @items.minimum 1
+         */
       ids?: number[];
     }
 
     /**
      * Schema-only — referenced from ``@extend_schema(responses=...)`` to describe the wire format.
-    Never instantiate this for validation or call ``.is_valid()`` / ``.errors`` on it: the
-    declared ``errors`` field shadows DRF's inherited ``Serializer.errors`` ReturnDict property,
-    so accessing ``serializer.errors`` would return this field descriptor instead of validation
-    errors. The handler builds the response dict directly; this class exists only so drf-spectacular
-    can render the response in the OpenAPI spec and downstream generated clients.
+     * Never instantiate this for validation or call ``.is_valid()`` / ``.errors`` on it: the
+     * declared ``errors`` field shadows DRF's inherited ``Serializer.errors`` ReturnDict property,
+     * so accessing ``serializer.errors`` would return this field descriptor instead of validation
+     * errors. The handler builds the response dict directly; this class exists only so drf-spectacular
+     * can render the response in the OpenAPI spec and downstream generated clients.
      */
     export interface BulkDeleteResponse {
       /** Flags successfully soft-deleted. */
@@ -10197,10 +10200,10 @@ export namespace Schemas {
 
     /**
      * * `new` - New
-    * `open` - Open
-    * `pending` - Pending
-    * `on_hold` - On hold
-    * `resolved` - Resolved
+     * * `open` - Open
+     * * `pending` - Pending
+     * * `on_hold` - On hold
+     * * `resolved` - Resolved
      */
     export type TicketStatusEnum = typeof TicketStatusEnum[keyof typeof TicketStatusEnum];
 
@@ -10220,12 +10223,12 @@ export namespace Schemas {
          */
       ids: string[];
       /** New status to apply to all selected tickets: new, open, pending, on_hold, or resolved.
-
-      * `new` - New
-      * `open` - Open
-      * `pending` - Pending
-      * `on_hold` - On hold
-      * `resolved` - Resolved */
+       *
+       * * `new` - New
+       * * `open` - Open
+       * * `pending` - Pending
+       * * `on_hold` - On hold
+       * * `resolved` - Resolved */
       status: TicketStatusEnum;
     }
 
@@ -10253,10 +10256,10 @@ export namespace Schemas {
          */
       ids: number[];
       /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
-
-      * `add` - add
-      * `remove` - remove
-      * `set` - set */
+       *
+       * * `add` - add
+       * * `remove` - remove
+       * * `set` - set */
       action: ActionEnum;
       /** Tag names to add, remove, or set. */
       tags: string[];
@@ -10269,8 +10272,8 @@ export namespace Schemas {
 
     /**
      * * `b2b` - B2B
-    * `b2c` - B2C
-    * `other` - Other
+     * * `b2c` - B2C
+     * * `other` - Other
      */
     export type BusinessModelEnum = typeof BusinessModelEnum[keyof typeof BusinessModelEnum];
 
@@ -10306,9 +10309,9 @@ export namespace Schemas {
 
     /**
      * Create-response variant that includes the plaintext token.
-
-    Only emitted from the create endpoint - storage-side we only persist the
-    hash, so subsequent reads use the base serializer.
+     *
+     * Only emitted from the create endpoint - storage-side we only persist the
+     * hash, so subsequent reads use the base serializer.
      */
     export interface CIMDVerificationTokenWithValue {
       readonly id: string;
@@ -10413,7 +10416,7 @@ export namespace Schemas {
 
     /**
      * * `error` - error
-    * `warning` - warning
+     * * `warning` - warning
      */
     export type UtmIssueSeverityEnum = typeof UtmIssueSeverityEnum[keyof typeof UtmIssueSeverityEnum];
 
@@ -10427,9 +10430,9 @@ export namespace Schemas {
       /** The UTM field with the issue (e.g. utm_campaign, utm_source) */
       field: string;
       /** Issue severity level
-
-      * `error` - error
-      * `warning` - warning */
+       *
+       * * `error` - error
+       * * `warning` - warning */
       severity: UtmIssueSeverityEnum;
       /** Human-readable description of the issue */
       message: string;
@@ -10484,7 +10487,11 @@ export namespace Schemas {
       pct_with_utm_source: number;
       /** Percentage of events that carry a utm_campaign */
       pct_with_utm_campaign: number;
-      /** List of [utm_source, count] pairs */
+      /**
+         * List of [utm_source, count] pairs
+         * @items.minItems 2
+         * @items.maxItems 2
+         */
       top_utm_sources: [string, number][];
       /** Whether this event is already configured as a goal */
       is_already_a_goal: boolean;
@@ -10501,11 +10508,11 @@ export namespace Schemas {
 
     /**
      * * `needs_setup` - needs_setup
-    * `detected` - detected
-    * `waiting_for_data` - waiting_for_data
-    * `ready` - ready
-    * `not_applicable` - not_applicable
-    * `unknown` - unknown
+     * * `detected` - detected
+     * * `waiting_for_data` - waiting_for_data
+     * * `ready` - ready
+     * * `not_applicable` - not_applicable
+     * * `unknown` - unknown
      */
     export type CapabilityStateStateEnum = typeof CapabilityStateStateEnum[keyof typeof CapabilityStateStateEnum];
 
@@ -10521,13 +10528,13 @@ export namespace Schemas {
 
     export interface CapabilityState {
       /** Current state of the capability
-
-      * `needs_setup` - needs_setup
-      * `detected` - detected
-      * `waiting_for_data` - waiting_for_data
-      * `ready` - ready
-      * `not_applicable` - not_applicable
-      * `unknown` - unknown */
+       *
+       * * `needs_setup` - needs_setup
+       * * `detected` - detected
+       * * `waiting_for_data` - waiting_for_data
+       * * `ready` - ready
+       * * `not_applicable` - not_applicable
+       * * `unknown` - unknown */
       state: CapabilityStateStateEnum;
       /** Whether the state is estimated from static analysis */
       estimated: boolean;
@@ -10574,7 +10581,7 @@ export namespace Schemas {
 
     /**
      * * `single` - single
-    * `multiple` - multiple
+     * * `multiple` - multiple
      */
     export type SelectionModeEnum = typeof SelectionModeEnum[keyof typeof SelectionModeEnum];
 
@@ -10588,9 +10595,9 @@ export namespace Schemas {
       /** Ordered categorical options available to the scorer. */
       options: CategoricalScoreOption[];
       /** Whether reviewers can select one option or multiple options. Defaults to `single`.
-
-      * `single` - single
-      * `multiple` - multiple */
+       *
+       * * `single` - single
+       * * `multiple` - multiple */
       selection_mode?: SelectionModeEnum;
       /**
          * Optional minimum number of options that can be selected when `selection_mode` is `multiple`.
@@ -10608,7 +10615,7 @@ export namespace Schemas {
 
     /**
      * * `marketing` - Marketing
-    * `transactional` - Transactional
+     * * `transactional` - Transactional
      */
     export type CategoryTypeEnum = typeof CategoryTypeEnum[keyof typeof CategoryTypeEnum];
 
@@ -10620,8 +10627,8 @@ export namespace Schemas {
 
     /**
      * * `consolidated` - consolidated
-    * `cdc_only` - cdc_only
-    * `both` - both
+     * * `cdc_only` - cdc_only
+     * * `both` - both
      */
     export type CdcTableModeEnum = typeof CdcTableModeEnum[keyof typeof CdcTableModeEnum];
 
@@ -10636,9 +10643,9 @@ export namespace Schemas {
 
     /**
      * * `valid` - Valid
-    * `invalid` - Invalid
-    * `expired` - Expired
-    * `stale` - Stale (resource changed)
+     * * `invalid` - Invalid
+     * * `expired` - Expired
+     * * `stale` - Stale (resource changed)
      */
     export type ValidationStatusEnum = typeof ValidationStatusEnum[keyof typeof ValidationStatusEnum];
 
@@ -10652,11 +10659,11 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-    * `approved` - Approved (awaiting application)
-    * `applied` - Applied
-    * `rejected` - Rejected
-    * `expired` - Expired
-    * `failed` - Failed to apply
+     * * `approved` - Approved (awaiting application)
+     * * `applied` - Applied
+     * * `rejected` - Rejected
+     * * `expired` - Expired
+     * * `failed` - Failed to apply
      */
     export type ChangeRequestStateEnum = typeof ChangeRequestStateEnum[keyof typeof ChangeRequestStateEnum];
 
@@ -10710,13 +10717,13 @@ export namespace Schemas {
 
     /**
      * * `slack_channel_message` - Channel message
-    * `slack_bot_mention` - Bot mention
-    * `slack_emoji_reaction` - Emoji reaction
-    * `teams_channel_message` - Teams channel message
-    * `teams_bot_mention` - Teams bot mention
-    * `widget_embedded` - Widget
-    * `widget_api` - API
-    * `github_issue` - GitHub issue
+     * * `slack_bot_mention` - Bot mention
+     * * `slack_emoji_reaction` - Emoji reaction
+     * * `teams_channel_message` - Teams channel message
+     * * `teams_bot_mention` - Teams bot mention
+     * * `widget_embedded` - Widget
+     * * `widget_api` - API
+     * * `github_issue` - GitHub issue
      */
     export type ChannelDetailEnum = typeof ChannelDetailEnum[keyof typeof ChannelDetailEnum];
 
@@ -10734,10 +10741,10 @@ export namespace Schemas {
 
     /**
      * * `widget` - Widget
-    * `email` - Email
-    * `slack` - Slack
-    * `teams` - Microsoft Teams
-    * `github` - GitHub
+     * * `email` - Email
+     * * `slack` - Slack
+     * * `teams` - Microsoft Teams
+     * * `github` - GitHub
      */
     export type ChannelSourceEnum = typeof ChannelSourceEnum[keyof typeof ChannelSourceEnum];
 
@@ -10757,7 +10764,7 @@ export namespace Schemas {
 
     /**
      * * `abandoned` - Abandoned
-    * `off-topic` - Off-topic
+     * * `off-topic` - Off-topic
      */
     export type ClassificationsEnum = typeof ClassificationsEnum[keyof typeof ClassificationsEnum];
 
@@ -10795,7 +10802,7 @@ export namespace Schemas {
 
     /**
      * * `interactive` - interactive
-    * `background` - background
+     * * `background` - background
      */
     export type TaskExecutionModeEnum = typeof TaskExecutionModeEnum[keyof typeof TaskExecutionModeEnum];
 
@@ -10807,7 +10814,7 @@ export namespace Schemas {
 
     /**
      * * `user` - user
-    * `bot` - bot
+     * * `bot` - bot
      */
     export type PrAuthorshipModeEnum = typeof PrAuthorshipModeEnum[keyof typeof PrAuthorshipModeEnum];
 
@@ -10819,7 +10826,7 @@ export namespace Schemas {
 
     /**
      * * `manual` - manual
-    * `signal_report` - signal_report
+     * * `signal_report` - signal_report
      */
     export type RunSourceEnum = typeof RunSourceEnum[keyof typeof RunSourceEnum];
 
@@ -10831,10 +10838,10 @@ export namespace Schemas {
 
     /**
      * * `low` - low
-    * `medium` - medium
-    * `high` - high
-    * `xhigh` - xhigh
-    * `max` - max
+     * * `medium` - medium
+     * * `high` - high
+     * * `xhigh` - xhigh
+     * * `max` - max
      */
     export type ReasoningEffortEnum = typeof ReasoningEffortEnum[keyof typeof ReasoningEffortEnum];
 
@@ -10849,10 +10856,10 @@ export namespace Schemas {
 
     /**
      * * `default` - default
-    * `acceptEdits` - acceptEdits
-    * `plan` - plan
-    * `bypassPermissions` - bypassPermissions
-    * `auto` - auto
+     * * `acceptEdits` - acceptEdits
+     * * `plan` - plan
+     * * `bypassPermissions` - bypassPermissions
+     * * `auto` - auto
      */
     export type ClaudeTaskRunCreateSchemaInitialPermissionModeEnum = typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnum[keyof typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnum];
 
@@ -10870,9 +10877,9 @@ export namespace Schemas {
      */
     export interface ClaudeTaskRunCreateSchema {
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-      * `interactive` - interactive
-      * `background` - background */
+       *
+       * * `interactive` - interactive
+       * * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -10884,45 +10891,48 @@ export namespace Schemas {
       resume_from_run_id?: string;
       /** Initial or follow-up user message to include in the run prompt. */
       pending_user_message?: string;
-      /** Identifiers for staged task artifacts that should be attached to the initial run prompt. */
+      /**
+         * Identifiers for staged task artifacts that should be attached to the initial run prompt.
+         * @items.maxLength 128
+         */
       pending_user_artifact_ids?: string[];
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-
-      * `user` - user
-      * `bot` - bot */
+       *
+       * * `user` - user
+       * * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-      * `manual` - manual
-      * `signal_report` - signal_report */
+       *
+       * * `manual` - manual
+       * * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
       /** Agent runtime adapter to launch for this run. Must be 'claude' for Claude runtimes.
-
-      * `claude` - claude */
+       *
+       * * `claude` - claude */
       runtime_adapter: ClaudeRuntimeAdapterEnum;
       /** LLM model identifier to run in the Claude runtime. */
       model: string;
       /** Reasoning effort to request for models that expose an effort control.
-
-      * `low` - low
-      * `medium` - medium
-      * `high` - high
-      * `xhigh` - xhigh
-      * `max` - max */
+       *
+       * * `low` - low
+       * * `medium` - medium
+       * * `high` - high
+       * * `xhigh` - xhigh
+       * * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
       github_user_token?: string;
       /** Initial permission mode for Claude runtimes.
-
-      * `default` - default
-      * `acceptEdits` - acceptEdits
-      * `plan` - plan
-      * `bypassPermissions` - bypassPermissions
-      * `auto` - auto */
+       *
+       * * `default` - default
+       * * `acceptEdits` - acceptEdits
+       * * `plan` - plan
+       * * `bypassPermissions` - bypassPermissions
+       * * `auto` - auto */
       initial_permission_mode?: ClaudeTaskRunCreateSchemaInitialPermissionModeEnum;
     }
 
@@ -10945,7 +10955,10 @@ export namespace Schemas {
          * @nullable
          */
       tag_name?: string | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 200
+         */
       attr_class?: string[] | null;
       /**
          * @maxLength 10000
@@ -11008,8 +11021,8 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-    * `generation` - generation
-    * `evaluation` - evaluation
+     * * `generation` - generation
+     * * `evaluation` - evaluation
      */
     export type ClusteringJobAnalysisLevelEnum = typeof ClusteringJobAnalysisLevelEnum[keyof typeof ClusteringJobAnalysisLevelEnum];
 
@@ -11033,7 +11046,7 @@ export namespace Schemas {
 
     /**
      * * `hdbscan` - hdbscan
-    * `kmeans` - kmeans
+     * * `kmeans` - kmeans
      */
     export type ClusteringMethodEnum = typeof ClusteringMethodEnum[keyof typeof ClusteringMethodEnum];
 
@@ -11047,7 +11060,7 @@ export namespace Schemas {
 
     /**
      * * `none` - none
-    * `l2` - l2
+     * * `l2` - l2
      */
     export type EmbeddingNormalizationEnum = typeof EmbeddingNormalizationEnum[keyof typeof EmbeddingNormalizationEnum];
 
@@ -11059,8 +11072,8 @@ export namespace Schemas {
 
     /**
      * * `none` - none
-    * `umap` - umap
-    * `pca` - pca
+     * * `umap` - umap
+     * * `pca` - pca
      */
     export type DimensionalityReductionMethodEnum = typeof DimensionalityReductionMethodEnum[keyof typeof DimensionalityReductionMethodEnum];
 
@@ -11073,8 +11086,8 @@ export namespace Schemas {
 
     /**
      * * `umap` - umap
-    * `pca` - pca
-    * `tsne` - tsne
+     * * `pca` - pca
+     * * `tsne` - tsne
      */
     export type VisualizationMethodEnum = typeof VisualizationMethodEnum[keyof typeof VisualizationMethodEnum];
 
@@ -11102,15 +11115,15 @@ export namespace Schemas {
          */
       max_samples?: number;
       /** Embedding normalization method: 'none' (raw embeddings) or 'l2' (L2 normalize before clustering)
-
-      * `none` - none
-      * `l2` - l2 */
+       *
+       * * `none` - none
+       * * `l2` - l2 */
       embedding_normalization?: EmbeddingNormalizationEnum;
       /** Dimensionality reduction method: 'none' (cluster on raw), 'umap', or 'pca'
-
-      * `none` - none
-      * `umap` - umap
-      * `pca` - pca */
+       *
+       * * `none` - none
+       * * `umap` - umap
+       * * `pca` - pca */
       dimensionality_reduction_method?: DimensionalityReductionMethodEnum;
       /**
          * Target dimensions for dimensionality reduction (ignored if method is 'none')
@@ -11119,9 +11132,9 @@ export namespace Schemas {
          */
       dimensionality_reduction_ndims?: number;
       /** Clustering algorithm: 'hdbscan' (density-based, auto-determines k) or 'kmeans' (centroid-based)
-
-      * `hdbscan` - hdbscan
-      * `kmeans` - kmeans */
+       *
+       * * `hdbscan` - hdbscan
+       * * `kmeans` - kmeans */
       clustering_method?: ClusteringMethodEnum;
       /**
          * Minimum cluster size as fraction of total samples (e.g., 0.02 = 2%)
@@ -11153,10 +11166,10 @@ export namespace Schemas {
          */
       run_label?: string;
       /** Method for 2D scatter plot visualization: 'umap', 'pca', or 'tsne'
-
-      * `umap` - umap
-      * `pca` - pca
-      * `tsne` - tsne */
+       *
+       * * `umap` - umap
+       * * `pca` - pca
+       * * `tsne` - tsne */
       visualization_method?: VisualizationMethodEnum;
       /** Property filters to scope which traces are included in clustering (PostHog standard format) */
       event_filters?: ClusteringRunRequestEventFiltersItem[];
@@ -11184,8 +11197,8 @@ export namespace Schemas {
 
     /**
      * * `auto` - auto
-    * `read-only` - read-only
-    * `full-access` - full-access
+     * * `read-only` - read-only
+     * * `full-access` - full-access
      */
     export type CodexTaskRunCreateSchemaInitialPermissionModeEnum = typeof CodexTaskRunCreateSchemaInitialPermissionModeEnum[keyof typeof CodexTaskRunCreateSchemaInitialPermissionModeEnum];
 
@@ -11201,9 +11214,9 @@ export namespace Schemas {
      */
     export interface CodexTaskRunCreateSchema {
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-      * `interactive` - interactive
-      * `background` - background */
+       *
+       * * `interactive` - interactive
+       * * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -11215,43 +11228,46 @@ export namespace Schemas {
       resume_from_run_id?: string;
       /** Initial or follow-up user message to include in the run prompt. */
       pending_user_message?: string;
-      /** Identifiers for staged task artifacts that should be attached to the initial run prompt. */
+      /**
+         * Identifiers for staged task artifacts that should be attached to the initial run prompt.
+         * @items.maxLength 128
+         */
       pending_user_artifact_ids?: string[];
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-
-      * `user` - user
-      * `bot` - bot */
+       *
+       * * `user` - user
+       * * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-      * `manual` - manual
-      * `signal_report` - signal_report */
+       *
+       * * `manual` - manual
+       * * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
       /** Agent runtime adapter to launch for this run. Must be 'codex' for Codex runtimes.
-
-      * `codex` - codex */
+       *
+       * * `codex` - codex */
       runtime_adapter: CodexRuntimeAdapterEnum;
       /** LLM model identifier to run in the Codex runtime. */
       model: string;
       /** Reasoning effort to request for models that expose an effort control.
-
-      * `low` - low
-      * `medium` - medium
-      * `high` - high
-      * `xhigh` - xhigh
-      * `max` - max */
+       *
+       * * `low` - low
+       * * `medium` - medium
+       * * `high` - high
+       * * `xhigh` - xhigh
+       * * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
       github_user_token?: string;
       /** Initial permission mode for Codex runtimes.
-
-      * `auto` - auto
-      * `read-only` - read-only
-      * `full-access` - full-access */
+       *
+       * * `auto` - auto
+       * * `read-only` - read-only
+       * * `full-access` - full-access */
       initial_permission_mode?: CodexTaskRunCreateSchemaInitialPermissionModeEnum;
     }
 
@@ -11298,10 +11314,10 @@ export namespace Schemas {
 
     /**
      * * `static` - static
-    * `person_property` - person_property
-    * `behavioral` - behavioral
-    * `realtime` - realtime
-    * `analytical` - analytical
+     * * `person_property` - person_property
+     * * `behavioral` - behavioral
+     * * `realtime` - realtime
+     * * `analytical` - analytical
      */
     export type CohortTypeEnum = typeof CohortTypeEnum[keyof typeof CohortTypeEnum];
 
@@ -11346,12 +11362,12 @@ export namespace Schemas {
       readonly count: number | null;
       is_static?: boolean;
       /** Type of cohort based on filter complexity
-
-      * `static` - static
-      * `person_property` - person_property
-      * `behavioral` - behavioral
-      * `realtime` - realtime
-      * `analytical` - analytical */
+       *
+       * * `static` - static
+       * * `person_property` - person_property
+       * * `behavioral` - behavioral
+       * * `realtime` - realtime
+       * * `analytical` - analytical */
       cohort_type?: CohortTypeEnum | BlankEnum | null;
       readonly experiment_set: readonly number[];
       _create_in_folder?: string;
@@ -11400,7 +11416,7 @@ export namespace Schemas {
 
     /**
      * * `private` - Private (only visible to creator)
-    * `shared` - Shared with team
+     * * `shared` - Shared with team
      */
     export type VisibilityEnum = typeof VisibilityEnum[keyof typeof VisibilityEnum];
 
@@ -11501,10 +11517,10 @@ export namespace Schemas {
 
     /**
      * * `won` - won
-    * `lost` - lost
-    * `inconclusive` - inconclusive
-    * `stopped_early` - stopped_early
-    * `invalid` - invalid
+     * * `lost` - lost
+     * * `inconclusive` - inconclusive
+     * * `stopped_early` - stopped_early
+     * * `invalid` - invalid
      */
     export type ConclusionEnum = typeof ConclusionEnum[keyof typeof ConclusionEnum];
 
@@ -11527,7 +11543,7 @@ export namespace Schemas {
 
     /**
      * * `utf-8` - utf-8
-    * `base64` - base64
+     * * `base64` - base64
      */
     export type ContentEncodingEnum = typeof ContentEncodingEnum[keyof typeof ContentEncodingEnum];
 
@@ -11543,8 +11559,8 @@ export namespace Schemas {
 
     /**
      * * `idle` - Idle
-    * `in_progress` - In progress
-    * `canceling` - Canceling
+     * * `in_progress` - In progress
+     * * `canceling` - Canceling
      */
     export type ConversationStatus = typeof ConversationStatus[keyof typeof ConversationStatus];
 
@@ -11557,9 +11573,9 @@ export namespace Schemas {
 
     /**
      * * `assistant` - Assistant
-    * `tool_call` - Tool call
-    * `deep_research` - Deep research
-    * `slack` - Slack
+     * * `tool_call` - Tool call
+     * * `deep_research` - Deep research
+     * * `slack` - Slack
      */
     export type ConversationType = typeof ConversationType[keyof typeof ConversationType];
 
@@ -11606,9 +11622,9 @@ export namespace Schemas {
       readonly agent_mode: string | null;
       readonly is_sandbox: boolean;
       /** Return pending approval cards as structured data.
-
-      Combines metadata from conversation.approval_decisions with payload from checkpoint
-      interrupts (single source of truth for payload data). */
+       *
+       * Combines metadata from conversation.approval_decisions with payload from checkpoint
+       * interrupts (single source of truth for payload data). */
       readonly pending_approvals: readonly ConversationPendingApprovalsItem[];
     }
 
@@ -11708,8 +11724,8 @@ export namespace Schemas {
 
     /**
      * * `0` - Disabled
-    * `1` - Stateless
-    * `2` - Stateful
+     * * `1` - Stateless
+     * * `2` - Stateful
      */
     export type CookielessServerHashModeEnum = typeof CookielessServerHashModeEnum[keyof typeof CookielessServerHashModeEnum];
 
@@ -11786,13 +11802,13 @@ export namespace Schemas {
 
     /**
      * * `acquisition` - Acquisition
-    * `activation` - Activation
-    * `monetization` - Monetization
-    * `expansion` - Expansion
-    * `referral` - Referral
-    * `retention` - Retention
-    * `churn` - Churn
-    * `reactivation` - Reactivation
+     * * `activation` - Activation
+     * * `monetization` - Monetization
+     * * `expansion` - Expansion
+     * * `referral` - Referral
+     * * `retention` - Retention
+     * * `churn` - Churn
+     * * `reactivation` - Reactivation
      */
     export type CoreEventCategoryEnum = typeof CoreEventCategoryEnum[keyof typeof CoreEventCategoryEnum];
 
@@ -11818,15 +11834,15 @@ export namespace Schemas {
       /** Optional description */
       description?: string;
       /** Lifecycle category for this core event
-
-      * `acquisition` - Acquisition
-      * `activation` - Activation
-      * `monetization` - Monetization
-      * `expansion` - Expansion
-      * `referral` - Referral
-      * `retention` - Retention
-      * `churn` - Churn
-      * `reactivation` - Reactivation */
+       *
+       * * `acquisition` - Acquisition
+       * * `activation` - Activation
+       * * `monetization` - Monetization
+       * * `expansion` - Expansion
+       * * `referral` - Referral
+       * * `retention` - Retention
+       * * `churn` - Churn
+       * * `reactivation` - Reactivation */
       category: CoreEventCategoryEnum;
       /** Filter configuration - event, action, or data warehouse node */
       filter: unknown;
@@ -11845,9 +11861,9 @@ export namespace Schemas {
 
     /**
      * * `single` - Single page
-    * `sitemap` - Sitemap
-    * `same_origin` - Same origin crawl
-    * `github_repo` - GitHub repository
+     * * `sitemap` - Sitemap
+     * * `same_origin` - Same origin crawl
+     * * `github_repo` - GitHub repository
      */
     export type CrawlModeEnum = typeof CrawlModeEnum[keyof typeof CrawlModeEnum];
 
@@ -11864,17 +11880,17 @@ export namespace Schemas {
      */
     export interface FileDownloadDestinationFileConfig {
       /** File format
-
-      * `Parquet` - Parquet
-      * `JSONLines` - JSONLines */
+       *
+       * * `Parquet` - Parquet
+       * * `JSONLines` - JSONLines */
       format?: FileFormatEnum;
       /** Compress the file with a supported compression format
-
-      * `zstd` - zstd
-      * `gzip` - gzip
-      * `brotli` - brotli
-      * `lz4` - lz4
-      * `snappy` - snappy */
+       *
+       * * `zstd` - zstd
+       * * `gzip` - gzip
+       * * `brotli` - brotli
+       * * `lz4` - lz4
+       * * `snappy` - snappy */
       compression?: CompressionEnum | null;
       /**
          * Split download into multiple files of at most this size in MB
@@ -11941,8 +11957,8 @@ export namespace Schemas {
 
     /**
      * * `cost` - cost
-    * `latency` - latency
-    * `eval_pass_rate` - eval_pass_rate
+     * * `latency` - latency
+     * * `eval_pass_rate` - eval_pass_rate
      */
     export type TemplatesEnum = typeof TemplatesEnum[keyof typeof TemplatesEnum];
 
@@ -11960,6 +11976,7 @@ export namespace Schemas {
          * Ordered list of prompt version numbers to assign to experiment variants. The first entry is the control variant. Must contain between 2 and 10 distinct versions.
          * @minItems 2
          * @maxItems 10
+         * @items.minimum 1
          */
       versions: number[];
       /**
@@ -11989,7 +12006,7 @@ export namespace Schemas {
 
     /**
      * * `BAA` - BAA
-    * `DPA` - DPA
+     * * `DPA` - DPA
      */
     export type CreateLegalDocumentDocumentTypeEnum = typeof CreateLegalDocumentDocumentTypeEnum[keyof typeof CreateLegalDocumentDocumentTypeEnum];
 
@@ -12001,14 +12018,14 @@ export namespace Schemas {
 
     /**
      * Input serializer for POST. Mirrors the submittable fields on the model plus
-    cross-field rules (BAA addon, DPA mode, uniqueness). The view supplies the
-    organization and submitting user.
+     * cross-field rules (BAA addon, DPA mode, uniqueness). The view supplies the
+     * organization and submitting user.
      */
     export interface CreateLegalDocument {
       /** Either 'BAA' or 'DPA'.
-
-      * `BAA` - BAA
-      * `DPA` - DPA */
+       *
+       * * `BAA` - BAA
+       * * `DPA` - DPA */
       document_type: CreateLegalDocumentDocumentTypeEnum;
       /**
          * The customer legal entity entering the agreement (PandaDoc's Client.Company).
@@ -12033,10 +12050,10 @@ export namespace Schemas {
 
     /**
      * * `zoom` - zoom
-    * `teams` - teams
-    * `meet` - meet
-    * `desktop_audio` - desktop_audio
-    * `slack` - slack
+     * * `teams` - teams
+     * * `meet` - meet
+     * * `desktop_audio` - desktop_audio
+     * * `slack` - slack
      */
     export type CreateRecordingRequestPlatformEnum = typeof CreateRecordingRequestPlatformEnum[keyof typeof CreateRecordingRequestPlatformEnum];
 
@@ -12054,21 +12071,21 @@ export namespace Schemas {
      */
     export interface CreateRecordingRequest {
       /** Meeting platform being recorded
-
-      * `zoom` - zoom
-      * `teams` - teams
-      * `meet` - meet
-      * `desktop_audio` - desktop_audio
-      * `slack` - slack */
+       *
+       * * `zoom` - zoom
+       * * `teams` - teams
+       * * `meet` - meet
+       * * `desktop_audio` - desktop_audio
+       * * `slack` - slack */
       platform?: CreateRecordingRequestPlatformEnum;
     }
 
     /**
      * * `zoom` - Zoom
-    * `teams` - Microsoft Teams
-    * `meet` - Google Meet
-    * `desktop_audio` - Desktop audio
-    * `slack` - Slack huddle
+     * * `teams` - Microsoft Teams
+     * * `meet` - Google Meet
+     * * `desktop_audio` - Desktop audio
+     * * `slack` - Slack huddle
      */
     export type MeetingPlatformEnum = typeof MeetingPlatformEnum[keyof typeof MeetingPlatformEnum];
 
@@ -12083,10 +12100,10 @@ export namespace Schemas {
 
     /**
      * * `recording` - Recording
-    * `uploading` - Uploading
-    * `processing` - Processing
-    * `ready` - Ready
-    * `error` - Error
+     * * `uploading` - Uploading
+     * * `processing` - Processing
+     * * `ready` - Ready
+     * * `error` - Error
      */
     export type DesktopRecordingStatusEnum = typeof DesktopRecordingStatusEnum[keyof typeof DesktopRecordingStatusEnum];
 
@@ -12252,8 +12269,8 @@ export namespace Schemas {
 
     /**
      * * `web` - web
-    * `api` - api
-    * `mcp` - mcp
+     * * `api` - api
+     * * `mcp` - mcp
      */
     export type CreatedViaEnum = typeof CreatedViaEnum[keyof typeof CreatedViaEnum];
 
@@ -12266,9 +12283,9 @@ export namespace Schemas {
 
     /**
      * * `default` - Default
-    * `template` - Template
-    * `duplicate` - Duplicate
-    * `unlisted` - Unlisted (product-embedded)
+     * * `template` - Template
+     * * `duplicate` - Duplicate
+     * * `unlisted` - Unlisted (product-embedded)
      */
     export type CreationModeEnum = typeof CreationModeEnum[keyof typeof CreationModeEnum];
 
@@ -12317,11 +12334,11 @@ export namespace Schemas {
 
     /**
      * * `person` - Person
-    * `group_0` - Group 0
-    * `group_1` - Group 1
-    * `group_2` - Group 2
-    * `group_3` - Group 3
-    * `group_4` - Group 4
+     * * `group_0` - Group 0
+     * * `group_1` - Group 1
+     * * `group_2` - Group 2
+     * * `group_3` - Group 3
+     * * `group_4` - Group 4
      */
     export type CustomerProfileConfigScopeEnum = typeof CustomerProfileConfigScopeEnum[keyof typeof CustomerProfileConfigScopeEnum];
 
@@ -12386,7 +12403,7 @@ export namespace Schemas {
 
     /**
      * * `21` - Everyone in the project can edit
-    * `37` - Only those invited to this dashboard can edit
+     * * `37` - Only those invited to this dashboard can edit
      */
     export type RestrictionLevelEnum = typeof RestrictionLevelEnum[keyof typeof RestrictionLevelEnum];
 
@@ -12488,9 +12505,9 @@ export namespace Schemas {
       readonly creation_mode: CreationModeEnum;
       tags?: unknown[];
       /** Controls who can edit the dashboard.
-
-      * `21` - Everyone in the project can edit
-      * `37` - Only those invited to this dashboard can edit */
+       *
+       * * `21` - Everyone in the project can edit
+       * * `37` - Only those invited to this dashboard can edit */
       readonly restriction_level: RestrictionLevelEnum;
       readonly effective_restriction_level: EffectivePrivilegeLevelEnum;
       readonly effective_privilege_level: EffectivePrivilegeLevelEnum;
@@ -12525,8 +12542,8 @@ export namespace Schemas {
 
     /**
      * * `team` - Only team
-    * `global` - Global
-    * `feature_flag` - Feature Flag
+     * * `global` - Global
+     * * `feature_flag` - Feature Flag
      */
     export type DashboardTemplateScopeEnum = typeof DashboardTemplateScopeEnum[keyof typeof DashboardTemplateScopeEnum];
 
@@ -12550,7 +12567,10 @@ export namespace Schemas {
          */
       dashboard_description?: string | null;
       dashboard_filters?: unknown;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 255
+         */
       tags?: string[] | null;
       tiles?: unknown;
       variables?: unknown;
@@ -12567,7 +12587,10 @@ export namespace Schemas {
       /** @nullable */
       readonly team_id: number | null;
       scope?: DashboardTemplateScopeEnum | BlankEnum | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 255
+         */
       availability_contexts?: string[] | null;
       /** Manually curated; used to highlight templates in the UI. */
       is_featured?: boolean;
@@ -12624,9 +12647,9 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-    * `Completed` - Completed
-    * `Failed` - Failed
-    * `Running` - Running
+     * * `Completed` - Completed
+     * * `Failed` - Failed
+     * * `Running` - Running
      */
     export type DataModelingJobStatusEnum = typeof DataModelingJobStatusEnum[keyof typeof DataModelingJobStatusEnum];
 
@@ -12771,10 +12794,10 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-    * `Modified` - Modified
-    * `Completed` - Completed
-    * `Failed` - Failed
-    * `Running` - Running
+     * * `Modified` - Modified
+     * * `Completed` - Completed
+     * * `Failed` - Failed
+     * * `Running` - Running
      */
     export type SavedQueryStatusEnum = typeof SavedQueryStatusEnum[keyof typeof SavedQueryStatusEnum];
 
@@ -12789,8 +12812,8 @@ export namespace Schemas {
 
     /**
      * * `data_warehouse` - Data Warehouse
-    * `endpoint` - Endpoint
-    * `managed_viewset` - Managed Viewset
+     * * `endpoint` - Endpoint
+     * * `managed_viewset` - Managed Viewset
      */
     export type OriginEnum = typeof OriginEnum[keyof typeof OriginEnum];
 
@@ -12803,8 +12826,8 @@ export namespace Schemas {
 
     /**
      * Shared methods for DataWarehouseSavedQuery serializers.
-
-    This mixin is intended to be used with serializers.ModelSerializer subclasses.
+     *
+     * This mixin is intended to be used with serializers.ModelSerializer subclasses.
      */
     export interface DataWarehouseSavedQuery {
       readonly id: string;
@@ -12823,12 +12846,12 @@ export namespace Schemas {
       readonly sync_frequency: string | null;
       readonly columns: readonly DataWarehouseSavedQueryColumnsItem[];
       /** The status of when this SavedQuery last ran.
-
-      * `Cancelled` - Cancelled
-      * `Modified` - Modified
-      * `Completed` - Completed
-      * `Failed` - Failed
-      * `Running` - Running */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Modified` - Modified
+       * * `Completed` - Completed
+       * * `Failed` - Failed
+       * * `Running` - Running */
       readonly status: SavedQueryStatusEnum | null;
       /** @nullable */
       readonly last_run_at: string | null;
@@ -12866,10 +12889,10 @@ export namespace Schemas {
       /** @nullable */
       readonly is_materialized: boolean | null;
       /** Where this SavedQuery is created.
-
-      * `data_warehouse` - Data Warehouse
-      * `endpoint` - Endpoint
-      * `managed_viewset` - Managed Viewset */
+       *
+       * * `data_warehouse` - Data Warehouse
+       * * `endpoint` - Endpoint
+       * * `managed_viewset` - Managed Viewset */
       readonly origin: OriginEnum | null;
       /** Whether this view is for testing only and will auto-expire. */
       is_test?: boolean;
@@ -12940,12 +12963,12 @@ export namespace Schemas {
       readonly sync_frequency: string | null;
       readonly columns: readonly DataWarehouseSavedQueryMinimalColumnsItem[];
       /** The status of when this SavedQuery last ran.
-
-      * `Cancelled` - Cancelled
-      * `Modified` - Modified
-      * `Completed` - Completed
-      * `Failed` - Failed
-      * `Running` - Running */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Modified` - Modified
+       * * `Completed` - Completed
+       * * `Failed` - Failed
+       * * `Running` - Running */
       readonly status: SavedQueryStatusEnum | null;
       /** @nullable */
       readonly last_run_at: string | null;
@@ -12960,10 +12983,10 @@ export namespace Schemas {
       /** @nullable */
       readonly is_materialized: boolean | null;
       /** Where this SavedQuery is created.
-
-      * `data_warehouse` - Data Warehouse
-      * `endpoint` - Endpoint
-      * `managed_viewset` - Managed Viewset */
+       *
+       * * `data_warehouse` - Data Warehouse
+       * * `endpoint` - Endpoint
+       * * `managed_viewset` - Managed Viewset */
       readonly origin: OriginEnum | null;
       /** Whether this view is for testing only and will auto-expire. */
       readonly is_test: boolean;
@@ -13237,153 +13260,153 @@ export namespace Schemas {
 
     /**
      * * `Ashby` - Ashby
-    * `Supabase` - Supabase
-    * `CustomerIO` - CustomerIO
-    * `Github` - Github
-    * `Stripe` - Stripe
-    * `Hubspot` - Hubspot
-    * `Postgres` - Postgres
-    * `Zendesk` - Zendesk
-    * `Snowflake` - Snowflake
-    * `Salesforce` - Salesforce
-    * `MySQL` - MySQL
-    * `MongoDB` - MongoDB
-    * `MSSQL` - MSSQL
-    * `Vitally` - Vitally
-    * `BigQuery` - BigQuery
-    * `Chargebee` - Chargebee
-    * `Clerk` - Clerk
-    * `GoogleAds` - GoogleAds
-    * `GoogleSearchConsole` - GoogleSearchConsole
-    * `TemporalIO` - TemporalIO
-    * `DoIt` - DoIt
-    * `GoogleSheets` - GoogleSheets
-    * `MetaAds` - MetaAds
-    * `Klaviyo` - Klaviyo
-    * `Mailchimp` - Mailchimp
-    * `Braze` - Braze
-    * `Mailjet` - Mailjet
-    * `Redshift` - Redshift
-    * `Polar` - Polar
-    * `RevenueCat` - RevenueCat
-    * `LinkedinAds` - LinkedinAds
-    * `RedditAds` - RedditAds
-    * `TikTokAds` - TikTokAds
-    * `BingAds` - BingAds
-    * `Shopify` - Shopify
-    * `Attio` - Attio
-    * `SnapchatAds` - SnapchatAds
-    * `Linear` - Linear
-    * `Intercom` - Intercom
-    * `Amplitude` - Amplitude
-    * `Mixpanel` - Mixpanel
-    * `Jira` - Jira
-    * `ActiveCampaign` - ActiveCampaign
-    * `Marketo` - Marketo
-    * `Adjust` - Adjust
-    * `AppsFlyer` - AppsFlyer
-    * `Freshdesk` - Freshdesk
-    * `GoogleAnalytics` - GoogleAnalytics
-    * `Pipedrive` - Pipedrive
-    * `SendGrid` - SendGrid
-    * `Slack` - Slack
-    * `PagerDuty` - PagerDuty
-    * `Asana` - Asana
-    * `Notion` - Notion
-    * `Airtable` - Airtable
-    * `Greenhouse` - Greenhouse
-    * `BambooHR` - BambooHR
-    * `Lever` - Lever
-    * `GitLab` - GitLab
-    * `Datadog` - Datadog
-    * `Sentry` - Sentry
-    * `Pendo` - Pendo
-    * `FullStory` - FullStory
-    * `AmazonAds` - AmazonAds
-    * `PinterestAds` - PinterestAds
-    * `AppleSearchAds` - AppleSearchAds
-    * `QuickBooks` - QuickBooks
-    * `Xero` - Xero
-    * `NetSuite` - NetSuite
-    * `WooCommerce` - WooCommerce
-    * `BigCommerce` - BigCommerce
-    * `PayPal` - PayPal
-    * `Square` - Square
-    * `Zoom` - Zoom
-    * `Trello` - Trello
-    * `Monday` - Monday
-    * `ClickUp` - ClickUp
-    * `Confluence` - Confluence
-    * `Recurly` - Recurly
-    * `SalesLoft` - SalesLoft
-    * `Outreach` - Outreach
-    * `Gong` - Gong
-    * `Calendly` - Calendly
-    * `Typeform` - Typeform
-    * `Iterable` - Iterable
-    * `ZohoCRM` - ZohoCRM
-    * `Close` - Close
-    * `Oracle` - Oracle
-    * `DynamoDB` - DynamoDB
-    * `Elasticsearch` - Elasticsearch
-    * `Kafka` - Kafka
-    * `LaunchDarkly` - LaunchDarkly
-    * `Braintree` - Braintree
-    * `Recharge` - Recharge
-    * `HelpScout` - HelpScout
-    * `Gorgias` - Gorgias
-    * `Instagram` - Instagram
-    * `YouTubeAnalytics` - YouTubeAnalytics
-    * `FacebookPages` - FacebookPages
-    * `TwitterAds` - TwitterAds
-    * `Workday` - Workday
-    * `ServiceNow` - ServiceNow
-    * `Pardot` - Pardot
-    * `Copper` - Copper
-    * `Front` - Front
-    * `ChartMogul` - ChartMogul
-    * `Zuora` - Zuora
-    * `Paddle` - Paddle
-    * `CircleCI` - CircleCI
-    * `CockroachDB` - CockroachDB
-    * `Firebase` - Firebase
-    * `AzureBlob` - AzureBlob
-    * `GoogleDrive` - GoogleDrive
-    * `OneDrive` - OneDrive
-    * `SharePoint` - SharePoint
-    * `Box` - Box
-    * `SFTP` - SFTP
-    * `MicrosoftTeams` - MicrosoftTeams
-    * `Aircall` - Aircall
-    * `Webflow` - Webflow
-    * `Okta` - Okta
-    * `Auth0` - Auth0
-    * `Productboard` - Productboard
-    * `Smartsheet` - Smartsheet
-    * `Wrike` - Wrike
-    * `Plaid` - Plaid
-    * `SurveyMonkey` - SurveyMonkey
-    * `Eventbrite` - Eventbrite
-    * `RingCentral` - RingCentral
-    * `Twilio` - Twilio
-    * `Freshsales` - Freshsales
-    * `Shortcut` - Shortcut
-    * `ConvertKit` - ConvertKit
-    * `Drip` - Drip
-    * `CampaignMonitor` - CampaignMonitor
-    * `MailerLite` - MailerLite
-    * `Omnisend` - Omnisend
-    * `Brevo` - Brevo
-    * `Postmark` - Postmark
-    * `Granola` - Granola
-    * `BuildBetter` - BuildBetter
-    * `Convex` - Convex
-    * `ClickHouse` - ClickHouse
-    * `Plain` - Plain
-    * `Resend` - Resend
-    * `PgAnalyze` - PgAnalyze
-    * `WorkOS` - WorkOS
-    * `Custom` - Custom
+     * * `Supabase` - Supabase
+     * * `CustomerIO` - CustomerIO
+     * * `Github` - Github
+     * * `Stripe` - Stripe
+     * * `Hubspot` - Hubspot
+     * * `Postgres` - Postgres
+     * * `Zendesk` - Zendesk
+     * * `Snowflake` - Snowflake
+     * * `Salesforce` - Salesforce
+     * * `MySQL` - MySQL
+     * * `MongoDB` - MongoDB
+     * * `MSSQL` - MSSQL
+     * * `Vitally` - Vitally
+     * * `BigQuery` - BigQuery
+     * * `Chargebee` - Chargebee
+     * * `Clerk` - Clerk
+     * * `GoogleAds` - GoogleAds
+     * * `GoogleSearchConsole` - GoogleSearchConsole
+     * * `TemporalIO` - TemporalIO
+     * * `DoIt` - DoIt
+     * * `GoogleSheets` - GoogleSheets
+     * * `MetaAds` - MetaAds
+     * * `Klaviyo` - Klaviyo
+     * * `Mailchimp` - Mailchimp
+     * * `Braze` - Braze
+     * * `Mailjet` - Mailjet
+     * * `Redshift` - Redshift
+     * * `Polar` - Polar
+     * * `RevenueCat` - RevenueCat
+     * * `LinkedinAds` - LinkedinAds
+     * * `RedditAds` - RedditAds
+     * * `TikTokAds` - TikTokAds
+     * * `BingAds` - BingAds
+     * * `Shopify` - Shopify
+     * * `Attio` - Attio
+     * * `SnapchatAds` - SnapchatAds
+     * * `Linear` - Linear
+     * * `Intercom` - Intercom
+     * * `Amplitude` - Amplitude
+     * * `Mixpanel` - Mixpanel
+     * * `Jira` - Jira
+     * * `ActiveCampaign` - ActiveCampaign
+     * * `Marketo` - Marketo
+     * * `Adjust` - Adjust
+     * * `AppsFlyer` - AppsFlyer
+     * * `Freshdesk` - Freshdesk
+     * * `GoogleAnalytics` - GoogleAnalytics
+     * * `Pipedrive` - Pipedrive
+     * * `SendGrid` - SendGrid
+     * * `Slack` - Slack
+     * * `PagerDuty` - PagerDuty
+     * * `Asana` - Asana
+     * * `Notion` - Notion
+     * * `Airtable` - Airtable
+     * * `Greenhouse` - Greenhouse
+     * * `BambooHR` - BambooHR
+     * * `Lever` - Lever
+     * * `GitLab` - GitLab
+     * * `Datadog` - Datadog
+     * * `Sentry` - Sentry
+     * * `Pendo` - Pendo
+     * * `FullStory` - FullStory
+     * * `AmazonAds` - AmazonAds
+     * * `PinterestAds` - PinterestAds
+     * * `AppleSearchAds` - AppleSearchAds
+     * * `QuickBooks` - QuickBooks
+     * * `Xero` - Xero
+     * * `NetSuite` - NetSuite
+     * * `WooCommerce` - WooCommerce
+     * * `BigCommerce` - BigCommerce
+     * * `PayPal` - PayPal
+     * * `Square` - Square
+     * * `Zoom` - Zoom
+     * * `Trello` - Trello
+     * * `Monday` - Monday
+     * * `ClickUp` - ClickUp
+     * * `Confluence` - Confluence
+     * * `Recurly` - Recurly
+     * * `SalesLoft` - SalesLoft
+     * * `Outreach` - Outreach
+     * * `Gong` - Gong
+     * * `Calendly` - Calendly
+     * * `Typeform` - Typeform
+     * * `Iterable` - Iterable
+     * * `ZohoCRM` - ZohoCRM
+     * * `Close` - Close
+     * * `Oracle` - Oracle
+     * * `DynamoDB` - DynamoDB
+     * * `Elasticsearch` - Elasticsearch
+     * * `Kafka` - Kafka
+     * * `LaunchDarkly` - LaunchDarkly
+     * * `Braintree` - Braintree
+     * * `Recharge` - Recharge
+     * * `HelpScout` - HelpScout
+     * * `Gorgias` - Gorgias
+     * * `Instagram` - Instagram
+     * * `YouTubeAnalytics` - YouTubeAnalytics
+     * * `FacebookPages` - FacebookPages
+     * * `TwitterAds` - TwitterAds
+     * * `Workday` - Workday
+     * * `ServiceNow` - ServiceNow
+     * * `Pardot` - Pardot
+     * * `Copper` - Copper
+     * * `Front` - Front
+     * * `ChartMogul` - ChartMogul
+     * * `Zuora` - Zuora
+     * * `Paddle` - Paddle
+     * * `CircleCI` - CircleCI
+     * * `CockroachDB` - CockroachDB
+     * * `Firebase` - Firebase
+     * * `AzureBlob` - AzureBlob
+     * * `GoogleDrive` - GoogleDrive
+     * * `OneDrive` - OneDrive
+     * * `SharePoint` - SharePoint
+     * * `Box` - Box
+     * * `SFTP` - SFTP
+     * * `MicrosoftTeams` - MicrosoftTeams
+     * * `Aircall` - Aircall
+     * * `Webflow` - Webflow
+     * * `Okta` - Okta
+     * * `Auth0` - Auth0
+     * * `Productboard` - Productboard
+     * * `Smartsheet` - Smartsheet
+     * * `Wrike` - Wrike
+     * * `Plaid` - Plaid
+     * * `SurveyMonkey` - SurveyMonkey
+     * * `Eventbrite` - Eventbrite
+     * * `RingCentral` - RingCentral
+     * * `Twilio` - Twilio
+     * * `Freshsales` - Freshsales
+     * * `Shortcut` - Shortcut
+     * * `ConvertKit` - ConvertKit
+     * * `Drip` - Drip
+     * * `CampaignMonitor` - CampaignMonitor
+     * * `MailerLite` - MailerLite
+     * * `Omnisend` - Omnisend
+     * * `Brevo` - Brevo
+     * * `Postmark` - Postmark
+     * * `Granola` - Granola
+     * * `BuildBetter` - BuildBetter
+     * * `Convex` - Convex
+     * * `ClickHouse` - ClickHouse
+     * * `Plain` - Plain
+     * * `Resend` - Resend
+     * * `PgAnalyze` - PgAnalyze
+     * * `WorkOS` - WorkOS
+     * * `Custom` - Custom
      */
     export type ExternalDataSourceTypeEnum = typeof ExternalDataSourceTypeEnum[keyof typeof ExternalDataSourceTypeEnum];
 
@@ -13541,162 +13564,162 @@ export namespace Schemas {
 
     /**
      * Validate credentials and preview available tables from a remote database.
-
-    The request body contains source_type plus flat source-specific credential fields
-    (e.g. host, port, database, user, password, schema for Postgres). The credential
-    fields vary per source_type and are validated dynamically by the source registry.
+     *
+     * The request body contains source_type plus flat source-specific credential fields
+     * (e.g. host, port, database, user, password, schema for Postgres). The credential
+     * fields vary per source_type and are validated dynamically by the source registry.
      */
     export interface DatabaseSchemaRequest {
       /** The source type to validate against.
-
-      * `Ashby` - Ashby
-      * `Supabase` - Supabase
-      * `CustomerIO` - CustomerIO
-      * `Github` - Github
-      * `Stripe` - Stripe
-      * `Hubspot` - Hubspot
-      * `Postgres` - Postgres
-      * `Zendesk` - Zendesk
-      * `Snowflake` - Snowflake
-      * `Salesforce` - Salesforce
-      * `MySQL` - MySQL
-      * `MongoDB` - MongoDB
-      * `MSSQL` - MSSQL
-      * `Vitally` - Vitally
-      * `BigQuery` - BigQuery
-      * `Chargebee` - Chargebee
-      * `Clerk` - Clerk
-      * `GoogleAds` - GoogleAds
-      * `GoogleSearchConsole` - GoogleSearchConsole
-      * `TemporalIO` - TemporalIO
-      * `DoIt` - DoIt
-      * `GoogleSheets` - GoogleSheets
-      * `MetaAds` - MetaAds
-      * `Klaviyo` - Klaviyo
-      * `Mailchimp` - Mailchimp
-      * `Braze` - Braze
-      * `Mailjet` - Mailjet
-      * `Redshift` - Redshift
-      * `Polar` - Polar
-      * `RevenueCat` - RevenueCat
-      * `LinkedinAds` - LinkedinAds
-      * `RedditAds` - RedditAds
-      * `TikTokAds` - TikTokAds
-      * `BingAds` - BingAds
-      * `Shopify` - Shopify
-      * `Attio` - Attio
-      * `SnapchatAds` - SnapchatAds
-      * `Linear` - Linear
-      * `Intercom` - Intercom
-      * `Amplitude` - Amplitude
-      * `Mixpanel` - Mixpanel
-      * `Jira` - Jira
-      * `ActiveCampaign` - ActiveCampaign
-      * `Marketo` - Marketo
-      * `Adjust` - Adjust
-      * `AppsFlyer` - AppsFlyer
-      * `Freshdesk` - Freshdesk
-      * `GoogleAnalytics` - GoogleAnalytics
-      * `Pipedrive` - Pipedrive
-      * `SendGrid` - SendGrid
-      * `Slack` - Slack
-      * `PagerDuty` - PagerDuty
-      * `Asana` - Asana
-      * `Notion` - Notion
-      * `Airtable` - Airtable
-      * `Greenhouse` - Greenhouse
-      * `BambooHR` - BambooHR
-      * `Lever` - Lever
-      * `GitLab` - GitLab
-      * `Datadog` - Datadog
-      * `Sentry` - Sentry
-      * `Pendo` - Pendo
-      * `FullStory` - FullStory
-      * `AmazonAds` - AmazonAds
-      * `PinterestAds` - PinterestAds
-      * `AppleSearchAds` - AppleSearchAds
-      * `QuickBooks` - QuickBooks
-      * `Xero` - Xero
-      * `NetSuite` - NetSuite
-      * `WooCommerce` - WooCommerce
-      * `BigCommerce` - BigCommerce
-      * `PayPal` - PayPal
-      * `Square` - Square
-      * `Zoom` - Zoom
-      * `Trello` - Trello
-      * `Monday` - Monday
-      * `ClickUp` - ClickUp
-      * `Confluence` - Confluence
-      * `Recurly` - Recurly
-      * `SalesLoft` - SalesLoft
-      * `Outreach` - Outreach
-      * `Gong` - Gong
-      * `Calendly` - Calendly
-      * `Typeform` - Typeform
-      * `Iterable` - Iterable
-      * `ZohoCRM` - ZohoCRM
-      * `Close` - Close
-      * `Oracle` - Oracle
-      * `DynamoDB` - DynamoDB
-      * `Elasticsearch` - Elasticsearch
-      * `Kafka` - Kafka
-      * `LaunchDarkly` - LaunchDarkly
-      * `Braintree` - Braintree
-      * `Recharge` - Recharge
-      * `HelpScout` - HelpScout
-      * `Gorgias` - Gorgias
-      * `Instagram` - Instagram
-      * `YouTubeAnalytics` - YouTubeAnalytics
-      * `FacebookPages` - FacebookPages
-      * `TwitterAds` - TwitterAds
-      * `Workday` - Workday
-      * `ServiceNow` - ServiceNow
-      * `Pardot` - Pardot
-      * `Copper` - Copper
-      * `Front` - Front
-      * `ChartMogul` - ChartMogul
-      * `Zuora` - Zuora
-      * `Paddle` - Paddle
-      * `CircleCI` - CircleCI
-      * `CockroachDB` - CockroachDB
-      * `Firebase` - Firebase
-      * `AzureBlob` - AzureBlob
-      * `GoogleDrive` - GoogleDrive
-      * `OneDrive` - OneDrive
-      * `SharePoint` - SharePoint
-      * `Box` - Box
-      * `SFTP` - SFTP
-      * `MicrosoftTeams` - MicrosoftTeams
-      * `Aircall` - Aircall
-      * `Webflow` - Webflow
-      * `Okta` - Okta
-      * `Auth0` - Auth0
-      * `Productboard` - Productboard
-      * `Smartsheet` - Smartsheet
-      * `Wrike` - Wrike
-      * `Plaid` - Plaid
-      * `SurveyMonkey` - SurveyMonkey
-      * `Eventbrite` - Eventbrite
-      * `RingCentral` - RingCentral
-      * `Twilio` - Twilio
-      * `Freshsales` - Freshsales
-      * `Shortcut` - Shortcut
-      * `ConvertKit` - ConvertKit
-      * `Drip` - Drip
-      * `CampaignMonitor` - CampaignMonitor
-      * `MailerLite` - MailerLite
-      * `Omnisend` - Omnisend
-      * `Brevo` - Brevo
-      * `Postmark` - Postmark
-      * `Granola` - Granola
-      * `BuildBetter` - BuildBetter
-      * `Convex` - Convex
-      * `ClickHouse` - ClickHouse
-      * `Plain` - Plain
-      * `Resend` - Resend
-      * `PgAnalyze` - PgAnalyze
-      * `WorkOS` - WorkOS
-      * `Custom` - Custom */
+       *
+       * * `Ashby` - Ashby
+       * * `Supabase` - Supabase
+       * * `CustomerIO` - CustomerIO
+       * * `Github` - Github
+       * * `Stripe` - Stripe
+       * * `Hubspot` - Hubspot
+       * * `Postgres` - Postgres
+       * * `Zendesk` - Zendesk
+       * * `Snowflake` - Snowflake
+       * * `Salesforce` - Salesforce
+       * * `MySQL` - MySQL
+       * * `MongoDB` - MongoDB
+       * * `MSSQL` - MSSQL
+       * * `Vitally` - Vitally
+       * * `BigQuery` - BigQuery
+       * * `Chargebee` - Chargebee
+       * * `Clerk` - Clerk
+       * * `GoogleAds` - GoogleAds
+       * * `GoogleSearchConsole` - GoogleSearchConsole
+       * * `TemporalIO` - TemporalIO
+       * * `DoIt` - DoIt
+       * * `GoogleSheets` - GoogleSheets
+       * * `MetaAds` - MetaAds
+       * * `Klaviyo` - Klaviyo
+       * * `Mailchimp` - Mailchimp
+       * * `Braze` - Braze
+       * * `Mailjet` - Mailjet
+       * * `Redshift` - Redshift
+       * * `Polar` - Polar
+       * * `RevenueCat` - RevenueCat
+       * * `LinkedinAds` - LinkedinAds
+       * * `RedditAds` - RedditAds
+       * * `TikTokAds` - TikTokAds
+       * * `BingAds` - BingAds
+       * * `Shopify` - Shopify
+       * * `Attio` - Attio
+       * * `SnapchatAds` - SnapchatAds
+       * * `Linear` - Linear
+       * * `Intercom` - Intercom
+       * * `Amplitude` - Amplitude
+       * * `Mixpanel` - Mixpanel
+       * * `Jira` - Jira
+       * * `ActiveCampaign` - ActiveCampaign
+       * * `Marketo` - Marketo
+       * * `Adjust` - Adjust
+       * * `AppsFlyer` - AppsFlyer
+       * * `Freshdesk` - Freshdesk
+       * * `GoogleAnalytics` - GoogleAnalytics
+       * * `Pipedrive` - Pipedrive
+       * * `SendGrid` - SendGrid
+       * * `Slack` - Slack
+       * * `PagerDuty` - PagerDuty
+       * * `Asana` - Asana
+       * * `Notion` - Notion
+       * * `Airtable` - Airtable
+       * * `Greenhouse` - Greenhouse
+       * * `BambooHR` - BambooHR
+       * * `Lever` - Lever
+       * * `GitLab` - GitLab
+       * * `Datadog` - Datadog
+       * * `Sentry` - Sentry
+       * * `Pendo` - Pendo
+       * * `FullStory` - FullStory
+       * * `AmazonAds` - AmazonAds
+       * * `PinterestAds` - PinterestAds
+       * * `AppleSearchAds` - AppleSearchAds
+       * * `QuickBooks` - QuickBooks
+       * * `Xero` - Xero
+       * * `NetSuite` - NetSuite
+       * * `WooCommerce` - WooCommerce
+       * * `BigCommerce` - BigCommerce
+       * * `PayPal` - PayPal
+       * * `Square` - Square
+       * * `Zoom` - Zoom
+       * * `Trello` - Trello
+       * * `Monday` - Monday
+       * * `ClickUp` - ClickUp
+       * * `Confluence` - Confluence
+       * * `Recurly` - Recurly
+       * * `SalesLoft` - SalesLoft
+       * * `Outreach` - Outreach
+       * * `Gong` - Gong
+       * * `Calendly` - Calendly
+       * * `Typeform` - Typeform
+       * * `Iterable` - Iterable
+       * * `ZohoCRM` - ZohoCRM
+       * * `Close` - Close
+       * * `Oracle` - Oracle
+       * * `DynamoDB` - DynamoDB
+       * * `Elasticsearch` - Elasticsearch
+       * * `Kafka` - Kafka
+       * * `LaunchDarkly` - LaunchDarkly
+       * * `Braintree` - Braintree
+       * * `Recharge` - Recharge
+       * * `HelpScout` - HelpScout
+       * * `Gorgias` - Gorgias
+       * * `Instagram` - Instagram
+       * * `YouTubeAnalytics` - YouTubeAnalytics
+       * * `FacebookPages` - FacebookPages
+       * * `TwitterAds` - TwitterAds
+       * * `Workday` - Workday
+       * * `ServiceNow` - ServiceNow
+       * * `Pardot` - Pardot
+       * * `Copper` - Copper
+       * * `Front` - Front
+       * * `ChartMogul` - ChartMogul
+       * * `Zuora` - Zuora
+       * * `Paddle` - Paddle
+       * * `CircleCI` - CircleCI
+       * * `CockroachDB` - CockroachDB
+       * * `Firebase` - Firebase
+       * * `AzureBlob` - AzureBlob
+       * * `GoogleDrive` - GoogleDrive
+       * * `OneDrive` - OneDrive
+       * * `SharePoint` - SharePoint
+       * * `Box` - Box
+       * * `SFTP` - SFTP
+       * * `MicrosoftTeams` - MicrosoftTeams
+       * * `Aircall` - Aircall
+       * * `Webflow` - Webflow
+       * * `Okta` - Okta
+       * * `Auth0` - Auth0
+       * * `Productboard` - Productboard
+       * * `Smartsheet` - Smartsheet
+       * * `Wrike` - Wrike
+       * * `Plaid` - Plaid
+       * * `SurveyMonkey` - SurveyMonkey
+       * * `Eventbrite` - Eventbrite
+       * * `RingCentral` - RingCentral
+       * * `Twilio` - Twilio
+       * * `Freshsales` - Freshsales
+       * * `Shortcut` - Shortcut
+       * * `ConvertKit` - ConvertKit
+       * * `Drip` - Drip
+       * * `CampaignMonitor` - CampaignMonitor
+       * * `MailerLite` - MailerLite
+       * * `Omnisend` - Omnisend
+       * * `Brevo` - Brevo
+       * * `Postmark` - Postmark
+       * * `Granola` - Granola
+       * * `BuildBetter` - BuildBetter
+       * * `Convex` - Convex
+       * * `ClickHouse` - ClickHouse
+       * * `Plain` - Plain
+       * * `Resend` - Resend
+       * * `PgAnalyze` - PgAnalyze
+       * * `WorkOS` - WorkOS
+       * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
     }
 
@@ -13760,7 +13783,7 @@ export namespace Schemas {
 
     /**
      * * `bayesian` - Bayesian
-    * `frequentist` - Frequentist
+     * * `frequentist` - Frequentist
      */
     export type DefaultExperimentStatsMethodEnum = typeof DefaultExperimentStatsMethodEnum[keyof typeof DefaultExperimentStatsMethodEnum];
 
@@ -13777,9 +13800,9 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-    * `delivered` - Delivered
-    * `partial_failure` - Partial Failure
-    * `failed` - Failed
+     * * `delivered` - Delivered
+     * * `partial_failure` - Partial Failure
+     * * `failed` - Failed
      */
     export type DeliveryStatusEnum = typeof DeliveryStatusEnum[keyof typeof DeliveryStatusEnum];
 
@@ -13807,7 +13830,7 @@ export namespace Schemas {
 
     /**
      * * `html` - html
-    * `text` - text
+     * * `text` - text
      */
     export type DescriptionContentTypeEnum = typeof DescriptionContentTypeEnum[keyof typeof DescriptionContentTypeEnum];
 
@@ -13880,8 +13903,8 @@ export namespace Schemas {
 
     /**
      * * `Desktop` - Desktop
-    * `Mobile` - Mobile
-    * `Tablet` - Tablet
+     * * `Mobile` - Mobile
+     * * `Tablet` - Tablet
      */
     export type DeviceTypesEnum = typeof DeviceTypesEnum[keyof typeof DeviceTypesEnum];
 
@@ -13894,9 +13917,9 @@ export namespace Schemas {
 
     /**
      * * `passed` - passed
-    * `warned` - warned
-    * `failed` - failed
-    * `skipped` - skipped
+     * * `warned` - warned
+     * * `failed` - failed
+     * * `skipped` - skipped
      */
     export type DiagnosticCheckResultStatusEnum = typeof DiagnosticCheckResultStatusEnum[keyof typeof DiagnosticCheckResultStatusEnum];
 
@@ -13910,9 +13933,9 @@ export namespace Schemas {
 
     /**
      * * `dns` - dns
-    * `config` - config
-    * `wait` - wait
-    * `retry` - retry
+     * * `config` - config
+     * * `wait` - wait
+     * * `retry` - retry
      */
     export type DiagnosticRemediationTypeEnum = typeof DiagnosticRemediationTypeEnum[keyof typeof DiagnosticRemediationTypeEnum];
 
@@ -13935,11 +13958,11 @@ export namespace Schemas {
 
     export interface DiagnosticRemediation {
       /** Category of fix. dns: customer must change DNS records. config: customer must adjust their server config (e.g. allow port 80). wait: no action — the system will resolve on its own. retry: hit Retry.
-
-      * `dns` - dns
-      * `config` - config
-      * `wait` - wait
-      * `retry` - retry */
+       *
+       * * `dns` - dns
+       * * `config` - config
+       * * `wait` - wait
+       * * `retry` - retry */
       type: DiagnosticRemediationTypeEnum;
       /** One-line, action-oriented summary of what to do. */
       summary: string;
@@ -13953,11 +13976,11 @@ export namespace Schemas {
       /** Human-readable check name. */
       name: string;
       /** passed: ok. warned: degraded but not blocking. failed: blocking. skipped: not run for this state.
-
-      * `passed` - passed
-      * `warned` - warned
-      * `failed` - failed
-      * `skipped` - skipped */
+       *
+       * * `passed` - passed
+       * * `warned` - warned
+       * * `failed` - failed
+       * * `skipped` - skipped */
       status: DiagnosticCheckResultStatusEnum;
       /** Customer-facing explanation of the check's outcome. */
       detail: string;
@@ -13967,8 +13990,8 @@ export namespace Schemas {
 
     /**
      * * `healthy` - healthy
-    * `warn` - warn
-    * `fail` - fail
+     * * `warn` - warn
+     * * `fail` - fail
      */
     export type DiagnosticReportSummaryStatusEnum = typeof DiagnosticReportSummaryStatusEnum[keyof typeof DiagnosticReportSummaryStatusEnum];
 
@@ -13981,10 +14004,10 @@ export namespace Schemas {
 
     export interface DiagnosticReportSummary {
       /** Overall outcome: healthy if the proxy is serving requests, warn for non-blocking issues, fail otherwise.
-
-      * `healthy` - healthy
-      * `warn` - warn
-      * `fail` - fail */
+       *
+       * * `healthy` - healthy
+       * * `warn` - warn
+       * * `fail` - fail */
       status: DiagnosticReportSummaryStatusEnum;
       /**
          * Check id of the most actionable failure, if any. Null when status is healthy.
@@ -14009,7 +14032,7 @@ export namespace Schemas {
 
     /**
      * * `Up` - Up
-    * `Down` - Down
+     * * `Down` - Down
      */
     export type DirectionEnum = typeof DirectionEnum[keyof typeof DirectionEnum];
 
@@ -14138,9 +14161,9 @@ export namespace Schemas {
       /** Absolute percentage change, rounded to nearest integer. */
       percent: number;
       /** Direction of the change relative to the prior period.
-
-      * `Up` - Up
-      * `Down` - Down */
+       *
+       * * `Up` - Up
+       * * `Down` - Down */
       direction: DirectionEnum;
       /** Hex color indicating whether the change is a positive or negative signal. */
       color: string;
@@ -14187,26 +14210,26 @@ export namespace Schemas {
          */
       version?: number | null;
       /** Specifies where this feature flag should be evaluated
-
-      * `server` - Server
-      * `client` - Client
-      * `all` - All */
+       *
+       * * `server` - Server
+       * * `client` - Client
+       * * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum | BlankEnum | null;
       /** Identifier used for bucketing users into rollout and variants
-
-      * `distinct_id` - User ID (default)
-      * `device_id` - Device ID */
+       *
+       * * `distinct_id` - User ID (default)
+       * * `device_id` - Device ID */
       bucketing_identifier?: BucketingIdentifierEnum | BlankEnum | null;
       readonly evaluation_contexts: readonly string[];
     }
 
     /**
      * * `draft` - draft
-    * `concept` - concept
-    * `alpha` - alpha
-    * `beta` - beta
-    * `general-availability` - general availability
-    * `archived` - archived
+     * * `concept` - concept
+     * * `alpha` - alpha
+     * * `beta` - beta
+     * * `general-availability` - general availability
+     * * `archived` - archived
      */
     export type StageEnum = typeof StageEnum[keyof typeof StageEnum];
 
@@ -14231,13 +14254,13 @@ export namespace Schemas {
       /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
       description?: string;
       /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-
-      * `draft` - draft
-      * `concept` - concept
-      * `alpha` - alpha
-      * `beta` - beta
-      * `general-availability` - general availability
-      * `archived` - archived */
+       *
+       * * `draft` - draft
+       * * `concept` - concept
+       * * `alpha` - alpha
+       * * `beta` - beta
+       * * `general-availability` - general availability
+       * * `archived` - archived */
       stage: StageEnum;
       /**
          * URL to external documentation for this feature. Shown to users in the opt-in UI.
@@ -14259,13 +14282,13 @@ export namespace Schemas {
       /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
       description?: string;
       /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-
-      * `draft` - draft
-      * `concept` - concept
-      * `alpha` - alpha
-      * `beta` - beta
-      * `general-availability` - general availability
-      * `archived` - archived */
+       *
+       * * `draft` - draft
+       * * `concept` - concept
+       * * `alpha` - alpha
+       * * `beta` - beta
+       * * `general-availability` - general availability
+       * * `archived` - archived */
       stage: StageEnum;
       /**
          * URL to external documentation for this feature. Shown to users in the opt-in UI.
@@ -14313,7 +14336,10 @@ export namespace Schemas {
          * @nullable
          */
       tag_name?: string | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 200
+         */
       attr_class?: string[] | null;
       /**
          * @maxLength 10000
@@ -14424,12 +14450,12 @@ export namespace Schemas {
          */
       hypothesis?: string | null;
       /** Optional severity tag — one of P0, P1, P2, P3, P4. Informational only.
-
-      * `P0` - P0
-      * `P1` - P1
-      * `P2` - P2
-      * `P3` - P3
-      * `P4` - P4 */
+       *
+       * * `P0` - P0
+       * * `P1` - P1
+       * * `P2` - P2
+       * * `P3` - P3
+       * * `P4` - P4 */
       severity?: AutonomyPriorityEnum | null;
       /** Optional keys for downstream dedupe (e.g. `error_tracking_issue:<id>`). */
       dedupe_keys?: string[];
@@ -14462,12 +14488,12 @@ export namespace Schemas {
 
     export interface EndExperiment {
       /** The conclusion of the experiment.
-
-      * `won` - won
-      * `lost` - lost
-      * `inconclusive` - inconclusive
-      * `stopped_early` - stopped_early
-      * `invalid` - invalid */
+       *
+       * * `won` - won
+       * * `lost` - lost
+       * * `inconclusive` - inconclusive
+       * * `stopped_early` - stopped_early
+       * * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Optional comment about the experiment conclusion.
@@ -14671,14 +14697,14 @@ export namespace Schemas {
 
     /**
      * Variables to parameterize the endpoint query. The key is the variable name and the value is the variable value.
-
-    For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
-
-    For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
-
-    For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
-
-    Unknown variable names will return a 400 error.
+     *
+     * For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
+     *
+     * For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
+     *
+     * For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
+     *
+     * Unknown variable names will return a 400 error.
      */
     export type EndpointRunRequestVariables = { [key: string]: unknown } | null;
 
@@ -14694,14 +14720,14 @@ export namespace Schemas {
       offset?: number | null;
       refresh?: EndpointRefreshMode | null;
       /** Variables to parameterize the endpoint query. The key is the variable name and the value is the variable value.
-
-      For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
-
-      For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
-
-      For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
-
-      Unknown variable names will return a 400 error. */
+       *
+       * For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
+       *
+       * For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
+       *
+       * For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
+       *
+       * Unknown variable names will return a 400 error. */
       variables?: EndpointRunRequestVariables;
       /** Specific endpoint version to execute. If not provided, the latest version is used. */
       version?: number | null;
@@ -14931,7 +14957,7 @@ export namespace Schemas {
 
     /**
      * * `allow` - Allow
-    * `reject` - Reject
+     * * `reject` - Reject
      */
     export type EnforcementModeEnum = typeof EnforcementModeEnum[keyof typeof EnforcementModeEnum];
 
@@ -14943,7 +14969,7 @@ export namespace Schemas {
 
     /**
      * * `duckdb` - duckdb
-    * `postgres` - postgres
+     * * `postgres` - postgres
      */
     export type EngineEnum = typeof EngineEnum[keyof typeof EngineEnum];
 
@@ -14955,8 +14981,8 @@ export namespace Schemas {
 
     /**
      * * `open` - OPEN
-    * `closed` - CLOSED
-    * `merged` - MERGED
+     * * `closed` - CLOSED
+     * * `merged` - MERGED
      */
     export type EngineeringAnalyticsPRStateEnum = typeof EngineeringAnalyticsPRStateEnum[keyof typeof EngineeringAnalyticsPRStateEnum];
 
@@ -15011,10 +15037,10 @@ export namespace Schemas {
 
     /**
      * * `DateTime` - DateTime
-    * `String` - String
-    * `Numeric` - Numeric
-    * `Boolean` - Boolean
-    * `Duration` - Duration
+     * * `String` - String
+     * * `Numeric` - Numeric
+     * * `Boolean` - Boolean
+     * * `Duration` - Duration
      */
     export type PropertyDefinitionTypeEnum = typeof PropertyDefinitionTypeEnum[keyof typeof PropertyDefinitionTypeEnum];
 
@@ -15113,9 +15139,9 @@ export namespace Schemas {
 
     export interface ErrorTrackingAssignmentRuleAssigneeRequest {
       /** Assignee type. Use `user` for a user ID or `role` for a role UUID.
-
-      * `user` - user
-      * `role` - role */
+       *
+       * * `user` - user
+       * * `role` - role */
       type: AssigneeTypeEnum;
       /** User ID when `type` is `user`, or role UUID when `type` is `role`. */
       id: number | string;
@@ -15263,9 +15289,9 @@ export namespace Schemas {
 
     export interface ErrorTrackingGroupingRuleAssigneeRequest {
       /** Assignee type. Use `user` for a user ID or `role` for a role UUID.
-
-      * `user` - user
-      * `role` - role */
+       *
+       * * `user` - user
+       * * `role` - role */
       type: AssigneeTypeEnum;
       /** User ID when `type` is `user`, or role UUID when `type` is `role`. */
       id: number | string;
@@ -15390,22 +15416,22 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `icontains` - icontains
-    * `not_icontains` - not_icontains
-    * `regex` - regex
-    * `not_regex` - not_regex
-    * `gt` - gt
-    * `lt` - lt
-    * `gte` - gte
-    * `lte` - lte
-    * `is_set` - is_set
-    * `is_not_set` - is_not_set
-    * `is_date_exact` - is_date_exact
-    * `is_date_after` - is_date_after
-    * `is_date_before` - is_date_before
-    * `in` - in
-    * `not_in` - not_in
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `lt` - lt
+     * * `gte` - gte
+     * * `lte` - lte
+     * * `is_set` - is_set
+     * * `is_not_set` - is_not_set
+     * * `is_date_exact` - is_date_exact
+     * * `is_date_after` - is_date_after
+     * * `is_date_before` - is_date_before
+     * * `in` - in
+     * * `not_in` - not_in
      */
     export type PropertyItemOperatorEnum = typeof PropertyItemOperatorEnum[keyof typeof PropertyItemOperatorEnum];
 
@@ -15442,8 +15468,8 @@ export namespace Schemas {
 
     /**
      * * `summary` - summary
-    * `stack` - stack
-    * `raw` - raw
+     * * `stack` - stack
+     * * `raw` - raw
      */
     export type VerbosityEnum = typeof VerbosityEnum[keyof typeof VerbosityEnum];
 
@@ -15469,9 +15495,9 @@ export namespace Schemas {
          */
       searchQuery?: string;
       /** Timestamp sort direction. Defaults to DESC.
-
-      * `ASC` - ASC
-      * `DESC` - DESC */
+       *
+       * * `ASC` - ASC
+       * * `DESC` - DESC */
       orderDirection?: OrderDirectionEnum;
       /**
          * Page size.
@@ -15485,10 +15511,10 @@ export namespace Schemas {
          */
       offset?: number;
       /** Controls exception detail size: summary, stack, or raw. Defaults to summary.
-
-      * `summary` - summary
-      * `stack` - stack
-      * `raw` - raw */
+       *
+       * * `summary` - summary
+       * * `stack` - stack
+       * * `raw` - raw */
       verbosity?: VerbosityEnum;
       /** When true, include only stack frames marked in_app. Defaults to true. */
       onlyAppFrames?: boolean;
@@ -15517,10 +15543,10 @@ export namespace Schemas {
 
     /**
      * * `archived` - Archived
-    * `active` - Active
-    * `resolved` - Resolved
-    * `pending_release` - Pending release
-    * `suppressed` - Suppressed
+     * * `active` - Active
+     * * `resolved` - Resolved
+     * * `pending_release` - Pending release
+     * * `suppressed` - Suppressed
      */
     export type ErrorTrackingIssueFullStatusEnum = typeof ErrorTrackingIssueFullStatusEnum[keyof typeof ErrorTrackingIssueFullStatusEnum];
 
@@ -15640,13 +15666,13 @@ export namespace Schemas {
       /** Date range for issue aggregates. Defaults to the last 7 days. */
       dateRange?: ErrorTrackingDateRange;
       /** Filter by issue status. Defaults to active.
-
-      * `archived` - archived
-      * `active` - active
-      * `resolved` - resolved
-      * `pending_release` - pending_release
-      * `suppressed` - suppressed
-      * `all` - all */
+       *
+       * * `archived` - archived
+       * * `active` - active
+       * * `resolved` - resolved
+       * * `pending_release` - pending_release
+       * * `suppressed` - suppressed
+       * * `all` - all */
       status?: ErrorTrackingIssueStatusEnum;
       /** Filter by issue assignee. Omit to include all assignees. */
       assignee?: ErrorTrackingAssignee | null;
@@ -15660,17 +15686,17 @@ export namespace Schemas {
       /** Advanced flat AND property filters. Prefer typed shortcut fields when they fit. HogQL filters are rejected. */
       filterGroup?: PropertyItem[];
       /** Field used to sort issues. Defaults to occurrences.
-
-      * `last_seen` - last_seen
-      * `first_seen` - first_seen
-      * `occurrences` - occurrences
-      * `users` - users
-      * `sessions` - sessions */
+       *
+       * * `last_seen` - last_seen
+       * * `first_seen` - first_seen
+       * * `occurrences` - occurrences
+       * * `users` - users
+       * * `sessions` - sessions */
       orderBy?: ErrorTrackingIssueOrderByEnum;
       /** Sort direction. Defaults to DESC.
-
-      * `ASC` - ASC
-      * `DESC` - DESC */
+       *
+       * * `ASC` - ASC
+       * * `DESC` - DESC */
       orderDirection?: OrderDirectionEnum;
       /**
          * Page size.
@@ -15747,7 +15773,7 @@ export namespace Schemas {
 
     /**
      * * `ready` - Ready
-    * `computing` - Computing
+     * * `computing` - Computing
      */
     export type ErrorTrackingRecommendationStatusEnum = typeof ErrorTrackingRecommendationStatusEnum[keyof typeof ErrorTrackingRecommendationStatusEnum];
 
@@ -15767,9 +15793,9 @@ export namespace Schemas {
       /** Whether the recommendation's recommended action has been satisfied. */
       readonly completed: boolean;
       /** 'ready' if meta is fresh, 'computing' if a refresh is in progress.
-
-      * `ready` - Ready
-      * `computing` - Computing */
+       *
+       * * `ready` - Ready
+       * * `computing` - Computing */
       readonly status: ErrorTrackingRecommendationStatusEnum;
       /**
          * Timestamp meta was last successfully computed.
@@ -16096,8 +16122,8 @@ export namespace Schemas {
 
     /**
      * * `active` - Active
-    * `paused` - Paused
-    * `error` - Error
+     * * `paused` - Paused
+     * * `error` - Error
      */
     export type EvaluationStatusEnum = typeof EvaluationStatusEnum[keyof typeof EvaluationStatusEnum];
 
@@ -16110,8 +16136,8 @@ export namespace Schemas {
 
     /**
      * * `trial_limit_reached` - Trial evaluation limit reached
-    * `model_not_allowed` - Model not available on the trial plan
-    * `provider_key_deleted` - Provider API key was deleted
+     * * `model_not_allowed` - Model not available on the trial plan
+     * * `provider_key_deleted` - Provider API key was deleted
      */
     export type StatusReasonEnum = typeof StatusReasonEnum[keyof typeof StatusReasonEnum];
 
@@ -16124,7 +16150,7 @@ export namespace Schemas {
 
     /**
      * * `llm_judge` - LLM as a judge
-    * `hog` - Hog
+     * * `hog` - Hog
      */
     export type EvaluationTypeEnum = typeof EvaluationTypeEnum[keyof typeof EvaluationTypeEnum];
 
@@ -16167,12 +16193,12 @@ export namespace Schemas {
 
     /**
      * * `openai` - Openai
-    * `anthropic` - Anthropic
-    * `gemini` - Gemini
-    * `openrouter` - Openrouter
-    * `fireworks` - Fireworks
-    * `azure_openai` - Azure OpenAI
-    * `together_ai` - Together AI
+     * * `anthropic` - Anthropic
+     * * `gemini` - Gemini
+     * * `openrouter` - Openrouter
+     * * `fireworks` - Fireworks
+     * * `azure_openai` - Azure OpenAI
+     * * `together_ai` - Together AI
      */
     export type LLMProviderEnum = typeof LLMProviderEnum[keyof typeof LLMProviderEnum];
 
@@ -16214,15 +16240,15 @@ export namespace Schemas {
       readonly status: EvaluationStatusEnum;
       readonly status_reason: StatusReasonEnum | null;
       /** 'llm_judge' uses an LLM to score outputs against a prompt; 'hog' runs deterministic Hog code.
-
-      * `llm_judge` - LLM as a judge
-      * `hog` - Hog */
+       *
+       * * `llm_judge` - LLM as a judge
+       * * `hog` - Hog */
       evaluation_type: EvaluationTypeEnum;
       /** Configuration dict. For 'llm_judge': {prompt}. For 'hog': {source}. */
       evaluation_config?: EvaluationEvaluationConfig;
       /** Output format. Currently only 'boolean' is supported.
-
-      * `boolean` - Boolean (Pass/Fail) */
+       *
+       * * `boolean` - Boolean (Pass/Fail) */
       output_type: OutputTypeEnum;
       /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
       output_config?: EvaluationOutputConfig;
@@ -16238,9 +16264,9 @@ export namespace Schemas {
 
     /**
      * * `unknown` - Unknown
-    * `ok` - Ok
-    * `invalid` - Invalid
-    * `error` - Error
+     * * `ok` - Ok
+     * * `invalid` - Invalid
+     * * `error` - Error
      */
     export type LLMProviderKeyStateEnum = typeof LLMProviderKeyStateEnum[keyof typeof LLMProviderKeyStateEnum];
 
@@ -16315,7 +16341,7 @@ export namespace Schemas {
 
     /**
      * * `scheduled` - Scheduled
-    * `every_n` - Every N
+     * * `every_n` - Every N
      */
     export type EvaluationReportFrequencyEnum = typeof EvaluationReportFrequencyEnum[keyof typeof EvaluationReportFrequencyEnum];
 
@@ -16330,9 +16356,9 @@ export namespace Schemas {
       /** UUID of the evaluation this report config belongs to. */
       evaluation: string;
       /** How report generation is triggered. 'every_n' fires once N new evaluation results have accumulated (subject to cooldown_minutes and daily_run_cap). 'scheduled' fires on the cadence defined by rrule + starts_at + timezone_name.
-
-      * `scheduled` - Scheduled
-      * `every_n` - Every N */
+       *
+       * * `scheduled` - Scheduled
+       * * `every_n` - Every N */
       frequency?: EvaluationReportFrequencyEnum;
       /** RFC 5545 recurrence rule string (e.g. 'FREQ=WEEKLY;BYDAY=MO'). Must not contain DTSTART — the anchor is set via starts_at. Required when frequency is 'scheduled'; ignored otherwise. */
       rrule?: string;
@@ -16402,11 +16428,11 @@ export namespace Schemas {
       /** End of the evaluation window covered by this report. */
       readonly period_end: string;
       /** 'pending', 'delivered', or 'failed'.
-
-      * `pending` - Pending
-      * `delivered` - Delivered
-      * `partial_failure` - Partial Failure
-      * `failed` - Failed */
+       *
+       * * `pending` - Pending
+       * * `delivered` - Delivered
+       * * `partial_failure` - Partial Failure
+       * * `failed` - Failed */
       readonly delivery_status: DeliveryStatusEnum;
       /** List of delivery error messages if delivery failed. */
       readonly delivery_errors: unknown;
@@ -16431,9 +16457,9 @@ export namespace Schemas {
 
     /**
      * * `all` - all
-    * `pass` - pass
-    * `fail` - fail
-    * `na` - na
+     * * `pass` - pass
+     * * `fail` - fail
+     * * `na` - na
      */
     export type FilterEnum = typeof FilterEnum[keyof typeof FilterEnum];
 
@@ -16452,11 +16478,11 @@ export namespace Schemas {
       /** UUID of the evaluation config to summarize */
       evaluation_id: string;
       /** Filter type to apply ('all', 'pass', 'fail', or 'na')
-
-      * `all` - all
-      * `pass` - pass
-      * `fail` - fail
-      * `na` - na */
+       *
+       * * `all` - all
+       * * `pass` - pass
+       * * `fail` - fail
+       * * `na` - na */
       filter?: FilterEnum;
       /**
          * Optional: specific generation IDs to include in summary (max 250)
@@ -16518,8 +16544,8 @@ export namespace Schemas {
 
     /**
      * * `disabled` - Disabled
-    * `dry_run` - Dry Run
-    * `live` - Live
+     * * `dry_run` - Dry Run
+     * * `live` - Live
      */
     export type EventFilterConfigModeEnum = typeof EventFilterConfigModeEnum[keyof typeof EventFilterConfigModeEnum];
 
@@ -16543,10 +16569,10 @@ export namespace Schemas {
 
     /**
      * * `DateTime` - DateTime
-    * `String` - String
-    * `Numeric` - Numeric
-    * `Boolean` - Boolean
-    * `Object` - Object
+     * * `String` - String
+     * * `Numeric` - Numeric
+     * * `Boolean` - Boolean
+     * * `Object` - Object
      */
     export type SchemaPropertyGroupPropertyPropertyTypeEnum = typeof SchemaPropertyGroupPropertyPropertyTypeEnum[keyof typeof SchemaPropertyGroupPropertyPropertyTypeEnum];
 
@@ -16674,9 +16700,9 @@ export namespace Schemas {
 
     /**
      * * `$ai_generation` - $ai_generation
-    * `$ai_span` - $ai_span
-    * `$ai_embedding` - $ai_embedding
-    * `$ai_trace` - $ai_trace
+     * * `$ai_span` - $ai_span
+     * * `$ai_embedding` - $ai_embedding
+     * * `$ai_trace` - $ai_trace
      */
     export type EventTypeEnum = typeof EventTypeEnum[keyof typeof EventTypeEnum];
 
@@ -16745,9 +16771,9 @@ export namespace Schemas {
 
     /**
      * * `exit_on_conversion` - Conversion
-    * `exit_on_trigger_not_matched` - Trigger Not Matched
-    * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
-    * `exit_only_at_end` - Only At End
+     * * `exit_on_trigger_not_matched` - Trigger Not Matched
+     * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+     * * `exit_only_at_end` - Only At End
      */
     export type ExitConditionEnum = typeof ExitConditionEnum[keyof typeof ExitConditionEnum];
 
@@ -16807,7 +16833,7 @@ export namespace Schemas {
 
     /**
      * * `web` - web
-    * `product` - product
+     * * `product` - product
      */
     export type ExperimentTypeEnum = typeof ExperimentTypeEnum[keyof typeof ExperimentTypeEnum];
 
@@ -16980,9 +17006,9 @@ export namespace Schemas {
       readonly created_at: string;
       readonly updated_at: string;
       /** Experiment type: web for frontend UI changes, product for backend/API changes.
-
-      * `web` - web
-      * `product` - product */
+       *
+       * * `web` - web
+       * * `product` - product */
       type?: ExperimentTypeEnum | null;
       /** Exposure configuration including filter test accounts and custom exposure events. */
       exposure_criteria?: ExperimentApiExposureCriteria | null;
@@ -16996,12 +17022,12 @@ export namespace Schemas {
       allow_unknown_events?: boolean;
       _create_in_folder?: string;
       /** Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.
-
-      * `won` - won
-      * `lost` - lost
-      * `inconclusive` - inconclusive
-      * `stopped_early` - stopped_early
-      * `invalid` - invalid */
+       *
+       * * `won` - won
+       * * `lost` - lost
+       * * `inconclusive` - inconclusive
+       * * `stopped_early` - stopped_early
+       * * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Comment about the experiment conclusion.
@@ -17095,8 +17121,8 @@ export namespace Schemas {
 
     /**
      * * `categorical` - categorical
-    * `numeric` - numeric
-    * `boolean` - boolean
+     * * `numeric` - numeric
+     * * `boolean` - boolean
      */
     export type ExperimentMetricKindEnum = typeof ExperimentMetricKindEnum[keyof typeof ExperimentMetricKindEnum];
 
@@ -17109,9 +17135,9 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-    * `in_progress` - In Progress
-    * `completed` - Completed
-    * `failed` - Failed
+     * * `in_progress` - In Progress
+     * * `completed` - Completed
+     * * `failed` - Failed
      */
     export type ExperimentMetricsRecalculationStatusEnum = typeof ExperimentMetricsRecalculationStatusEnum[keyof typeof ExperimentMetricsRecalculationStatusEnum];
 
@@ -17125,9 +17151,9 @@ export namespace Schemas {
 
     /**
      * * `manual` - Manual
-    * `experiment_launch` - Experiment Launch
-    * `experiment_stop` - Experiment Stop
-    * `experiment_update` - Experiment Update
+     * * `experiment_launch` - Experiment Launch
+     * * `experiment_stop` - Experiment Stop
+     * * `experiment_update` - Experiment Update
      */
     export type ExperimentMetricsRecalculationTriggerEnum = typeof ExperimentMetricsRecalculationTriggerEnum[keyof typeof ExperimentMetricsRecalculationTriggerEnum];
 
@@ -17141,8 +17167,8 @@ export namespace Schemas {
 
     /**
      * * `pending` - pending
-    * `completed` - completed
-    * `failed` - failed
+     * * `completed` - completed
+     * * `failed` - failed
      */
     export type MetricRecalculationResultStatusEnum = typeof MetricRecalculationResultStatusEnum[keyof typeof MetricRecalculationResultStatusEnum];
 
@@ -17160,10 +17186,10 @@ export namespace Schemas {
       /** UUID of the metric this result belongs to */
       readonly metric_uuid: string;
       /** Status of this metric's calculation in the run
-
-      * `pending` - pending
-      * `completed` - completed
-      * `failed` - failed */
+       *
+       * * `pending` - pending
+       * * `completed` - completed
+       * * `failed` - failed */
       readonly status: MetricRecalculationResultStatusEnum;
       /** The computed metric result (ExperimentQueryResponse shape); null when status is pending or failed */
       readonly result: unknown;
@@ -17183,11 +17209,11 @@ export namespace Schemas {
       /** ID of the experiment being recalculated */
       readonly experiment_id: number;
       /** Current status of the recalculation job
-
-      * `pending` - Pending
-      * `in_progress` - In Progress
-      * `completed` - Completed
-      * `failed` - Failed */
+       *
+       * * `pending` - Pending
+       * * `in_progress` - In Progress
+       * * `completed` - Completed
+       * * `failed` - Failed */
       readonly status: ExperimentMetricsRecalculationStatusEnum;
       /** Total number of metrics to recalculate */
       readonly total_metrics: number;
@@ -17198,11 +17224,11 @@ export namespace Schemas {
       /** Map of metric_uuid to error details */
       readonly metric_errors: unknown;
       /** What triggered this recalculation
-
-      * `manual` - Manual
-      * `experiment_launch` - Experiment Launch
-      * `experiment_stop` - Experiment Stop
-      * `experiment_update` - Experiment Update */
+       *
+       * * `manual` - Manual
+       * * `experiment_launch` - Experiment Launch
+       * * `experiment_stop` - Experiment Stop
+       * * `experiment_update` - Experiment Update */
       readonly trigger: ExperimentMetricsRecalculationTriggerEnum;
       /** When the job was created */
       readonly created_at: string;
@@ -17262,13 +17288,13 @@ export namespace Schemas {
 
     /**
      * * `image/png` - image/png
-    * `application/pdf` - application/pdf
-    * `text/csv` - text/csv
-    * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
-    * `video/webm` - video/webm
-    * `video/mp4` - video/mp4
-    * `image/gif` - image/gif
-    * `application/json` - application/json
+     * * `application/pdf` - application/pdf
+     * * `text/csv` - text/csv
+     * * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+     * * `video/webm` - video/webm
+     * * `video/mp4` - video/mp4
+     * * `image/gif` - image/gif
+     * * `application/json` - application/json
      */
     export type ExportFormatEnum = typeof ExportFormatEnum[keyof typeof ExportFormatEnum];
 
@@ -17329,10 +17355,10 @@ export namespace Schemas {
 
     /**
      * * `full_refresh` - full_refresh
-    * `incremental` - incremental
-    * `append` - append
-    * `webhook` - webhook
-    * `cdc` - cdc
+     * * `incremental` - incremental
+     * * `append` - append
+     * * `webhook` - webhook
+     * * `cdc` - cdc
      */
     export type SyncTypeEnum = typeof SyncTypeEnum[keyof typeof SyncTypeEnum];
 
@@ -17347,11 +17373,11 @@ export namespace Schemas {
 
     /**
      * * `integer` - integer
-    * `numeric` - numeric
-    * `datetime` - datetime
-    * `date` - date
-    * `timestamp` - timestamp
-    * `objectid` - objectid
+     * * `numeric` - numeric
+     * * `datetime` - datetime
+     * * `date` - date
+     * * `timestamp` - timestamp
+     * * `objectid` - objectid
      */
     export type IncrementalFieldTypeEnum = typeof IncrementalFieldTypeEnum[keyof typeof IncrementalFieldTypeEnum];
 
@@ -17367,16 +17393,16 @@ export namespace Schemas {
 
     /**
      * * `never` - never
-    * `1min` - 1min
-    * `5min` - 5min
-    * `15min` - 15min
-    * `30min` - 30min
-    * `1hour` - 1hour
-    * `6hour` - 6hour
-    * `12hour` - 12hour
-    * `24hour` - 24hour
-    * `7day` - 7day
-    * `30day` - 30day
+     * * `1min` - 1min
+     * * `5min` - 5min
+     * * `15min` - 15min
+     * * `30min` - 30min
+     * * `1hour` - 1hour
+     * * `6hour` - 6hour
+     * * `12hour` - 12hour
+     * * `24hour` - 24hour
+     * * `7day` - 7day
+     * * `30day` - 30day
      */
     export type SyncFrequencyEnum = typeof SyncFrequencyEnum[keyof typeof SyncFrequencyEnum];
 
@@ -17414,12 +17440,12 @@ export namespace Schemas {
       /** @nullable */
       readonly status: string | null;
       /** Sync strategy: incremental, full_refresh, append, or cdc.
-
-      * `full_refresh` - full_refresh
-      * `incremental` - incremental
-      * `append` - append
-      * `webhook` - webhook
-      * `cdc` - cdc */
+       *
+       * * `full_refresh` - full_refresh
+       * * `incremental` - incremental
+       * * `append` - append
+       * * `webhook` - webhook
+       * * `cdc` - cdc */
       sync_type?: SyncTypeEnum | null;
       /**
          * Column name used to track sync progress.
@@ -17427,27 +17453,27 @@ export namespace Schemas {
          */
       incremental_field?: string | null;
       /** Data type of the incremental field.
-
-      * `integer` - integer
-      * `numeric` - numeric
-      * `datetime` - datetime
-      * `date` - date
-      * `timestamp` - timestamp
-      * `objectid` - objectid */
+       *
+       * * `integer` - integer
+       * * `numeric` - numeric
+       * * `datetime` - datetime
+       * * `date` - date
+       * * `timestamp` - timestamp
+       * * `objectid` - objectid */
       incremental_field_type?: IncrementalFieldTypeEnum | null;
       /** How often to sync.
-
-      * `never` - never
-      * `1min` - 1min
-      * `5min` - 5min
-      * `15min` - 15min
-      * `30min` - 30min
-      * `1hour` - 1hour
-      * `6hour` - 6hour
-      * `12hour` - 12hour
-      * `24hour` - 24hour
-      * `7day` - 7day
-      * `30day` - 30day */
+       *
+       * * `never` - never
+       * * `1min` - 1min
+       * * `5min` - 5min
+       * * `15min` - 15min
+       * * `30min` - 30min
+       * * `1hour` - 1hour
+       * * `6hour` - 6hour
+       * * `12hour` - 12hour
+       * * `24hour` - 24hour
+       * * `7day` - 7day
+       * * `30day` - 30day */
       sync_frequency?: SyncFrequencyEnum | null;
       /**
          * UTC time of day to run the sync (HH:MM:SS).
@@ -17462,10 +17488,10 @@ export namespace Schemas {
          */
       primary_key_columns?: string[] | null;
       /** For CDC syncs: consolidated, cdc_only, or both.
-
-      * `consolidated` - consolidated
-      * `cdc_only` - cdc_only
-      * `both` - both */
+       *
+       * * `consolidated` - consolidated
+       * * `cdc_only` - cdc_only
+       * * `both` - both */
       cdc_table_mode?: CdcTableModeEnum | null;
       /**
          * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
@@ -17487,12 +17513,12 @@ export namespace Schemas {
       /** Whether the schema should be queryable/synced. */
       should_sync?: boolean;
       /** Requested sync mode for the schema.
-
-      * `full_refresh` - full_refresh
-      * `incremental` - incremental
-      * `append` - append
-      * `webhook` - webhook
-      * `cdc` - cdc */
+       *
+       * * `full_refresh` - full_refresh
+       * * `incremental` - incremental
+       * * `append` - append
+       * * `webhook` - webhook
+       * * `cdc` - cdc */
       sync_type?: SyncTypeEnum | null;
       /**
          * Incremental cursor field for incremental or append syncs.
@@ -17515,10 +17541,10 @@ export namespace Schemas {
          */
       sync_time_of_day?: string | null;
       /** How CDC-backed tables should be exposed.
-
-      * `consolidated` - consolidated
-      * `cdc_only` - cdc_only
-      * `both` - both */
+       *
+       * * `consolidated` - consolidated
+       * * `cdc_only` - cdc_only
+       * * `both` - both */
       cdc_table_mode?: CdcTableModeEnum | null;
       /**
          * Columns to sync. Null means sync all columns.
@@ -17532,9 +17558,9 @@ export namespace Schemas {
       /** @nullable */
       readonly prefix: string | null;
       /** Backend engine detected for the direct connection.
-
-      * `duckdb` - duckdb
-      * `postgres` - postgres */
+       *
+       * * `duckdb` - duckdb
+       * * `postgres` - postgres */
       readonly engine: EngineEnum | null;
     }
 
@@ -17545,155 +17571,155 @@ export namespace Schemas {
 
     export interface ExternalDataSourceCreate {
       /** The source type (e.g. 'Postgres', 'Stripe').
-
-      * `Ashby` - Ashby
-      * `Supabase` - Supabase
-      * `CustomerIO` - CustomerIO
-      * `Github` - Github
-      * `Stripe` - Stripe
-      * `Hubspot` - Hubspot
-      * `Postgres` - Postgres
-      * `Zendesk` - Zendesk
-      * `Snowflake` - Snowflake
-      * `Salesforce` - Salesforce
-      * `MySQL` - MySQL
-      * `MongoDB` - MongoDB
-      * `MSSQL` - MSSQL
-      * `Vitally` - Vitally
-      * `BigQuery` - BigQuery
-      * `Chargebee` - Chargebee
-      * `Clerk` - Clerk
-      * `GoogleAds` - GoogleAds
-      * `GoogleSearchConsole` - GoogleSearchConsole
-      * `TemporalIO` - TemporalIO
-      * `DoIt` - DoIt
-      * `GoogleSheets` - GoogleSheets
-      * `MetaAds` - MetaAds
-      * `Klaviyo` - Klaviyo
-      * `Mailchimp` - Mailchimp
-      * `Braze` - Braze
-      * `Mailjet` - Mailjet
-      * `Redshift` - Redshift
-      * `Polar` - Polar
-      * `RevenueCat` - RevenueCat
-      * `LinkedinAds` - LinkedinAds
-      * `RedditAds` - RedditAds
-      * `TikTokAds` - TikTokAds
-      * `BingAds` - BingAds
-      * `Shopify` - Shopify
-      * `Attio` - Attio
-      * `SnapchatAds` - SnapchatAds
-      * `Linear` - Linear
-      * `Intercom` - Intercom
-      * `Amplitude` - Amplitude
-      * `Mixpanel` - Mixpanel
-      * `Jira` - Jira
-      * `ActiveCampaign` - ActiveCampaign
-      * `Marketo` - Marketo
-      * `Adjust` - Adjust
-      * `AppsFlyer` - AppsFlyer
-      * `Freshdesk` - Freshdesk
-      * `GoogleAnalytics` - GoogleAnalytics
-      * `Pipedrive` - Pipedrive
-      * `SendGrid` - SendGrid
-      * `Slack` - Slack
-      * `PagerDuty` - PagerDuty
-      * `Asana` - Asana
-      * `Notion` - Notion
-      * `Airtable` - Airtable
-      * `Greenhouse` - Greenhouse
-      * `BambooHR` - BambooHR
-      * `Lever` - Lever
-      * `GitLab` - GitLab
-      * `Datadog` - Datadog
-      * `Sentry` - Sentry
-      * `Pendo` - Pendo
-      * `FullStory` - FullStory
-      * `AmazonAds` - AmazonAds
-      * `PinterestAds` - PinterestAds
-      * `AppleSearchAds` - AppleSearchAds
-      * `QuickBooks` - QuickBooks
-      * `Xero` - Xero
-      * `NetSuite` - NetSuite
-      * `WooCommerce` - WooCommerce
-      * `BigCommerce` - BigCommerce
-      * `PayPal` - PayPal
-      * `Square` - Square
-      * `Zoom` - Zoom
-      * `Trello` - Trello
-      * `Monday` - Monday
-      * `ClickUp` - ClickUp
-      * `Confluence` - Confluence
-      * `Recurly` - Recurly
-      * `SalesLoft` - SalesLoft
-      * `Outreach` - Outreach
-      * `Gong` - Gong
-      * `Calendly` - Calendly
-      * `Typeform` - Typeform
-      * `Iterable` - Iterable
-      * `ZohoCRM` - ZohoCRM
-      * `Close` - Close
-      * `Oracle` - Oracle
-      * `DynamoDB` - DynamoDB
-      * `Elasticsearch` - Elasticsearch
-      * `Kafka` - Kafka
-      * `LaunchDarkly` - LaunchDarkly
-      * `Braintree` - Braintree
-      * `Recharge` - Recharge
-      * `HelpScout` - HelpScout
-      * `Gorgias` - Gorgias
-      * `Instagram` - Instagram
-      * `YouTubeAnalytics` - YouTubeAnalytics
-      * `FacebookPages` - FacebookPages
-      * `TwitterAds` - TwitterAds
-      * `Workday` - Workday
-      * `ServiceNow` - ServiceNow
-      * `Pardot` - Pardot
-      * `Copper` - Copper
-      * `Front` - Front
-      * `ChartMogul` - ChartMogul
-      * `Zuora` - Zuora
-      * `Paddle` - Paddle
-      * `CircleCI` - CircleCI
-      * `CockroachDB` - CockroachDB
-      * `Firebase` - Firebase
-      * `AzureBlob` - AzureBlob
-      * `GoogleDrive` - GoogleDrive
-      * `OneDrive` - OneDrive
-      * `SharePoint` - SharePoint
-      * `Box` - Box
-      * `SFTP` - SFTP
-      * `MicrosoftTeams` - MicrosoftTeams
-      * `Aircall` - Aircall
-      * `Webflow` - Webflow
-      * `Okta` - Okta
-      * `Auth0` - Auth0
-      * `Productboard` - Productboard
-      * `Smartsheet` - Smartsheet
-      * `Wrike` - Wrike
-      * `Plaid` - Plaid
-      * `SurveyMonkey` - SurveyMonkey
-      * `Eventbrite` - Eventbrite
-      * `RingCentral` - RingCentral
-      * `Twilio` - Twilio
-      * `Freshsales` - Freshsales
-      * `Shortcut` - Shortcut
-      * `ConvertKit` - ConvertKit
-      * `Drip` - Drip
-      * `CampaignMonitor` - CampaignMonitor
-      * `MailerLite` - MailerLite
-      * `Omnisend` - Omnisend
-      * `Brevo` - Brevo
-      * `Postmark` - Postmark
-      * `Granola` - Granola
-      * `BuildBetter` - BuildBetter
-      * `Convex` - Convex
-      * `ClickHouse` - ClickHouse
-      * `Plain` - Plain
-      * `Resend` - Resend
-      * `PgAnalyze` - PgAnalyze
-      * `WorkOS` - WorkOS
-      * `Custom` - Custom */
+       *
+       * * `Ashby` - Ashby
+       * * `Supabase` - Supabase
+       * * `CustomerIO` - CustomerIO
+       * * `Github` - Github
+       * * `Stripe` - Stripe
+       * * `Hubspot` - Hubspot
+       * * `Postgres` - Postgres
+       * * `Zendesk` - Zendesk
+       * * `Snowflake` - Snowflake
+       * * `Salesforce` - Salesforce
+       * * `MySQL` - MySQL
+       * * `MongoDB` - MongoDB
+       * * `MSSQL` - MSSQL
+       * * `Vitally` - Vitally
+       * * `BigQuery` - BigQuery
+       * * `Chargebee` - Chargebee
+       * * `Clerk` - Clerk
+       * * `GoogleAds` - GoogleAds
+       * * `GoogleSearchConsole` - GoogleSearchConsole
+       * * `TemporalIO` - TemporalIO
+       * * `DoIt` - DoIt
+       * * `GoogleSheets` - GoogleSheets
+       * * `MetaAds` - MetaAds
+       * * `Klaviyo` - Klaviyo
+       * * `Mailchimp` - Mailchimp
+       * * `Braze` - Braze
+       * * `Mailjet` - Mailjet
+       * * `Redshift` - Redshift
+       * * `Polar` - Polar
+       * * `RevenueCat` - RevenueCat
+       * * `LinkedinAds` - LinkedinAds
+       * * `RedditAds` - RedditAds
+       * * `TikTokAds` - TikTokAds
+       * * `BingAds` - BingAds
+       * * `Shopify` - Shopify
+       * * `Attio` - Attio
+       * * `SnapchatAds` - SnapchatAds
+       * * `Linear` - Linear
+       * * `Intercom` - Intercom
+       * * `Amplitude` - Amplitude
+       * * `Mixpanel` - Mixpanel
+       * * `Jira` - Jira
+       * * `ActiveCampaign` - ActiveCampaign
+       * * `Marketo` - Marketo
+       * * `Adjust` - Adjust
+       * * `AppsFlyer` - AppsFlyer
+       * * `Freshdesk` - Freshdesk
+       * * `GoogleAnalytics` - GoogleAnalytics
+       * * `Pipedrive` - Pipedrive
+       * * `SendGrid` - SendGrid
+       * * `Slack` - Slack
+       * * `PagerDuty` - PagerDuty
+       * * `Asana` - Asana
+       * * `Notion` - Notion
+       * * `Airtable` - Airtable
+       * * `Greenhouse` - Greenhouse
+       * * `BambooHR` - BambooHR
+       * * `Lever` - Lever
+       * * `GitLab` - GitLab
+       * * `Datadog` - Datadog
+       * * `Sentry` - Sentry
+       * * `Pendo` - Pendo
+       * * `FullStory` - FullStory
+       * * `AmazonAds` - AmazonAds
+       * * `PinterestAds` - PinterestAds
+       * * `AppleSearchAds` - AppleSearchAds
+       * * `QuickBooks` - QuickBooks
+       * * `Xero` - Xero
+       * * `NetSuite` - NetSuite
+       * * `WooCommerce` - WooCommerce
+       * * `BigCommerce` - BigCommerce
+       * * `PayPal` - PayPal
+       * * `Square` - Square
+       * * `Zoom` - Zoom
+       * * `Trello` - Trello
+       * * `Monday` - Monday
+       * * `ClickUp` - ClickUp
+       * * `Confluence` - Confluence
+       * * `Recurly` - Recurly
+       * * `SalesLoft` - SalesLoft
+       * * `Outreach` - Outreach
+       * * `Gong` - Gong
+       * * `Calendly` - Calendly
+       * * `Typeform` - Typeform
+       * * `Iterable` - Iterable
+       * * `ZohoCRM` - ZohoCRM
+       * * `Close` - Close
+       * * `Oracle` - Oracle
+       * * `DynamoDB` - DynamoDB
+       * * `Elasticsearch` - Elasticsearch
+       * * `Kafka` - Kafka
+       * * `LaunchDarkly` - LaunchDarkly
+       * * `Braintree` - Braintree
+       * * `Recharge` - Recharge
+       * * `HelpScout` - HelpScout
+       * * `Gorgias` - Gorgias
+       * * `Instagram` - Instagram
+       * * `YouTubeAnalytics` - YouTubeAnalytics
+       * * `FacebookPages` - FacebookPages
+       * * `TwitterAds` - TwitterAds
+       * * `Workday` - Workday
+       * * `ServiceNow` - ServiceNow
+       * * `Pardot` - Pardot
+       * * `Copper` - Copper
+       * * `Front` - Front
+       * * `ChartMogul` - ChartMogul
+       * * `Zuora` - Zuora
+       * * `Paddle` - Paddle
+       * * `CircleCI` - CircleCI
+       * * `CockroachDB` - CockroachDB
+       * * `Firebase` - Firebase
+       * * `AzureBlob` - AzureBlob
+       * * `GoogleDrive` - GoogleDrive
+       * * `OneDrive` - OneDrive
+       * * `SharePoint` - SharePoint
+       * * `Box` - Box
+       * * `SFTP` - SFTP
+       * * `MicrosoftTeams` - MicrosoftTeams
+       * * `Aircall` - Aircall
+       * * `Webflow` - Webflow
+       * * `Okta` - Okta
+       * * `Auth0` - Auth0
+       * * `Productboard` - Productboard
+       * * `Smartsheet` - Smartsheet
+       * * `Wrike` - Wrike
+       * * `Plaid` - Plaid
+       * * `SurveyMonkey` - SurveyMonkey
+       * * `Eventbrite` - Eventbrite
+       * * `RingCentral` - RingCentral
+       * * `Twilio` - Twilio
+       * * `Freshsales` - Freshsales
+       * * `Shortcut` - Shortcut
+       * * `ConvertKit` - ConvertKit
+       * * `Drip` - Drip
+       * * `CampaignMonitor` - CampaignMonitor
+       * * `MailerLite` - MailerLite
+       * * `Omnisend` - Omnisend
+       * * `Brevo` - Brevo
+       * * `Postmark` - Postmark
+       * * `Granola` - Granola
+       * * `BuildBetter` - BuildBetter
+       * * `Convex` - Convex
+       * * `ClickHouse` - ClickHouse
+       * * `Plain` - Plain
+       * * `Resend` - Resend
+       * * `PgAnalyze` - PgAnalyze
+       * * `WorkOS` - WorkOS
+       * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
       /** Connection credentials and a 'schemas' array. Keys depend on source_type. */
       payload: ExternalDataSourceCreatePayload;
@@ -17710,15 +17736,15 @@ export namespace Schemas {
          */
       description?: string | null;
       /** Connection mode: 'warehouse' (import) or 'direct' (live query).
-
-      * `warehouse` - warehouse
-      * `direct` - direct */
+       *
+       * * `warehouse` - warehouse
+       * * `direct` - direct */
       access_method?: AccessMethodEnum;
       /** Where the request came from
-
-      * `web` - web
-      * `api` - api
-      * `mcp` - mcp */
+       *
+       * * `web` - web
+       * * `api` - api
+       * * `mcp` - mcp */
       created_via?: CreatedViaEnum;
     }
 
@@ -17755,10 +17781,10 @@ export namespace Schemas {
       /** @nullable */
       readonly created_by: string | null;
       /** How this source was created. Defaults to `api` on create when omitted. `web` for the in-app UI, `api` for direct API callers, `mcp` for agent/MCP tool calls. Ignored on update.
-
-      * `web` - web
-      * `api` - api
-      * `mcp` - mcp */
+       *
+       * * `web` - web
+       * * `api` - api
+       * * `mcp` - mcp */
       created_via?: CreatedViaEnum | null;
       readonly status: string;
       client_secret: string;
@@ -17778,9 +17804,9 @@ export namespace Schemas {
       description?: string | null;
       readonly access_method: AccessMethodEnum;
       /** Backend engine detected for the direct connection.
-
-      * `duckdb` - duckdb
-      * `postgres` - postgres */
+       *
+       * * `duckdb` - duckdb
+       * * `postgres` - postgres */
       readonly engine: EngineEnum | null;
       /** @nullable */
       readonly last_run_at: string | null;
@@ -17828,11 +17854,11 @@ export namespace Schemas {
 
     /**
      * * `feature_flags` - feature_flags
-    * `experiments` - experiments
-    * `surveys` - surveys
-    * `early_access_features` - early_access_features
-    * `web_experiments` - web_experiments
-    * `product_tours` - product_tours
+     * * `experiments` - experiments
+     * * `surveys` - surveys
+     * * `early_access_features` - early_access_features
+     * * `web_experiments` - web_experiments
+     * * `product_tours` - product_tours
      */
     export type FeatureFlagCreationContextEnum = typeof FeatureFlagCreationContextEnum[keyof typeof FeatureFlagCreationContextEnum];
 
@@ -17886,13 +17912,13 @@ export namespace Schemas {
          */
       readonly user_access_level: string | null;
       /** Indicates the origin product of the feature flag. Choices: 'feature_flags', 'experiments', 'surveys', 'early_access_features', 'web_experiments', 'product_tours'.
-
-      * `feature_flags` - feature_flags
-      * `experiments` - experiments
-      * `surveys` - surveys
-      * `early_access_features` - early_access_features
-      * `web_experiments` - web_experiments
-      * `product_tours` - product_tours */
+       *
+       * * `feature_flags` - feature_flags
+       * * `experiments` - experiments
+       * * `surveys` - surveys
+       * * `early_access_features` - early_access_features
+       * * `web_experiments` - web_experiments
+       * * `product_tours` - product_tours */
       creation_context?: FeatureFlagCreationContextEnum;
       /** @nullable */
       is_remote_configuration?: boolean | null;
@@ -17900,15 +17926,15 @@ export namespace Schemas {
       has_encrypted_payloads?: boolean | null;
       readonly status: string;
       /** Specifies where this feature flag should be evaluated
-
-      * `server` - Server
-      * `client` - Client
-      * `all` - All */
+       *
+       * * `server` - Server
+       * * `client` - Client
+       * * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum | BlankEnum | null;
       /** Identifier used for bucketing users into rollout and variants
-
-      * `distinct_id` - User ID (default)
-      * `device_id` - Device ID */
+       *
+       * * `distinct_id` - User ID (default)
+       * * `device_id` - Device ID */
       bucketing_identifier?: BucketingIdentifierEnum | BlankEnum | null;
       /**
          * Last time this feature flag was called (from $feature_flag_called events)
@@ -17962,8 +17988,8 @@ export namespace Schemas {
 
     /**
      * * `cohort` - cohort
-    * `person` - person
-    * `group` - group
+     * * `person` - person
+     * * `group` - group
      */
     export type PropertyGroupTypeEnum = typeof PropertyGroupTypeEnum[keyof typeof PropertyGroupTypeEnum];
 
@@ -17976,15 +18002,15 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `icontains` - icontains
-    * `not_icontains` - not_icontains
-    * `regex` - regex
-    * `not_regex` - not_regex
-    * `gt` - gt
-    * `gte` - gte
-    * `lt` - lt
-    * `lte` - lte
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `gte` - gte
+     * * `lt` - lt
+     * * `lte` - lte
      */
     export type FeatureFlagFilterPropertyGenericSchemaOperatorEnum = typeof FeatureFlagFilterPropertyGenericSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertyGenericSchemaOperatorEnum];
 
@@ -18006,10 +18032,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-
-      * `cohort` - cohort
-      * `person` - person
-      * `group` - group */
+       *
+       * * `cohort` - cohort
+       * * `person` - person
+       * * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18024,17 +18050,17 @@ export namespace Schemas {
       /** Comparison value for the property filter. Supports strings, numbers, booleans, and arrays. */
       value: unknown;
       /** Operator used to compare the property value.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains
-      * `regex` - regex
-      * `not_regex` - not_regex
-      * `gt` - gt
-      * `gte` - gte
-      * `lt` - lt
-      * `lte` - lte */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains
+       * * `regex` - regex
+       * * `not_regex` - not_regex
+       * * `gt` - gt
+       * * `gte` - gte
+       * * `lt` - lt
+       * * `lte` - lte */
       operator: FeatureFlagFilterPropertyGenericSchemaOperatorEnum;
     }
 
@@ -18042,10 +18068,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-
-      * `cohort` - cohort
-      * `person` - person
-      * `group` - group */
+       *
+       * * `cohort` - cohort
+       * * `person` - person
+       * * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18058,9 +18084,9 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Existence operator.
-
-      * `is_set` - is_set
-      * `is_not_set` - is_not_set */
+       *
+       * * `is_set` - is_set
+       * * `is_not_set` - is_not_set */
       operator: ExistenceOperatorEnum;
       /** Optional value. Runtime behavior determines whether this is ignored. */
       value?: unknown;
@@ -18070,10 +18096,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-
-      * `cohort` - cohort
-      * `person` - person
-      * `group` - group */
+       *
+       * * `cohort` - cohort
+       * * `person` - person
+       * * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18086,10 +18112,10 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Date comparison operator.
-
-      * `is_date_exact` - is_date_exact
-      * `is_date_after` - is_date_after
-      * `is_date_before` - is_date_before */
+       *
+       * * `is_date_exact` - is_date_exact
+       * * `is_date_after` - is_date_after
+       * * `is_date_before` - is_date_before */
       operator: DateOperatorEnum;
       /** Date value in ISO format or relative date expression. */
       value: string;
@@ -18097,14 +18123,14 @@ export namespace Schemas {
 
     /**
      * * `semver_gt` - semver_gt
-    * `semver_gte` - semver_gte
-    * `semver_lt` - semver_lt
-    * `semver_lte` - semver_lte
-    * `semver_eq` - semver_eq
-    * `semver_neq` - semver_neq
-    * `semver_tilde` - semver_tilde
-    * `semver_caret` - semver_caret
-    * `semver_wildcard` - semver_wildcard
+     * * `semver_gte` - semver_gte
+     * * `semver_lt` - semver_lt
+     * * `semver_lte` - semver_lte
+     * * `semver_eq` - semver_eq
+     * * `semver_neq` - semver_neq
+     * * `semver_tilde` - semver_tilde
+     * * `semver_caret` - semver_caret
+     * * `semver_wildcard` - semver_wildcard
      */
     export type FeatureFlagFilterPropertySemverSchemaOperatorEnum = typeof FeatureFlagFilterPropertySemverSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertySemverSchemaOperatorEnum];
 
@@ -18125,10 +18151,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-
-      * `cohort` - cohort
-      * `person` - person
-      * `group` - group */
+       *
+       * * `cohort` - cohort
+       * * `person` - person
+       * * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18141,16 +18167,16 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Semantic version comparison operator.
-
-      * `semver_gt` - semver_gt
-      * `semver_gte` - semver_gte
-      * `semver_lt` - semver_lt
-      * `semver_lte` - semver_lte
-      * `semver_eq` - semver_eq
-      * `semver_neq` - semver_neq
-      * `semver_tilde` - semver_tilde
-      * `semver_caret` - semver_caret
-      * `semver_wildcard` - semver_wildcard */
+       *
+       * * `semver_gt` - semver_gt
+       * * `semver_gte` - semver_gte
+       * * `semver_lt` - semver_lt
+       * * `semver_lte` - semver_lte
+       * * `semver_eq` - semver_eq
+       * * `semver_neq` - semver_neq
+       * * `semver_tilde` - semver_tilde
+       * * `semver_caret` - semver_caret
+       * * `semver_wildcard` - semver_wildcard */
       operator: FeatureFlagFilterPropertySemverSchemaOperatorEnum;
       /** Semantic version string. */
       value: string;
@@ -18158,7 +18184,7 @@ export namespace Schemas {
 
     /**
      * * `icontains_multi` - icontains_multi
-    * `not_icontains_multi` - not_icontains_multi
+     * * `not_icontains_multi` - not_icontains_multi
      */
     export type FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum = typeof FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum];
 
@@ -18172,10 +18198,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-
-      * `cohort` - cohort
-      * `person` - person
-      * `group` - group */
+       *
+       * * `cohort` - cohort
+       * * `person` - person
+       * * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18188,9 +18214,9 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Multi-contains operator.
-
-      * `icontains_multi` - icontains_multi
-      * `not_icontains_multi` - not_icontains_multi */
+       *
+       * * `icontains_multi` - icontains_multi
+       * * `not_icontains_multi` - not_icontains_multi */
       operator: FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum;
       /** List of strings to evaluate against. */
       value: string[];
@@ -18208,7 +18234,7 @@ export namespace Schemas {
 
     /**
      * * `in` - in
-    * `not_in` - not_in
+     * * `not_in` - not_in
      */
     export type FeatureFlagFilterPropertyCohortInSchemaOperatorEnum = typeof FeatureFlagFilterPropertyCohortInSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertyCohortInSchemaOperatorEnum];
 
@@ -18222,8 +18248,8 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Cohort property type required for in/not_in operators.
-
-      * `cohort` - cohort */
+       *
+       * * `cohort` - cohort */
       type: FeatureFlagFilterPropertyCohortInSchemaTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18236,9 +18262,9 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Membership operator for cohort properties.
-
-      * `in` - in
-      * `not_in` - not_in */
+       *
+       * * `in` - in
+       * * `not_in` - not_in */
       operator: FeatureFlagFilterPropertyCohortInSchemaOperatorEnum;
       /** Cohort comparison value (single or list, depending on usage). */
       value: unknown;
@@ -18268,8 +18294,8 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Flag property type required for flag dependency checks.
-
-      * `flag` - flag */
+       *
+       * * `flag` - flag */
       type: FeatureFlagFilterPropertyFlagEvaluatesSchemaTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18282,8 +18308,8 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Operator for feature flag dependency evaluation.
-
-      * `flag_evaluates_to` - flag_evaluates_to */
+       *
+       * * `flag_evaluates_to` - flag_evaluates_to */
       operator: FeatureFlagFilterPropertyFlagEvaluatesSchemaOperatorEnum;
       /** Value to compare flag evaluation against. */
       value: unknown;
@@ -18445,15 +18471,15 @@ export namespace Schemas {
       /** @nullable */
       has_encrypted_payloads?: boolean | null;
       /** Specifies where this feature flag should be evaluated
-
-      * `server` - Server
-      * `client` - Client
-      * `all` - All */
+       *
+       * * `server` - Server
+       * * `client` - Client
+       * * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum | BlankEnum | null;
       /** Identifier used for bucketing users into rollout and variants
-
-      * `distinct_id` - User ID (default)
-      * `device_id` - Device ID */
+       *
+       * * `distinct_id` - User ID (default)
+       * * `device_id` - Device ID */
       bucketing_identifier?: BucketingIdentifierEnum | BlankEnum | null;
       /**
          * Last time this feature flag was called (from $feature_flag_called events)
@@ -18476,8 +18502,8 @@ export namespace Schemas {
 
     /**
      * * `events` - events
-    * `persons` - persons
-    * `sessions` - sessions
+     * * `persons` - persons
+     * * `sessions` - sessions
      */
     export type FileDownloadBatchExportOnDemandModelEnum = typeof FileDownloadBatchExportOnDemandModelEnum[keyof typeof FileDownloadBatchExportOnDemandModelEnum];
 
@@ -18924,11 +18950,23 @@ export namespace Schemas {
          * @nullable
          */
       non_integrated_count: number | null;
-      /** List of [event_name, count] pairs */
+      /**
+         * List of [event_name, count] pairs
+         * @items.minItems 2
+         * @items.maxItems 2
+         */
       by_event: [string, number][];
-      /** List of [utm_source, count] pairs */
+      /**
+         * List of [utm_source, count] pairs
+         * @items.minItems 2
+         * @items.maxItems 2
+         */
       by_utm_source: [string, number][];
-      /** List of [integration, count] pairs */
+      /**
+         * List of [integration, count] pairs
+         * @items.minItems 2
+         * @items.maxItems 2
+         */
       by_matched_integration: [string, number][];
       /** A small sample of matching events */
       samples: GoalEventSample[];
@@ -18971,16 +19009,16 @@ export namespace Schemas {
 
     /**
      * Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-    **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-    **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
+     *
+     * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+     *
+     * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
      */
     export type GroupUsageMetricFilters = { [key: string]: unknown };
 
     /**
      * * `numeric` - numeric
-    * `currency` - currency
+     * * `currency` - currency
      */
     export type GroupUsageMetricFormatEnum = typeof GroupUsageMetricFormatEnum[keyof typeof GroupUsageMetricFormatEnum];
 
@@ -18992,7 +19030,7 @@ export namespace Schemas {
 
     /**
      * * `number` - number
-    * `sparkline` - sparkline
+     * * `sparkline` - sparkline
      */
     export type GroupUsageMetricDisplayEnum = typeof GroupUsageMetricDisplayEnum[keyof typeof GroupUsageMetricDisplayEnum];
 
@@ -19004,7 +19042,7 @@ export namespace Schemas {
 
     /**
      * * `count` - count
-    * `sum` - sum
+     * * `sum` - sum
      */
     export type MathEnum = typeof MathEnum[keyof typeof MathEnum];
 
@@ -19022,27 +19060,27 @@ export namespace Schemas {
          */
       name: string;
       /** How the metric value is formatted in the UI. One of `numeric` or `currency`.
-
-      * `numeric` - numeric
-      * `currency` - currency */
+       *
+       * * `numeric` - numeric
+       * * `currency` - currency */
       format?: GroupUsageMetricFormatEnum;
       /** Rolling time window in days used to compute the metric. Defaults to 7. */
       interval?: number;
       /** Visual representation in the UI. One of `number` or `sparkline`.
-
-      * `number` - number
-      * `sparkline` - sparkline */
+       *
+       * * `number` - number
+       * * `sparkline` - sparkline */
       display?: GroupUsageMetricDisplayEnum;
       /** Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-      **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-      **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
+       *
+       * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+       *
+       * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
       filters: GroupUsageMetricFilters;
       /** Aggregation function. `count` counts matching events; `sum` sums the value of `math_property` on matching events.
-
-      * `count` - count
-      * `sum` - sum */
+       *
+       * * `count` - count
+       * * `sum` - sum */
       math?: MathEnum;
       /**
          * Required when `math` is `sum`; must be empty when `math` is `count`. For events metrics this is an event property name. For data warehouse metrics this is the column name (or HogQL expression) to sum on the DW table.
@@ -19054,8 +19092,8 @@ export namespace Schemas {
 
     /**
      * * `success` - success
-    * `warning` - warning
-    * `danger` - danger
+     * * `warning` - warning
+     * * `danger` - danger
      */
     export type HealthEnum = typeof HealthEnum[keyof typeof HealthEnum];
 
@@ -19073,8 +19111,8 @@ export namespace Schemas {
 
     /**
      * * `critical` - Critical
-    * `warning` - Warning
-    * `info` - Info
+     * * `warning` - Warning
+     * * `info` - Info
      */
     export type HealthIssueSeverityEnum = typeof HealthIssueSeverityEnum[keyof typeof HealthIssueSeverityEnum];
 
@@ -19087,7 +19125,7 @@ export namespace Schemas {
 
     /**
      * * `active` - Active
-    * `resolved` - Resolved
+     * * `resolved` - Resolved
      */
     export type HealthIssueStatusEnum = typeof HealthIssueStatusEnum[keyof typeof HealthIssueStatusEnum];
 
@@ -19103,15 +19141,15 @@ export namespace Schemas {
       /** Which health check produced this issue (e.g. 'sdk_outdated', 'external_data_failure', 'no_live_events', 'ingestion_warnings'). Stable string key — use it to filter issues by category. */
       readonly kind: string;
       /** How serious the issue is: 'critical', 'warning', or 'info'.
-
-      * `critical` - Critical
-      * `warning` - Warning
-      * `info` - Info */
+       *
+       * * `critical` - Critical
+       * * `warning` - Warning
+       * * `info` - Info */
       readonly severity: HealthIssueSeverityEnum;
       /** 'active' while the underlying problem is still detected; 'resolved' once a later check run no longer finds it.
-
-      * `active` - Active
-      * `resolved` - Resolved */
+       *
+       * * `active` - Active
+       * * `resolved` - Resolved */
       readonly status: HealthIssueStatusEnum;
       /** Whether a user has dismissed this issue from the Health UI. Dismissed issues stay in the list but are hidden by default. */
       dismissed?: boolean;
@@ -19142,11 +19180,11 @@ export namespace Schemas {
 
     /**
      * Single-issue view that adds the rendered, human-readable explanation.
-
-    `render_alert` produces the per-issue title/summary/link; `remediation` is
-    the static, kind-level fix-it guide (split into a human and an agent half).
-    Together they let the detail view explain what's wrong and how to fix it
-    without the caller having to interpret the raw payload.
+     *
+     * `render_alert` produces the per-issue title/summary/link; `remediation` is
+     * the static, kind-level fix-it guide (split into a human and an agent half).
+     * Together they let the detail view explain what's wrong and how to fix it
+     * without the caller having to interpret the raw payload.
      */
     export interface HealthIssueDetail {
       /** Unique identifier for the health issue. */
@@ -19154,15 +19192,15 @@ export namespace Schemas {
       /** Which health check produced this issue (e.g. 'sdk_outdated', 'external_data_failure', 'no_live_events', 'ingestion_warnings'). Stable string key — use it to filter issues by category. */
       readonly kind: string;
       /** How serious the issue is: 'critical', 'warning', or 'info'.
-
-      * `critical` - Critical
-      * `warning` - Warning
-      * `info` - Info */
+       *
+       * * `critical` - Critical
+       * * `warning` - Warning
+       * * `info` - Info */
       readonly severity: HealthIssueSeverityEnum;
       /** 'active' while the underlying problem is still detected; 'resolved' once a later check run no longer finds it.
-
-      * `active` - Active
-      * `resolved` - Resolved */
+       *
+       * * `active` - Active
+       * * `resolved` - Resolved */
       readonly status: HealthIssueStatusEnum;
       /** Whether a user has dismissed this issue from the Health UI. Dismissed issues stay in the list but are hidden by default. */
       dismissed?: boolean;
@@ -19246,8 +19284,8 @@ export namespace Schemas {
 
     /**
      * * `screenshot` - Screenshot
-    * `iframe` - Iframe
-    * `recording` - Recording
+     * * `iframe` - Iframe
+     * * `recording` - Recording
      */
     export type HeatmapType = typeof HeatmapType[keyof typeof HeatmapType];
 
@@ -19260,8 +19298,8 @@ export namespace Schemas {
 
     /**
      * * `processing` - Processing
-    * `completed` - Completed
-    * `failed` - Failed
+     * * `completed` - Completed
+     * * `failed` - Failed
      */
     export type HeatmapScreenshotResponseStatusEnum = typeof HeatmapScreenshotResponseStatusEnum[keyof typeof HeatmapScreenshotResponseStatusEnum];
 
@@ -19303,16 +19341,16 @@ export namespace Schemas {
       /** Viewport widths (CSS pixels) the screenshot is rendered at. */
       target_widths?: unknown;
       /** Render mode: 'screenshot', 'iframe', or 'recording'.
-
-      * `screenshot` - Screenshot
-      * `iframe` - Iframe
-      * `recording` - Recording */
+       *
+       * * `screenshot` - Screenshot
+       * * `iframe` - Iframe
+       * * `recording` - Recording */
       type?: HeatmapType;
       /** Screenshot generation status: 'processing', 'completed', or 'failed'.
-
-      * `processing` - Processing
-      * `completed` - Completed
-      * `failed` - Failed */
+       *
+       * * `processing` - Processing
+       * * `completed` - Completed
+       * * `failed` - Failed */
       readonly status: HeatmapScreenshotResponseStatusEnum;
       /** Whether at least one rendered image is ready to fetch. */
       readonly has_content: boolean;
@@ -19351,8 +19389,8 @@ export namespace Schemas {
 
     /**
      * * `draft` - Draft
-    * `active` - Active
-    * `archived` - Archived
+     * * `active` - Active
+     * * `archived` - Archived
      */
     export type HogFlowStatusEnum = typeof HogFlowStatusEnum[keyof typeof HogFlowStatusEnum];
 
@@ -19384,7 +19422,7 @@ export namespace Schemas {
 
     /**
      * * `continue` - continue
-    * `branch` - branch
+     * * `branch` - branch
      */
     export type HogFlowEdgeTypeEnum = typeof HogFlowEdgeTypeEnum[keyof typeof HogFlowEdgeTypeEnum];
 
@@ -19398,9 +19436,9 @@ export namespace Schemas {
       /** Target action id. */
       to: string;
       /** continue: fall-through (sequential or the no-match path of conditional_branch). branch: requires 'index' matching config.conditions[index].
-
-      * `continue` - continue
-      * `branch` - branch */
+       *
+       * * `continue` - continue
+       * * `branch` - branch */
       type: HogFlowEdgeTypeEnum;
       /** Required for type='branch'. Index into config.conditions on conditional_branch / wait_until_condition. */
       index?: number;
@@ -19410,9 +19448,9 @@ export namespace Schemas {
 
     /**
      * * `continue` - continue
-    * `abort` - abort
-    * `complete` - complete
-    * `branch` - branch
+     * * `abort` - abort
+     * * `complete` - complete
+     * * `branch` - branch
      */
     export type OnErrorEnum = typeof OnErrorEnum[keyof typeof OnErrorEnum];
 
@@ -19426,8 +19464,8 @@ export namespace Schemas {
 
     /**
      * * `events` - events
-    * `person-updates` - person-updates
-    * `data-warehouse-table` - data-warehouse-table
+     * * `person-updates` - person-updates
+     * * `data-warehouse-table` - data-warehouse-table
      */
     export type HogFunctionFiltersSourceEnum = typeof HogFunctionFiltersSourceEnum[keyof typeof HogFunctionFiltersSourceEnum];
 
@@ -19469,11 +19507,11 @@ export namespace Schemas {
       /** Optional description. */
       description?: string;
       /** On failure: continue (skip), abort (stop), complete (mark done), branch (follow error edge).
-
-      * `continue` - continue
-      * `abort` - abort
-      * `complete` - complete
-      * `branch` - branch */
+       *
+       * * `continue` - continue
+       * * `abort` - abort
+       * * `complete` - complete
+       * * `branch` - branch */
       on_error?: OnErrorEnum | null;
       /** Created at (epoch ms). Frontend-managed. */
       created_at?: number;
@@ -19494,8 +19532,8 @@ export namespace Schemas {
 
     /**
      * * `active` - Active
-    * `paused` - Paused
-    * `completed` - Completed
+     * * `paused` - Paused
+     * * `completed` - Completed
      */
     export type HogFlowScheduleStatusEnum = typeof HogFlowScheduleStatusEnum[keyof typeof HogFlowScheduleStatusEnum];
 
@@ -19520,10 +19558,10 @@ export namespace Schemas {
       /** Variable value overrides merged with the workflow defaults on each run. */
       variables?: unknown;
       /** active, paused, or completed (set once the RRULE's COUNT/UNTIL is exhausted).
-
-      * `active` - Active
-      * `paused` - Paused
-      * `completed` - Completed */
+       *
+       * * `active` - Active
+       * * `paused` - Paused
+       * * `completed` - Completed */
       readonly status: HogFlowScheduleStatusEnum;
       /**
          * Next scheduled fire time, computed by the scheduler.
@@ -19546,10 +19584,10 @@ export namespace Schemas {
       description?: string;
       readonly version: number;
       /** draft (no execution), active (live), archived (disabled).
-
-      * `draft` - Draft
-      * `active` - Active
-      * `archived` - Archived */
+       *
+       * * `draft` - Draft
+       * * `active` - Active
+       * * `archived` - Archived */
       status?: HogFlowStatusEnum;
       readonly created_at: string;
       readonly created_by: UserBasic;
@@ -19560,11 +19598,11 @@ export namespace Schemas {
       /** Conversion goal: {filters: [<cond>, ...], window_minutes}. <cond>: {key, value, operator, type: event|person|group}. Empty filters = any event in window. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
       conversion?: unknown;
       /** exit_only_at_end: only at exit node (default). exit_on_conversion: also on conversion (needs 'conversion'; silent no-op otherwise). exit_on_trigger_not_matched: also when trigger filter stops matching. exit_on_trigger_not_matched_or_conversion: both (needs 'conversion').
-
-      * `exit_on_conversion` - Conversion
-      * `exit_on_trigger_not_matched` - Trigger Not Matched
-      * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
-      * `exit_only_at_end` - Only At End */
+       *
+       * * `exit_on_conversion` - Conversion
+       * * `exit_on_trigger_not_matched` - Trigger Not Matched
+       * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+       * * `exit_only_at_end` - Only At End */
       exit_condition?: ExitConditionEnum;
       /** Graph edges: [{from, to, type: 'continue'|'branch', index?}]. 'continue' = fall-through (sequential, or no-match path of conditional_branch). 'branch' requires 'index': matches config.conditions[index] on conditional_branch / wait_until_condition. Every non-exit action needs a reachable next action ('No next action found' otherwise). */
       edges?: HogFlowEdge[];
@@ -19581,11 +19619,11 @@ export namespace Schemas {
 
     /**
      * * `waiting` - Waiting
-    * `queued` - Queued
-    * `active` - Active
-    * `completed` - Completed
-    * `cancelled` - Cancelled
-    * `failed` - Failed
+     * * `queued` - Queued
+     * * `active` - Active
+     * * `completed` - Completed
+     * * `cancelled` - Cancelled
+     * * `failed` - Failed
      */
     export type HogFlowBatchJobStatusEnum = typeof HogFlowBatchJobStatusEnum[keyof typeof HogFlowBatchJobStatusEnum];
 
@@ -19602,13 +19640,13 @@ export namespace Schemas {
     export interface HogFlowBatchJob {
       readonly id: string;
       /** Not currently tracked — stays at its initial value. Use the workflow logs/metrics endpoints for run outcome.
-
-      * `waiting` - Waiting
-      * `queued` - Queued
-      * `active` - Active
-      * `completed` - Completed
-      * `cancelled` - Cancelled
-      * `failed` - Failed */
+       *
+       * * `waiting` - Waiting
+       * * `queued` - Queued
+       * * `active` - Active
+       * * `completed` - Completed
+       * * `cancelled` - Cancelled
+       * * `failed` - Failed */
       status?: HogFlowBatchJobStatusEnum;
       /** ID of the workflow this batch run belongs to. */
       hog_flow: string;
@@ -19671,8 +19709,8 @@ export namespace Schemas {
 
     /**
      * * `team` - Only team
-    * `organization` - Organization
-    * `global` - Global
+     * * `organization` - Organization
+     * * `global` - Global
      */
     export type HogFlowTemplateScopeEnum = typeof HogFlowTemplateScopeEnum[keyof typeof HogFlowTemplateScopeEnum];
 
@@ -19685,7 +19723,7 @@ export namespace Schemas {
 
     /**
      * Custom action serializer for templates that skips input validation
-    (since templates should have default/empty values).
+     * (since templates should have default/empty values).
      */
     export interface HogFlowTemplateAction {
       id: string;
@@ -19704,7 +19742,7 @@ export namespace Schemas {
 
     /**
      * Serializer for creating hog flow templates.
-    Validates and sanitizes the workflow before creating it as a template.
+     * Validates and sanitizes the workflow before creating it as a template.
      */
     export interface HogFlowTemplate {
       readonly id: string;
@@ -19738,7 +19776,7 @@ export namespace Schemas {
 
     /**
      * * `hog` - hog
-    * `liquid` - liquid
+     * * `liquid` - liquid
      */
     export type HogFunctionTemplatingEnum = typeof HogFunctionTemplatingEnum[keyof typeof HogFunctionTemplatingEnum];
 
@@ -19763,12 +19801,12 @@ export namespace Schemas {
 
     /**
      * * `destination` - Destination
-    * `site_destination` - Site Destination
-    * `internal_destination` - Internal Destination
-    * `source_webhook` - Source Webhook
-    * `warehouse_source_webhook` - Warehouse Source Webhook
-    * `site_app` - Site App
-    * `transformation` - Transformation
+     * * `site_destination` - Site Destination
+     * * `internal_destination` - Internal Destination
+     * * `source_webhook` - Source Webhook
+     * * `warehouse_source_webhook` - Warehouse Source Webhook
+     * * `site_app` - Site App
+     * * `transformation` - Transformation
      */
     export type HogFunctionTypeEnum = typeof HogFunctionTypeEnum[keyof typeof HogFunctionTypeEnum];
 
@@ -19785,19 +19823,19 @@ export namespace Schemas {
 
     /**
      * * `string` - string
-    * `number` - number
-    * `boolean` - boolean
-    * `dictionary` - dictionary
-    * `choice` - choice
-    * `json` - json
-    * `integration` - integration
-    * `integration_field` - integration_field
-    * `email` - email
-    * `native_email` - native_email
-    * `posthog_assignee` - posthog_assignee
-    * `posthog_ticket_tags` - posthog_ticket_tags
-    * `posthog_business_hours` - posthog_business_hours
-    * `non_failure_status_codes` - non_failure_status_codes
+     * * `number` - number
+     * * `boolean` - boolean
+     * * `dictionary` - dictionary
+     * * `choice` - choice
+     * * `json` - json
+     * * `integration` - integration
+     * * `integration_field` - integration_field
+     * * `email` - email
+     * * `native_email` - native_email
+     * * `posthog_assignee` - posthog_assignee
+     * * `posthog_ticket_tags` - posthog_ticket_tags
+     * * `posthog_business_hours` - posthog_business_hours
+     * * `non_failure_status_codes` - non_failure_status_codes
      */
     export type InputsSchemaItemTypeEnum = typeof InputsSchemaItemTypeEnum[keyof typeof InputsSchemaItemTypeEnum];
 
@@ -19942,11 +19980,11 @@ export namespace Schemas {
 
     /**
      * * `0` - 0
-    * `1` - 1
-    * `2` - 2
-    * `3` - 3
-    * `11` - 11
-    * `12` - 12
+     * * `1` - 1
+     * * `2` - 2
+     * * `3` - 3
+     * * `11` - 11
+     * * `12` - 12
      */
     export type HogFunctionStatusStateEnum = typeof HogFunctionStatusStateEnum[keyof typeof HogFunctionStatusStateEnum];
 
@@ -19968,14 +20006,14 @@ export namespace Schemas {
     export interface HogFunction {
       readonly id: string;
       /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
-
-      * `destination` - Destination
-      * `site_destination` - Site Destination
-      * `internal_destination` - Internal Destination
-      * `source_webhook` - Source Webhook
-      * `warehouse_source_webhook` - Warehouse Source Webhook
-      * `site_app` - Site App
-      * `transformation` - Transformation */
+       *
+       * * `destination` - Destination
+       * * `site_destination` - Site Destination
+       * * `internal_destination` - Internal Destination
+       * * `source_webhook` - Source Webhook
+       * * `warehouse_source_webhook` - Warehouse Source Webhook
+       * * `site_app` - Site App
+       * * `transformation` - Transformation */
       type?: HogFunctionTypeEnum | null;
       /**
          * Display name for the function.
@@ -20804,7 +20842,7 @@ export namespace Schemas {
       /** count of all mouse activity in the recording, not just clicks */
       mouse_activity_count?: number | null;
       /** whether we have received data for this recording in the last 5 minutes (assumes the recording was loaded from ClickHouse)
-      * */
+       * * */
       ongoing?: boolean | null;
       person?: PersonType | null;
       /** Length of recording in seconds. */
@@ -21115,9 +21153,9 @@ export namespace Schemas {
 
     /**
      * * `trends` - trends
-    * `funnel` - funnel
-    * `retention` - retention
-    * `sql` - sql
+     * * `funnel` - funnel
+     * * `retention` - retention
+     * * `sql` - sql
      */
     export type InsightTypeEnum = typeof InsightTypeEnum[keyof typeof InsightTypeEnum];
 
@@ -21131,10 +21169,10 @@ export namespace Schemas {
 
     /**
      * * `String` - String
-    * `Number` - Number
-    * `Boolean` - Boolean
-    * `List` - List
-    * `Date` - Date
+     * * `Number` - Number
+     * * `Boolean` - Boolean
+     * * `List` - List
+     * * `Date` - Date
      */
     export type InsightVariableTypeEnum = typeof InsightVariableTypeEnum[keyof typeof InsightVariableTypeEnum];
 
@@ -21156,12 +21194,12 @@ export namespace Schemas {
          */
       name: string;
       /** Variable type. Controls how the value is rendered and substituted in HogQL.
-
-      * `String` - String
-      * `Number` - Number
-      * `Boolean` - Boolean
-      * `List` - List
-      * `Date` - Date */
+       *
+       * * `String` - String
+       * * `Number` - Number
+       * * `Boolean` - Boolean
+       * * `List` - List
+       * * `Date` - Date */
       type: InsightVariableTypeEnum;
       /** Default value used when a query references this variable. */
       default_value?: unknown;
@@ -21197,7 +21235,7 @@ export namespace Schemas {
 
     /**
      * * `api_key` - api_key
-    * `oauth` - oauth
+     * * `oauth` - oauth
      */
     export type InstallCustomAuthTypeEnum = typeof InstallCustomAuthTypeEnum[keyof typeof InstallCustomAuthTypeEnum];
 
@@ -21209,7 +21247,7 @@ export namespace Schemas {
 
     /**
      * * `posthog` - posthog
-    * `posthog-code` - posthog-code
+     * * `posthog-code` - posthog-code
      */
     export type InstallSourceEnum = typeof InstallSourceEnum[keyof typeof InstallSourceEnum];
 
@@ -21242,41 +21280,41 @@ export namespace Schemas {
 
     /**
      * * `anthropic` - Anthropic
-    * `apns` - Apple Push
-    * `azure-blob` - Azure Blob
-    * `bing-ads` - Bing Ads
-    * `clickup` - Clickup
-    * `customerio-app` - Customerio App
-    * `customerio-track` - Customerio Track
-    * `customerio-webhook` - Customerio Webhook
-    * `databricks` - Databricks
-    * `email` - Email
-    * `firebase` - Firebase
-    * `github` - Github
-    * `gitlab` - Gitlab
-    * `google-ads` - Google Ads
-    * `google-cloud-service-account` - Google Cloud Service Account
-    * `google-cloud-storage` - Google Cloud Storage
-    * `google-pubsub` - Google Pubsub
-    * `google-search-console` - Google Search Console
-    * `google-sheets` - Google Sheets
-    * `hubspot` - Hubspot
-    * `intercom` - Intercom
-    * `jira` - Jira
-    * `linear` - Linear
-    * `linkedin-ads` - Linkedin Ads
-    * `meta-ads` - Meta Ads
-    * `pinterest-ads` - Pinterest Ads
-    * `postgresql` - Postgresql
-    * `reddit-ads` - Reddit Ads
-    * `salesforce` - Salesforce
-    * `slack` - Slack
-    * `slack-posthog-code` - Slack Posthog Code
-    * `snapchat` - Snapchat
-    * `stripe` - Stripe
-    * `tiktok-ads` - Tiktok Ads
-    * `twilio` - Twilio
-    * `vercel` - Vercel
+     * * `apns` - Apple Push
+     * * `azure-blob` - Azure Blob
+     * * `bing-ads` - Bing Ads
+     * * `clickup` - Clickup
+     * * `customerio-app` - Customerio App
+     * * `customerio-track` - Customerio Track
+     * * `customerio-webhook` - Customerio Webhook
+     * * `databricks` - Databricks
+     * * `email` - Email
+     * * `firebase` - Firebase
+     * * `github` - Github
+     * * `gitlab` - Gitlab
+     * * `google-ads` - Google Ads
+     * * `google-cloud-service-account` - Google Cloud Service Account
+     * * `google-cloud-storage` - Google Cloud Storage
+     * * `google-pubsub` - Google Pubsub
+     * * `google-search-console` - Google Search Console
+     * * `google-sheets` - Google Sheets
+     * * `hubspot` - Hubspot
+     * * `intercom` - Intercom
+     * * `jira` - Jira
+     * * `linear` - Linear
+     * * `linkedin-ads` - Linkedin Ads
+     * * `meta-ads` - Meta Ads
+     * * `pinterest-ads` - Pinterest Ads
+     * * `postgresql` - Postgresql
+     * * `reddit-ads` - Reddit Ads
+     * * `salesforce` - Salesforce
+     * * `slack` - Slack
+     * * `slack-posthog-code` - Slack Posthog Code
+     * * `snapchat` - Snapchat
+     * * `stripe` - Stripe
+     * * `tiktok-ads` - Tiktok Ads
+     * * `twilio` - Twilio
+     * * `vercel` - Vercel
      */
     export type IntegrationKindEnum = typeof IntegrationKindEnum[keyof typeof IntegrationKindEnum];
 
@@ -21450,8 +21488,8 @@ export namespace Schemas {
 
     /**
      * * `text` - Text
-    * `url` - URL
-    * `file` - File
+     * * `url` - URL
+     * * `file` - File
      */
     export type KnowledgeSourceSourceTypeEnum = typeof KnowledgeSourceSourceTypeEnum[keyof typeof KnowledgeSourceSourceTypeEnum];
 
@@ -21464,9 +21502,9 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-    * `processing` - Processing
-    * `ready` - Ready
-    * `error` - Error
+     * * `processing` - Processing
+     * * `ready` - Ready
+     * * `error` - Error
      */
     export type KnowledgeSourceStatusEnum = typeof KnowledgeSourceStatusEnum[keyof typeof KnowledgeSourceStatusEnum];
 
@@ -21480,8 +21518,8 @@ export namespace Schemas {
 
     /**
      * * `success` - Success
-    * `not_modified` - Not modified
-    * `error` - Error
+     * * `not_modified` - Not modified
+     * * `error` - Error
      */
     export type LastRefreshStatusEnum = typeof LastRefreshStatusEnum[keyof typeof LastRefreshStatusEnum];
 
@@ -21494,10 +21532,10 @@ export namespace Schemas {
 
     /**
      * * `manual` - Manual only
-    * `1h` - Every hour
-    * `6h` - Every 6 hours
-    * `24h` - Every day
-    * `7d` - Every week
+     * * `1h` - Every hour
+     * * `6h` - Every 6 hours
+     * * `24h` - Every day
+     * * `7d` - Every week
      */
     export type RefreshIntervalEnum = typeof RefreshIntervalEnum[keyof typeof RefreshIntervalEnum];
 
@@ -21946,9 +21984,9 @@ export namespace Schemas {
 
     /**
      * * `today` - today
-    * `this_week` - this_week
-    * `inactive` - inactive
-    * `never` - never
+     * * `this_week` - this_week
+     * * `inactive` - inactive
+     * * `never` - never
      */
     export type LastActiveEnum = typeof LastActiveEnum[keyof typeof LastActiveEnum];
 
@@ -21971,8 +22009,8 @@ export namespace Schemas {
 
     /**
      * * `preserve` - preserve
-    * `two_column` - two_column
-    * `full_width` - full_width
+     * * `two_column` - two_column
+     * * `full_width` - full_width
      */
     export type LayoutEnum = typeof LayoutEnum[keyof typeof LayoutEnum];
 
@@ -22010,7 +22048,7 @@ export namespace Schemas {
 
     /**
      * * `burst` - burst
-    * `sustained` - sustained
+     * * `sustained` - sustained
      */
     export type LimitTypeEnum = typeof LimitTypeEnum[keyof typeof LimitTypeEnum];
 
@@ -22027,17 +22065,17 @@ export namespace Schemas {
       /** ID of the file download batch export run. */
       id: string;
       /** Current status of the file download batch export run.
-
-      * `Cancelled` - Cancelled
-      * `Completed` - Completed
-      * `ContinuedAsNew` - Continued As New
-      * `Failed` - Failed
-      * `FailedRetryable` - Failed Retryable
-      * `FailedBilling` - Failed Billing
-      * `Terminated` - Terminated
-      * `TimedOut` - Timedout
-      * `Running` - Running
-      * `Starting` - Starting */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Completed` - Completed
+       * * `ContinuedAsNew` - Continued As New
+       * * `Failed` - Failed
+       * * `FailedRetryable` - Failed Retryable
+       * * `FailedBilling` - Failed Billing
+       * * `Terminated` - Terminated
+       * * `TimedOut` - Timedout
+       * * `Running` - Running
+       * * `Starting` - Starting */
       status: BatchExportRunStatusEnum;
     }
 
@@ -22066,7 +22104,7 @@ export namespace Schemas {
 
     /**
      * * `above` - Above
-    * `below` - Below
+     * * `below` - Below
      */
     export type ThresholdOperatorEnum = typeof ThresholdOperatorEnum[keyof typeof ThresholdOperatorEnum];
 
@@ -22078,11 +22116,11 @@ export namespace Schemas {
 
     /**
      * * `not_firing` - Not firing
-    * `firing` - Firing
-    * `pending_resolve` - Pending resolve
-    * `errored` - Errored
-    * `snoozed` - Snoozed
-    * `broken` - Broken
+     * * `firing` - Firing
+     * * `pending_resolve` - Pending resolve
+     * * `errored` - Errored
+     * * `snoozed` - Snoozed
+     * * `broken` - Broken
      */
     export type LogsAlertConfigurationStateEnum = typeof LogsAlertConfigurationStateEnum[keyof typeof LogsAlertConfigurationStateEnum];
 
@@ -22102,13 +22140,13 @@ export namespace Schemas {
       /** Interval end (UTC, exclusive). */
       end: string;
       /** Alert state during this interval.
-
-      * `not_firing` - Not firing
-      * `firing` - Firing
-      * `pending_resolve` - Pending resolve
-      * `errored` - Errored
-      * `snoozed` - Snoozed
-      * `broken` - Broken */
+       *
+       * * `not_firing` - Not firing
+       * * `firing` - Firing
+       * * `pending_resolve` - Pending resolve
+       * * `errored` - Errored
+       * * `snoozed` - Snoozed
+       * * `broken` - Broken */
       state: LogsAlertConfigurationStateEnum;
       /** Whether the alert was enabled during this interval. Disabled alerts keep their state but are inactive. */
       enabled: boolean;
@@ -22116,7 +22154,7 @@ export namespace Schemas {
 
     /**
      * * `slack` - slack
-    * `webhook` - webhook
+     * * `webhook` - webhook
      */
     export type NotificationDestinationTypeEnum = typeof NotificationDestinationTypeEnum[keyof typeof NotificationDestinationTypeEnum];
 
@@ -22144,22 +22182,22 @@ export namespace Schemas {
          */
       threshold_count?: number;
       /** Whether the alert fires when the count is above or below the threshold.
-
-      * `above` - Above
-      * `below` - Below */
+       *
+       * * `above` - Above
+       * * `below` - Below */
       threshold_operator?: ThresholdOperatorEnum;
       /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
       window_minutes?: number;
       /** How often the alert is evaluated, in minutes. Server-managed. */
       readonly check_interval_minutes: number;
       /** Current alert state: not_firing, firing, pending_resolve, errored, or snoozed. Server-managed.
-
-      * `not_firing` - Not firing
-      * `firing` - Firing
-      * `pending_resolve` - Pending resolve
-      * `errored` - Errored
-      * `snoozed` - Snoozed
-      * `broken` - Broken */
+       *
+       * * `not_firing` - Not firing
+       * * `firing` - Firing
+       * * `pending_resolve` - Pending resolve
+       * * `errored` - Errored
+       * * `snoozed` - Snoozed
+       * * `broken` - Broken */
       readonly state: LogsAlertConfigurationStateEnum;
       /**
          * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
@@ -22226,9 +22264,9 @@ export namespace Schemas {
 
     export interface LogsAlertCreateDestination {
       /** Destination type — slack or webhook.
-
-      * `slack` - slack
-      * `webhook` - webhook */
+       *
+       * * `slack` - slack
+       * * `webhook` - webhook */
       type: NotificationDestinationTypeEnum;
       /** Integration ID for the Slack workspace. Required when type=slack. */
       slack_workspace_id?: number;
@@ -22254,13 +22292,13 @@ export namespace Schemas {
 
     /**
      * * `check` - Check
-    * `reset` - Reset
-    * `enable` - Enable
-    * `disable` - Disable
-    * `snooze` - Snooze
-    * `unsnooze` - Unsnooze
-    * `threshold_change` - Threshold change
-    * `broken_config` - Broken config
+     * * `reset` - Reset
+     * * `enable` - Enable
+     * * `disable` - Disable
+     * * `snooze` - Snooze
+     * * `unsnooze` - Unsnooze
+     * * `threshold_change` - Threshold change
+     * * `broken_config` - Broken config
      */
     export type LogsAlertEventKindEnum = typeof LogsAlertEventKindEnum[keyof typeof LogsAlertEventKindEnum];
 
@@ -22315,9 +22353,9 @@ export namespace Schemas {
          */
       threshold_count: number;
       /** Whether the alert fires when the count is above or below the threshold.
-
-      * `above` - Above
-      * `below` - Below */
+       *
+       * * `above` - Above
+       * * `below` - Below */
       threshold_operator: ThresholdOperatorEnum;
       /** Window size in minutes — determines bucket interval. */
       window_minutes: number;
@@ -22367,8 +22405,8 @@ export namespace Schemas {
 
     /**
      * * `severity_sampling` - Severity-based reduction
-    * `path_drop` - Path exclusion
-    * `rate_limit` - Rate limit
+     * * `path_drop` - Path exclusion
+     * * `rate_limit` - Rate limit
      */
     export type RuleTypeEnum = typeof RuleTypeEnum[keyof typeof RuleTypeEnum];
 
@@ -22396,10 +22434,10 @@ export namespace Schemas {
          */
       priority?: number | null;
       /** Rule kind: severity_sampling, path_drop, or rate_limit (caps matching log volume at ingestion).
-
-      * `severity_sampling` - Severity-based reduction
-      * `path_drop` - Path exclusion
-      * `rate_limit` - Rate limit */
+       *
+       * * `severity_sampling` - Severity-based reduction
+       * * `path_drop` - Path exclusion
+       * * `rate_limit` - Rate limit */
       rule_type: RuleTypeEnum;
       /**
          * Optional legacy service-name scope; new rules use `config.filter_group` for matching instead.
@@ -22458,7 +22496,7 @@ export namespace Schemas {
 
     /**
      * * `feedback` - Feedback
-    * `missing_capability` - Missing capability
+     * * `missing_capability` - Missing capability
      */
     export type MCPAnalyticsSubmissionKindEnum = typeof MCPAnalyticsSubmissionKindEnum[keyof typeof MCPAnalyticsSubmissionKindEnum];
 
@@ -22472,9 +22510,9 @@ export namespace Schemas {
       /** Unique identifier for this submission. */
       readonly id: string;
       /** Whether this submission is general feedback or a missing capability report.
-
-      * `feedback` - Feedback
-      * `missing_capability` - Missing capability */
+       *
+       * * `feedback` - Feedback
+       * * `missing_capability` - Missing capability */
       readonly kind: MCPAnalyticsSubmissionKindEnum;
       /** The user's goal in plain language. */
       goal: string;
@@ -22509,7 +22547,7 @@ export namespace Schemas {
 
     /**
      * * `api_key` - API Key
-    * `oauth` - OAuth
+     * * `oauth` - OAuth
      */
     export type MCPAuthTypeEnum = typeof MCPAuthTypeEnum[keyof typeof MCPAuthTypeEnum];
 
@@ -22521,10 +22559,10 @@ export namespace Schemas {
 
     /**
      * * `results` - Results
-    * `usability` - Usability
-    * `bug` - Bug
-    * `docs` - Docs
-    * `other` - Other
+     * * `usability` - Usability
+     * * `bug` - Bug
+     * * `docs` - Docs
+     * * `other` - Other
      */
     export type MCPFeedbackCreateCategoryEnum = typeof MCPFeedbackCreateCategoryEnum[keyof typeof MCPFeedbackCreateCategoryEnum];
 
@@ -22584,12 +22622,12 @@ export namespace Schemas {
          */
       feedback: string;
       /** High-level category for the feedback.
-
-      * `results` - Results
-      * `usability` - Usability
-      * `bug` - Bug
-      * `docs` - Docs
-      * `other` - Other */
+       *
+       * * `results` - Results
+       * * `usability` - Usability
+       * * `bug` - Bug
+       * * `docs` - Docs
+       * * `other` - Other */
       category?: MCPFeedbackCreateCategoryEnum;
     }
 
@@ -22608,7 +22646,7 @@ export namespace Schemas {
 
     /**
      * * `completed` - Completed
-    * `error` - Error
+     * * `error` - Error
      */
     export type OutcomeEnum = typeof OutcomeEnum[keyof typeof OutcomeEnum];
 
@@ -22622,9 +22660,9 @@ export namespace Schemas {
       /** Ordered tool names called during the path. Length is fixed; null entries indicate the session ended before this step. */
       readonly steps: readonly (string | null)[];
       /** Terminal outcome of the sessions following this path.
-
-      * `completed` - Completed
-      * `error` - Error */
+       *
+       * * `completed` - Completed
+       * * `error` - Error */
       readonly outcome: OutcomeEnum;
       /** Number of sessions in this cluster that followed this exact path. */
       readonly count: number;
@@ -22666,8 +22704,8 @@ export namespace Schemas {
 
     /**
      * * `idle` - Idle
-    * `computing` - Computing
-    * `error` - Error
+     * * `computing` - Computing
+     * * `error` - Error
      */
     export type MCPIntentClusterSnapshotStatusEnum = typeof MCPIntentClusterSnapshotStatusEnum[keyof typeof MCPIntentClusterSnapshotStatusEnum];
 
@@ -22691,10 +22729,10 @@ export namespace Schemas {
 
     export interface MCPIntentClusterSnapshot {
       /** Whether a snapshot is current (idle), being recomputed (computing), or failed (error).
-
-      * `idle` - Idle
-      * `computing` - Computing
-      * `error` - Error */
+       *
+       * * `idle` - Idle
+       * * `computing` - Computing
+       * * `error` - Error */
       readonly status: MCPIntentClusterSnapshotStatusEnum;
       /** Error message from the most recent failed run, otherwise empty. */
       readonly error_message: string;
@@ -22787,8 +22825,8 @@ export namespace Schemas {
 
     /**
      * * `approved` - Approved
-    * `needs_approval` - Needs approval
-    * `do_not_use` - Do not use
+     * * `needs_approval` - Needs approval
+     * * `do_not_use` - Do not use
      */
     export type MCPServerInstallationToolApprovalStateEnum = typeof MCPServerInstallationToolApprovalStateEnum[keyof typeof MCPServerInstallationToolApprovalStateEnum];
 
@@ -22816,11 +22854,11 @@ export namespace Schemas {
 
     /**
      * * `business` - Business Operations
-    * `data` - Data & Analytics
-    * `design` - Design & Content
-    * `dev` - Developer Tools & APIs
-    * `infra` - Infrastructure
-    * `productivity` - Productivity & Collaboration
+     * * `data` - Data & Analytics
+     * * `design` - Design & Content
+     * * `dev` - Developer Tools & APIs
+     * * `infra` - Infrastructure
+     * * `productivity` - Productivity & Collaboration
      */
     export type MCPServerTemplateCategoryEnum = typeof MCPServerTemplateCategoryEnum[keyof typeof MCPServerTemplateCategoryEnum];
 
@@ -22921,7 +22959,7 @@ export namespace Schemas {
 
     /**
      * * `key` - key
-    * `value` - value
+     * * `value` - value
      */
     export type MatchedOnEnum = typeof MatchedOnEnum[keyof typeof MatchedOnEnum];
 
@@ -22955,9 +22993,9 @@ export namespace Schemas {
 
     /**
      * * `PENDING` - Pending
-    * `BACKFILL` - Backfill
-    * `READY` - Ready
-    * `ERROR` - Error
+     * * `BACKFILL` - Backfill
+     * * `READY` - Ready
+     * * `ERROR` - Error
      */
     export type MaterializedColumnSlotStateEnum = typeof MaterializedColumnSlotStateEnum[keyof typeof MaterializedColumnSlotStateEnum];
 
@@ -22994,8 +23032,8 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-    * `completed` - Completed
-    * `skipped` - Skipped
+     * * `completed` - Completed
+     * * `skipped` - Skipped
      */
     export type ScrapingStatusEnum = typeof ScrapingStatusEnum[keyof typeof ScrapingStatusEnum];
 
@@ -23115,10 +23153,10 @@ export namespace Schemas {
 
     /**
      * * `user_message` - user_message
-    * `cancel` - cancel
-    * `close` - close
-    * `permission_response` - permission_response
-    * `set_config_option` - set_config_option
+     * * `cancel` - cancel
+     * * `close` - close
+     * * `permission_response` - permission_response
+     * * `set_config_option` - set_config_option
      */
     export type MethodEnum = typeof MethodEnum[keyof typeof MethodEnum];
 
@@ -23133,8 +23171,8 @@ export namespace Schemas {
 
     /**
      * * `precise` - PRECISE
-    * `coarse` - COARSE
-    * `partial` - PARTIAL
+     * * `coarse` - COARSE
+     * * `partial` - PARTIAL
      */
     export type MetricQualityEnum = typeof MetricQualityEnum[keyof typeof MetricQualityEnum];
 
@@ -23202,8 +23240,8 @@ export namespace Schemas {
 
     /**
      * * `trusted` - Trusted
-    * `full` - Full
-    * `custom` - Custom
+     * * `full` - Full
+     * * `custom` - Custom
      */
     export type NetworkAccessLevelEnum = typeof NetworkAccessLevelEnum[keyof typeof NetworkAccessLevelEnum];
 
@@ -23216,9 +23254,9 @@ export namespace Schemas {
 
     /**
      * * `table` - Table
-    * `view` - View
-    * `matview` - Mat View
-    * `endpoint` - Endpoint
+     * * `view` - View
+     * * `matview` - Mat View
+     * * `endpoint` - Endpoint
      */
     export type NodeTypeEnum = typeof NodeTypeEnum[keyof typeof NodeTypeEnum];
 
@@ -23354,13 +23392,13 @@ export namespace Schemas {
 
     /**
      * * `replay` - REPLAY
-    * `notebook` - NOTEBOOK
-    * `insight` - INSIGHT
-    * `feature_flag` - FEATURE_FLAG
-    * `dashboard` - DASHBOARD
-    * `survey` - SURVEY
-    * `experiment` - EXPERIMENT
-    * `error_tracking` - ERROR_TRACKING
+     * * `notebook` - NOTEBOOK
+     * * `insight` - INSIGHT
+     * * `feature_flag` - FEATURE_FLAG
+     * * `dashboard` - DASHBOARD
+     * * `survey` - SURVEY
+     * * `experiment` - EXPERIMENT
+     * * `error_tracking` - ERROR_TRACKING
      */
     export type NotificationEventSourceTypeEnum = typeof NotificationEventSourceTypeEnum[keyof typeof NotificationEventSourceTypeEnum];
 
@@ -23516,10 +23554,10 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-    * `running` - Running
-    * `succeeded` - Succeeded
-    * `failed` - Failed
-    * `ineligible` - Ineligible
+     * * `running` - Running
+     * * `succeeded` - Succeeded
+     * * `failed` - Failed
+     * * `ineligible` - Ineligible
      */
     export type ObservationStatusEnum = typeof ObservationStatusEnum[keyof typeof ObservationStatusEnum];
 
@@ -23534,7 +23572,7 @@ export namespace Schemas {
 
     /**
      * * `schedule` - Schedule
-    * `on_demand` - On demand
+     * * `on_demand` - On demand
      */
     export type ObservationTriggerEnum = typeof ObservationTriggerEnum[keyof typeof ObservationTriggerEnum];
 
@@ -23585,7 +23623,7 @@ export namespace Schemas {
 
     /**
      * * `later` - Later
-    * `other` - Other
+     * * `other` - Other
      */
     export type OnboardingSkipRequestReasonEnum = typeof OnboardingSkipRequestReasonEnum[keyof typeof OnboardingSkipRequestReasonEnum];
 
@@ -23597,16 +23635,16 @@ export namespace Schemas {
 
     /**
      * Request body for POST /api/users/{id}/onboarding/skip/.
-
-    Source of truth for OpenAPI / generated TS / zod / MCP — bind this serializer at
-    runtime so the contract clients believe is enforced (length cap, choice validation,
-    no extra fields) is actually enforced server-side.
+     *
+     * Source of truth for OpenAPI / generated TS / zod / MCP — bind this serializer at
+     * runtime so the contract clients believe is enforced (length cap, choice validation,
+     * no extra fields) is actually enforced server-side.
      */
     export interface OnboardingSkipRequest {
       /** Why the user is leaving onboarding. 'later' keeps them able to return; 'other' is a catch-all. 'delegated' is rejected here — use the delegate endpoint so the delegation invite is created atomically.
-
-      * `later` - Later
-      * `other` - Other */
+       *
+       * * `later` - Later
+       * * `other` - Other */
       reason: OnboardingSkipRequestReasonEnum;
       /**
          * Onboarding step key the user was on when skipping, for analytics only.
@@ -23617,8 +23655,8 @@ export namespace Schemas {
 
     /**
      * * `delegated` - Delegated to teammate
-    * `later` - Skipped for later
-    * `other` - Other
+     * * `later` - Skipped for later
+     * * `other` - Other
      */
     export type OnboardingSkippedReasonEnum = typeof OnboardingSkippedReasonEnum[keyof typeof OnboardingSkippedReasonEnum];
 
@@ -23631,7 +23669,7 @@ export namespace Schemas {
 
     /**
      * * `latest` - latest
-    * `earliest` - earliest
+     * * `earliest` - earliest
      */
     export type OrderByEnum = typeof OrderByEnum[keyof typeof OrderByEnum];
 
@@ -23649,9 +23687,9 @@ export namespace Schemas {
 
     /**
      * * `0` - none
-    * `3` - config
-    * `6` - install
-    * `9` - root
+     * * `3` - config
+     * * `6` - install
+     * * `9` - root
      */
     export type PluginsAccessLevelEnum = typeof PluginsAccessLevelEnum[keyof typeof PluginsAccessLevelEnum];
 
@@ -23716,9 +23754,9 @@ export namespace Schemas {
       /** @nullable */
       readonly is_hipaa: boolean | null;
       /** Default statistical method for new experiments in this organization.
-
-      * `bayesian` - Bayesian
-      * `frequentist` - Frequentist */
+       *
+       * * `bayesian` - Bayesian
+       * * `frequentist` - Frequentist */
       default_experiment_stats_method?: DefaultExperimentStatsMethodEnum | BlankEnum | null;
       /** Default setting for 'Discard client IP data' for new projects in this organization. */
       default_anonymize_ips?: boolean;
@@ -23746,7 +23784,7 @@ export namespace Schemas {
 
     /**
      * Serializer for `Organization` model with minimal attributes to speeed up loading and transfer times.
-    Also used for nested serializers.
+     * Also used for nested serializers.
      */
     export interface OrganizationBasic {
       readonly id: string;
@@ -23826,7 +23864,10 @@ export namespace Schemas {
          * @nullable
          */
       id_jag_jwks_url?: string | null;
-      /** Allowed ID-JAG client IDs. Empty list allows any client_id. */
+      /**
+         * Allowed ID-JAG client IDs. Empty list allows any client_id.
+         * @items.maxLength 256
+         */
       id_jag_allowed_clients?: string[];
     }
 
@@ -23856,8 +23897,8 @@ export namespace Schemas {
 
     /**
      * * `1` - member
-    * `8` - administrator
-    * `15` - owner
+     * * `8` - administrator
+     * * `15` - owner
      */
     export type OrganizationMembershipLevelEnum = typeof OrganizationMembershipLevelEnum[keyof typeof OrganizationMembershipLevelEnum];
 
@@ -23974,14 +24015,14 @@ export namespace Schemas {
 
     /**
      * * `error_tracking` - Error Tracking
-    * `eval_clusters` - Eval Clusters
-    * `user_created` - User Created
-    * `automation` - Automation
-    * `slack` - Slack
-    * `support_queue` - Support Queue
-    * `session_summaries` - Session Summaries
-    * `signal_report` - Signal Report
-    * `signals_scout` - Signals Scout
+     * * `eval_clusters` - Eval Clusters
+     * * `user_created` - User Created
+     * * `automation` - Automation
+     * * `slack` - Slack
+     * * `support_queue` - Support Queue
+     * * `session_summaries` - Session Summaries
+     * * `signal_report` - Signal Report
+     * * `signals_scout` - Signals Scout
      */
     export type OriginProductEnum = typeof OriginProductEnum[keyof typeof OriginProductEnum];
 
@@ -24021,7 +24062,7 @@ export namespace Schemas {
 
     /**
      * * `healthy` - healthy
-    * `needs_attention` - needs_attention
+     * * `needs_attention` - needs_attention
      */
     export type OverallHealthEnum = typeof OverallHealthEnum[keyof typeof OverallHealthEnum];
 
@@ -24052,10 +24093,10 @@ export namespace Schemas {
       /** Pull request title. */
       title: string;
       /** Derived state: 'open', 'closed', or 'merged'.
-
-      * `open` - OPEN
-      * `closed` - CLOSED
-      * `merged` - MERGED */
+       *
+       * * `open` - OPEN
+       * * `closed` - CLOSED
+       * * `merged` - MERGED */
       state: EngineeringAnalyticsPRStateEnum;
       /** True if the pull request is a draft. */
       is_draft: boolean;
@@ -24075,10 +24116,10 @@ export namespace Schemas {
 
     /**
      * * `opened` - OPENED
-    * `ci_started` - CI_STARTED
-    * `ci_finished` - CI_FINISHED
-    * `merged` - MERGED
-    * `closed` - CLOSED
+     * * `ci_started` - CI_STARTED
+     * * `ci_finished` - CI_FINISHED
+     * * `merged` - MERGED
+     * * `closed` - CLOSED
      */
     export type PRLifecycleEventKindEnum = typeof PRLifecycleEventKindEnum[keyof typeof PRLifecycleEventKindEnum];
 
@@ -24093,12 +24134,12 @@ export namespace Schemas {
 
     export interface PRLifecycleEvent {
       /** Event kind: opened, ci_started, ci_finished, merged, or closed.
-
-      * `opened` - OPENED
-      * `ci_started` - CI_STARTED
-      * `ci_finished` - CI_FINISHED
-      * `merged` - MERGED
-      * `closed` - CLOSED */
+       *
+       * * `opened` - OPENED
+       * * `ci_started` - CI_STARTED
+       * * `ci_finished` - CI_FINISHED
+       * * `merged` - MERGED
+       * * `closed` - CLOSED */
       kind: PRLifecycleEventKindEnum;
       /** When the event occurred. */
       at: string;
@@ -24115,10 +24156,10 @@ export namespace Schemas {
       /** Lifecycle events ordered by time. */
       events: PRLifecycleEvent[];
       /** Always 'partial' — CI events only; reviews and comments are not yet available.
-
-      * `precise` - PRECISE
-      * `coarse` - COARSE
-      * `partial` - PARTIAL */
+       *
+       * * `precise` - PRECISE
+       * * `coarse` - COARSE
+       * * `partial` - PARTIAL */
       metric_quality?: MetricQualityEnum;
     }
 
@@ -25143,8 +25184,8 @@ export namespace Schemas {
 
     /**
      * * `home` - Home
-    * `pinned` - Pinned
-    * `custom_products` - Custom Products
+     * * `pinned` - Pinned
+     * * `custom_products` - Custom Products
      */
     export type PersistedFolderTypeEnum = typeof PersistedFolderTypeEnum[keyof typeof PersistedFolderTypeEnum];
 
@@ -25158,10 +25199,10 @@ export namespace Schemas {
     export interface PersistedFolder {
       readonly id: string;
       /** Which persisted folder this is for the user (home, pinned, custom_products).
-
-      * `home` - Home
-      * `pinned` - Pinned
-      * `custom_products` - Custom Products */
+       *
+       * * `home` - Home
+       * * `pinned` - Pinned
+       * * `custom_products` - Custom Products */
       type: PersistedFolderTypeEnum;
       /**
          * Protocol prefix of the folder location, e.g. 'products://'.
@@ -25213,8 +25254,8 @@ export namespace Schemas {
 
     /**
      * * `SYSTEM` - SYSTEM
-    * `PLUGIN` - PLUGIN
-    * `CONSOLE` - CONSOLE
+     * * `PLUGIN` - PLUGIN
+     * * `CONSOLE` - CONSOLE
      */
     export type PluginLogEntrySourceEnum = typeof PluginLogEntrySourceEnum[keyof typeof PluginLogEntrySourceEnum];
 
@@ -25227,10 +25268,10 @@ export namespace Schemas {
 
     /**
      * * `DEBUG` - DEBUG
-    * `LOG` - LOG
-    * `INFO` - INFO
-    * `WARN` - WARN
-    * `ERROR` - ERROR
+     * * `LOG` - LOG
+     * * `INFO` - INFO
+     * * `WARN` - WARN
+     * * `ERROR` - ERROR
      */
     export type PluginLogEntryTypeEnum = typeof PluginLogEntryTypeEnum[keyof typeof PluginLogEntryTypeEnum];
 
@@ -25310,9 +25351,9 @@ export namespace Schemas {
 
     /**
      * Like `ProjectBasicSerializer`, but also works as a drop-in replacement for `TeamBasicSerializer` by way of
-    passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
-    backward compatibility of the REST API.
-    Do not use this in greenfield endpoints!
+     * passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
+     * backward compatibility of the REST API.
+     * Do not use this in greenfield endpoints!
      */
     export interface ProjectBackwardCompatBasic {
       readonly id: number;
@@ -25388,11 +25429,11 @@ export namespace Schemas {
     export interface QueryTabState {
       readonly id: string;
       /**
-                  Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
-                  and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
-                  ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
-                  for a user.
-                   */
+       *             Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
+       *             and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
+       *             ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
+       *             for a user.
+       *              */
       state?: unknown;
     }
 
@@ -25407,7 +25448,7 @@ export namespace Schemas {
 
     /**
      * * `manual-options` - manual-options
-    * `auto-discovery` - auto-discovery
+     * * `auto-discovery` - auto-discovery
      */
     export type QuickFilterTypeEnum = typeof QuickFilterTypeEnum[keyof typeof QuickFilterTypeEnum];
 
@@ -25441,9 +25482,9 @@ export namespace Schemas {
 
     /**
      * * `monitor` - Monitor
-    * `classifier` - Classifier
-    * `scorer` - Scorer
-    * `summarizer` - Summarizer
+     * * `classifier` - Classifier
+     * * `scorer` - Scorer
+     * * `summarizer` - Summarizer
      */
     export type ScannerTypeEnum = typeof ScannerTypeEnum[keyof typeof ScannerTypeEnum];
 
@@ -25457,7 +25498,7 @@ export namespace Schemas {
 
     /**
      * * `gemini-3-flash-preview` - Gemini 3 Flash
-    * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
+     * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
      */
     export type ScannerModelEnum = typeof ScannerModelEnum[keyof typeof ScannerModelEnum];
 
@@ -25484,22 +25525,22 @@ export namespace Schemas {
       /** Scanner name at run time. */
       name: string;
       /** Scanner type (monitor, classifier, scorer, summarizer) at run time.
-
-      * `monitor` - Monitor
-      * `classifier` - Classifier
-      * `scorer` - Scorer
-      * `summarizer` - Summarizer */
+       *
+       * * `monitor` - Monitor
+       * * `classifier` - Classifier
+       * * `scorer` - Scorer
+       * * `summarizer` - Summarizer */
       scanner_type: ScannerTypeEnum;
       /** The `ReplayScanner.scanner_version` value at the moment the workflow ran. */
       scanner_version: number;
       /** Concrete model that ran the observation.
-
-      * `gemini-3-flash-preview` - Gemini 3 Flash
-      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+       *
+       * * `gemini-3-flash-preview` - Gemini 3 Flash
+       * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
       model: ScannerModelEnum;
       /** Concrete provider that ran the observation.
-
-      * `google` - Google */
+       *
+       * * `google` - Google */
       provider: ScannerProviderEnum;
       /** Whether the observation was run with Signal emission enabled. */
       emits_signals: boolean;
@@ -25527,12 +25568,12 @@ export namespace Schemas {
       /** Session recording id this scanner was applied to. */
       readonly session_id: string;
       /** Observation status (pending, running, succeeded, failed, ineligible).
-
-      * `pending` - Pending
-      * `running` - Running
-      * `succeeded` - Succeeded
-      * `failed` - Failed
-      * `ineligible` - Ineligible */
+       *
+       * * `pending` - Pending
+       * * `running` - Running
+       * * `succeeded` - Succeeded
+       * * `failed` - Failed
+       * * `ineligible` - Ineligible */
       readonly status: ObservationStatusEnum;
       /** Populated on terminal non-success statuses; formatted as `kind:human-readable message`. For `ineligible`, kind is one of no_recording / too_short / too_inactive / too_long / no_events. For `failed`, kind is one of provider_transient / provider_rejected / rasterization_failed / validation_failed / internal_error. */
       readonly error_reason: string;
@@ -25543,9 +25584,9 @@ export namespace Schemas {
       /** Result data persisted on success; null until the observation succeeds. */
       readonly scanner_result: ScannerResult | null;
       /** Whether this observation came from the schedule or an on-demand request.
-
-      * `schedule` - Schedule
-      * `on_demand` - On demand */
+       *
+       * * `schedule` - Schedule
+       * * `on_demand` - On demand */
       readonly triggered_by: ObservationTriggerEnum;
       /** User who triggered an on-demand observation; null for scheduled observations. */
       readonly triggered_by_user: UserBasic | null;
@@ -25575,11 +25616,11 @@ export namespace Schemas {
       /** Free-form description shown in the scanner management UI. */
       description?: string;
       /** What the scanner does: monitor, classifier, scorer, or summarizer.
-
-      * `monitor` - Monitor
-      * `classifier` - Classifier
-      * `scorer` - Scorer
-      * `summarizer` - Summarizer */
+       *
+       * * `monitor` - Monitor
+       * * `classifier` - Classifier
+       * * `scorer` - Scorer
+       * * `summarizer` - Summarizer */
       scanner_type: ScannerTypeEnum;
       /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
       scanner_config: unknown;
@@ -25592,13 +25633,13 @@ export namespace Schemas {
          */
       sampling_rate?: number;
       /** LLM provider. v1 is Google-only.
-
-      * `google` - Google */
+       *
+       * * `google` - Google */
       provider?: ScannerProviderEnum;
       /** Concrete model to use for this scanner.
-
-      * `gemini-3-flash-preview` - Gemini 3 Flash
-      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+       *
+       * * `gemini-3-flash-preview` - Gemini 3 Flash
+       * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
       model: ScannerModelEnum;
       /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
       enabled?: boolean;
@@ -25790,9 +25831,15 @@ export namespace Schemas {
       /** @maxLength 255 */
       name: string;
       network_access_level?: NetworkAccessLevelEnum;
-      /** List of allowed domains for custom network access */
+      /**
+         * List of allowed domains for custom network access
+         * @items.maxLength 255
+         */
       allowed_domains?: string[];
-      /** List of repositories this environment applies to (format: org/repo) */
+      /**
+         * List of repositories this environment applies to (format: org/repo)
+         * @items.maxLength 255
+         */
       repositories?: string[];
       /** If true, only the creator can see this environment. Otherwise visible to whole team. */
       private?: boolean;
@@ -25814,9 +25861,9 @@ export namespace Schemas {
 
     /**
      * * `daily` - daily
-    * `weekly` - weekly
-    * `monthly` - monthly
-    * `yearly` - yearly
+     * * `weekly` - weekly
+     * * `monthly` - monthly
+     * * `yearly` - yearly
      */
     export type RecurrenceIntervalEnum = typeof RecurrenceIntervalEnum[keyof typeof RecurrenceIntervalEnum];
 
@@ -25837,8 +25884,8 @@ export namespace Schemas {
          */
       record_id: string;
       /** The type of record to modify. Currently only "FeatureFlag" is supported.
-
-      * `FeatureFlag` - feature flag */
+       *
+       * * `FeatureFlag` - feature flag */
       model_name: ModelNameEnum;
       /** The change to apply. Must include an 'operation' key and a 'value' key. Supported operations: 'update_status' (value: true/false to enable/disable the flag), 'add_release_condition' (value: object with 'groups', 'payloads', and 'multivariate' keys), 'update_variants' (value: object with 'variants' and 'payloads' keys). */
       payload: unknown;
@@ -25857,11 +25904,11 @@ export namespace Schemas {
       /** Whether this schedule repeats. Only the 'update_status' operation supports recurring schedules. */
       is_recurring?: boolean;
       /** How often the schedule repeats. Required when is_recurring is true. One of: daily, weekly, monthly, yearly.
-
-      * `daily` - daily
-      * `weekly` - weekly
-      * `monthly` - monthly
-      * `yearly` - yearly */
+       *
+       * * `daily` - daily
+       * * `weekly` - weekly
+       * * `monthly` - monthly
+       * * `yearly` - yearly */
       recurrence_interval?: RecurrenceIntervalEnum | null;
       /**
          * @maxLength 100
@@ -25965,7 +26012,7 @@ export namespace Schemas {
 
     /**
      * Serializer for linking session recordings to external issue trackers.
-    Reuses error tracking's integration infrastructure
+     * Reuses error tracking's integration infrastructure
      */
     export interface SessionRecordingExternalRef {
       readonly id: string;
@@ -26052,7 +26099,7 @@ export namespace Schemas {
 
     /**
      * * `collection` - Collection
-    * `filters` - Filters
+     * * `filters` - Filters
      */
     export type SessionRecordingPlaylistTypeEnum = typeof SessionRecordingPlaylistTypeEnum[keyof typeof SessionRecordingPlaylistTypeEnum];
 
@@ -26092,9 +26139,9 @@ export namespace Schemas {
       readonly last_modified_by: UserBasic;
       readonly recordings_counts: SessionRecordingPlaylistRecordingsCounts;
       /** Playlist type: 'collection' for manually curated recordings, 'filters' for saved filter views. Required on create, cannot be changed after.
-
-      * `collection` - Collection
-      * `filters` - Filters */
+       *
+       * * `collection` - Collection
+       * * `filters` - Filters */
       type?: SessionRecordingPlaylistTypeEnum | null;
       /** Return whether this is a synthetic playlist */
       readonly is_synthetic: boolean;
@@ -26112,14 +26159,14 @@ export namespace Schemas {
 
     /**
      * * `potential` - Potential
-    * `candidate` - Candidate
-    * `in_progress` - In Progress
-    * `pending_input` - Pending Input
-    * `ready` - Ready
-    * `resolved` - Resolved
-    * `failed` - Failed
-    * `deleted` - Deleted
-    * `suppressed` - Suppressed
+     * * `candidate` - Candidate
+     * * `in_progress` - In Progress
+     * * `pending_input` - Pending Input
+     * * `ready` - Ready
+     * * `resolved` - Resolved
+     * * `failed` - Failed
+     * * `deleted` - Deleted
+     * * `suppressed` - Suppressed
      */
     export type SignalReportStatusEnum = typeof SignalReportStatusEnum[keyof typeof SignalReportStatusEnum];
 
@@ -26185,15 +26232,15 @@ export namespace Schemas {
 
     /**
      * * `session_replay` - Session replay
-    * `llm_analytics` - LLM analytics
-    * `github` - GitHub
-    * `linear` - Linear
-    * `zendesk` - Zendesk
-    * `conversations` - Conversations
-    * `error_tracking` - Error tracking
-    * `pganalyze` - pganalyze
-    * `signals_scout` - Signals scout
-    * `logs` - Logs
+     * * `llm_analytics` - LLM analytics
+     * * `github` - GitHub
+     * * `linear` - Linear
+     * * `zendesk` - Zendesk
+     * * `conversations` - Conversations
+     * * `error_tracking` - Error tracking
+     * * `pganalyze` - pganalyze
+     * * `signals_scout` - Signals scout
+     * * `logs` - Logs
      */
     export type SourceProductEnum = typeof SourceProductEnum[keyof typeof SourceProductEnum];
 
@@ -26213,14 +26260,14 @@ export namespace Schemas {
 
     /**
      * * `session_analysis_cluster` - Session analysis cluster
-    * `evaluation` - Evaluation
-    * `issue` - Issue
-    * `ticket` - Ticket
-    * `issue_created` - Issue created
-    * `issue_reopened` - Issue reopened
-    * `issue_spiking` - Issue spiking
-    * `cross_source_issue` - Cross source issue
-    * `alert_state_change` - Alert state change
+     * * `evaluation` - Evaluation
+     * * `issue` - Issue
+     * * `ticket` - Ticket
+     * * `issue_created` - Issue created
+     * * `issue_reopened` - Issue reopened
+     * * `issue_spiking` - Issue spiking
+     * * `cross_source_issue` - Cross source issue
+     * * `alert_state_change` - Alert state change
      */
     export type SignalSourceConfigSourceTypeEnum = typeof SignalSourceConfigSourceTypeEnum[keyof typeof SignalSourceConfigSourceTypeEnum];
 
@@ -26403,9 +26450,9 @@ export namespace Schemas {
 
     /**
      * * `starting` - Starting
-    * `completed` - Completed
-    * `failed` - Failed
-    * `skipped` - Skipped
+     * * `completed` - Completed
+     * * `failed` - Failed
+     * * `skipped` - Skipped
      */
     export type SubscriptionDeliveryStatusEnum = typeof SubscriptionDeliveryStatusEnum[keyof typeof SubscriptionDeliveryStatusEnum];
 
@@ -26437,18 +26484,22 @@ export namespace Schemas {
       readonly target_type: string;
       /** Destination snapshot at send time (emails, channel id, URL). */
       readonly target_value: string;
-      /** ExportedAsset ids generated for this send. */
+      /**
+         * ExportedAsset ids generated for this send.
+         * @items.minimum -2147483648
+         * @items.maximum 2147483647
+         */
       readonly exported_asset_ids: readonly number[];
       /** Snapshot at send time: dashboard metadata, total_insight_count, and per-exported-insight entries (id, short_id, name, query_hash, cache_key, query_results, optional query_error). */
       readonly content_snapshot: unknown;
       /** Per-destination outcomes; items use status success, failed, or partial. */
       readonly recipient_results: unknown;
       /** Overall run status: starting, completed, failed, or skipped.
-
-      * `starting` - Starting
-      * `completed` - Completed
-      * `failed` - Failed
-      * `skipped` - Skipped */
+       *
+       * * `starting` - Starting
+       * * `completed` - Completed
+       * * `failed` - Failed
+       * * `skipped` - Skipped */
       readonly status: SubscriptionDeliveryStatusEnum;
       /** Top-level failure payload when status is failed, if any. */
       readonly error: unknown;
@@ -26478,8 +26529,8 @@ export namespace Schemas {
 
     /**
      * * `insight` - Insight
-    * `dashboard` - Dashboard
-    * `ai_prompt` - AI prompt
+     * * `dashboard` - Dashboard
+     * * `ai_prompt` - AI prompt
      */
     export type ResourceTypeEnum = typeof ResourceTypeEnum[keyof typeof ResourceTypeEnum];
 
@@ -26492,7 +26543,7 @@ export namespace Schemas {
 
     /**
      * * `email` - Email
-    * `slack` - Slack
+     * * `slack` - Slack
      */
     export type TargetTypeEnum = typeof TargetTypeEnum[keyof typeof TargetTypeEnum];
 
@@ -26504,9 +26555,9 @@ export namespace Schemas {
 
     /**
      * * `daily` - Daily
-    * `weekly` - Weekly
-    * `monthly` - Monthly
-    * `yearly` - Yearly
+     * * `weekly` - Weekly
+     * * `monthly` - Monthly
+     * * `yearly` - Yearly
      */
     export type SubscriptionFrequencyEnum = typeof SubscriptionFrequencyEnum[keyof typeof SubscriptionFrequencyEnum];
 
@@ -26520,12 +26571,12 @@ export namespace Schemas {
 
     /**
      * * `monday` - Monday
-    * `tuesday` - Tuesday
-    * `wednesday` - Wednesday
-    * `thursday` - Thursday
-    * `friday` - Friday
-    * `saturday` - Saturday
-    * `sunday` - Sunday
+     * * `tuesday` - Tuesday
+     * * `wednesday` - Wednesday
+     * * `thursday` - Thursday
+     * * `friday` - Friday
+     * * `saturday` - Saturday
+     * * `sunday` - Sunday
      */
     export type SubscriptionByweekdayItem = typeof SubscriptionByweekdayItem[keyof typeof SubscriptionByweekdayItem];
 
@@ -26546,10 +26597,10 @@ export namespace Schemas {
     export interface Subscription {
       readonly id: number;
       /** What the subscription delivers: 'insight' (snapshot of one insight), 'dashboard' (snapshot of one dashboard), or 'ai_prompt' (LLM-generated report). Read-only — derived from the populated target (insight → insight, dashboard → dashboard, prompt → ai_prompt).
-
-      * `insight` - Insight
-      * `dashboard` - Dashboard
-      * `ai_prompt` - AI prompt */
+       *
+       * * `insight` - Insight
+       * * `dashboard` - Dashboard
+       * * `ai_prompt` - AI prompt */
       readonly resource_type: ResourceTypeEnum;
       /**
          * Dashboard ID to subscribe to (mutually exclusive with insight on create).
@@ -26573,18 +26624,18 @@ export namespace Schemas {
          */
       prompt?: string | null;
       /** Delivery channel: email or slack.
-
-      * `email` - Email
-      * `slack` - Slack */
+       *
+       * * `email` - Email
+       * * `slack` - Slack */
       target_type: TargetTypeEnum;
       /** Recipient(s): comma-separated email addresses for email, or Slack channel name/ID for slack. */
       target_value: string;
       /** How often to deliver: daily, weekly, monthly, or yearly.
-
-      * `daily` - Daily
-      * `weekly` - Weekly
-      * `monthly` - Monthly
-      * `yearly` - Yearly */
+       *
+       * * `daily` - Daily
+       * * `weekly` - Weekly
+       * * `monthly` - Monthly
+       * * `yearly` - Yearly */
       frequency: SubscriptionFrequencyEnum;
       /**
          * Interval multiplier (e.g. 2 with weekly frequency means every 2 weeks). Required on create; must be 1 or greater.
@@ -26664,9 +26715,9 @@ export namespace Schemas {
 
     /**
      * * `popover` - popover
-    * `widget` - widget
-    * `external_survey` - external survey
-    * `api` - api
+     * * `widget` - widget
+     * * `external_survey` - external survey
+     * * `api` - api
      */
     export type SurveyType = typeof SurveyType[keyof typeof SurveyType];
 
@@ -26680,8 +26731,8 @@ export namespace Schemas {
 
     /**
      * * `day` - day
-    * `week` - week
-    * `month` - month
+     * * `week` - week
+     * * `month` - month
      */
     export type ResponseSamplingIntervalTypeEnum = typeof ResponseSamplingIntervalTypeEnum[keyof typeof ResponseSamplingIntervalTypeEnum];
 
@@ -26718,117 +26769,117 @@ export namespace Schemas {
       readonly targeting_flag: MinimalFeatureFlag;
       readonly internal_targeting_flag: MinimalFeatureFlag;
       /**
-              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-              Basic (open-ended question)
-              - `id`: The question ID
-              - `type`: `open`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Link (a question with a link)
-              - `id`: The question ID
-              - `type`: `link`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `link`: The URL associated with the question.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Rating (a question with a rating scale)
-              - `id`: The question ID
-              - `type`: `rating`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `display`: Display style of the rating (`number` or `emoji`).
-              - `scale`: The scale of the rating (`number`).
-              - `lowerBoundLabel`: Label for the lower bound of the scale.
-              - `upperBoundLabel`: Label for the upper bound of the scale.
-              - `isNpsQuestion`: Whether the question is an NPS rating.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Multiple choice
-              - `id`: The question ID
-              - `type`: `single_choice` or `multiple_choice`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `choices`: An array of choices for the question.
-              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Branching logic can be one of the following types:
-
-              Next question: Proceeds to the next question
-              ```json
-              {
-                  "type": "next_question"
-              }
-              ```
-
-              End: Ends the survey, optionally displaying a confirmation message.
-              ```json
-              {
-                  "type": "end"
-              }
-              ```
-
-              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-              ```json
-              {
-                  "type": "response_based",
-                  "responseValues": {
-                      "responseKey": "value"
-                  }
-              }
-              ```
-
-              Specific question: Proceeds to a specific question by index.
-              ```json
-              {
-                  "type": "specific_question",
-                  "index": 2
-              }
-              ```
-
-              Translations: Each question can include inline translations.
-              - `translations`: Object mapping language codes to translated fields.
-              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-              Example with translations:
-              ```json
-              {
-                  "id": "uuid",
-                  "type": "rating",
-                  "question": "How satisfied are you?",
-                  "lowerBoundLabel": "Not satisfied",
-                  "upperBoundLabel": "Very satisfied",
-                  "translations": {
-                      "es": {
-                          "question": "¿Qué tan satisfecho estás?",
-                          "lowerBoundLabel": "No satisfecho",
-                          "upperBoundLabel": "Muy satisfecho"
-                      },
-                      "fr": {
-                          "question": "Dans quelle mesure êtes-vous satisfait?"
-                      }
-                  }
-              }
-              ```
-               */
+       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+       *
+       *         Basic (open-ended question)
+       *         - `id`: The question ID
+       *         - `type`: `open`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Link (a question with a link)
+       *         - `id`: The question ID
+       *         - `type`: `link`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `link`: The URL associated with the question.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Rating (a question with a rating scale)
+       *         - `id`: The question ID
+       *         - `type`: `rating`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `display`: Display style of the rating (`number` or `emoji`).
+       *         - `scale`: The scale of the rating (`number`).
+       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+       *         - `upperBoundLabel`: Label for the upper bound of the scale.
+       *         - `isNpsQuestion`: Whether the question is an NPS rating.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Multiple choice
+       *         - `id`: The question ID
+       *         - `type`: `single_choice` or `multiple_choice`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `choices`: An array of choices for the question.
+       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Branching logic can be one of the following types:
+       *
+       *         Next question: Proceeds to the next question
+       *         ```json
+       *         {
+       *             "type": "next_question"
+       *         }
+       *         ```
+       *
+       *         End: Ends the survey, optionally displaying a confirmation message.
+       *         ```json
+       *         {
+       *             "type": "end"
+       *         }
+       *         ```
+       *
+       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+       *         ```json
+       *         {
+       *             "type": "response_based",
+       *             "responseValues": {
+       *                 "responseKey": "value"
+       *             }
+       *         }
+       *         ```
+       *
+       *         Specific question: Proceeds to a specific question by index.
+       *         ```json
+       *         {
+       *             "type": "specific_question",
+       *             "index": 2
+       *         }
+       *         ```
+       *
+       *         Translations: Each question can include inline translations.
+       *         - `translations`: Object mapping language codes to translated fields.
+       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+       *
+       *         Example with translations:
+       *         ```json
+       *         {
+       *             "id": "uuid",
+       *             "type": "rating",
+       *             "question": "How satisfied are you?",
+       *             "lowerBoundLabel": "Not satisfied",
+       *             "upperBoundLabel": "Very satisfied",
+       *             "translations": {
+       *                 "es": {
+       *                     "question": "¿Qué tan satisfecho estás?",
+       *                     "lowerBoundLabel": "No satisfecho",
+       *                     "upperBoundLabel": "Muy satisfecho"
+       *                 },
+       *                 "fr": {
+       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+       *                 }
+       *             }
+       *         }
+       *         ```
+       *          */
       questions?: unknown;
       /** @nullable */
       readonly conditions: SurveyConditions;
@@ -26914,11 +26965,11 @@ export namespace Schemas {
 
     /**
      * * `CSV` - CSV
-    * `CSVWithNames` - CSVWithNames
-    * `Parquet` - Parquet
-    * `JSONEachRow` - JSON
-    * `Delta` - Delta
-    * `DeltaS3Wrapper` - DeltaS3Wrapper
+     * * `CSVWithNames` - CSVWithNames
+     * * `Parquet` - Parquet
+     * * `JSONEachRow` - JSON
+     * * `Delta` - Delta
+     * * `DeltaS3Wrapper` - DeltaS3Wrapper
      */
     export type TableFormatEnum = typeof TableFormatEnum[keyof typeof TableFormatEnum];
 
@@ -27001,7 +27052,7 @@ export namespace Schemas {
 
     /**
      * * `llm` - LLM
-    * `hog` - Hog
+     * * `hog` - Hog
      */
     export type TaggerTypeEnum = typeof TaggerTypeEnum[keyof typeof TaggerTypeEnum];
 
@@ -27036,14 +27087,14 @@ export namespace Schemas {
      */
     export interface TaggerModelConfiguration {
       /** LLM provider to use for this tagger.
-
-      * `openai` - Openai
-      * `anthropic` - Anthropic
-      * `gemini` - Gemini
-      * `openrouter` - Openrouter
-      * `fireworks` - Fireworks
-      * `azure_openai` - Azure OpenAI
-      * `together_ai` - Together AI */
+       *
+       * * `openai` - Openai
+       * * `anthropic` - Anthropic
+       * * `gemini` - Gemini
+       * * `openrouter` - Openrouter
+       * * `fireworks` - Fireworks
+       * * `azure_openai` - Azure OpenAI
+       * * `together_ai` - Together AI */
       provider: LLMProviderEnum;
       /**
          * Provider model identifier to use for this tagger.
@@ -27158,16 +27209,16 @@ export namespace Schemas {
       /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
       description?: string;
       /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-
-      * `error_tracking` - Error Tracking
-      * `eval_clusters` - Eval Clusters
-      * `user_created` - User Created
-      * `automation` - Automation
-      * `slack` - Slack
-      * `support_queue` - Support Queue
-      * `session_summaries` - Session Summaries
-      * `signal_report` - Signal Report
-      * `signals_scout` - Signals Scout */
+       *
+       * * `error_tracking` - Error Tracking
+       * * `eval_clusters` - Eval Clusters
+       * * `user_created` - User Created
+       * * `automation` - Automation
+       * * `slack` - Slack
+       * * `support_queue` - Support Queue
+       * * `session_summaries` - Session Summaries
+       * * `signal_report` - Signal Report
+       * * `signals_scout` - Signals Scout */
       origin_product?: OriginProductEnum;
       /**
          * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
@@ -27222,11 +27273,11 @@ export namespace Schemas {
 
     /**
      * * `not_started` - Not Started
-    * `queued` - Queued
-    * `in_progress` - In Progress
-    * `completed` - Completed
-    * `failed` - Failed
-    * `cancelled` - Cancelled
+     * * `queued` - Queued
+     * * `in_progress` - In Progress
+     * * `completed` - Completed
+     * * `failed` - Failed
+     * * `cancelled` - Cancelled
      */
     export type TaskRunStatusEnum = typeof TaskRunStatusEnum[keyof typeof TaskRunStatusEnum];
 
@@ -27242,7 +27293,7 @@ export namespace Schemas {
 
     /**
      * * `local` - Local
-    * `cloud` - Cloud
+     * * `cloud` - Cloud
      */
     export type TaskRunEnvironmentEnum = typeof TaskRunEnvironmentEnum[keyof typeof TaskRunEnvironmentEnum];
 
@@ -27254,7 +27305,7 @@ export namespace Schemas {
 
     /**
      * * `claude` - claude
-    * `codex` - codex
+     * * `codex` - codex
      */
     export type RuntimeAdapterEnum = typeof RuntimeAdapterEnum[keyof typeof RuntimeAdapterEnum];
 
@@ -27308,9 +27359,9 @@ export namespace Schemas {
       branch?: string | null;
       status?: TaskRunStatusEnum;
       /** Execution environment
-
-      * `local` - Local
-      * `cloud` - Cloud */
+       *
+       * * `local` - Local
+       * * `cloud` - Cloud */
       environment?: TaskRunEnvironmentEnum;
       /** Configured runtime adapter for this run, such as 'claude' or 'codex'. */
       readonly runtime_adapter: RuntimeAdapterEnum | null;
@@ -27379,7 +27430,7 @@ export namespace Schemas {
 
     /**
      * Serializer for `Team` model with minimal attributes to speeed up loading and transfer times.
-    Also used for nested serializers.
+     * Also used for nested serializers.
      */
     export interface TeamBasic {
       readonly id: number;
@@ -27430,8 +27481,8 @@ export namespace Schemas {
 
     /**
      * * `low` - Low
-    * `medium` - Medium
-    * `high` - High
+     * * `medium` - Medium
+     * * `high` - High
      */
     export type PriorityEnum = typeof PriorityEnum[keyof typeof PriorityEnum];
 
@@ -27489,18 +27540,18 @@ export namespace Schemas {
       readonly channel_detail: ChannelDetailEnum | null;
       readonly distinct_id: string;
       /** Ticket status: new, open, pending, on_hold, or resolved
-
-      * `new` - New
-      * `open` - Open
-      * `pending` - Pending
-      * `on_hold` - On hold
-      * `resolved` - Resolved */
+       *
+       * * `new` - New
+       * * `open` - Open
+       * * `pending` - Pending
+       * * `on_hold` - On hold
+       * * `resolved` - Resolved */
       status?: TicketStatusEnum;
       /** Ticket priority: low, medium, or high. Null if unset.
-
-      * `low` - Low
-      * `medium` - Medium
-      * `high` - High */
+       *
+       * * `low` - Low
+       * * `medium` - Medium
+       * * `high` - High */
       priority?: PriorityEnum | BlankEnum | null;
       readonly assignee: TicketAssignment;
       /** Customer-provided traits such as name and email */
@@ -27708,7 +27759,7 @@ export namespace Schemas {
       readonly user_access_level: string | null;
       /** @nullable */
       readonly last_viewed_at: string | null;
-      /** How this row matched the `search` term: `exact` (the term is a case-insensitive substring of the name, derived_name, description, or a tag name) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
       readonly search_match_type: SearchMatchTypeEnum | null;
       /** Number of distinct viewers in the time window. Higher values indicate insights that more people in the project actively look at, which is a strong proxy for which insights matter. */
       readonly view_count: number;
@@ -27778,6 +27829,7 @@ export namespace Schemas {
       readonly id: string;
       readonly created_by: UserBasic;
       readonly created_at: string;
+      /** @items.maxLength 254 */
       interviewee_emails?: string[];
       readonly interviewee_identifier: string;
       /** @nullable */
@@ -27802,9 +27854,15 @@ export namespace Schemas {
       readonly id: string;
       readonly created_by: UserBasic;
       readonly created_at: string;
-      /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
+      /**
+         * Email addresses of people to interview. May be combined with interviewee_distinct_ids.
+         * @items.maxLength 254
+         */
       interviewee_emails?: string[];
-      /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
+      /**
+         * PostHog distinct IDs of people to interview. May be combined with interviewee_emails.
+         * @items.maxLength 400
+         */
       interviewee_distinct_ids?: string[];
       /** The product, feature, or idea you want to ask interviewees about. */
       topic: string;
@@ -27835,7 +27893,7 @@ export namespace Schemas {
 
     /**
      * * `disabled` - disabled
-    * `toolbar` - toolbar
+     * * `toolbar` - toolbar
      */
     export type ToolbarModeEnum = typeof ToolbarModeEnum[keyof typeof ToolbarModeEnum];
 
@@ -27854,8 +27912,8 @@ export namespace Schemas {
 
     /**
      * * `light` - Light
-    * `dark` - Dark
-    * `system` - System
+     * * `dark` - Dark
+     * * `system` - System
      */
     export type ThemeModeEnum = typeof ThemeModeEnum[keyof typeof ThemeModeEnum];
 
@@ -27868,8 +27926,8 @@ export namespace Schemas {
 
     /**
      * * `above` - Above
-    * `below` - Below
-    * `hidden` - Hidden
+     * * `below` - Below
+     * * `hidden` - Hidden
      */
     export type ShortcutPositionEnum = typeof ShortcutPositionEnum[keyof typeof ShortcutPositionEnum];
 
@@ -27995,13 +28053,13 @@ export namespace Schemas {
 
     /**
      * * `onboarding` - Onboarding
-    * `product_intent` - Product Intent
-    * `used_by_colleagues` - Used by Colleagues
-    * `used_similar_products` - Used Similar Products
-    * `used_on_separate_team` - Used on Separate Team
-    * `new_product` - New Product
-    * `sales_led` - Sales Led
-    * `onboarding_delegated` - Onboarding Delegated
+     * * `product_intent` - Product Intent
+     * * `used_by_colleagues` - Used by Colleagues
+     * * `used_similar_products` - Used Similar Products
+     * * `used_on_separate_team` - Used on Separate Team
+     * * `new_product` - New Product
+     * * `sales_led` - Sales Led
+     * * `onboarding_delegated` - Onboarding Delegated
      */
     export type UserProductListReasonEnum = typeof UserProductListReasonEnum[keyof typeof UserProductListReasonEnum];
 
@@ -28100,20 +28158,20 @@ export namespace Schemas {
       created_at?: string;
       readonly feature_flag_key: string;
       /** Variants for the web experiment. Example:
-
-              {
-                  "control": {
-                      "transforms": [
-                          {
-                              "text": "Here comes Superman!",
-                              "html": "",
-                              "selector": "#page > #body > .header h1"
-                          }
-                      ],
-                      "conditions": "None",
-                      "rollout_percentage": 50
-                  },
-              } */
+       *
+       *         {
+       *             "control": {
+       *                 "transforms": [
+       *                     {
+       *                         "text": "Here comes Superman!",
+       *                         "html": "",
+       *                         "selector": "#page > #body > .header h1"
+       *                     }
+       *                 ],
+       *                 "conditions": "None",
+       *                 "rollout_percentage": 50
+       *             },
+       *         } */
       variants: unknown;
     }
 
@@ -28128,9 +28186,9 @@ export namespace Schemas {
 
     /**
      * * `idle` - IDLE
-    * `running` - RUNNING
-    * `completed` - COMPLETED
-    * `error` - ERROR
+     * * `running` - RUNNING
+     * * `completed` - COMPLETED
+     * * `error` - ERROR
      */
     export type RunPhaseEnum = typeof RunPhaseEnum[keyof typeof RunPhaseEnum];
 
@@ -28144,10 +28202,10 @@ export namespace Schemas {
 
     /**
      * * `pending` - PENDING
-    * `in_progress` - IN_PROGRESS
-    * `completed` - COMPLETED
-    * `failed` - FAILED
-    * `canceled` - CANCELED
+     * * `in_progress` - IN_PROGRESS
+     * * `completed` - COMPLETED
+     * * `failed` - FAILED
+     * * `canceled` - CANCELED
      */
     export type WizardTaskDTOStatusEnum = typeof WizardTaskDTOStatusEnum[keyof typeof WizardTaskDTOStatusEnum];
 
@@ -28360,12 +28418,12 @@ export namespace Schemas {
       config?: TrendsAlertConfig | null;
       detector_config?: DetectorConfig | null;
       /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
-
-      * `every_15_minutes` - every_15_minutes
-      * `hourly` - hourly
-      * `daily` - daily
-      * `weekly` - weekly
-      * `monthly` - monthly */
+       *
+       * * `every_15_minutes` - every_15_minutes
+       * * `hourly` - hourly
+       * * `daily` - daily
+       * * `weekly` - weekly
+       * * `monthly` - monthly */
       calculation_interval?: CalculationIntervalEnum;
       /**
          * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
@@ -28389,9 +28447,9 @@ export namespace Schemas {
       /** When enabled (and investigation_agent_enabled is on), notification dispatch is held until the investigation agent produces a verdict. Notifications are suppressed when the verdict is false_positive (and optionally when inconclusive). A safety-net task force-fires after a few minutes if the investigation stalls. */
       investigation_gates_notifications?: boolean;
       /** How to handle an 'inconclusive' verdict when notifications are gated. 'notify' is the safe default — an agent that can't be sure is itself useful signal.
-
-      * `notify` - Notify
-      * `suppress` - Suppress */
+       *
+       * * `notify` - Notify
+       * * `suppress` - Suppress */
       investigation_inconclusive_action?: InvestigationInconclusiveActionEnum;
     }
 
@@ -28409,9 +28467,9 @@ export namespace Schemas {
          */
       date_marker?: string | null;
       /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
-
-      * `USR` - user
-      * `GIT` - GitHub */
+       *
+       * * `USR` - user
+       * * `GIT` - GitHub */
       creation_type?: CreationTypeEnum;
       /** @nullable */
       dashboard_item?: number | null;
@@ -28432,12 +28490,12 @@ export namespace Schemas {
       /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
       deleted?: boolean;
       /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
-
-      * `dashboard_item` - insight
-      * `dashboard` - dashboard
-      * `project` - project
-      * `organization` - organization
-      * `recording` - recording */
+       *
+       * * `dashboard_item` - insight
+       * * `dashboard` - dashboard
+       * * `project` - project
+       * * `organization` - organization
+       * * `recording` - recording */
       scope?: AnnotationScopeEnum;
       /**
          * Optional emoji shown in place of the default badge when this annotation is surfaced on a chart.
@@ -28467,29 +28525,29 @@ export namespace Schemas {
 
     /**
      * Request body for create/partial_update on BatchExportViewSet.
-
-    Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
-    `destination` schema so integration_id is marked required on the types that need
-    it. Responses continue to use `BatchExportSerializer`.
+     *
+     * Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
+     * `destination` schema so integration_id is marked required on the types that need
+     * it. Responses continue to use `BatchExportSerializer`.
      */
     export interface PatchedBatchExportRequest {
       /** Human-readable name for the batch export. */
       name?: string;
       /** Which data model to export (events, persons, sessions).
-
-      * `events` - Events
-      * `persons` - Persons
-      * `sessions` - Sessions */
+       *
+       * * `events` - Events
+       * * `persons` - Persons
+       * * `sessions` - Sessions */
       model?: ModelEnum;
       /** Destination configuration. Required integration_id is enforced per destination type. */
       destination?: BatchExportDestinationRequest;
       /** How often the batch export should run.
-
-      * `hour` - hour
-      * `day` - day
-      * `week` - week
-      * `every 5 minutes` - every 5 minutes
-      * `every 15 minutes` - every 15 minutes */
+       *
+       * * `hour` - hour
+       * * `day` - day
+       * * `week` - week
+       * * `every 5 minutes` - every 5 minutes
+       * * `every 15 minutes` - every 15 minutes */
       interval?: IntervalEnum;
       /** Whether the batch export is paused. */
       paused?: boolean;
@@ -28582,12 +28640,12 @@ export namespace Schemas {
       readonly count?: number | null;
       is_static?: boolean;
       /** Type of cohort based on filter complexity
-
-      * `static` - static
-      * `person_property` - person_property
-      * `behavioral` - behavioral
-      * `realtime` - realtime
-      * `analytical` - analytical */
+       *
+       * * `static` - static
+       * * `person_property` - person_property
+       * * `behavioral` - behavioral
+       * * `realtime` - realtime
+       * * `analytical` - analytical */
       cohort_type?: CohortTypeEnum | BlankEnum | null;
       readonly experiment_set?: readonly number[];
       _create_in_folder?: string;
@@ -28686,9 +28744,9 @@ export namespace Schemas {
       readonly agent_mode?: string | null;
       readonly is_sandbox?: boolean;
       /** Return pending approval cards as structured data.
-
-      Combines metadata from conversation.approval_decisions with payload from checkpoint
-      interrupts (single source of truth for payload data). */
+       *
+       * Combines metadata from conversation.approval_decisions with payload from checkpoint
+       * interrupts (single source of truth for payload data). */
       readonly pending_approvals?: readonly PatchedConversationPendingApprovalsItem[];
     }
 
@@ -28702,15 +28760,15 @@ export namespace Schemas {
       /** Optional description */
       description?: string;
       /** Lifecycle category for this core event
-
-      * `acquisition` - Acquisition
-      * `activation` - Activation
-      * `monetization` - Monetization
-      * `expansion` - Expansion
-      * `referral` - Referral
-      * `retention` - Retention
-      * `churn` - Churn
-      * `reactivation` - Reactivation */
+       *
+       * * `acquisition` - Acquisition
+       * * `activation` - Activation
+       * * `monetization` - Monetization
+       * * `expansion` - Expansion
+       * * `referral` - Referral
+       * * `retention` - Retention
+       * * `churn` - Churn
+       * * `reactivation` - Reactivation */
       category?: CoreEventCategoryEnum;
       /** Filter configuration - event, action, or data warehouse node */
       filter?: unknown;
@@ -28861,7 +28919,10 @@ export namespace Schemas {
          */
       dashboard_description?: string | null;
       dashboard_filters?: unknown;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 255
+         */
       tags?: string[] | null;
       tiles?: unknown;
       variables?: unknown;
@@ -28878,7 +28939,10 @@ export namespace Schemas {
       /** @nullable */
       readonly team_id?: number | null;
       scope?: DashboardTemplateScopeEnum | BlankEnum | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 255
+         */
       availability_contexts?: string[] | null;
       /** Manually curated; used to highlight templates in the UI. */
       is_featured?: boolean;
@@ -28914,8 +28978,8 @@ export namespace Schemas {
 
     /**
      * Shared methods for DataWarehouseSavedQuery serializers.
-
-    This mixin is intended to be used with serializers.ModelSerializer subclasses.
+     *
+     * This mixin is intended to be used with serializers.ModelSerializer subclasses.
      */
     export interface PatchedDataWarehouseSavedQuery {
       readonly id?: string;
@@ -28934,12 +28998,12 @@ export namespace Schemas {
       readonly sync_frequency?: string | null;
       readonly columns?: readonly PatchedDataWarehouseSavedQueryColumnsItem[];
       /** The status of when this SavedQuery last ran.
-
-      * `Cancelled` - Cancelled
-      * `Modified` - Modified
-      * `Completed` - Completed
-      * `Failed` - Failed
-      * `Running` - Running */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Modified` - Modified
+       * * `Completed` - Completed
+       * * `Failed` - Failed
+       * * `Running` - Running */
       readonly status?: SavedQueryStatusEnum | null;
       /** @nullable */
       readonly last_run_at?: string | null;
@@ -28977,10 +29041,10 @@ export namespace Schemas {
       /** @nullable */
       readonly is_materialized?: boolean | null;
       /** Where this SavedQuery is created.
-
-      * `data_warehouse` - Data Warehouse
-      * `endpoint` - Endpoint
-      * `managed_viewset` - Managed Viewset */
+       *
+       * * `data_warehouse` - Data Warehouse
+       * * `endpoint` - Endpoint
+       * * `managed_viewset` - Managed Viewset */
       readonly origin?: OriginEnum | null;
       /** Whether this view is for testing only and will auto-expire. */
       is_test?: boolean;
@@ -29155,13 +29219,13 @@ export namespace Schemas {
       /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
       description?: string;
       /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-
-      * `draft` - draft
-      * `concept` - concept
-      * `alpha` - alpha
-      * `beta` - beta
-      * `general-availability` - general availability
-      * `archived` - archived */
+       *
+       * * `draft` - draft
+       * * `concept` - concept
+       * * `alpha` - alpha
+       * * `beta` - beta
+       * * `general-availability` - general availability
+       * * `archived` - archived */
       stage?: StageEnum;
       /**
          * URL to external documentation for this feature. Shown to users in the opt-in UI.
@@ -29196,7 +29260,10 @@ export namespace Schemas {
          * @nullable
          */
       tag_name?: string | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 200
+         */
       attr_class?: string[] | null;
       /**
          * @maxLength 10000
@@ -29570,15 +29637,15 @@ export namespace Schemas {
       readonly status?: EvaluationStatusEnum;
       readonly status_reason?: StatusReasonEnum | null;
       /** 'llm_judge' uses an LLM to score outputs against a prompt; 'hog' runs deterministic Hog code.
-
-      * `llm_judge` - LLM as a judge
-      * `hog` - Hog */
+       *
+       * * `llm_judge` - LLM as a judge
+       * * `hog` - Hog */
       evaluation_type?: EvaluationTypeEnum;
       /** Configuration dict. For 'llm_judge': {prompt}. For 'hog': {source}. */
       evaluation_config?: PatchedEvaluationEvaluationConfig;
       /** Output format. Currently only 'boolean' is supported.
-
-      * `boolean` - Boolean (Pass/Fail) */
+       *
+       * * `boolean` - Boolean (Pass/Fail) */
       output_type?: OutputTypeEnum;
       /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
       output_config?: PatchedEvaluationOutputConfig;
@@ -29597,9 +29664,9 @@ export namespace Schemas {
       /** UUID of the evaluation this report config belongs to. */
       evaluation?: string;
       /** How report generation is triggered. 'every_n' fires once N new evaluation results have accumulated (subject to cooldown_minutes and daily_run_cap). 'scheduled' fires on the cadence defined by rrule + starts_at + timezone_name.
-
-      * `scheduled` - Scheduled
-      * `every_n` - Every N */
+       *
+       * * `scheduled` - Scheduled
+       * * `every_n` - Every N */
       frequency?: EvaluationReportFrequencyEnum;
       /** RFC 5545 recurrence rule string (e.g. 'FREQ=WEEKLY;BYDAY=MO'). Must not contain DTSTART — the anchor is set via starts_at. Required when frequency is 'scheduled'; ignored otherwise. */
       rrule?: string;
@@ -29713,9 +29780,9 @@ export namespace Schemas {
       readonly created_at?: string;
       readonly updated_at?: string;
       /** Experiment type: web for frontend UI changes, product for backend/API changes.
-
-      * `web` - web
-      * `product` - product */
+       *
+       * * `web` - web
+       * * `product` - product */
       type?: ExperimentTypeEnum | null;
       /** Exposure configuration including filter test accounts and custom exposure events. */
       exposure_criteria?: ExperimentApiExposureCriteria | null;
@@ -29729,12 +29796,12 @@ export namespace Schemas {
       allow_unknown_events?: boolean;
       _create_in_folder?: string;
       /** Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.
-
-      * `won` - won
-      * `lost` - lost
-      * `inconclusive` - inconclusive
-      * `stopped_early` - stopped_early
-      * `invalid` - invalid */
+       *
+       * * `won` - won
+       * * `lost` - lost
+       * * `inconclusive` - inconclusive
+       * * `stopped_early` - stopped_early
+       * * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Comment about the experiment conclusion.
@@ -29841,12 +29908,12 @@ export namespace Schemas {
       /** @nullable */
       readonly status?: string | null;
       /** Sync strategy: incremental, full_refresh, append, or cdc.
-
-      * `full_refresh` - full_refresh
-      * `incremental` - incremental
-      * `append` - append
-      * `webhook` - webhook
-      * `cdc` - cdc */
+       *
+       * * `full_refresh` - full_refresh
+       * * `incremental` - incremental
+       * * `append` - append
+       * * `webhook` - webhook
+       * * `cdc` - cdc */
       sync_type?: SyncTypeEnum | null;
       /**
          * Column name used to track sync progress.
@@ -29854,27 +29921,27 @@ export namespace Schemas {
          */
       incremental_field?: string | null;
       /** Data type of the incremental field.
-
-      * `integer` - integer
-      * `numeric` - numeric
-      * `datetime` - datetime
-      * `date` - date
-      * `timestamp` - timestamp
-      * `objectid` - objectid */
+       *
+       * * `integer` - integer
+       * * `numeric` - numeric
+       * * `datetime` - datetime
+       * * `date` - date
+       * * `timestamp` - timestamp
+       * * `objectid` - objectid */
       incremental_field_type?: IncrementalFieldTypeEnum | null;
       /** How often to sync.
-
-      * `never` - never
-      * `1min` - 1min
-      * `5min` - 5min
-      * `15min` - 15min
-      * `30min` - 30min
-      * `1hour` - 1hour
-      * `6hour` - 6hour
-      * `12hour` - 12hour
-      * `24hour` - 24hour
-      * `7day` - 7day
-      * `30day` - 30day */
+       *
+       * * `never` - never
+       * * `1min` - 1min
+       * * `5min` - 5min
+       * * `15min` - 15min
+       * * `30min` - 30min
+       * * `1hour` - 1hour
+       * * `6hour` - 6hour
+       * * `12hour` - 12hour
+       * * `24hour` - 24hour
+       * * `7day` - 7day
+       * * `30day` - 30day */
       sync_frequency?: SyncFrequencyEnum | null;
       /**
          * UTC time of day to run the sync (HH:MM:SS).
@@ -29889,10 +29956,10 @@ export namespace Schemas {
          */
       primary_key_columns?: string[] | null;
       /** For CDC syncs: consolidated, cdc_only, or both.
-
-      * `consolidated` - consolidated
-      * `cdc_only` - cdc_only
-      * `both` - both */
+       *
+       * * `consolidated` - consolidated
+       * * `cdc_only` - cdc_only
+       * * `both` - both */
       cdc_table_mode?: CdcTableModeEnum | null;
       /**
          * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
@@ -29924,10 +29991,10 @@ export namespace Schemas {
       /** @nullable */
       readonly created_by?: string | null;
       /** How this source was created. Defaults to `api` on create when omitted. `web` for the in-app UI, `api` for direct API callers, `mcp` for agent/MCP tool calls. Ignored on update.
-
-      * `web` - web
-      * `api` - api
-      * `mcp` - mcp */
+       *
+       * * `web` - web
+       * * `api` - api
+       * * `mcp` - mcp */
       created_via?: CreatedViaEnum | null;
       readonly status?: string;
       client_secret?: string;
@@ -29947,9 +30014,9 @@ export namespace Schemas {
       description?: string | null;
       readonly access_method?: AccessMethodEnum;
       /** Backend engine detected for the direct connection.
-
-      * `duckdb` - duckdb
-      * `postgres` - postgres */
+       *
+       * * `duckdb` - duckdb
+       * * `postgres` - postgres */
       readonly engine?: EngineEnum | null;
       /** @nullable */
       readonly last_run_at?: string | null;
@@ -30065,10 +30132,10 @@ export namespace Schemas {
 
     /**
      * Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-    **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-    **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
+     *
+     * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+     *
+     * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
      */
     export type PatchedGroupUsageMetricFilters = { [key: string]: unknown };
 
@@ -30080,27 +30147,27 @@ export namespace Schemas {
          */
       name?: string;
       /** How the metric value is formatted in the UI. One of `numeric` or `currency`.
-
-      * `numeric` - numeric
-      * `currency` - currency */
+       *
+       * * `numeric` - numeric
+       * * `currency` - currency */
       format?: GroupUsageMetricFormatEnum;
       /** Rolling time window in days used to compute the metric. Defaults to 7. */
       interval?: number;
       /** Visual representation in the UI. One of `number` or `sparkline`.
-
-      * `number` - number
-      * `sparkline` - sparkline */
+       *
+       * * `number` - number
+       * * `sparkline` - sparkline */
       display?: GroupUsageMetricDisplayEnum;
       /** Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-      **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-      **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
+       *
+       * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+       *
+       * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
       filters?: PatchedGroupUsageMetricFilters;
       /** Aggregation function. `count` counts matching events; `sum` sums the value of `math_property` on matching events.
-
-      * `count` - count
-      * `sum` - sum */
+       *
+       * * `count` - count
+       * * `sum` - sum */
       math?: MathEnum;
       /**
          * Required when `math` is `sum`; must be empty when `math` is `count`. For events metrics this is an event property name. For data warehouse metrics this is the column name (or HogQL expression) to sum on the DW table.
@@ -30121,15 +30188,15 @@ export namespace Schemas {
       /** Which health check produced this issue (e.g. 'sdk_outdated', 'external_data_failure', 'no_live_events', 'ingestion_warnings'). Stable string key — use it to filter issues by category. */
       readonly kind?: string;
       /** How serious the issue is: 'critical', 'warning', or 'info'.
-
-      * `critical` - Critical
-      * `warning` - Warning
-      * `info` - Info */
+       *
+       * * `critical` - Critical
+       * * `warning` - Warning
+       * * `info` - Info */
       readonly severity?: HealthIssueSeverityEnum;
       /** 'active' while the underlying problem is still detected; 'resolved' once a later check run no longer finds it.
-
-      * `active` - Active
-      * `resolved` - Resolved */
+       *
+       * * `active` - Active
+       * * `resolved` - Resolved */
       readonly status?: HealthIssueStatusEnum;
       /** Whether a user has dismissed this issue from the Health UI. Dismissed issues stay in the list but are hidden by default. */
       dismissed?: boolean;
@@ -30163,10 +30230,10 @@ export namespace Schemas {
       description?: string;
       readonly version?: number;
       /** draft (no execution), active (live), archived (disabled).
-
-      * `draft` - Draft
-      * `active` - Active
-      * `archived` - Archived */
+       *
+       * * `draft` - Draft
+       * * `active` - Active
+       * * `archived` - Archived */
       status?: HogFlowStatusEnum;
       readonly created_at?: string;
       readonly created_by?: UserBasic;
@@ -30177,11 +30244,11 @@ export namespace Schemas {
       /** Conversion goal: {filters: [<cond>, ...], window_minutes}. <cond>: {key, value, operator, type: event|person|group}. Empty filters = any event in window. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
       conversion?: unknown;
       /** exit_only_at_end: only at exit node (default). exit_on_conversion: also on conversion (needs 'conversion'; silent no-op otherwise). exit_on_trigger_not_matched: also when trigger filter stops matching. exit_on_trigger_not_matched_or_conversion: both (needs 'conversion').
-
-      * `exit_on_conversion` - Conversion
-      * `exit_on_trigger_not_matched` - Trigger Not Matched
-      * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
-      * `exit_only_at_end` - Only At End */
+       *
+       * * `exit_on_conversion` - Conversion
+       * * `exit_on_trigger_not_matched` - Trigger Not Matched
+       * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+       * * `exit_only_at_end` - Only At End */
       exit_condition?: ExitConditionEnum;
       /** Graph edges: [{from, to, type: 'continue'|'branch', index?}]. 'continue' = fall-through (sequential, or no-match path of conditional_branch). 'branch' requires 'index': matches config.conditions[index] on conditional_branch / wait_until_condition. Every non-exit action needs a reachable next action ('No next action found' otherwise). */
       edges?: HogFlowEdge[];
@@ -30210,10 +30277,10 @@ export namespace Schemas {
       /** Variable value overrides merged with the workflow defaults on each run. */
       variables?: unknown;
       /** active, paused, or completed (set once the RRULE's COUNT/UNTIL is exhausted).
-
-      * `active` - Active
-      * `paused` - Paused
-      * `completed` - Completed */
+       *
+       * * `active` - Active
+       * * `paused` - Paused
+       * * `completed` - Completed */
       readonly status?: HogFlowScheduleStatusEnum;
       /**
          * Next scheduled fire time, computed by the scheduler.
@@ -30236,7 +30303,7 @@ export namespace Schemas {
 
     /**
      * Serializer for creating hog flow templates.
-    Validates and sanitizes the workflow before creating it as a template.
+     * Validates and sanitizes the workflow before creating it as a template.
      */
     export interface PatchedHogFlowTemplate {
       readonly id?: string;
@@ -30276,14 +30343,14 @@ export namespace Schemas {
     export interface PatchedHogFunction {
       readonly id?: string;
       /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
-
-      * `destination` - Destination
-      * `site_destination` - Site Destination
-      * `internal_destination` - Internal Destination
-      * `source_webhook` - Source Webhook
-      * `warehouse_source_webhook` - Warehouse Source Webhook
-      * `site_app` - Site App
-      * `transformation` - Transformation */
+       *
+       * * `destination` - Destination
+       * * `site_destination` - Site Destination
+       * * `internal_destination` - Internal Destination
+       * * `source_webhook` - Source Webhook
+       * * `warehouse_source_webhook` - Warehouse Source Webhook
+       * * `site_app` - Site App
+       * * `transformation` - Transformation */
       type?: HogFunctionTypeEnum | null;
       /**
          * Display name for the function.
@@ -30386,21 +30453,21 @@ export namespace Schemas {
       order?: number | null;
       deleted?: boolean;
       /**
-              DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
-              A dashboard ID for each of the dashboards that this insight is displayed on.
-               */
+       *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
+       *         A dashboard ID for each of the dashboards that this insight is displayed on.
+       *          */
       dashboards?: number[];
       /**
-          A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
-           */
+       *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
+       *      */
       readonly dashboard_tiles?: readonly DashboardTileBasic[];
       /**
          *
-          The datetime this insight's results were generated.
-          If added to one or more dashboards the insight can be refreshed separately on each.
-          Returns the appropriate last_refresh datetime for the context the insight is viewed in
-          (see from_dashboard query parameter).
-
+       *     The datetime this insight's results were generated.
+       *     If added to one or more dashboards the insight can be refreshed separately on each.
+       *     Returns the appropriate last_refresh datetime for the context the insight is viewed in
+       *     (see from_dashboard query parameter).
+       *
          * @nullable
          */
       readonly last_refresh?: string | null;
@@ -30411,9 +30478,9 @@ export namespace Schemas {
       readonly cache_target_age?: string | null;
       /**
          *
-          The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
-          by querying the database.
-
+       *     The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
+       *     by querying the database.
+       *
          * @nullable
          */
       readonly next_allowed_client_refresh?: string | null;
@@ -30460,7 +30527,7 @@ export namespace Schemas {
       readonly alerts?: readonly unknown[];
       /** @nullable */
       readonly last_viewed_at?: string | null;
-      /** How this row matched the `search` term: `exact` (the term is a case-insensitive substring of the name, derived_name, description, or a tag name) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
       readonly search_match_type?: SearchMatchTypeEnum | null;
     }
 
@@ -30473,12 +30540,12 @@ export namespace Schemas {
          */
       name?: string;
       /** Variable type. Controls how the value is rendered and substituted in HogQL.
-
-      * `String` - String
-      * `Number` - Number
-      * `Boolean` - Boolean
-      * `List` - List
-      * `Date` - Date */
+       *
+       * * `String` - String
+       * * `Number` - Number
+       * * `Boolean` - Boolean
+       * * `List` - List
+       * * `Date` - Date */
       type?: InsightVariableTypeEnum;
       /** Default value used when a query references this variable. */
       default_value?: unknown;
@@ -30657,22 +30724,22 @@ export namespace Schemas {
          */
       threshold_count?: number;
       /** Whether the alert fires when the count is above or below the threshold.
-
-      * `above` - Above
-      * `below` - Below */
+       *
+       * * `above` - Above
+       * * `below` - Below */
       threshold_operator?: ThresholdOperatorEnum;
       /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
       window_minutes?: number;
       /** How often the alert is evaluated, in minutes. Server-managed. */
       readonly check_interval_minutes?: number;
       /** Current alert state: not_firing, firing, pending_resolve, errored, or snoozed. Server-managed.
-
-      * `not_firing` - Not firing
-      * `firing` - Firing
-      * `pending_resolve` - Pending resolve
-      * `errored` - Errored
-      * `snoozed` - Snoozed
-      * `broken` - Broken */
+       *
+       * * `not_firing` - Not firing
+       * * `firing` - Firing
+       * * `pending_resolve` - Pending resolve
+       * * `errored` - Errored
+       * * `snoozed` - Snoozed
+       * * `broken` - Broken */
       readonly state?: LogsAlertConfigurationStateEnum;
       /**
          * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
@@ -30756,10 +30823,10 @@ export namespace Schemas {
          */
       priority?: number | null;
       /** Rule kind: severity_sampling, path_drop, or rate_limit (caps matching log volume at ingestion).
-
-      * `severity_sampling` - Severity-based reduction
-      * `path_drop` - Path exclusion
-      * `rate_limit` - Rate limit */
+       *
+       * * `severity_sampling` - Severity-based reduction
+       * * `path_drop` - Path exclusion
+       * * `rate_limit` - Rate limit */
       rule_type?: RuleTypeEnum;
       /**
          * Optional legacy service-name scope; new rules use `config.filter_group` for matching instead.
@@ -31033,9 +31100,9 @@ export namespace Schemas {
       /** @nullable */
       readonly is_hipaa?: boolean | null;
       /** Default statistical method for new experiments in this organization.
-
-      * `bayesian` - Bayesian
-      * `frequentist` - Frequentist */
+       *
+       * * `bayesian` - Bayesian
+       * * `frequentist` - Frequentist */
       default_experiment_stats_method?: DefaultExperimentStatsMethodEnum | BlankEnum | null;
       /** Default setting for 'Discard client IP data' for new projects in this organization. */
       default_anonymize_ips?: boolean;
@@ -31108,7 +31175,10 @@ export namespace Schemas {
          * @nullable
          */
       id_jag_jwks_url?: string | null;
-      /** Allowed ID-JAG client IDs. Empty list allows any client_id. */
+      /**
+         * Allowed ID-JAG client IDs. Empty list allows any client_id.
+         * @items.maxLength 256
+         */
       id_jag_allowed_clients?: string[];
     }
 
@@ -31156,10 +31226,10 @@ export namespace Schemas {
     export interface PatchedPersistedFolder {
       readonly id?: string;
       /** Which persisted folder this is for the user (home, pinned, custom_products).
-
-      * `home` - Home
-      * `pinned` - Pinned
-      * `custom_products` - Custom Products */
+       *
+       * * `home` - Home
+       * * `pinned` - Pinned
+       * * `custom_products` - Custom Products */
       type?: PersistedFolderTypeEnum;
       /**
          * Protocol prefix of the folder location, e.g. 'products://'.
@@ -31234,7 +31304,7 @@ export namespace Schemas {
 
     /**
      * * `app` - app
-    * `toolbar` - toolbar
+     * * `toolbar` - toolbar
      */
     export type ProductTourSerializerCreateUpdateOnlyCreationContextEnum = typeof ProductTourSerializerCreateUpdateOnlyCreationContextEnum[keyof typeof ProductTourSerializerCreateUpdateOnlyCreationContextEnum];
 
@@ -31268,9 +31338,9 @@ export namespace Schemas {
       readonly updated_at?: string;
       archived?: boolean;
       /** Where the tour was created/updated from
-
-      * `app` - app
-      * `toolbar` - toolbar */
+       *
+       * * `app` - app
+       * * `toolbar` - toolbar */
       creation_context?: ProductTourSerializerCreateUpdateOnlyCreationContextEnum;
     }
 
@@ -31288,9 +31358,9 @@ export namespace Schemas {
 
     /**
      * * `30d` - 30 Days
-    * `90d` - 90 Days
-    * `1y` - 1 Year
-    * `5y` - 5 Years
+     * * `90d` - 90 Days
+     * * `1y` - 1 Year
+     * * `5y` - 5 Years
      */
     export type SessionRecordingRetentionPeriodEnum = typeof SessionRecordingRetentionPeriodEnum[keyof typeof SessionRecordingRetentionPeriodEnum];
 
@@ -31304,7 +31374,7 @@ export namespace Schemas {
 
     /**
      * * `0` - Sunday
-    * `1` - Monday
+     * * `1` - Monday
      */
     export type WeekStartDayEnum = typeof WeekStartDayEnum[keyof typeof WeekStartDayEnum];
 
@@ -31342,6 +31412,7 @@ export namespace Schemas {
       readonly updated_at?: string | null;
       readonly uuid?: string;
       readonly api_token?: string;
+      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       /** When true, PostHog drops the IP address from every ingested event. */
       anonymize_ips?: boolean;
@@ -31358,609 +31429,610 @@ export namespace Schemas {
       path_cleaning_filters?: unknown;
       is_demo?: boolean;
       /** IANA timezone used for date-based filters and reporting (e.g. `America/Los_Angeles`).
-
-      * `Africa/Abidjan` - Africa/Abidjan
-      * `Africa/Accra` - Africa/Accra
-      * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-      * `Africa/Algiers` - Africa/Algiers
-      * `Africa/Asmara` - Africa/Asmara
-      * `Africa/Asmera` - Africa/Asmera
-      * `Africa/Bamako` - Africa/Bamako
-      * `Africa/Bangui` - Africa/Bangui
-      * `Africa/Banjul` - Africa/Banjul
-      * `Africa/Bissau` - Africa/Bissau
-      * `Africa/Blantyre` - Africa/Blantyre
-      * `Africa/Brazzaville` - Africa/Brazzaville
-      * `Africa/Bujumbura` - Africa/Bujumbura
-      * `Africa/Cairo` - Africa/Cairo
-      * `Africa/Casablanca` - Africa/Casablanca
-      * `Africa/Ceuta` - Africa/Ceuta
-      * `Africa/Conakry` - Africa/Conakry
-      * `Africa/Dakar` - Africa/Dakar
-      * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-      * `Africa/Djibouti` - Africa/Djibouti
-      * `Africa/Douala` - Africa/Douala
-      * `Africa/El_Aaiun` - Africa/El_Aaiun
-      * `Africa/Freetown` - Africa/Freetown
-      * `Africa/Gaborone` - Africa/Gaborone
-      * `Africa/Harare` - Africa/Harare
-      * `Africa/Johannesburg` - Africa/Johannesburg
-      * `Africa/Juba` - Africa/Juba
-      * `Africa/Kampala` - Africa/Kampala
-      * `Africa/Khartoum` - Africa/Khartoum
-      * `Africa/Kigali` - Africa/Kigali
-      * `Africa/Kinshasa` - Africa/Kinshasa
-      * `Africa/Lagos` - Africa/Lagos
-      * `Africa/Libreville` - Africa/Libreville
-      * `Africa/Lome` - Africa/Lome
-      * `Africa/Luanda` - Africa/Luanda
-      * `Africa/Lubumbashi` - Africa/Lubumbashi
-      * `Africa/Lusaka` - Africa/Lusaka
-      * `Africa/Malabo` - Africa/Malabo
-      * `Africa/Maputo` - Africa/Maputo
-      * `Africa/Maseru` - Africa/Maseru
-      * `Africa/Mbabane` - Africa/Mbabane
-      * `Africa/Mogadishu` - Africa/Mogadishu
-      * `Africa/Monrovia` - Africa/Monrovia
-      * `Africa/Nairobi` - Africa/Nairobi
-      * `Africa/Ndjamena` - Africa/Ndjamena
-      * `Africa/Niamey` - Africa/Niamey
-      * `Africa/Nouakchott` - Africa/Nouakchott
-      * `Africa/Ouagadougou` - Africa/Ouagadougou
-      * `Africa/Porto-Novo` - Africa/Porto-Novo
-      * `Africa/Sao_Tome` - Africa/Sao_Tome
-      * `Africa/Timbuktu` - Africa/Timbuktu
-      * `Africa/Tripoli` - Africa/Tripoli
-      * `Africa/Tunis` - Africa/Tunis
-      * `Africa/Windhoek` - Africa/Windhoek
-      * `America/Adak` - America/Adak
-      * `America/Anchorage` - America/Anchorage
-      * `America/Anguilla` - America/Anguilla
-      * `America/Antigua` - America/Antigua
-      * `America/Araguaina` - America/Araguaina
-      * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-      * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-      * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-      * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-      * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-      * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-      * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-      * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-      * `America/Argentina/Salta` - America/Argentina/Salta
-      * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-      * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-      * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-      * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-      * `America/Aruba` - America/Aruba
-      * `America/Asuncion` - America/Asuncion
-      * `America/Atikokan` - America/Atikokan
-      * `America/Atka` - America/Atka
-      * `America/Bahia` - America/Bahia
-      * `America/Bahia_Banderas` - America/Bahia_Banderas
-      * `America/Barbados` - America/Barbados
-      * `America/Belem` - America/Belem
-      * `America/Belize` - America/Belize
-      * `America/Blanc-Sablon` - America/Blanc-Sablon
-      * `America/Boa_Vista` - America/Boa_Vista
-      * `America/Bogota` - America/Bogota
-      * `America/Boise` - America/Boise
-      * `America/Buenos_Aires` - America/Buenos_Aires
-      * `America/Cambridge_Bay` - America/Cambridge_Bay
-      * `America/Campo_Grande` - America/Campo_Grande
-      * `America/Cancun` - America/Cancun
-      * `America/Caracas` - America/Caracas
-      * `America/Catamarca` - America/Catamarca
-      * `America/Cayenne` - America/Cayenne
-      * `America/Cayman` - America/Cayman
-      * `America/Chicago` - America/Chicago
-      * `America/Chihuahua` - America/Chihuahua
-      * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-      * `America/Coral_Harbour` - America/Coral_Harbour
-      * `America/Cordoba` - America/Cordoba
-      * `America/Costa_Rica` - America/Costa_Rica
-      * `America/Creston` - America/Creston
-      * `America/Cuiaba` - America/Cuiaba
-      * `America/Curacao` - America/Curacao
-      * `America/Danmarkshavn` - America/Danmarkshavn
-      * `America/Dawson` - America/Dawson
-      * `America/Dawson_Creek` - America/Dawson_Creek
-      * `America/Denver` - America/Denver
-      * `America/Detroit` - America/Detroit
-      * `America/Dominica` - America/Dominica
-      * `America/Edmonton` - America/Edmonton
-      * `America/Eirunepe` - America/Eirunepe
-      * `America/El_Salvador` - America/El_Salvador
-      * `America/Ensenada` - America/Ensenada
-      * `America/Fort_Nelson` - America/Fort_Nelson
-      * `America/Fort_Wayne` - America/Fort_Wayne
-      * `America/Fortaleza` - America/Fortaleza
-      * `America/Glace_Bay` - America/Glace_Bay
-      * `America/Godthab` - America/Godthab
-      * `America/Goose_Bay` - America/Goose_Bay
-      * `America/Grand_Turk` - America/Grand_Turk
-      * `America/Grenada` - America/Grenada
-      * `America/Guadeloupe` - America/Guadeloupe
-      * `America/Guatemala` - America/Guatemala
-      * `America/Guayaquil` - America/Guayaquil
-      * `America/Guyana` - America/Guyana
-      * `America/Halifax` - America/Halifax
-      * `America/Havana` - America/Havana
-      * `America/Hermosillo` - America/Hermosillo
-      * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-      * `America/Indiana/Knox` - America/Indiana/Knox
-      * `America/Indiana/Marengo` - America/Indiana/Marengo
-      * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-      * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-      * `America/Indiana/Vevay` - America/Indiana/Vevay
-      * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-      * `America/Indiana/Winamac` - America/Indiana/Winamac
-      * `America/Indianapolis` - America/Indianapolis
-      * `America/Inuvik` - America/Inuvik
-      * `America/Iqaluit` - America/Iqaluit
-      * `America/Jamaica` - America/Jamaica
-      * `America/Jujuy` - America/Jujuy
-      * `America/Juneau` - America/Juneau
-      * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-      * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-      * `America/Knox_IN` - America/Knox_IN
-      * `America/Kralendijk` - America/Kralendijk
-      * `America/La_Paz` - America/La_Paz
-      * `America/Lima` - America/Lima
-      * `America/Los_Angeles` - America/Los_Angeles
-      * `America/Louisville` - America/Louisville
-      * `America/Lower_Princes` - America/Lower_Princes
-      * `America/Maceio` - America/Maceio
-      * `America/Managua` - America/Managua
-      * `America/Manaus` - America/Manaus
-      * `America/Marigot` - America/Marigot
-      * `America/Martinique` - America/Martinique
-      * `America/Matamoros` - America/Matamoros
-      * `America/Mazatlan` - America/Mazatlan
-      * `America/Mendoza` - America/Mendoza
-      * `America/Menominee` - America/Menominee
-      * `America/Merida` - America/Merida
-      * `America/Metlakatla` - America/Metlakatla
-      * `America/Mexico_City` - America/Mexico_City
-      * `America/Miquelon` - America/Miquelon
-      * `America/Moncton` - America/Moncton
-      * `America/Monterrey` - America/Monterrey
-      * `America/Montevideo` - America/Montevideo
-      * `America/Montreal` - America/Montreal
-      * `America/Montserrat` - America/Montserrat
-      * `America/Nassau` - America/Nassau
-      * `America/New_York` - America/New_York
-      * `America/Nipigon` - America/Nipigon
-      * `America/Nome` - America/Nome
-      * `America/Noronha` - America/Noronha
-      * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-      * `America/North_Dakota/Center` - America/North_Dakota/Center
-      * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-      * `America/Nuuk` - America/Nuuk
-      * `America/Ojinaga` - America/Ojinaga
-      * `America/Panama` - America/Panama
-      * `America/Pangnirtung` - America/Pangnirtung
-      * `America/Paramaribo` - America/Paramaribo
-      * `America/Phoenix` - America/Phoenix
-      * `America/Port-au-Prince` - America/Port-au-Prince
-      * `America/Port_of_Spain` - America/Port_of_Spain
-      * `America/Porto_Acre` - America/Porto_Acre
-      * `America/Porto_Velho` - America/Porto_Velho
-      * `America/Puerto_Rico` - America/Puerto_Rico
-      * `America/Punta_Arenas` - America/Punta_Arenas
-      * `America/Rainy_River` - America/Rainy_River
-      * `America/Rankin_Inlet` - America/Rankin_Inlet
-      * `America/Recife` - America/Recife
-      * `America/Regina` - America/Regina
-      * `America/Resolute` - America/Resolute
-      * `America/Rio_Branco` - America/Rio_Branco
-      * `America/Rosario` - America/Rosario
-      * `America/Santa_Isabel` - America/Santa_Isabel
-      * `America/Santarem` - America/Santarem
-      * `America/Santiago` - America/Santiago
-      * `America/Santo_Domingo` - America/Santo_Domingo
-      * `America/Sao_Paulo` - America/Sao_Paulo
-      * `America/Scoresbysund` - America/Scoresbysund
-      * `America/Shiprock` - America/Shiprock
-      * `America/Sitka` - America/Sitka
-      * `America/St_Barthelemy` - America/St_Barthelemy
-      * `America/St_Johns` - America/St_Johns
-      * `America/St_Kitts` - America/St_Kitts
-      * `America/St_Lucia` - America/St_Lucia
-      * `America/St_Thomas` - America/St_Thomas
-      * `America/St_Vincent` - America/St_Vincent
-      * `America/Swift_Current` - America/Swift_Current
-      * `America/Tegucigalpa` - America/Tegucigalpa
-      * `America/Thule` - America/Thule
-      * `America/Thunder_Bay` - America/Thunder_Bay
-      * `America/Tijuana` - America/Tijuana
-      * `America/Toronto` - America/Toronto
-      * `America/Tortola` - America/Tortola
-      * `America/Vancouver` - America/Vancouver
-      * `America/Virgin` - America/Virgin
-      * `America/Whitehorse` - America/Whitehorse
-      * `America/Winnipeg` - America/Winnipeg
-      * `America/Yakutat` - America/Yakutat
-      * `America/Yellowknife` - America/Yellowknife
-      * `Antarctica/Casey` - Antarctica/Casey
-      * `Antarctica/Davis` - Antarctica/Davis
-      * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-      * `Antarctica/Macquarie` - Antarctica/Macquarie
-      * `Antarctica/Mawson` - Antarctica/Mawson
-      * `Antarctica/McMurdo` - Antarctica/McMurdo
-      * `Antarctica/Palmer` - Antarctica/Palmer
-      * `Antarctica/Rothera` - Antarctica/Rothera
-      * `Antarctica/South_Pole` - Antarctica/South_Pole
-      * `Antarctica/Syowa` - Antarctica/Syowa
-      * `Antarctica/Troll` - Antarctica/Troll
-      * `Antarctica/Vostok` - Antarctica/Vostok
-      * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-      * `Asia/Aden` - Asia/Aden
-      * `Asia/Almaty` - Asia/Almaty
-      * `Asia/Amman` - Asia/Amman
-      * `Asia/Anadyr` - Asia/Anadyr
-      * `Asia/Aqtau` - Asia/Aqtau
-      * `Asia/Aqtobe` - Asia/Aqtobe
-      * `Asia/Ashgabat` - Asia/Ashgabat
-      * `Asia/Ashkhabad` - Asia/Ashkhabad
-      * `Asia/Atyrau` - Asia/Atyrau
-      * `Asia/Baghdad` - Asia/Baghdad
-      * `Asia/Bahrain` - Asia/Bahrain
-      * `Asia/Baku` - Asia/Baku
-      * `Asia/Bangkok` - Asia/Bangkok
-      * `Asia/Barnaul` - Asia/Barnaul
-      * `Asia/Beirut` - Asia/Beirut
-      * `Asia/Bishkek` - Asia/Bishkek
-      * `Asia/Brunei` - Asia/Brunei
-      * `Asia/Calcutta` - Asia/Calcutta
-      * `Asia/Chita` - Asia/Chita
-      * `Asia/Choibalsan` - Asia/Choibalsan
-      * `Asia/Chongqing` - Asia/Chongqing
-      * `Asia/Chungking` - Asia/Chungking
-      * `Asia/Colombo` - Asia/Colombo
-      * `Asia/Dacca` - Asia/Dacca
-      * `Asia/Damascus` - Asia/Damascus
-      * `Asia/Dhaka` - Asia/Dhaka
-      * `Asia/Dili` - Asia/Dili
-      * `Asia/Dubai` - Asia/Dubai
-      * `Asia/Dushanbe` - Asia/Dushanbe
-      * `Asia/Famagusta` - Asia/Famagusta
-      * `Asia/Gaza` - Asia/Gaza
-      * `Asia/Harbin` - Asia/Harbin
-      * `Asia/Hebron` - Asia/Hebron
-      * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-      * `Asia/Hong_Kong` - Asia/Hong_Kong
-      * `Asia/Hovd` - Asia/Hovd
-      * `Asia/Irkutsk` - Asia/Irkutsk
-      * `Asia/Istanbul` - Asia/Istanbul
-      * `Asia/Jakarta` - Asia/Jakarta
-      * `Asia/Jayapura` - Asia/Jayapura
-      * `Asia/Jerusalem` - Asia/Jerusalem
-      * `Asia/Kabul` - Asia/Kabul
-      * `Asia/Kamchatka` - Asia/Kamchatka
-      * `Asia/Karachi` - Asia/Karachi
-      * `Asia/Kashgar` - Asia/Kashgar
-      * `Asia/Kathmandu` - Asia/Kathmandu
-      * `Asia/Katmandu` - Asia/Katmandu
-      * `Asia/Khandyga` - Asia/Khandyga
-      * `Asia/Kolkata` - Asia/Kolkata
-      * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-      * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-      * `Asia/Kuching` - Asia/Kuching
-      * `Asia/Kuwait` - Asia/Kuwait
-      * `Asia/Macao` - Asia/Macao
-      * `Asia/Macau` - Asia/Macau
-      * `Asia/Magadan` - Asia/Magadan
-      * `Asia/Makassar` - Asia/Makassar
-      * `Asia/Manila` - Asia/Manila
-      * `Asia/Muscat` - Asia/Muscat
-      * `Asia/Nicosia` - Asia/Nicosia
-      * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-      * `Asia/Novosibirsk` - Asia/Novosibirsk
-      * `Asia/Omsk` - Asia/Omsk
-      * `Asia/Oral` - Asia/Oral
-      * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-      * `Asia/Pontianak` - Asia/Pontianak
-      * `Asia/Pyongyang` - Asia/Pyongyang
-      * `Asia/Qatar` - Asia/Qatar
-      * `Asia/Qostanay` - Asia/Qostanay
-      * `Asia/Qyzylorda` - Asia/Qyzylorda
-      * `Asia/Rangoon` - Asia/Rangoon
-      * `Asia/Riyadh` - Asia/Riyadh
-      * `Asia/Saigon` - Asia/Saigon
-      * `Asia/Sakhalin` - Asia/Sakhalin
-      * `Asia/Samarkand` - Asia/Samarkand
-      * `Asia/Seoul` - Asia/Seoul
-      * `Asia/Shanghai` - Asia/Shanghai
-      * `Asia/Singapore` - Asia/Singapore
-      * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-      * `Asia/Taipei` - Asia/Taipei
-      * `Asia/Tashkent` - Asia/Tashkent
-      * `Asia/Tbilisi` - Asia/Tbilisi
-      * `Asia/Tehran` - Asia/Tehran
-      * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-      * `Asia/Thimbu` - Asia/Thimbu
-      * `Asia/Thimphu` - Asia/Thimphu
-      * `Asia/Tokyo` - Asia/Tokyo
-      * `Asia/Tomsk` - Asia/Tomsk
-      * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-      * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-      * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-      * `Asia/Urumqi` - Asia/Urumqi
-      * `Asia/Ust-Nera` - Asia/Ust-Nera
-      * `Asia/Vientiane` - Asia/Vientiane
-      * `Asia/Vladivostok` - Asia/Vladivostok
-      * `Asia/Yakutsk` - Asia/Yakutsk
-      * `Asia/Yangon` - Asia/Yangon
-      * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-      * `Asia/Yerevan` - Asia/Yerevan
-      * `Atlantic/Azores` - Atlantic/Azores
-      * `Atlantic/Bermuda` - Atlantic/Bermuda
-      * `Atlantic/Canary` - Atlantic/Canary
-      * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-      * `Atlantic/Faeroe` - Atlantic/Faeroe
-      * `Atlantic/Faroe` - Atlantic/Faroe
-      * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-      * `Atlantic/Madeira` - Atlantic/Madeira
-      * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-      * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-      * `Atlantic/St_Helena` - Atlantic/St_Helena
-      * `Atlantic/Stanley` - Atlantic/Stanley
-      * `Australia/ACT` - Australia/ACT
-      * `Australia/Adelaide` - Australia/Adelaide
-      * `Australia/Brisbane` - Australia/Brisbane
-      * `Australia/Broken_Hill` - Australia/Broken_Hill
-      * `Australia/Canberra` - Australia/Canberra
-      * `Australia/Currie` - Australia/Currie
-      * `Australia/Darwin` - Australia/Darwin
-      * `Australia/Eucla` - Australia/Eucla
-      * `Australia/Hobart` - Australia/Hobart
-      * `Australia/LHI` - Australia/LHI
-      * `Australia/Lindeman` - Australia/Lindeman
-      * `Australia/Lord_Howe` - Australia/Lord_Howe
-      * `Australia/Melbourne` - Australia/Melbourne
-      * `Australia/NSW` - Australia/NSW
-      * `Australia/North` - Australia/North
-      * `Australia/Perth` - Australia/Perth
-      * `Australia/Queensland` - Australia/Queensland
-      * `Australia/South` - Australia/South
-      * `Australia/Sydney` - Australia/Sydney
-      * `Australia/Tasmania` - Australia/Tasmania
-      * `Australia/Victoria` - Australia/Victoria
-      * `Australia/West` - Australia/West
-      * `Australia/Yancowinna` - Australia/Yancowinna
-      * `Brazil/Acre` - Brazil/Acre
-      * `Brazil/DeNoronha` - Brazil/DeNoronha
-      * `Brazil/East` - Brazil/East
-      * `Brazil/West` - Brazil/West
-      * `CET` - CET
-      * `CST6CDT` - CST6CDT
-      * `Canada/Atlantic` - Canada/Atlantic
-      * `Canada/Central` - Canada/Central
-      * `Canada/Eastern` - Canada/Eastern
-      * `Canada/Mountain` - Canada/Mountain
-      * `Canada/Newfoundland` - Canada/Newfoundland
-      * `Canada/Pacific` - Canada/Pacific
-      * `Canada/Saskatchewan` - Canada/Saskatchewan
-      * `Canada/Yukon` - Canada/Yukon
-      * `Chile/Continental` - Chile/Continental
-      * `Chile/EasterIsland` - Chile/EasterIsland
-      * `Cuba` - Cuba
-      * `EET` - EET
-      * `EST` - EST
-      * `EST5EDT` - EST5EDT
-      * `Egypt` - Egypt
-      * `Eire` - Eire
-      * `Etc/GMT` - Etc/GMT
-      * `Etc/GMT+0` - Etc/GMT+0
-      * `Etc/GMT+1` - Etc/GMT+1
-      * `Etc/GMT+10` - Etc/GMT+10
-      * `Etc/GMT+11` - Etc/GMT+11
-      * `Etc/GMT+12` - Etc/GMT+12
-      * `Etc/GMT+2` - Etc/GMT+2
-      * `Etc/GMT+3` - Etc/GMT+3
-      * `Etc/GMT+4` - Etc/GMT+4
-      * `Etc/GMT+5` - Etc/GMT+5
-      * `Etc/GMT+6` - Etc/GMT+6
-      * `Etc/GMT+7` - Etc/GMT+7
-      * `Etc/GMT+8` - Etc/GMT+8
-      * `Etc/GMT+9` - Etc/GMT+9
-      * `Etc/GMT-0` - Etc/GMT-0
-      * `Etc/GMT-1` - Etc/GMT-1
-      * `Etc/GMT-10` - Etc/GMT-10
-      * `Etc/GMT-11` - Etc/GMT-11
-      * `Etc/GMT-12` - Etc/GMT-12
-      * `Etc/GMT-13` - Etc/GMT-13
-      * `Etc/GMT-14` - Etc/GMT-14
-      * `Etc/GMT-2` - Etc/GMT-2
-      * `Etc/GMT-3` - Etc/GMT-3
-      * `Etc/GMT-4` - Etc/GMT-4
-      * `Etc/GMT-5` - Etc/GMT-5
-      * `Etc/GMT-6` - Etc/GMT-6
-      * `Etc/GMT-7` - Etc/GMT-7
-      * `Etc/GMT-8` - Etc/GMT-8
-      * `Etc/GMT-9` - Etc/GMT-9
-      * `Etc/GMT0` - Etc/GMT0
-      * `Etc/Greenwich` - Etc/Greenwich
-      * `Etc/UCT` - Etc/UCT
-      * `Etc/UTC` - Etc/UTC
-      * `Etc/Universal` - Etc/Universal
-      * `Etc/Zulu` - Etc/Zulu
-      * `Europe/Amsterdam` - Europe/Amsterdam
-      * `Europe/Andorra` - Europe/Andorra
-      * `Europe/Astrakhan` - Europe/Astrakhan
-      * `Europe/Athens` - Europe/Athens
-      * `Europe/Belfast` - Europe/Belfast
-      * `Europe/Belgrade` - Europe/Belgrade
-      * `Europe/Berlin` - Europe/Berlin
-      * `Europe/Bratislava` - Europe/Bratislava
-      * `Europe/Brussels` - Europe/Brussels
-      * `Europe/Bucharest` - Europe/Bucharest
-      * `Europe/Budapest` - Europe/Budapest
-      * `Europe/Busingen` - Europe/Busingen
-      * `Europe/Chisinau` - Europe/Chisinau
-      * `Europe/Copenhagen` - Europe/Copenhagen
-      * `Europe/Dublin` - Europe/Dublin
-      * `Europe/Gibraltar` - Europe/Gibraltar
-      * `Europe/Guernsey` - Europe/Guernsey
-      * `Europe/Helsinki` - Europe/Helsinki
-      * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-      * `Europe/Istanbul` - Europe/Istanbul
-      * `Europe/Jersey` - Europe/Jersey
-      * `Europe/Kaliningrad` - Europe/Kaliningrad
-      * `Europe/Kiev` - Europe/Kiev
-      * `Europe/Kirov` - Europe/Kirov
-      * `Europe/Kyiv` - Europe/Kyiv
-      * `Europe/Lisbon` - Europe/Lisbon
-      * `Europe/Ljubljana` - Europe/Ljubljana
-      * `Europe/London` - Europe/London
-      * `Europe/Luxembourg` - Europe/Luxembourg
-      * `Europe/Madrid` - Europe/Madrid
-      * `Europe/Malta` - Europe/Malta
-      * `Europe/Mariehamn` - Europe/Mariehamn
-      * `Europe/Minsk` - Europe/Minsk
-      * `Europe/Monaco` - Europe/Monaco
-      * `Europe/Moscow` - Europe/Moscow
-      * `Europe/Nicosia` - Europe/Nicosia
-      * `Europe/Oslo` - Europe/Oslo
-      * `Europe/Paris` - Europe/Paris
-      * `Europe/Podgorica` - Europe/Podgorica
-      * `Europe/Prague` - Europe/Prague
-      * `Europe/Riga` - Europe/Riga
-      * `Europe/Rome` - Europe/Rome
-      * `Europe/Samara` - Europe/Samara
-      * `Europe/San_Marino` - Europe/San_Marino
-      * `Europe/Sarajevo` - Europe/Sarajevo
-      * `Europe/Saratov` - Europe/Saratov
-      * `Europe/Simferopol` - Europe/Simferopol
-      * `Europe/Skopje` - Europe/Skopje
-      * `Europe/Sofia` - Europe/Sofia
-      * `Europe/Stockholm` - Europe/Stockholm
-      * `Europe/Tallinn` - Europe/Tallinn
-      * `Europe/Tirane` - Europe/Tirane
-      * `Europe/Tiraspol` - Europe/Tiraspol
-      * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-      * `Europe/Uzhgorod` - Europe/Uzhgorod
-      * `Europe/Vaduz` - Europe/Vaduz
-      * `Europe/Vatican` - Europe/Vatican
-      * `Europe/Vienna` - Europe/Vienna
-      * `Europe/Vilnius` - Europe/Vilnius
-      * `Europe/Volgograd` - Europe/Volgograd
-      * `Europe/Warsaw` - Europe/Warsaw
-      * `Europe/Zagreb` - Europe/Zagreb
-      * `Europe/Zaporozhye` - Europe/Zaporozhye
-      * `Europe/Zurich` - Europe/Zurich
-      * `GB` - GB
-      * `GB-Eire` - GB-Eire
-      * `GMT` - GMT
-      * `GMT+0` - GMT+0
-      * `GMT-0` - GMT-0
-      * `GMT0` - GMT0
-      * `Greenwich` - Greenwich
-      * `HST` - HST
-      * `Hongkong` - Hongkong
-      * `Iceland` - Iceland
-      * `Indian/Antananarivo` - Indian/Antananarivo
-      * `Indian/Chagos` - Indian/Chagos
-      * `Indian/Christmas` - Indian/Christmas
-      * `Indian/Cocos` - Indian/Cocos
-      * `Indian/Comoro` - Indian/Comoro
-      * `Indian/Kerguelen` - Indian/Kerguelen
-      * `Indian/Mahe` - Indian/Mahe
-      * `Indian/Maldives` - Indian/Maldives
-      * `Indian/Mauritius` - Indian/Mauritius
-      * `Indian/Mayotte` - Indian/Mayotte
-      * `Indian/Reunion` - Indian/Reunion
-      * `Iran` - Iran
-      * `Israel` - Israel
-      * `Jamaica` - Jamaica
-      * `Japan` - Japan
-      * `Kwajalein` - Kwajalein
-      * `Libya` - Libya
-      * `MET` - MET
-      * `MST` - MST
-      * `MST7MDT` - MST7MDT
-      * `Mexico/BajaNorte` - Mexico/BajaNorte
-      * `Mexico/BajaSur` - Mexico/BajaSur
-      * `Mexico/General` - Mexico/General
-      * `NZ` - NZ
-      * `NZ-CHAT` - NZ-CHAT
-      * `Navajo` - Navajo
-      * `PRC` - PRC
-      * `PST8PDT` - PST8PDT
-      * `Pacific/Apia` - Pacific/Apia
-      * `Pacific/Auckland` - Pacific/Auckland
-      * `Pacific/Bougainville` - Pacific/Bougainville
-      * `Pacific/Chatham` - Pacific/Chatham
-      * `Pacific/Chuuk` - Pacific/Chuuk
-      * `Pacific/Easter` - Pacific/Easter
-      * `Pacific/Efate` - Pacific/Efate
-      * `Pacific/Enderbury` - Pacific/Enderbury
-      * `Pacific/Fakaofo` - Pacific/Fakaofo
-      * `Pacific/Fiji` - Pacific/Fiji
-      * `Pacific/Funafuti` - Pacific/Funafuti
-      * `Pacific/Galapagos` - Pacific/Galapagos
-      * `Pacific/Gambier` - Pacific/Gambier
-      * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-      * `Pacific/Guam` - Pacific/Guam
-      * `Pacific/Honolulu` - Pacific/Honolulu
-      * `Pacific/Johnston` - Pacific/Johnston
-      * `Pacific/Kanton` - Pacific/Kanton
-      * `Pacific/Kiritimati` - Pacific/Kiritimati
-      * `Pacific/Kosrae` - Pacific/Kosrae
-      * `Pacific/Kwajalein` - Pacific/Kwajalein
-      * `Pacific/Majuro` - Pacific/Majuro
-      * `Pacific/Marquesas` - Pacific/Marquesas
-      * `Pacific/Midway` - Pacific/Midway
-      * `Pacific/Nauru` - Pacific/Nauru
-      * `Pacific/Niue` - Pacific/Niue
-      * `Pacific/Norfolk` - Pacific/Norfolk
-      * `Pacific/Noumea` - Pacific/Noumea
-      * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-      * `Pacific/Palau` - Pacific/Palau
-      * `Pacific/Pitcairn` - Pacific/Pitcairn
-      * `Pacific/Pohnpei` - Pacific/Pohnpei
-      * `Pacific/Ponape` - Pacific/Ponape
-      * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-      * `Pacific/Rarotonga` - Pacific/Rarotonga
-      * `Pacific/Saipan` - Pacific/Saipan
-      * `Pacific/Samoa` - Pacific/Samoa
-      * `Pacific/Tahiti` - Pacific/Tahiti
-      * `Pacific/Tarawa` - Pacific/Tarawa
-      * `Pacific/Tongatapu` - Pacific/Tongatapu
-      * `Pacific/Truk` - Pacific/Truk
-      * `Pacific/Wake` - Pacific/Wake
-      * `Pacific/Wallis` - Pacific/Wallis
-      * `Pacific/Yap` - Pacific/Yap
-      * `Poland` - Poland
-      * `Portugal` - Portugal
-      * `ROC` - ROC
-      * `ROK` - ROK
-      * `Singapore` - Singapore
-      * `Turkey` - Turkey
-      * `UCT` - UCT
-      * `US/Alaska` - US/Alaska
-      * `US/Aleutian` - US/Aleutian
-      * `US/Arizona` - US/Arizona
-      * `US/Central` - US/Central
-      * `US/East-Indiana` - US/East-Indiana
-      * `US/Eastern` - US/Eastern
-      * `US/Hawaii` - US/Hawaii
-      * `US/Indiana-Starke` - US/Indiana-Starke
-      * `US/Michigan` - US/Michigan
-      * `US/Mountain` - US/Mountain
-      * `US/Pacific` - US/Pacific
-      * `US/Samoa` - US/Samoa
-      * `UTC` - UTC
-      * `Universal` - Universal
-      * `W-SU` - W-SU
-      * `WET` - WET
-      * `Zulu` - Zulu */
+       *
+       * * `Africa/Abidjan` - Africa/Abidjan
+       * * `Africa/Accra` - Africa/Accra
+       * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+       * * `Africa/Algiers` - Africa/Algiers
+       * * `Africa/Asmara` - Africa/Asmara
+       * * `Africa/Asmera` - Africa/Asmera
+       * * `Africa/Bamako` - Africa/Bamako
+       * * `Africa/Bangui` - Africa/Bangui
+       * * `Africa/Banjul` - Africa/Banjul
+       * * `Africa/Bissau` - Africa/Bissau
+       * * `Africa/Blantyre` - Africa/Blantyre
+       * * `Africa/Brazzaville` - Africa/Brazzaville
+       * * `Africa/Bujumbura` - Africa/Bujumbura
+       * * `Africa/Cairo` - Africa/Cairo
+       * * `Africa/Casablanca` - Africa/Casablanca
+       * * `Africa/Ceuta` - Africa/Ceuta
+       * * `Africa/Conakry` - Africa/Conakry
+       * * `Africa/Dakar` - Africa/Dakar
+       * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+       * * `Africa/Djibouti` - Africa/Djibouti
+       * * `Africa/Douala` - Africa/Douala
+       * * `Africa/El_Aaiun` - Africa/El_Aaiun
+       * * `Africa/Freetown` - Africa/Freetown
+       * * `Africa/Gaborone` - Africa/Gaborone
+       * * `Africa/Harare` - Africa/Harare
+       * * `Africa/Johannesburg` - Africa/Johannesburg
+       * * `Africa/Juba` - Africa/Juba
+       * * `Africa/Kampala` - Africa/Kampala
+       * * `Africa/Khartoum` - Africa/Khartoum
+       * * `Africa/Kigali` - Africa/Kigali
+       * * `Africa/Kinshasa` - Africa/Kinshasa
+       * * `Africa/Lagos` - Africa/Lagos
+       * * `Africa/Libreville` - Africa/Libreville
+       * * `Africa/Lome` - Africa/Lome
+       * * `Africa/Luanda` - Africa/Luanda
+       * * `Africa/Lubumbashi` - Africa/Lubumbashi
+       * * `Africa/Lusaka` - Africa/Lusaka
+       * * `Africa/Malabo` - Africa/Malabo
+       * * `Africa/Maputo` - Africa/Maputo
+       * * `Africa/Maseru` - Africa/Maseru
+       * * `Africa/Mbabane` - Africa/Mbabane
+       * * `Africa/Mogadishu` - Africa/Mogadishu
+       * * `Africa/Monrovia` - Africa/Monrovia
+       * * `Africa/Nairobi` - Africa/Nairobi
+       * * `Africa/Ndjamena` - Africa/Ndjamena
+       * * `Africa/Niamey` - Africa/Niamey
+       * * `Africa/Nouakchott` - Africa/Nouakchott
+       * * `Africa/Ouagadougou` - Africa/Ouagadougou
+       * * `Africa/Porto-Novo` - Africa/Porto-Novo
+       * * `Africa/Sao_Tome` - Africa/Sao_Tome
+       * * `Africa/Timbuktu` - Africa/Timbuktu
+       * * `Africa/Tripoli` - Africa/Tripoli
+       * * `Africa/Tunis` - Africa/Tunis
+       * * `Africa/Windhoek` - Africa/Windhoek
+       * * `America/Adak` - America/Adak
+       * * `America/Anchorage` - America/Anchorage
+       * * `America/Anguilla` - America/Anguilla
+       * * `America/Antigua` - America/Antigua
+       * * `America/Araguaina` - America/Araguaina
+       * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+       * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+       * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+       * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+       * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+       * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+       * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+       * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+       * * `America/Argentina/Salta` - America/Argentina/Salta
+       * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+       * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+       * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+       * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+       * * `America/Aruba` - America/Aruba
+       * * `America/Asuncion` - America/Asuncion
+       * * `America/Atikokan` - America/Atikokan
+       * * `America/Atka` - America/Atka
+       * * `America/Bahia` - America/Bahia
+       * * `America/Bahia_Banderas` - America/Bahia_Banderas
+       * * `America/Barbados` - America/Barbados
+       * * `America/Belem` - America/Belem
+       * * `America/Belize` - America/Belize
+       * * `America/Blanc-Sablon` - America/Blanc-Sablon
+       * * `America/Boa_Vista` - America/Boa_Vista
+       * * `America/Bogota` - America/Bogota
+       * * `America/Boise` - America/Boise
+       * * `America/Buenos_Aires` - America/Buenos_Aires
+       * * `America/Cambridge_Bay` - America/Cambridge_Bay
+       * * `America/Campo_Grande` - America/Campo_Grande
+       * * `America/Cancun` - America/Cancun
+       * * `America/Caracas` - America/Caracas
+       * * `America/Catamarca` - America/Catamarca
+       * * `America/Cayenne` - America/Cayenne
+       * * `America/Cayman` - America/Cayman
+       * * `America/Chicago` - America/Chicago
+       * * `America/Chihuahua` - America/Chihuahua
+       * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+       * * `America/Coral_Harbour` - America/Coral_Harbour
+       * * `America/Cordoba` - America/Cordoba
+       * * `America/Costa_Rica` - America/Costa_Rica
+       * * `America/Creston` - America/Creston
+       * * `America/Cuiaba` - America/Cuiaba
+       * * `America/Curacao` - America/Curacao
+       * * `America/Danmarkshavn` - America/Danmarkshavn
+       * * `America/Dawson` - America/Dawson
+       * * `America/Dawson_Creek` - America/Dawson_Creek
+       * * `America/Denver` - America/Denver
+       * * `America/Detroit` - America/Detroit
+       * * `America/Dominica` - America/Dominica
+       * * `America/Edmonton` - America/Edmonton
+       * * `America/Eirunepe` - America/Eirunepe
+       * * `America/El_Salvador` - America/El_Salvador
+       * * `America/Ensenada` - America/Ensenada
+       * * `America/Fort_Nelson` - America/Fort_Nelson
+       * * `America/Fort_Wayne` - America/Fort_Wayne
+       * * `America/Fortaleza` - America/Fortaleza
+       * * `America/Glace_Bay` - America/Glace_Bay
+       * * `America/Godthab` - America/Godthab
+       * * `America/Goose_Bay` - America/Goose_Bay
+       * * `America/Grand_Turk` - America/Grand_Turk
+       * * `America/Grenada` - America/Grenada
+       * * `America/Guadeloupe` - America/Guadeloupe
+       * * `America/Guatemala` - America/Guatemala
+       * * `America/Guayaquil` - America/Guayaquil
+       * * `America/Guyana` - America/Guyana
+       * * `America/Halifax` - America/Halifax
+       * * `America/Havana` - America/Havana
+       * * `America/Hermosillo` - America/Hermosillo
+       * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+       * * `America/Indiana/Knox` - America/Indiana/Knox
+       * * `America/Indiana/Marengo` - America/Indiana/Marengo
+       * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+       * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+       * * `America/Indiana/Vevay` - America/Indiana/Vevay
+       * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+       * * `America/Indiana/Winamac` - America/Indiana/Winamac
+       * * `America/Indianapolis` - America/Indianapolis
+       * * `America/Inuvik` - America/Inuvik
+       * * `America/Iqaluit` - America/Iqaluit
+       * * `America/Jamaica` - America/Jamaica
+       * * `America/Jujuy` - America/Jujuy
+       * * `America/Juneau` - America/Juneau
+       * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+       * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+       * * `America/Knox_IN` - America/Knox_IN
+       * * `America/Kralendijk` - America/Kralendijk
+       * * `America/La_Paz` - America/La_Paz
+       * * `America/Lima` - America/Lima
+       * * `America/Los_Angeles` - America/Los_Angeles
+       * * `America/Louisville` - America/Louisville
+       * * `America/Lower_Princes` - America/Lower_Princes
+       * * `America/Maceio` - America/Maceio
+       * * `America/Managua` - America/Managua
+       * * `America/Manaus` - America/Manaus
+       * * `America/Marigot` - America/Marigot
+       * * `America/Martinique` - America/Martinique
+       * * `America/Matamoros` - America/Matamoros
+       * * `America/Mazatlan` - America/Mazatlan
+       * * `America/Mendoza` - America/Mendoza
+       * * `America/Menominee` - America/Menominee
+       * * `America/Merida` - America/Merida
+       * * `America/Metlakatla` - America/Metlakatla
+       * * `America/Mexico_City` - America/Mexico_City
+       * * `America/Miquelon` - America/Miquelon
+       * * `America/Moncton` - America/Moncton
+       * * `America/Monterrey` - America/Monterrey
+       * * `America/Montevideo` - America/Montevideo
+       * * `America/Montreal` - America/Montreal
+       * * `America/Montserrat` - America/Montserrat
+       * * `America/Nassau` - America/Nassau
+       * * `America/New_York` - America/New_York
+       * * `America/Nipigon` - America/Nipigon
+       * * `America/Nome` - America/Nome
+       * * `America/Noronha` - America/Noronha
+       * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+       * * `America/North_Dakota/Center` - America/North_Dakota/Center
+       * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+       * * `America/Nuuk` - America/Nuuk
+       * * `America/Ojinaga` - America/Ojinaga
+       * * `America/Panama` - America/Panama
+       * * `America/Pangnirtung` - America/Pangnirtung
+       * * `America/Paramaribo` - America/Paramaribo
+       * * `America/Phoenix` - America/Phoenix
+       * * `America/Port-au-Prince` - America/Port-au-Prince
+       * * `America/Port_of_Spain` - America/Port_of_Spain
+       * * `America/Porto_Acre` - America/Porto_Acre
+       * * `America/Porto_Velho` - America/Porto_Velho
+       * * `America/Puerto_Rico` - America/Puerto_Rico
+       * * `America/Punta_Arenas` - America/Punta_Arenas
+       * * `America/Rainy_River` - America/Rainy_River
+       * * `America/Rankin_Inlet` - America/Rankin_Inlet
+       * * `America/Recife` - America/Recife
+       * * `America/Regina` - America/Regina
+       * * `America/Resolute` - America/Resolute
+       * * `America/Rio_Branco` - America/Rio_Branco
+       * * `America/Rosario` - America/Rosario
+       * * `America/Santa_Isabel` - America/Santa_Isabel
+       * * `America/Santarem` - America/Santarem
+       * * `America/Santiago` - America/Santiago
+       * * `America/Santo_Domingo` - America/Santo_Domingo
+       * * `America/Sao_Paulo` - America/Sao_Paulo
+       * * `America/Scoresbysund` - America/Scoresbysund
+       * * `America/Shiprock` - America/Shiprock
+       * * `America/Sitka` - America/Sitka
+       * * `America/St_Barthelemy` - America/St_Barthelemy
+       * * `America/St_Johns` - America/St_Johns
+       * * `America/St_Kitts` - America/St_Kitts
+       * * `America/St_Lucia` - America/St_Lucia
+       * * `America/St_Thomas` - America/St_Thomas
+       * * `America/St_Vincent` - America/St_Vincent
+       * * `America/Swift_Current` - America/Swift_Current
+       * * `America/Tegucigalpa` - America/Tegucigalpa
+       * * `America/Thule` - America/Thule
+       * * `America/Thunder_Bay` - America/Thunder_Bay
+       * * `America/Tijuana` - America/Tijuana
+       * * `America/Toronto` - America/Toronto
+       * * `America/Tortola` - America/Tortola
+       * * `America/Vancouver` - America/Vancouver
+       * * `America/Virgin` - America/Virgin
+       * * `America/Whitehorse` - America/Whitehorse
+       * * `America/Winnipeg` - America/Winnipeg
+       * * `America/Yakutat` - America/Yakutat
+       * * `America/Yellowknife` - America/Yellowknife
+       * * `Antarctica/Casey` - Antarctica/Casey
+       * * `Antarctica/Davis` - Antarctica/Davis
+       * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+       * * `Antarctica/Macquarie` - Antarctica/Macquarie
+       * * `Antarctica/Mawson` - Antarctica/Mawson
+       * * `Antarctica/McMurdo` - Antarctica/McMurdo
+       * * `Antarctica/Palmer` - Antarctica/Palmer
+       * * `Antarctica/Rothera` - Antarctica/Rothera
+       * * `Antarctica/South_Pole` - Antarctica/South_Pole
+       * * `Antarctica/Syowa` - Antarctica/Syowa
+       * * `Antarctica/Troll` - Antarctica/Troll
+       * * `Antarctica/Vostok` - Antarctica/Vostok
+       * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+       * * `Asia/Aden` - Asia/Aden
+       * * `Asia/Almaty` - Asia/Almaty
+       * * `Asia/Amman` - Asia/Amman
+       * * `Asia/Anadyr` - Asia/Anadyr
+       * * `Asia/Aqtau` - Asia/Aqtau
+       * * `Asia/Aqtobe` - Asia/Aqtobe
+       * * `Asia/Ashgabat` - Asia/Ashgabat
+       * * `Asia/Ashkhabad` - Asia/Ashkhabad
+       * * `Asia/Atyrau` - Asia/Atyrau
+       * * `Asia/Baghdad` - Asia/Baghdad
+       * * `Asia/Bahrain` - Asia/Bahrain
+       * * `Asia/Baku` - Asia/Baku
+       * * `Asia/Bangkok` - Asia/Bangkok
+       * * `Asia/Barnaul` - Asia/Barnaul
+       * * `Asia/Beirut` - Asia/Beirut
+       * * `Asia/Bishkek` - Asia/Bishkek
+       * * `Asia/Brunei` - Asia/Brunei
+       * * `Asia/Calcutta` - Asia/Calcutta
+       * * `Asia/Chita` - Asia/Chita
+       * * `Asia/Choibalsan` - Asia/Choibalsan
+       * * `Asia/Chongqing` - Asia/Chongqing
+       * * `Asia/Chungking` - Asia/Chungking
+       * * `Asia/Colombo` - Asia/Colombo
+       * * `Asia/Dacca` - Asia/Dacca
+       * * `Asia/Damascus` - Asia/Damascus
+       * * `Asia/Dhaka` - Asia/Dhaka
+       * * `Asia/Dili` - Asia/Dili
+       * * `Asia/Dubai` - Asia/Dubai
+       * * `Asia/Dushanbe` - Asia/Dushanbe
+       * * `Asia/Famagusta` - Asia/Famagusta
+       * * `Asia/Gaza` - Asia/Gaza
+       * * `Asia/Harbin` - Asia/Harbin
+       * * `Asia/Hebron` - Asia/Hebron
+       * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+       * * `Asia/Hong_Kong` - Asia/Hong_Kong
+       * * `Asia/Hovd` - Asia/Hovd
+       * * `Asia/Irkutsk` - Asia/Irkutsk
+       * * `Asia/Istanbul` - Asia/Istanbul
+       * * `Asia/Jakarta` - Asia/Jakarta
+       * * `Asia/Jayapura` - Asia/Jayapura
+       * * `Asia/Jerusalem` - Asia/Jerusalem
+       * * `Asia/Kabul` - Asia/Kabul
+       * * `Asia/Kamchatka` - Asia/Kamchatka
+       * * `Asia/Karachi` - Asia/Karachi
+       * * `Asia/Kashgar` - Asia/Kashgar
+       * * `Asia/Kathmandu` - Asia/Kathmandu
+       * * `Asia/Katmandu` - Asia/Katmandu
+       * * `Asia/Khandyga` - Asia/Khandyga
+       * * `Asia/Kolkata` - Asia/Kolkata
+       * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+       * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+       * * `Asia/Kuching` - Asia/Kuching
+       * * `Asia/Kuwait` - Asia/Kuwait
+       * * `Asia/Macao` - Asia/Macao
+       * * `Asia/Macau` - Asia/Macau
+       * * `Asia/Magadan` - Asia/Magadan
+       * * `Asia/Makassar` - Asia/Makassar
+       * * `Asia/Manila` - Asia/Manila
+       * * `Asia/Muscat` - Asia/Muscat
+       * * `Asia/Nicosia` - Asia/Nicosia
+       * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+       * * `Asia/Novosibirsk` - Asia/Novosibirsk
+       * * `Asia/Omsk` - Asia/Omsk
+       * * `Asia/Oral` - Asia/Oral
+       * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+       * * `Asia/Pontianak` - Asia/Pontianak
+       * * `Asia/Pyongyang` - Asia/Pyongyang
+       * * `Asia/Qatar` - Asia/Qatar
+       * * `Asia/Qostanay` - Asia/Qostanay
+       * * `Asia/Qyzylorda` - Asia/Qyzylorda
+       * * `Asia/Rangoon` - Asia/Rangoon
+       * * `Asia/Riyadh` - Asia/Riyadh
+       * * `Asia/Saigon` - Asia/Saigon
+       * * `Asia/Sakhalin` - Asia/Sakhalin
+       * * `Asia/Samarkand` - Asia/Samarkand
+       * * `Asia/Seoul` - Asia/Seoul
+       * * `Asia/Shanghai` - Asia/Shanghai
+       * * `Asia/Singapore` - Asia/Singapore
+       * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+       * * `Asia/Taipei` - Asia/Taipei
+       * * `Asia/Tashkent` - Asia/Tashkent
+       * * `Asia/Tbilisi` - Asia/Tbilisi
+       * * `Asia/Tehran` - Asia/Tehran
+       * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+       * * `Asia/Thimbu` - Asia/Thimbu
+       * * `Asia/Thimphu` - Asia/Thimphu
+       * * `Asia/Tokyo` - Asia/Tokyo
+       * * `Asia/Tomsk` - Asia/Tomsk
+       * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+       * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+       * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+       * * `Asia/Urumqi` - Asia/Urumqi
+       * * `Asia/Ust-Nera` - Asia/Ust-Nera
+       * * `Asia/Vientiane` - Asia/Vientiane
+       * * `Asia/Vladivostok` - Asia/Vladivostok
+       * * `Asia/Yakutsk` - Asia/Yakutsk
+       * * `Asia/Yangon` - Asia/Yangon
+       * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+       * * `Asia/Yerevan` - Asia/Yerevan
+       * * `Atlantic/Azores` - Atlantic/Azores
+       * * `Atlantic/Bermuda` - Atlantic/Bermuda
+       * * `Atlantic/Canary` - Atlantic/Canary
+       * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+       * * `Atlantic/Faeroe` - Atlantic/Faeroe
+       * * `Atlantic/Faroe` - Atlantic/Faroe
+       * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+       * * `Atlantic/Madeira` - Atlantic/Madeira
+       * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+       * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+       * * `Atlantic/St_Helena` - Atlantic/St_Helena
+       * * `Atlantic/Stanley` - Atlantic/Stanley
+       * * `Australia/ACT` - Australia/ACT
+       * * `Australia/Adelaide` - Australia/Adelaide
+       * * `Australia/Brisbane` - Australia/Brisbane
+       * * `Australia/Broken_Hill` - Australia/Broken_Hill
+       * * `Australia/Canberra` - Australia/Canberra
+       * * `Australia/Currie` - Australia/Currie
+       * * `Australia/Darwin` - Australia/Darwin
+       * * `Australia/Eucla` - Australia/Eucla
+       * * `Australia/Hobart` - Australia/Hobart
+       * * `Australia/LHI` - Australia/LHI
+       * * `Australia/Lindeman` - Australia/Lindeman
+       * * `Australia/Lord_Howe` - Australia/Lord_Howe
+       * * `Australia/Melbourne` - Australia/Melbourne
+       * * `Australia/NSW` - Australia/NSW
+       * * `Australia/North` - Australia/North
+       * * `Australia/Perth` - Australia/Perth
+       * * `Australia/Queensland` - Australia/Queensland
+       * * `Australia/South` - Australia/South
+       * * `Australia/Sydney` - Australia/Sydney
+       * * `Australia/Tasmania` - Australia/Tasmania
+       * * `Australia/Victoria` - Australia/Victoria
+       * * `Australia/West` - Australia/West
+       * * `Australia/Yancowinna` - Australia/Yancowinna
+       * * `Brazil/Acre` - Brazil/Acre
+       * * `Brazil/DeNoronha` - Brazil/DeNoronha
+       * * `Brazil/East` - Brazil/East
+       * * `Brazil/West` - Brazil/West
+       * * `CET` - CET
+       * * `CST6CDT` - CST6CDT
+       * * `Canada/Atlantic` - Canada/Atlantic
+       * * `Canada/Central` - Canada/Central
+       * * `Canada/Eastern` - Canada/Eastern
+       * * `Canada/Mountain` - Canada/Mountain
+       * * `Canada/Newfoundland` - Canada/Newfoundland
+       * * `Canada/Pacific` - Canada/Pacific
+       * * `Canada/Saskatchewan` - Canada/Saskatchewan
+       * * `Canada/Yukon` - Canada/Yukon
+       * * `Chile/Continental` - Chile/Continental
+       * * `Chile/EasterIsland` - Chile/EasterIsland
+       * * `Cuba` - Cuba
+       * * `EET` - EET
+       * * `EST` - EST
+       * * `EST5EDT` - EST5EDT
+       * * `Egypt` - Egypt
+       * * `Eire` - Eire
+       * * `Etc/GMT` - Etc/GMT
+       * * `Etc/GMT+0` - Etc/GMT+0
+       * * `Etc/GMT+1` - Etc/GMT+1
+       * * `Etc/GMT+10` - Etc/GMT+10
+       * * `Etc/GMT+11` - Etc/GMT+11
+       * * `Etc/GMT+12` - Etc/GMT+12
+       * * `Etc/GMT+2` - Etc/GMT+2
+       * * `Etc/GMT+3` - Etc/GMT+3
+       * * `Etc/GMT+4` - Etc/GMT+4
+       * * `Etc/GMT+5` - Etc/GMT+5
+       * * `Etc/GMT+6` - Etc/GMT+6
+       * * `Etc/GMT+7` - Etc/GMT+7
+       * * `Etc/GMT+8` - Etc/GMT+8
+       * * `Etc/GMT+9` - Etc/GMT+9
+       * * `Etc/GMT-0` - Etc/GMT-0
+       * * `Etc/GMT-1` - Etc/GMT-1
+       * * `Etc/GMT-10` - Etc/GMT-10
+       * * `Etc/GMT-11` - Etc/GMT-11
+       * * `Etc/GMT-12` - Etc/GMT-12
+       * * `Etc/GMT-13` - Etc/GMT-13
+       * * `Etc/GMT-14` - Etc/GMT-14
+       * * `Etc/GMT-2` - Etc/GMT-2
+       * * `Etc/GMT-3` - Etc/GMT-3
+       * * `Etc/GMT-4` - Etc/GMT-4
+       * * `Etc/GMT-5` - Etc/GMT-5
+       * * `Etc/GMT-6` - Etc/GMT-6
+       * * `Etc/GMT-7` - Etc/GMT-7
+       * * `Etc/GMT-8` - Etc/GMT-8
+       * * `Etc/GMT-9` - Etc/GMT-9
+       * * `Etc/GMT0` - Etc/GMT0
+       * * `Etc/Greenwich` - Etc/Greenwich
+       * * `Etc/UCT` - Etc/UCT
+       * * `Etc/UTC` - Etc/UTC
+       * * `Etc/Universal` - Etc/Universal
+       * * `Etc/Zulu` - Etc/Zulu
+       * * `Europe/Amsterdam` - Europe/Amsterdam
+       * * `Europe/Andorra` - Europe/Andorra
+       * * `Europe/Astrakhan` - Europe/Astrakhan
+       * * `Europe/Athens` - Europe/Athens
+       * * `Europe/Belfast` - Europe/Belfast
+       * * `Europe/Belgrade` - Europe/Belgrade
+       * * `Europe/Berlin` - Europe/Berlin
+       * * `Europe/Bratislava` - Europe/Bratislava
+       * * `Europe/Brussels` - Europe/Brussels
+       * * `Europe/Bucharest` - Europe/Bucharest
+       * * `Europe/Budapest` - Europe/Budapest
+       * * `Europe/Busingen` - Europe/Busingen
+       * * `Europe/Chisinau` - Europe/Chisinau
+       * * `Europe/Copenhagen` - Europe/Copenhagen
+       * * `Europe/Dublin` - Europe/Dublin
+       * * `Europe/Gibraltar` - Europe/Gibraltar
+       * * `Europe/Guernsey` - Europe/Guernsey
+       * * `Europe/Helsinki` - Europe/Helsinki
+       * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+       * * `Europe/Istanbul` - Europe/Istanbul
+       * * `Europe/Jersey` - Europe/Jersey
+       * * `Europe/Kaliningrad` - Europe/Kaliningrad
+       * * `Europe/Kiev` - Europe/Kiev
+       * * `Europe/Kirov` - Europe/Kirov
+       * * `Europe/Kyiv` - Europe/Kyiv
+       * * `Europe/Lisbon` - Europe/Lisbon
+       * * `Europe/Ljubljana` - Europe/Ljubljana
+       * * `Europe/London` - Europe/London
+       * * `Europe/Luxembourg` - Europe/Luxembourg
+       * * `Europe/Madrid` - Europe/Madrid
+       * * `Europe/Malta` - Europe/Malta
+       * * `Europe/Mariehamn` - Europe/Mariehamn
+       * * `Europe/Minsk` - Europe/Minsk
+       * * `Europe/Monaco` - Europe/Monaco
+       * * `Europe/Moscow` - Europe/Moscow
+       * * `Europe/Nicosia` - Europe/Nicosia
+       * * `Europe/Oslo` - Europe/Oslo
+       * * `Europe/Paris` - Europe/Paris
+       * * `Europe/Podgorica` - Europe/Podgorica
+       * * `Europe/Prague` - Europe/Prague
+       * * `Europe/Riga` - Europe/Riga
+       * * `Europe/Rome` - Europe/Rome
+       * * `Europe/Samara` - Europe/Samara
+       * * `Europe/San_Marino` - Europe/San_Marino
+       * * `Europe/Sarajevo` - Europe/Sarajevo
+       * * `Europe/Saratov` - Europe/Saratov
+       * * `Europe/Simferopol` - Europe/Simferopol
+       * * `Europe/Skopje` - Europe/Skopje
+       * * `Europe/Sofia` - Europe/Sofia
+       * * `Europe/Stockholm` - Europe/Stockholm
+       * * `Europe/Tallinn` - Europe/Tallinn
+       * * `Europe/Tirane` - Europe/Tirane
+       * * `Europe/Tiraspol` - Europe/Tiraspol
+       * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+       * * `Europe/Uzhgorod` - Europe/Uzhgorod
+       * * `Europe/Vaduz` - Europe/Vaduz
+       * * `Europe/Vatican` - Europe/Vatican
+       * * `Europe/Vienna` - Europe/Vienna
+       * * `Europe/Vilnius` - Europe/Vilnius
+       * * `Europe/Volgograd` - Europe/Volgograd
+       * * `Europe/Warsaw` - Europe/Warsaw
+       * * `Europe/Zagreb` - Europe/Zagreb
+       * * `Europe/Zaporozhye` - Europe/Zaporozhye
+       * * `Europe/Zurich` - Europe/Zurich
+       * * `GB` - GB
+       * * `GB-Eire` - GB-Eire
+       * * `GMT` - GMT
+       * * `GMT+0` - GMT+0
+       * * `GMT-0` - GMT-0
+       * * `GMT0` - GMT0
+       * * `Greenwich` - Greenwich
+       * * `HST` - HST
+       * * `Hongkong` - Hongkong
+       * * `Iceland` - Iceland
+       * * `Indian/Antananarivo` - Indian/Antananarivo
+       * * `Indian/Chagos` - Indian/Chagos
+       * * `Indian/Christmas` - Indian/Christmas
+       * * `Indian/Cocos` - Indian/Cocos
+       * * `Indian/Comoro` - Indian/Comoro
+       * * `Indian/Kerguelen` - Indian/Kerguelen
+       * * `Indian/Mahe` - Indian/Mahe
+       * * `Indian/Maldives` - Indian/Maldives
+       * * `Indian/Mauritius` - Indian/Mauritius
+       * * `Indian/Mayotte` - Indian/Mayotte
+       * * `Indian/Reunion` - Indian/Reunion
+       * * `Iran` - Iran
+       * * `Israel` - Israel
+       * * `Jamaica` - Jamaica
+       * * `Japan` - Japan
+       * * `Kwajalein` - Kwajalein
+       * * `Libya` - Libya
+       * * `MET` - MET
+       * * `MST` - MST
+       * * `MST7MDT` - MST7MDT
+       * * `Mexico/BajaNorte` - Mexico/BajaNorte
+       * * `Mexico/BajaSur` - Mexico/BajaSur
+       * * `Mexico/General` - Mexico/General
+       * * `NZ` - NZ
+       * * `NZ-CHAT` - NZ-CHAT
+       * * `Navajo` - Navajo
+       * * `PRC` - PRC
+       * * `PST8PDT` - PST8PDT
+       * * `Pacific/Apia` - Pacific/Apia
+       * * `Pacific/Auckland` - Pacific/Auckland
+       * * `Pacific/Bougainville` - Pacific/Bougainville
+       * * `Pacific/Chatham` - Pacific/Chatham
+       * * `Pacific/Chuuk` - Pacific/Chuuk
+       * * `Pacific/Easter` - Pacific/Easter
+       * * `Pacific/Efate` - Pacific/Efate
+       * * `Pacific/Enderbury` - Pacific/Enderbury
+       * * `Pacific/Fakaofo` - Pacific/Fakaofo
+       * * `Pacific/Fiji` - Pacific/Fiji
+       * * `Pacific/Funafuti` - Pacific/Funafuti
+       * * `Pacific/Galapagos` - Pacific/Galapagos
+       * * `Pacific/Gambier` - Pacific/Gambier
+       * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+       * * `Pacific/Guam` - Pacific/Guam
+       * * `Pacific/Honolulu` - Pacific/Honolulu
+       * * `Pacific/Johnston` - Pacific/Johnston
+       * * `Pacific/Kanton` - Pacific/Kanton
+       * * `Pacific/Kiritimati` - Pacific/Kiritimati
+       * * `Pacific/Kosrae` - Pacific/Kosrae
+       * * `Pacific/Kwajalein` - Pacific/Kwajalein
+       * * `Pacific/Majuro` - Pacific/Majuro
+       * * `Pacific/Marquesas` - Pacific/Marquesas
+       * * `Pacific/Midway` - Pacific/Midway
+       * * `Pacific/Nauru` - Pacific/Nauru
+       * * `Pacific/Niue` - Pacific/Niue
+       * * `Pacific/Norfolk` - Pacific/Norfolk
+       * * `Pacific/Noumea` - Pacific/Noumea
+       * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+       * * `Pacific/Palau` - Pacific/Palau
+       * * `Pacific/Pitcairn` - Pacific/Pitcairn
+       * * `Pacific/Pohnpei` - Pacific/Pohnpei
+       * * `Pacific/Ponape` - Pacific/Ponape
+       * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+       * * `Pacific/Rarotonga` - Pacific/Rarotonga
+       * * `Pacific/Saipan` - Pacific/Saipan
+       * * `Pacific/Samoa` - Pacific/Samoa
+       * * `Pacific/Tahiti` - Pacific/Tahiti
+       * * `Pacific/Tarawa` - Pacific/Tarawa
+       * * `Pacific/Tongatapu` - Pacific/Tongatapu
+       * * `Pacific/Truk` - Pacific/Truk
+       * * `Pacific/Wake` - Pacific/Wake
+       * * `Pacific/Wallis` - Pacific/Wallis
+       * * `Pacific/Yap` - Pacific/Yap
+       * * `Poland` - Poland
+       * * `Portugal` - Portugal
+       * * `ROC` - ROC
+       * * `ROK` - ROK
+       * * `Singapore` - Singapore
+       * * `Turkey` - Turkey
+       * * `UCT` - UCT
+       * * `US/Alaska` - US/Alaska
+       * * `US/Aleutian` - US/Aleutian
+       * * `US/Arizona` - US/Arizona
+       * * `US/Central` - US/Central
+       * * `US/East-Indiana` - US/East-Indiana
+       * * `US/Eastern` - US/Eastern
+       * * `US/Hawaii` - US/Hawaii
+       * * `US/Indiana-Starke` - US/Indiana-Starke
+       * * `US/Michigan` - US/Michigan
+       * * `US/Mountain` - US/Mountain
+       * * `US/Pacific` - US/Pacific
+       * * `US/Samoa` - US/Samoa
+       * * `UTC` - UTC
+       * * `Universal` - Universal
+       * * `W-SU` - W-SU
+       * * `WET` - WET
+       * * `Zulu` - Zulu */
       timezone?: string;
       /** Element attributes that posthog-js should capture as action identifiers (e.g. `['data-attr']`). */
       data_attributes?: unknown;
       /**
          * Ordered list of person properties used to render a human-friendly display name in the UI.
          * @nullable
+         * @items.maxLength 400
          */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
@@ -32023,19 +32095,19 @@ export namespace Schemas {
       /** V2 trigger groups configuration for session recording. If present, takes precedence over legacy trigger fields. */
       session_recording_trigger_groups?: unknown;
       /** How long to retain new session recordings. One of `30d`, `90d`, `1y`, or `5y` (availability depends on plan).
-
-      * `30d` - 30 Days
-      * `90d` - 90 Days
-      * `1y` - 1 Year
-      * `5y` - 5 Years */
+       *
+       * * `30d` - 30 Days
+       * * `90d` - 90 Days
+       * * `1y` - 1 Year
+       * * `5y` - 5 Years */
       session_recording_retention_period?: SessionRecordingRetentionPeriodEnum;
       session_replay_config?: unknown;
       survey_config?: unknown;
       access_control?: boolean;
       /** First day of the week for date range filters. 0 = Sunday, 1 = Monday.
-
-      * `0` - Sunday
-      * `1` - Monday */
+       *
+       * * `0` - Sunday
+       * * `1` - Monday */
       week_start_day?: WeekStartDayEnum | null;
       /**
          * ID of the dashboard shown as the project's default landing dashboard.
@@ -32047,6 +32119,7 @@ export namespace Schemas {
       /**
          * Origins permitted to record session replays and heatmaps. Empty list allows all origins.
          * @nullable
+         * @items.maxLength 200
          */
       recording_domains?: (string | null)[] | null;
       readonly person_on_events_querying_enabled?: boolean;
@@ -32079,10 +32152,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts.
-
-      * `b2b` - B2B
-      * `b2c` - B2C
-      * `other` - Other */
+       *
+       * * `b2b` - B2B
+       * * `b2c` - B2C
+       * * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /**
          * Enables the customer conversations / live chat product for this project.
@@ -32120,11 +32193,11 @@ export namespace Schemas {
     export interface PatchedQueryTabState {
       readonly id?: string;
       /**
-                  Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
-                  and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
-                  ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
-                  for a user.
-                   */
+       *             Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
+       *             and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
+       *             ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
+       *             for a user.
+       *              */
       state?: unknown;
     }
 
@@ -32156,11 +32229,11 @@ export namespace Schemas {
       /** Free-form description shown in the scanner management UI. */
       description?: string;
       /** What the scanner does: monitor, classifier, scorer, or summarizer.
-
-      * `monitor` - Monitor
-      * `classifier` - Classifier
-      * `scorer` - Scorer
-      * `summarizer` - Summarizer */
+       *
+       * * `monitor` - Monitor
+       * * `classifier` - Classifier
+       * * `scorer` - Scorer
+       * * `summarizer` - Summarizer */
       scanner_type?: ScannerTypeEnum;
       /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
       scanner_config?: unknown;
@@ -32173,13 +32246,13 @@ export namespace Schemas {
          */
       sampling_rate?: number;
       /** LLM provider. v1 is Google-only.
-
-      * `google` - Google */
+       *
+       * * `google` - Google */
       provider?: ScannerProviderEnum;
       /** Concrete model to use for this scanner.
-
-      * `gemini-3-flash-preview` - Gemini 3 Flash
-      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+       *
+       * * `gemini-3-flash-preview` - Gemini 3 Flash
+       * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
       model?: ScannerModelEnum;
       /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
       enabled?: boolean;
@@ -32226,11 +32299,17 @@ export namespace Schemas {
       /** @maxLength 255 */
       name?: string;
       network_access_level?: NetworkAccessLevelEnum;
-      /** List of allowed domains for custom network access */
+      /**
+         * List of allowed domains for custom network access
+         * @items.maxLength 255
+         */
       allowed_domains?: string[];
       /** Whether to include default trusted domains (GitHub, npm, PyPI) */
       include_default_domains?: boolean;
-      /** List of repositories this environment applies to (format: org/repo) */
+      /**
+         * List of repositories this environment applies to (format: org/repo)
+         * @items.maxLength 255
+         */
       repositories?: string[];
       /** Encrypted environment variables (write-only, never returned in responses) */
       environment_variables?: unknown;
@@ -32268,13 +32347,15 @@ export namespace Schemas {
       /**
          * Viewport widths (px, 100-3000) to render the heatmap screenshot at — one render per width. Defaults to [320, 375, 425, 768, 1024, 1440, 1920] when omitted. At most 16 widths.
          * @maxItems 16
+         * @items.minimum 100
+         * @items.maximum 3000
          */
       widths?: number[];
       /** Render mode: 'screenshot' (renders the page headlessly, default), 'iframe', or 'recording'. Only 'screenshot' generates image bytes.
-
-      * `screenshot` - Screenshot
-      * `iframe` - Iframe
-      * `recording` - Recording */
+       *
+       * * `screenshot` - Screenshot
+       * * `iframe` - Iframe
+       * * `recording` - Recording */
       type?: HeatmapType;
       /** Set true to soft-delete the saved heatmap. */
       deleted?: boolean;
@@ -32289,8 +32370,8 @@ export namespace Schemas {
          */
       record_id?: string;
       /** The type of record to modify. Currently only "FeatureFlag" is supported.
-
-      * `FeatureFlag` - feature flag */
+       *
+       * * `FeatureFlag` - feature flag */
       model_name?: ModelNameEnum;
       /** The change to apply. Must include an 'operation' key and a 'value' key. Supported operations: 'update_status' (value: true/false to enable/disable the flag), 'add_release_condition' (value: object with 'groups', 'payloads', and 'multivariate' keys), 'update_variants' (value: object with 'variants' and 'payloads' keys). */
       payload?: unknown;
@@ -32309,11 +32390,11 @@ export namespace Schemas {
       /** Whether this schedule repeats. Only the 'update_status' operation supports recurring schedules. */
       is_recurring?: boolean;
       /** How often the schedule repeats. Required when is_recurring is true. One of: daily, weekly, monthly, yearly.
-
-      * `daily` - daily
-      * `weekly` - weekly
-      * `monthly` - monthly
-      * `yearly` - yearly */
+       *
+       * * `daily` - daily
+       * * `weekly` - weekly
+       * * `monthly` - monthly
+       * * `yearly` - yearly */
       recurrence_interval?: RecurrenceIntervalEnum | null;
       /**
          * @maxLength 100
@@ -32362,7 +32443,10 @@ export namespace Schemas {
       readonly id?: string;
       /** Title of the group session summary */
       readonly title?: string;
-      /** List of session replay IDs included in this group summary */
+      /**
+         * List of session replay IDs included in this group summary
+         * @items.maxLength 200
+         */
       readonly session_ids?: readonly string[];
       /** Group summary in JSON format (EnrichedSessionGroupSummaryPatternsList schema) */
       readonly summary?: unknown;
@@ -32433,7 +32517,7 @@ export namespace Schemas {
 
     /**
      * Serializer for linking session recordings to external issue trackers.
-    Reuses error tracking's integration infrastructure
+     * Reuses error tracking's integration infrastructure
      */
     export interface PatchedSessionRecordingExternalRef {
       readonly id?: string;
@@ -32479,9 +32563,9 @@ export namespace Schemas {
       readonly last_modified_by?: UserBasic;
       readonly recordings_counts?: PatchedSessionRecordingPlaylistRecordingsCounts;
       /** Playlist type: 'collection' for manually curated recordings, 'filters' for saved filter views. Required on create, cannot be changed after.
-
-      * `collection` - Collection
-      * `filters` - Filters */
+       *
+       * * `collection` - Collection
+       * * `filters` - Filters */
       type?: SessionRecordingPlaylistTypeEnum | null;
       /** Return whether this is a synthetic playlist */
       readonly is_synthetic?: boolean;
@@ -32505,9 +32589,9 @@ export namespace Schemas {
 
     /**
      * Per-(team, skill) scout config: schedule, enablement, and emit posture.
-
-    One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
-    when it discovers a scout skill; this serializer lets agents tune the row.
+     *
+     * One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
+     * when it discovers a scout skill; this serializer lets agents tune the row.
      */
     export interface PatchedSignalScoutConfig {
       readonly id?: string;
@@ -32545,12 +32629,12 @@ export namespace Schemas {
 
     /**
      * * `monday` - Monday
-    * `tuesday` - Tuesday
-    * `wednesday` - Wednesday
-    * `thursday` - Thursday
-    * `friday` - Friday
-    * `saturday` - Saturday
-    * `sunday` - Sunday
+     * * `tuesday` - Tuesday
+     * * `wednesday` - Wednesday
+     * * `thursday` - Thursday
+     * * `friday` - Friday
+     * * `saturday` - Saturday
+     * * `sunday` - Sunday
      */
     export type PatchedSubscriptionByweekdayItem = typeof PatchedSubscriptionByweekdayItem[keyof typeof PatchedSubscriptionByweekdayItem];
 
@@ -32571,10 +32655,10 @@ export namespace Schemas {
     export interface PatchedSubscription {
       readonly id?: number;
       /** What the subscription delivers: 'insight' (snapshot of one insight), 'dashboard' (snapshot of one dashboard), or 'ai_prompt' (LLM-generated report). Read-only — derived from the populated target (insight → insight, dashboard → dashboard, prompt → ai_prompt).
-
-      * `insight` - Insight
-      * `dashboard` - Dashboard
-      * `ai_prompt` - AI prompt */
+       *
+       * * `insight` - Insight
+       * * `dashboard` - Dashboard
+       * * `ai_prompt` - AI prompt */
       readonly resource_type?: ResourceTypeEnum;
       /**
          * Dashboard ID to subscribe to (mutually exclusive with insight on create).
@@ -32598,18 +32682,18 @@ export namespace Schemas {
          */
       prompt?: string | null;
       /** Delivery channel: email or slack.
-
-      * `email` - Email
-      * `slack` - Slack */
+       *
+       * * `email` - Email
+       * * `slack` - Slack */
       target_type?: TargetTypeEnum;
       /** Recipient(s): comma-separated email addresses for email, or Slack channel name/ID for slack. */
       target_value?: string;
       /** How often to deliver: daily, weekly, monthly, or yearly.
-
-      * `daily` - Daily
-      * `weekly` - Weekly
-      * `monthly` - Monthly
-      * `yearly` - Yearly */
+       *
+       * * `daily` - Daily
+       * * `weekly` - Weekly
+       * * `monthly` - Monthly
+       * * `yearly` - Yearly */
       frequency?: SubscriptionFrequencyEnum;
       /**
          * Interval multiplier (e.g. 2 with weekly frequency means every 2 weeks). Required on create; must be 1 or greater.
@@ -32680,8 +32764,8 @@ export namespace Schemas {
 
     /**
      * * `once` - once
-    * `recurring` - recurring
-    * `always` - always
+     * * `recurring` - recurring
+     * * `always` - always
      */
     export type ScheduleEnum = typeof ScheduleEnum[keyof typeof ScheduleEnum];
 
@@ -32709,9 +32793,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-
-      * `text` - text
-      * `html` - html */
+       *
+       * * `text` - text
+       * * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -32736,9 +32820,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-
-      * `text` - text
-      * `html` - html */
+       *
+       * * `text` - text
+       * * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -32760,7 +32844,7 @@ export namespace Schemas {
 
     /**
      * * `number` - number
-    * `emoji` - emoji
+     * * `emoji` - emoji
      */
     export type SurveyRatingQuestionSchemaDisplayEnum = typeof SurveyRatingQuestionSchemaDisplayEnum[keyof typeof SurveyRatingQuestionSchemaDisplayEnum];
 
@@ -32782,8 +32866,8 @@ export namespace Schemas {
 
     export interface SurveyNextQuestionBranching {
       /** Continue to the next question in sequence.
-
-      * `next_question` - next_question */
+       *
+       * * `next_question` - next_question */
       type: SurveyNextQuestionBranchingTypeEnum;
     }
 
@@ -32799,8 +32883,8 @@ export namespace Schemas {
 
     export interface SurveyEndBranching {
       /** End the survey.
-
-      * `end` - end */
+       *
+       * * `end` - end */
       type: SurveyEndBranchingTypeEnum;
     }
 
@@ -32816,8 +32900,8 @@ export namespace Schemas {
 
     export interface SurveySpecificQuestionBranching {
       /** Jump to a specific question index.
-
-      * `specific_question` - specific_question */
+       *
+       * * `specific_question` - specific_question */
       type: SurveySpecificQuestionBranchingTypeEnum;
       /**
          * 0-based index of the next question.
@@ -32843,8 +32927,8 @@ export namespace Schemas {
 
     export interface SurveyResponseBasedBranching {
       /** Branch based on the selected or entered response.
-
-      * `response_based` - response_based */
+       *
+       * * `response_based` - response_based */
       type: SurveyResponseBasedBranchingTypeEnum;
       /** Response-based branching map. Values can be a question index or 'end'. */
       responseValues: SurveyResponseBasedBranchingResponseValues;
@@ -32859,18 +32943,18 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-
-      * `text` - text
-      * `html` - html */
+       *
+       * * `text` - text
+       * * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
       /** Custom button label. */
       buttonText?: string;
       /** Display format: 'number' shows numeric scale, 'emoji' shows emoji scale.
-
-      * `number` - number
-      * `emoji` - emoji */
+       *
+       * * `number` - number
+       * * `emoji` - emoji */
       display?: SurveyRatingQuestionSchemaDisplayEnum;
       /**
          * Rating scale can be one of 3, 5, or 7
@@ -32901,9 +32985,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-
-      * `text` - text
-      * `html` - html */
+       *
+       * * `text` - text
+       * * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -32939,9 +33023,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-
-      * `text` - text
-      * `html` - html */
+       *
+       * * `text` - text
+       * * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -32982,25 +33066,25 @@ export namespace Schemas {
          */
       seenSurveyWaitPeriodInDays?: number;
       /** URL/device matching types: 'regex' (matches regex pattern), 'not_regex' (does not match regex pattern), 'exact' (exact string match), 'is_not' (not exact match), 'icontains' (case-insensitive contains), 'not_icontains' (case-insensitive does not contain).
-
-      * `regex` - regex
-      * `not_regex` - not_regex
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains */
+       *
+       * * `regex` - regex
+       * * `not_regex` - not_regex
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains */
       urlMatchType?: StringMatchOperatorEnum;
       events?: SurveyEventsConditionSchema;
       /** Device types that should match for this survey to be shown. */
       deviceTypes?: DeviceTypesEnum[];
       /** URL/device matching types: 'regex' (matches regex pattern), 'not_regex' (does not match regex pattern), 'exact' (exact string match), 'is_not' (not exact match), 'icontains' (case-insensitive contains), 'not_icontains' (case-insensitive does not contain).
-
-      * `regex` - regex
-      * `not_regex` - not_regex
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains */
+       *
+       * * `regex` - regex
+       * * `not_regex` - not_regex
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains */
       deviceTypesMatchType?: StringMatchOperatorEnum;
       /** The variant of the feature flag linked to this survey. */
       linkedFlagVariant?: string;
@@ -33008,8 +33092,8 @@ export namespace Schemas {
 
     /**
      * * `button` - button
-    * `tab` - tab
-    * `selector` - selector
+     * * `tab` - tab
+     * * `selector` - selector
      */
     export type WidgetTypeEnum = typeof WidgetTypeEnum[keyof typeof WidgetTypeEnum];
 
@@ -33067,17 +33151,17 @@ export namespace Schemas {
       /** Survey description. */
       description?: string;
       /** Survey type.
-
-      * `popover` - popover
-      * `widget` - widget
-      * `external_survey` - external survey
-      * `api` - api */
+       *
+       * * `popover` - popover
+       * * `widget` - widget
+       * * `external_survey` - external survey
+       * * `api` - api */
       type?: SurveyType;
       /** Survey scheduling behavior: 'once' = show once per user (default), 'recurring' = repeat based on iteration_count and iteration_frequency_days settings, 'always' = show every time conditions are met (mainly for widget surveys)
-
-      * `once` - once
-      * `recurring` - recurring
-      * `always` - always */
+       *
+       * * `once` - once
+       * * `recurring` - recurring
+       * * `always` - always */
       schedule?: ScheduleEnum | null;
       readonly linked_flag?: MinimalFeatureFlag;
       /**
@@ -33100,117 +33184,117 @@ export namespace Schemas {
       remove_targeting_flag?: boolean | null;
       /**
          *
-              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-              Basic (open-ended question)
-              - `id`: The question ID
-              - `type`: `open`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Link (a question with a link)
-              - `id`: The question ID
-              - `type`: `link`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `link`: The URL associated with the question.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Rating (a question with a rating scale)
-              - `id`: The question ID
-              - `type`: `rating`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `display`: Display style of the rating (`number` or `emoji`).
-              - `scale`: The scale of the rating (`number`).
-              - `lowerBoundLabel`: Label for the lower bound of the scale.
-              - `upperBoundLabel`: Label for the upper bound of the scale.
-              - `isNpsQuestion`: Whether the question is an NPS rating.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Multiple choice
-              - `id`: The question ID
-              - `type`: `single_choice` or `multiple_choice`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `choices`: An array of choices for the question.
-              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Branching logic can be one of the following types:
-
-              Next question: Proceeds to the next question
-              ```json
-              {
-                  "type": "next_question"
-              }
-              ```
-
-              End: Ends the survey, optionally displaying a confirmation message.
-              ```json
-              {
-                  "type": "end"
-              }
-              ```
-
-              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-              ```json
-              {
-                  "type": "response_based",
-                  "responseValues": {
-                      "responseKey": "value"
-                  }
-              }
-              ```
-
-              Specific question: Proceeds to a specific question by index.
-              ```json
-              {
-                  "type": "specific_question",
-                  "index": 2
-              }
-              ```
-
-              Translations: Each question can include inline translations.
-              - `translations`: Object mapping language codes to translated fields.
-              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-              Example with translations:
-              ```json
-              {
-                  "id": "uuid",
-                  "type": "rating",
-                  "question": "How satisfied are you?",
-                  "lowerBoundLabel": "Not satisfied",
-                  "upperBoundLabel": "Very satisfied",
-                  "translations": {
-                      "es": {
-                          "question": "¿Qué tan satisfecho estás?",
-                          "lowerBoundLabel": "No satisfecho",
-                          "upperBoundLabel": "Muy satisfecho"
-                      },
-                      "fr": {
-                          "question": "Dans quelle mesure êtes-vous satisfait?"
-                      }
-                  }
-              }
-              ```
-
+       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+       *
+       *         Basic (open-ended question)
+       *         - `id`: The question ID
+       *         - `type`: `open`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Link (a question with a link)
+       *         - `id`: The question ID
+       *         - `type`: `link`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `link`: The URL associated with the question.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Rating (a question with a rating scale)
+       *         - `id`: The question ID
+       *         - `type`: `rating`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `display`: Display style of the rating (`number` or `emoji`).
+       *         - `scale`: The scale of the rating (`number`).
+       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+       *         - `upperBoundLabel`: Label for the upper bound of the scale.
+       *         - `isNpsQuestion`: Whether the question is an NPS rating.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Multiple choice
+       *         - `id`: The question ID
+       *         - `type`: `single_choice` or `multiple_choice`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `choices`: An array of choices for the question.
+       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Branching logic can be one of the following types:
+       *
+       *         Next question: Proceeds to the next question
+       *         ```json
+       *         {
+       *             "type": "next_question"
+       *         }
+       *         ```
+       *
+       *         End: Ends the survey, optionally displaying a confirmation message.
+       *         ```json
+       *         {
+       *             "type": "end"
+       *         }
+       *         ```
+       *
+       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+       *         ```json
+       *         {
+       *             "type": "response_based",
+       *             "responseValues": {
+       *                 "responseKey": "value"
+       *             }
+       *         }
+       *         ```
+       *
+       *         Specific question: Proceeds to a specific question by index.
+       *         ```json
+       *         {
+       *             "type": "specific_question",
+       *             "index": 2
+       *         }
+       *         ```
+       *
+       *         Translations: Each question can include inline translations.
+       *         - `translations`: Object mapping language codes to translated fields.
+       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+       *
+       *         Example with translations:
+       *         ```json
+       *         {
+       *             "id": "uuid",
+       *             "type": "rating",
+       *             "question": "How satisfied are you?",
+       *             "lowerBoundLabel": "Not satisfied",
+       *             "upperBoundLabel": "Very satisfied",
+       *             "translations": {
+       *                 "es": {
+       *                     "question": "¿Qué tan satisfecho estás?",
+       *                     "lowerBoundLabel": "No satisfecho",
+       *                     "upperBoundLabel": "Muy satisfecho"
+       *                 },
+       *                 "fr": {
+       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+       *                 }
+       *             }
+       *         }
+       *         ```
+       *
          * @nullable
          */
       questions?: SurveyQuestionInputSchema[] | null;
@@ -33332,14 +33416,14 @@ export namespace Schemas {
 
     export interface TaggerModelConfigurationWrite {
       /** LLM provider to use for this tagger.
-
-      * `openai` - Openai
-      * `anthropic` - Anthropic
-      * `gemini` - Gemini
-      * `openrouter` - Openrouter
-      * `fireworks` - Fireworks
-      * `azure_openai` - Azure OpenAI
-      * `together_ai` - Together AI */
+       *
+       * * `openai` - Openai
+       * * `anthropic` - Anthropic
+       * * `gemini` - Gemini
+       * * `openrouter` - Openrouter
+       * * `fireworks` - Fireworks
+       * * `azure_openai` - Azure OpenAI
+       * * `together_ai` - Together AI */
       provider: LLMProviderEnum;
       /**
          * Provider model identifier to use for this tagger.
@@ -33387,16 +33471,16 @@ export namespace Schemas {
       /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
       description?: string;
       /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-
-      * `error_tracking` - Error Tracking
-      * `eval_clusters` - Eval Clusters
-      * `user_created` - User Created
-      * `automation` - Automation
-      * `slack` - Slack
-      * `support_queue` - Support Queue
-      * `session_summaries` - Session Summaries
-      * `signal_report` - Signal Report
-      * `signals_scout` - Signals Scout */
+       *
+       * * `error_tracking` - Error Tracking
+       * * `eval_clusters` - Eval Clusters
+       * * `user_created` - User Created
+       * * `automation` - Automation
+       * * `slack` - Slack
+       * * `support_queue` - Support Queue
+       * * `session_summaries` - Session Summaries
+       * * `signal_report` - Signal Report
+       * * `signals_scout` - Signals Scout */
       origin_product?: OriginProductEnum;
       /**
          * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
@@ -33480,11 +33564,11 @@ export namespace Schemas {
 
     /**
      * * `not_started` - not_started
-    * `queued` - queued
-    * `in_progress` - in_progress
-    * `completed` - completed
-    * `failed` - failed
-    * `cancelled` - cancelled
+     * * `queued` - queued
+     * * `in_progress` - in_progress
+     * * `completed` - completed
+     * * `failed` - failed
+     * * `cancelled` - cancelled
      */
     export type TaskRunUpdateStatusEnum = typeof TaskRunUpdateStatusEnum[keyof typeof TaskRunUpdateStatusEnum];
 
@@ -33510,13 +33594,13 @@ export namespace Schemas {
 
     export interface PatchedTaskRunUpdate {
       /** Current execution status
-
-      * `not_started` - not_started
-      * `queued` - queued
-      * `in_progress` - in_progress
-      * `completed` - completed
-      * `failed` - failed
-      * `cancelled` - cancelled */
+       *
+       * * `not_started` - not_started
+       * * `queued` - queued
+       * * `in_progress` - in_progress
+       * * `completed` - completed
+       * * `failed` - failed
+       * * `cancelled` - cancelled */
       status?: TaskRunUpdateStatusEnum;
       /**
          * Git branch name to associate with the task
@@ -33540,8 +33624,8 @@ export namespace Schemas {
          */
       error_message?: string | null;
       /** Transition a cloud run to local. Use the resume_in_cloud action to move a run into cloud.
-
-      * `local` - local */
+       *
+       * * `local` - local */
       environment?: TaskRunUpdateEnvironmentEnum;
     }
 
@@ -33627,28 +33711,29 @@ export namespace Schemas {
          * @nullable
          */
       readonly user_access_level?: string | null;
+      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       anonymize_ips?: boolean;
       completed_snippet_onboarding?: boolean;
       /** Filters used to identify internal/test users. Each entry is a property filter.
-
-                  Supported entry types and the exact shape each accepts:
-
-                  # Person property — match (or exclude) by a person property
-                  {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
-
-                  # Event property — match by an event property
-                  {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
-
-                  # Cohort membership — match (or exclude) members of a cohort.
-                  # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
-                  # `negation` field here — `negation` is specific to cohort *definitions*
-                  # (the inner sub-filters that build a cohort) and is rejected by the
-                  # property-filter schema.
-                  {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
-
-                  Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
-                  "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
+       *
+       *             Supported entry types and the exact shape each accepts:
+       *
+       *             # Person property — match (or exclude) by a person property
+       *             {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
+       *
+       *             # Event property — match by an event property
+       *             {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
+       *
+       *             # Cohort membership — match (or exclude) members of a cohort.
+       *             # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
+       *             # `negation` field here — `negation` is specific to cohort *definitions*
+       *             # (the inner sub-filters that build a cohort) and is rejected by the
+       *             # property-filter schema.
+       *             {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
+       *
+       *             Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
+       *             "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
       test_account_filters?: unknown;
       /** @nullable */
       test_account_filters_default_checked?: boolean | null;
@@ -33656,7 +33741,10 @@ export namespace Schemas {
       is_demo?: boolean;
       timezone?: string;
       data_attributes?: unknown;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 400
+         */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
       /** @nullable */
@@ -33708,7 +33796,10 @@ export namespace Schemas {
       primary_dashboard?: number | null;
       /** @nullable */
       live_events_columns?: string[] | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 200
+         */
       recording_domains?: (string | null)[] | null;
       cookieless_server_hash_mode?: CookielessServerHashModeEnum | null;
       /** @nullable */
@@ -33756,10 +33847,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers, used to optimize the UI layout.
-
-      * `b2b` - B2B
-      * `b2c` - B2C
-      * `other` - Other */
+       *
+       * * `b2b` - B2B
+       * * `b2c` - B2C
+       * * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /** @nullable */
       conversations_enabled?: boolean | null;
@@ -33787,18 +33878,18 @@ export namespace Schemas {
       readonly channel_detail?: ChannelDetailEnum | null;
       readonly distinct_id?: string;
       /** Ticket status: new, open, pending, on_hold, or resolved
-
-      * `new` - New
-      * `open` - Open
-      * `pending` - Pending
-      * `on_hold` - On hold
-      * `resolved` - Resolved */
+       *
+       * * `new` - New
+       * * `open` - Open
+       * * `pending` - Pending
+       * * `on_hold` - On hold
+       * * `resolved` - Resolved */
       status?: TicketStatusEnum;
       /** Ticket priority: low, medium, or high. Null if unset.
-
-      * `low` - Low
-      * `medium` - Medium
-      * `high` - High */
+       *
+       * * `low` - Low
+       * * `medium` - Medium
+       * * `high` - High */
       priority?: PriorityEnum | BlankEnum | null;
       readonly assignee?: TicketAssignment;
       /** Customer-provided traits such as name and email */
@@ -33848,8 +33939,8 @@ export namespace Schemas {
 
     /**
      * * `approved` - approved
-    * `needs_approval` - needs_approval
-    * `do_not_use` - do_not_use
+     * * `needs_approval` - needs_approval
+     * * `do_not_use` - do_not_use
      */
     export type ToolApprovalUpdateApprovalStateEnum = typeof ToolApprovalUpdateApprovalStateEnum[keyof typeof ToolApprovalUpdateApprovalStateEnum];
 
@@ -33876,6 +33967,7 @@ export namespace Schemas {
          * Categorical option keys selected for this score.
          * @minItems 1
          * @nullable
+         * @items.maxLength 128
          */
       categorical_values?: string[] | null;
       /**
@@ -33925,7 +34017,7 @@ export namespace Schemas {
 
     /**
      * PATCH payload for text sources. Both fields optional, at least one
-    required. `text` triggers a re-chunk; `name` alone does not.
+     * required. `text` triggers a re-chunk; `name` alone does not.
      */
     export interface PatchedUpdateTextSource {
       /**
@@ -34034,6 +34126,7 @@ export namespace Schemas {
       readonly id?: string;
       readonly created_by?: UserBasic;
       readonly created_at?: string;
+      /** @items.maxLength 254 */
       interviewee_emails?: string[];
       readonly interviewee_identifier?: string;
       /** @nullable */
@@ -34049,9 +34142,15 @@ export namespace Schemas {
       readonly id?: string;
       readonly created_by?: UserBasic;
       readonly created_at?: string;
-      /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
+      /**
+         * Email addresses of people to interview. May be combined with interviewee_distinct_ids.
+         * @items.maxLength 254
+         */
       interviewee_emails?: string[];
-      /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
+      /**
+         * PostHog distinct IDs of people to interview. May be combined with interviewee_emails.
+         * @items.maxLength 400
+         */
       interviewee_distinct_ids?: string[];
       /** The product, feature, or idea you want to ask interviewees about. */
       topic?: string;
@@ -34127,20 +34226,20 @@ export namespace Schemas {
       created_at?: string;
       readonly feature_flag_key?: string;
       /** Variants for the web experiment. Example:
-
-              {
-                  "control": {
-                      "transforms": [
-                          {
-                              "text": "Here comes Superman!",
-                              "html": "",
-                              "selector": "#page > #body > .header h1"
-                          }
-                      ],
-                      "conditions": "None",
-                      "rollout_percentage": 50
-                  },
-              } */
+       *
+       *         {
+       *             "control": {
+       *                 "transforms": [
+       *                     {
+       *                         "text": "Here comes Superman!",
+       *                         "html": "",
+       *                         "selector": "#page > #body > .header h1"
+       *                     }
+       *                 ],
+       *                 "conditions": "None",
+       *                 "rollout_percentage": 50
+       *             },
+       *         } */
       variants?: unknown;
     }
 
@@ -34481,9 +34580,9 @@ export namespace Schemas {
       readonly updated_at: string;
       archived?: boolean;
       /** Where the tour was created/updated from
-
-      * `app` - app
-      * `toolbar` - toolbar */
+       *
+       * * `app` - app
+       * * `toolbar` - toolbar */
       creation_context?: ProductTourSerializerCreateUpdateOnlyCreationContextEnum;
     }
 
@@ -34527,6 +34626,7 @@ export namespace Schemas {
       readonly updated_at: string | null;
       readonly uuid: string;
       readonly api_token: string;
+      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       /** When true, PostHog drops the IP address from every ingested event. */
       anonymize_ips?: boolean;
@@ -34543,609 +34643,610 @@ export namespace Schemas {
       path_cleaning_filters?: unknown;
       is_demo?: boolean;
       /** IANA timezone used for date-based filters and reporting (e.g. `America/Los_Angeles`).
-
-      * `Africa/Abidjan` - Africa/Abidjan
-      * `Africa/Accra` - Africa/Accra
-      * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-      * `Africa/Algiers` - Africa/Algiers
-      * `Africa/Asmara` - Africa/Asmara
-      * `Africa/Asmera` - Africa/Asmera
-      * `Africa/Bamako` - Africa/Bamako
-      * `Africa/Bangui` - Africa/Bangui
-      * `Africa/Banjul` - Africa/Banjul
-      * `Africa/Bissau` - Africa/Bissau
-      * `Africa/Blantyre` - Africa/Blantyre
-      * `Africa/Brazzaville` - Africa/Brazzaville
-      * `Africa/Bujumbura` - Africa/Bujumbura
-      * `Africa/Cairo` - Africa/Cairo
-      * `Africa/Casablanca` - Africa/Casablanca
-      * `Africa/Ceuta` - Africa/Ceuta
-      * `Africa/Conakry` - Africa/Conakry
-      * `Africa/Dakar` - Africa/Dakar
-      * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-      * `Africa/Djibouti` - Africa/Djibouti
-      * `Africa/Douala` - Africa/Douala
-      * `Africa/El_Aaiun` - Africa/El_Aaiun
-      * `Africa/Freetown` - Africa/Freetown
-      * `Africa/Gaborone` - Africa/Gaborone
-      * `Africa/Harare` - Africa/Harare
-      * `Africa/Johannesburg` - Africa/Johannesburg
-      * `Africa/Juba` - Africa/Juba
-      * `Africa/Kampala` - Africa/Kampala
-      * `Africa/Khartoum` - Africa/Khartoum
-      * `Africa/Kigali` - Africa/Kigali
-      * `Africa/Kinshasa` - Africa/Kinshasa
-      * `Africa/Lagos` - Africa/Lagos
-      * `Africa/Libreville` - Africa/Libreville
-      * `Africa/Lome` - Africa/Lome
-      * `Africa/Luanda` - Africa/Luanda
-      * `Africa/Lubumbashi` - Africa/Lubumbashi
-      * `Africa/Lusaka` - Africa/Lusaka
-      * `Africa/Malabo` - Africa/Malabo
-      * `Africa/Maputo` - Africa/Maputo
-      * `Africa/Maseru` - Africa/Maseru
-      * `Africa/Mbabane` - Africa/Mbabane
-      * `Africa/Mogadishu` - Africa/Mogadishu
-      * `Africa/Monrovia` - Africa/Monrovia
-      * `Africa/Nairobi` - Africa/Nairobi
-      * `Africa/Ndjamena` - Africa/Ndjamena
-      * `Africa/Niamey` - Africa/Niamey
-      * `Africa/Nouakchott` - Africa/Nouakchott
-      * `Africa/Ouagadougou` - Africa/Ouagadougou
-      * `Africa/Porto-Novo` - Africa/Porto-Novo
-      * `Africa/Sao_Tome` - Africa/Sao_Tome
-      * `Africa/Timbuktu` - Africa/Timbuktu
-      * `Africa/Tripoli` - Africa/Tripoli
-      * `Africa/Tunis` - Africa/Tunis
-      * `Africa/Windhoek` - Africa/Windhoek
-      * `America/Adak` - America/Adak
-      * `America/Anchorage` - America/Anchorage
-      * `America/Anguilla` - America/Anguilla
-      * `America/Antigua` - America/Antigua
-      * `America/Araguaina` - America/Araguaina
-      * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-      * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-      * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-      * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-      * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-      * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-      * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-      * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-      * `America/Argentina/Salta` - America/Argentina/Salta
-      * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-      * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-      * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-      * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-      * `America/Aruba` - America/Aruba
-      * `America/Asuncion` - America/Asuncion
-      * `America/Atikokan` - America/Atikokan
-      * `America/Atka` - America/Atka
-      * `America/Bahia` - America/Bahia
-      * `America/Bahia_Banderas` - America/Bahia_Banderas
-      * `America/Barbados` - America/Barbados
-      * `America/Belem` - America/Belem
-      * `America/Belize` - America/Belize
-      * `America/Blanc-Sablon` - America/Blanc-Sablon
-      * `America/Boa_Vista` - America/Boa_Vista
-      * `America/Bogota` - America/Bogota
-      * `America/Boise` - America/Boise
-      * `America/Buenos_Aires` - America/Buenos_Aires
-      * `America/Cambridge_Bay` - America/Cambridge_Bay
-      * `America/Campo_Grande` - America/Campo_Grande
-      * `America/Cancun` - America/Cancun
-      * `America/Caracas` - America/Caracas
-      * `America/Catamarca` - America/Catamarca
-      * `America/Cayenne` - America/Cayenne
-      * `America/Cayman` - America/Cayman
-      * `America/Chicago` - America/Chicago
-      * `America/Chihuahua` - America/Chihuahua
-      * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-      * `America/Coral_Harbour` - America/Coral_Harbour
-      * `America/Cordoba` - America/Cordoba
-      * `America/Costa_Rica` - America/Costa_Rica
-      * `America/Creston` - America/Creston
-      * `America/Cuiaba` - America/Cuiaba
-      * `America/Curacao` - America/Curacao
-      * `America/Danmarkshavn` - America/Danmarkshavn
-      * `America/Dawson` - America/Dawson
-      * `America/Dawson_Creek` - America/Dawson_Creek
-      * `America/Denver` - America/Denver
-      * `America/Detroit` - America/Detroit
-      * `America/Dominica` - America/Dominica
-      * `America/Edmonton` - America/Edmonton
-      * `America/Eirunepe` - America/Eirunepe
-      * `America/El_Salvador` - America/El_Salvador
-      * `America/Ensenada` - America/Ensenada
-      * `America/Fort_Nelson` - America/Fort_Nelson
-      * `America/Fort_Wayne` - America/Fort_Wayne
-      * `America/Fortaleza` - America/Fortaleza
-      * `America/Glace_Bay` - America/Glace_Bay
-      * `America/Godthab` - America/Godthab
-      * `America/Goose_Bay` - America/Goose_Bay
-      * `America/Grand_Turk` - America/Grand_Turk
-      * `America/Grenada` - America/Grenada
-      * `America/Guadeloupe` - America/Guadeloupe
-      * `America/Guatemala` - America/Guatemala
-      * `America/Guayaquil` - America/Guayaquil
-      * `America/Guyana` - America/Guyana
-      * `America/Halifax` - America/Halifax
-      * `America/Havana` - America/Havana
-      * `America/Hermosillo` - America/Hermosillo
-      * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-      * `America/Indiana/Knox` - America/Indiana/Knox
-      * `America/Indiana/Marengo` - America/Indiana/Marengo
-      * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-      * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-      * `America/Indiana/Vevay` - America/Indiana/Vevay
-      * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-      * `America/Indiana/Winamac` - America/Indiana/Winamac
-      * `America/Indianapolis` - America/Indianapolis
-      * `America/Inuvik` - America/Inuvik
-      * `America/Iqaluit` - America/Iqaluit
-      * `America/Jamaica` - America/Jamaica
-      * `America/Jujuy` - America/Jujuy
-      * `America/Juneau` - America/Juneau
-      * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-      * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-      * `America/Knox_IN` - America/Knox_IN
-      * `America/Kralendijk` - America/Kralendijk
-      * `America/La_Paz` - America/La_Paz
-      * `America/Lima` - America/Lima
-      * `America/Los_Angeles` - America/Los_Angeles
-      * `America/Louisville` - America/Louisville
-      * `America/Lower_Princes` - America/Lower_Princes
-      * `America/Maceio` - America/Maceio
-      * `America/Managua` - America/Managua
-      * `America/Manaus` - America/Manaus
-      * `America/Marigot` - America/Marigot
-      * `America/Martinique` - America/Martinique
-      * `America/Matamoros` - America/Matamoros
-      * `America/Mazatlan` - America/Mazatlan
-      * `America/Mendoza` - America/Mendoza
-      * `America/Menominee` - America/Menominee
-      * `America/Merida` - America/Merida
-      * `America/Metlakatla` - America/Metlakatla
-      * `America/Mexico_City` - America/Mexico_City
-      * `America/Miquelon` - America/Miquelon
-      * `America/Moncton` - America/Moncton
-      * `America/Monterrey` - America/Monterrey
-      * `America/Montevideo` - America/Montevideo
-      * `America/Montreal` - America/Montreal
-      * `America/Montserrat` - America/Montserrat
-      * `America/Nassau` - America/Nassau
-      * `America/New_York` - America/New_York
-      * `America/Nipigon` - America/Nipigon
-      * `America/Nome` - America/Nome
-      * `America/Noronha` - America/Noronha
-      * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-      * `America/North_Dakota/Center` - America/North_Dakota/Center
-      * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-      * `America/Nuuk` - America/Nuuk
-      * `America/Ojinaga` - America/Ojinaga
-      * `America/Panama` - America/Panama
-      * `America/Pangnirtung` - America/Pangnirtung
-      * `America/Paramaribo` - America/Paramaribo
-      * `America/Phoenix` - America/Phoenix
-      * `America/Port-au-Prince` - America/Port-au-Prince
-      * `America/Port_of_Spain` - America/Port_of_Spain
-      * `America/Porto_Acre` - America/Porto_Acre
-      * `America/Porto_Velho` - America/Porto_Velho
-      * `America/Puerto_Rico` - America/Puerto_Rico
-      * `America/Punta_Arenas` - America/Punta_Arenas
-      * `America/Rainy_River` - America/Rainy_River
-      * `America/Rankin_Inlet` - America/Rankin_Inlet
-      * `America/Recife` - America/Recife
-      * `America/Regina` - America/Regina
-      * `America/Resolute` - America/Resolute
-      * `America/Rio_Branco` - America/Rio_Branco
-      * `America/Rosario` - America/Rosario
-      * `America/Santa_Isabel` - America/Santa_Isabel
-      * `America/Santarem` - America/Santarem
-      * `America/Santiago` - America/Santiago
-      * `America/Santo_Domingo` - America/Santo_Domingo
-      * `America/Sao_Paulo` - America/Sao_Paulo
-      * `America/Scoresbysund` - America/Scoresbysund
-      * `America/Shiprock` - America/Shiprock
-      * `America/Sitka` - America/Sitka
-      * `America/St_Barthelemy` - America/St_Barthelemy
-      * `America/St_Johns` - America/St_Johns
-      * `America/St_Kitts` - America/St_Kitts
-      * `America/St_Lucia` - America/St_Lucia
-      * `America/St_Thomas` - America/St_Thomas
-      * `America/St_Vincent` - America/St_Vincent
-      * `America/Swift_Current` - America/Swift_Current
-      * `America/Tegucigalpa` - America/Tegucigalpa
-      * `America/Thule` - America/Thule
-      * `America/Thunder_Bay` - America/Thunder_Bay
-      * `America/Tijuana` - America/Tijuana
-      * `America/Toronto` - America/Toronto
-      * `America/Tortola` - America/Tortola
-      * `America/Vancouver` - America/Vancouver
-      * `America/Virgin` - America/Virgin
-      * `America/Whitehorse` - America/Whitehorse
-      * `America/Winnipeg` - America/Winnipeg
-      * `America/Yakutat` - America/Yakutat
-      * `America/Yellowknife` - America/Yellowknife
-      * `Antarctica/Casey` - Antarctica/Casey
-      * `Antarctica/Davis` - Antarctica/Davis
-      * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-      * `Antarctica/Macquarie` - Antarctica/Macquarie
-      * `Antarctica/Mawson` - Antarctica/Mawson
-      * `Antarctica/McMurdo` - Antarctica/McMurdo
-      * `Antarctica/Palmer` - Antarctica/Palmer
-      * `Antarctica/Rothera` - Antarctica/Rothera
-      * `Antarctica/South_Pole` - Antarctica/South_Pole
-      * `Antarctica/Syowa` - Antarctica/Syowa
-      * `Antarctica/Troll` - Antarctica/Troll
-      * `Antarctica/Vostok` - Antarctica/Vostok
-      * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-      * `Asia/Aden` - Asia/Aden
-      * `Asia/Almaty` - Asia/Almaty
-      * `Asia/Amman` - Asia/Amman
-      * `Asia/Anadyr` - Asia/Anadyr
-      * `Asia/Aqtau` - Asia/Aqtau
-      * `Asia/Aqtobe` - Asia/Aqtobe
-      * `Asia/Ashgabat` - Asia/Ashgabat
-      * `Asia/Ashkhabad` - Asia/Ashkhabad
-      * `Asia/Atyrau` - Asia/Atyrau
-      * `Asia/Baghdad` - Asia/Baghdad
-      * `Asia/Bahrain` - Asia/Bahrain
-      * `Asia/Baku` - Asia/Baku
-      * `Asia/Bangkok` - Asia/Bangkok
-      * `Asia/Barnaul` - Asia/Barnaul
-      * `Asia/Beirut` - Asia/Beirut
-      * `Asia/Bishkek` - Asia/Bishkek
-      * `Asia/Brunei` - Asia/Brunei
-      * `Asia/Calcutta` - Asia/Calcutta
-      * `Asia/Chita` - Asia/Chita
-      * `Asia/Choibalsan` - Asia/Choibalsan
-      * `Asia/Chongqing` - Asia/Chongqing
-      * `Asia/Chungking` - Asia/Chungking
-      * `Asia/Colombo` - Asia/Colombo
-      * `Asia/Dacca` - Asia/Dacca
-      * `Asia/Damascus` - Asia/Damascus
-      * `Asia/Dhaka` - Asia/Dhaka
-      * `Asia/Dili` - Asia/Dili
-      * `Asia/Dubai` - Asia/Dubai
-      * `Asia/Dushanbe` - Asia/Dushanbe
-      * `Asia/Famagusta` - Asia/Famagusta
-      * `Asia/Gaza` - Asia/Gaza
-      * `Asia/Harbin` - Asia/Harbin
-      * `Asia/Hebron` - Asia/Hebron
-      * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-      * `Asia/Hong_Kong` - Asia/Hong_Kong
-      * `Asia/Hovd` - Asia/Hovd
-      * `Asia/Irkutsk` - Asia/Irkutsk
-      * `Asia/Istanbul` - Asia/Istanbul
-      * `Asia/Jakarta` - Asia/Jakarta
-      * `Asia/Jayapura` - Asia/Jayapura
-      * `Asia/Jerusalem` - Asia/Jerusalem
-      * `Asia/Kabul` - Asia/Kabul
-      * `Asia/Kamchatka` - Asia/Kamchatka
-      * `Asia/Karachi` - Asia/Karachi
-      * `Asia/Kashgar` - Asia/Kashgar
-      * `Asia/Kathmandu` - Asia/Kathmandu
-      * `Asia/Katmandu` - Asia/Katmandu
-      * `Asia/Khandyga` - Asia/Khandyga
-      * `Asia/Kolkata` - Asia/Kolkata
-      * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-      * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-      * `Asia/Kuching` - Asia/Kuching
-      * `Asia/Kuwait` - Asia/Kuwait
-      * `Asia/Macao` - Asia/Macao
-      * `Asia/Macau` - Asia/Macau
-      * `Asia/Magadan` - Asia/Magadan
-      * `Asia/Makassar` - Asia/Makassar
-      * `Asia/Manila` - Asia/Manila
-      * `Asia/Muscat` - Asia/Muscat
-      * `Asia/Nicosia` - Asia/Nicosia
-      * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-      * `Asia/Novosibirsk` - Asia/Novosibirsk
-      * `Asia/Omsk` - Asia/Omsk
-      * `Asia/Oral` - Asia/Oral
-      * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-      * `Asia/Pontianak` - Asia/Pontianak
-      * `Asia/Pyongyang` - Asia/Pyongyang
-      * `Asia/Qatar` - Asia/Qatar
-      * `Asia/Qostanay` - Asia/Qostanay
-      * `Asia/Qyzylorda` - Asia/Qyzylorda
-      * `Asia/Rangoon` - Asia/Rangoon
-      * `Asia/Riyadh` - Asia/Riyadh
-      * `Asia/Saigon` - Asia/Saigon
-      * `Asia/Sakhalin` - Asia/Sakhalin
-      * `Asia/Samarkand` - Asia/Samarkand
-      * `Asia/Seoul` - Asia/Seoul
-      * `Asia/Shanghai` - Asia/Shanghai
-      * `Asia/Singapore` - Asia/Singapore
-      * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-      * `Asia/Taipei` - Asia/Taipei
-      * `Asia/Tashkent` - Asia/Tashkent
-      * `Asia/Tbilisi` - Asia/Tbilisi
-      * `Asia/Tehran` - Asia/Tehran
-      * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-      * `Asia/Thimbu` - Asia/Thimbu
-      * `Asia/Thimphu` - Asia/Thimphu
-      * `Asia/Tokyo` - Asia/Tokyo
-      * `Asia/Tomsk` - Asia/Tomsk
-      * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-      * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-      * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-      * `Asia/Urumqi` - Asia/Urumqi
-      * `Asia/Ust-Nera` - Asia/Ust-Nera
-      * `Asia/Vientiane` - Asia/Vientiane
-      * `Asia/Vladivostok` - Asia/Vladivostok
-      * `Asia/Yakutsk` - Asia/Yakutsk
-      * `Asia/Yangon` - Asia/Yangon
-      * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-      * `Asia/Yerevan` - Asia/Yerevan
-      * `Atlantic/Azores` - Atlantic/Azores
-      * `Atlantic/Bermuda` - Atlantic/Bermuda
-      * `Atlantic/Canary` - Atlantic/Canary
-      * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-      * `Atlantic/Faeroe` - Atlantic/Faeroe
-      * `Atlantic/Faroe` - Atlantic/Faroe
-      * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-      * `Atlantic/Madeira` - Atlantic/Madeira
-      * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-      * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-      * `Atlantic/St_Helena` - Atlantic/St_Helena
-      * `Atlantic/Stanley` - Atlantic/Stanley
-      * `Australia/ACT` - Australia/ACT
-      * `Australia/Adelaide` - Australia/Adelaide
-      * `Australia/Brisbane` - Australia/Brisbane
-      * `Australia/Broken_Hill` - Australia/Broken_Hill
-      * `Australia/Canberra` - Australia/Canberra
-      * `Australia/Currie` - Australia/Currie
-      * `Australia/Darwin` - Australia/Darwin
-      * `Australia/Eucla` - Australia/Eucla
-      * `Australia/Hobart` - Australia/Hobart
-      * `Australia/LHI` - Australia/LHI
-      * `Australia/Lindeman` - Australia/Lindeman
-      * `Australia/Lord_Howe` - Australia/Lord_Howe
-      * `Australia/Melbourne` - Australia/Melbourne
-      * `Australia/NSW` - Australia/NSW
-      * `Australia/North` - Australia/North
-      * `Australia/Perth` - Australia/Perth
-      * `Australia/Queensland` - Australia/Queensland
-      * `Australia/South` - Australia/South
-      * `Australia/Sydney` - Australia/Sydney
-      * `Australia/Tasmania` - Australia/Tasmania
-      * `Australia/Victoria` - Australia/Victoria
-      * `Australia/West` - Australia/West
-      * `Australia/Yancowinna` - Australia/Yancowinna
-      * `Brazil/Acre` - Brazil/Acre
-      * `Brazil/DeNoronha` - Brazil/DeNoronha
-      * `Brazil/East` - Brazil/East
-      * `Brazil/West` - Brazil/West
-      * `CET` - CET
-      * `CST6CDT` - CST6CDT
-      * `Canada/Atlantic` - Canada/Atlantic
-      * `Canada/Central` - Canada/Central
-      * `Canada/Eastern` - Canada/Eastern
-      * `Canada/Mountain` - Canada/Mountain
-      * `Canada/Newfoundland` - Canada/Newfoundland
-      * `Canada/Pacific` - Canada/Pacific
-      * `Canada/Saskatchewan` - Canada/Saskatchewan
-      * `Canada/Yukon` - Canada/Yukon
-      * `Chile/Continental` - Chile/Continental
-      * `Chile/EasterIsland` - Chile/EasterIsland
-      * `Cuba` - Cuba
-      * `EET` - EET
-      * `EST` - EST
-      * `EST5EDT` - EST5EDT
-      * `Egypt` - Egypt
-      * `Eire` - Eire
-      * `Etc/GMT` - Etc/GMT
-      * `Etc/GMT+0` - Etc/GMT+0
-      * `Etc/GMT+1` - Etc/GMT+1
-      * `Etc/GMT+10` - Etc/GMT+10
-      * `Etc/GMT+11` - Etc/GMT+11
-      * `Etc/GMT+12` - Etc/GMT+12
-      * `Etc/GMT+2` - Etc/GMT+2
-      * `Etc/GMT+3` - Etc/GMT+3
-      * `Etc/GMT+4` - Etc/GMT+4
-      * `Etc/GMT+5` - Etc/GMT+5
-      * `Etc/GMT+6` - Etc/GMT+6
-      * `Etc/GMT+7` - Etc/GMT+7
-      * `Etc/GMT+8` - Etc/GMT+8
-      * `Etc/GMT+9` - Etc/GMT+9
-      * `Etc/GMT-0` - Etc/GMT-0
-      * `Etc/GMT-1` - Etc/GMT-1
-      * `Etc/GMT-10` - Etc/GMT-10
-      * `Etc/GMT-11` - Etc/GMT-11
-      * `Etc/GMT-12` - Etc/GMT-12
-      * `Etc/GMT-13` - Etc/GMT-13
-      * `Etc/GMT-14` - Etc/GMT-14
-      * `Etc/GMT-2` - Etc/GMT-2
-      * `Etc/GMT-3` - Etc/GMT-3
-      * `Etc/GMT-4` - Etc/GMT-4
-      * `Etc/GMT-5` - Etc/GMT-5
-      * `Etc/GMT-6` - Etc/GMT-6
-      * `Etc/GMT-7` - Etc/GMT-7
-      * `Etc/GMT-8` - Etc/GMT-8
-      * `Etc/GMT-9` - Etc/GMT-9
-      * `Etc/GMT0` - Etc/GMT0
-      * `Etc/Greenwich` - Etc/Greenwich
-      * `Etc/UCT` - Etc/UCT
-      * `Etc/UTC` - Etc/UTC
-      * `Etc/Universal` - Etc/Universal
-      * `Etc/Zulu` - Etc/Zulu
-      * `Europe/Amsterdam` - Europe/Amsterdam
-      * `Europe/Andorra` - Europe/Andorra
-      * `Europe/Astrakhan` - Europe/Astrakhan
-      * `Europe/Athens` - Europe/Athens
-      * `Europe/Belfast` - Europe/Belfast
-      * `Europe/Belgrade` - Europe/Belgrade
-      * `Europe/Berlin` - Europe/Berlin
-      * `Europe/Bratislava` - Europe/Bratislava
-      * `Europe/Brussels` - Europe/Brussels
-      * `Europe/Bucharest` - Europe/Bucharest
-      * `Europe/Budapest` - Europe/Budapest
-      * `Europe/Busingen` - Europe/Busingen
-      * `Europe/Chisinau` - Europe/Chisinau
-      * `Europe/Copenhagen` - Europe/Copenhagen
-      * `Europe/Dublin` - Europe/Dublin
-      * `Europe/Gibraltar` - Europe/Gibraltar
-      * `Europe/Guernsey` - Europe/Guernsey
-      * `Europe/Helsinki` - Europe/Helsinki
-      * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-      * `Europe/Istanbul` - Europe/Istanbul
-      * `Europe/Jersey` - Europe/Jersey
-      * `Europe/Kaliningrad` - Europe/Kaliningrad
-      * `Europe/Kiev` - Europe/Kiev
-      * `Europe/Kirov` - Europe/Kirov
-      * `Europe/Kyiv` - Europe/Kyiv
-      * `Europe/Lisbon` - Europe/Lisbon
-      * `Europe/Ljubljana` - Europe/Ljubljana
-      * `Europe/London` - Europe/London
-      * `Europe/Luxembourg` - Europe/Luxembourg
-      * `Europe/Madrid` - Europe/Madrid
-      * `Europe/Malta` - Europe/Malta
-      * `Europe/Mariehamn` - Europe/Mariehamn
-      * `Europe/Minsk` - Europe/Minsk
-      * `Europe/Monaco` - Europe/Monaco
-      * `Europe/Moscow` - Europe/Moscow
-      * `Europe/Nicosia` - Europe/Nicosia
-      * `Europe/Oslo` - Europe/Oslo
-      * `Europe/Paris` - Europe/Paris
-      * `Europe/Podgorica` - Europe/Podgorica
-      * `Europe/Prague` - Europe/Prague
-      * `Europe/Riga` - Europe/Riga
-      * `Europe/Rome` - Europe/Rome
-      * `Europe/Samara` - Europe/Samara
-      * `Europe/San_Marino` - Europe/San_Marino
-      * `Europe/Sarajevo` - Europe/Sarajevo
-      * `Europe/Saratov` - Europe/Saratov
-      * `Europe/Simferopol` - Europe/Simferopol
-      * `Europe/Skopje` - Europe/Skopje
-      * `Europe/Sofia` - Europe/Sofia
-      * `Europe/Stockholm` - Europe/Stockholm
-      * `Europe/Tallinn` - Europe/Tallinn
-      * `Europe/Tirane` - Europe/Tirane
-      * `Europe/Tiraspol` - Europe/Tiraspol
-      * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-      * `Europe/Uzhgorod` - Europe/Uzhgorod
-      * `Europe/Vaduz` - Europe/Vaduz
-      * `Europe/Vatican` - Europe/Vatican
-      * `Europe/Vienna` - Europe/Vienna
-      * `Europe/Vilnius` - Europe/Vilnius
-      * `Europe/Volgograd` - Europe/Volgograd
-      * `Europe/Warsaw` - Europe/Warsaw
-      * `Europe/Zagreb` - Europe/Zagreb
-      * `Europe/Zaporozhye` - Europe/Zaporozhye
-      * `Europe/Zurich` - Europe/Zurich
-      * `GB` - GB
-      * `GB-Eire` - GB-Eire
-      * `GMT` - GMT
-      * `GMT+0` - GMT+0
-      * `GMT-0` - GMT-0
-      * `GMT0` - GMT0
-      * `Greenwich` - Greenwich
-      * `HST` - HST
-      * `Hongkong` - Hongkong
-      * `Iceland` - Iceland
-      * `Indian/Antananarivo` - Indian/Antananarivo
-      * `Indian/Chagos` - Indian/Chagos
-      * `Indian/Christmas` - Indian/Christmas
-      * `Indian/Cocos` - Indian/Cocos
-      * `Indian/Comoro` - Indian/Comoro
-      * `Indian/Kerguelen` - Indian/Kerguelen
-      * `Indian/Mahe` - Indian/Mahe
-      * `Indian/Maldives` - Indian/Maldives
-      * `Indian/Mauritius` - Indian/Mauritius
-      * `Indian/Mayotte` - Indian/Mayotte
-      * `Indian/Reunion` - Indian/Reunion
-      * `Iran` - Iran
-      * `Israel` - Israel
-      * `Jamaica` - Jamaica
-      * `Japan` - Japan
-      * `Kwajalein` - Kwajalein
-      * `Libya` - Libya
-      * `MET` - MET
-      * `MST` - MST
-      * `MST7MDT` - MST7MDT
-      * `Mexico/BajaNorte` - Mexico/BajaNorte
-      * `Mexico/BajaSur` - Mexico/BajaSur
-      * `Mexico/General` - Mexico/General
-      * `NZ` - NZ
-      * `NZ-CHAT` - NZ-CHAT
-      * `Navajo` - Navajo
-      * `PRC` - PRC
-      * `PST8PDT` - PST8PDT
-      * `Pacific/Apia` - Pacific/Apia
-      * `Pacific/Auckland` - Pacific/Auckland
-      * `Pacific/Bougainville` - Pacific/Bougainville
-      * `Pacific/Chatham` - Pacific/Chatham
-      * `Pacific/Chuuk` - Pacific/Chuuk
-      * `Pacific/Easter` - Pacific/Easter
-      * `Pacific/Efate` - Pacific/Efate
-      * `Pacific/Enderbury` - Pacific/Enderbury
-      * `Pacific/Fakaofo` - Pacific/Fakaofo
-      * `Pacific/Fiji` - Pacific/Fiji
-      * `Pacific/Funafuti` - Pacific/Funafuti
-      * `Pacific/Galapagos` - Pacific/Galapagos
-      * `Pacific/Gambier` - Pacific/Gambier
-      * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-      * `Pacific/Guam` - Pacific/Guam
-      * `Pacific/Honolulu` - Pacific/Honolulu
-      * `Pacific/Johnston` - Pacific/Johnston
-      * `Pacific/Kanton` - Pacific/Kanton
-      * `Pacific/Kiritimati` - Pacific/Kiritimati
-      * `Pacific/Kosrae` - Pacific/Kosrae
-      * `Pacific/Kwajalein` - Pacific/Kwajalein
-      * `Pacific/Majuro` - Pacific/Majuro
-      * `Pacific/Marquesas` - Pacific/Marquesas
-      * `Pacific/Midway` - Pacific/Midway
-      * `Pacific/Nauru` - Pacific/Nauru
-      * `Pacific/Niue` - Pacific/Niue
-      * `Pacific/Norfolk` - Pacific/Norfolk
-      * `Pacific/Noumea` - Pacific/Noumea
-      * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-      * `Pacific/Palau` - Pacific/Palau
-      * `Pacific/Pitcairn` - Pacific/Pitcairn
-      * `Pacific/Pohnpei` - Pacific/Pohnpei
-      * `Pacific/Ponape` - Pacific/Ponape
-      * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-      * `Pacific/Rarotonga` - Pacific/Rarotonga
-      * `Pacific/Saipan` - Pacific/Saipan
-      * `Pacific/Samoa` - Pacific/Samoa
-      * `Pacific/Tahiti` - Pacific/Tahiti
-      * `Pacific/Tarawa` - Pacific/Tarawa
-      * `Pacific/Tongatapu` - Pacific/Tongatapu
-      * `Pacific/Truk` - Pacific/Truk
-      * `Pacific/Wake` - Pacific/Wake
-      * `Pacific/Wallis` - Pacific/Wallis
-      * `Pacific/Yap` - Pacific/Yap
-      * `Poland` - Poland
-      * `Portugal` - Portugal
-      * `ROC` - ROC
-      * `ROK` - ROK
-      * `Singapore` - Singapore
-      * `Turkey` - Turkey
-      * `UCT` - UCT
-      * `US/Alaska` - US/Alaska
-      * `US/Aleutian` - US/Aleutian
-      * `US/Arizona` - US/Arizona
-      * `US/Central` - US/Central
-      * `US/East-Indiana` - US/East-Indiana
-      * `US/Eastern` - US/Eastern
-      * `US/Hawaii` - US/Hawaii
-      * `US/Indiana-Starke` - US/Indiana-Starke
-      * `US/Michigan` - US/Michigan
-      * `US/Mountain` - US/Mountain
-      * `US/Pacific` - US/Pacific
-      * `US/Samoa` - US/Samoa
-      * `UTC` - UTC
-      * `Universal` - Universal
-      * `W-SU` - W-SU
-      * `WET` - WET
-      * `Zulu` - Zulu */
+       *
+       * * `Africa/Abidjan` - Africa/Abidjan
+       * * `Africa/Accra` - Africa/Accra
+       * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+       * * `Africa/Algiers` - Africa/Algiers
+       * * `Africa/Asmara` - Africa/Asmara
+       * * `Africa/Asmera` - Africa/Asmera
+       * * `Africa/Bamako` - Africa/Bamako
+       * * `Africa/Bangui` - Africa/Bangui
+       * * `Africa/Banjul` - Africa/Banjul
+       * * `Africa/Bissau` - Africa/Bissau
+       * * `Africa/Blantyre` - Africa/Blantyre
+       * * `Africa/Brazzaville` - Africa/Brazzaville
+       * * `Africa/Bujumbura` - Africa/Bujumbura
+       * * `Africa/Cairo` - Africa/Cairo
+       * * `Africa/Casablanca` - Africa/Casablanca
+       * * `Africa/Ceuta` - Africa/Ceuta
+       * * `Africa/Conakry` - Africa/Conakry
+       * * `Africa/Dakar` - Africa/Dakar
+       * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+       * * `Africa/Djibouti` - Africa/Djibouti
+       * * `Africa/Douala` - Africa/Douala
+       * * `Africa/El_Aaiun` - Africa/El_Aaiun
+       * * `Africa/Freetown` - Africa/Freetown
+       * * `Africa/Gaborone` - Africa/Gaborone
+       * * `Africa/Harare` - Africa/Harare
+       * * `Africa/Johannesburg` - Africa/Johannesburg
+       * * `Africa/Juba` - Africa/Juba
+       * * `Africa/Kampala` - Africa/Kampala
+       * * `Africa/Khartoum` - Africa/Khartoum
+       * * `Africa/Kigali` - Africa/Kigali
+       * * `Africa/Kinshasa` - Africa/Kinshasa
+       * * `Africa/Lagos` - Africa/Lagos
+       * * `Africa/Libreville` - Africa/Libreville
+       * * `Africa/Lome` - Africa/Lome
+       * * `Africa/Luanda` - Africa/Luanda
+       * * `Africa/Lubumbashi` - Africa/Lubumbashi
+       * * `Africa/Lusaka` - Africa/Lusaka
+       * * `Africa/Malabo` - Africa/Malabo
+       * * `Africa/Maputo` - Africa/Maputo
+       * * `Africa/Maseru` - Africa/Maseru
+       * * `Africa/Mbabane` - Africa/Mbabane
+       * * `Africa/Mogadishu` - Africa/Mogadishu
+       * * `Africa/Monrovia` - Africa/Monrovia
+       * * `Africa/Nairobi` - Africa/Nairobi
+       * * `Africa/Ndjamena` - Africa/Ndjamena
+       * * `Africa/Niamey` - Africa/Niamey
+       * * `Africa/Nouakchott` - Africa/Nouakchott
+       * * `Africa/Ouagadougou` - Africa/Ouagadougou
+       * * `Africa/Porto-Novo` - Africa/Porto-Novo
+       * * `Africa/Sao_Tome` - Africa/Sao_Tome
+       * * `Africa/Timbuktu` - Africa/Timbuktu
+       * * `Africa/Tripoli` - Africa/Tripoli
+       * * `Africa/Tunis` - Africa/Tunis
+       * * `Africa/Windhoek` - Africa/Windhoek
+       * * `America/Adak` - America/Adak
+       * * `America/Anchorage` - America/Anchorage
+       * * `America/Anguilla` - America/Anguilla
+       * * `America/Antigua` - America/Antigua
+       * * `America/Araguaina` - America/Araguaina
+       * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+       * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+       * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+       * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+       * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+       * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+       * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+       * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+       * * `America/Argentina/Salta` - America/Argentina/Salta
+       * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+       * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+       * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+       * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+       * * `America/Aruba` - America/Aruba
+       * * `America/Asuncion` - America/Asuncion
+       * * `America/Atikokan` - America/Atikokan
+       * * `America/Atka` - America/Atka
+       * * `America/Bahia` - America/Bahia
+       * * `America/Bahia_Banderas` - America/Bahia_Banderas
+       * * `America/Barbados` - America/Barbados
+       * * `America/Belem` - America/Belem
+       * * `America/Belize` - America/Belize
+       * * `America/Blanc-Sablon` - America/Blanc-Sablon
+       * * `America/Boa_Vista` - America/Boa_Vista
+       * * `America/Bogota` - America/Bogota
+       * * `America/Boise` - America/Boise
+       * * `America/Buenos_Aires` - America/Buenos_Aires
+       * * `America/Cambridge_Bay` - America/Cambridge_Bay
+       * * `America/Campo_Grande` - America/Campo_Grande
+       * * `America/Cancun` - America/Cancun
+       * * `America/Caracas` - America/Caracas
+       * * `America/Catamarca` - America/Catamarca
+       * * `America/Cayenne` - America/Cayenne
+       * * `America/Cayman` - America/Cayman
+       * * `America/Chicago` - America/Chicago
+       * * `America/Chihuahua` - America/Chihuahua
+       * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+       * * `America/Coral_Harbour` - America/Coral_Harbour
+       * * `America/Cordoba` - America/Cordoba
+       * * `America/Costa_Rica` - America/Costa_Rica
+       * * `America/Creston` - America/Creston
+       * * `America/Cuiaba` - America/Cuiaba
+       * * `America/Curacao` - America/Curacao
+       * * `America/Danmarkshavn` - America/Danmarkshavn
+       * * `America/Dawson` - America/Dawson
+       * * `America/Dawson_Creek` - America/Dawson_Creek
+       * * `America/Denver` - America/Denver
+       * * `America/Detroit` - America/Detroit
+       * * `America/Dominica` - America/Dominica
+       * * `America/Edmonton` - America/Edmonton
+       * * `America/Eirunepe` - America/Eirunepe
+       * * `America/El_Salvador` - America/El_Salvador
+       * * `America/Ensenada` - America/Ensenada
+       * * `America/Fort_Nelson` - America/Fort_Nelson
+       * * `America/Fort_Wayne` - America/Fort_Wayne
+       * * `America/Fortaleza` - America/Fortaleza
+       * * `America/Glace_Bay` - America/Glace_Bay
+       * * `America/Godthab` - America/Godthab
+       * * `America/Goose_Bay` - America/Goose_Bay
+       * * `America/Grand_Turk` - America/Grand_Turk
+       * * `America/Grenada` - America/Grenada
+       * * `America/Guadeloupe` - America/Guadeloupe
+       * * `America/Guatemala` - America/Guatemala
+       * * `America/Guayaquil` - America/Guayaquil
+       * * `America/Guyana` - America/Guyana
+       * * `America/Halifax` - America/Halifax
+       * * `America/Havana` - America/Havana
+       * * `America/Hermosillo` - America/Hermosillo
+       * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+       * * `America/Indiana/Knox` - America/Indiana/Knox
+       * * `America/Indiana/Marengo` - America/Indiana/Marengo
+       * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+       * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+       * * `America/Indiana/Vevay` - America/Indiana/Vevay
+       * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+       * * `America/Indiana/Winamac` - America/Indiana/Winamac
+       * * `America/Indianapolis` - America/Indianapolis
+       * * `America/Inuvik` - America/Inuvik
+       * * `America/Iqaluit` - America/Iqaluit
+       * * `America/Jamaica` - America/Jamaica
+       * * `America/Jujuy` - America/Jujuy
+       * * `America/Juneau` - America/Juneau
+       * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+       * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+       * * `America/Knox_IN` - America/Knox_IN
+       * * `America/Kralendijk` - America/Kralendijk
+       * * `America/La_Paz` - America/La_Paz
+       * * `America/Lima` - America/Lima
+       * * `America/Los_Angeles` - America/Los_Angeles
+       * * `America/Louisville` - America/Louisville
+       * * `America/Lower_Princes` - America/Lower_Princes
+       * * `America/Maceio` - America/Maceio
+       * * `America/Managua` - America/Managua
+       * * `America/Manaus` - America/Manaus
+       * * `America/Marigot` - America/Marigot
+       * * `America/Martinique` - America/Martinique
+       * * `America/Matamoros` - America/Matamoros
+       * * `America/Mazatlan` - America/Mazatlan
+       * * `America/Mendoza` - America/Mendoza
+       * * `America/Menominee` - America/Menominee
+       * * `America/Merida` - America/Merida
+       * * `America/Metlakatla` - America/Metlakatla
+       * * `America/Mexico_City` - America/Mexico_City
+       * * `America/Miquelon` - America/Miquelon
+       * * `America/Moncton` - America/Moncton
+       * * `America/Monterrey` - America/Monterrey
+       * * `America/Montevideo` - America/Montevideo
+       * * `America/Montreal` - America/Montreal
+       * * `America/Montserrat` - America/Montserrat
+       * * `America/Nassau` - America/Nassau
+       * * `America/New_York` - America/New_York
+       * * `America/Nipigon` - America/Nipigon
+       * * `America/Nome` - America/Nome
+       * * `America/Noronha` - America/Noronha
+       * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+       * * `America/North_Dakota/Center` - America/North_Dakota/Center
+       * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+       * * `America/Nuuk` - America/Nuuk
+       * * `America/Ojinaga` - America/Ojinaga
+       * * `America/Panama` - America/Panama
+       * * `America/Pangnirtung` - America/Pangnirtung
+       * * `America/Paramaribo` - America/Paramaribo
+       * * `America/Phoenix` - America/Phoenix
+       * * `America/Port-au-Prince` - America/Port-au-Prince
+       * * `America/Port_of_Spain` - America/Port_of_Spain
+       * * `America/Porto_Acre` - America/Porto_Acre
+       * * `America/Porto_Velho` - America/Porto_Velho
+       * * `America/Puerto_Rico` - America/Puerto_Rico
+       * * `America/Punta_Arenas` - America/Punta_Arenas
+       * * `America/Rainy_River` - America/Rainy_River
+       * * `America/Rankin_Inlet` - America/Rankin_Inlet
+       * * `America/Recife` - America/Recife
+       * * `America/Regina` - America/Regina
+       * * `America/Resolute` - America/Resolute
+       * * `America/Rio_Branco` - America/Rio_Branco
+       * * `America/Rosario` - America/Rosario
+       * * `America/Santa_Isabel` - America/Santa_Isabel
+       * * `America/Santarem` - America/Santarem
+       * * `America/Santiago` - America/Santiago
+       * * `America/Santo_Domingo` - America/Santo_Domingo
+       * * `America/Sao_Paulo` - America/Sao_Paulo
+       * * `America/Scoresbysund` - America/Scoresbysund
+       * * `America/Shiprock` - America/Shiprock
+       * * `America/Sitka` - America/Sitka
+       * * `America/St_Barthelemy` - America/St_Barthelemy
+       * * `America/St_Johns` - America/St_Johns
+       * * `America/St_Kitts` - America/St_Kitts
+       * * `America/St_Lucia` - America/St_Lucia
+       * * `America/St_Thomas` - America/St_Thomas
+       * * `America/St_Vincent` - America/St_Vincent
+       * * `America/Swift_Current` - America/Swift_Current
+       * * `America/Tegucigalpa` - America/Tegucigalpa
+       * * `America/Thule` - America/Thule
+       * * `America/Thunder_Bay` - America/Thunder_Bay
+       * * `America/Tijuana` - America/Tijuana
+       * * `America/Toronto` - America/Toronto
+       * * `America/Tortola` - America/Tortola
+       * * `America/Vancouver` - America/Vancouver
+       * * `America/Virgin` - America/Virgin
+       * * `America/Whitehorse` - America/Whitehorse
+       * * `America/Winnipeg` - America/Winnipeg
+       * * `America/Yakutat` - America/Yakutat
+       * * `America/Yellowknife` - America/Yellowknife
+       * * `Antarctica/Casey` - Antarctica/Casey
+       * * `Antarctica/Davis` - Antarctica/Davis
+       * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+       * * `Antarctica/Macquarie` - Antarctica/Macquarie
+       * * `Antarctica/Mawson` - Antarctica/Mawson
+       * * `Antarctica/McMurdo` - Antarctica/McMurdo
+       * * `Antarctica/Palmer` - Antarctica/Palmer
+       * * `Antarctica/Rothera` - Antarctica/Rothera
+       * * `Antarctica/South_Pole` - Antarctica/South_Pole
+       * * `Antarctica/Syowa` - Antarctica/Syowa
+       * * `Antarctica/Troll` - Antarctica/Troll
+       * * `Antarctica/Vostok` - Antarctica/Vostok
+       * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+       * * `Asia/Aden` - Asia/Aden
+       * * `Asia/Almaty` - Asia/Almaty
+       * * `Asia/Amman` - Asia/Amman
+       * * `Asia/Anadyr` - Asia/Anadyr
+       * * `Asia/Aqtau` - Asia/Aqtau
+       * * `Asia/Aqtobe` - Asia/Aqtobe
+       * * `Asia/Ashgabat` - Asia/Ashgabat
+       * * `Asia/Ashkhabad` - Asia/Ashkhabad
+       * * `Asia/Atyrau` - Asia/Atyrau
+       * * `Asia/Baghdad` - Asia/Baghdad
+       * * `Asia/Bahrain` - Asia/Bahrain
+       * * `Asia/Baku` - Asia/Baku
+       * * `Asia/Bangkok` - Asia/Bangkok
+       * * `Asia/Barnaul` - Asia/Barnaul
+       * * `Asia/Beirut` - Asia/Beirut
+       * * `Asia/Bishkek` - Asia/Bishkek
+       * * `Asia/Brunei` - Asia/Brunei
+       * * `Asia/Calcutta` - Asia/Calcutta
+       * * `Asia/Chita` - Asia/Chita
+       * * `Asia/Choibalsan` - Asia/Choibalsan
+       * * `Asia/Chongqing` - Asia/Chongqing
+       * * `Asia/Chungking` - Asia/Chungking
+       * * `Asia/Colombo` - Asia/Colombo
+       * * `Asia/Dacca` - Asia/Dacca
+       * * `Asia/Damascus` - Asia/Damascus
+       * * `Asia/Dhaka` - Asia/Dhaka
+       * * `Asia/Dili` - Asia/Dili
+       * * `Asia/Dubai` - Asia/Dubai
+       * * `Asia/Dushanbe` - Asia/Dushanbe
+       * * `Asia/Famagusta` - Asia/Famagusta
+       * * `Asia/Gaza` - Asia/Gaza
+       * * `Asia/Harbin` - Asia/Harbin
+       * * `Asia/Hebron` - Asia/Hebron
+       * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+       * * `Asia/Hong_Kong` - Asia/Hong_Kong
+       * * `Asia/Hovd` - Asia/Hovd
+       * * `Asia/Irkutsk` - Asia/Irkutsk
+       * * `Asia/Istanbul` - Asia/Istanbul
+       * * `Asia/Jakarta` - Asia/Jakarta
+       * * `Asia/Jayapura` - Asia/Jayapura
+       * * `Asia/Jerusalem` - Asia/Jerusalem
+       * * `Asia/Kabul` - Asia/Kabul
+       * * `Asia/Kamchatka` - Asia/Kamchatka
+       * * `Asia/Karachi` - Asia/Karachi
+       * * `Asia/Kashgar` - Asia/Kashgar
+       * * `Asia/Kathmandu` - Asia/Kathmandu
+       * * `Asia/Katmandu` - Asia/Katmandu
+       * * `Asia/Khandyga` - Asia/Khandyga
+       * * `Asia/Kolkata` - Asia/Kolkata
+       * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+       * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+       * * `Asia/Kuching` - Asia/Kuching
+       * * `Asia/Kuwait` - Asia/Kuwait
+       * * `Asia/Macao` - Asia/Macao
+       * * `Asia/Macau` - Asia/Macau
+       * * `Asia/Magadan` - Asia/Magadan
+       * * `Asia/Makassar` - Asia/Makassar
+       * * `Asia/Manila` - Asia/Manila
+       * * `Asia/Muscat` - Asia/Muscat
+       * * `Asia/Nicosia` - Asia/Nicosia
+       * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+       * * `Asia/Novosibirsk` - Asia/Novosibirsk
+       * * `Asia/Omsk` - Asia/Omsk
+       * * `Asia/Oral` - Asia/Oral
+       * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+       * * `Asia/Pontianak` - Asia/Pontianak
+       * * `Asia/Pyongyang` - Asia/Pyongyang
+       * * `Asia/Qatar` - Asia/Qatar
+       * * `Asia/Qostanay` - Asia/Qostanay
+       * * `Asia/Qyzylorda` - Asia/Qyzylorda
+       * * `Asia/Rangoon` - Asia/Rangoon
+       * * `Asia/Riyadh` - Asia/Riyadh
+       * * `Asia/Saigon` - Asia/Saigon
+       * * `Asia/Sakhalin` - Asia/Sakhalin
+       * * `Asia/Samarkand` - Asia/Samarkand
+       * * `Asia/Seoul` - Asia/Seoul
+       * * `Asia/Shanghai` - Asia/Shanghai
+       * * `Asia/Singapore` - Asia/Singapore
+       * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+       * * `Asia/Taipei` - Asia/Taipei
+       * * `Asia/Tashkent` - Asia/Tashkent
+       * * `Asia/Tbilisi` - Asia/Tbilisi
+       * * `Asia/Tehran` - Asia/Tehran
+       * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+       * * `Asia/Thimbu` - Asia/Thimbu
+       * * `Asia/Thimphu` - Asia/Thimphu
+       * * `Asia/Tokyo` - Asia/Tokyo
+       * * `Asia/Tomsk` - Asia/Tomsk
+       * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+       * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+       * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+       * * `Asia/Urumqi` - Asia/Urumqi
+       * * `Asia/Ust-Nera` - Asia/Ust-Nera
+       * * `Asia/Vientiane` - Asia/Vientiane
+       * * `Asia/Vladivostok` - Asia/Vladivostok
+       * * `Asia/Yakutsk` - Asia/Yakutsk
+       * * `Asia/Yangon` - Asia/Yangon
+       * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+       * * `Asia/Yerevan` - Asia/Yerevan
+       * * `Atlantic/Azores` - Atlantic/Azores
+       * * `Atlantic/Bermuda` - Atlantic/Bermuda
+       * * `Atlantic/Canary` - Atlantic/Canary
+       * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+       * * `Atlantic/Faeroe` - Atlantic/Faeroe
+       * * `Atlantic/Faroe` - Atlantic/Faroe
+       * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+       * * `Atlantic/Madeira` - Atlantic/Madeira
+       * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+       * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+       * * `Atlantic/St_Helena` - Atlantic/St_Helena
+       * * `Atlantic/Stanley` - Atlantic/Stanley
+       * * `Australia/ACT` - Australia/ACT
+       * * `Australia/Adelaide` - Australia/Adelaide
+       * * `Australia/Brisbane` - Australia/Brisbane
+       * * `Australia/Broken_Hill` - Australia/Broken_Hill
+       * * `Australia/Canberra` - Australia/Canberra
+       * * `Australia/Currie` - Australia/Currie
+       * * `Australia/Darwin` - Australia/Darwin
+       * * `Australia/Eucla` - Australia/Eucla
+       * * `Australia/Hobart` - Australia/Hobart
+       * * `Australia/LHI` - Australia/LHI
+       * * `Australia/Lindeman` - Australia/Lindeman
+       * * `Australia/Lord_Howe` - Australia/Lord_Howe
+       * * `Australia/Melbourne` - Australia/Melbourne
+       * * `Australia/NSW` - Australia/NSW
+       * * `Australia/North` - Australia/North
+       * * `Australia/Perth` - Australia/Perth
+       * * `Australia/Queensland` - Australia/Queensland
+       * * `Australia/South` - Australia/South
+       * * `Australia/Sydney` - Australia/Sydney
+       * * `Australia/Tasmania` - Australia/Tasmania
+       * * `Australia/Victoria` - Australia/Victoria
+       * * `Australia/West` - Australia/West
+       * * `Australia/Yancowinna` - Australia/Yancowinna
+       * * `Brazil/Acre` - Brazil/Acre
+       * * `Brazil/DeNoronha` - Brazil/DeNoronha
+       * * `Brazil/East` - Brazil/East
+       * * `Brazil/West` - Brazil/West
+       * * `CET` - CET
+       * * `CST6CDT` - CST6CDT
+       * * `Canada/Atlantic` - Canada/Atlantic
+       * * `Canada/Central` - Canada/Central
+       * * `Canada/Eastern` - Canada/Eastern
+       * * `Canada/Mountain` - Canada/Mountain
+       * * `Canada/Newfoundland` - Canada/Newfoundland
+       * * `Canada/Pacific` - Canada/Pacific
+       * * `Canada/Saskatchewan` - Canada/Saskatchewan
+       * * `Canada/Yukon` - Canada/Yukon
+       * * `Chile/Continental` - Chile/Continental
+       * * `Chile/EasterIsland` - Chile/EasterIsland
+       * * `Cuba` - Cuba
+       * * `EET` - EET
+       * * `EST` - EST
+       * * `EST5EDT` - EST5EDT
+       * * `Egypt` - Egypt
+       * * `Eire` - Eire
+       * * `Etc/GMT` - Etc/GMT
+       * * `Etc/GMT+0` - Etc/GMT+0
+       * * `Etc/GMT+1` - Etc/GMT+1
+       * * `Etc/GMT+10` - Etc/GMT+10
+       * * `Etc/GMT+11` - Etc/GMT+11
+       * * `Etc/GMT+12` - Etc/GMT+12
+       * * `Etc/GMT+2` - Etc/GMT+2
+       * * `Etc/GMT+3` - Etc/GMT+3
+       * * `Etc/GMT+4` - Etc/GMT+4
+       * * `Etc/GMT+5` - Etc/GMT+5
+       * * `Etc/GMT+6` - Etc/GMT+6
+       * * `Etc/GMT+7` - Etc/GMT+7
+       * * `Etc/GMT+8` - Etc/GMT+8
+       * * `Etc/GMT+9` - Etc/GMT+9
+       * * `Etc/GMT-0` - Etc/GMT-0
+       * * `Etc/GMT-1` - Etc/GMT-1
+       * * `Etc/GMT-10` - Etc/GMT-10
+       * * `Etc/GMT-11` - Etc/GMT-11
+       * * `Etc/GMT-12` - Etc/GMT-12
+       * * `Etc/GMT-13` - Etc/GMT-13
+       * * `Etc/GMT-14` - Etc/GMT-14
+       * * `Etc/GMT-2` - Etc/GMT-2
+       * * `Etc/GMT-3` - Etc/GMT-3
+       * * `Etc/GMT-4` - Etc/GMT-4
+       * * `Etc/GMT-5` - Etc/GMT-5
+       * * `Etc/GMT-6` - Etc/GMT-6
+       * * `Etc/GMT-7` - Etc/GMT-7
+       * * `Etc/GMT-8` - Etc/GMT-8
+       * * `Etc/GMT-9` - Etc/GMT-9
+       * * `Etc/GMT0` - Etc/GMT0
+       * * `Etc/Greenwich` - Etc/Greenwich
+       * * `Etc/UCT` - Etc/UCT
+       * * `Etc/UTC` - Etc/UTC
+       * * `Etc/Universal` - Etc/Universal
+       * * `Etc/Zulu` - Etc/Zulu
+       * * `Europe/Amsterdam` - Europe/Amsterdam
+       * * `Europe/Andorra` - Europe/Andorra
+       * * `Europe/Astrakhan` - Europe/Astrakhan
+       * * `Europe/Athens` - Europe/Athens
+       * * `Europe/Belfast` - Europe/Belfast
+       * * `Europe/Belgrade` - Europe/Belgrade
+       * * `Europe/Berlin` - Europe/Berlin
+       * * `Europe/Bratislava` - Europe/Bratislava
+       * * `Europe/Brussels` - Europe/Brussels
+       * * `Europe/Bucharest` - Europe/Bucharest
+       * * `Europe/Budapest` - Europe/Budapest
+       * * `Europe/Busingen` - Europe/Busingen
+       * * `Europe/Chisinau` - Europe/Chisinau
+       * * `Europe/Copenhagen` - Europe/Copenhagen
+       * * `Europe/Dublin` - Europe/Dublin
+       * * `Europe/Gibraltar` - Europe/Gibraltar
+       * * `Europe/Guernsey` - Europe/Guernsey
+       * * `Europe/Helsinki` - Europe/Helsinki
+       * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+       * * `Europe/Istanbul` - Europe/Istanbul
+       * * `Europe/Jersey` - Europe/Jersey
+       * * `Europe/Kaliningrad` - Europe/Kaliningrad
+       * * `Europe/Kiev` - Europe/Kiev
+       * * `Europe/Kirov` - Europe/Kirov
+       * * `Europe/Kyiv` - Europe/Kyiv
+       * * `Europe/Lisbon` - Europe/Lisbon
+       * * `Europe/Ljubljana` - Europe/Ljubljana
+       * * `Europe/London` - Europe/London
+       * * `Europe/Luxembourg` - Europe/Luxembourg
+       * * `Europe/Madrid` - Europe/Madrid
+       * * `Europe/Malta` - Europe/Malta
+       * * `Europe/Mariehamn` - Europe/Mariehamn
+       * * `Europe/Minsk` - Europe/Minsk
+       * * `Europe/Monaco` - Europe/Monaco
+       * * `Europe/Moscow` - Europe/Moscow
+       * * `Europe/Nicosia` - Europe/Nicosia
+       * * `Europe/Oslo` - Europe/Oslo
+       * * `Europe/Paris` - Europe/Paris
+       * * `Europe/Podgorica` - Europe/Podgorica
+       * * `Europe/Prague` - Europe/Prague
+       * * `Europe/Riga` - Europe/Riga
+       * * `Europe/Rome` - Europe/Rome
+       * * `Europe/Samara` - Europe/Samara
+       * * `Europe/San_Marino` - Europe/San_Marino
+       * * `Europe/Sarajevo` - Europe/Sarajevo
+       * * `Europe/Saratov` - Europe/Saratov
+       * * `Europe/Simferopol` - Europe/Simferopol
+       * * `Europe/Skopje` - Europe/Skopje
+       * * `Europe/Sofia` - Europe/Sofia
+       * * `Europe/Stockholm` - Europe/Stockholm
+       * * `Europe/Tallinn` - Europe/Tallinn
+       * * `Europe/Tirane` - Europe/Tirane
+       * * `Europe/Tiraspol` - Europe/Tiraspol
+       * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+       * * `Europe/Uzhgorod` - Europe/Uzhgorod
+       * * `Europe/Vaduz` - Europe/Vaduz
+       * * `Europe/Vatican` - Europe/Vatican
+       * * `Europe/Vienna` - Europe/Vienna
+       * * `Europe/Vilnius` - Europe/Vilnius
+       * * `Europe/Volgograd` - Europe/Volgograd
+       * * `Europe/Warsaw` - Europe/Warsaw
+       * * `Europe/Zagreb` - Europe/Zagreb
+       * * `Europe/Zaporozhye` - Europe/Zaporozhye
+       * * `Europe/Zurich` - Europe/Zurich
+       * * `GB` - GB
+       * * `GB-Eire` - GB-Eire
+       * * `GMT` - GMT
+       * * `GMT+0` - GMT+0
+       * * `GMT-0` - GMT-0
+       * * `GMT0` - GMT0
+       * * `Greenwich` - Greenwich
+       * * `HST` - HST
+       * * `Hongkong` - Hongkong
+       * * `Iceland` - Iceland
+       * * `Indian/Antananarivo` - Indian/Antananarivo
+       * * `Indian/Chagos` - Indian/Chagos
+       * * `Indian/Christmas` - Indian/Christmas
+       * * `Indian/Cocos` - Indian/Cocos
+       * * `Indian/Comoro` - Indian/Comoro
+       * * `Indian/Kerguelen` - Indian/Kerguelen
+       * * `Indian/Mahe` - Indian/Mahe
+       * * `Indian/Maldives` - Indian/Maldives
+       * * `Indian/Mauritius` - Indian/Mauritius
+       * * `Indian/Mayotte` - Indian/Mayotte
+       * * `Indian/Reunion` - Indian/Reunion
+       * * `Iran` - Iran
+       * * `Israel` - Israel
+       * * `Jamaica` - Jamaica
+       * * `Japan` - Japan
+       * * `Kwajalein` - Kwajalein
+       * * `Libya` - Libya
+       * * `MET` - MET
+       * * `MST` - MST
+       * * `MST7MDT` - MST7MDT
+       * * `Mexico/BajaNorte` - Mexico/BajaNorte
+       * * `Mexico/BajaSur` - Mexico/BajaSur
+       * * `Mexico/General` - Mexico/General
+       * * `NZ` - NZ
+       * * `NZ-CHAT` - NZ-CHAT
+       * * `Navajo` - Navajo
+       * * `PRC` - PRC
+       * * `PST8PDT` - PST8PDT
+       * * `Pacific/Apia` - Pacific/Apia
+       * * `Pacific/Auckland` - Pacific/Auckland
+       * * `Pacific/Bougainville` - Pacific/Bougainville
+       * * `Pacific/Chatham` - Pacific/Chatham
+       * * `Pacific/Chuuk` - Pacific/Chuuk
+       * * `Pacific/Easter` - Pacific/Easter
+       * * `Pacific/Efate` - Pacific/Efate
+       * * `Pacific/Enderbury` - Pacific/Enderbury
+       * * `Pacific/Fakaofo` - Pacific/Fakaofo
+       * * `Pacific/Fiji` - Pacific/Fiji
+       * * `Pacific/Funafuti` - Pacific/Funafuti
+       * * `Pacific/Galapagos` - Pacific/Galapagos
+       * * `Pacific/Gambier` - Pacific/Gambier
+       * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+       * * `Pacific/Guam` - Pacific/Guam
+       * * `Pacific/Honolulu` - Pacific/Honolulu
+       * * `Pacific/Johnston` - Pacific/Johnston
+       * * `Pacific/Kanton` - Pacific/Kanton
+       * * `Pacific/Kiritimati` - Pacific/Kiritimati
+       * * `Pacific/Kosrae` - Pacific/Kosrae
+       * * `Pacific/Kwajalein` - Pacific/Kwajalein
+       * * `Pacific/Majuro` - Pacific/Majuro
+       * * `Pacific/Marquesas` - Pacific/Marquesas
+       * * `Pacific/Midway` - Pacific/Midway
+       * * `Pacific/Nauru` - Pacific/Nauru
+       * * `Pacific/Niue` - Pacific/Niue
+       * * `Pacific/Norfolk` - Pacific/Norfolk
+       * * `Pacific/Noumea` - Pacific/Noumea
+       * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+       * * `Pacific/Palau` - Pacific/Palau
+       * * `Pacific/Pitcairn` - Pacific/Pitcairn
+       * * `Pacific/Pohnpei` - Pacific/Pohnpei
+       * * `Pacific/Ponape` - Pacific/Ponape
+       * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+       * * `Pacific/Rarotonga` - Pacific/Rarotonga
+       * * `Pacific/Saipan` - Pacific/Saipan
+       * * `Pacific/Samoa` - Pacific/Samoa
+       * * `Pacific/Tahiti` - Pacific/Tahiti
+       * * `Pacific/Tarawa` - Pacific/Tarawa
+       * * `Pacific/Tongatapu` - Pacific/Tongatapu
+       * * `Pacific/Truk` - Pacific/Truk
+       * * `Pacific/Wake` - Pacific/Wake
+       * * `Pacific/Wallis` - Pacific/Wallis
+       * * `Pacific/Yap` - Pacific/Yap
+       * * `Poland` - Poland
+       * * `Portugal` - Portugal
+       * * `ROC` - ROC
+       * * `ROK` - ROK
+       * * `Singapore` - Singapore
+       * * `Turkey` - Turkey
+       * * `UCT` - UCT
+       * * `US/Alaska` - US/Alaska
+       * * `US/Aleutian` - US/Aleutian
+       * * `US/Arizona` - US/Arizona
+       * * `US/Central` - US/Central
+       * * `US/East-Indiana` - US/East-Indiana
+       * * `US/Eastern` - US/Eastern
+       * * `US/Hawaii` - US/Hawaii
+       * * `US/Indiana-Starke` - US/Indiana-Starke
+       * * `US/Michigan` - US/Michigan
+       * * `US/Mountain` - US/Mountain
+       * * `US/Pacific` - US/Pacific
+       * * `US/Samoa` - US/Samoa
+       * * `UTC` - UTC
+       * * `Universal` - Universal
+       * * `W-SU` - W-SU
+       * * `WET` - WET
+       * * `Zulu` - Zulu */
       timezone?: string;
       /** Element attributes that posthog-js should capture as action identifiers (e.g. `['data-attr']`). */
       data_attributes?: unknown;
       /**
          * Ordered list of person properties used to render a human-friendly display name in the UI.
          * @nullable
+         * @items.maxLength 400
          */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
@@ -35208,19 +35309,19 @@ export namespace Schemas {
       /** V2 trigger groups configuration for session recording. If present, takes precedence over legacy trigger fields. */
       session_recording_trigger_groups?: unknown;
       /** How long to retain new session recordings. One of `30d`, `90d`, `1y`, or `5y` (availability depends on plan).
-
-      * `30d` - 30 Days
-      * `90d` - 90 Days
-      * `1y` - 1 Year
-      * `5y` - 5 Years */
+       *
+       * * `30d` - 30 Days
+       * * `90d` - 90 Days
+       * * `1y` - 1 Year
+       * * `5y` - 5 Years */
       session_recording_retention_period?: SessionRecordingRetentionPeriodEnum;
       session_replay_config?: unknown;
       survey_config?: unknown;
       access_control?: boolean;
       /** First day of the week for date range filters. 0 = Sunday, 1 = Monday.
-
-      * `0` - Sunday
-      * `1` - Monday */
+       *
+       * * `0` - Sunday
+       * * `1` - Monday */
       week_start_day?: WeekStartDayEnum | null;
       /**
          * ID of the dashboard shown as the project's default landing dashboard.
@@ -35232,6 +35333,7 @@ export namespace Schemas {
       /**
          * Origins permitted to record session replays and heatmaps. Empty list allows all origins.
          * @nullable
+         * @items.maxLength 200
          */
       recording_domains?: (string | null)[] | null;
       readonly person_on_events_querying_enabled: boolean;
@@ -35264,10 +35366,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts.
-
-      * `b2b` - B2B
-      * `b2c` - B2C
-      * `other` - Other */
+       *
+       * * `b2b` - B2B
+       * * `b2c` - B2C
+       * * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /**
          * Enables the customer conversations / live chat product for this project.
@@ -35686,10 +35788,10 @@ export namespace Schemas {
 
     /**
      * The deterministic inventory layer of a project profile.
-
-    Read this to orient on the team's product mix, integrations, warehouse sources, signal
-    coverage, and existing inbox surface in one tool call. Distinct from `SignalScratchpad`:
-    profile is ground truth from authoritative tables; memory is agent inference.
+     *
+     * Read this to orient on the team's product mix, integrations, warehouse sources, signal
+     * coverage, and existing inbox surface in one tool call. Distinct from `SignalScratchpad`:
+     * profile is ground truth from authoritative tables; memory is agent inference.
      */
     export interface ProjectProfileInventory {
       /** Free-form orientation: human-set product description + registered app URLs. */
@@ -35737,9 +35839,9 @@ export namespace Schemas {
 
     /**
      * Top-level `payload` shape on a `SignalProjectProfile` row.
-
-    v1 carries `inventory` only. Phase 7 will add `deltas`, `activity_notes`, and
-    `narrative` slots — they're absent (not null) in v1 responses.
+     *
+     * v1 carries `inventory` only. Phase 7 will add `deltas`, `activity_notes`, and
+     * `narrative` slots — they're absent (not null) in v1 responses.
      */
     export interface ProjectProfilePayload {
       /** Deterministic snapshot of what's true about the project. */
@@ -35748,11 +35850,11 @@ export namespace Schemas {
 
     /**
      * Wire shape for the project profile returned by `signals-scout-harness-project-profile-list`.
-
-    Read this once at the start of a run (after `skill-get`) to orient on the team. Cache
-    is per-team with a soft TTL (`PROFILE_TTL`); the response always reflects either the
-    latest cached profile or a freshly-built one if the cache was stale or the caller passed
-    `force_refresh=true`.
+     *
+     * Read this once at the start of a run (after `skill-get`) to orient on the team. Cache
+     * is per-team with a soft TTL (`PROFILE_TTL`); the response always reflects either the
+     * latest cached profile or a freshly-built one if the cache was stale or the caller passed
+     * `force_refresh=true`.
      */
     export interface ProjectProfile {
       /** UUID of the `SignalProjectProfile` row. */
@@ -35777,48 +35879,48 @@ export namespace Schemas {
 
     export interface Property {
       /**
-       You can use a simplified version:
-      ```json
-      {
-          "properties": [
-              {
-                  "key": "email",
-                  "value": "x@y.com",
-                  "operator": "exact",
-                  "type": "event"
-              }
-          ]
-      }
-      ```
-
-      Or you can create more complicated queries with AND and OR:
-      ```json
-      {
-          "properties": {
-              "type": "AND",
-              "values": [
-                  {
-                      "type": "OR",
-                      "values": [
-                          {"key": "email", ...},
-                          {"key": "email", ...}
-                      ]
-                  },
-                  {
-                      "type": "AND",
-                      "values": [
-                          {"key": "email", ...},
-                          {"key": "email", ...}
-                      ]
-                  }
-              ]
-          ]
-      }
-      ```
-
-
-      * `AND` - AND
-      * `OR` - OR */
+       *  You can use a simplified version:
+       * ```json
+       * {
+       *     "properties": [
+       *         {
+       *             "key": "email",
+       *             "value": "x@y.com",
+       *             "operator": "exact",
+       *             "type": "event"
+       *         }
+       *     ]
+       * }
+       * ```
+       *
+       * Or you can create more complicated queries with AND and OR:
+       * ```json
+       * {
+       *     "properties": {
+       *         "type": "AND",
+       *         "values": [
+       *             {
+       *                 "type": "OR",
+       *                 "values": [
+       *                     {"key": "email", ...},
+       *                     {"key": "email", ...}
+       *                 ]
+       *             },
+       *             {
+       *                 "type": "AND",
+       *                 "values": [
+       *                     {"key": "email", ...},
+       *                     {"key": "email", ...}
+       *                 ]
+       *             }
+       *         ]
+       *     ]
+       * }
+       * ```
+       *
+       *
+       * * `AND` - AND
+       * * `OR` - OR */
       type?: PropertyGroupOperator;
       values: PropertyItem[];
     }
@@ -35829,10 +35931,10 @@ export namespace Schemas {
     export interface PropertyAccessControlRule {
       readonly id: string;
       /** The access level for this rule.
-
-      * `read_write` - read_write
-      * `read` - read
-      * `none` - none */
+       *
+       * * `read_write` - read_write
+       * * `read` - read
+       * * `none` - none */
       access_level: AccessLevelEnum;
       /**
          * The organization member UUID this rule applies to, if any.
@@ -35852,9 +35954,9 @@ export namespace Schemas {
 
     /**
      * Serializes the aggregate state for a property definition.
-
-    Preserves the existing API shape: ``access_controls`` is the list
-    of rules, plus the available levels and the computed default.
+     *
+     * Preserves the existing API shape: ``access_controls`` is the list
+     * of rules, plus the available levels and the computed default.
      */
     export interface PropertyAccessControlState {
       /** List of all access control rules for this property definition. */
@@ -35872,10 +35974,10 @@ export namespace Schemas {
       /** The property definition ID this rule applies to. */
       property_definition_id: string;
       /** The access level to set for this rule.
-
-      * `read_write` - read_write
-      * `read` - read
-      * `none` - none */
+       *
+       * * `read_write` - read_write
+       * * `read` - read
+       * * `none` - none */
       access_level: AccessLevelEnum;
       /**
          * The organization member UUID to set an override for.
@@ -35949,12 +36051,12 @@ export namespace Schemas {
 
     /**
      * * `waiting` - Waiting
-    * `issuing` - Issuing
-    * `valid` - Valid
-    * `warning` - Warning
-    * `erroring` - Erroring
-    * `deleting` - Deleting
-    * `timed_out` - Timed Out
+     * * `issuing` - Issuing
+     * * `valid` - Valid
+     * * `warning` - Warning
+     * * `erroring` - Erroring
+     * * `deleting` - Deleting
+     * * `timed_out` - Timed Out
      */
     export type ProxyRecordStatusEnum = typeof ProxyRecordStatusEnum[keyof typeof ProxyRecordStatusEnum];
 
@@ -35977,14 +36079,14 @@ export namespace Schemas {
       /** The CNAME target to add as a DNS record for your domain. Point your domain's CNAME to this value. */
       readonly target_cname: string;
       /** Current provisioning status. Values: waiting (DNS verification pending), issuing (SSL certificate being issued), valid (proxy is live and working), warning (proxy has issues but is operational), erroring (proxy setup failed), deleting (removal in progress), timed_out (DNS verification timed out).
-
-      * `waiting` - Waiting
-      * `issuing` - Issuing
-      * `valid` - Valid
-      * `warning` - Warning
-      * `erroring` - Erroring
-      * `deleting` - Deleting
-      * `timed_out` - Timed Out */
+       *
+       * * `waiting` - Waiting
+       * * `issuing` - Issuing
+       * * `valid` - Valid
+       * * `warning` - Warning
+       * * `erroring` - Erroring
+       * * `deleting` - Deleting
+       * * `timed_out` - Timed Out */
       readonly status: ProxyRecordStatusEnum;
       /**
          * Human-readable status message with details about errors or warnings, if any.
@@ -36017,10 +36119,10 @@ export namespace Schemas {
       /** Pull request title. */
       title: string;
       /** Derived state: 'open', 'closed', or 'merged'.
-
-      * `open` - OPEN
-      * `closed` - CLOSED
-      * `merged` - MERGED */
+       *
+       * * `open` - OPEN
+       * * `closed` - CLOSED
+       * * `merged` - MERGED */
       state: EngineeringAnalyticsPRStateEnum;
       /** True if the pull request is a draft. */
       is_draft: boolean;
@@ -36051,8 +36153,8 @@ export namespace Schemas {
 
     /**
      * * `ios` - iOS
-    * `android` - Android
-    * `web` - Web
+     * * `android` - Android
+     * * `web` - Web
      */
     export type PushTokenPlatformEnum = typeof PushTokenPlatformEnum[keyof typeof PushTokenPlatformEnum];
 
@@ -36246,24 +36348,24 @@ export namespace Schemas {
       /** Name given to a query. It's used to identify the query in the UI. Up to 128 characters for a name. */
       name?: string | null;
       /** Submit a JSON string representing a query for PostHog data analysis, for example a HogQL query.
-
-      Example payload:
-
-      ```
-
-      {"query": {"kind": "HogQLQuery", "query": "select * from events limit 100"}}
-
-      ```
-
-      For more details on HogQL queries, see the [PostHog HogQL documentation](/docs/hogql#api-access). */
+       *
+       * Example payload:
+       *
+       * ```
+       *
+       * {"query": {"kind": "HogQLQuery", "query": "select * from events limit 100"}}
+       *
+       * ```
+       *
+       * For more details on HogQL queries, see the [PostHog HogQL documentation](/docs/hogql#api-access). */
       query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | PropertyValuesQuery;
       /** Whether results should be calculated sync or async, and how much to rely on the cache:
-      - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-      - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-      - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-      - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-      - `'force_async'` - kick off background calculation, even if fresh results are already cached
-      - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates Background calculation can be tracked using the `query_status` response field. */
+       * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+       * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+       * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+       * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+       * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+       * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates Background calculation can be tracked using the `query_status` response field. */
       refresh?: RefreshType | null;
       variables_override?: QueryRequestVariablesOverride;
     }
@@ -38310,9 +38412,9 @@ export namespace Schemas {
 
     /**
      * * `manual` - manual
-    * `experiment_launch` - experiment_launch
-    * `experiment_stop` - experiment_stop
-    * `experiment_update` - experiment_update
+     * * `experiment_launch` - experiment_launch
+     * * `experiment_stop` - experiment_stop
+     * * `experiment_update` - experiment_update
      */
     export type RecalculateMetricsRequestTriggerEnum = typeof RecalculateMetricsRequestTriggerEnum[keyof typeof RecalculateMetricsRequestTriggerEnum];
 
@@ -38329,11 +38431,11 @@ export namespace Schemas {
      */
     export interface RecalculateMetricsRequest {
       /** What triggered this recalculation (manual is the default for user-initiated runs)
-
-      * `manual` - manual
-      * `experiment_launch` - experiment_launch
-      * `experiment_stop` - experiment_stop
-      * `experiment_update` - experiment_update */
+       *
+       * * `manual` - manual
+       * * `experiment_launch` - experiment_launch
+       * * `experiment_stop` - experiment_stop
+       * * `experiment_update` - experiment_update */
       trigger?: RecalculateMetricsRequestTriggerEnum;
     }
 
@@ -38374,10 +38476,10 @@ export namespace Schemas {
          */
       tile_order: number[];
       /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.
-
-      * `preserve` - preserve
-      * `two_column` - two_column
-      * `full_width` - full_width */
+       *
+       * * `preserve` - preserve
+       * * `two_column` - two_column
+       * * `full_width` - full_width */
       layout?: LayoutEnum;
     }
 
@@ -38446,8 +38548,8 @@ export namespace Schemas {
 
     /**
      * * `Starting` - Starting
-    * `Running` - Running
-    * `Cancelled` - Cancelled
+     * * `Running` - Running
+     * * `Cancelled` - Cancelled
      */
     export type RetrieveBasicOutputStatusEnum = typeof RetrieveBasicOutputStatusEnum[keyof typeof RetrieveBasicOutputStatusEnum];
 
@@ -38504,10 +38606,10 @@ export namespace Schemas {
 
     /**
      * * `Failed` - Failed
-    * `FailedRetryable` - FailedRetryable
-    * `FailedBilling` - FailedBilling
-    * `Terminated` - Terminated
-    * `TimedOut` - TimedOut
+     * * `FailedRetryable` - FailedRetryable
+     * * `FailedBilling` - FailedBilling
+     * * `Terminated` - Terminated
+     * * `TimedOut` - TimedOut
      */
     export type RetrieveFailedOutputStatusEnum = typeof RetrieveFailedOutputStatusEnum[keyof typeof RetrieveFailedOutputStatusEnum];
 
@@ -38579,11 +38681,17 @@ export namespace Schemas {
       /** @maxLength 255 */
       name: string;
       network_access_level?: NetworkAccessLevelEnum;
-      /** List of allowed domains for custom network access */
+      /**
+         * List of allowed domains for custom network access
+         * @items.maxLength 255
+         */
       allowed_domains?: string[];
       /** Whether to include default trusted domains (GitHub, npm, PyPI) */
       include_default_domains?: boolean;
-      /** List of repositories this environment applies to (format: org/repo) */
+      /**
+         * List of repositories this environment applies to (format: org/repo)
+         * @items.maxLength 255
+         */
       repositories?: string[];
       /** Encrypted environment variables (write-only, never returned in responses) */
       environment_variables?: unknown;
@@ -38627,13 +38735,15 @@ export namespace Schemas {
       /**
          * Viewport widths (px, 100-3000) to render the heatmap screenshot at — one render per width. Defaults to [320, 375, 425, 768, 1024, 1440, 1920] when omitted. At most 16 widths.
          * @maxItems 16
+         * @items.minimum 100
+         * @items.maximum 3000
          */
       widths?: number[];
       /** Render mode: 'screenshot' (renders the page headlessly, default), 'iframe', or 'recording'. Only 'screenshot' generates image bytes.
-
-      * `screenshot` - Screenshot
-      * `iframe` - Iframe
-      * `recording` - Recording */
+       *
+       * * `screenshot` - Screenshot
+       * * `iframe` - Iframe
+       * * `recording` - Recording */
       type?: HeatmapType;
       /** Set true to soft-delete the saved heatmap. */
       deleted?: boolean;
@@ -38691,10 +38801,10 @@ export namespace Schemas {
          */
       description?: string | null;
       /** Scorer kind. This cannot be changed after creation.
-
-      * `categorical` - categorical
-      * `numeric` - numeric
-      * `boolean` - boolean */
+       *
+       * * `categorical` - categorical
+       * * `numeric` - numeric
+       * * `boolean` - boolean */
       kind: ExperimentMetricKindEnum;
       /** New scorers are always created as active. */
       archived?: boolean;
@@ -38739,8 +38849,8 @@ export namespace Schemas {
 
     /**
      * * `none` - none
-    * `warning` - warning
-    * `danger` - danger
+     * * `warning` - warning
+     * * `danger` - danger
      */
     export type SdkAssessmentSeverityEnum = typeof SdkAssessmentSeverityEnum[keyof typeof SdkAssessmentSeverityEnum];
 
@@ -38803,10 +38913,10 @@ export namespace Schemas {
       /** True if the primary in-use version is flagged as old by age alone. */
       is_old: boolean;
       /** UI severity badge — 'none' when healthy, 'warning' when outdated, 'danger' when the majority of team SDKs are outdated.
-
-      * `none` - none
-      * `warning` - warning
-      * `danger` - danger */
+       *
+       * * `none` - none
+       * * `warning` - warning
+       * * `danger` - danger */
       severity: SdkAssessmentSeverityEnum;
       /** Per-SDK programmatic summary (used for ranking/filtering). For user-facing copy, prefer releases[].status_reason (badge tooltip) and banners (top-level alert text) — those match the UI exactly. */
       reason: string;
@@ -38820,15 +38930,15 @@ export namespace Schemas {
 
     export interface SdkHealthReport {
       /** 'healthy' when no SDKs need updating, 'needs_attention' otherwise.
-
-      * `healthy` - healthy
-      * `needs_attention` - needs_attention */
+       *
+       * * `healthy` - healthy
+       * * `needs_attention` - needs_attention */
       overall_health: OverallHealthEnum;
       /** UI-level status — 'success' when healthy, 'warning' when some SDKs are outdated, 'danger' when the majority are outdated.
-
-      * `success` - success
-      * `warning` - warning
-      * `danger` - danger */
+       *
+       * * `success` - success
+       * * `warning` - warning
+       * * `danger` - danger */
       health: HealthEnum;
       /** Number of SDKs that need updating. */
       needs_updating_count: number;
@@ -38870,10 +38980,10 @@ export namespace Schemas {
 
     /**
      * Filter shape mirrors the previous frontend `api.query({filters: ...})` payload.
-
-    `filters` accepts the same `HogQLFilters` schema that the legacy frontend HogQL
-    path used (dateRange, filterTestAccounts, properties), so the migration is
-    behaviour-preserving for callers that pass a request unchanged.
+     *
+     * `filters` accepts the same `HogQLFilters` schema that the legacy frontend HogQL
+     * path used (dateRange, filterTestAccounts, properties), so the migration is
+     * behaviour-preserving for callers that pass a request unchanged.
      */
     export interface SentimentGenerationsRequest {
       filters?: unknown;
@@ -38885,7 +38995,7 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-    * `generation` - generation
+     * * `generation` - generation
      */
     export type SentimentRequestAnalysisLevelEnum = typeof SentimentRequestAnalysisLevelEnum[keyof typeof SentimentRequestAnalysisLevelEnum];
 
@@ -38903,9 +39013,9 @@ export namespace Schemas {
          */
       ids: string[];
       /** Whether the IDs are 'trace' IDs or 'generation' IDs.
-
-      * `trace` - trace
-      * `generation` - generation */
+       *
+       * * `trace` - trace
+       * * `generation` - generation */
       analysis_level?: SentimentRequestAnalysisLevelEnum;
       /** If true, bypass cache and reclassify. */
       force_refresh?: boolean;
@@ -38925,7 +39035,10 @@ export namespace Schemas {
       readonly id: string;
       /** Title of the group session summary */
       readonly title: string;
-      /** List of session replay IDs included in this group summary */
+      /**
+         * List of session replay IDs included in this group summary
+         * @items.maxLength 200
+         */
       readonly session_ids: readonly string[];
       /** Group summary in JSON format (EnrichedSessionGroupSummaryPatternsList schema) */
       readonly summary: unknown;
@@ -38979,11 +39092,11 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-    * `debug` - debug
-    * `info` - info
-    * `warn` - warn
-    * `error` - error
-    * `fatal` - fatal
+     * * `debug` - debug
+     * * `info` - info
+     * * `warn` - warn
+     * * `error` - error
+     * * `fatal` - fatal
      */
     export type SeverityLevelsEnum = typeof SeverityLevelsEnum[keyof typeof SeverityLevelsEnum];
 
@@ -39021,12 +39134,12 @@ export namespace Schemas {
 
     export interface ShipVariant {
       /** The conclusion of the experiment.
-
-      * `won` - won
-      * `lost` - lost
-      * `inconclusive` - inconclusive
-      * `stopped_early` - stopped_early
-      * `invalid` - invalid */
+       *
+       * * `won` - won
+       * * `lost` - lost
+       * * `inconclusive` - inconclusive
+       * * `stopped_early` - stopped_early
+       * * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Optional comment about the experiment conclusion.
@@ -39041,7 +39154,7 @@ export namespace Schemas {
 
     /**
      * * `suppressed` - suppressed
-    * `potential` - potential
+     * * `potential` - potential
      */
     export type SignalReportStateRequestStateEnum = typeof SignalReportStateRequestStateEnum[keyof typeof SignalReportStateRequestStateEnum];
 
@@ -39053,9 +39166,9 @@ export namespace Schemas {
 
     export interface SignalReportStateRequest {
       /** Target state for the report. Use 'suppressed' to dismiss the report from the inbox, or 'potential' to snooze/reopen it for later review.
-
-      * `suppressed` - suppressed
-      * `potential` - potential */
+       *
+       * * `suppressed` - suppressed
+       * * `potential` - potential */
       state: SignalReportStateRequestStateEnum;
       /** Optional short reason code for the dismissal (e.g. 'not_a_bug', 'wont_fix', 'duplicate'). The set of reason codes is owned by the caller and is not validated server-side. */
       dismissal_reason?: string;
@@ -39074,9 +39187,9 @@ export namespace Schemas {
 
     /**
      * Per-(team, skill) scout config: schedule, enablement, and emit posture.
-
-    One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
-    when it discovers a scout skill; this serializer lets agents tune the row.
+     *
+     * One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
+     * when it discovers a scout skill; this serializer lets agents tune the row.
      */
     export interface SignalScoutConfig {
       readonly id: string;
@@ -39102,9 +39215,9 @@ export namespace Schemas {
 
     /**
      * One finding a scout run emitted to the inbox — the persisted, queryable record of
-    *what* the run surfaced, returned by `signals-scout-runs-emissions-list`. The emitted text
-    lives in `description`; `source_id` is the join key (`run:<run_id>:finding:<finding_id>`)
-    back into the underlying signal store.
+     * *what* the run surfaced, returned by `signals-scout-runs-emissions-list`. The emitted text
+     * lives in `description`; `source_id` is the join key (`run:<run_id>:finding:<finding_id>`)
+     * back into the underlying signal store.
      */
     export interface SignalScoutEmission {
       readonly id: string;
@@ -39127,12 +39240,12 @@ export namespace Schemas {
          */
       confidence: number;
       /** Optional severity tag — one of P0, P1, P2, P3, P4 — or null if the run didn't set one.
-
-      * `P0` - P0
-      * `P1` - P1
-      * `P2` - P2
-      * `P3` - P3
-      * `P4` - P4 */
+       *
+       * * `P0` - P0
+       * * `P1` - P1
+       * * `P2` - P2
+       * * `P3` - P3
+       * * `P4` - P4 */
       severity: AutonomyPriorityEnum | null;
       /** Deterministic `run:<run_id>:finding:<finding_id>` — the join key into the underlying signal store. */
       source_id: string;
@@ -39142,8 +39255,8 @@ export namespace Schemas {
 
     /**
      * Full `SignalScoutRun` projection used by `get-run`. Same shape as the summary
-    today; kept distinct so future detail-only extensions (linked Signal rows,
-    LLMA token-cost join) can land here without bloating the list response.
+     * today; kept distinct so future detail-only extensions (linked Signal rows,
+     * LLMA token-cost join) can land here without bloating the list response.
      */
     export interface SignalScoutRunDetail {
       /** UUID of the bridge row. */
@@ -39186,8 +39299,8 @@ export namespace Schemas {
 
     /**
      * Lightweight projection of a `SignalScoutRun` row used by `search-recent-runs`.
-
-    Status and timestamps flow from the linked `tasks.TaskRun`.
+     *
+     * Status and timestamps flow from the linked `tasks.TaskRun`.
      */
     export interface SignalScoutRunSummary {
       /** UUID of the bridge row. */
@@ -39252,12 +39365,12 @@ export namespace Schemas {
          */
       slack_notification_channel?: string | null;
       /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority (and reports without a priority judgment).
-
-      * `P0` - P0
-      * `P1` - P1
-      * `P2` - P2
-      * `P3` - P3
-      * `P4` - P4 */
+       *
+       * * `P0` - P0
+       * * `P1` - P1
+       * * `P2` - P2
+       * * `P3` - P3
+       * * `P4` - P4 */
       slack_notification_min_priority?: AutonomyPriorityEnum | BlankEnum | null;
       readonly created_at: string;
       readonly updated_at: string;
@@ -39351,10 +39464,10 @@ export namespace Schemas {
 
     /**
      * The internal sandbox run the discovery agent used to pick this run's repo.
-
-    Only present when the originating mention was ambiguous (multiple candidate
-    repos, no explicit mention) — that's the only path that spins up a research
-    sandbox. Null otherwise.
+     *
+     * Only present when the originating mention was ambiguous (multiple candidate
+     * repos, no explicit mention) — that's the only path that spins up a research
+     * sandbox. Null otherwise.
      */
     export interface SlackThreadContextRepoResearch {
       /** UUID of the internal repo-research Task. */
@@ -39515,8 +39628,8 @@ export namespace Schemas {
 
     /**
      * * `none` - none
-    * `auto` - auto
-    * `mapped` - mapped
+     * * `auto` - auto
+     * * `mapped` - mapped
      */
     export type SourceMatchEnum = typeof SourceMatchEnum[keyof typeof SourceMatchEnum];
 
@@ -39529,7 +39642,7 @@ export namespace Schemas {
 
     /**
      * * `severity` - severity
-    * `service` - service
+     * * `service` - service
      */
     export type SparklineBreakdownByEnum = typeof SparklineBreakdownByEnum[keyof typeof SparklineBreakdownByEnum];
 
@@ -39566,7 +39679,7 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-    * `event` - event
+     * * `event` - event
      */
     export type SummarizeTypeEnum = typeof SummarizeTypeEnum[keyof typeof SummarizeTypeEnum];
 
@@ -39578,14 +39691,14 @@ export namespace Schemas {
 
     export interface SummarizeRequest {
       /** Type of entity to summarize. Inferred automatically when using trace_id or generation_id.
-
-      * `trace` - trace
-      * `event` - event */
+       *
+       * * `trace` - trace
+       * * `event` - event */
       summarize_type?: SummarizeTypeEnum;
       /** Summary detail level: 'minimal' for 3-5 points, 'detailed' for 5-10 points
-
-      * `minimal` - minimal
-      * `detailed` - detailed */
+       *
+       * * `minimal` - minimal
+       * * `detailed` - detailed */
       mode?: DetailModeValueEnum;
       /** Data to summarize. For traces: {trace, hierarchy}. For events: {event}. Not required when using trace_id or generation_id. */
       data?: unknown;
@@ -39761,117 +39874,117 @@ export namespace Schemas {
       /** @nullable */
       remove_targeting_flag?: boolean | null;
       /**
-              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-              Basic (open-ended question)
-              - `id`: The question ID
-              - `type`: `open`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Link (a question with a link)
-              - `id`: The question ID
-              - `type`: `link`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `link`: The URL associated with the question.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Rating (a question with a rating scale)
-              - `id`: The question ID
-              - `type`: `rating`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `display`: Display style of the rating (`number` or `emoji`).
-              - `scale`: The scale of the rating (`number`).
-              - `lowerBoundLabel`: Label for the lower bound of the scale.
-              - `upperBoundLabel`: Label for the upper bound of the scale.
-              - `isNpsQuestion`: Whether the question is an NPS rating.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Multiple choice
-              - `id`: The question ID
-              - `type`: `single_choice` or `multiple_choice`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `choices`: An array of choices for the question.
-              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Branching logic can be one of the following types:
-
-              Next question: Proceeds to the next question
-              ```json
-              {
-                  "type": "next_question"
-              }
-              ```
-
-              End: Ends the survey, optionally displaying a confirmation message.
-              ```json
-              {
-                  "type": "end"
-              }
-              ```
-
-              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-              ```json
-              {
-                  "type": "response_based",
-                  "responseValues": {
-                      "responseKey": "value"
-                  }
-              }
-              ```
-
-              Specific question: Proceeds to a specific question by index.
-              ```json
-              {
-                  "type": "specific_question",
-                  "index": 2
-              }
-              ```
-
-              Translations: Each question can include inline translations.
-              - `translations`: Object mapping language codes to translated fields.
-              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-              Example with translations:
-              ```json
-              {
-                  "id": "uuid",
-                  "type": "rating",
-                  "question": "How satisfied are you?",
-                  "lowerBoundLabel": "Not satisfied",
-                  "upperBoundLabel": "Very satisfied",
-                  "translations": {
-                      "es": {
-                          "question": "¿Qué tan satisfecho estás?",
-                          "lowerBoundLabel": "No satisfecho",
-                          "upperBoundLabel": "Muy satisfecho"
-                      },
-                      "fr": {
-                          "question": "Dans quelle mesure êtes-vous satisfait?"
-                      }
-                  }
-              }
-              ```
-               */
+       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+       *
+       *         Basic (open-ended question)
+       *         - `id`: The question ID
+       *         - `type`: `open`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Link (a question with a link)
+       *         - `id`: The question ID
+       *         - `type`: `link`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `link`: The URL associated with the question.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Rating (a question with a rating scale)
+       *         - `id`: The question ID
+       *         - `type`: `rating`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `display`: Display style of the rating (`number` or `emoji`).
+       *         - `scale`: The scale of the rating (`number`).
+       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+       *         - `upperBoundLabel`: Label for the upper bound of the scale.
+       *         - `isNpsQuestion`: Whether the question is an NPS rating.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Multiple choice
+       *         - `id`: The question ID
+       *         - `type`: `single_choice` or `multiple_choice`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `choices`: An array of choices for the question.
+       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Branching logic can be one of the following types:
+       *
+       *         Next question: Proceeds to the next question
+       *         ```json
+       *         {
+       *             "type": "next_question"
+       *         }
+       *         ```
+       *
+       *         End: Ends the survey, optionally displaying a confirmation message.
+       *         ```json
+       *         {
+       *             "type": "end"
+       *         }
+       *         ```
+       *
+       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+       *         ```json
+       *         {
+       *             "type": "response_based",
+       *             "responseValues": {
+       *                 "responseKey": "value"
+       *             }
+       *         }
+       *         ```
+       *
+       *         Specific question: Proceeds to a specific question by index.
+       *         ```json
+       *         {
+       *             "type": "specific_question",
+       *             "index": 2
+       *         }
+       *         ```
+       *
+       *         Translations: Each question can include inline translations.
+       *         - `translations`: Object mapping language codes to translated fields.
+       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+       *
+       *         Example with translations:
+       *         ```json
+       *         {
+       *             "id": "uuid",
+       *             "type": "rating",
+       *             "question": "How satisfied are you?",
+       *             "lowerBoundLabel": "Not satisfied",
+       *             "upperBoundLabel": "Very satisfied",
+       *             "translations": {
+       *                 "es": {
+       *                     "question": "¿Qué tan satisfecho estás?",
+       *                     "lowerBoundLabel": "No satisfecho",
+       *                     "upperBoundLabel": "Muy satisfecho"
+       *                 },
+       *                 "fr": {
+       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+       *                 }
+       *             }
+       *         }
+       *         ```
+       *          */
       questions?: unknown;
       conditions?: unknown;
       appearance?: unknown;
@@ -39951,17 +40064,17 @@ export namespace Schemas {
       /** Survey description. */
       description?: string;
       /** Survey type.
-
-      * `popover` - popover
-      * `widget` - widget
-      * `external_survey` - external survey
-      * `api` - api */
+       *
+       * * `popover` - popover
+       * * `widget` - widget
+       * * `external_survey` - external survey
+       * * `api` - api */
       type: SurveyType;
       /** Survey scheduling behavior: 'once' = show once per user (default), 'recurring' = repeat based on iteration_count and iteration_frequency_days settings, 'always' = show every time conditions are met (mainly for widget surveys)
-
-      * `once` - once
-      * `recurring` - recurring
-      * `always` - always */
+       *
+       * * `once` - once
+       * * `recurring` - recurring
+       * * `always` - always */
       schedule?: ScheduleEnum | null;
       readonly linked_flag: MinimalFeatureFlag;
       /**
@@ -39984,117 +40097,117 @@ export namespace Schemas {
       remove_targeting_flag?: boolean | null;
       /**
          *
-              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-              Basic (open-ended question)
-              - `id`: The question ID
-              - `type`: `open`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Link (a question with a link)
-              - `id`: The question ID
-              - `type`: `link`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `link`: The URL associated with the question.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Rating (a question with a rating scale)
-              - `id`: The question ID
-              - `type`: `rating`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `display`: Display style of the rating (`number` or `emoji`).
-              - `scale`: The scale of the rating (`number`).
-              - `lowerBoundLabel`: Label for the lower bound of the scale.
-              - `upperBoundLabel`: Label for the upper bound of the scale.
-              - `isNpsQuestion`: Whether the question is an NPS rating.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Multiple choice
-              - `id`: The question ID
-              - `type`: `single_choice` or `multiple_choice`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `choices`: An array of choices for the question.
-              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Branching logic can be one of the following types:
-
-              Next question: Proceeds to the next question
-              ```json
-              {
-                  "type": "next_question"
-              }
-              ```
-
-              End: Ends the survey, optionally displaying a confirmation message.
-              ```json
-              {
-                  "type": "end"
-              }
-              ```
-
-              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-              ```json
-              {
-                  "type": "response_based",
-                  "responseValues": {
-                      "responseKey": "value"
-                  }
-              }
-              ```
-
-              Specific question: Proceeds to a specific question by index.
-              ```json
-              {
-                  "type": "specific_question",
-                  "index": 2
-              }
-              ```
-
-              Translations: Each question can include inline translations.
-              - `translations`: Object mapping language codes to translated fields.
-              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-              Example with translations:
-              ```json
-              {
-                  "id": "uuid",
-                  "type": "rating",
-                  "question": "How satisfied are you?",
-                  "lowerBoundLabel": "Not satisfied",
-                  "upperBoundLabel": "Very satisfied",
-                  "translations": {
-                      "es": {
-                          "question": "¿Qué tan satisfecho estás?",
-                          "lowerBoundLabel": "No satisfecho",
-                          "upperBoundLabel": "Muy satisfecho"
-                      },
-                      "fr": {
-                          "question": "Dans quelle mesure êtes-vous satisfait?"
-                      }
-                  }
-              }
-              ```
-
+       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+       *
+       *         Basic (open-ended question)
+       *         - `id`: The question ID
+       *         - `type`: `open`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Link (a question with a link)
+       *         - `id`: The question ID
+       *         - `type`: `link`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `link`: The URL associated with the question.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Rating (a question with a rating scale)
+       *         - `id`: The question ID
+       *         - `type`: `rating`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `display`: Display style of the rating (`number` or `emoji`).
+       *         - `scale`: The scale of the rating (`number`).
+       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+       *         - `upperBoundLabel`: Label for the upper bound of the scale.
+       *         - `isNpsQuestion`: Whether the question is an NPS rating.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Multiple choice
+       *         - `id`: The question ID
+       *         - `type`: `single_choice` or `multiple_choice`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `choices`: An array of choices for the question.
+       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Branching logic can be one of the following types:
+       *
+       *         Next question: Proceeds to the next question
+       *         ```json
+       *         {
+       *             "type": "next_question"
+       *         }
+       *         ```
+       *
+       *         End: Ends the survey, optionally displaying a confirmation message.
+       *         ```json
+       *         {
+       *             "type": "end"
+       *         }
+       *         ```
+       *
+       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+       *         ```json
+       *         {
+       *             "type": "response_based",
+       *             "responseValues": {
+       *                 "responseKey": "value"
+       *             }
+       *         }
+       *         ```
+       *
+       *         Specific question: Proceeds to a specific question by index.
+       *         ```json
+       *         {
+       *             "type": "specific_question",
+       *             "index": 2
+       *         }
+       *         ```
+       *
+       *         Translations: Each question can include inline translations.
+       *         - `translations`: Object mapping language codes to translated fields.
+       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+       *
+       *         Example with translations:
+       *         ```json
+       *         {
+       *             "id": "uuid",
+       *             "type": "rating",
+       *             "question": "How satisfied are you?",
+       *             "lowerBoundLabel": "Not satisfied",
+       *             "upperBoundLabel": "Very satisfied",
+       *             "translations": {
+       *                 "es": {
+       *                     "question": "¿Qué tan satisfecho estás?",
+       *                     "lowerBoundLabel": "No satisfecho",
+       *                     "upperBoundLabel": "Muy satisfecho"
+       *                 },
+       *                 "fr": {
+       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+       *                 }
+       *             }
+       *         }
+       *         ```
+       *
          * @nullable
          */
       questions?: SurveyQuestionInputSchema[] | null;
@@ -40269,13 +40382,13 @@ export namespace Schemas {
 
     /**
      * Request body for the presence beacon and beacon-leave endpoints.
-
-    `device_id` is the UUID of the caller's `UserPushToken` row, which the
-    client received when it registered for push via `/api/users/@me/push_tokens/`.
-    The client is expected to use the same identifier on the beacon and leave
-    calls; if the user has unregistered the underlying push token, the value
-    won't resolve and the call returns 404 — at which point pushes were
-    already not going there anyway.
+     *
+     * `device_id` is the UUID of the caller's `UserPushToken` row, which the
+     * client received when it registered for push via `/api/users/@me/push_tokens/`.
+     * The client is expected to use the same identifier on the beacon and leave
+     * calls; if the user has unregistered the underlying push token, the value
+     * won't resolve and the call returns 404 — at which point pushes were
+     * already not going there anyway.
      */
     export interface TaskPresenceBeaconRequest {
       /** UUID of the caller's UserPushToken (returned by `/api/users/@me/push_tokens/` on register). */
@@ -40296,12 +40409,12 @@ export namespace Schemas {
 
     /**
      * * `plan` - plan
-    * `context` - context
-    * `reference` - reference
-    * `output` - output
-    * `artifact` - artifact
-    * `tree_snapshot` - tree_snapshot
-    * `user_attachment` - user_attachment
+     * * `context` - context
+     * * `reference` - reference
+     * * `output` - output
+     * * `artifact` - artifact
+     * * `tree_snapshot` - tree_snapshot
+     * * `user_attachment` - user_attachment
      */
     export type TaskRunArtifactTypeEnum = typeof TaskRunArtifactTypeEnum[keyof typeof TaskRunArtifactTypeEnum];
 
@@ -40325,14 +40438,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-
-      * `plan` - plan
-      * `context` - context
-      * `reference` - reference
-      * `output` - output
-      * `artifact` - artifact
-      * `tree_snapshot` - tree_snapshot
-      * `user_attachment` - user_attachment */
+       *
+       * * `plan` - plan
+       * * `context` - context
+       * * `reference` - reference
+       * * `output` - output
+       * * `artifact` - artifact
+       * * `tree_snapshot` - tree_snapshot
+       * * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -40358,14 +40471,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-
-      * `plan` - plan
-      * `context` - context
-      * `reference` - reference
-      * `output` - output
-      * `artifact` - artifact
-      * `tree_snapshot` - tree_snapshot
-      * `user_attachment` - user_attachment */
+       *
+       * * `plan` - plan
+       * * `context` - context
+       * * `reference` - reference
+       * * `output` - output
+       * * `artifact` - artifact
+       * * `tree_snapshot` - tree_snapshot
+       * * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -40428,14 +40541,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-
-      * `plan` - plan
-      * `context` - context
-      * `reference` - reference
-      * `output` - output
-      * `artifact` - artifact
-      * `tree_snapshot` - tree_snapshot
-      * `user_attachment` - user_attachment */
+       *
+       * * `plan` - plan
+       * * `context` - context
+       * * `reference` - reference
+       * * `output` - output
+       * * `artifact` - artifact
+       * * `tree_snapshot` - tree_snapshot
+       * * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -40445,9 +40558,9 @@ export namespace Schemas {
       /** Artifact contents encoded according to content_encoding */
       content: string;
       /** Encoding used for content. Use base64 for binary files and utf-8 for text payloads.
-
-      * `utf-8` - utf-8
-      * `base64` - base64 */
+       *
+       * * `utf-8` - utf-8
+       * * `base64` - base64 */
       content_encoding?: ContentEncodingEnum;
       /**
          * Optional MIME type for the artifact
@@ -40488,7 +40601,7 @@ export namespace Schemas {
 
     /**
      * * `local` - local
-    * `cloud` - cloud
+     * * `cloud` - cloud
      */
     export type TaskRunBootstrapCreateRequestEnvironmentEnum = typeof TaskRunBootstrapCreateRequestEnvironmentEnum[keyof typeof TaskRunBootstrapCreateRequestEnvironmentEnum];
 
@@ -40500,12 +40613,12 @@ export namespace Schemas {
 
     /**
      * * `default` - default
-    * `acceptEdits` - acceptEdits
-    * `plan` - plan
-    * `bypassPermissions` - bypassPermissions
-    * `auto` - auto
-    * `read-only` - read-only
-    * `full-access` - full-access
+     * * `acceptEdits` - acceptEdits
+     * * `plan` - plan
+     * * `bypassPermissions` - bypassPermissions
+     * * `auto` - auto
+     * * `read-only` - read-only
+     * * `full-access` - full-access
      */
     export type TaskRunBootstrapCreateRequestInitialPermissionModeEnum = typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnum[keyof typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnum];
 
@@ -40525,14 +40638,14 @@ export namespace Schemas {
      */
     export interface TaskRunBootstrapCreateRequest {
       /** Execution environment for the new run. Use 'cloud' for remote sandbox runs and 'local' for desktop sessions.
-
-      * `local` - local
-      * `cloud` - cloud */
+       *
+       * * `local` - local
+       * * `cloud` - cloud */
       environment?: TaskRunBootstrapCreateRequestEnvironmentEnum;
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-      * `interactive` - interactive
-      * `background` - background */
+       *
+       * * `interactive` - interactive
+       * * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -40543,43 +40656,43 @@ export namespace Schemas {
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-
-      * `user` - user
-      * `bot` - bot */
+       *
+       * * `user` - user
+       * * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-      * `manual` - manual
-      * `signal_report` - signal_report */
+       *
+       * * `manual` - manual
+       * * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
       /** Agent runtime adapter to launch for this run. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime.
-
-      * `claude` - claude
-      * `codex` - codex */
+       *
+       * * `claude` - claude
+       * * `codex` - codex */
       runtime_adapter?: RuntimeAdapterEnum;
       /** LLM model identifier to run in the selected runtime. */
       model?: string;
       /** Reasoning effort to request for models that expose an effort control.
-
-      * `low` - low
-      * `medium` - medium
-      * `high` - high
-      * `xhigh` - xhigh
-      * `max` - max */
+       *
+       * * `low` - low
+       * * `medium` - medium
+       * * `high` - high
+       * * `xhigh` - xhigh
+       * * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
       github_user_token?: string;
       /** Initial permission mode for the agent session. Claude runtimes accept PostHog permission presets like 'plan'. Codex runtimes accept native Codex modes like 'auto' and 'read-only'.
-
-      * `default` - default
-      * `acceptEdits` - acceptEdits
-      * `plan` - plan
-      * `bypassPermissions` - bypassPermissions
-      * `auto` - auto
-      * `read-only` - read-only
-      * `full-access` - full-access */
+       *
+       * * `default` - default
+       * * `acceptEdits` - acceptEdits
+       * * `plan` - plan
+       * * `bypassPermissions` - bypassPermissions
+       * * `auto` - auto
+       * * `read-only` - read-only
+       * * `full-access` - full-access */
       initial_permission_mode?: TaskRunBootstrapCreateRequestInitialPermissionModeEnum;
     }
 
@@ -40593,16 +40706,16 @@ export namespace Schemas {
      */
     export interface TaskRunCommandRequest {
       /** JSON-RPC version, must be '2.0'
-
-      * `2.0` - 2.0 */
+       *
+       * * `2.0` - 2.0 */
       jsonrpc: JsonrpcEnum;
       /** Command method to execute on the agent server
-
-      * `user_message` - user_message
-      * `cancel` - cancel
-      * `close` - close
-      * `permission_response` - permission_response
-      * `set_config_option` - set_config_option */
+       *
+       * * `user_message` - user_message
+       * * `cancel` - cancel
+       * * `close` - close
+       * * `permission_response` - permission_response
+       * * `set_config_option` - set_config_option */
       method: MethodEnum;
       /** Parameters for the command */
       params?: TaskRunCommandRequestParams;
@@ -40636,9 +40749,9 @@ export namespace Schemas {
 
     export interface TaskRunResumeRequestSchema {
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-      * `interactive` - interactive
-      * `background` - background */
+       *
+       * * `interactive` - interactive
+       * * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -40653,14 +40766,14 @@ export namespace Schemas {
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-
-      * `user` - user
-      * `bot` - bot */
+       *
+       * * `user` - user
+       * * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-      * `manual` - manual
-      * `signal_report` - signal_report */
+       *
+       * * `manual` - manual
+       * * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
@@ -40684,9 +40797,9 @@ export namespace Schemas {
       /** Artifact ids that could not be resolved for the run */
       missing_artifact_ids?: string[];
       /** Which usage limit was hit on a rate_limited error: 'burst' (daily) or 'sustained' (monthly)
-
-      * `burst` - burst
-      * `sustained` - sustained */
+       *
+       * * `burst` - burst
+       * * `sustained` - sustained */
       limit_type?: LimitTypeEnum;
       /** ISO 8601 timestamp when the hit usage limit resets, when known */
       reset_at?: string;
@@ -40709,7 +40822,10 @@ export namespace Schemas {
     export interface TaskRunStartRequest {
       /** Initial or follow-up user message to include in the run prompt. */
       pending_user_message?: string;
-      /** Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox. */
+      /**
+         * Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox.
+         * @items.maxLength 128
+         */
       pending_user_artifact_ids?: string[];
     }
 
@@ -40722,14 +40838,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-
-      * `plan` - plan
-      * `context` - context
-      * `reference` - reference
-      * `output` - output
-      * `artifact` - artifact
-      * `tree_snapshot` - tree_snapshot
-      * `user_attachment` - user_attachment */
+       *
+       * * `plan` - plan
+       * * `context` - context
+       * * `reference` - reference
+       * * `output` - output
+       * * `artifact` - artifact
+       * * `tree_snapshot` - tree_snapshot
+       * * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -40755,14 +40871,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-
-      * `plan` - plan
-      * `context` - context
-      * `reference` - reference
-      * `output` - output
-      * `artifact` - artifact
-      * `tree_snapshot` - tree_snapshot
-      * `user_attachment` - user_attachment */
+       *
+       * * `plan` - plan
+       * * `context` - context
+       * * `reference` - reference
+       * * `output` - output
+       * * `artifact` - artifact
+       * * `tree_snapshot` - tree_snapshot
+       * * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -40869,28 +40985,29 @@ export namespace Schemas {
          * @nullable
          */
       readonly user_access_level: string | null;
+      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       anonymize_ips?: boolean;
       completed_snippet_onboarding?: boolean;
       /** Filters used to identify internal/test users. Each entry is a property filter.
-
-                  Supported entry types and the exact shape each accepts:
-
-                  # Person property — match (or exclude) by a person property
-                  {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
-
-                  # Event property — match by an event property
-                  {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
-
-                  # Cohort membership — match (or exclude) members of a cohort.
-                  # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
-                  # `negation` field here — `negation` is specific to cohort *definitions*
-                  # (the inner sub-filters that build a cohort) and is rejected by the
-                  # property-filter schema.
-                  {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
-
-                  Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
-                  "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
+       *
+       *             Supported entry types and the exact shape each accepts:
+       *
+       *             # Person property — match (or exclude) by a person property
+       *             {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
+       *
+       *             # Event property — match by an event property
+       *             {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
+       *
+       *             # Cohort membership — match (or exclude) members of a cohort.
+       *             # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
+       *             # `negation` field here — `negation` is specific to cohort *definitions*
+       *             # (the inner sub-filters that build a cohort) and is rejected by the
+       *             # property-filter schema.
+       *             {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
+       *
+       *             Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
+       *             "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
       test_account_filters?: unknown;
       /** @nullable */
       test_account_filters_default_checked?: boolean | null;
@@ -40898,7 +41015,10 @@ export namespace Schemas {
       is_demo?: boolean;
       timezone?: string;
       data_attributes?: unknown;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 400
+         */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
       /** @nullable */
@@ -40950,7 +41070,10 @@ export namespace Schemas {
       primary_dashboard?: number | null;
       /** @nullable */
       live_events_columns?: string[] | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 200
+         */
       recording_domains?: (string | null)[] | null;
       cookieless_server_hash_mode?: CookielessServerHashModeEnum | null;
       /** @nullable */
@@ -40998,10 +41121,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers, used to optimize the UI layout.
-
-      * `b2b` - B2B
-      * `b2c` - B2C
-      * `other` - Other */
+       *
+       * * `b2b` - B2B
+       * * `b2c` - B2C
+       * * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /** @nullable */
       conversations_enabled?: boolean | null;
@@ -41175,11 +41298,11 @@ export namespace Schemas {
 
     export interface TextReprRequest {
       /** Type of LLM event to stringify
-
-      * `$ai_generation` - $ai_generation
-      * `$ai_span` - $ai_span
-      * `$ai_embedding` - $ai_embedding
-      * `$ai_trace` - $ai_trace */
+       *
+       * * `$ai_generation` - $ai_generation
+       * * `$ai_span` - $ai_span
+       * * `$ai_embedding` - $ai_embedding
+       * * `$ai_trace` - $ai_trace */
       event_type: EventTypeEnum;
       /** Event data to stringify. For traces, should include 'trace' and 'hierarchy' fields. */
       data: unknown;
@@ -41300,11 +41423,11 @@ export namespace Schemas {
       /** UTC timestamp when the wizard started this run. Matches the timestamp encoded in session_id. */
       started_at: string;
       /** Lifecycle stage of the wizard run.
-
-      * `idle` - IDLE
-      * `running` - RUNNING
-      * `completed` - COMPLETED
-      * `error` - ERROR */
+       *
+       * * `idle` - IDLE
+       * * `running` - RUNNING
+       * * `completed` - COMPLETED
+       * * `error` - ERROR */
       run_phase: RunPhaseEnum;
       tasks: WizardTaskDTO[];
       /**
@@ -41360,7 +41483,7 @@ export namespace Schemas {
 
     /**
      * * `transcript` - transcript
-    * `summary` - summary
+     * * `summary` - summary
      */
     export type UserInterviewSearchDocumentTypeEnum = typeof UserInterviewSearchDocumentTypeEnum[keyof typeof UserInterviewSearchDocumentTypeEnum];
 
@@ -41403,9 +41526,9 @@ export namespace Schemas {
       /** ID of the matched UserInterview. */
       interview_id: string;
       /** Which document type matched — `transcript` is the raw conversation, `summary` is the AI-generated abstract.
-
-      * `transcript` - transcript
-      * `summary` - summary */
+       *
+       * * `transcript` - transcript
+       * * `summary` - summary */
       document_type: UserInterviewSearchDocumentTypeEnum;
       /** Cosine similarity in [0, 1]; higher is closer to the query. Computed as `1 - cosineDistance`. */
       similarity: number;
@@ -41426,10 +41549,10 @@ export namespace Schemas {
       /** PostHog UserPushToken row id. */
       id: string;
       /** Device platform the token was issued for.
-
-      * `ios` - iOS
-      * `android` - Android
-      * `web` - Web */
+       *
+       * * `ios` - iOS
+       * * `android` - Android
+       * * `web` - Web */
       platform: PushTokenPlatformEnum;
       /** When this token was first registered. */
       created_at: string;
@@ -41444,10 +41567,10 @@ export namespace Schemas {
          */
       token: string;
       /** Device platform the token was issued for. One of `ios`, `android`, or `web`.
-
-      * `ios` - iOS
-      * `android` - Android
-      * `web` - Web */
+       *
+       * * `ios` - iOS
+       * * `android` - Android
+       * * `web` - Web */
       platform: PushTokenPlatformEnum;
     }
 
@@ -41467,16 +41590,16 @@ export namespace Schemas {
       /** Number of pageview events with this UTM combination */
       event_count: number;
       /** How utm_campaign matched: none, auto (direct name/id), or mapped (manual mapping)
-
-      * `none` - none
-      * `auto` - auto
-      * `mapped` - mapped */
+       *
+       * * `none` - none
+       * * `auto` - auto
+       * * `mapped` - mapped */
       campaign_match: SourceMatchEnum;
       /** How utm_source matched: none, auto (default source), or mapped (custom mapping)
-
-      * `none` - none
-      * `auto` - auto
-      * `mapped` - mapped */
+       *
+       * * `none` - none
+       * * `auto` - auto
+       * * `mapped` - mapped */
       source_match: SourceMatchEnum;
       /**
          * Name of the matched campaign, if any
@@ -41549,11 +41672,11 @@ export namespace Schemas {
 
     /**
      * * `pending` - pending
-    * `provisioning` - provisioning
-    * `ready` - ready
-    * `failed` - failed
-    * `deleting` - deleting
-    * `deleted` - deleted
+     * * `provisioning` - provisioning
+     * * `ready` - ready
+     * * `failed` - failed
+     * * `deleting` - deleting
+     * * `deleted` - deleted
      */
     export type WarehouseStatusResponseStateEnum = typeof WarehouseStatusResponseStateEnum[keyof typeof WarehouseStatusResponseStateEnum];
 
@@ -41751,9 +41874,9 @@ export namespace Schemas {
       /** Property filter type: "log_attribute" or "log_resource_attribute". Use this as the `type` field when filtering. */
       propertyFilterType: string;
       /** How the search query matched this row: "key" if the attribute key matched, "value" if a value matched.
-
-      * `key` - key
-      * `value` - value */
+       *
+       * * `key` - key
+       * * `value` - value */
       matchedOn: MatchedOnEnum;
       /**
          * Sample matching value — only set when matchedOn is "value".
@@ -41808,8 +41931,8 @@ export namespace Schemas {
 
     /**
      * * `log` - log
-    * `log_attribute` - log_attribute
-    * `log_resource_attribute` - log_resource_attribute
+     * * `log_attribute` - log_attribute
+     * * `log_resource_attribute` - log_resource_attribute
      */
     export type _LogPropertyFilterTypeEnum = typeof _LogPropertyFilterTypeEnum[keyof typeof _LogPropertyFilterTypeEnum];
 
@@ -41822,18 +41945,18 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `icontains` - icontains
-    * `not_icontains` - not_icontains
-    * `regex` - regex
-    * `not_regex` - not_regex
-    * `gt` - gt
-    * `lt` - lt
-    * `is_date_exact` - is_date_exact
-    * `is_date_before` - is_date_before
-    * `is_date_after` - is_date_after
-    * `is_set` - is_set
-    * `is_not_set` - is_not_set
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `lt` - lt
+     * * `is_date_exact` - is_date_exact
+     * * `is_date_before` - is_date_before
+     * * `is_date_after` - is_date_after
+     * * `is_set` - is_set
+     * * `is_not_set` - is_not_set
      */
     export type _LogPropertyFilterOperatorEnum = typeof _LogPropertyFilterOperatorEnum[keyof typeof _LogPropertyFilterOperatorEnum];
 
@@ -41858,26 +41981,26 @@ export namespace Schemas {
       /** Attribute key. For type "log", use "message". For "log_attribute"/"log_resource_attribute", use the attribute key (e.g. "k8s.container.name"). */
       key: string;
       /** "log" filters the log body/message. "log_attribute" filters log-level attributes. "log_resource_attribute" filters resource-level attributes.
-
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute */
+       *
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute */
       type: _LogPropertyFilterTypeEnum;
       /** Comparison operator.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains
-      * `regex` - regex
-      * `not_regex` - not_regex
-      * `gt` - gt
-      * `lt` - lt
-      * `is_date_exact` - is_date_exact
-      * `is_date_before` - is_date_before
-      * `is_date_after` - is_date_after
-      * `is_set` - is_set
-      * `is_not_set` - is_not_set */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains
+       * * `regex` - regex
+       * * `not_regex` - not_regex
+       * * `gt` - gt
+       * * `lt` - lt
+       * * `is_date_exact` - is_date_exact
+       * * `is_date_before` - is_date_before
+       * * `is_date_after` - is_date_after
+       * * `is_set` - is_set
+       * * `is_not_set` - is_not_set */
       operator: _LogPropertyFilterOperatorEnum;
       /** Value to compare against. String, number, or array of strings. Omit for is_set/is_not_set operators. */
       value?: unknown;
@@ -41961,9 +42084,9 @@ export namespace Schemas {
       /** Filter by service names. */
       serviceNames?: string[];
       /** Order results by timestamp.
-
-      * `latest` - latest
-      * `earliest` - earliest */
+       *
+       * * `latest` - latest
+       * * `earliest` - earliest */
       orderBy?: OrderByEnum;
       /** Full-text search term to filter log bodies. */
       searchTerm?: string;
@@ -42086,9 +42209,9 @@ export namespace Schemas {
       /** Property filters for the query. */
       filterGroup?: _LogPropertyFilter[];
       /** Break down sparkline by "severity" (default) or "service".
-
-      * `severity` - severity
-      * `service` - service */
+       *
+       * * `severity` - severity
+       * * `service` - service */
       sparklineBreakdownBy?: SparklineBreakdownByEnum;
     }
 
@@ -42140,11 +42263,11 @@ export namespace Schemas {
          */
       metricName: string;
       /** Aggregation applied per time bucket.
-
-      * `sum` - sum
-      * `avg` - avg
-      * `count` - count
-      * `p95` - p95 */
+       *
+       * * `sum` - sum
+       * * `avg` - avg
+       * * `count` - count
+       * * `p95` - p95 */
       aggregation?: AggregationEnum;
       /** Lower bound (inclusive) for the query range. ISO 8601. */
       dateFrom: string;
@@ -42171,8 +42294,8 @@ export namespace Schemas {
 
     /**
      * * `span` - span
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
      */
     export type _SpanPropertyFilterTypeEnum = typeof _SpanPropertyFilterTypeEnum[keyof typeof _SpanPropertyFilterTypeEnum];
 
@@ -42185,15 +42308,15 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `icontains` - icontains
-    * `not_icontains` - not_icontains
-    * `regex` - regex
-    * `not_regex` - not_regex
-    * `gt` - gt
-    * `lt` - lt
-    * `is_set` - is_set
-    * `is_not_set` - is_not_set
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `lt` - lt
+     * * `is_set` - is_set
+     * * `is_not_set` - is_not_set
      */
     export type _SpanPropertyFilterOperatorEnum = typeof _SpanPropertyFilterOperatorEnum[keyof typeof _SpanPropertyFilterOperatorEnum];
 
@@ -42215,23 +42338,23 @@ export namespace Schemas {
       /** Attribute key. For type "span", use built-in fields (trace_id, span_id, duration, name, kind, status_code, is_root_span). For "span_attribute"/"span_resource_attribute", use the attribute key (e.g. "http.method"). */
       key: string;
       /** "span" filters built-in span fields. "span_attribute" filters span-level attributes. "span_resource_attribute" filters resource-level attributes.
-
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute */
+       *
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute */
       type: _SpanPropertyFilterTypeEnum;
       /** Comparison operator.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains
-      * `regex` - regex
-      * `not_regex` - not_regex
-      * `gt` - gt
-      * `lt` - lt
-      * `is_set` - is_set
-      * `is_not_set` - is_not_set */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains
+       * * `regex` - regex
+       * * `not_regex` - not_regex
+       * * `gt` - gt
+       * * `lt` - lt
+       * * `is_set` - is_set
+       * * `is_not_set` - is_not_set */
       operator: _SpanPropertyFilterOperatorEnum;
       /** Value to compare against. String, number, or array of strings. Omit for is_set/is_not_set operators. */
       value?: unknown;
@@ -42300,9 +42423,9 @@ export namespace Schemas {
       /** Filter by HTTP status codes. */
       statusCodes?: number[];
       /** Order results by timestamp. Defaults to latest.
-
-      * `latest` - latest
-      * `earliest` - earliest */
+       *
+       * * `latest` - latest
+       * * `earliest` - earliest */
       orderBy?: OrderByEnum;
       /** Property filters for the query. */
       filterGroup?: _SpanPropertyFilter[];
@@ -43049,11 +43172,11 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
      */
     order_by?: string[];
     /**
@@ -43273,13 +43396,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort order for symbol sets. Prefix with `-` for descending order.
-
-    * `created_at` - created_at
-    * `-created_at` - -created_at
-    * `ref` - ref
-    * `-ref` - -ref
-    * `last_used` - last_used
-    * `-last_used` - -last_used
+     *
+     * * `created_at` - created_at
+     * * `-created_at` - -created_at
+     * * `ref` - ref
+     * * `-ref` - -ref
+     * * `last_used` - last_used
+     * * `-last_used` - -last_used
      * @minLength 1
      */
     order_by?: string;
@@ -43295,10 +43418,10 @@ export namespace Schemas {
     search?: string;
     /**
      * Upload status filter: `valid` has an uploaded file, `invalid` is missing a file, `all` returns both.
-
-    * `all` - all
-    * `valid` - valid
-    * `invalid` - invalid
+     *
+     * * `all` - all
+     * * `valid` - valid
+     * * `invalid` - invalid
      * @minLength 1
      */
     status?: EnvironmentsErrorTrackingSymbolSetsListStatus;
@@ -43334,13 +43457,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
-    * `name` - Name
-    * `-name` - Name (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
+     * * `name` - Name
+     * * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -43708,9 +43831,9 @@ export namespace Schemas {
     export type EnvironmentsHeatmapsListParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-
-    * `unique_visitors` - unique_visitors
-    * `total_count` - total_count
+     *
+     * * `unique_visitors` - unique_visitors
+     * * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: EnvironmentsHeatmapsListAggregation;
@@ -43774,9 +43897,9 @@ export namespace Schemas {
     export type EnvironmentsHeatmapsEventsRetrieveParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-
-    * `unique_visitors` - unique_visitors
-    * `total_count` - total_count
+     *
+     * * `unique_visitors` - unique_visitors
+     * * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: EnvironmentsHeatmapsEventsRetrieveAggregation;
@@ -43910,8 +44033,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * * `draft` - Draft
-    * `active` - Active
-    * `archived` - Archived
+     * * `active` - Active
+     * * `archived` - Archived
      */
     status?: EnvironmentsHogFlowsListStatus;
     updated_at?: string;
@@ -44000,9 +44123,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFlowsMetricsRetrieveBreakdownBy;
@@ -44013,10 +44136,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFlowsMetricsRetrieveInterval;
@@ -44062,9 +44185,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFlowsMetricsTotalsRetrieveBreakdownBy;
@@ -44075,10 +44198,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFlowsMetricsTotalsRetrieveInterval;
@@ -44189,9 +44312,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFunctionsMetricsRetrieveBreakdownBy;
@@ -44202,10 +44325,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFunctionsMetricsRetrieveInterval;
@@ -44251,9 +44374,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFunctionsMetricsTotalsRetrieveBreakdownBy;
@@ -44264,10 +44387,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFunctionsMetricsTotalsRetrieveInterval;
@@ -44363,14 +44486,14 @@ export namespace Schemas {
     offset?: number;
     /**
      *
-    Whether to refresh the retrieved insights, how aggressively, and if sync or async:
-    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-    - `'force_async'` - kick off background calculation, even if fresh results are already cached
-    Background calculation can be tracked using the `query_status` response field.
+     * Whether to refresh the retrieved insights, how aggressively, and if sync or async:
+     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+     * Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: EnvironmentsInsightsListRefresh;
     /**
@@ -44458,20 +44581,20 @@ export namespace Schemas {
     format?: EnvironmentsInsightsRetrieveFormat;
     /**
      *
-    Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
-    When set, the specified dashboard's filters and date range override will be applied.
+     * Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
+     * When set, the specified dashboard's filters and date range override will be applied.
      */
     from_dashboard?: number;
     /**
      *
-    Whether to refresh the insight, how aggresively, and if sync or async:
-    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-    - `'force_async'` - kick off background calculation, even if fresh results are already cached
-    Background calculation can be tracked using the `query_status` response field.
+     * Whether to refresh the insight, how aggresively, and if sync or async:
+     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+     * Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: EnvironmentsInsightsRetrieveRefresh;
     /**
@@ -44700,41 +44823,41 @@ export namespace Schemas {
     export type EnvironmentsIntegrationsListParams = {
     /**
      * * `anthropic` - Anthropic
-    * `apns` - Apple Push
-    * `azure-blob` - Azure Blob
-    * `bing-ads` - Bing Ads
-    * `clickup` - Clickup
-    * `customerio-app` - Customerio App
-    * `customerio-track` - Customerio Track
-    * `customerio-webhook` - Customerio Webhook
-    * `databricks` - Databricks
-    * `email` - Email
-    * `firebase` - Firebase
-    * `github` - Github
-    * `gitlab` - Gitlab
-    * `google-ads` - Google Ads
-    * `google-cloud-service-account` - Google Cloud Service Account
-    * `google-cloud-storage` - Google Cloud Storage
-    * `google-pubsub` - Google Pubsub
-    * `google-search-console` - Google Search Console
-    * `google-sheets` - Google Sheets
-    * `hubspot` - Hubspot
-    * `intercom` - Intercom
-    * `jira` - Jira
-    * `linear` - Linear
-    * `linkedin-ads` - Linkedin Ads
-    * `meta-ads` - Meta Ads
-    * `pinterest-ads` - Pinterest Ads
-    * `postgresql` - Postgresql
-    * `reddit-ads` - Reddit Ads
-    * `salesforce` - Salesforce
-    * `slack` - Slack
-    * `slack-posthog-code` - Slack Posthog Code
-    * `snapchat` - Snapchat
-    * `stripe` - Stripe
-    * `tiktok-ads` - Tiktok Ads
-    * `twilio` - Twilio
-    * `vercel` - Vercel
+     * * `apns` - Apple Push
+     * * `azure-blob` - Azure Blob
+     * * `bing-ads` - Bing Ads
+     * * `clickup` - Clickup
+     * * `customerio-app` - Customerio App
+     * * `customerio-track` - Customerio Track
+     * * `customerio-webhook` - Customerio Webhook
+     * * `databricks` - Databricks
+     * * `email` - Email
+     * * `firebase` - Firebase
+     * * `github` - Github
+     * * `gitlab` - Gitlab
+     * * `google-ads` - Google Ads
+     * * `google-cloud-service-account` - Google Cloud Service Account
+     * * `google-cloud-storage` - Google Cloud Storage
+     * * `google-pubsub` - Google Pubsub
+     * * `google-search-console` - Google Search Console
+     * * `google-sheets` - Google Sheets
+     * * `hubspot` - Hubspot
+     * * `intercom` - Intercom
+     * * `jira` - Jira
+     * * `linear` - Linear
+     * * `linkedin-ads` - Linkedin Ads
+     * * `meta-ads` - Meta Ads
+     * * `pinterest-ads` - Pinterest Ads
+     * * `postgresql` - Postgresql
+     * * `reddit-ads` - Reddit Ads
+     * * `salesforce` - Salesforce
+     * * `slack` - Slack
+     * * `slack-posthog-code` - Slack Posthog Code
+     * * `snapchat` - Snapchat
+     * * `stripe` - Stripe
+     * * `tiktok-ads` - Tiktok Ads
+     * * `twilio` - Twilio
+     * * `vercel` - Vercel
      */
     kind?: EnvironmentsIntegrationsListKind;
     /**
@@ -45094,10 +45217,10 @@ export namespace Schemas {
     export type EnvironmentsLlmPromptsListParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-
-    * `full` - full
-    * `preview` - preview
-    * `none` - none
+     *
+     * * `full` - full
+     * * `preview` - preview
+     * * `none` - none
      * @minLength 1
      */
     content?: EnvironmentsLlmPromptsListContent;
@@ -45131,10 +45254,10 @@ export namespace Schemas {
     export type EnvironmentsLlmPromptsNameRetrieveParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-
-    * `full` - full
-    * `preview` - preview
-    * `none` - none
+     *
+     * * `full` - full
+     * * `preview` - preview
+     * * `none` - none
      * @minLength 1
      */
     content?: EnvironmentsLlmPromptsNameRetrieveContent;
@@ -45278,9 +45401,9 @@ export namespace Schemas {
     export type EnvironmentsLogsAttributesRetrieveParams = {
     /**
      * Type of attributes: "log" for log attributes, "resource" for resource attributes. Defaults to "log".
-
-    * `log` - log
-    * `resource` - resource
+     *
+     * * `log` - log
+     * * `resource` - resource
      * @minLength 1
      */
     attribute_type?: EnvironmentsLogsAttributesRetrieveAttributeType;
@@ -45355,9 +45478,9 @@ export namespace Schemas {
     export type EnvironmentsLogsValuesRetrieveParams = {
     /**
      * Type of attribute: "log" or "resource". Defaults to "log".
-
-    * `log` - log
-    * `resource` - resource
+     *
+     * * `log` - log
+     * * `resource` - resource
      * @minLength 1
      */
     attribute_type?: EnvironmentsLogsValuesRetrieveAttributeType;
@@ -45510,7 +45633,7 @@ export namespace Schemas {
     export type EnvironmentsMcpServerInstallationsAuthorizeRetrieveParams = {
     /**
      * * `posthog` - posthog
-    * `posthog-code` - posthog-code
+     * * `posthog-code` - posthog-code
      * @minLength 1
      */
     install_source?: EnvironmentsMcpServerInstallationsAuthorizeRetrieveInstallSource;
@@ -46157,13 +46280,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
-    * `name` - Name
-    * `-name` - Name (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
+     * * `name` - Name
+     * * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -46175,9 +46298,9 @@ export namespace Schemas {
     export type EnvironmentsTracingSpansAttributesRetrieveParams = {
     /**
      * Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
+     *
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: EnvironmentsTracingSpansAttributesRetrieveAttributeType;
@@ -46223,10 +46346,10 @@ export namespace Schemas {
     export type EnvironmentsTracingSpansValuesRetrieveParams = {
     /**
      * Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-
-    * `span` - span
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
+     *
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: EnvironmentsTracingSpansValuesRetrieveAttributeType;
@@ -47149,69 +47272,69 @@ export namespace Schemas {
     page_size?: number;
     /**
      * Filter by a single activity scope, e.g. "FeatureFlag", "Insight", "Dashboard", "Experiment".
-
-    * `Cohort` - Cohort
-    * `FeatureFlag` - FeatureFlag
-    * `Person` - Person
-    * `Group` - Group
-    * `Insight` - Insight
-    * `Plugin` - Plugin
-    * `PluginConfig` - PluginConfig
-    * `HogFunction` - HogFunction
-    * `HogFlow` - HogFlow
-    * `DataManagement` - DataManagement
-    * `EventDefinition` - EventDefinition
-    * `PropertyDefinition` - PropertyDefinition
-    * `Notebook` - Notebook
-    * `Endpoint` - Endpoint
-    * `EndpointVersion` - EndpointVersion
-    * `Dashboard` - Dashboard
-    * `Replay` - Replay
-    * `Experiment` - Experiment
-    * `ExperimentHoldout` - ExperimentHoldout
-    * `ExperimentSavedMetric` - ExperimentSavedMetric
-    * `Survey` - Survey
-    * `EarlyAccessFeature` - EarlyAccessFeature
-    * `SessionRecordingPlaylist` - SessionRecordingPlaylist
-    * `Comment` - Comment
-    * `Team` - Team
-    * `Project` - Project
-    * `ErrorTrackingIssue` - ErrorTrackingIssue
-    * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
-    * `LegalDocument` - LegalDocument
-    * `Organization` - Organization
-    * `OrganizationDomain` - OrganizationDomain
-    * `OrganizationMembership` - OrganizationMembership
-    * `Role` - Role
-    * `UserGroup` - UserGroup
-    * `BatchExport` - BatchExport
-    * `BatchImport` - BatchImport
-    * `Integration` - Integration
-    * `Annotation` - Annotation
-    * `Tag` - Tag
-    * `TaggedItem` - TaggedItem
-    * `Subscription` - Subscription
-    * `PersonalAPIKey` - PersonalAPIKey
-    * `ProjectSecretAPIKey` - ProjectSecretAPIKey
-    * `User` - User
-    * `Action` - Action
-    * `AlertConfiguration` - AlertConfiguration
-    * `Threshold` - Threshold
-    * `AlertSubscription` - AlertSubscription
-    * `ExternalDataSource` - ExternalDataSource
-    * `ExternalDataSchema` - ExternalDataSchema
-    * `Evaluation` - Evaluation
-    * `LLMTrace` - LLMTrace
-    * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
-    * `CustomerProfileConfig` - CustomerProfileConfig
-    * `Log` - Log
-    * `LogsAlertConfiguration` - LogsAlertConfiguration
-    * `LogsExclusionRule` - LogsExclusionRule
-    * `DashboardWidget` - DashboardWidget
-    * `ProductTour` - ProductTour
-    * `Ticket` - Ticket
-    * `InstanceSetting` - InstanceSetting
-    * `SignalScoutConfig` - SignalScoutConfig
+     *
+     * * `Cohort` - Cohort
+     * * `FeatureFlag` - FeatureFlag
+     * * `Person` - Person
+     * * `Group` - Group
+     * * `Insight` - Insight
+     * * `Plugin` - Plugin
+     * * `PluginConfig` - PluginConfig
+     * * `HogFunction` - HogFunction
+     * * `HogFlow` - HogFlow
+     * * `DataManagement` - DataManagement
+     * * `EventDefinition` - EventDefinition
+     * * `PropertyDefinition` - PropertyDefinition
+     * * `Notebook` - Notebook
+     * * `Endpoint` - Endpoint
+     * * `EndpointVersion` - EndpointVersion
+     * * `Dashboard` - Dashboard
+     * * `Replay` - Replay
+     * * `Experiment` - Experiment
+     * * `ExperimentHoldout` - ExperimentHoldout
+     * * `ExperimentSavedMetric` - ExperimentSavedMetric
+     * * `Survey` - Survey
+     * * `EarlyAccessFeature` - EarlyAccessFeature
+     * * `SessionRecordingPlaylist` - SessionRecordingPlaylist
+     * * `Comment` - Comment
+     * * `Team` - Team
+     * * `Project` - Project
+     * * `ErrorTrackingIssue` - ErrorTrackingIssue
+     * * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
+     * * `LegalDocument` - LegalDocument
+     * * `Organization` - Organization
+     * * `OrganizationDomain` - OrganizationDomain
+     * * `OrganizationMembership` - OrganizationMembership
+     * * `Role` - Role
+     * * `UserGroup` - UserGroup
+     * * `BatchExport` - BatchExport
+     * * `BatchImport` - BatchImport
+     * * `Integration` - Integration
+     * * `Annotation` - Annotation
+     * * `Tag` - Tag
+     * * `TaggedItem` - TaggedItem
+     * * `Subscription` - Subscription
+     * * `PersonalAPIKey` - PersonalAPIKey
+     * * `ProjectSecretAPIKey` - ProjectSecretAPIKey
+     * * `User` - User
+     * * `Action` - Action
+     * * `AlertConfiguration` - AlertConfiguration
+     * * `Threshold` - Threshold
+     * * `AlertSubscription` - AlertSubscription
+     * * `ExternalDataSource` - ExternalDataSource
+     * * `ExternalDataSchema` - ExternalDataSchema
+     * * `Evaluation` - Evaluation
+     * * `LLMTrace` - LLMTrace
+     * * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
+     * * `CustomerProfileConfig` - CustomerProfileConfig
+     * * `Log` - Log
+     * * `LogsAlertConfiguration` - LogsAlertConfiguration
+     * * `LogsExclusionRule` - LogsExclusionRule
+     * * `DashboardWidget` - DashboardWidget
+     * * `ProductTour` - ProductTour
+     * * `Ticket` - Ticket
+     * * `InstanceSetting` - InstanceSetting
+     * * `SignalScoutConfig` - SignalScoutConfig
      * @minLength 1
      */
     scope?: ActivityLogListScope;
@@ -47295,67 +47418,67 @@ export namespace Schemas {
 
     /**
      * * `Cohort` - Cohort
-    * `FeatureFlag` - FeatureFlag
-    * `Person` - Person
-    * `Group` - Group
-    * `Insight` - Insight
-    * `Plugin` - Plugin
-    * `PluginConfig` - PluginConfig
-    * `HogFunction` - HogFunction
-    * `HogFlow` - HogFlow
-    * `DataManagement` - DataManagement
-    * `EventDefinition` - EventDefinition
-    * `PropertyDefinition` - PropertyDefinition
-    * `Notebook` - Notebook
-    * `Endpoint` - Endpoint
-    * `EndpointVersion` - EndpointVersion
-    * `Dashboard` - Dashboard
-    * `Replay` - Replay
-    * `Experiment` - Experiment
-    * `ExperimentHoldout` - ExperimentHoldout
-    * `ExperimentSavedMetric` - ExperimentSavedMetric
-    * `Survey` - Survey
-    * `EarlyAccessFeature` - EarlyAccessFeature
-    * `SessionRecordingPlaylist` - SessionRecordingPlaylist
-    * `Comment` - Comment
-    * `Team` - Team
-    * `Project` - Project
-    * `ErrorTrackingIssue` - ErrorTrackingIssue
-    * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
-    * `LegalDocument` - LegalDocument
-    * `Organization` - Organization
-    * `OrganizationDomain` - OrganizationDomain
-    * `OrganizationMembership` - OrganizationMembership
-    * `Role` - Role
-    * `UserGroup` - UserGroup
-    * `BatchExport` - BatchExport
-    * `BatchImport` - BatchImport
-    * `Integration` - Integration
-    * `Annotation` - Annotation
-    * `Tag` - Tag
-    * `TaggedItem` - TaggedItem
-    * `Subscription` - Subscription
-    * `PersonalAPIKey` - PersonalAPIKey
-    * `ProjectSecretAPIKey` - ProjectSecretAPIKey
-    * `User` - User
-    * `Action` - Action
-    * `AlertConfiguration` - AlertConfiguration
-    * `Threshold` - Threshold
-    * `AlertSubscription` - AlertSubscription
-    * `ExternalDataSource` - ExternalDataSource
-    * `ExternalDataSchema` - ExternalDataSchema
-    * `Evaluation` - Evaluation
-    * `LLMTrace` - LLMTrace
-    * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
-    * `CustomerProfileConfig` - CustomerProfileConfig
-    * `Log` - Log
-    * `LogsAlertConfiguration` - LogsAlertConfiguration
-    * `LogsExclusionRule` - LogsExclusionRule
-    * `DashboardWidget` - DashboardWidget
-    * `ProductTour` - ProductTour
-    * `Ticket` - Ticket
-    * `InstanceSetting` - InstanceSetting
-    * `SignalScoutConfig` - SignalScoutConfig
+     * * `FeatureFlag` - FeatureFlag
+     * * `Person` - Person
+     * * `Group` - Group
+     * * `Insight` - Insight
+     * * `Plugin` - Plugin
+     * * `PluginConfig` - PluginConfig
+     * * `HogFunction` - HogFunction
+     * * `HogFlow` - HogFlow
+     * * `DataManagement` - DataManagement
+     * * `EventDefinition` - EventDefinition
+     * * `PropertyDefinition` - PropertyDefinition
+     * * `Notebook` - Notebook
+     * * `Endpoint` - Endpoint
+     * * `EndpointVersion` - EndpointVersion
+     * * `Dashboard` - Dashboard
+     * * `Replay` - Replay
+     * * `Experiment` - Experiment
+     * * `ExperimentHoldout` - ExperimentHoldout
+     * * `ExperimentSavedMetric` - ExperimentSavedMetric
+     * * `Survey` - Survey
+     * * `EarlyAccessFeature` - EarlyAccessFeature
+     * * `SessionRecordingPlaylist` - SessionRecordingPlaylist
+     * * `Comment` - Comment
+     * * `Team` - Team
+     * * `Project` - Project
+     * * `ErrorTrackingIssue` - ErrorTrackingIssue
+     * * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
+     * * `LegalDocument` - LegalDocument
+     * * `Organization` - Organization
+     * * `OrganizationDomain` - OrganizationDomain
+     * * `OrganizationMembership` - OrganizationMembership
+     * * `Role` - Role
+     * * `UserGroup` - UserGroup
+     * * `BatchExport` - BatchExport
+     * * `BatchImport` - BatchImport
+     * * `Integration` - Integration
+     * * `Annotation` - Annotation
+     * * `Tag` - Tag
+     * * `TaggedItem` - TaggedItem
+     * * `Subscription` - Subscription
+     * * `PersonalAPIKey` - PersonalAPIKey
+     * * `ProjectSecretAPIKey` - ProjectSecretAPIKey
+     * * `User` - User
+     * * `Action` - Action
+     * * `AlertConfiguration` - AlertConfiguration
+     * * `Threshold` - Threshold
+     * * `AlertSubscription` - AlertSubscription
+     * * `ExternalDataSource` - ExternalDataSource
+     * * `ExternalDataSchema` - ExternalDataSchema
+     * * `Evaluation` - Evaluation
+     * * `LLMTrace` - LLMTrace
+     * * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
+     * * `CustomerProfileConfig` - CustomerProfileConfig
+     * * `Log` - Log
+     * * `LogsAlertConfiguration` - LogsAlertConfiguration
+     * * `LogsExclusionRule` - LogsExclusionRule
+     * * `DashboardWidget` - DashboardWidget
+     * * `ProductTour` - ProductTour
+     * * `Ticket` - Ticket
+     * * `InstanceSetting` - InstanceSetting
+     * * `SignalScoutConfig` - SignalScoutConfig
      */
     export type ActivityLogListScopesItem = typeof ActivityLogListScopesItem[keyof typeof ActivityLogListScopesItem];
 
@@ -47749,10 +47872,10 @@ export namespace Schemas {
     export type CommentsListParams = {
     /**
      * When kind=task, restrict to open (incomplete) or completed tasks. Ignored when kind is not 'task'. Defaults to 'any' (no filter).
-
-    * `any` - any
-    * `open` - open
-    * `completed` - completed
+     *
+     * * `any` - any
+     * * `open` - open
+     * * `completed` - completed
      * @minLength 1
      */
     completed?: CommentsListCompleted;
@@ -47767,10 +47890,10 @@ export namespace Schemas {
     item_id?: string;
     /**
      * Filter by comment kind. 'task' returns only items intentionally created as actionable. 'comment' excludes tasks. Defaults to 'any' (no filter).
-
-    * `any` - any
-    * `comment` - comment
-    * `task` - task
+     *
+     * * `any` - any
+     * * `comment` - comment
+     * * `task` - task
      * @minLength 1
      */
     kind?: CommentsListKind;
@@ -48401,11 +48524,11 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
      */
     order_by?: string[];
     /**
@@ -48728,13 +48851,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort order for symbol sets. Prefix with `-` for descending order.
-
-    * `created_at` - created_at
-    * `-created_at` - -created_at
-    * `ref` - ref
-    * `-ref` - -ref
-    * `last_used` - last_used
-    * `-last_used` - -last_used
+     *
+     * * `created_at` - created_at
+     * * `-created_at` - -created_at
+     * * `ref` - ref
+     * * `-ref` - -ref
+     * * `last_used` - last_used
+     * * `-last_used` - -last_used
      * @minLength 1
      */
     order_by?: string;
@@ -48750,10 +48873,10 @@ export namespace Schemas {
     search?: string;
     /**
      * Upload status filter: `valid` has an uploaded file, `invalid` is missing a file, `all` returns both.
-
-    * `all` - all
-    * `valid` - valid
-    * `invalid` - invalid
+     *
+     * * `all` - all
+     * * `valid` - valid
+     * * `invalid` - invalid
      * @minLength 1
      */
     status?: ErrorTrackingSymbolSetsListStatus;
@@ -48789,13 +48912,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
-    * `name` - Name
-    * `-name` - Name (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
+     * * `name` - Name
+     * * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -49441,9 +49564,9 @@ export namespace Schemas {
     export type HeatmapsListParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-
-    * `unique_visitors` - unique_visitors
-    * `total_count` - total_count
+     *
+     * * `unique_visitors` - unique_visitors
+     * * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: HeatmapsListAggregation;
@@ -49507,9 +49630,9 @@ export namespace Schemas {
     export type HeatmapsEventsRetrieveParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-
-    * `unique_visitors` - unique_visitors
-    * `total_count` - total_count
+     *
+     * * `unique_visitors` - unique_visitors
+     * * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: HeatmapsEventsRetrieveAggregation;
@@ -49643,8 +49766,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * * `draft` - Draft
-    * `active` - Active
-    * `archived` - Archived
+     * * `active` - Active
+     * * `archived` - Archived
      */
     status?: HogFlowsListStatus;
     updated_at?: string;
@@ -49733,9 +49856,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFlowsMetricsRetrieveBreakdownBy;
@@ -49746,10 +49869,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: HogFlowsMetricsRetrieveInterval;
@@ -49795,9 +49918,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFlowsMetricsTotalsRetrieveBreakdownBy;
@@ -49808,10 +49931,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: HogFlowsMetricsTotalsRetrieveInterval;
@@ -49945,9 +50068,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFunctionsMetricsRetrieveBreakdownBy;
@@ -49958,10 +50081,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: HogFunctionsMetricsRetrieveInterval;
@@ -50007,9 +50130,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFunctionsMetricsTotalsRetrieveBreakdownBy;
@@ -50020,10 +50143,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: HogFunctionsMetricsTotalsRetrieveInterval;
@@ -50119,14 +50242,14 @@ export namespace Schemas {
     offset?: number;
     /**
      *
-    Whether to refresh the retrieved insights, how aggressively, and if sync or async:
-    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-    - `'force_async'` - kick off background calculation, even if fresh results are already cached
-    Background calculation can be tracked using the `query_status` response field.
+     * Whether to refresh the retrieved insights, how aggressively, and if sync or async:
+     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+     * Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: InsightsListRefresh;
     /**
@@ -50214,20 +50337,20 @@ export namespace Schemas {
     format?: InsightsRetrieveFormat;
     /**
      *
-    Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
-    When set, the specified dashboard's filters and date range override will be applied.
+     * Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
+     * When set, the specified dashboard's filters and date range override will be applied.
      */
     from_dashboard?: number;
     /**
      *
-    Whether to refresh the insight, how aggresively, and if sync or async:
-    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-    - `'force_async'` - kick off background calculation, even if fresh results are already cached
-    Background calculation can be tracked using the `query_status` response field.
+     * Whether to refresh the insight, how aggresively, and if sync or async:
+     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+     * Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: InsightsRetrieveRefresh;
     /**
@@ -50456,41 +50579,41 @@ export namespace Schemas {
     export type IntegrationsListParams = {
     /**
      * * `anthropic` - Anthropic
-    * `apns` - Apple Push
-    * `azure-blob` - Azure Blob
-    * `bing-ads` - Bing Ads
-    * `clickup` - Clickup
-    * `customerio-app` - Customerio App
-    * `customerio-track` - Customerio Track
-    * `customerio-webhook` - Customerio Webhook
-    * `databricks` - Databricks
-    * `email` - Email
-    * `firebase` - Firebase
-    * `github` - Github
-    * `gitlab` - Gitlab
-    * `google-ads` - Google Ads
-    * `google-cloud-service-account` - Google Cloud Service Account
-    * `google-cloud-storage` - Google Cloud Storage
-    * `google-pubsub` - Google Pubsub
-    * `google-search-console` - Google Search Console
-    * `google-sheets` - Google Sheets
-    * `hubspot` - Hubspot
-    * `intercom` - Intercom
-    * `jira` - Jira
-    * `linear` - Linear
-    * `linkedin-ads` - Linkedin Ads
-    * `meta-ads` - Meta Ads
-    * `pinterest-ads` - Pinterest Ads
-    * `postgresql` - Postgresql
-    * `reddit-ads` - Reddit Ads
-    * `salesforce` - Salesforce
-    * `slack` - Slack
-    * `slack-posthog-code` - Slack Posthog Code
-    * `snapchat` - Snapchat
-    * `stripe` - Stripe
-    * `tiktok-ads` - Tiktok Ads
-    * `twilio` - Twilio
-    * `vercel` - Vercel
+     * * `apns` - Apple Push
+     * * `azure-blob` - Azure Blob
+     * * `bing-ads` - Bing Ads
+     * * `clickup` - Clickup
+     * * `customerio-app` - Customerio App
+     * * `customerio-track` - Customerio Track
+     * * `customerio-webhook` - Customerio Webhook
+     * * `databricks` - Databricks
+     * * `email` - Email
+     * * `firebase` - Firebase
+     * * `github` - Github
+     * * `gitlab` - Gitlab
+     * * `google-ads` - Google Ads
+     * * `google-cloud-service-account` - Google Cloud Service Account
+     * * `google-cloud-storage` - Google Cloud Storage
+     * * `google-pubsub` - Google Pubsub
+     * * `google-search-console` - Google Search Console
+     * * `google-sheets` - Google Sheets
+     * * `hubspot` - Hubspot
+     * * `intercom` - Intercom
+     * * `jira` - Jira
+     * * `linear` - Linear
+     * * `linkedin-ads` - Linkedin Ads
+     * * `meta-ads` - Meta Ads
+     * * `pinterest-ads` - Pinterest Ads
+     * * `postgresql` - Postgresql
+     * * `reddit-ads` - Reddit Ads
+     * * `salesforce` - Salesforce
+     * * `slack` - Slack
+     * * `slack-posthog-code` - Slack Posthog Code
+     * * `snapchat` - Snapchat
+     * * `stripe` - Stripe
+     * * `tiktok-ads` - Tiktok Ads
+     * * `twilio` - Twilio
+     * * `vercel` - Vercel
      */
     kind?: IntegrationsListKind;
     /**
@@ -50910,10 +51033,10 @@ export namespace Schemas {
     export type LlmPromptsListParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-
-    * `full` - full
-    * `preview` - preview
-    * `none` - none
+     *
+     * * `full` - full
+     * * `preview` - preview
+     * * `none` - none
      * @minLength 1
      */
     content?: LlmPromptsListContent;
@@ -50947,10 +51070,10 @@ export namespace Schemas {
     export type LlmPromptsNameRetrieveParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-
-    * `full` - full
-    * `preview` - preview
-    * `none` - none
+     *
+     * * `full` - full
+     * * `preview` - preview
+     * * `none` - none
      * @minLength 1
      */
     content?: LlmPromptsNameRetrieveContent;
@@ -51094,9 +51217,9 @@ export namespace Schemas {
     export type LogsAttributesRetrieveParams = {
     /**
      * Type of attributes: "log" for log attributes, "resource" for resource attributes. Defaults to "log".
-
-    * `log` - log
-    * `resource` - resource
+     *
+     * * `log` - log
+     * * `resource` - resource
      * @minLength 1
      */
     attribute_type?: LogsAttributesRetrieveAttributeType;
@@ -51171,9 +51294,9 @@ export namespace Schemas {
     export type LogsValuesRetrieveParams = {
     /**
      * Type of attribute: "log" or "resource". Defaults to "log".
-
-    * `log` - log
-    * `resource` - resource
+     *
+     * * `log` - log
+     * * `resource` - resource
      * @minLength 1
      */
     attribute_type?: LogsValuesRetrieveAttributeType;
@@ -51239,9 +51362,9 @@ export namespace Schemas {
     search?: string;
     /**
      * * `completed` - Completed
-    * `failed` - Failed
-    * `paused` - Paused
-    * `running` - Running
+     * * `failed` - Failed
+     * * `paused` - Paused
+     * * `running` - Running
      */
     status?: ManagedMigrationsListStatus;
     };
@@ -51362,7 +51485,7 @@ export namespace Schemas {
     export type McpServerInstallationsAuthorizeRetrieveParams = {
     /**
      * * `posthog` - posthog
-    * `posthog-code` - posthog-code
+     * * `posthog-code` - posthog-code
      * @minLength 1
      */
     install_source?: McpServerInstallationsAuthorizeRetrieveInstallSource;
@@ -51430,8 +51553,8 @@ export namespace Schemas {
     export type NotebooksListParams = {
     /**
      * Filter for notebooks that match a provided filter.
-                    Each match pair is separated by a colon,
-                    multiple match pairs can be sent separated by a space or a comma
+     *                 Each match pair is separated by a colon,
+     *                 multiple match pairs can be sent separated by a space or a comma
      */
     contains?: string;
     /**
@@ -51960,11 +52083,11 @@ export namespace Schemas {
     search?: string;
     /**
      * What property definitions to return
-
-    * `event` - event
-    * `person` - person
-    * `group` - group
-    * `session` - session
+     *
+     * * `event` - event
+     * * `person` - person
+     * * `group` - group
+     * * `session` - session
      * @minLength 1
      */
     type?: PropertyDefinitionsListType;
@@ -52381,9 +52504,9 @@ export namespace Schemas {
     search?: string;
     /**
      * * `popover` - popover
-    * `widget` - widget
-    * `external_survey` - external survey
-    * `api` - api
+     * * `widget` - widget
+     * * `external_survey` - external survey
+     * * `api` - api
      */
     type?: SurveysListType;
     };
@@ -52493,13 +52616,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
-    * `name` - Name
-    * `-name` - Name (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
+     * * `name` - Name
+     * * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -52533,10 +52656,10 @@ export namespace Schemas {
     export type TasksListParams = {
     /**
      * Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.
-
-    * `true` - true
-    * `false` - false
-    * `all` - all
+     *
+     * * `true` - true
+     * * `false` - false
+     * * `all` - all
      * @minLength 1
      */
     archived?: TasksListArchived;
@@ -52585,13 +52708,13 @@ export namespace Schemas {
     stage?: string;
     /**
      * Filter tasks by the status of their most recent run.
-
-    * `not_started` - not_started
-    * `queued` - queued
-    * `in_progress` - in_progress
-    * `completed` - completed
-    * `failed` - failed
-    * `cancelled` - cancelled
+     *
+     * * `not_started` - not_started
+     * * `queued` - queued
+     * * `in_progress` - in_progress
+     * * `completed` - completed
+     * * `failed` - failed
+     * * `cancelled` - cancelled
      * @minLength 1
      */
     status?: TasksListStatus;
@@ -52696,9 +52819,9 @@ export namespace Schemas {
     export type TracingSpansAttributesRetrieveParams = {
     /**
      * Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
+     *
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: TracingSpansAttributesRetrieveAttributeType;
@@ -52744,10 +52867,10 @@ export namespace Schemas {
     export type TracingSpansValuesRetrieveParams = {
     /**
      * Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-
-    * `span` - span
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
+     *
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: TracingSpansValuesRetrieveAttributeType;


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

This PR closes the request-cycle gap: a service module that owns the idempotency, staleness, and concurrency logic; three DRF endpoints (POST to trigger, GET-latest, GET-by-id) wired to start the Temporal workflow and read results back; generated frontend + MCP types; and a serializer that surfaces per-run results plus derived counters.

## Workflow

The end-to-end shape of the system across the stack. Highlighted modules are introduced or touched by **this PR**; the rest land in subsequent PRs.

```mermaid
sequenceDiagram
    autonumber
    actor User

    box Browser
        participant FE as Frontend (experimentLogic)
    end
    box DRF (web request cycle)
        participant API as DRF viewset 🟢
        participant Service as recalculation.py 🟢
    end
    box Temporal (worker process)
        participant Worker as Temporal worker (interceptor)
        participant Workflow as Temporal workflow
        participant Activity as Calc activity
    end
    box Persistence (Postgres)
        participant DB as ExperimentMetricsRecalculation
        participant Result as ExperimentMetricResult
    end

    User->>FE: click "Reload metrics"
    FE->>API: POST /metrics_recalculation/
    API->>Service: request_recalculation(experiment, user, trigger)
    Service->>DB: create or fetch active run
    DB-->>Service: row (id, status)
    Service-->>API: ExperimentMetricsRecalculationSerializer
    API->>Workflow: start_workflow(recalculation_id)
    API-->>FE: 201 (or 200 if reusing active run)

    Worker->>Workflow: wrap execute_workflow (latency + finished counter)
    Workflow->>Activity: per metric (fan-out, concurrency 10)
    Worker->>Activity: wrap execute_activity (latency + success/failure counters)
    Activity->>Result: upsert recalc-fingerprinted row
    Activity->>DB: fold progress (counters + errors)

    loop poll until terminal
        FE->>API: GET /metrics_recalculation/{id}/
        API->>Service: get_recalculation_by_id + get_run_results
        Service->>DB: load job row
        Service->>Result: filter by recalc fingerprint
        API-->>FE: status + counts + results
    end
```

🟢 = introduced or modified by this PR.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR adds the request-cycle layer for the recalculation feature: a service module, three DRF endpoints, serializer additions for per-run results + derived counters, and the generated TypeScript and MCP types that flow from those serializers.

### Service layer

`recalculation.py` is a module of free functions (not methods on `ExperimentService`) so the view composes them directly without instantiating a service object. Four public entry points:

- `request_recalculation(experiment, user, trigger)`: idempotent create, returns the active run if one already exists.
- `get_latest_recalculation(experiment)`: most recent completed run, powers `GET .../latest`.
- `get_recalculation_by_id(experiment, recalculation_id)`: id lookup scoped to the experiment, powers `GET .../<id>`.
- `get_run_results(recalc)`: per-metric results read back by recomputing the recalc fingerprint and filtering `ExperimentMetricResult` rows.
- `build_job_payload(recalc, *, is_existing, results)`: shapes a recalc row + derived counters into the dict the serializer re-serializes. Exported because the view's GET shape calls it too.

The service has three pieces of meaningful logic that the API alone couldn't sit on top of:

1. **Activity-aware staleness.** Active rows (`pending` or `in_progress`) only block new requests within a 30-minute window. Past the threshold, the row is treated as dead, marked `FAILED` with `completed_at` set, and a fresh run is allowed. Without this, a Temporal-connect failure that also lost its rollback `UPDATE` would permanently lock the experiment out of recalculations.
2. **Concurrency lock.** The filter-then-create block runs inside `transaction.atomic()` with an upfront `Experiment.objects.select_for_update().filter(...)` to serialize two simultaneous POSTs for the same experiment. Without this, both POSTs see no active row and reach `.create()`; the second hits the per-experiment unique constraint and returns HTTP 500. The lock converts that into a clean `is_existing=True` response.
3. **Derived counters.** `completed_metrics` and `failed_metrics` are not stored on the row; they're computed from `ExperimentMetricResult` rows scoped by the recalc fingerprint, plus `metric_errors` keys that never made it to a result row (discovery-step failures). This preserves the "no FK on ExperimentMetricResult" architectural decision from PR1 while still giving the API the counts dashboards need.

The fingerprint-divergence hazard is documented inline on `_recalc_fingerprints_for_run`, `get_run_results`, and `_derive_counters`. If `experiment.start_date` / `exposure_criteria` / stats config / `only_count_matured_users` changes between the workflow's writes and a later read, the recomputed fingerprints will not match, and the results will disappear. Acceptable trade-off, but the docstrings spell out the symptom so a future reader debugging "results disappeared after editing exposure_criteria" finds the cause immediately.

- `products/experiments/backend/recalculation.py`

### DRF endpoints

Three actions on `EnterpriseExperimentsViewSet`, all nested under `metrics_recalculation`:

- `POST /api/projects/{team}/experiments/{id}/metrics_recalculation/`: trigger a recalc. 201 with the new pending row, 200 if reusing an active run. The response intentionally omits the `results` array. The workflow has just been queued, so no per-metric data exists yet; clients poll the GET-by-id endpoint for results. The Temporal `start_workflow` call is wrapped in a try/except that rolls the row back to `FAILED` on connect failure. The service's 30-minute TTL is the second-line backstop if that rollback itself fails.
- `GET .../metrics_recalculation/latest/`: most recent completed run for the experiment, or 404 if no completed run exists.
- `GET .../metrics_recalculation/{recalculation_id}/`: id lookup with a strict UUID regex on the URL pattern so it never matches the `/latest/` sibling route. Returns 404 if the id doesn't belong to this experiment.

Both GETs surface the per-run `results` array via the serializer's nested `MetricRecalculationResultSerializer`. `_serialize_recalculation` computes `get_run_results(recalc)` once and threads the same list into both the derived counters and the response — no duplicate fingerprint computation per request.

- `products/experiments/backend/presentation/views.py`

### Serializer additions

Three new serializer classes in `serializers.py`:

- `RecalculateMetricsRequestSerializer`: POST body, validates the `trigger` enum (`manual` default; other values cover automated triggers from experiment lifecycle events).
- `MetricRecalculationResultSerializer`: one per-metric result row, declared as a `JSONField` for the result blob since the concrete shape is `posthog.schema.ExperimentQueryResponse` (varies by metric type).
- `ExperimentMetricsRecalculationSerializer`: Added a nested `results` field backed by `MetricRecalculationResultSerializer(many=True, required=False)`, so the OpenAPI schema includes the array on GETs without forcing it onto POSTs.

- `products/experiments/backend/presentation/serializers.py`

### Generated frontend + MCP types

OpenAPI codegen produces three frontend artifacts and the MCP API types from the serializers. Regenerated; no manual edits.

- `products/experiments/frontend/generated/api.schemas.ts` (generated)
- `products/experiments/frontend/generated/api.ts` (generated)
- `products/experiments/frontend/generated/api.zod.ts` (generated)
- `services/mcp/src/api/generated.ts` (generated)

> [!IMPORTANT]
We are not including MCP tool definitions for this to reduce the feature's surface area during testing.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/f7edd22d-ac9e-4c5b-814a-fea867b4dff5)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
Model: Opus 4.7
Manually refactored: **yes**
Skills used:
- /brainstorming (superpowers)
- /writing-plans (superpowers)
- /executing-plans (superpowers)
- /improving-drf-endpoints (local)
- /adopting-generated-api-types (local)
- /writing-pull-requests (local)

Relevant decisions:
- Per-experiment concurrency lock via `Experiment.objects.select_for_update()` rather than a partial unique index migration. The unique constraint already prevents duplicate active rows at the DB level; the race manifests as the second POST returning an HTTP 500 due to `IntegrityError` rather than as duplicate workflows. The lock converts that into a clean `is_existing=True` response without a migration, and locking the Experiment row (not the recalc table) keeps the lock scope minimal. Concurrent reads of the experiment from other code paths are unaffected.