### PR TITLE
fix(error-tracking): use upload-source-maps wizard command

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/sourceMapsFixWizardLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/sourceMapsFixWizardLogic.ts
@@ -108,7 +108,7 @@ export const sourceMapsFixWizardLogic = kea<sourceMapsFixWizardLogicType>([
         wizardCommand: [
             () => [preflightLogic.selectors.preflight],
             (preflight): string =>
-                `npx -y @posthog/wizard@latest upload-sourcemaps${preflight?.region === Region.EU ? ' --region eu' : ''}`,
+                `npx -y @posthog/wizard@latest upload-source-maps${preflight?.region === Region.EU ? ' --region eu' : ''}`,
         ],
     }),
 


### PR DESCRIPTION
## Changes

Fix the source maps fix modal to use the `upload-source-maps` wizard subcommand (was `upload-sourcemaps`).

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). One-line string change to the `wizardCommand` selector in `sourceMapsFixWizardLogic.ts`.
