### PR TITLE
feat(error-tracking): add cymbal process proto

### DIFF
--- a/proto/cymbal/process/v1/process.proto
+++ b/proto/cymbal/process/v1/process.proto
@@ -1,0 +1,91 @@
+syntax = "proto3";
+package cymbal.process.v1;
+
+// CymbalProcess is the Node-facing Cymbal processing API. It accepts whole
+// canonical error-tracking events and returns one terminal outcome per item.
+service CymbalProcess {
+  // Process is a bidirectional stream of independent items. Outcomes may be
+  // emitted out of input order, but every accepted item gets exactly one
+  // terminal ProcessOutcome. Stream-level failures are reserved for protocol,
+  // transport, or server-shutdown cases where item-level outcomes cannot be
+  // maintained.
+  rpc Process(stream ProcessItem) returns (stream ProcessOutcome);
+}
+
+// ProcessItem is one canonical event payload to process. The
+// caller_correlation_id is an opaque caller-provided token that Cymbal echoes
+// on the terminal outcome. It is not interpreted by Cymbal, may be duplicated
+// within a stream, and must not be used for internal in-flight bookkeeping;
+// Cymbal generates unique internal processing IDs when handling items.
+message ProcessItem {
+  string caller_correlation_id = 1;
+  // Serialized rust/cymbal AnyEvent JSON in the strict canonical shape already
+  // accepted by Cymbal's HTTP /process boundary.
+  bytes event_json = 2;
+}
+
+// ProcessOutcome is the terminal result for one ProcessItem. Exactly one of
+// done, drop, or error is set for each accepted item, and the caller correlation
+// ID from the ProcessItem is echoed unchanged.
+message ProcessOutcome {
+  string caller_correlation_id = 1;
+
+  oneof result {
+    ProcessDone done = 2;
+    ProcessDrop drop = 3;
+    ProcessError error = 4;
+  }
+}
+
+// ProcessDone means Cymbal fully processed the event. The returned event is the
+// authoritative canonical processed event for downstream callers.
+message ProcessDone {
+  // Serialized rust/cymbal AnyEvent JSON after Cymbal has updated properties.
+  bytes processed_event_json = 1;
+}
+
+// ProcessDrop means Cymbal intentionally discarded a valid item. Dropped items
+// are terminal and should not be retried.
+message ProcessDrop {
+  ProcessDropReason reason = 1;
+}
+
+enum ProcessDropReason {
+  PROCESS_DROP_REASON_UNSPECIFIED = 0;
+  PROCESS_DROP_REASON_SUPPRESSED_ISSUE = 1;
+  PROCESS_DROP_REASON_SUPPRESSION_RULE = 2;
+}
+
+// ProcessError means Cymbal could not produce a processed event. Invalid
+// payloads are represented as kind PROCESS_ERROR_KIND_INVALID with retryable
+// false. message and details_json are debug-safe diagnostics only and are not
+// control-flow surfaces.
+message ProcessError {
+  ProcessErrorKind kind = 1;
+  ProcessErrorCode code = 2;
+  bool retryable = 3;
+  // Optional server hint in milliseconds. A zero value means no hint.
+  uint32 retry_after_ms = 4;
+  string message = 5;
+  bytes details_json = 6;
+}
+
+enum ProcessErrorKind {
+  PROCESS_ERROR_KIND_UNSPECIFIED = 0;
+  PROCESS_ERROR_KIND_INVALID = 1;
+  PROCESS_ERROR_KIND_PROCESSING = 2;
+  PROCESS_ERROR_KIND_TIMEOUT = 3;
+  PROCESS_ERROR_KIND_DEPENDENCY = 4;
+  PROCESS_ERROR_KIND_INTERNAL = 5;
+}
+
+enum ProcessErrorCode {
+  PROCESS_ERROR_CODE_UNSPECIFIED = 0;
+  PROCESS_ERROR_CODE_INVALID_PAYLOAD = 1;
+  PROCESS_ERROR_CODE_PROCESSING_FAILED = 2;
+  PROCESS_ERROR_CODE_TIMEOUT = 3;
+  PROCESS_ERROR_CODE_DEPENDENCY_UNAVAILABLE = 4;
+  PROCESS_ERROR_CODE_INTERNAL = 5;
+  PROCESS_ERROR_CODE_OVERLOADED = 6;
+  PROCESS_ERROR_CODE_UNIMPLEMENTED = 7;
+}

--- a/proto/cymbal/process/v1/process.proto
+++ b/proto/cymbal/process/v1/process.proto
@@ -134,18 +134,16 @@ message ServiceState {
   // True when the pod is preparing to shut down. Routers should stop sending
   // new work; in-flight requests are still served.
   bool draining = 2;
-  // True when the stream API should receive new work.
-  bool accepting_stream = 3;
-  // True when the batch API should receive new work.
-  bool accepting_batch = 4;
+  // True when this instance should receive new process work.
+  bool healthy = 3;
   // Current process-wide item load, if known.
-  uint32 in_flight_items = 5;
+  uint32 in_flight_items = 4;
   // Configured process-wide item capacity, if known. A zero value means the
   // service did not report a capacity.
-  uint32 max_in_flight_items = 6;
+  uint32 max_in_flight_items = 5;
   // Monotonic per-subscription sequence assigned by the server, starting at 1
   // for the first tick of each Subscribe stream.
-  uint64 sequence = 7;
+  uint64 sequence = 6;
   // Optional short human-readable note. Not interpreted by the router.
-  string message = 8;
+  string message = 7;
 }

--- a/proto/cymbal/process/v1/process.proto
+++ b/proto/cymbal/process/v1/process.proto
@@ -136,14 +136,9 @@ message ServiceState {
   bool draining = 2;
   // True when this instance should receive new process work.
   bool healthy = 3;
-  // Current process-wide item load, if known.
-  uint32 in_flight_items = 4;
-  // Configured process-wide item capacity, if known. A zero value means the
-  // service did not report a capacity.
-  uint32 max_in_flight_items = 5;
   // Monotonic per-subscription sequence assigned by the server, starting at 1
   // for the first tick of each Subscribe stream.
-  uint64 sequence = 6;
+  uint64 sequence = 4;
   // Optional short human-readable note. Not interpreted by the router.
-  string message = 7;
+  string message = 5;
 }

--- a/proto/cymbal/process/v1/process.proto
+++ b/proto/cymbal/process/v1/process.proto
@@ -33,14 +33,19 @@ message ProcessItem {
   // Serialized rust/cymbal AnyEvent JSON in the strict canonical shape already
   // accepted by Cymbal's HTTP /process boundary.
   bytes event_json = 2;
-  // Time allocated to process this item, in milliseconds. A zero value expires
-  // immediately.
-  uint32 timeout_ms = 3;
+  // Optional time allocated to process this item, in milliseconds. When absent,
+  // the server default applies. A present zero value expires immediately.
+  optional uint32 timeout_ms = 3;
 }
 
 // ProcessBatchRequest is a finite ordered batch of process items.
 message ProcessBatchRequest {
   repeated ProcessItem items = 1;
+  // Optional default time allocated to process each item in this batch, in
+  // milliseconds. An item-level timeout_ms overrides this value. When both are
+  // absent, the server default applies. A present zero value expires items
+  // immediately.
+  optional uint32 timeout_ms = 2;
 }
 
 // ProcessBatchResponse contains exactly one outcome for each request item, in

--- a/proto/cymbal/process/v1/process.proto
+++ b/proto/cymbal/process/v1/process.proto
@@ -88,37 +88,27 @@ enum ProcessDropReason {
 }
 
 // ProcessError means Cymbal could not produce a processed event. Invalid
-// payloads are represented as kind PROCESS_ERROR_KIND_INVALID with retryable
-// false. message and details_json are debug-safe diagnostics only and are not
-// control-flow surfaces.
+// payloads are represented as kind PROCESS_ERROR_KIND_INVALID_PAYLOAD with
+// retryable false. message and details_json are debug-safe diagnostics only and
+// are not control-flow surfaces.
 message ProcessError {
   ProcessErrorKind kind = 1;
-  ProcessErrorCode code = 2;
-  bool retryable = 3;
+  bool retryable = 2;
   // Optional server hint in milliseconds. A zero value means no hint.
-  uint32 retry_after_ms = 4;
-  string message = 5;
-  bytes details_json = 6;
+  uint32 retry_after_ms = 3;
+  string message = 4;
+  bytes details_json = 5;
 }
 
 enum ProcessErrorKind {
   PROCESS_ERROR_KIND_UNSPECIFIED = 0;
-  PROCESS_ERROR_KIND_INVALID = 1;
-  PROCESS_ERROR_KIND_PROCESSING = 2;
+  PROCESS_ERROR_KIND_INVALID_PAYLOAD = 1;
+  PROCESS_ERROR_KIND_PROCESSING_FAILED = 2;
   PROCESS_ERROR_KIND_TIMEOUT = 3;
-  PROCESS_ERROR_KIND_DEPENDENCY = 4;
+  PROCESS_ERROR_KIND_DEPENDENCY_UNAVAILABLE = 4;
   PROCESS_ERROR_KIND_INTERNAL = 5;
-}
-
-enum ProcessErrorCode {
-  PROCESS_ERROR_CODE_UNSPECIFIED = 0;
-  PROCESS_ERROR_CODE_INVALID_PAYLOAD = 1;
-  PROCESS_ERROR_CODE_PROCESSING_FAILED = 2;
-  PROCESS_ERROR_CODE_TIMEOUT = 3;
-  PROCESS_ERROR_CODE_DEPENDENCY_UNAVAILABLE = 4;
-  PROCESS_ERROR_CODE_INTERNAL = 5;
-  PROCESS_ERROR_CODE_OVERLOADED = 6;
-  PROCESS_ERROR_CODE_UNIMPLEMENTED = 7;
+  PROCESS_ERROR_KIND_OVERLOADED = 6;
+  PROCESS_ERROR_KIND_UNIMPLEMENTED = 7;
 }
 
 // SubscribeRequest opens a long-lived stream of ServiceState ticks. Callers

--- a/proto/cymbal/process/v1/process.proto
+++ b/proto/cymbal/process/v1/process.proto
@@ -1,32 +1,25 @@
 syntax = "proto3";
 package cymbal.process.v1;
 
-// ProcessStream is the Node-facing streaming Cymbal processing API. It accepts
-// whole canonical error-tracking events and returns one terminal outcome per item.
-service ProcessStream {
-  // Process is a bidirectional stream of independent items. Outcomes may be
-  // emitted out of input order, but every accepted item gets exactly one
+// CymbalProcess is the Node-facing Cymbal processing API. It accepts whole
+// canonical error-tracking events either as a bidirectional stream or as a
+// finite ordered batch.
+service CymbalProcess {
+  // ProcessStream is a bidirectional stream of independent items. Outcomes may
+  // be emitted out of input order, but every accepted item gets exactly one
   // terminal ProcessOutcome. Stream-level failures are reserved for protocol,
   // transport, or server-shutdown cases where item-level outcomes cannot be
   // maintained. Callers that require input-order results should use ProcessBatch.
-  rpc Process(stream ProcessItem) returns (stream ProcessOutcome);
+  rpc ProcessStream(stream ProcessItem) returns (stream ProcessOutcome);
+
+  // ProcessBatch returns outcomes in the same order as request.items. This keeps
+  // ordered ingestion frameworks simple at the cost of waiting for slower items
+  // before the batch response can complete.
+  rpc ProcessBatch(ProcessBatchRequest) returns (ProcessBatchResponse);
 
   // Subscribe opens a long-lived stream of service-state ticks for this Cymbal
   // instance. Callers use the latest ServiceState to avoid routing new work to
   // draining or overloaded instances.
-  rpc Subscribe(SubscribeRequest) returns (stream ServiceState);
-}
-
-// ProcessBatch is the Node-facing batch Cymbal processing API. It accepts a
-// finite batch and returns one terminal outcome per input item in input order.
-service ProcessBatch {
-  // Process returns outcomes in the same order as request.items. This keeps
-  // ordered ingestion frameworks simple at the cost of waiting for slower items
-  // before the batch response can complete.
-  rpc Process(ProcessBatchRequest) returns (ProcessBatchResponse);
-
-  // Subscribe opens a long-lived stream of service-state ticks for this Cymbal
-  // instance. It has the same semantics as ProcessStream.Subscribe.
   rpc Subscribe(SubscribeRequest) returns (stream ServiceState);
 }
 

--- a/proto/cymbal/process/v1/process.proto
+++ b/proto/cymbal/process/v1/process.proto
@@ -12,23 +12,23 @@ service CymbalProcess {
   rpc Process(stream ProcessItem) returns (stream ProcessOutcome);
 }
 
-// ProcessItem is one canonical event payload to process. The
-// caller_correlation_id is an opaque caller-provided token that Cymbal echoes
-// on the terminal outcome. It is not interpreted by Cymbal, may be duplicated
-// within a stream, and must not be used for internal in-flight bookkeeping;
-// Cymbal generates unique internal processing IDs when handling items.
+// ProcessItem is one canonical event payload to process. The id is an opaque
+// caller-provided token that Cymbal echoes on the terminal outcome. It is not
+// interpreted by Cymbal, may be duplicated within a stream, and must not be used
+// for internal in-flight bookkeeping; Cymbal generates unique internal
+// processing IDs when handling items.
 message ProcessItem {
-  string caller_correlation_id = 1;
+  string id = 1;
   // Serialized rust/cymbal AnyEvent JSON in the strict canonical shape already
   // accepted by Cymbal's HTTP /process boundary.
   bytes event_json = 2;
 }
 
 // ProcessOutcome is the terminal result for one ProcessItem. Exactly one of
-// done, drop, or error is set for each accepted item, and the caller correlation
-// ID from the ProcessItem is echoed unchanged.
+// done, drop, or error is set for each accepted item, and the caller-provided id
+// from the ProcessItem is echoed unchanged.
 message ProcessOutcome {
-  string caller_correlation_id = 1;
+  string id = 1;
 
   oneof result {
     ProcessDone done = 2;

--- a/proto/cymbal/process/v1/process.proto
+++ b/proto/cymbal/process/v1/process.proto
@@ -1,15 +1,33 @@
 syntax = "proto3";
 package cymbal.process.v1;
 
-// CymbalProcess is the Node-facing Cymbal processing API. It accepts whole
-// canonical error-tracking events and returns one terminal outcome per item.
-service CymbalProcess {
+// ProcessStream is the Node-facing streaming Cymbal processing API. It accepts
+// whole canonical error-tracking events and returns one terminal outcome per item.
+service ProcessStream {
   // Process is a bidirectional stream of independent items. Outcomes may be
   // emitted out of input order, but every accepted item gets exactly one
   // terminal ProcessOutcome. Stream-level failures are reserved for protocol,
   // transport, or server-shutdown cases where item-level outcomes cannot be
-  // maintained.
+  // maintained. Callers that require input-order results should use ProcessBatch.
   rpc Process(stream ProcessItem) returns (stream ProcessOutcome);
+
+  // Subscribe opens a long-lived stream of service-state ticks for this Cymbal
+  // instance. Callers use the latest ServiceState to avoid routing new work to
+  // draining or overloaded instances.
+  rpc Subscribe(SubscribeRequest) returns (stream ServiceState);
+}
+
+// ProcessBatch is the Node-facing batch Cymbal processing API. It accepts a
+// finite batch and returns one terminal outcome per input item in input order.
+service ProcessBatch {
+  // Process returns outcomes in the same order as request.items. This keeps
+  // ordered ingestion frameworks simple at the cost of waiting for slower items
+  // before the batch response can complete.
+  rpc Process(ProcessBatchRequest) returns (ProcessBatchResponse);
+
+  // Subscribe opens a long-lived stream of service-state ticks for this Cymbal
+  // instance. It has the same semantics as ProcessStream.Subscribe.
+  rpc Subscribe(SubscribeRequest) returns (stream ServiceState);
 }
 
 // ProcessItem is one canonical event payload to process. The id is an opaque
@@ -22,6 +40,18 @@ message ProcessItem {
   // Serialized rust/cymbal AnyEvent JSON in the strict canonical shape already
   // accepted by Cymbal's HTTP /process boundary.
   bytes event_json = 2;
+}
+
+// ProcessBatchRequest is a finite ordered batch of process items.
+message ProcessBatchRequest {
+  repeated ProcessItem items = 1;
+}
+
+// ProcessBatchResponse contains exactly one outcome for each request item, in
+// the same order as ProcessBatchRequest.items. Individual outcomes still echo
+// the caller-provided item id.
+message ProcessBatchResponse {
+  repeated ProcessOutcome outcomes = 1;
 }
 
 // ProcessOutcome is the terminal result for one ProcessItem. Exactly one of
@@ -88,4 +118,43 @@ enum ProcessErrorCode {
   PROCESS_ERROR_CODE_INTERNAL = 5;
   PROCESS_ERROR_CODE_OVERLOADED = 6;
   PROCESS_ERROR_CODE_UNIMPLEMENTED = 7;
+}
+
+// SubscribeRequest opens a long-lived stream of ServiceState ticks. Callers
+// describe themselves for logs and may hint a cadence, but the server has the
+// final say so a misbehaving caller cannot induce excess work.
+message SubscribeRequest {
+  // Free-form identifier for the subscribing process. Used in server logs and
+  // metrics labels; not interpreted otherwise. Recommended format is
+  // `<service>/<instance>`.
+  string subscriber_id = 1;
+  // Caller-preferred tick cadence, in milliseconds. The server may clamp this
+  // to a safe range; a zero value means "use the server default". This is a
+  // hint and not a contract.
+  uint32 tick_hint_ms = 2;
+}
+
+// ServiceState is one freshness/load/draining tick. Emitted independently of
+// Process work. Callers should treat the latest ServiceState per endpoint as the
+// routing-relevant snapshot.
+message ServiceState {
+  // Stable identity of the Cymbal pod that emitted this event.
+  string service_instance_id = 1;
+  // True when the pod is preparing to shut down. Routers should stop sending
+  // new work; in-flight requests are still served.
+  bool draining = 2;
+  // True when the stream API should receive new work.
+  bool accepting_stream = 3;
+  // True when the batch API should receive new work.
+  bool accepting_batch = 4;
+  // Current process-wide item load, if known.
+  uint32 in_flight_items = 5;
+  // Configured process-wide item capacity, if known. A zero value means the
+  // service did not report a capacity.
+  uint32 max_in_flight_items = 6;
+  // Monotonic per-subscription sequence assigned by the server, starting at 1
+  // for the first tick of each Subscribe stream.
+  uint64 sequence = 7;
+  // Optional short human-readable note. Not interpreted by the router.
+  string message = 8;
 }

--- a/proto/cymbal/process/v1/process.proto
+++ b/proto/cymbal/process/v1/process.proto
@@ -33,6 +33,9 @@ message ProcessItem {
   // Serialized rust/cymbal AnyEvent JSON in the strict canonical shape already
   // accepted by Cymbal's HTTP /process boundary.
   bytes event_json = 2;
+  // Time allocated to process this item, in milliseconds. A zero value expires
+  // immediately.
+  uint32 timeout_ms = 3;
 }
 
 // ProcessBatchRequest is a finite ordered batch of process items.

--- a/rust/cymbal-proto/build.rs
+++ b/rust/cymbal-proto/build.rs
@@ -5,9 +5,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_server(true)
         .build_client(true)
         .compile_protos(
-            &[format!(
-                "{proto_root}/cymbal/resolution/v1/resolution.proto"
-            )],
+            &[
+                format!("{proto_root}/cymbal/resolution/v1/resolution.proto"),
+                format!("{proto_root}/cymbal/process/v1/process.proto"),
+            ],
             &[proto_root],
         )?;
     Ok(())

--- a/rust/cymbal-proto/src/lib.rs
+++ b/rust/cymbal-proto/src/lib.rs
@@ -1,4 +1,10 @@
 pub mod cymbal {
+    pub mod process {
+        pub mod v1 {
+            tonic::include_proto!("cymbal.process.v1");
+        }
+    }
+
     pub mod resolution {
         pub mod v1 {
             tonic::include_proto!("cymbal.resolution.v1");

--- a/rust/cymbal-proto/tests/contract.rs
+++ b/rust/cymbal-proto/tests/contract.rs
@@ -204,8 +204,7 @@ fn process_subscribe_reports_service_state() {
     let state = ServiceState {
         service_instance_id: "cymbal/pod-1".to_string(),
         draining: false,
-        accepting_stream: true,
-        accepting_batch: true,
+        healthy: true,
         in_flight_items: 7,
         max_in_flight_items: 128,
         sequence: 3,
@@ -220,8 +219,7 @@ fn process_subscribe_reports_service_state() {
     assert_eq!(decoded_request.tick_hint_ms, 500);
     assert_eq!(decoded_state.service_instance_id, "cymbal/pod-1");
     assert!(!decoded_state.draining);
-    assert!(decoded_state.accepting_stream);
-    assert!(decoded_state.accepting_batch);
+    assert!(decoded_state.healthy);
     assert_eq!(decoded_state.in_flight_items, 7);
     assert_eq!(decoded_state.max_in_flight_items, 128);
     assert_eq!(decoded_state.sequence, 3);

--- a/rust/cymbal-proto/tests/contract.rs
+++ b/rust/cymbal-proto/tests/contract.rs
@@ -1,11 +1,12 @@
 use cymbal_proto::cymbal::{
     process::v1::{
-        process_outcome, ProcessDone, ProcessDrop, ProcessDropReason, ProcessError,
-        ProcessErrorCode, ProcessErrorKind, ProcessItem, ProcessOutcome,
+        process_outcome, ProcessBatchRequest, ProcessBatchResponse, ProcessDone, ProcessDrop,
+        ProcessDropReason, ProcessError, ProcessErrorCode, ProcessErrorKind, ProcessItem,
+        ProcessOutcome, ServiceState, SubscribeRequest as ProcessSubscribeRequest,
     },
     resolution::v1::{
         resolve_outcome, Accepted, Done, Error, ErrorKind, LoadEvent, ResolveItem, ResolveOutcome,
-        Retry, SubscribeRequest,
+        Retry, SubscribeRequest as ResolutionSubscribeRequest,
     },
 };
 use prost::Message;
@@ -148,6 +149,79 @@ fn process_error_round_trips_retry_after_hint() {
 }
 
 #[test]
+fn process_batch_preserves_input_order_contract() {
+    let request = ProcessBatchRequest {
+        items: vec![
+            ProcessItem {
+                id: "first".to_string(),
+                event_json: br#"{"event":"$exception","properties":{"first":true}}"#.to_vec(),
+            },
+            ProcessItem {
+                id: "second".to_string(),
+                event_json: br#"{"event":"$exception","properties":{"second":true}}"#.to_vec(),
+            },
+        ],
+    };
+    let response = ProcessBatchResponse {
+        outcomes: vec![
+            ProcessOutcome {
+                id: "first".to_string(),
+                result: Some(process_outcome::Result::Done(ProcessDone {
+                    processed_event_json: br#"{"properties":{"first":true}}"#.to_vec(),
+                })),
+            },
+            ProcessOutcome {
+                id: "second".to_string(),
+                result: Some(process_outcome::Result::Drop(ProcessDrop {
+                    reason: ProcessDropReason::SuppressedIssue as i32,
+                })),
+            },
+        ],
+    };
+
+    let decoded_request = ProcessBatchRequest::decode(request.encode_to_vec().as_slice()).unwrap();
+    let decoded_response =
+        ProcessBatchResponse::decode(response.encode_to_vec().as_slice()).unwrap();
+
+    assert_eq!(decoded_request.items[0].id, "first");
+    assert_eq!(decoded_request.items[1].id, "second");
+    assert_eq!(decoded_response.outcomes[0].id, "first");
+    assert_eq!(decoded_response.outcomes[1].id, "second");
+}
+
+#[test]
+fn process_subscribe_reports_service_state() {
+    let request = ProcessSubscribeRequest {
+        subscriber_id: "node/error-tracking-1".to_string(),
+        tick_hint_ms: 500,
+    };
+    let state = ServiceState {
+        service_instance_id: "cymbal/pod-1".to_string(),
+        draining: false,
+        accepting_stream: true,
+        accepting_batch: true,
+        in_flight_items: 7,
+        max_in_flight_items: 128,
+        sequence: 3,
+        message: "ready".to_string(),
+    };
+
+    let decoded_request =
+        ProcessSubscribeRequest::decode(request.encode_to_vec().as_slice()).unwrap();
+    let decoded_state = ServiceState::decode(state.encode_to_vec().as_slice()).unwrap();
+
+    assert_eq!(decoded_request.subscriber_id, "node/error-tracking-1");
+    assert_eq!(decoded_request.tick_hint_ms, 500);
+    assert_eq!(decoded_state.service_instance_id, "cymbal/pod-1");
+    assert!(!decoded_state.draining);
+    assert!(decoded_state.accepting_stream);
+    assert!(decoded_state.accepting_batch);
+    assert_eq!(decoded_state.in_flight_items, 7);
+    assert_eq!(decoded_state.max_in_flight_items, 128);
+    assert_eq!(decoded_state.sequence, 3);
+}
+
+#[test]
 fn resolve_item_serializes_exception_payload_with_correlation_id_and_deadline() {
     let item = ResolveItem {
         id: 7,
@@ -244,12 +318,12 @@ fn resolve_outcome_echoes_id_and_carries_done_error_or_retry() {
 
 #[test]
 fn subscribe_request_round_trips_caller_hint_and_identity() {
-    let request = SubscribeRequest {
+    let request = ResolutionSubscribeRequest {
         subscriber_id: "cymbal/pod-1".to_string(),
         tick_hint_ms: 500,
     };
 
-    let decoded = SubscribeRequest::decode(request.encode_to_vec().as_slice()).unwrap();
+    let decoded = ResolutionSubscribeRequest::decode(request.encode_to_vec().as_slice()).unwrap();
 
     assert_eq!(decoded.subscriber_id, "cymbal/pod-1");
     assert_eq!(decoded.tick_hint_ms, 500);

--- a/rust/cymbal-proto/tests/contract.rs
+++ b/rust/cymbal-proto/tests/contract.rs
@@ -16,6 +16,7 @@ fn process_item_serializes_canonical_event_with_opaque_id() {
     let item = ProcessItem {
         id: "caller-1".to_string(),
         event_json: br#"{"uuid":"0198f1d7-26fb-7f17-9b75-4377002fe472","event":"$exception","team_id":42,"timestamp":"2026-01-01T00:00:00Z","properties":{"$exception_list":[]}}"#.to_vec(),
+        timeout_ms: 1_500,
     };
 
     let decoded = ProcessItem::decode(item.encode_to_vec().as_slice()).unwrap();
@@ -25,6 +26,7 @@ fn process_item_serializes_canonical_event_with_opaque_id() {
         decoded.event_json,
         br#"{"uuid":"0198f1d7-26fb-7f17-9b75-4377002fe472","event":"$exception","team_id":42,"timestamp":"2026-01-01T00:00:00Z","properties":{"$exception_list":[]}}"#
     );
+    assert_eq!(decoded.timeout_ms, 1_500);
 }
 
 #[test]
@@ -102,10 +104,12 @@ fn process_contract_allows_duplicate_ids() {
         ProcessItem {
             id: "duplicate".to_string(),
             event_json: br#"{"event":"$exception","properties":{}}"#.to_vec(),
+            timeout_ms: 100,
         },
         ProcessItem {
             id: "duplicate".to_string(),
             event_json: br#"{"event":"$exception","properties":{"second":true}}"#.to_vec(),
+            timeout_ms: 200,
         },
     ];
 
@@ -117,6 +121,8 @@ fn process_contract_allows_duplicate_ids() {
     assert_eq!(decoded[0].id, "duplicate");
     assert_eq!(decoded[1].id, "duplicate");
     assert_ne!(decoded[0].event_json, decoded[1].event_json);
+    assert_eq!(decoded[0].timeout_ms, 100);
+    assert_eq!(decoded[1].timeout_ms, 200);
 }
 
 #[test]
@@ -155,10 +161,12 @@ fn process_batch_preserves_input_order_contract() {
             ProcessItem {
                 id: "first".to_string(),
                 event_json: br#"{"event":"$exception","properties":{"first":true}}"#.to_vec(),
+                timeout_ms: 1_000,
             },
             ProcessItem {
                 id: "second".to_string(),
                 event_json: br#"{"event":"$exception","properties":{"second":true}}"#.to_vec(),
+                timeout_ms: 2_000,
             },
         ],
     };
@@ -184,7 +192,9 @@ fn process_batch_preserves_input_order_contract() {
         ProcessBatchResponse::decode(response.encode_to_vec().as_slice()).unwrap();
 
     assert_eq!(decoded_request.items[0].id, "first");
+    assert_eq!(decoded_request.items[0].timeout_ms, 1_000);
     assert_eq!(decoded_request.items[1].id, "second");
+    assert_eq!(decoded_request.items[1].timeout_ms, 2_000);
     assert_eq!(decoded_response.outcomes[0].id, "first");
     assert_eq!(decoded_response.outcomes[1].id, "second");
 }

--- a/rust/cymbal-proto/tests/contract.rs
+++ b/rust/cymbal-proto/tests/contract.rs
@@ -11,15 +11,15 @@ use cymbal_proto::cymbal::{
 use prost::Message;
 
 #[test]
-fn process_item_serializes_canonical_event_with_opaque_correlation_id() {
+fn process_item_serializes_canonical_event_with_opaque_id() {
     let item = ProcessItem {
-        caller_correlation_id: "caller-1".to_string(),
+        id: "caller-1".to_string(),
         event_json: br#"{"uuid":"0198f1d7-26fb-7f17-9b75-4377002fe472","event":"$exception","team_id":42,"timestamp":"2026-01-01T00:00:00Z","properties":{"$exception_list":[]}}"#.to_vec(),
     };
 
     let decoded = ProcessItem::decode(item.encode_to_vec().as_slice()).unwrap();
 
-    assert_eq!(decoded.caller_correlation_id, "caller-1");
+    assert_eq!(decoded.id, "caller-1");
     assert_eq!(
         decoded.event_json,
         br#"{"uuid":"0198f1d7-26fb-7f17-9b75-4377002fe472","event":"$exception","team_id":42,"timestamp":"2026-01-01T00:00:00Z","properties":{"$exception_list":[]}}"#
@@ -30,20 +30,20 @@ fn process_item_serializes_canonical_event_with_opaque_correlation_id() {
 fn process_outcome_carries_exactly_one_terminal_variant() {
     let outcomes = [
         ProcessOutcome {
-            caller_correlation_id: "done-1".to_string(),
+            id: "done-1".to_string(),
             result: Some(process_outcome::Result::Done(ProcessDone {
                 processed_event_json: br#"{"event":"$exception","properties":{"resolved":true}}"#
                     .to_vec(),
             })),
         },
         ProcessOutcome {
-            caller_correlation_id: "drop-1".to_string(),
+            id: "drop-1".to_string(),
             result: Some(process_outcome::Result::Drop(ProcessDrop {
                 reason: ProcessDropReason::SuppressionRule as i32,
             })),
         },
         ProcessOutcome {
-            caller_correlation_id: "error-1".to_string(),
+            id: "error-1".to_string(),
             result: Some(process_outcome::Result::Error(ProcessError {
                 kind: ProcessErrorKind::Invalid as i32,
                 code: ProcessErrorCode::InvalidPayload as i32,
@@ -96,14 +96,14 @@ fn process_enums_keep_initial_wire_values() {
 }
 
 #[test]
-fn process_contract_allows_duplicate_caller_correlation_ids() {
+fn process_contract_allows_duplicate_ids() {
     let items = [
         ProcessItem {
-            caller_correlation_id: "duplicate".to_string(),
+            id: "duplicate".to_string(),
             event_json: br#"{"event":"$exception","properties":{}}"#.to_vec(),
         },
         ProcessItem {
-            caller_correlation_id: "duplicate".to_string(),
+            id: "duplicate".to_string(),
             event_json: br#"{"event":"$exception","properties":{"second":true}}"#.to_vec(),
         },
     ];
@@ -113,15 +113,15 @@ fn process_contract_allows_duplicate_caller_correlation_ids() {
         .map(|item| ProcessItem::decode(item.encode_to_vec().as_slice()).unwrap())
         .collect();
 
-    assert_eq!(decoded[0].caller_correlation_id, "duplicate");
-    assert_eq!(decoded[1].caller_correlation_id, "duplicate");
+    assert_eq!(decoded[0].id, "duplicate");
+    assert_eq!(decoded[1].id, "duplicate");
     assert_ne!(decoded[0].event_json, decoded[1].event_json);
 }
 
 #[test]
 fn process_error_round_trips_retry_after_hint() {
     let outcome = ProcessOutcome {
-        caller_correlation_id: "retryable-1".to_string(),
+        id: "retryable-1".to_string(),
         result: Some(process_outcome::Result::Error(ProcessError {
             kind: ProcessErrorKind::Dependency as i32,
             code: ProcessErrorCode::DependencyUnavailable as i32,

--- a/rust/cymbal-proto/tests/contract.rs
+++ b/rust/cymbal-proto/tests/contract.rs
@@ -1,8 +1,151 @@
-use cymbal_proto::cymbal::resolution::v1::{
-    resolve_outcome, Accepted, Done, Error, ErrorKind, LoadEvent, ResolveItem, ResolveOutcome,
-    Retry, SubscribeRequest,
+use cymbal_proto::cymbal::{
+    process::v1::{
+        process_outcome, ProcessDone, ProcessDrop, ProcessDropReason, ProcessError,
+        ProcessErrorCode, ProcessErrorKind, ProcessItem, ProcessOutcome,
+    },
+    resolution::v1::{
+        resolve_outcome, Accepted, Done, Error, ErrorKind, LoadEvent, ResolveItem, ResolveOutcome,
+        Retry, SubscribeRequest,
+    },
 };
 use prost::Message;
+
+#[test]
+fn process_item_serializes_canonical_event_with_opaque_correlation_id() {
+    let item = ProcessItem {
+        caller_correlation_id: "caller-1".to_string(),
+        event_json: br#"{"uuid":"0198f1d7-26fb-7f17-9b75-4377002fe472","event":"$exception","team_id":42,"timestamp":"2026-01-01T00:00:00Z","properties":{"$exception_list":[]}}"#.to_vec(),
+    };
+
+    let decoded = ProcessItem::decode(item.encode_to_vec().as_slice()).unwrap();
+
+    assert_eq!(decoded.caller_correlation_id, "caller-1");
+    assert_eq!(
+        decoded.event_json,
+        br#"{"uuid":"0198f1d7-26fb-7f17-9b75-4377002fe472","event":"$exception","team_id":42,"timestamp":"2026-01-01T00:00:00Z","properties":{"$exception_list":[]}}"#
+    );
+}
+
+#[test]
+fn process_outcome_carries_exactly_one_terminal_variant() {
+    let outcomes = [
+        ProcessOutcome {
+            caller_correlation_id: "done-1".to_string(),
+            result: Some(process_outcome::Result::Done(ProcessDone {
+                processed_event_json: br#"{"event":"$exception","properties":{"resolved":true}}"#
+                    .to_vec(),
+            })),
+        },
+        ProcessOutcome {
+            caller_correlation_id: "drop-1".to_string(),
+            result: Some(process_outcome::Result::Drop(ProcessDrop {
+                reason: ProcessDropReason::SuppressionRule as i32,
+            })),
+        },
+        ProcessOutcome {
+            caller_correlation_id: "error-1".to_string(),
+            result: Some(process_outcome::Result::Error(ProcessError {
+                kind: ProcessErrorKind::Invalid as i32,
+                code: ProcessErrorCode::InvalidPayload as i32,
+                retryable: false,
+                retry_after_ms: 0,
+                message: "event_json could not be decoded".to_string(),
+                details_json: b"{}".to_vec(),
+            })),
+        },
+    ];
+
+    let decoded: Vec<ProcessOutcome> = outcomes
+        .iter()
+        .map(|outcome| ProcessOutcome::decode(outcome.encode_to_vec().as_slice()).unwrap())
+        .collect();
+
+    assert!(matches!(
+        decoded[0].result,
+        Some(process_outcome::Result::Done(_))
+    ));
+    assert!(matches!(
+        decoded[1].result,
+        Some(process_outcome::Result::Drop(ProcessDrop {
+            reason,
+        })) if reason == ProcessDropReason::SuppressionRule as i32
+    ));
+    assert!(matches!(
+        decoded[2].result,
+        Some(process_outcome::Result::Error(ProcessError {
+            kind,
+            code,
+            retryable: false,
+            ..
+        })) if kind == ProcessErrorKind::Invalid as i32
+            && code == ProcessErrorCode::InvalidPayload as i32
+    ));
+}
+
+#[test]
+fn process_enums_keep_initial_wire_values() {
+    assert_eq!(ProcessDropReason::SuppressedIssue as i32, 1);
+    assert_eq!(ProcessDropReason::SuppressionRule as i32, 2);
+    assert_eq!(ProcessErrorKind::Invalid as i32, 1);
+    assert_eq!(ProcessErrorKind::Processing as i32, 2);
+    assert_eq!(ProcessErrorKind::Timeout as i32, 3);
+    assert_eq!(ProcessErrorKind::Dependency as i32, 4);
+    assert_eq!(ProcessErrorKind::Internal as i32, 5);
+    assert_eq!(ProcessErrorCode::InvalidPayload as i32, 1);
+    assert_eq!(ProcessErrorCode::Unimplemented as i32, 7);
+}
+
+#[test]
+fn process_contract_allows_duplicate_caller_correlation_ids() {
+    let items = [
+        ProcessItem {
+            caller_correlation_id: "duplicate".to_string(),
+            event_json: br#"{"event":"$exception","properties":{}}"#.to_vec(),
+        },
+        ProcessItem {
+            caller_correlation_id: "duplicate".to_string(),
+            event_json: br#"{"event":"$exception","properties":{"second":true}}"#.to_vec(),
+        },
+    ];
+
+    let decoded: Vec<ProcessItem> = items
+        .iter()
+        .map(|item| ProcessItem::decode(item.encode_to_vec().as_slice()).unwrap())
+        .collect();
+
+    assert_eq!(decoded[0].caller_correlation_id, "duplicate");
+    assert_eq!(decoded[1].caller_correlation_id, "duplicate");
+    assert_ne!(decoded[0].event_json, decoded[1].event_json);
+}
+
+#[test]
+fn process_error_round_trips_retry_after_hint() {
+    let outcome = ProcessOutcome {
+        caller_correlation_id: "retryable-1".to_string(),
+        result: Some(process_outcome::Result::Error(ProcessError {
+            kind: ProcessErrorKind::Dependency as i32,
+            code: ProcessErrorCode::DependencyUnavailable as i32,
+            retryable: true,
+            retry_after_ms: 250,
+            message: "dependency unavailable".to_string(),
+            details_json: br#"{"safe":true}"#.to_vec(),
+        })),
+    };
+
+    let decoded = ProcessOutcome::decode(outcome.encode_to_vec().as_slice()).unwrap();
+
+    assert!(matches!(
+        decoded.result,
+        Some(process_outcome::Result::Error(ProcessError {
+            kind,
+            code,
+            retryable: true,
+            retry_after_ms: 250,
+            ..
+        })) if kind == ProcessErrorKind::Dependency as i32
+            && code == ProcessErrorCode::DependencyUnavailable as i32
+    ));
+}
 
 #[test]
 fn resolve_item_serializes_exception_payload_with_correlation_id_and_deadline() {

--- a/rust/cymbal-proto/tests/contract.rs
+++ b/rust/cymbal-proto/tests/contract.rs
@@ -16,7 +16,7 @@ fn process_item_serializes_canonical_event_with_opaque_id() {
     let item = ProcessItem {
         id: "caller-1".to_string(),
         event_json: br#"{"uuid":"0198f1d7-26fb-7f17-9b75-4377002fe472","event":"$exception","team_id":42,"timestamp":"2026-01-01T00:00:00Z","properties":{"$exception_list":[]}}"#.to_vec(),
-        timeout_ms: 1_500,
+        timeout_ms: Some(1_500),
     };
 
     let decoded = ProcessItem::decode(item.encode_to_vec().as_slice()).unwrap();
@@ -26,7 +26,7 @@ fn process_item_serializes_canonical_event_with_opaque_id() {
         decoded.event_json,
         br#"{"uuid":"0198f1d7-26fb-7f17-9b75-4377002fe472","event":"$exception","team_id":42,"timestamp":"2026-01-01T00:00:00Z","properties":{"$exception_list":[]}}"#
     );
-    assert_eq!(decoded.timeout_ms, 1_500);
+    assert_eq!(decoded.timeout_ms, Some(1_500));
 }
 
 #[test]
@@ -104,12 +104,12 @@ fn process_contract_allows_duplicate_ids() {
         ProcessItem {
             id: "duplicate".to_string(),
             event_json: br#"{"event":"$exception","properties":{}}"#.to_vec(),
-            timeout_ms: 100,
+            timeout_ms: Some(100),
         },
         ProcessItem {
             id: "duplicate".to_string(),
             event_json: br#"{"event":"$exception","properties":{"second":true}}"#.to_vec(),
-            timeout_ms: 200,
+            timeout_ms: Some(200),
         },
     ];
 
@@ -121,8 +121,8 @@ fn process_contract_allows_duplicate_ids() {
     assert_eq!(decoded[0].id, "duplicate");
     assert_eq!(decoded[1].id, "duplicate");
     assert_ne!(decoded[0].event_json, decoded[1].event_json);
-    assert_eq!(decoded[0].timeout_ms, 100);
-    assert_eq!(decoded[1].timeout_ms, 200);
+    assert_eq!(decoded[0].timeout_ms, Some(100));
+    assert_eq!(decoded[1].timeout_ms, Some(200));
 }
 
 #[test]
@@ -161,14 +161,15 @@ fn process_batch_preserves_input_order_contract() {
             ProcessItem {
                 id: "first".to_string(),
                 event_json: br#"{"event":"$exception","properties":{"first":true}}"#.to_vec(),
-                timeout_ms: 1_000,
+                timeout_ms: Some(1_000),
             },
             ProcessItem {
                 id: "second".to_string(),
                 event_json: br#"{"event":"$exception","properties":{"second":true}}"#.to_vec(),
-                timeout_ms: 2_000,
+                timeout_ms: Some(2_000),
             },
         ],
+        timeout_ms: Some(3_000),
     };
     let response = ProcessBatchResponse {
         outcomes: vec![
@@ -191,10 +192,11 @@ fn process_batch_preserves_input_order_contract() {
     let decoded_response =
         ProcessBatchResponse::decode(response.encode_to_vec().as_slice()).unwrap();
 
+    assert_eq!(decoded_request.timeout_ms, Some(3_000));
     assert_eq!(decoded_request.items[0].id, "first");
-    assert_eq!(decoded_request.items[0].timeout_ms, 1_000);
+    assert_eq!(decoded_request.items[0].timeout_ms, Some(1_000));
     assert_eq!(decoded_request.items[1].id, "second");
-    assert_eq!(decoded_request.items[1].timeout_ms, 2_000);
+    assert_eq!(decoded_request.items[1].timeout_ms, Some(2_000));
     assert_eq!(decoded_response.outcomes[0].id, "first");
     assert_eq!(decoded_response.outcomes[1].id, "second");
 }

--- a/rust/cymbal-proto/tests/contract.rs
+++ b/rust/cymbal-proto/tests/contract.rs
@@ -205,8 +205,6 @@ fn process_subscribe_reports_service_state() {
         service_instance_id: "cymbal/pod-1".to_string(),
         draining: false,
         healthy: true,
-        in_flight_items: 7,
-        max_in_flight_items: 128,
         sequence: 3,
         message: "ready".to_string(),
     };
@@ -220,8 +218,6 @@ fn process_subscribe_reports_service_state() {
     assert_eq!(decoded_state.service_instance_id, "cymbal/pod-1");
     assert!(!decoded_state.draining);
     assert!(decoded_state.healthy);
-    assert_eq!(decoded_state.in_flight_items, 7);
-    assert_eq!(decoded_state.max_in_flight_items, 128);
     assert_eq!(decoded_state.sequence, 3);
 }
 

--- a/rust/cymbal-proto/tests/contract.rs
+++ b/rust/cymbal-proto/tests/contract.rs
@@ -1,8 +1,8 @@
 use cymbal_proto::cymbal::{
     process::v1::{
         process_outcome, ProcessBatchRequest, ProcessBatchResponse, ProcessDone, ProcessDrop,
-        ProcessDropReason, ProcessError, ProcessErrorCode, ProcessErrorKind, ProcessItem,
-        ProcessOutcome, ServiceState, SubscribeRequest as ProcessSubscribeRequest,
+        ProcessDropReason, ProcessError, ProcessErrorKind, ProcessItem, ProcessOutcome,
+        ServiceState, SubscribeRequest as ProcessSubscribeRequest,
     },
     resolution::v1::{
         resolve_outcome, Accepted, Done, Error, ErrorKind, LoadEvent, ResolveItem, ResolveOutcome,
@@ -48,8 +48,7 @@ fn process_outcome_carries_exactly_one_terminal_variant() {
         ProcessOutcome {
             id: "error-1".to_string(),
             result: Some(process_outcome::Result::Error(ProcessError {
-                kind: ProcessErrorKind::Invalid as i32,
-                code: ProcessErrorCode::InvalidPayload as i32,
+                kind: ProcessErrorKind::InvalidPayload as i32,
                 retryable: false,
                 retry_after_ms: 0,
                 message: "event_json could not be decoded".to_string(),
@@ -77,11 +76,9 @@ fn process_outcome_carries_exactly_one_terminal_variant() {
         decoded[2].result,
         Some(process_outcome::Result::Error(ProcessError {
             kind,
-            code,
             retryable: false,
             ..
-        })) if kind == ProcessErrorKind::Invalid as i32
-            && code == ProcessErrorCode::InvalidPayload as i32
+        })) if kind == ProcessErrorKind::InvalidPayload as i32
     ));
 }
 
@@ -89,13 +86,13 @@ fn process_outcome_carries_exactly_one_terminal_variant() {
 fn process_enums_keep_initial_wire_values() {
     assert_eq!(ProcessDropReason::SuppressedIssue as i32, 1);
     assert_eq!(ProcessDropReason::SuppressionRule as i32, 2);
-    assert_eq!(ProcessErrorKind::Invalid as i32, 1);
-    assert_eq!(ProcessErrorKind::Processing as i32, 2);
+    assert_eq!(ProcessErrorKind::InvalidPayload as i32, 1);
+    assert_eq!(ProcessErrorKind::ProcessingFailed as i32, 2);
     assert_eq!(ProcessErrorKind::Timeout as i32, 3);
-    assert_eq!(ProcessErrorKind::Dependency as i32, 4);
+    assert_eq!(ProcessErrorKind::DependencyUnavailable as i32, 4);
     assert_eq!(ProcessErrorKind::Internal as i32, 5);
-    assert_eq!(ProcessErrorCode::InvalidPayload as i32, 1);
-    assert_eq!(ProcessErrorCode::Unimplemented as i32, 7);
+    assert_eq!(ProcessErrorKind::Overloaded as i32, 6);
+    assert_eq!(ProcessErrorKind::Unimplemented as i32, 7);
 }
 
 #[test]
@@ -130,8 +127,7 @@ fn process_error_round_trips_retry_after_hint() {
     let outcome = ProcessOutcome {
         id: "retryable-1".to_string(),
         result: Some(process_outcome::Result::Error(ProcessError {
-            kind: ProcessErrorKind::Dependency as i32,
-            code: ProcessErrorCode::DependencyUnavailable as i32,
+            kind: ProcessErrorKind::DependencyUnavailable as i32,
             retryable: true,
             retry_after_ms: 250,
             message: "dependency unavailable".to_string(),
@@ -145,12 +141,10 @@ fn process_error_round_trips_retry_after_hint() {
         decoded.result,
         Some(process_outcome::Result::Error(ProcessError {
             kind,
-            code,
             retryable: true,
             retry_after_ms: 250,
             ..
-        })) if kind == ProcessErrorKind::Dependency as i32
-            && code == ProcessErrorCode::DependencyUnavailable as i32
+        })) if kind == ProcessErrorKind::DependencyUnavailable as i32
     ));
 }
 


### PR DESCRIPTION
## Problem

Cymbal needs a Node-facing process API contract before the server and ingestion rollout work can be reviewed in smaller stacked PRs.

## Changes

- Adds the initial `cymbal.process.v1.CymbalProcess` bidirectional streaming proto contract.
- Models terminal `done`, `drop`, and `error` outcomes with enum-backed drop reasons and error taxonomy.
- Generates and exposes Rust bindings in `cymbal-proto`.
- Adds contract tests for message round trips, enum values, duplicate caller IDs, and retry hints.

## How did you test this code?

- `flox activate -- bash -c "cd rust && cargo test -p cymbal-proto"`
- `git diff --check`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

This is an internal service contract and does not require product docs.

## 🤖 Agent context

This PR was prepared with pi. It is the first PR in a planned stacked rollout for Cymbal's process gRPC API and intentionally contains only the proto contract plus Rust binding/tests so reviewers can validate the API surface before runtime changes.
