### PR TITLE
fix(llma): make /ticket org check async-safe

### DIFF
--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
@@ -1,11 +1,10 @@
 from collections.abc import Sequence
 from uuid import uuid4
 
-from asgiref.sync import sync_to_async
-
 from django.conf import settings
 from django.utils import timezone
 
+from asgiref.sync import sync_to_async
 from langchain_core.messages import (
     AIMessage,
     HumanMessage as LangchainHumanMessage,

--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
@@ -1,6 +1,8 @@
 from collections.abc import Sequence
 from uuid import uuid4
 
+from asgiref.sync import sync_to_async
+
 from django.conf import settings
 from django.utils import timezone
 
@@ -29,21 +31,23 @@ class TicketCommand(SlashCommand):
 
     _window_manager = AnthropicConversationCompactionManager()
 
-    def _is_organization_new(self) -> bool:
+    async def _is_organization_new(self) -> bool:
         """Check if the organization was created less than 3 months ago."""
-        org_created_at = self._team.organization.created_at
+        # `self._team.organization` is a FK access that hits the DB when not prefetched,
+        # so it must be wrapped to be safe inside this async context.
+        org_created_at = await sync_to_async(lambda: self._team.organization.created_at)()
         if not org_created_at:
             return False
         months_since_creation = (timezone.now() - org_created_at).days / 30
         return months_since_creation < 3
 
-    def _can_create_ticket(self, config: RunnableConfig) -> bool:
+    async def _can_create_ticket(self, config: RunnableConfig) -> bool:
         """Check if user's subscription allows ticket creation."""
         # Enable ticket creation in local dev
         if settings.DEBUG:
             return True
 
-        if self._is_organization_new():
+        if await self._is_organization_new():
             return True
 
         billing_context_data = config.get("configurable", {}).get("billing_context")
@@ -61,7 +65,7 @@ class TicketCommand(SlashCommand):
         return has_paid_subscription or has_active_trial
 
     async def execute(self, config: RunnableConfig, state: AssistantState) -> PartialAssistantState:
-        if not self._can_create_ticket(config):
+        if not await self._can_create_ticket(config):
             return PartialAssistantState(
                 messages=[
                     AssistantMessage(

--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/test/test_ticket.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/test/test_ticket.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import pytest
 from posthog.test.base import BaseTest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from django.utils import timezone
 
@@ -168,20 +168,22 @@ class TestTicketCommand(BaseTest):
         )
         self.assertFalse(self.command._is_first_message(state))
 
-    def test_is_organization_new_returns_true_for_recent_org(self):
+    @pytest.mark.asyncio
+    async def test_is_organization_new_returns_true_for_recent_org(self):
         """Test that _is_organization_new returns True for org created less than 3 months ago."""
         self.team.organization.created_at = timezone.now() - timedelta(days=30)
         self.team.organization.save()
-        self.assertTrue(self.command._is_organization_new())
+        self.assertTrue(await self.command._is_organization_new())
 
-    def test_is_organization_new_returns_false_for_old_org(self):
+    @pytest.mark.asyncio
+    async def test_is_organization_new_returns_false_for_old_org(self):
         """Test that _is_organization_new returns False for org created more than 3 months ago."""
         self.team.organization.created_at = timezone.now() - timedelta(days=100)
         self.team.organization.save()
-        self.assertFalse(self.command._is_organization_new())
+        self.assertFalse(await self.command._is_organization_new())
 
     @pytest.mark.asyncio
-    @patch.object(TicketCommand, "_is_organization_new", return_value=True)
+    @patch.object(TicketCommand, "_is_organization_new", new_callable=AsyncMock, return_value=True)
     async def test_execute_new_org_free_user_allowed(self, mock_is_new):
         """Test that /ticket works for free users in new organizations."""
         state = AssistantState(messages=[HumanMessage(content="/ticket")])
@@ -197,7 +199,7 @@ class TestTicketCommand(BaseTest):
         self.assertIn("describe your issue", message.content.lower())
 
     @pytest.mark.asyncio
-    @patch.object(TicketCommand, "_is_organization_new", return_value=False)
+    @patch.object(TicketCommand, "_is_organization_new", new_callable=AsyncMock, return_value=False)
     async def test_execute_old_org_free_user_blocked(self, mock_is_new):
         """Test that /ticket returns upgrade message for free users in old organizations."""
         state = AssistantState(messages=[HumanMessage(content="/ticket")])

--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/test/test_ticket.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/test/test_ticket.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 from django.utils import timezone
 
+from asgiref.sync import sync_to_async
 from langchain_core.runnables import RunnableConfig
 
 from posthog.schema import AssistantMessage, HumanMessage
@@ -172,14 +173,14 @@ class TestTicketCommand(BaseTest):
     async def test_is_organization_new_returns_true_for_recent_org(self):
         """Test that _is_organization_new returns True for org created less than 3 months ago."""
         self.team.organization.created_at = timezone.now() - timedelta(days=30)
-        self.team.organization.save()
+        await sync_to_async(self.team.organization.save)()
         self.assertTrue(await self.command._is_organization_new())
 
     @pytest.mark.asyncio
     async def test_is_organization_new_returns_false_for_old_org(self):
         """Test that _is_organization_new returns False for org created more than 3 months ago."""
         self.team.organization.created_at = timezone.now() - timedelta(days=100)
-        self.team.organization.save()
+        await sync_to_async(self.team.organization.save)()
         self.assertFalse(await self.command._is_organization_new())
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Fixes: https://posthog.slack.com/archives/C0ASU43UAMS/p1780548924327849

The `/ticket` slash command in Max throws every time for users on the paid-plan / trial path, producing only an error and a frustrated 👎.

The root cause is a `django.core.exceptions.SynchronousOnlyOperation`: the async `TicketCommand.execute()` calls `_can_create_ticket()` → `_is_organization_new()`, which reads `self._team.organization.created_at`. That foreign-key access issues a **synchronous DB query** when `organization` isn't already prefetched, and Django forbids sync queries inside an async context.

The existing unit tests didn't catch it because their `setUp` touches `self.team.organization` synchronously, caching the relation on the instance — so the later FK access never hit the DB. In production the `Team` is loaded fresh without that cache, so it failed deterministically.

## Changes

- `command.py`: wrap the FK access in `sync_to_async` and make `_is_organization_new` / `_can_create_ticket` async (awaited from `execute`). This matches the pattern already used by the sibling `/usage` command, which wraps all its DB-touching helpers in `sync_to_async`.
- `test_ticket.py`: the two `_is_organization_new` unit tests are now async and awaited; the two `patch.object(..., return_value=...)` mocks use `new_callable=AsyncMock` so the awaited call resolves.

No behavior change beyond making the org-age check safe to run on the event loop.

## How did you test this code?

I'm an agent. I made these changes via the PostHog Slack app after diagnosing the failure from the production LLM trace.

I could **not** run the test suite — the environment had no Django/DB available — so the tests were verified by inspection only, not executed. They should be run before merge:

```
hogli test ee/hogai/chat_agent/slash_commands/commands/ticket/
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) after a user reported the `/ticket` command was broken. I traced the failure from the production LLM trace (`LangGraph`, span `slash_command_handler`, `$ai_is_error=true` with `SynchronousOnlyOperation`), then cloned the repo and located the offending FK access.

Decision: rather than prefetching `organization` upstream (broad blast radius, easy to regress), I wrapped the single FK access in `sync_to_async` and made the small call chain async — the same idiom the neighbouring `/usage` command already uses, so the fix is locally consistent. Tests were updated to match the new async signatures.

Needs a human reviewer and a real test run before merge.
