### PR TITLE
fix: Show correct breakdown values on tooltips with formula mode

### DIFF
--- a/frontend/src/test/insight-testing/mocks.ts
+++ b/frontend/src/test/insight-testing/mocks.ts
@@ -27,7 +27,17 @@ export interface QueryBody {
         breakdowns?: Array<{ property?: string }>
         breakdown?: string
     }
+    trendsFilter?: {
+        formula?: string
+        formulas?: string[]
+        formulaNodes?: unknown[]
+    }
     [key: string]: unknown
+}
+
+function hasFormula(query: QueryBody): boolean {
+    const tf = query.trendsFilter
+    return !!(tf?.formula || tf?.formulas?.length || tf?.formulaNodes?.length)
 }
 
 interface FunnelsQueryResponseLike {
@@ -66,27 +76,35 @@ export function buildActorsResponse(
     } as ActorsQueryResponse
 }
 
-function buildTrendsResponse(series: SeriesData[]): TrendsQueryResponse {
+// `isFormula` only models the single-formula shape: the real runner combines series per
+// formula (`action: null`, `order` = formula index). This mock doesn't combine series, so
+// it stamps `order: 0` on every row, which works for a single formula. A future multi-formula
+// test would need this to derive the formula index per row (0 for A, 1 for B, …).
+function buildTrendsResponse(series: SeriesData[], opts: { isFormula?: boolean } = {}): TrendsQueryResponse {
     return {
-        results: series.map((s, i) => ({
-            action: {
-                id: `$${s.label.toLowerCase().replace(/\s+/g, '_')}`,
-                type: 'events',
-                name: s.label,
-                // Breakdown rows of a single series share the series' order (as the real query
-                // runner does); only distinct series get distinct orders.
-                order: s.compare || s.breakdown_value != null ? 0 : i,
-            },
-            label: s.label,
-            count: s.data.reduce((a, b) => a + b, 0),
-            aggregated_value: s.data.reduce((a, b) => a + b, 0),
-            data: s.data,
-            labels: s.labels ?? s.data.map((_, j) => `Day ${j + 1}`),
-            days: s.days ?? s.data.map((_, j) => `2024-01-0${j + 1}`),
-            breakdown_value: s.breakdown_value,
-            compare: s.compare,
-            compare_label: s.compare_label,
-        })),
+        results: series.map((s, i) => {
+            const seriesOrder = s.compare || s.breakdown_value != null ? 0 : i
+            return {
+                action: opts.isFormula
+                    ? null
+                    : {
+                          id: `$${s.label.toLowerCase().replace(/\s+/g, '_')}`,
+                          type: 'events',
+                          name: s.label,
+                          order: seriesOrder,
+                      },
+                order: opts.isFormula ? 0 : seriesOrder,
+                label: s.label,
+                count: s.data.reduce((a, b) => a + b, 0),
+                aggregated_value: s.data.reduce((a, b) => a + b, 0),
+                data: s.data,
+                labels: s.labels ?? s.data.map((_, j) => `Day ${j + 1}`),
+                days: s.days ?? s.data.map((_, j) => `2024-01-0${j + 1}`),
+                breakdown_value: s.breakdown_value,
+                compare: s.compare,
+                compare_label: s.compare_label,
+            }
+        }),
     } as TrendsQueryResponse
 }
 
@@ -217,7 +235,7 @@ export function setupInsightMocks({
     const defaults: MockResponse[] = [
         {
             match: (query) => query.kind === NodeKind.TrendsQuery,
-            response: (query) => buildTrendsResponse(resolveSeriesData(query)),
+            response: (query) => buildTrendsResponse(resolveSeriesData(query), { isFormula: hasFormula(query) }),
         },
         {
             match: (query) => query.kind === NodeKind.StickinessQuery,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3260,6 +3260,10 @@ export interface TrendResult {
     persons_urls?: { url: string }[]
     persons?: Person
     filter?: TrendsFilterType
+    /** Series order set by the query runner: the action order for plain series, or the
+     * formula index for formula results (uniform across a formula's breakdown rows).
+     * Unlike `action.order`, this is always populated — formula results carry `action: null`. */
+    order?: number
 }
 
 interface Person {

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
@@ -116,6 +116,24 @@ describe('TrendsLineChart', () => {
             expect(tooltip.row('Spike')).toContain('3')
         })
 
+        it('shows every breakdown value when a formula is applied', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    series: [{ kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' }],
+                    breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
+                    trendsFilter: { formula: 'A' },
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            await chart.clickAtIndex(2)
+
+            const tooltip = createInsightTooltipAccessor(chart.getTooltip()!)
+            expect(tooltip.row('Spike')).toContain('3')
+            expect(tooltip.row('Bramble')).toContain('1')
+            expect(tooltip.row('Prickles')).toContain('1')
+        })
+
         it('shows current and previous period rows in compare mode', async () => {
             renderInsight({
                 query: buildTrendsQuery({

--- a/products/product_analytics/frontend/insights/trends/shared/trendsSeriesMeta.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/trendsSeriesMeta.ts
@@ -23,7 +23,7 @@ export const buildTrendsSeriesMeta = (r: IndexedTrendResult): TrendsSeriesMeta =
     breakdown_value: r.breakdown_value,
     compare_label: r.compare_label,
     days: r.days,
-    order: r.action?.order ?? r.id,
+    order: r.order ?? r.action?.order ?? 0,
     filter: r.filter,
 })
 


### PR DESCRIPTION
## Problem

With formula mode enabled, tooltips for charts with breakdowns were displaying a '-' for all breakdown values except the first.

## Changes

Read the same top-level order the legacy path uses, and never fall back to the per-row r.id, i.e. `order: r.order ?? r.action?.order ?? 0`

## How did you test this code?

Unit test + local testing