### PR TITLE
feat(error-tracking): add cymbal process grpc skeleton

### DIFF
--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -47,6 +47,7 @@ pub struct AppContext {
     pub symbol_resolver: Arc<dyn SymbolResolver>,
     pub symbol_resolution_limiter: Arc<Semaphore>,
     pub process_request_limiter: Arc<Semaphore>,
+    pub process_grpc_item_limiter: Arc<Semaphore>,
     /// When set, cymbal's resolution stage routes exception resolution to the
     /// remote `cymbal-resolution` service pool instead of running the local
     /// resolver. Built once at startup; the endpoint pool refreshes itself in
@@ -265,6 +266,9 @@ impl AppContext {
             Arc::new(Semaphore::new(config.symbol_resolution_concurrency.max(1)));
         let process_request_limiter =
             Arc::new(Semaphore::new(config.process_max_in_flight_requests.max(1)));
+        let process_grpc_item_limiter = Arc::new(Semaphore::new(
+            config.process_grpc_max_in_flight_items.max(1),
+        ));
 
         let issue_cache = CacheBuilder::new(1000)
             .time_to_live(Duration::from_secs(config.issue_cache_ttl_seconds))
@@ -282,6 +286,7 @@ impl AppContext {
             config: config.clone(),
             symbol_resolution_limiter,
             process_request_limiter,
+            process_grpc_item_limiter,
             team_manager,
             issue_buckets_redis_client,
             signal_client,

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -139,20 +139,9 @@ pub struct Config {
     #[envconfig(from = "CYMBAL_PROCESS_GRPC_MAX_CONCURRENT_STREAMS", default = "128")]
     pub process_grpc_max_concurrent_streams: usize,
 
-    // Maximum concurrently handled items for one Process stream.
-    #[envconfig(
-        from = "CYMBAL_PROCESS_GRPC_PER_STREAM_MAX_IN_FLIGHT_ITEMS",
-        default = "64"
-    )]
-    pub process_grpc_per_stream_max_in_flight_items: usize,
-
     // Process stream response buffer capacity.
     #[envconfig(from = "CYMBAL_PROCESS_GRPC_STREAM_OUTPUT_BUFFER", default = "64")]
     pub process_grpc_stream_output_buffer: usize,
-
-    // Server-configured per-item deadline for the Process API.
-    #[envconfig(from = "CYMBAL_PROCESS_GRPC_ITEM_DEADLINE_MS", default = "60000")]
-    pub process_grpc_item_deadline_ms: u64,
 
     // Global maximum number of gRPC Process items in flight.
     #[envconfig(from = "CYMBAL_PROCESS_GRPC_MAX_IN_FLIGHT_ITEMS", default = "512")]

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -131,6 +131,33 @@ pub struct Config {
     #[envconfig(default = "60000")]
     pub process_slow_log_threshold_ms: u64,
 
+    // Bind address for the parallel cymbal.process.v1 gRPC API.
+    #[envconfig(from = "CYMBAL_PROCESS_GRPC_BIND_ADDR", default = "[::]:50062")]
+    pub process_grpc_bind_addr: String,
+
+    // Maximum concurrent Process streams per gRPC connection.
+    #[envconfig(from = "CYMBAL_PROCESS_GRPC_MAX_CONCURRENT_STREAMS", default = "128")]
+    pub process_grpc_max_concurrent_streams: usize,
+
+    // Maximum concurrently handled items for one Process stream.
+    #[envconfig(
+        from = "CYMBAL_PROCESS_GRPC_PER_STREAM_MAX_IN_FLIGHT_ITEMS",
+        default = "64"
+    )]
+    pub process_grpc_per_stream_max_in_flight_items: usize,
+
+    // Process stream response buffer capacity.
+    #[envconfig(from = "CYMBAL_PROCESS_GRPC_STREAM_OUTPUT_BUFFER", default = "64")]
+    pub process_grpc_stream_output_buffer: usize,
+
+    // Server-configured per-item deadline for the Process API.
+    #[envconfig(from = "CYMBAL_PROCESS_GRPC_ITEM_DEADLINE_MS", default = "60000")]
+    pub process_grpc_item_deadline_ms: u64,
+
+    // Global maximum number of gRPC Process items in flight.
+    #[envconfig(from = "CYMBAL_PROCESS_GRPC_MAX_IN_FLIGHT_ITEMS", default = "512")]
+    pub process_grpc_max_in_flight_items: usize,
+
     #[envconfig(default = "300")]
     pub team_cache_ttl_secs: u64,
 

--- a/rust/cymbal/src/lib.rs
+++ b/rust/cymbal/src/lib.rs
@@ -19,6 +19,7 @@ pub mod metric_consts;
 pub mod posthog_utils;
 pub mod router;
 pub mod server;
+pub mod service;
 pub mod signals;
 pub mod spike_config;
 pub mod stages;

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -88,13 +88,13 @@ pub const PROCESS_REQUEST_DURATION_SECONDS: &str = "cymbal_process_request_durat
 pub const PROCESS_BATCH_EVENTS: &str = "cymbal_process_batch_events";
 pub const PROCESS_IN_FLIGHT: &str = "cymbal_process_in_flight";
 
-// gRPC cymbal.process.v1 observability metrics
-pub const PROCESS_GRPC_STREAMS_TOTAL: &str = "cymbal_process_grpc_streams_total";
-pub const PROCESS_GRPC_ITEMS_RECEIVED_TOTAL: &str = "cymbal_process_grpc_items_received_total";
-pub const PROCESS_GRPC_TERMINAL_OUTCOMES_TOTAL: &str =
-    "cymbal_process_grpc_terminal_outcomes_total";
-pub const PROCESS_GRPC_ITEM_DURATION_SECONDS: &str = "cymbal_process_grpc_item_duration_seconds";
-pub const PROCESS_GRPC_IN_FLIGHT_ITEMS: &str = "cymbal_process_grpc_in_flight_items";
+// cymbal.process.v1 service observability metrics
+pub const PROCESS_SERVICE_STREAMS_TOTAL: &str = "cymbal_process_service_streams_total";
+pub const PROCESS_SERVICE_TERMINAL_OUTCOMES_TOTAL: &str =
+    "cymbal_process_service_terminal_outcomes_total";
+pub const PROCESS_SERVICE_ITEM_DURATION_SECONDS: &str =
+    "cymbal_process_service_item_duration_seconds";
+pub const PROCESS_SERVICE_IN_FLIGHT_ITEMS: &str = "cymbal_process_service_in_flight_items";
 
 // Spike detection metrics
 pub const SPIKE_INCREMENT_ISSUE_BUCKETS_TIME: &str = "cymbal_spike_increment_issue_buckets_time";

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -88,6 +88,14 @@ pub const PROCESS_REQUEST_DURATION_SECONDS: &str = "cymbal_process_request_durat
 pub const PROCESS_BATCH_EVENTS: &str = "cymbal_process_batch_events";
 pub const PROCESS_IN_FLIGHT: &str = "cymbal_process_in_flight";
 
+// gRPC cymbal.process.v1 observability metrics
+pub const PROCESS_GRPC_STREAMS_TOTAL: &str = "cymbal_process_grpc_streams_total";
+pub const PROCESS_GRPC_ITEMS_RECEIVED_TOTAL: &str = "cymbal_process_grpc_items_received_total";
+pub const PROCESS_GRPC_TERMINAL_OUTCOMES_TOTAL: &str =
+    "cymbal_process_grpc_terminal_outcomes_total";
+pub const PROCESS_GRPC_ITEM_DURATION_SECONDS: &str = "cymbal_process_grpc_item_duration_seconds";
+pub const PROCESS_GRPC_IN_FLIGHT_ITEMS: &str = "cymbal_process_grpc_in_flight_items";
+
 // Spike detection metrics
 pub const SPIKE_INCREMENT_ISSUE_BUCKETS_TIME: &str = "cymbal_spike_increment_issue_buckets_time";
 pub const SPIKE_INCREMENT_TEAM_BUCKETS_TIME: &str = "cymbal_spike_increment_team_buckets_time";

--- a/rust/cymbal/src/server.rs
+++ b/rust/cymbal/src/server.rs
@@ -1,7 +1,9 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use common_metrics::{serve, setup_metrics_routes_with_overrides, Matcher};
-use tracing::info;
+use cymbal_proto::cymbal::process::v1::cymbal_process_server::CymbalProcessServer;
+use tonic::transport::Server;
+use tracing::{error, info};
 
 use crate::{
     app_context::AppContext,
@@ -11,9 +13,12 @@ use crate::{
         SYMBOL_SET_DECOMPRESSED_BYTES,
     },
     router::get_router,
+    service::process::{CymbalProcessService, ProcessServiceConfig},
 };
 
 pub async fn start_server(config: Config, context: Arc<AppContext>) -> () {
+    let grpc_handle = tokio::spawn(start_process_grpc_server(config.clone(), context.clone()));
+
     let router = get_router(context);
     let bucket_overrides: &[(Matcher, &[f64])] = &[
         (
@@ -36,4 +41,48 @@ pub async fn start_server(config: Config, context: Arc<AppContext>) -> () {
     serve(router, &bind)
         .await
         .expect("failed to start serving metrics");
+
+    grpc_handle.abort();
+}
+
+async fn start_process_grpc_server(config: Config, context: Arc<AppContext>) {
+    let service_config = ProcessServiceConfig::new(
+        config.process_grpc_stream_output_buffer,
+        config.process_grpc_per_stream_max_in_flight_items,
+        config.process_grpc_item_deadline_ms,
+    );
+    let service =
+        CymbalProcessService::new(service_config, context.process_grpc_item_limiter.clone());
+
+    let addr = match config.process_grpc_bind_addr.parse() {
+        Ok(addr) => addr,
+        Err(err) => {
+            error!(
+                bind = %config.process_grpc_bind_addr,
+                error = %err,
+                "failed to parse Cymbal process gRPC bind address"
+            );
+            return;
+        }
+    };
+
+    info!(
+        bind = %config.process_grpc_bind_addr,
+        max_concurrent_streams = config.process_grpc_max_concurrent_streams,
+        per_stream_max_in_flight_items = config.process_grpc_per_stream_max_in_flight_items,
+        max_in_flight_items = config.process_grpc_max_in_flight_items,
+        item_deadline_ms = config.process_grpc_item_deadline_ms,
+        "Cymbal process gRPC server listening"
+    );
+
+    if let Err(err) = Server::builder()
+        .http2_keepalive_interval(Some(Duration::from_secs(30)))
+        .http2_keepalive_timeout(Some(Duration::from_secs(20)))
+        .concurrency_limit_per_connection(config.process_grpc_max_concurrent_streams.max(1))
+        .add_service(CymbalProcessServer::new(service))
+        .serve(addr)
+        .await
+    {
+        error!(error = %err, "Cymbal process gRPC server stopped with error");
+    }
 }

--- a/rust/cymbal/src/server.rs
+++ b/rust/cymbal/src/server.rs
@@ -46,11 +46,7 @@ pub async fn start_server(config: Config, context: Arc<AppContext>) -> () {
 }
 
 async fn start_process_grpc_server(config: Config, context: Arc<AppContext>) {
-    let service_config = ProcessServiceConfig::new(
-        config.process_grpc_stream_output_buffer,
-        config.process_grpc_per_stream_max_in_flight_items,
-        config.process_grpc_item_deadline_ms,
-    );
+    let service_config = ProcessServiceConfig::new(config.process_grpc_stream_output_buffer);
     let service =
         CymbalProcessService::new(service_config, context.process_grpc_item_limiter.clone());
 
@@ -69,9 +65,7 @@ async fn start_process_grpc_server(config: Config, context: Arc<AppContext>) {
     info!(
         bind = %config.process_grpc_bind_addr,
         max_concurrent_streams = config.process_grpc_max_concurrent_streams,
-        per_stream_max_in_flight_items = config.process_grpc_per_stream_max_in_flight_items,
         max_in_flight_items = config.process_grpc_max_in_flight_items,
-        item_deadline_ms = config.process_grpc_item_deadline_ms,
         "Cymbal process gRPC server listening"
     );
 

--- a/rust/cymbal/src/service/mod.rs
+++ b/rust/cymbal/src/service/mod.rs
@@ -1,0 +1,1 @@
+pub mod process;

--- a/rust/cymbal/src/service/process.rs
+++ b/rust/cymbal/src/service/process.rs
@@ -1,0 +1,332 @@
+use std::{pin::Pin, sync::Arc, time::Instant};
+
+use cymbal_proto::cymbal::process::v1::{
+    cymbal_process_server::CymbalProcess, process_outcome, ProcessError, ProcessErrorCode,
+    ProcessErrorKind, ProcessItem, ProcessOutcome,
+};
+use futures::{Stream, StreamExt};
+use tokio::sync::{mpsc, Semaphore};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status, Streaming};
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::metric_consts::{
+    PROCESS_GRPC_IN_FLIGHT_ITEMS, PROCESS_GRPC_ITEMS_RECEIVED_TOTAL,
+    PROCESS_GRPC_ITEM_DURATION_SECONDS, PROCESS_GRPC_STREAMS_TOTAL,
+    PROCESS_GRPC_TERMINAL_OUTCOMES_TOTAL,
+};
+
+#[derive(Clone, Debug)]
+pub struct ProcessServiceConfig {
+    pub stream_output_buffer: usize,
+    pub per_stream_max_in_flight_items: usize,
+    pub item_deadline_ms: u64,
+}
+
+impl ProcessServiceConfig {
+    pub fn new(
+        stream_output_buffer: usize,
+        per_stream_max_in_flight_items: usize,
+        item_deadline_ms: u64,
+    ) -> Self {
+        Self {
+            stream_output_buffer: stream_output_buffer.max(1),
+            per_stream_max_in_flight_items: per_stream_max_in_flight_items.max(1),
+            item_deadline_ms: item_deadline_ms.max(1),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct CymbalProcessService {
+    config: ProcessServiceConfig,
+    item_limiter: Arc<Semaphore>,
+}
+
+impl CymbalProcessService {
+    pub fn new(config: ProcessServiceConfig, item_limiter: Arc<Semaphore>) -> Self {
+        Self {
+            config,
+            item_limiter,
+        }
+    }
+}
+
+type ProcessResponseStream =
+    Pin<Box<dyn Stream<Item = Result<ProcessOutcome, Status>> + Send + 'static>>;
+
+#[tonic::async_trait]
+impl CymbalProcess for CymbalProcessService {
+    type ProcessStream = ProcessResponseStream;
+
+    async fn process(
+        &self,
+        request: Request<Streaming<ProcessItem>>,
+    ) -> Result<Response<Self::ProcessStream>, Status> {
+        let (tx, rx) = mpsc::channel(self.config.stream_output_buffer);
+        let input = request.into_inner();
+        let config = self.config.clone();
+        let item_limiter = self.item_limiter.clone();
+
+        tokio::spawn(async move {
+            run_process(input, tx, config, item_limiter).await;
+        });
+
+        Ok(Response::new(Box::pin(ReceiverStream::new(rx))))
+    }
+}
+
+async fn run_process<S>(
+    mut input: S,
+    tx: mpsc::Sender<Result<ProcessOutcome, Status>>,
+    config: ProcessServiceConfig,
+    item_limiter: Arc<Semaphore>,
+) where
+    S: Stream<Item = Result<ProcessItem, Status>> + Unpin,
+{
+    metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "opened").increment(1);
+    let stream_limiter = Arc::new(Semaphore::new(config.per_stream_max_in_flight_items));
+    let mut item_tasks = tokio::task::JoinSet::new();
+
+    loop {
+        tokio::select! {
+            _ = tx.closed() => {
+                metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "closed", "reason" => "cancelled").increment(1);
+                return;
+            }
+            maybe_item = input.next() => {
+                let item = match maybe_item {
+                    Some(Ok(item)) => item,
+                    Some(Err(err)) => {
+                        warn!(error = %err, "process gRPC input stream failed");
+                        metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "closed", "reason" => "input_error").increment(1);
+                        return;
+                    }
+                    None => break,
+                };
+
+                metrics::counter!(PROCESS_GRPC_ITEMS_RECEIVED_TOTAL).increment(1);
+                let processing_id = Uuid::now_v7();
+                let item_started_at = Instant::now();
+
+                let stream_permit = match stream_limiter.clone().try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        let outcome = error_outcome(
+                            item.id,
+                            ProcessErrorKind::Processing,
+                            ProcessErrorCode::Overloaded,
+                            true,
+                            0,
+                            "process stream item concurrency limit reached",
+                        );
+                        record_terminal_outcome(&outcome, item_started_at);
+                        if tx.send(Ok(outcome)).await.is_err() {
+                            metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "closed", "reason" => "cancelled").increment(1);
+                            return;
+                        }
+                        continue;
+                    }
+                };
+
+                let global_permit = match item_limiter.clone().try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        drop(stream_permit);
+                        let outcome = error_outcome(
+                            item.id,
+                            ProcessErrorKind::Processing,
+                            ProcessErrorCode::Overloaded,
+                            true,
+                            0,
+                            "process global item concurrency limit reached",
+                        );
+                        record_terminal_outcome(&outcome, item_started_at);
+                        if tx.send(Ok(outcome)).await.is_err() {
+                            metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "closed", "reason" => "cancelled").increment(1);
+                            return;
+                        }
+                        continue;
+                    }
+                };
+
+                let item_tx = tx.clone();
+                let item_deadline_ms = config.item_deadline_ms;
+                item_tasks.spawn(async move {
+                    let _stream_permit = stream_permit;
+                    let _global_permit = global_permit;
+                    let _in_flight = ProcessGrpcInFlightGuard::start();
+                    let outcome = process_item_placeholder(processing_id, item, item_deadline_ms).await;
+                    let _ignored = item_tx.send(Ok(outcome)).await;
+                });
+            }
+        }
+    }
+
+    while item_tasks.join_next().await.is_some() {}
+    metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "closed", "reason" => "completed")
+        .increment(1);
+}
+
+struct ProcessGrpcInFlightGuard;
+
+impl ProcessGrpcInFlightGuard {
+    fn start() -> Self {
+        metrics::gauge!(PROCESS_GRPC_IN_FLIGHT_ITEMS).increment(1.0);
+        Self
+    }
+}
+
+impl Drop for ProcessGrpcInFlightGuard {
+    fn drop(&mut self) {
+        metrics::gauge!(PROCESS_GRPC_IN_FLIGHT_ITEMS).decrement(1.0);
+    }
+}
+
+async fn process_item_placeholder(
+    processing_id: Uuid,
+    item: ProcessItem,
+    item_deadline_ms: u64,
+) -> ProcessOutcome {
+    let started_at = Instant::now();
+    let caller_id = item.id;
+    let timeout_caller_id = caller_id.clone();
+
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_millis(item_deadline_ms),
+        async move {
+            warn!(
+                processing_id = %processing_id,
+                caller_id = %caller_id,
+                "process gRPC pipeline adapter is not implemented yet"
+            );
+            error_outcome(
+                caller_id,
+                ProcessErrorKind::Processing,
+                ProcessErrorCode::Unimplemented,
+                false,
+                0,
+                "cymbal process gRPC pipeline adapter is not implemented yet",
+            )
+        },
+    )
+    .await
+    .unwrap_or_else(|_| {
+        error_outcome(
+            timeout_caller_id,
+            ProcessErrorKind::Timeout,
+            ProcessErrorCode::Timeout,
+            true,
+            0,
+            "process item deadline expired",
+        )
+    });
+
+    record_terminal_outcome(&outcome, started_at);
+    outcome
+}
+
+fn error_outcome(
+    id: String,
+    kind: ProcessErrorKind,
+    code: ProcessErrorCode,
+    retryable: bool,
+    retry_after_ms: u32,
+    message: impl Into<String>,
+) -> ProcessOutcome {
+    ProcessOutcome {
+        id,
+        result: Some(process_outcome::Result::Error(ProcessError {
+            kind: kind as i32,
+            code: code as i32,
+            retryable,
+            retry_after_ms,
+            message: message.into(),
+            details_json: Vec::new(),
+        })),
+    }
+}
+
+fn record_terminal_outcome(outcome: &ProcessOutcome, started_at: Instant) {
+    let (outcome_type, kind, code) = match outcome.result.as_ref() {
+        Some(process_outcome::Result::Done(_)) => ("done", "ok", "ok"),
+        Some(process_outcome::Result::Drop(drop)) => (
+            "drop",
+            "drop",
+            cymbal_proto::cymbal::process::v1::ProcessDropReason::try_from(drop.reason)
+                .unwrap_or(cymbal_proto::cymbal::process::v1::ProcessDropReason::Unspecified)
+                .as_str_name(),
+        ),
+        Some(process_outcome::Result::Error(error)) => (
+            "error",
+            ProcessErrorKind::try_from(error.kind)
+                .unwrap_or(ProcessErrorKind::Unspecified)
+                .as_str_name(),
+            ProcessErrorCode::try_from(error.code)
+                .unwrap_or(ProcessErrorCode::Unspecified)
+                .as_str_name(),
+        ),
+        None => ("error", "missing_result", "missing_result"),
+    };
+
+    metrics::counter!(
+        PROCESS_GRPC_TERMINAL_OUTCOMES_TOTAL,
+        "type" => outcome_type,
+        "kind" => kind,
+        "code" => code,
+    )
+    .increment(1);
+    metrics::histogram!(
+        PROCESS_GRPC_ITEM_DURATION_SECONDS,
+        "type" => outcome_type,
+        "kind" => kind,
+        "code" => code,
+    )
+    .record(started_at.elapsed().as_secs_f64());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+
+    #[tokio::test]
+    async fn placeholder_echoes_duplicate_caller_ids_with_unimplemented_errors() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let input = stream::iter(vec![
+            Ok(ProcessItem {
+                id: "duplicate".to_string(),
+                event_json: b"{}".to_vec(),
+            }),
+            Ok(ProcessItem {
+                id: "duplicate".to_string(),
+                event_json: b"{}".to_vec(),
+            }),
+        ]);
+
+        run_process(
+            input,
+            tx,
+            ProcessServiceConfig::new(4, 2, 1_000),
+            Arc::new(Semaphore::new(2)),
+        )
+        .await;
+
+        let mut outcomes = Vec::new();
+        while let Some(Ok(outcome)) = rx.recv().await {
+            outcomes.push(outcome);
+        }
+
+        assert_eq!(outcomes.len(), 2);
+        for outcome in outcomes {
+            assert_eq!(outcome.id, "duplicate");
+            let Some(process_outcome::Result::Error(error)) = outcome.result else {
+                panic!("expected error outcome");
+            };
+            assert_eq!(error.kind, ProcessErrorKind::Processing as i32);
+            assert_eq!(error.code, ProcessErrorCode::Unimplemented as i32);
+            assert!(!error.retryable);
+        }
+    }
+}

--- a/rust/cymbal/src/service/process.rs
+++ b/rust/cymbal/src/service/process.rs
@@ -1,8 +1,9 @@
 use std::{pin::Pin, sync::Arc, time::Instant};
 
 use cymbal_proto::cymbal::process::v1::{
-    cymbal_process_server::CymbalProcess, process_outcome, ProcessError, ProcessErrorCode,
-    ProcessErrorKind, ProcessItem, ProcessOutcome,
+    cymbal_process_server::CymbalProcess, process_outcome, ProcessBatchRequest,
+    ProcessBatchResponse, ProcessError, ProcessErrorKind, ProcessItem, ProcessOutcome,
+    ServiceState, SubscribeRequest,
 };
 use futures::{Stream, StreamExt};
 use tokio::sync::{mpsc, Semaphore};
@@ -46,21 +47,62 @@ impl CymbalProcessService {
 
 type ProcessResponseStream =
     Pin<Box<dyn Stream<Item = Result<ProcessOutcome, Status>> + Send + 'static>>;
+type SubscribeResponseStream =
+    Pin<Box<dyn Stream<Item = Result<ServiceState, Status>> + Send + 'static>>;
 
 #[tonic::async_trait]
 impl CymbalProcess for CymbalProcessService {
-    type ProcessStream = ProcessResponseStream;
+    type ProcessStreamStream = ProcessResponseStream;
+    type SubscribeStream = SubscribeResponseStream;
 
-    async fn process(
+    async fn process_stream(
         &self,
         request: Request<Streaming<ProcessItem>>,
-    ) -> Result<Response<Self::ProcessStream>, Status> {
+    ) -> Result<Response<Self::ProcessStreamStream>, Status> {
         let (tx, rx) = mpsc::channel(self.config.stream_output_buffer);
         let input = request.into_inner();
         let item_limiter = self.item_limiter.clone();
 
         tokio::spawn(async move {
             run_process(input, tx, item_limiter).await;
+        });
+
+        Ok(Response::new(Box::pin(ReceiverStream::new(rx))))
+    }
+
+    async fn process_batch(
+        &self,
+        request: Request<ProcessBatchRequest>,
+    ) -> Result<Response<ProcessBatchResponse>, Status> {
+        let request = request.into_inner();
+        let mut outcomes = Vec::with_capacity(request.items.len());
+
+        for mut item in request.items {
+            if item.timeout_ms.is_none() {
+                item.timeout_ms = request.timeout_ms;
+            }
+            outcomes.push(process_item_with_limiter(item, self.item_limiter.clone()).await);
+        }
+
+        Ok(Response::new(ProcessBatchResponse { outcomes }))
+    }
+
+    async fn subscribe(
+        &self,
+        _request: Request<SubscribeRequest>,
+    ) -> Result<Response<Self::SubscribeStream>, Status> {
+        let (tx, rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            let _ignored = tx
+                .send(Ok(ServiceState {
+                    service_instance_id: std::env::var("HOSTNAME")
+                        .unwrap_or_else(|_| "cymbal-process".to_string()),
+                    draining: false,
+                    healthy: true,
+                    sequence: 1,
+                    message: "ready".to_string(),
+                }))
+                .await;
         });
 
         Ok(Response::new(Box::pin(ReceiverStream::new(rx))))
@@ -94,34 +136,10 @@ async fn run_process<S>(
                     None => break,
                 };
 
-                let processing_id = Uuid::now_v7();
-                let item_started_at = Instant::now();
-
-                let global_permit = match item_limiter.clone().try_acquire_owned() {
-                    Ok(permit) => permit,
-                    Err(_) => {
-                        let outcome = error_outcome(
-                            item.id,
-                            ProcessErrorKind::Processing,
-                            ProcessErrorCode::Overloaded,
-                            true,
-                            0,
-                            "process global item concurrency limit reached",
-                        );
-                        record_terminal_outcome(&outcome, item_started_at);
-                        if tx.send(Ok(outcome)).await.is_err() {
-                            metrics::counter!(PROCESS_SERVICE_STREAMS_TOTAL, "event" => "closed", "reason" => "cancelled").increment(1);
-                            return;
-                        }
-                        continue;
-                    }
-                };
-
+                let item_limiter = item_limiter.clone();
                 let item_tx = tx.clone();
                 item_tasks.spawn(async move {
-                    let _global_permit = global_permit;
-                    let _in_flight = ProcessServiceInFlightGuard::start();
-                    let outcome = process_item_placeholder(processing_id, item).await;
+                    let outcome = process_item_with_limiter(item, item_limiter).await;
                     let _ignored = item_tx.send(Ok(outcome)).await;
                 });
             }
@@ -148,40 +166,68 @@ impl Drop for ProcessServiceInFlightGuard {
     }
 }
 
+async fn process_item_with_limiter(
+    item: ProcessItem,
+    item_limiter: Arc<Semaphore>,
+) -> ProcessOutcome {
+    let started_at = Instant::now();
+    let global_permit = match item_limiter.try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            let outcome = error_outcome(
+                item.id,
+                ProcessErrorKind::Overloaded,
+                true,
+                0,
+                "process global item concurrency limit reached",
+            );
+            record_terminal_outcome(&outcome, started_at);
+            return outcome;
+        }
+    };
+
+    let _global_permit = global_permit;
+    let _in_flight = ProcessServiceInFlightGuard::start();
+    process_item_placeholder(Uuid::now_v7(), item).await
+}
+
 async fn process_item_placeholder(processing_id: Uuid, item: ProcessItem) -> ProcessOutcome {
     let started_at = Instant::now();
     let caller_id = item.id;
     let timeout_caller_id = caller_id.clone();
 
-    let outcome = tokio::time::timeout(
-        std::time::Duration::from_millis(item.timeout_ms as u64),
-        async move {
-            warn!(
-                processing_id = %processing_id,
-                caller_id = %caller_id,
-                "process gRPC pipeline adapter is not implemented yet"
-            );
-            error_outcome(
-                caller_id,
-                ProcessErrorKind::Processing,
-                ProcessErrorCode::Unimplemented,
-                false,
-                0,
-                "cymbal process gRPC pipeline adapter is not implemented yet",
-            )
-        },
-    )
-    .await
-    .unwrap_or_else(|_| {
+    let process_future = async move {
+        warn!(
+            processing_id = %processing_id,
+            caller_id = %caller_id,
+            "process gRPC pipeline adapter is not implemented yet"
+        );
         error_outcome(
-            timeout_caller_id,
-            ProcessErrorKind::Timeout,
-            ProcessErrorCode::Timeout,
-            true,
+            caller_id,
+            ProcessErrorKind::Unimplemented,
+            false,
             0,
-            "process item deadline expired",
+            "cymbal process gRPC pipeline adapter is not implemented yet",
         )
-    });
+    };
+
+    let outcome = match item.timeout_ms {
+        Some(timeout_ms) => tokio::time::timeout(
+            std::time::Duration::from_millis(timeout_ms as u64),
+            process_future,
+        )
+        .await
+        .unwrap_or_else(|_| {
+            error_outcome(
+                timeout_caller_id,
+                ProcessErrorKind::Timeout,
+                true,
+                0,
+                "process item deadline expired",
+            )
+        }),
+        None => process_future.await,
+    };
 
     record_terminal_outcome(&outcome, started_at);
     outcome
@@ -190,7 +236,6 @@ async fn process_item_placeholder(processing_id: Uuid, item: ProcessItem) -> Pro
 fn error_outcome(
     id: String,
     kind: ProcessErrorKind,
-    code: ProcessErrorCode,
     retryable: bool,
     retry_after_ms: u32,
     message: impl Into<String>,
@@ -199,7 +244,6 @@ fn error_outcome(
         id,
         result: Some(process_outcome::Result::Error(ProcessError {
             kind: kind as i32,
-            code: code as i32,
             retryable,
             retry_after_ms,
             message: message.into(),
@@ -209,10 +253,9 @@ fn error_outcome(
 }
 
 fn record_terminal_outcome(outcome: &ProcessOutcome, started_at: Instant) {
-    let (outcome_type, kind, code) = match outcome.result.as_ref() {
-        Some(process_outcome::Result::Done(_)) => ("done", "ok", "ok"),
+    let (outcome_type, kind) = match outcome.result.as_ref() {
+        Some(process_outcome::Result::Done(_)) => ("done", "ok"),
         Some(process_outcome::Result::Drop(drop)) => (
-            "drop",
             "drop",
             cymbal_proto::cymbal::process::v1::ProcessDropReason::try_from(drop.reason)
                 .unwrap_or(cymbal_proto::cymbal::process::v1::ProcessDropReason::Unspecified)
@@ -223,25 +266,20 @@ fn record_terminal_outcome(outcome: &ProcessOutcome, started_at: Instant) {
             ProcessErrorKind::try_from(error.kind)
                 .unwrap_or(ProcessErrorKind::Unspecified)
                 .as_str_name(),
-            ProcessErrorCode::try_from(error.code)
-                .unwrap_or(ProcessErrorCode::Unspecified)
-                .as_str_name(),
         ),
-        None => ("error", "missing_result", "missing_result"),
+        None => ("error", "missing_result"),
     };
 
     metrics::counter!(
         PROCESS_SERVICE_TERMINAL_OUTCOMES_TOTAL,
         "type" => outcome_type,
         "kind" => kind,
-        "code" => code,
     )
     .increment(1);
     metrics::histogram!(
         PROCESS_SERVICE_ITEM_DURATION_SECONDS,
         "type" => outcome_type,
         "kind" => kind,
-        "code" => code,
     )
     .record(started_at.elapsed().as_secs_f64());
 }
@@ -258,12 +296,12 @@ mod tests {
             Ok(ProcessItem {
                 id: "duplicate".to_string(),
                 event_json: b"{}".to_vec(),
-                timeout_ms: 1_000,
+                timeout_ms: Some(1_000),
             }),
             Ok(ProcessItem {
                 id: "duplicate".to_string(),
                 event_json: b"{}".to_vec(),
-                timeout_ms: 1_000,
+                timeout_ms: Some(1_000),
             }),
         ]);
 
@@ -280,8 +318,7 @@ mod tests {
             let Some(process_outcome::Result::Error(error)) = outcome.result else {
                 panic!("expected error outcome");
             };
-            assert_eq!(error.kind, ProcessErrorKind::Processing as i32);
-            assert_eq!(error.code, ProcessErrorCode::Unimplemented as i32);
+            assert_eq!(error.kind, ProcessErrorKind::Unimplemented as i32);
             assert!(!error.retryable);
         }
     }

--- a/rust/cymbal/src/service/process.rs
+++ b/rust/cymbal/src/service/process.rs
@@ -12,28 +12,19 @@ use tracing::warn;
 use uuid::Uuid;
 
 use crate::metric_consts::{
-    PROCESS_GRPC_IN_FLIGHT_ITEMS, PROCESS_GRPC_ITEMS_RECEIVED_TOTAL,
-    PROCESS_GRPC_ITEM_DURATION_SECONDS, PROCESS_GRPC_STREAMS_TOTAL,
-    PROCESS_GRPC_TERMINAL_OUTCOMES_TOTAL,
+    PROCESS_SERVICE_IN_FLIGHT_ITEMS, PROCESS_SERVICE_ITEM_DURATION_SECONDS,
+    PROCESS_SERVICE_STREAMS_TOTAL, PROCESS_SERVICE_TERMINAL_OUTCOMES_TOTAL,
 };
 
 #[derive(Clone, Debug)]
 pub struct ProcessServiceConfig {
     pub stream_output_buffer: usize,
-    pub per_stream_max_in_flight_items: usize,
-    pub item_deadline_ms: u64,
 }
 
 impl ProcessServiceConfig {
-    pub fn new(
-        stream_output_buffer: usize,
-        per_stream_max_in_flight_items: usize,
-        item_deadline_ms: u64,
-    ) -> Self {
+    pub fn new(stream_output_buffer: usize) -> Self {
         Self {
             stream_output_buffer: stream_output_buffer.max(1),
-            per_stream_max_in_flight_items: per_stream_max_in_flight_items.max(1),
-            item_deadline_ms: item_deadline_ms.max(1),
         }
     }
 }
@@ -66,11 +57,10 @@ impl CymbalProcess for CymbalProcessService {
     ) -> Result<Response<Self::ProcessStream>, Status> {
         let (tx, rx) = mpsc::channel(self.config.stream_output_buffer);
         let input = request.into_inner();
-        let config = self.config.clone();
         let item_limiter = self.item_limiter.clone();
 
         tokio::spawn(async move {
-            run_process(input, tx, config, item_limiter).await;
+            run_process(input, tx, item_limiter).await;
         });
 
         Ok(Response::new(Box::pin(ReceiverStream::new(rx))))
@@ -80,19 +70,17 @@ impl CymbalProcess for CymbalProcessService {
 async fn run_process<S>(
     mut input: S,
     tx: mpsc::Sender<Result<ProcessOutcome, Status>>,
-    config: ProcessServiceConfig,
     item_limiter: Arc<Semaphore>,
 ) where
     S: Stream<Item = Result<ProcessItem, Status>> + Unpin,
 {
-    metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "opened").increment(1);
-    let stream_limiter = Arc::new(Semaphore::new(config.per_stream_max_in_flight_items));
+    metrics::counter!(PROCESS_SERVICE_STREAMS_TOTAL, "event" => "opened").increment(1);
     let mut item_tasks = tokio::task::JoinSet::new();
 
     loop {
         tokio::select! {
             _ = tx.closed() => {
-                metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "closed", "reason" => "cancelled").increment(1);
+                metrics::counter!(PROCESS_SERVICE_STREAMS_TOTAL, "event" => "closed", "reason" => "cancelled").increment(1);
                 return;
             }
             maybe_item = input.next() => {
@@ -100,40 +88,18 @@ async fn run_process<S>(
                     Some(Ok(item)) => item,
                     Some(Err(err)) => {
                         warn!(error = %err, "process gRPC input stream failed");
-                        metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "closed", "reason" => "input_error").increment(1);
+                        metrics::counter!(PROCESS_SERVICE_STREAMS_TOTAL, "event" => "closed", "reason" => "input_error").increment(1);
                         return;
                     }
                     None => break,
                 };
 
-                metrics::counter!(PROCESS_GRPC_ITEMS_RECEIVED_TOTAL).increment(1);
                 let processing_id = Uuid::now_v7();
                 let item_started_at = Instant::now();
-
-                let stream_permit = match stream_limiter.clone().try_acquire_owned() {
-                    Ok(permit) => permit,
-                    Err(_) => {
-                        let outcome = error_outcome(
-                            item.id,
-                            ProcessErrorKind::Processing,
-                            ProcessErrorCode::Overloaded,
-                            true,
-                            0,
-                            "process stream item concurrency limit reached",
-                        );
-                        record_terminal_outcome(&outcome, item_started_at);
-                        if tx.send(Ok(outcome)).await.is_err() {
-                            metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "closed", "reason" => "cancelled").increment(1);
-                            return;
-                        }
-                        continue;
-                    }
-                };
 
                 let global_permit = match item_limiter.clone().try_acquire_owned() {
                     Ok(permit) => permit,
                     Err(_) => {
-                        drop(stream_permit);
                         let outcome = error_outcome(
                             item.id,
                             ProcessErrorKind::Processing,
@@ -144,7 +110,7 @@ async fn run_process<S>(
                         );
                         record_terminal_outcome(&outcome, item_started_at);
                         if tx.send(Ok(outcome)).await.is_err() {
-                            metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "closed", "reason" => "cancelled").increment(1);
+                            metrics::counter!(PROCESS_SERVICE_STREAMS_TOTAL, "event" => "closed", "reason" => "cancelled").increment(1);
                             return;
                         }
                         continue;
@@ -152,12 +118,10 @@ async fn run_process<S>(
                 };
 
                 let item_tx = tx.clone();
-                let item_deadline_ms = config.item_deadline_ms;
                 item_tasks.spawn(async move {
-                    let _stream_permit = stream_permit;
                     let _global_permit = global_permit;
-                    let _in_flight = ProcessGrpcInFlightGuard::start();
-                    let outcome = process_item_placeholder(processing_id, item, item_deadline_ms).await;
+                    let _in_flight = ProcessServiceInFlightGuard::start();
+                    let outcome = process_item_placeholder(processing_id, item).await;
                     let _ignored = item_tx.send(Ok(outcome)).await;
                 });
             }
@@ -165,36 +129,32 @@ async fn run_process<S>(
     }
 
     while item_tasks.join_next().await.is_some() {}
-    metrics::counter!(PROCESS_GRPC_STREAMS_TOTAL, "event" => "closed", "reason" => "completed")
+    metrics::counter!(PROCESS_SERVICE_STREAMS_TOTAL, "event" => "closed", "reason" => "completed")
         .increment(1);
 }
 
-struct ProcessGrpcInFlightGuard;
+struct ProcessServiceInFlightGuard;
 
-impl ProcessGrpcInFlightGuard {
+impl ProcessServiceInFlightGuard {
     fn start() -> Self {
-        metrics::gauge!(PROCESS_GRPC_IN_FLIGHT_ITEMS).increment(1.0);
+        metrics::gauge!(PROCESS_SERVICE_IN_FLIGHT_ITEMS).increment(1.0);
         Self
     }
 }
 
-impl Drop for ProcessGrpcInFlightGuard {
+impl Drop for ProcessServiceInFlightGuard {
     fn drop(&mut self) {
-        metrics::gauge!(PROCESS_GRPC_IN_FLIGHT_ITEMS).decrement(1.0);
+        metrics::gauge!(PROCESS_SERVICE_IN_FLIGHT_ITEMS).decrement(1.0);
     }
 }
 
-async fn process_item_placeholder(
-    processing_id: Uuid,
-    item: ProcessItem,
-    item_deadline_ms: u64,
-) -> ProcessOutcome {
+async fn process_item_placeholder(processing_id: Uuid, item: ProcessItem) -> ProcessOutcome {
     let started_at = Instant::now();
     let caller_id = item.id;
     let timeout_caller_id = caller_id.clone();
 
     let outcome = tokio::time::timeout(
-        std::time::Duration::from_millis(item_deadline_ms),
+        std::time::Duration::from_millis(item.timeout_ms as u64),
         async move {
             warn!(
                 processing_id = %processing_id,
@@ -271,14 +231,14 @@ fn record_terminal_outcome(outcome: &ProcessOutcome, started_at: Instant) {
     };
 
     metrics::counter!(
-        PROCESS_GRPC_TERMINAL_OUTCOMES_TOTAL,
+        PROCESS_SERVICE_TERMINAL_OUTCOMES_TOTAL,
         "type" => outcome_type,
         "kind" => kind,
         "code" => code,
     )
     .increment(1);
     metrics::histogram!(
-        PROCESS_GRPC_ITEM_DURATION_SECONDS,
+        PROCESS_SERVICE_ITEM_DURATION_SECONDS,
         "type" => outcome_type,
         "kind" => kind,
         "code" => code,
@@ -298,20 +258,16 @@ mod tests {
             Ok(ProcessItem {
                 id: "duplicate".to_string(),
                 event_json: b"{}".to_vec(),
+                timeout_ms: 1_000,
             }),
             Ok(ProcessItem {
                 id: "duplicate".to_string(),
                 event_json: b"{}".to_vec(),
+                timeout_ms: 1_000,
             }),
         ]);
 
-        run_process(
-            input,
-            tx,
-            ProcessServiceConfig::new(4, 2, 1_000),
-            Arc::new(Semaphore::new(2)),
-        )
-        .await;
+        run_process(input, tx, Arc::new(Semaphore::new(2))).await;
 
         let mut outcomes = Vec::new();
         while let Some(Ok(outcome)) = rx.recv().await {


### PR DESCRIPTION
## Problem

This is the next stacked PR after #61536. The process proto contract needs a minimal Cymbal server implementation so follow-up PRs can wire the real pipeline without mixing server startup, configuration, and processing behavior in one review.

## Changes

- Starts a parallel Cymbal gRPC server for the process API alongside the existing HTTP server.
- Adds process gRPC configuration for bind address, stream output buffering, concurrent streams, and process-wide item limits.
- Implements placeholder `CymbalProcess` handlers for `ProcessStream`, `ProcessBatch`, and `Subscribe` against the current proto from #61536.
- Returns explicit non-retryable `UNIMPLEMENTED` item outcomes until the shared pipeline adapter lands.
- Keeps HTTP `/process` behavior unchanged.

Stacked on #61536.

## How did you test this code?

- `flox activate -- bash -c "cd rust/cymbal && cargo fmt --check && cargo test service::process"`
- `flox activate -- bash -c "cd rust && cargo test -p cymbal-proto"`
- `git diff --check`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No product docs update needed. This PR adds an internal service skeleton; follow-up PRs will document the final rollout behavior.

## 🤖 Agent context

This PR was prepared with pi as part of a stacked Cymbal process gRPC rollout. The stack is split so reviewers can first validate the proto contract in #61536, then review this server skeleton before pipeline wiring.

The skeleton intentionally returns placeholder item-level `UNIMPLEMENTED` outcomes and does not change HTTP `/process` behavior. The implementation was adapted to the latest proto shape from the base branch, including `ProcessStream`, `ProcessBatch`, and `Subscribe` on one service.
