### PR TITLE
fix(data-warehouse): align temporalio FakeSettings with codec contract

### DIFF
--- a/posthog/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/temporalio.py
@@ -3,6 +3,7 @@ import asyncio
 import datetime
 import threading
 import dataclasses
+from collections.abc import Iterable
 from enum import StrEnum
 from queue import Queue
 from typing import Any, Optional
@@ -110,7 +111,10 @@ def _sanitize(obj):
 class FakeSettings:
     """Required to trick temporal.io client to think its reading from django settings"""
 
-    SECRET_KEY: str
+    TEMPORAL_SECRET_KEY: str | bytes
+    TEMPORAL_FALLBACK_KEYS: Iterable[str | bytes] = dataclasses.field(default_factory=list)
+    TEST: bool = False
+    DEBUG: bool = False
 
 
 async def _get_temporal_client(config: TemporalIOSourceConfig) -> Client:

--- a/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -1,0 +1,36 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from temporalio.client import Client
+
+from posthog.temporal.common.codec import EncryptionCodec
+from posthog.temporal.data_imports.sources.generated_configs import TemporalIOSourceConfig
+from posthog.temporal.data_imports.sources.temporalio.temporalio import FakeSettings, _get_temporal_client
+
+
+class TestTemporalIOClient:
+    def test_fake_settings_satisfies_encryption_codec_contract(self):
+        # FakeSettings must expose every attribute EncryptionCodec.from_settings reads
+        # (TEST, DEBUG, TEMPORAL_SECRET_KEY, TEMPORAL_FALLBACK_KEYS); a missing one raises
+        # AttributeError. The 32-byte key clears the prod (TEST=False) length guard.
+        codec = EncryptionCodec.from_settings(FakeSettings(TEMPORAL_SECRET_KEY="k" * 32))
+
+        assert isinstance(codec, EncryptionCodec)
+
+    async def test_get_temporal_client_builds_encryption_codec(self):
+        config = TemporalIOSourceConfig.from_dict(
+            {
+                "host": "host",
+                "port": "7233",
+                "namespace": "namespace",
+                "encryption_key": "k" * 32,
+                "server_client_root_ca": "ca",
+                "client_certificate": "cert",
+                "client_private_key": "key",
+            }
+        )
+
+        with patch.object(Client, "connect", new=AsyncMock(return_value=MagicMock())) as mock_connect:
+            await _get_temporal_client(config)
+
+        data_converter = mock_connect.call_args.kwargs["data_converter"]
+        assert isinstance(data_converter.payload_codec, EncryptionCodec)


### PR DESCRIPTION
## Problem

v3 data warehouse imports for the Temporal.io source fail at client construction with `AttributeError: 'FakeSettings' object has no attribute 'TEST'` whenever the source is configured with an encryption key.

The Temporal.io source builds its client through `posthog.temporal.common.client.connect(...)`, passing a local `FakeSettings` shim in place of Django settings so the encryption codec can be constructed. #61080 reworked `EncryptionCodec` to obtain its keys via `EncryptionCodec.from_settings(...)`, which now reads four attributes off the settings object (`TEMPORAL_SECRET_KEY`, `TEMPORAL_FALLBACK_KEYS`, `TEST`, `DEBUG`) instead of the old single `SECRET_KEY`. The `FakeSettings` shim was never updated, so it still only defined `SECRET_KEY` — and `from_settings` reads `.TEST` first, hence the crash.

## Changes

- Update `FakeSettings` in `posthog/temporal/data_imports/sources/temporalio/temporalio.py` to satisfy the codec's `_RequiredSettings` protocol: rename the now-dead `SECRET_KEY` field to `TEMPORAL_SECRET_KEY`, and add `TEMPORAL_FALLBACK_KEYS` (empty by default — the source has no key rotation), `TEST` and `DEBUG` (both default `False`, matching production Django settings). The call site is unchanged; the encryption key maps positionally to `TEMPORAL_SECRET_KEY`.
- Add `test_temporalio.py`: one test asserts `FakeSettings` satisfies the codec contract, the other exercises the full `_get_temporal_client` build path with `Client.connect` mocked.

Note: with `TEST`/`DEBUG` = `False`, the codec enforces its production guard that keys must be ≥ 32 bytes, so a shorter key now surfaces a clear `ValueError` instead of the previous `AttributeError`. This matches how real Django settings behave in production.

## How did you test this code?

I'm an agent (PostHog Code) and did **not** perform any manual testing — only the automated checks below:

- `hogli test posthog/temporal/data_imports/sources/temporalio/` → **2 passed**.
- Regression check: with the source fix reverted (tests kept), both new tests fail and reproduce the exact error (`AttributeError: 'FakeSettings' object has no attribute 'TEST'` at `codec.py:74`); with the fix applied they pass.
- `ruff check` + `ruff format` on the changed files: clean. Pre-commit lint-staged (ruff + type check) passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes — internal bug fix with no user-facing surface change.

## 🤖 Agent context

Authored by PostHog Code (Claude). Read-only exploration agents traced the bug, followed by code edits and tests.

- Root cause found via git history: `EncryptionCodec` was refactored in #61080 (settings contract changed from `SECRET_KEY` to `TEMPORAL_SECRET_KEY` + `TEMPORAL_FALLBACK_KEYS` + `TEST` + `DEBUG`), and the `FakeSettings` shim in the temporalio source was not updated to match.
- Chose to rename `SECRET_KEY` → `TEMPORAL_SECRET_KEY` rather than keep both, since nothing reads `SECRET_KEY` after the refactor. An initial proposal to also switch the call site to a keyword argument was dropped as unnecessary, keeping the diff minimal.
- `TEST`/`DEBUG` default to `False` to mirror production settings; confirmed this keeps the codec's ≥ 32-byte key guard active and flagged the resulting short-key behavior change in the description above.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
