### PR TITLE
feat(signals): configurable base branch for inbox auto-PRs

### DIFF
--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -163,6 +163,10 @@ async def maybe_autostart_implementation_task(
     if task_user is None:
         return
 
+    base_branch = None
+    if repository and team_config:
+        base_branch = (team_config.autostart_base_branches or {}).get(repository.lower())
+
     task = await database_sync_to_async(Task.create_and_run, thread_sensitive=False)(
         team=team,
         title=title,
@@ -172,6 +176,7 @@ async def maybe_autostart_implementation_task(
         origin_product=Task.OriginProduct.SIGNAL_REPORT,
         user_id=task_user.id,
         repository=repository,
+        branch=base_branch,
         signal_report_id=report_id,
         posthog_mcp_scopes="read_only",
         interaction_origin="signal_report",  # Makes the agent auto-push and open a draft PR

--- a/products/signals/backend/migrations/0032_signalteamconfig_autostart_base_branches.py
+++ b/products/signals/backend/migrations/0032_signalteamconfig_autostart_base_branches.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("signals", "0031_alter_signalscoutconfig_emit"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="signalteamconfig",
+            name="autostart_base_branches",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+    ]

--- a/products/signals/backend/migrations/max_migration.txt
+++ b/products/signals/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0031_alter_signalscoutconfig_emit
+0032_signalteamconfig_autostart_base_branches

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -95,6 +95,7 @@ class SignalTeamConfig(UUIDModel):
     )
     default_autostart_priority = models.CharField(max_length=2, choices=AutonomyPriority, default=AutonomyPriority.P0)
     default_slack_notification_channel = models.CharField(max_length=255, null=True, blank=True)
+    autostart_base_branches = models.JSONField(default=dict, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -144,12 +144,23 @@ class SignalSourceConfigSerializer(serializers.ModelSerializer):
 
 
 class SignalTeamConfigSerializer(serializers.ModelSerializer):
+    autostart_base_branches = serializers.DictField(
+        child=serializers.CharField(max_length=255, allow_blank=True),
+        required=False,
+        help_text=(
+            "Per-repository base branch overrides for auto-started inbox PRs, keyed by "
+            "'organization/repository'. The branch is what the auto-PR targets; omit a repo "
+            "(or send {}) to keep targeting the repo default branch."
+        ),
+    )
+
     class Meta:
         model = SignalTeamConfig
         fields = [
             "id",
             "default_autostart_priority",
             "default_slack_notification_channel",
+            "autostart_base_branches",
             "created_at",
             "updated_at",
         ]
@@ -163,6 +174,19 @@ class SignalTeamConfigSerializer(serializers.ModelSerializer):
                 )
             },
         }
+
+    def validate_autostart_base_branches(self, value: dict) -> dict:
+        cleaned: dict[str, str] = {}
+        for repo, branch in value.items():
+            repo_key = (repo or "").strip()
+            if repo_key.count("/") != 1 or any(not part for part in repo_key.split("/")):
+                raise serializers.ValidationError(
+                    f"Repository keys must be in 'organization/repository' form, got '{repo}'."
+                )
+            branch_value = (branch or "").strip()
+            if branch_value:
+                cleaned[repo_key.lower()] = branch_value
+        return cleaned
 
 
 class _UserSerializer(serializers.ModelSerializer):

--- a/products/signals/backend/test/test_autostart_base_branches.py
+++ b/products/signals/backend/test/test_autostart_base_branches.py
@@ -1,0 +1,25 @@
+import pytest
+
+from products.signals.backend.serializers import SignalTeamConfigSerializer
+
+
+@pytest.mark.parametrize(
+    ("input_branches", "expected"),
+    [
+        # Whitespace trimmed, repo key lowercased, and the blank-branch entry
+        # dropped (the UI removes an override by clearing its branch).
+        ({"Acme/Web": "  staging  ", "acme/api": ""}, {"acme/web": "staging"}),
+        ({}, {}),
+    ],
+)
+def test_serializer_normalizes_valid_branches(input_branches, expected):
+    serializer = SignalTeamConfigSerializer(data={"autostart_base_branches": input_branches}, partial=True)
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["autostart_base_branches"] == expected
+
+
+@pytest.mark.parametrize("bad_repo", ["acme", "acme/web/extra", "/web", "acme/", ""])
+def test_serializer_rejects_malformed_repo_keys(bad_repo):
+    serializer = SignalTeamConfigSerializer(data={"autostart_base_branches": {bad_repo: "staging"}}, partial=True)
+    assert not serializer.is_valid()
+    assert "autostart_base_branches" in serializer.errors

--- a/products/signals/backend/test/test_signal_team_config_api.py
+++ b/products/signals/backend/test/test_signal_team_config_api.py
@@ -60,3 +60,45 @@ class TestSignalTeamConfigAPI(APIBaseTest):
         self.config.refresh_from_db()
         assert self.config.default_autostart_priority == "P2"
         assert self.config.default_slack_notification_channel == "C123|#posthog-signals"
+
+    def test_get_config_includes_autostart_base_branches(self):
+        self.config.autostart_base_branches = {"acme/web": "staging"}
+        self.config.save(update_fields=["autostart_base_branches"])
+        response = self.client.get(self._url())
+        data = response.json()
+        assert response.status_code == status.HTTP_200_OK, data
+        assert data["autostart_base_branches"] == {"acme/web": "staging"}
+
+    def test_update_autostart_base_branches_normalizes_and_persists(self):
+        response = self.client.post(
+            self._url(),
+            # Mixed case key is lowercased; blank-branch entry is dropped.
+            data={"autostart_base_branches": {"Acme/Web": "  staging  ", "acme/api": ""}},
+            format="json",
+        )
+        data = response.json()
+        assert response.status_code == status.HTTP_200_OK, data
+        assert data["autostart_base_branches"] == {"acme/web": "staging"}
+        self.config.refresh_from_db()
+        assert self.config.autostart_base_branches == {"acme/web": "staging"}
+
+    def test_update_autostart_base_branches_rejects_malformed_repo_key(self):
+        response = self.client.post(
+            self._url(),
+            data={"autostart_base_branches": {"not-a-repo": "staging"}},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["attr"] == "autostart_base_branches"
+
+    def test_partial_update_preserves_autostart_base_branches(self):
+        self.config.autostart_base_branches = {"acme/web": "staging"}
+        self.config.save(update_fields=["autostart_base_branches"])
+        response = self.client.post(
+            self._url(),
+            data={"default_slack_notification_channel": "C123|#posthog-signals"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        self.config.refresh_from_db()
+        assert self.config.autostart_base_branches == {"acme/web": "staging"}

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -413,6 +413,9 @@ class Task(DeletedMetaFields, models.Model):
         if sandbox_env is not None:
             extra_state["sandbox_environment_id"] = str(sandbox_env.id)
 
+        if branch:
+            extra_state["pr_base_branch"] = branch
+
         if model:
             extra_state["model"] = model
 


### PR DESCRIPTION
## Summary

configurable base branch for inbox auto-PRs (PostHog/code#2470). Stores per-repository base branch overrides and applies them when auto-starting implementation tasks, so inbox PRs can target a chosen branch instead of the repo default if needed

<img width="786" height="904" alt="configurable_base" src="https://github.com/user-attachments/assets/e965da29-a30b-4789-9d7a-cd13ffe01845" />

