### PR TITLE
feat(replay-vision): server-side scanner list pagination, filtering, sorting

### DIFF
--- a/products/replay_vision/backend/api/filters.py
+++ b/products/replay_vision/backend/api/filters.py
@@ -1,0 +1,98 @@
+"""Shared django-filter primitives for the Replay Vision viewsets."""
+
+from typing import Any
+
+from django.db.models import F, Q, QuerySet
+
+import django_filters
+from rest_framework.exceptions import ValidationError
+
+
+def split_csv(value: str) -> list[str]:
+    """Split a CSV string on commas, strip each entry, drop empties."""
+    return [v for v in (v.strip() for v in value.split(",")) if v]
+
+
+def validate_csv_choices(
+    value: str,
+    valid_choices: frozenset[str],
+    error_key: str,
+) -> list[str]:
+    """Parse a CSV string and reject any value outside `valid_choices` with a 400."""
+    values = split_csv(value)
+    if not values:
+        return values
+    invalid = sorted({v for v in values if v not in valid_choices})
+    if invalid:
+        raise ValidationError({error_key: f"Invalid value(s) {invalid}; allowed: {sorted(valid_choices)}."})
+    return values
+
+
+def ordering_enum(fields: tuple[str, ...]) -> list[str]:
+    """Ascending + descending (`-`-prefixed) variants of each ordering key."""
+    return [value for field in fields for value in (field, f"-{field}")]
+
+
+class MultiChoiceFilter(django_filters.CharFilter):
+    """CSV multi-value filter; 400s on values outside `valid_choices` (unlike `BaseInFilter`, which silently matches nothing)."""
+
+    def __init__(
+        self,
+        *args: Any,
+        valid_choices: frozenset[str] | None = None,
+        error_key: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._valid_choices = valid_choices
+        # `error_key` overrides the default response key so ORM traversal paths don't leak to the client.
+        self._error_key = error_key
+
+    def filter(self, qs: QuerySet, value: str | None) -> QuerySet:
+        if not value:
+            return qs
+        if self._valid_choices is not None:
+            values = validate_csv_choices(value, self._valid_choices, self._error_key or self.field_name)
+        else:
+            values = split_csv(value)
+        if not values:
+            return qs
+        return qs.filter(Q((f"{self.field_name}__in", values)))
+
+
+class OrderByFilter(django_filters.CharFilter):
+    """Base for `?order_by=` filters. Subclasses set `_allowed_keys` and implement `_handle`."""
+
+    _allowed_keys: frozenset[str] = frozenset()
+    _tiebreaker: str = "id"
+
+    def filter(self, qs: QuerySet, value: str | None) -> QuerySet:
+        if not value:
+            return qs
+        descending = value.startswith("-")
+        key = value[1:] if descending else value
+        if key not in self._allowed_keys:
+            raise ValidationError(
+                {"order_by": f"Invalid order_by '{value}'. Allowed keys: {sorted(self._allowed_keys)}."}
+            )
+        return self._handle(qs, key, descending)
+
+    def _handle(self, qs: QuerySet, key: str, descending: bool) -> QuerySet:
+        raise NotImplementedError
+
+    def _order_plain(self, qs: QuerySet, key: str, descending: bool) -> QuerySet:
+        return qs.order_by(("-" if descending else "") + key, self._tiebreaker)
+
+    def _order_nulls_last(self, qs: QuerySet, annotation: str, descending: bool) -> QuerySet:
+        f = F(annotation)
+        expr = f.desc(nulls_last=True) if descending else f.asc(nulls_last=True)
+        return qs.order_by(expr, self._tiebreaker)
+
+
+__all__ = [
+    "MultiChoiceFilter",
+    "OrderByFilter",
+    "ordering_enum",
+    "split_csv",
+    "validate_csv_choices",
+]

--- a/products/replay_vision/backend/api/observations.py
+++ b/products/replay_vision/backend/api/observations.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Any
 
-from django.db.models import Case, CharField, F, FloatField, Func, IntegerField, Q, QuerySet, Value, When
+from django.db.models import Case, CharField, FloatField, Func, IntegerField, Q, QuerySet, Value, When
 from django.db.models.fields.json import KeyTextTransform, KeyTransform
 from django.db.models.functions import Cast
 
@@ -19,6 +19,7 @@ from rest_framework.response import Response
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 
+from products.replay_vision.backend.api.filters import MultiChoiceFilter, OrderByFilter, ordering_enum
 from products.replay_vision.backend.api.observation_stats import compute_observation_stats
 from products.replay_vision.backend.feature_flag import ReplayVisionEnabledPermission
 from products.replay_vision.backend.models.replay_observation import (
@@ -38,7 +39,6 @@ logger = structlog.get_logger(__name__)
 
 
 def _jsonb_typeof(expr: Any) -> Func:
-    """Postgres `JSONB_TYPEOF(value)` — built inline to avoid extending a custom Expression class."""
     return Func(expr, function="JSONB_TYPEOF", output_field=CharField())
 
 
@@ -264,23 +264,17 @@ _JSONB_ORDER_KEYS = ("result_score", "result_verdict", "scanner_version")
 _ALL_ORDER_KEYS = OBSERVATION_ORDER_FIELDS + _JSONB_ORDER_KEYS
 
 
-def _ordering_enum(fields: tuple[str, ...] = _ALL_ORDER_KEYS) -> list[str]:
-    """Ascending + descending (`-`-prefixed) variants of each field, matching OrderingFilter's accepted values."""
-    return [value for field in fields for value in (field, f"-{field}")]
+_MONITOR_VERDICTS = frozenset({"yes", "no", "inconclusive"})
 
 
-class _OrderByFilter(django_filters.CharFilter):
-    """Ordering filter supporting plain columns and JSONB-backed keys with numeric casts and nulls-last."""
+class _ObservationOrderByFilter(OrderByFilter):
+    """Observation-specific ordering: plain columns + JSONB-backed keys with numeric casts and nulls-last."""
 
-    def filter(self, qs: QuerySet[ReplayObservation], value: str) -> QuerySet[ReplayObservation]:
-        if not value:
-            return qs
-        descending = value.startswith("-")
-        key = value[1:] if descending else value
-        if key not in _ALL_ORDER_KEYS:
-            raise ValidationError({"order_by": f"Invalid order_by '{value}'. Allowed keys: {sorted(_ALL_ORDER_KEYS)}."})
+    _allowed_keys = frozenset(_ALL_ORDER_KEYS)
+
+    def _handle(self, qs: QuerySet[ReplayObservation], key: str, descending: bool) -> QuerySet[ReplayObservation]:
         if key in OBSERVATION_ORDER_FIELDS:
-            return qs.order_by(("-" if descending else "") + key, "id")
+            return self._order_plain(qs, key, descending)
         if key == "result_score":
             # CASE-guard the cast so a non-numeric `score` (schema drift, manual fixup) doesn't 500 the query.
             score_jsonb = KeyTransform("score", KeyTransform("model_output", "scanner_result"))
@@ -293,8 +287,7 @@ class _OrderByFilter(django_filters.CharFilter):
                     output_field=FloatField(),
                 ),
             )
-            expr = F("_order_score").desc(nulls_last=True) if descending else F("_order_score").asc(nulls_last=True)
-            return qs.order_by(expr, "id")
+            return self._order_nulls_last(qs, "_order_score", descending)
         if key == "scanner_version":
             version_jsonb = KeyTransform("scanner_version", "scanner_snapshot")
             version_text = KeyTextTransform("scanner_version", "scanner_snapshot")
@@ -306,62 +299,25 @@ class _OrderByFilter(django_filters.CharFilter):
                     output_field=IntegerField(),
                 ),
             )
-            expr = F("_order_version").desc(nulls_last=True) if descending else F("_order_version").asc(nulls_last=True)
-            return qs.order_by(expr, "id")
-        # `result_verdict` — short text enum, annotated so we get nulls-last like the other JSONB keys.
+            return self._order_nulls_last(qs, "_order_version", descending)
         qs = qs.annotate(
             _order_verdict=KeyTextTransform("verdict", KeyTextTransform("model_output", "scanner_result")),
         )
-        expr = F("_order_verdict").desc(nulls_last=True) if descending else F("_order_verdict").asc(nulls_last=True)
-        return qs.order_by(expr, "id")
-
-
-_MONITOR_VERDICTS = frozenset({"yes", "no", "inconclusive"})
-
-
-class _MultiChoiceFilter(django_filters.CharFilter):
-    """CSV-encoded multi-value filter; 400s on values outside `valid_choices` when supplied."""
-
-    def __init__(
-        self,
-        *args: Any,
-        valid_choices: frozenset[str] | None = None,
-        error_key: str | None = None,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self._valid_choices = valid_choices
-        # When `field_name` is an ORM traversal path (e.g. `scanner_result__model_output__verdict`), the
-        # default error dict key would leak it; override so the response keys match the public param name.
-        self._error_key = error_key
-
-    def filter(self, qs: QuerySet[ReplayObservation], value: str | None) -> QuerySet[ReplayObservation]:
-        if not value:
-            return qs
-        values = [v for v in (v.strip() for v in value.split(",")) if v]
-        if not values:
-            return qs
-        if self._valid_choices is not None:
-            invalid = sorted({v for v in values if v not in self._valid_choices})
-            if invalid:
-                key = self._error_key or self.field_name
-                raise ValidationError({key: f"Invalid value(s) {invalid}; allowed: {sorted(self._valid_choices)}."})
-        # nosemgrep: orm-field-injection -- `field_name` is a class-init constant; `values` validated above.
-        return qs.filter(**{f"{self.field_name}__in": values})
+        return self._order_nulls_last(qs, "_order_verdict", descending)
 
 
 class ReplayObservationFilter(django_filters.FilterSet):
-    status = _MultiChoiceFilter(
+    status = MultiChoiceFilter(
         field_name="status",
         valid_choices=frozenset(v for v, _ in ObservationStatus.choices),
         help_text="Filter by observation status. Accepts a comma-separated list.",
     )
-    triggered_by = _MultiChoiceFilter(
+    triggered_by = MultiChoiceFilter(
         field_name="triggered_by",
         valid_choices=frozenset(v for v, _ in ObservationTrigger.choices),
         help_text="Filter by trigger source (schedule or on_demand). Accepts a comma-separated list.",
     )
-    verdict = _MultiChoiceFilter(
+    verdict = MultiChoiceFilter(
         field_name="scanner_result__model_output__verdict",
         valid_choices=_MONITOR_VERDICTS,
         error_key="verdict",
@@ -378,7 +334,7 @@ class ReplayObservationFilter(django_filters.FilterSet):
         field_name="session_id",
         help_text="Filter to observations of a specific session recording.",
     )
-    order_by = _OrderByFilter(
+    order_by = _ObservationOrderByFilter(
         help_text=(
             "Sort observations by created_at, started_at, completed_at, status, result_score, result_verdict, "
             "or scanner_version. Prefix with `-` for descending. JSONB-backed keys (result_*, scanner_version) "
@@ -429,7 +385,7 @@ class ReplayObservationFilter(django_filters.FilterSet):
                 str,
                 OpenApiParameter.QUERY,
                 required=False,
-                enum=_ordering_enum(),
+                enum=ordering_enum(_ALL_ORDER_KEYS),
                 description=(
                     "Sort observations. Plain keys: created_at, started_at, completed_at, status. JSONB keys: "
                     "result_score (scorer), result_verdict (monitor), scanner_version. Prefix with `-` for descending."

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -3,7 +3,8 @@ from typing import Any, NoReturn, cast
 
 from django.conf import settings
 from django.db import IntegrityError
-from django.db.models import QuerySet
+from django.db.models import CharField, F, Q, QuerySet, Value
+from django.db.models.functions import Coalesce, NullIf
 
 import structlog
 import django_filters
@@ -13,7 +14,7 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema
 from pydantic import ValidationError as PydanticValidationError
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from temporalio.exceptions import WorkflowAlreadyStartedError
@@ -26,6 +27,13 @@ from posthog.exceptions import QuotaLimitExceeded
 from posthog.models.user import User
 from posthog.temporal.common.client import sync_connect
 
+from products.replay_vision.backend.api.filters import (
+    MultiChoiceFilter,
+    OrderByFilter,
+    ordering_enum,
+    split_csv,
+    validate_csv_choices,
+)
 from products.replay_vision.backend.feature_flag import ReplayVisionEnabledPermission
 from products.replay_vision.backend.models.replay_observation import ObservationTrigger
 from products.replay_vision.backend.models.replay_scanner import (
@@ -216,32 +224,100 @@ class ReplayScannerSerializer(serializers.ModelSerializer):
         raise error
 
 
-# Single source of truth for orderable fields; the list endpoint's OpenAPI override mirrors these as a string enum.
-SCANNER_ORDER_FIELDS = ("name", "created_at", "updated_at", "scanner_type")
+SCANNER_ORDER_FIELDS = (
+    "name",
+    "created_at",
+    "updated_at",
+    "scanner_type",
+    "enabled",
+    "sampling_rate",
+    "created_by",
+)
+_SCANNER_ENABLED_CHOICES = frozenset({"enabled", "disabled"})
+# Map `?enabled=true/false/1/0` to the CSV form so the conventional boolean stays supported.
+_SCANNER_ENABLED_ALIASES = {"true": "enabled", "false": "disabled", "1": "enabled", "0": "disabled"}
+
+
+class _ScannerOrderByFilter(OrderByFilter):
+    """Plain columns + `created_by` sorted by the display label so UI order matches the column."""
+
+    _allowed_keys = frozenset(SCANNER_ORDER_FIELDS)
+
+    def _handle(self, qs: QuerySet[ReplayScanner], key: str, descending: bool) -> QuerySet[ReplayScanner]:
+        if key == "created_by":
+            # Mirrors the frontend `createdByLabel` fallback so a row rendered "Brown" sorts on "Brown", not its email.
+            qs = qs.annotate(
+                _order_created_by=Coalesce(
+                    NullIf(F("created_by__first_name"), Value("")),
+                    NullIf(F("created_by__last_name"), Value("")),
+                    F("created_by__email"),
+                    output_field=CharField(),
+                ),
+            )
+            return self._order_nulls_last(qs, "_order_created_by", descending)
+        return self._order_plain(qs, key, descending)
 
 
 class ReplayScannerFilter(django_filters.FilterSet):
-    enabled = django_filters.BooleanFilter(
-        field_name="enabled",
-        help_text="Filter to enabled vs disabled scanners.",
+    enabled = django_filters.CharFilter(
+        method="_filter_enabled",
+        help_text="Filter by enabled state. Accepts a comma-separated list of `enabled`/`disabled`.",
     )
-    scanner_type = django_filters.ChoiceFilter(
+    scanner_type = MultiChoiceFilter(
         field_name="scanner_type",
-        choices=ScannerType.choices,
-        help_text="Filter by scanner type (monitor, classifier, scorer, summarizer).",
+        valid_choices=frozenset(v for v, _ in ScannerType.choices),
+        help_text=("Filter by scanner type (monitor, classifier, scorer, summarizer). Accepts a comma-separated list."),
     )
     emits_signals = django_filters.BooleanFilter(
         field_name="emits_signals",
         help_text="Filter to scanners that emit Signals.",
     )
-    order_by = django_filters.OrderingFilter(
-        fields=tuple((field, field) for field in SCANNER_ORDER_FIELDS),
-        help_text="Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.",
+    created_by = django_filters.CharFilter(
+        method="_filter_created_by",
+        help_text="Filter to scanners created by the given user IDs (comma-separated).",
+    )
+    search = django_filters.CharFilter(
+        method="_filter_search",
+        help_text="Case-insensitive substring match across name, description, and the prompt in scanner_config.",
+    )
+    order_by = _ScannerOrderByFilter(
+        help_text=(
+            "Sort scanners by name, created_at, updated_at, scanner_type, enabled, sampling_rate, or "
+            "created_by. Prefix with `-` for descending."
+        ),
     )
 
     class Meta:
         model = ReplayScanner
-        fields = ["enabled", "scanner_type", "emits_signals"]
+        fields = ["enabled", "scanner_type", "emits_signals", "created_by", "search"]
+
+    @staticmethod
+    def _filter_enabled(queryset: QuerySet[ReplayScanner], _name: str, value: str) -> QuerySet[ReplayScanner]:
+        # `method=` bypasses `MultiChoiceFilter.filter`, so call the shared validator directly.
+        normalized = ",".join(_SCANNER_ENABLED_ALIASES.get(v.strip().lower(), v) for v in split_csv(value))
+        values = set(validate_csv_choices(normalized, _SCANNER_ENABLED_CHOICES, "enabled"))
+        if not values or values == _SCANNER_ENABLED_CHOICES:
+            return queryset
+        return queryset.filter(enabled=("enabled" in values))
+
+    @staticmethod
+    def _filter_created_by(queryset: QuerySet[ReplayScanner], _name: str, value: str) -> QuerySet[ReplayScanner]:
+        tokens = split_csv(value)
+        if not tokens:
+            return queryset
+        invalid = sorted(t for t in tokens if not t.isdigit())
+        if invalid:
+            raise ValidationError({"created_by": f"Non-numeric value(s) {invalid}; user IDs must be integers."})
+        return queryset.filter(created_by_id__in=tokens)
+
+    @staticmethod
+    def _filter_search(queryset: QuerySet[ReplayScanner], _name: str, value: str) -> QuerySet[ReplayScanner]:
+        q = value.strip()
+        if not q:
+            return queryset
+        return queryset.filter(
+            Q(name__icontains=q) | Q(description__icontains=q) | Q(scanner_config__prompt__icontains=q)
+        )
 
 
 class ObserveRequestSerializer(serializers.Serializer):
@@ -293,6 +369,18 @@ class EstimateRequestSerializer(serializers.Serializer):
         return {k: v for k, v in value.items() if k not in _QUERY_FIELDS_TO_STRIP}
 
 
+class ScannerCreatorsResponseSerializer(serializers.Serializer):
+    """Distinct creators across all scanners on the team — feeds the `Created by` filter dropdown."""
+
+    creators = UserBasicSerializer(
+        many=True,
+        help_text=(
+            "Users who created at least one scanner on this team. Returned regardless of pagination state "
+            "so the dropdown stays stable across pages."
+        ),
+    )
+
+
 class EstimateResponseSerializer(serializers.Serializer):
     """Forward-looking observation-volume estimate for a proposed scanner. Pricing-agnostic."""
 
@@ -322,8 +410,11 @@ class EstimateResponseSerializer(serializers.Serializer):
                 str,
                 OpenApiParameter.QUERY,
                 required=False,
-                enum=[value for field in SCANNER_ORDER_FIELDS for value in (field, f"-{field}")],
-                description="Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.",
+                enum=ordering_enum(SCANNER_ORDER_FIELDS),
+                description=(
+                    "Sort scanners by name, created_at, updated_at, scanner_type, enabled, sampling_rate, or "
+                    "created_by. Prefix with `-` for descending."
+                ),
             )
         ]
     )
@@ -333,6 +424,7 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     scope_object = "replay_scanner"
     # Custom actions must be listed explicitly or personal-API-key callers 403 silently.
+    scope_object_read_actions = ["list", "retrieve", "creators"]
     scope_object_write_actions = ["create", "update", "partial_update", "destroy", "observe"]
     permission_classes = [ReplayVisionEnabledPermission]
     serializer_class = ReplayScannerSerializer
@@ -358,6 +450,20 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def safely_get_queryset(self, queryset: QuerySet[ReplayScanner]) -> QuerySet[ReplayScanner]:
         return queryset.filter(team_id=self.team_id).select_related("created_by").order_by("name", "id")
+
+    @extend_schema(responses={200: ScannerCreatorsResponseSerializer})
+    @action(detail=False, methods=["get"], pagination_class=None)
+    def creators(self, request: Request, **kwargs: Any) -> Response:
+        """Distinct creators across the team's scanners — feeds the `Created by` filter dropdown."""
+        # Mirror the per-resource RBAC the `list` action applies — the dropdown must not leak creator
+        # identities for scanners the caller can't see.
+        accessible = self.user_access_control.filter_queryset_by_access_level(
+            ReplayScanner.objects.filter(team_id=self.team_id, created_by_id__isnull=False)
+        )
+        users = User.objects.filter(
+            id__in=accessible.values_list("created_by_id", flat=True),
+        ).order_by("first_name", "last_name", "email", "id")
+        return Response({"creators": UserBasicSerializer(users, many=True).data})
 
     @extend_schema(
         request=ObserveRequestSerializer,

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from parameterized import parameterized
 from temporalio.exceptions import WorkflowAlreadyStartedError
 
-from posthog.models import Organization, Team
+from posthog.models import Organization, Team, User
 from posthog.models.utils import uuid7
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
 
@@ -311,8 +311,14 @@ class TestReplayScannerViewSet(_VisionAPITestCase):
 
     @parameterized.expand(
         [
+            ("enabled", "disabled", 1),
+            ("enabled", "enabled,disabled", 2),
+            ("enabled", "true", 1),
             ("enabled", "false", 1),
+            ("enabled", "1", 1),
+            ("enabled", "0", 1),
             ("scanner_type", ScannerType.CLASSIFIER, 1),
+            ("scanner_type", f"{ScannerType.CLASSIFIER},{ScannerType.MONITOR}", 2),
             ("emits_signals", "true", 1),
         ]
     )
@@ -330,12 +336,115 @@ class TestReplayScannerViewSet(_VisionAPITestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.json()["results"]), expected_count)
 
+    @parameterized.expand(
+        [
+            ("enabled=bogus", "enabled"),
+            ("scanner_type=does_not_exist", "scanner_type"),
+            ("order_by=nope", "order_by"),
+            ("created_by=alice", "created_by"),
+        ]
+    )
+    def test_invalid_filter_or_order_returns_400(self, query: str, attr: str) -> None:
+        resp = self.client.get(f"{self.scanners_url}?{query}")
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json().get("attr"), attr)
+
+    @parameterized.expand(
+        [
+            ("prompt match", "dead", ["beta"]),
+            ("description match", "first", ["alpha"]),
+            ("case-insensitive name match", "AmMa", ["gamma"]),
+        ]
+    )
+    def test_search_matches_name_description_or_prompt(
+        self, _label: str, query: str, expected_names: list[str]
+    ) -> None:
+        self._create_scanner(name="alpha", description="first scanner")
+        self._create_scanner(name="beta", description="something else", scanner_config={"prompt": "find dead ends"})
+        self._create_scanner(name="gamma", description="third")
+        resp = self.client.get(f"{self.scanners_url}?search={query}")
+        self.assertEqual([r["name"] for r in resp.json()["results"]], expected_names)
+
+    def test_created_by_filter_multi_value(self) -> None:
+        other_user = User.objects.create_and_join(self.team.organization, "other@example.com", "pw")
+        a = self._create_scanner(name="a")
+        a.created_by = self.user
+        a.save(update_fields=["created_by"])
+        b = self._create_scanner(name="b")
+        b.created_by = other_user
+        b.save(update_fields=["created_by"])
+        self._create_scanner(name="c")
+        resp = self.client.get(f"{self.scanners_url}?created_by={self.user.id},{other_user.id}")
+        names = sorted(r["name"] for r in resp.json()["results"])
+        self.assertEqual(names, ["a", "b"])
+
     def test_order_by_descending(self) -> None:
         self._create_scanner(name="a-scanner")
         self._create_scanner(name="b-scanner")
         resp = self.client.get(f"{self.scanners_url}?order_by=-name")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual([r["name"] for r in resp.json()["results"]], ["b-scanner", "a-scanner"])
+
+    def test_order_by_sampling_rate(self) -> None:
+        self._create_scanner(name="low", sampling_rate=0.1)
+        self._create_scanner(name="mid", sampling_rate=0.5)
+        self._create_scanner(name="high", sampling_rate=1.0)
+        resp = self.client.get(f"{self.scanners_url}?order_by=sampling_rate")
+        self.assertEqual([r["name"] for r in resp.json()["results"]], ["low", "mid", "high"])
+
+    def test_creators_endpoint_respects_per_scanner_access_control(self) -> None:
+        other = User.objects.create_and_join(self.team.organization, "hidden@example.com", "pw")
+        visible = self._create_scanner(name="visible")
+        visible.created_by = self.user
+        visible.save(update_fields=["created_by"])
+        hidden = self._create_scanner(name="hidden")
+        hidden.created_by = other
+        hidden.save(update_fields=["created_by"])
+        with patch(
+            "posthog.rbac.user_access_control.UserAccessControl.filter_queryset_by_access_level",
+            side_effect=lambda qs, **_: qs.exclude(pk=hidden.pk),
+        ):
+            resp = self.client.get(f"{self.scanners_url}creators/")
+        self.assertEqual(resp.status_code, 200)
+        ids = [u["id"] for u in resp.json()["creators"]]
+        self.assertEqual(ids, [self.user.id])
+
+    def test_creators_endpoint_returns_distinct_users(self) -> None:
+        other = User.objects.create_and_join(self.team.organization, "other@example.com", "pw")
+        a = self._create_scanner(name="a")
+        a.created_by = self.user
+        a.save(update_fields=["created_by"])
+        b = self._create_scanner(name="b")
+        b.created_by = other
+        b.save(update_fields=["created_by"])
+        c = self._create_scanner(name="c")
+        c.created_by = self.user
+        c.save(update_fields=["created_by"])
+        self._create_scanner(name="d")
+
+        resp = self.client.get(f"{self.scanners_url}creators/")
+        self.assertEqual(resp.status_code, 200)
+        ids = sorted(u["id"] for u in resp.json()["creators"])
+        self.assertEqual(ids, sorted([self.user.id, other.id]))
+
+    def test_order_by_created_by_falls_back_through_name_then_email(self) -> None:
+        alice = User.objects.create_and_join(self.organization, "alice@example.com", None, first_name="Alice")
+        bob = User.objects.create_and_join(
+            self.organization, "bob@example.com", None, first_name="", last_name="Bobson"
+        )
+        carol = User.objects.create_and_join(self.organization, "carol@example.com", None, first_name="", last_name="")
+        for owner, name in [(alice, "a"), (bob, "b"), (carol, "c")]:
+            s = self._create_scanner(name=name)
+            s.created_by = owner
+            s.save(update_fields=["created_by"])
+        resp = self.client.get(f"{self.scanners_url}?order_by=created_by")
+        self.assertEqual([r["name"] for r in resp.json()["results"]], ["a", "b", "c"])
+
+    def test_order_by_enabled(self) -> None:
+        self._create_scanner(name="on")
+        self._create_scanner(name="off", enabled=False)
+        resp = self.client.get(f"{self.scanners_url}?order_by=-enabled")
+        self.assertEqual([r["name"] for r in resp.json()["results"]], ["on", "off"])
 
     def _patch_deny_session_recording(self):
         return patch(

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -453,6 +453,14 @@ export interface ObservationStatsApi {
 }
 
 /**
+ * Distinct creators across all scanners on the team — feeds the `Created by` filter dropdown.
+ */
+export interface ScannerCreatorsResponseApi {
+    /** Users who created at least one scanner on this team. Returned regardless of pagination state so the dropdown stays stable across pages. */
+    creators: UserBasicApi[]
+}
+
+/**
  * Body of POST /vision/scanners/estimate/ — a proposed, unsaved scanner config.
  */
 export interface EstimateRequestApi {
@@ -501,13 +509,17 @@ export type VisionObservationsListParams = {
 
 export type VisionScannersListParams = {
     /**
+     * Filter to scanners created by the given user IDs (comma-separated).
+     */
+    created_by?: string
+    /**
      * Filter to scanners that emit Signals.
      */
     emits_signals?: boolean
     /**
-     * Filter to enabled vs disabled scanners.
+     * Filter by enabled state. Accepts a comma-separated list of `enabled`/`disabled`.
      */
-    enabled?: boolean
+    enabled?: string
     /**
      * Number of results to return per page.
      */
@@ -517,29 +529,18 @@ export type VisionScannersListParams = {
      */
     offset?: number
     /**
-     * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
+     * Sort scanners by name, created_at, updated_at, scanner_type, enabled, sampling_rate, or created_by. Prefix with `-` for descending.
      */
     order_by?: string
     /**
- * Filter by scanner type (monitor, classifier, scorer, summarizer).
-
-* `monitor` - Monitor
-* `classifier` - Classifier
-* `scorer` - Scorer
-* `summarizer` - Summarizer
- */
-    scanner_type?: VisionScannersListScannerType
+     * Filter by scanner type (monitor, classifier, scorer, summarizer). Accepts a comma-separated list.
+     */
+    scanner_type?: string
+    /**
+     * Case-insensitive substring match across name, description, and the prompt in scanner_config.
+     */
+    search?: string
 }
-
-export type VisionScannersListScannerType =
-    (typeof VisionScannersListScannerType)[keyof typeof VisionScannersListScannerType]
-
-export const VisionScannersListScannerType = {
-    Classifier: 'classifier',
-    Monitor: 'monitor',
-    Scorer: 'scorer',
-    Summarizer: 'summarizer',
-} as const
 
 export type VisionScannersObservationsListParams = {
     /**

--- a/products/replay_vision/frontend/generated/api.ts
+++ b/products/replay_vision/frontend/generated/api.ts
@@ -19,6 +19,7 @@ import type {
     PatchedReplayScannerApi,
     ReplayObservationApi,
     ReplayScannerApi,
+    ScannerCreatorsResponseApi,
     VisionObservationsListParams,
     VisionQuotaApi,
     VisionScannersListParams,
@@ -322,6 +323,23 @@ export const visionScannersObservationsStatsRetrieve = async (
             method: 'GET',
         }
     )
+}
+
+export const getVisionScannersCreatorsRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/vision/scanners/creators/`
+}
+
+/**
+ * Distinct creators across the team's scanners — feeds the `Created by` filter dropdown.
+ */
+export const visionScannersCreatorsRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<ScannerCreatorsResponseApi> => {
+    return apiMutator<ScannerCreatorsResponseApi>(getVisionScannersCreatorsRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
 }
 
 export const getVisionScannersEstimateCreateUrl = (projectId: string) => {

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
@@ -21,7 +21,7 @@ import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { FilterPill } from '../components/FilterPill'
 import { VisionMetrics } from './components/VisionMetrics'
-import { replayScannersLogic } from './replayScannersLogic'
+import { type ScannersSorting, SCANNERS_PAGE_SIZE, replayScannersLogic } from './replayScannersLogic'
 import {
     ENABLED_OPTIONS,
     EnabledFilter,
@@ -29,7 +29,6 @@ import {
     SCANNER_TYPE_TAG_TYPE,
     ScannerType,
     ReplayScanner,
-    createdByLabel,
     scannerTypeLabel,
 } from './types'
 
@@ -46,9 +45,11 @@ export const scene: SceneExport = {
 
 export function ReplayScannersScene(): JSX.Element {
     const {
-        filteredScanners,
         scanners,
         scannersLoading,
+        scannersPage,
+        scannersTotal,
+        scannersSort,
         togglingIds,
         search,
         enabledFilter,
@@ -57,24 +58,15 @@ export function ReplayScannersScene(): JSX.Element {
         createdByOptions,
         hasActiveFilters,
     } = useValues(replayScannersLogic)
-    const {
-        loadScanners,
-        deleteScanner,
-        duplicateScanner,
-        toggleScannerEnabled,
-        setSearch,
-        setEnabledFilter,
-        setScannerTypeFilter,
-        setCreatedByFilter,
-        clearFilters,
-    } = useActions(replayScannersLogic)
+    const { loadScanners, deleteScanner, duplicateScanner, toggleScannerEnabled, setScannersFilters, clearFilters } =
+        useActions(replayScannersLogic)
     const { push } = useActions(router)
 
     const columns: LemonTableColumns<ReplayScanner> = [
         {
             title: 'Name',
             key: 'name',
-            sorter: (a, b) => a.name.localeCompare(b.name),
+            sorter: true,
             render: (_, scanner) => (
                 <div className="flex flex-col">
                     <Link to={urls.replayVision(scanner.id)} className="font-semibold text-primary">
@@ -105,7 +97,7 @@ export function ReplayScannersScene(): JSX.Element {
                     </span>
                 </div>
             ),
-            sorter: (a, b) => Number(b.enabled) - Number(a.enabled),
+            sorter: true,
         },
         {
             title: 'Type',
@@ -115,7 +107,7 @@ export function ReplayScannersScene(): JSX.Element {
                     {scannerTypeLabel(scanner.scanner_type)}
                 </LemonTag>
             ),
-            sorter: (a, b) => a.scanner_type.localeCompare(b.scanner_type),
+            sorter: true,
         },
         {
             title: 'Description',
@@ -128,13 +120,13 @@ export function ReplayScannersScene(): JSX.Element {
         },
         {
             title: 'Sampling',
-            key: 'sampling',
+            key: 'sampling_rate',
             render: (_, scanner) => (
                 <span className="text-sm tabular-nums">
                     {(scanner.sampling_rate * 100).toFixed(scanner.sampling_rate < 0.1 ? 2 : 1)}%
                 </span>
             ),
-            sorter: (a, b) => a.sampling_rate - b.sampling_rate,
+            sorter: true,
         },
         {
             title: 'Created by',
@@ -145,7 +137,7 @@ export function ReplayScannersScene(): JSX.Element {
                 ) : (
                     <span className="text-muted">—</span>
                 ),
-            sorter: (a, b) => createdByLabel(a.created_by).localeCompare(createdByLabel(b.created_by)),
+            sorter: true,
         },
         {
             title: 'Actions',
@@ -248,7 +240,7 @@ export function ReplayScannersScene(): JSX.Element {
                         type="search"
                         placeholder="Search scanners..."
                         value={search}
-                        onChange={setSearch}
+                        onChange={(v) => setScannersFilters({ search: v })}
                         prefix={<IconSearch />}
                         className="max-w-sm"
                     />
@@ -257,19 +249,19 @@ export function ReplayScannersScene(): JSX.Element {
                             label="Status"
                             options={ENABLED_OPTIONS}
                             value={enabledFilter}
-                            onChange={setEnabledFilter}
+                            onChange={(v) => setScannersFilters({ enabledFilter: v })}
                         />
                         <FilterPill<ScannerType>
                             label="Type"
                             options={TYPE_OPTIONS}
                             value={scannerTypeFilter}
-                            onChange={setScannerTypeFilter}
+                            onChange={(v) => setScannersFilters({ scannerTypeFilter: v })}
                         />
                         <FilterPill<string>
                             label="Created by"
                             options={createdByOptions}
                             value={createdByFilter}
-                            onChange={setCreatedByFilter}
+                            onChange={(v) => setScannersFilters({ createdByFilter: v })}
                         />
                         {hasActiveFilters && (
                             <LemonButton type="tertiary" size="small" onClick={() => clearFilters()}>
@@ -284,13 +276,24 @@ export function ReplayScannersScene(): JSX.Element {
 
                 <LemonTable
                     columns={columns}
-                    dataSource={filteredScanners}
+                    dataSource={scanners}
                     loading={scannersLoading}
                     rowKey="id"
-                    pagination={{ pageSize: 50 }}
+                    pagination={{
+                        controlled: true,
+                        pageSize: SCANNERS_PAGE_SIZE,
+                        currentPage: scannersPage,
+                        entryCount: scannersTotal,
+                        onForward: () => setScannersFilters({ page: scannersPage + 1 }),
+                        onBackward: () => setScannersFilters({ page: scannersPage - 1 }),
+                    }}
+                    sorting={scannersSort}
+                    onSort={(next) => setScannersFilters({ sort: next as ScannersSorting | null })}
+                    noSortingCancellation
+                    useURLForSorting={false}
                     nouns={['scanner', 'scanners']}
                     emptyState={
-                        scanners.length === 0 ? (
+                        scannersTotal === 0 && !hasActiveFilters ? (
                             <div className="flex flex-col items-center gap-3 p-8 text-center">
                                 <div className="text-muted">No scanners yet.</div>
                                 <LemonButton type="primary" icon={<IconPlus />} to={urls.replayVisionTemplates()}>

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
@@ -1,9 +1,15 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
-import { replayScannersLogic } from './replayScannersLogic'
+import {
+    buildScannerListParams,
+    replayScannersLogic,
+    resolveScannerOrderByKey,
+    type ScannerOrderKey,
+} from './replayScannersLogic'
 import { ScannerConfig, ScannerType, ReplayScanner } from './types'
 
 function defaultConfigForType(scannerType: ScannerType): ScannerConfig {
@@ -48,7 +54,8 @@ describe('replayScannersLogic', () => {
     beforeEach(() => {
         useMocks({
             get: {
-                '/api/projects/:team/vision/scanners/': { results: [] },
+                '/api/projects/:team/vision/scanners/': { results: [], count: 0 },
+                '/api/projects/:team/vision/scanners/creators/': { creators: [] },
             },
             patch: {
                 '/api/projects/:team/vision/scanners/:id/': () => [200, {}],
@@ -63,8 +70,22 @@ describe('replayScannersLogic', () => {
         logic?.unmount()
     })
 
-    const alice = { id: 1, first_name: 'Alice', last_name: 'Anderson', email: 'alice@example.com' }
-    const bob = { id: 2, first_name: 'Bob', last_name: 'Brown', email: 'bob@example.com' }
+    const alice = {
+        id: 1,
+        uuid: '00000000-0000-0000-0000-000000000001',
+        first_name: 'Alice',
+        last_name: 'Anderson',
+        email: 'alice@example.com',
+        hedgehog_config: null,
+    }
+    const bob = {
+        id: 2,
+        uuid: '00000000-0000-0000-0000-000000000002',
+        first_name: 'Bob',
+        last_name: 'Brown',
+        email: 'bob@example.com',
+        hedgehog_config: null,
+    }
 
     const scanners: ReplayScanner[] = [
         makeScanner({ id: 'a', name: 'Confused checkout', scanner_type: 'monitor', enabled: true, created_by: alice }),
@@ -72,162 +93,224 @@ describe('replayScannersLogic', () => {
         makeScanner({ id: 'c', name: 'Refund summarizer', scanner_type: 'summarizer', enabled: true, created_by: bob }),
     ]
 
-    it.each([
-        {
-            name: 'no filters returns all',
-            search: '',
-            enabled: [],
-            types: [],
-            createdBy: [],
-            expected: ['a', 'b', 'c'],
-        },
-        { name: 'search by name', search: 'checkout', enabled: [], types: [], createdBy: [], expected: ['a'] },
-        {
-            name: 'search by prompt fragment',
-            search: 'struggle',
-            enabled: [],
-            types: [],
-            createdBy: [],
-            expected: ['a'],
-        },
-        {
-            name: 'enabled filter',
-            search: '',
-            enabled: ['enabled' as const],
-            types: [],
-            createdBy: [],
-            expected: ['a', 'c'],
-        },
-        {
-            name: 'disabled filter',
-            search: '',
-            enabled: ['disabled' as const],
-            types: [],
-            createdBy: [],
-            expected: ['b'],
-        },
-        {
-            name: 'scanner type filter',
-            search: '',
-            enabled: [],
-            types: ['classifier' as ScannerType, 'summarizer' as ScannerType],
-            createdBy: [],
-            expected: ['b', 'c'],
-        },
-        {
-            name: 'combined search + enabled',
-            search: 'refund',
-            enabled: ['enabled' as const],
-            types: [],
-            createdBy: [],
-            expected: ['c'],
-        },
-        { name: 'created by single user', search: '', enabled: [], types: [], createdBy: ['1'], expected: ['a'] },
-        {
-            name: 'created by multiple users excludes null creator',
-            search: '',
-            enabled: [],
-            types: [],
-            createdBy: ['1', '2'],
-            expected: ['a', 'c'],
-        },
-        {
-            name: 'created by unknown id matches nothing',
-            search: '',
-            enabled: [],
-            types: [],
-            createdBy: ['999'],
-            expected: [],
-        },
-    ])('filteredScanners: $name', async ({ search, enabled, types, createdBy, expected }) => {
-        await expectLogic(logic, () => {
-            logic.actions.loadScannersSuccess(scanners)
-            logic.actions.setSearch(search)
-            logic.actions.setEnabledFilter(enabled)
-            logic.actions.setScannerTypeFilter(types)
-            logic.actions.setCreatedByFilter(createdBy)
-        }).toMatchValues({
-            filteredScanners: scanners.filter((l) => expected.includes(l.id)),
-        })
-    })
-
-    it.each([
-        {
-            name: 'distinct creators sorted by label, null creators excluded',
-            createdBy: [],
-            expected: [
-                { value: '1', label: 'Alice Anderson' },
-                { value: '2', label: 'Bob Brown' },
-            ],
-        },
-        {
-            name: 'selected-but-unloaded id is surfaced so it stays untickable',
-            createdBy: ['999'],
-            expected: [
-                { value: '1', label: 'Alice Anderson' },
-                { value: '2', label: 'Bob Brown' },
-                { value: '999', label: 'User 999' },
-            ],
-        },
-    ])('createdByOptions: $name', async ({ createdBy, expected }) => {
-        await expectLogic(logic, () => {
-            logic.actions.loadScannersSuccess(scanners)
-            logic.actions.setCreatedByFilter(createdBy)
-        }).toMatchValues({
-            createdByOptions: expected,
-        })
-    })
-
-    it('hasActiveFilters tracks any active filter', async () => {
-        await expectLogic(logic).toMatchValues({ hasActiveFilters: false })
-
-        await expectLogic(logic, () => logic.actions.setSearch('foo')).toMatchValues({ hasActiveFilters: true })
-        await expectLogic(logic, () => logic.actions.setSearch('')).toMatchValues({ hasActiveFilters: false })
-
-        await expectLogic(logic, () => logic.actions.setEnabledFilter(['enabled'])).toMatchValues({
-            hasActiveFilters: true,
-        })
-        await expectLogic(logic, () => logic.actions.setEnabledFilter([])).toMatchValues({ hasActiveFilters: false })
-
-        await expectLogic(logic, () => logic.actions.setCreatedByFilter(['1'])).toMatchValues({
-            hasActiveFilters: true,
-        })
-    })
-
-    it('clearFilters resets all filter state', async () => {
-        logic.actions.setSearch('foo')
-        logic.actions.setEnabledFilter(['enabled'])
-        logic.actions.setScannerTypeFilter(['monitor'])
-        logic.actions.setCreatedByFilter(['1'])
-        await expectLogic(logic).toMatchValues({ hasActiveFilters: true })
-
-        await expectLogic(logic, () => logic.actions.clearFilters()).toMatchValues({
+    describe('buildScannerListParams', () => {
+        const emptyValues = {
             search: '',
             enabledFilter: [],
             scannerTypeFilter: [],
             createdByFilter: [],
-            hasActiveFilters: false,
+            scannersSort: null,
+        }
+
+        it('returns empty params when nothing is set', () => {
+            expect(buildScannerListParams({ ...emptyValues })).toEqual({})
+        })
+
+        it('passes limit and offset (offset only when > 0)', () => {
+            expect(buildScannerListParams({ ...emptyValues }, 50, 0)).toEqual({ limit: 50 })
+            expect(buildScannerListParams({ ...emptyValues }, 50, 100)).toEqual({ limit: 50, offset: 100 })
+        })
+
+        it('CSV-joins each filter array; trims search', () => {
+            const params = buildScannerListParams({
+                ...emptyValues,
+                search: '   hello   ',
+                enabledFilter: ['enabled', 'disabled'],
+                scannerTypeFilter: ['monitor', 'classifier'],
+                createdByFilter: ['1', '42'],
+            })
+            expect(params.search).toBe('hello')
+            expect(params.enabled).toBe('enabled,disabled')
+            expect(params.scanner_type).toBe('monitor,classifier')
+            expect(params.created_by).toBe('1,42')
+        })
+
+        it('omits an all-whitespace search', () => {
+            const params = buildScannerListParams({ ...emptyValues, search: '   ' })
+            expect(params.search).toBeUndefined()
+        })
+
+        it.each<[ScannerOrderKey, 1 | -1, string]>([
+            ['name', 1, 'name'],
+            ['created_at', -1, '-created_at'],
+            ['sampling_rate', 1, 'sampling_rate'],
+            ['created_by', -1, '-created_by'],
+        ])('serializes sort %p:%p as %s', (columnKey, order, expected) => {
+            const params = buildScannerListParams({
+                ...emptyValues,
+                scannersSort: { columnKey, order },
+            })
+            expect(params.order_by).toBe(expected)
+        })
+
+        it('drops sort on unknown column key', () => {
+            const params = buildScannerListParams({
+                ...emptyValues,
+                scannersSort: { columnKey: 'unknown_column' as ScannerOrderKey, order: 1 },
+            })
+            expect(params.order_by).toBeUndefined()
         })
     })
 
-    it('toggleScannerEnabled optimistically flips the row and marks it in-flight', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.loadScannersSuccess(scanners)
-            logic.actions.toggleScannerEnabled('a')
-        }).toMatchValues({
-            scanners: expect.arrayContaining([expect.objectContaining({ id: 'a', enabled: false })]),
-            togglingIds: ['a'],
+    describe('resolveScannerOrderByKey', () => {
+        it.each(['name', 'enabled', 'scanner_type', 'sampling_rate', 'created_by', 'created_at', 'updated_at'])(
+            'accepts %s',
+            (key) => {
+                expect(resolveScannerOrderByKey(key)).toBe(key)
+            }
+        )
+
+        it('rejects unknown keys', () => {
+            expect(resolveScannerOrderByKey('description')).toBeNull()
+            expect(resolveScannerOrderByKey('')).toBeNull()
         })
     })
 
-    it('revertScannerEnabled flips the row back and clears the in-flight id', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.loadScannersSuccess(scanners)
-            logic.actions.toggleScannerEnabled('a')
-            logic.actions.revertScannerEnabled('a')
-        }).toMatchValues({
-            scanners: expect.arrayContaining([expect.objectContaining({ id: 'a', enabled: true })]),
-            togglingIds: [],
+    describe('hasActiveFilters', () => {
+        it('tracks any active filter', async () => {
+            await expectLogic(logic).toMatchValues({ hasActiveFilters: false })
+
+            await expectLogic(logic, () => logic.actions.setScannersFilters({ search: 'foo' })).toMatchValues({
+                hasActiveFilters: true,
+            })
+            await expectLogic(logic, () => logic.actions.setScannersFilters({ search: '' })).toMatchValues({
+                hasActiveFilters: false,
+            })
+
+            await expectLogic(logic, () =>
+                logic.actions.setScannersFilters({ enabledFilter: ['enabled'] })
+            ).toMatchValues({
+                hasActiveFilters: true,
+            })
+            await expectLogic(logic, () => logic.actions.setScannersFilters({ enabledFilter: [] })).toMatchValues({
+                hasActiveFilters: false,
+            })
+
+            await expectLogic(logic, () => logic.actions.setScannersFilters({ createdByFilter: ['1'] })).toMatchValues({
+                hasActiveFilters: true,
+            })
+        })
+    })
+
+    describe('clearFilters', () => {
+        it('resets all filter state', async () => {
+            logic.actions.setScannersFilters({ search: 'foo' })
+            logic.actions.setScannersFilters({ enabledFilter: ['enabled'] })
+            logic.actions.setScannersFilters({ scannerTypeFilter: ['monitor'] })
+            logic.actions.setScannersFilters({ createdByFilter: ['1'] })
+            await expectLogic(logic).toMatchValues({ hasActiveFilters: true })
+
+            await expectLogic(logic, () => logic.actions.clearFilters()).toMatchValues({
+                search: '',
+                enabledFilter: [],
+                scannerTypeFilter: [],
+                createdByFilter: [],
+                hasActiveFilters: false,
+            })
+        })
+    })
+
+    describe('createdByOptions', () => {
+        it.each([
+            {
+                name: 'distinct creators sorted by label, null creators excluded',
+                createdBy: [],
+                expected: [
+                    { value: '1', label: 'Alice Anderson' },
+                    { value: '2', label: 'Bob Brown' },
+                ],
+            },
+            {
+                name: 'selected-but-unloaded id is surfaced so it stays untickable',
+                createdBy: ['999'],
+                expected: [
+                    { value: '1', label: 'Alice Anderson' },
+                    { value: '2', label: 'Bob Brown' },
+                    { value: '999', label: 'User 999' },
+                ],
+            },
+        ])('createdByOptions: $name', async ({ createdBy, expected }) => {
+            await expectLogic(logic, () => {
+                logic.actions.loadCreatorsSuccess([alice, bob])
+                logic.actions.setScannersFilters({ createdByFilter: createdBy })
+            }).toMatchValues({
+                createdByOptions: expected,
+            })
+        })
+    })
+
+    describe('page / sort interactions', () => {
+        it('changing a filter resets page to 1', async () => {
+            logic.actions.setScannersFilters({ page: 5 })
+            expect(logic.values.scannersPage).toBe(5)
+            await expectLogic(logic, () => {
+                logic.actions.setScannersFilters({ enabledFilter: ['enabled'] })
+            }).toMatchValues({ scannersPage: 1 })
+        })
+
+        it('changing sort resets page to 1', async () => {
+            logic.actions.setScannersFilters({ page: 3 })
+            await expectLogic(logic, () => {
+                logic.actions.setScannersFilters({ sort: { columnKey: 'name', order: 1 } })
+            }).toMatchValues({ scannersPage: 1 })
+        })
+
+        it('writes non-default state into the URL', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setScannersFilters({ enabledFilter: ['enabled'] })
+                logic.actions.setScannersFilters({ page: 2 })
+            }).toFinishAllListeners()
+            expect(router.values.searchParams.enabled).toBe('enabled')
+            expect(String(router.values.searchParams.page)).toBe('2')
+        })
+
+        it('omits defaults from the URL', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setScannersFilters({ page: 1 })
+                logic.actions.setScannersFilters({ sort: { columnKey: 'created_at', order: -1 } })
+            }).toFinishAllListeners()
+            expect(router.values.searchParams.page).toBeUndefined()
+            expect(router.values.searchParams.sort).toBeUndefined()
+        })
+    })
+
+    describe('delete / duplicate refresh', () => {
+        it('deleteScannerSuccess refetches the page and the creators list', async () => {
+            await expectLogic(logic, () => logic.actions.deleteScannerSuccess('a')).toDispatchActions([
+                'loadScanners',
+                'loadCreators',
+            ])
+        })
+
+        it('duplicateScannerSuccess refetches the page and the creators list', async () => {
+            const dup = makeScanner({ id: 'd', name: 'Copied' })
+            await expectLogic(logic, () => logic.actions.duplicateScannerSuccess(dup)).toDispatchActions([
+                'loadScanners',
+                'loadCreators',
+            ])
+        })
+    })
+
+    describe('optimistic toggle', () => {
+        it('toggleScannerEnabled optimistically flips the row and marks it in-flight', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadScannersSuccess(scanners, scanners.length)
+                logic.actions.toggleScannerEnabled('a')
+            }).toMatchValues({
+                scanners: expect.arrayContaining([expect.objectContaining({ id: 'a', enabled: false })]),
+                togglingIds: ['a'],
+            })
+        })
+
+        it('revertScannerEnabled flips the row back and clears the in-flight id', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadScannersSuccess(scanners, scanners.length)
+                logic.actions.toggleScannerEnabled('a')
+                logic.actions.revertScannerEnabled('a')
+            }).toMatchValues({
+                scanners: expect.arrayContaining([expect.objectContaining({ id: 'a', enabled: true })]),
+                togglingIds: [],
+            })
         })
     })
 

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
@@ -1,3 +1,4 @@
+import equal from 'fast-deep-equal'
 import { actions, afterMount, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
 
@@ -10,10 +11,12 @@ import { urls } from 'scenes/urls'
 
 import {
     visionScannersCreate,
+    visionScannersCreatorsRetrieve,
     visionScannersDestroy,
     visionScannersList,
     visionScannersPartialUpdate,
 } from '../generated/api'
+import type { UserBasicApi, VisionScannersListParams } from '../generated/api.schemas'
 import type { replayScannersLogicType } from './replayScannersLogicType'
 import {
     ENABLED_OPTIONS,
@@ -27,17 +30,56 @@ import {
     scannersFromApi,
 } from './types'
 
+// Filter fields whose change shifts the result set; auto-reset page unless the caller passes a new one.
+const FILTER_RESET_KEYS = ['search', 'enabledFilter', 'scannerTypeFilter', 'createdByFilter', 'sort'] as const
+
 export interface ReplayScannersLogicProps {
     tabId: string
 }
 
+// Keep in sync with `SCANNER_ORDER_FIELDS` in products/replay_vision/backend/api/scanners.py.
+export const SORTABLE_COLUMN_KEYS = [
+    'name',
+    'enabled',
+    'scanner_type',
+    'sampling_rate',
+    'created_by',
+    'created_at',
+    'updated_at',
+] as const
+export type ScannerOrderKey = (typeof SORTABLE_COLUMN_KEYS)[number]
+
+export interface ScannersSorting {
+    columnKey: ScannerOrderKey
+    order: 1 | -1
+}
+
+export const SCANNERS_PAGE_SIZE = 50
 const ALL_ENABLED: EnabledFilter[] = ENABLED_OPTIONS.map((o) => o.value)
 const ALL_SCANNER_TYPES: ScannerType[] = SCANNER_TYPE_OPTIONS.map((o) => o.value)
+const DEFAULT_SORT: ScannersSorting = { columnKey: 'created_at', order: -1 }
+
+export interface ScannersFilters {
+    search: string
+    enabledFilter: EnabledFilter[]
+    scannerTypeFilter: ScannerType[]
+    createdByFilter: string[]
+    page: number
+    sort: ScannersSorting | null
+}
+
+export const DEFAULT_FILTERS: ScannersFilters = {
+    search: '',
+    enabledFilter: [],
+    scannerTypeFilter: [],
+    createdByFilter: [],
+    page: 1,
+    sort: DEFAULT_SORT,
+}
 
 const csv = (values: string[]): string | undefined => (values.length > 0 ? values.join(',') : undefined)
 const splitCsv = (value: unknown): string[] =>
-    // The router coerces a purely-numeric single param (e.g. `created_by=1`) to a number,
-    // so coerce back to a string before splitting rather than dropping it.
+    // The router coerces a single numeric param to a number, so coerce back to a string before splitting.
     value === null || value === undefined || value === ''
         ? []
         : String(value)
@@ -47,6 +89,62 @@ const splitCsv = (value: unknown): string[] =>
 const fromCsv = <T extends string>(value: unknown, allowed: readonly T[]): T[] =>
     splitCsv(value).filter((v): v is T => (allowed as readonly string[]).includes(v))
 
+export function resolveScannerOrderByKey(columnKey: string): ScannerOrderKey | null {
+    return (SORTABLE_COLUMN_KEYS as readonly string[]).includes(columnKey) ? (columnKey as ScannerOrderKey) : null
+}
+
+export function buildScannerListParams(
+    values: {
+        search: string
+        enabledFilter: EnabledFilter[]
+        scannerTypeFilter: ScannerType[]
+        createdByFilter: string[]
+        scannersSort: ScannersSorting | null
+    },
+    limit?: number,
+    offset?: number
+): VisionScannersListParams {
+    const params: VisionScannersListParams = {}
+    if (limit !== undefined) {
+        params.limit = limit
+    }
+    if (offset !== undefined && offset > 0) {
+        params.offset = offset
+    }
+    const trimmed = values.search.trim()
+    if (trimmed.length > 0) {
+        params.search = trimmed
+    }
+    if (values.enabledFilter.length > 0) {
+        params.enabled = values.enabledFilter.join(',')
+    }
+    if (values.scannerTypeFilter.length > 0) {
+        params.scanner_type = values.scannerTypeFilter.join(',')
+    }
+    if (values.createdByFilter.length > 0) {
+        params.created_by = values.createdByFilter.join(',')
+    }
+    if (values.scannersSort) {
+        const orderKey = resolveScannerOrderByKey(values.scannersSort.columnKey)
+        if (orderKey) {
+            params.order_by = values.scannersSort.order === -1 ? `-${orderKey}` : orderKey
+        }
+    }
+    return params
+}
+
+function parseSortParam(value: unknown): ScannersSorting | null {
+    if (typeof value !== 'string' || value.length === 0) {
+        return null
+    }
+    const descending = value.startsWith('-')
+    const key = resolveScannerOrderByKey(descending ? value.slice(1) : value)
+    if (!key) {
+        return null
+    }
+    return { columnKey: key, order: descending ? -1 : 1 }
+}
+
 export const replayScannersLogic = kea<replayScannersLogicType>([
     path(['products', 'replay_vision', 'frontend', 'replay_scanners', 'replayScannersLogic']),
     props({} as ReplayScannersLogicProps),
@@ -54,8 +152,11 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
 
     actions({
         loadScanners: true,
-        loadScannersSuccess: (scanners: ReplayScanner[]) => ({ scanners }),
+        loadScannersSuccess: (scanners: ReplayScanner[], total: number) => ({ scanners, total }),
         loadScannersFailure: (error: string) => ({ error }),
+        loadCreators: true,
+        loadCreatorsSuccess: (creators: UserBasicApi[]) => ({ creators }),
+        loadCreatorsFailure: true,
         deleteScanner: (id: string) => ({ id }),
         deleteScannerSuccess: (id: string) => ({ id }),
         duplicateScanner: (id: string) => ({ id }),
@@ -63,11 +164,8 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
         toggleScannerEnabled: (id: string) => ({ id }),
         toggleScannerEnabledDone: (id: string) => ({ id }),
         revertScannerEnabled: (id: string) => ({ id }),
-        setSearch: (search: string) => ({ search }),
-        setEnabledFilter: (values: EnabledFilter[]) => ({ values }),
-        setScannerTypeFilter: (scannerTypes: ScannerType[]) => ({ scannerTypes }),
         setChartDateRange: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
-        setCreatedByFilter: (userIds: string[]) => ({ userIds }),
+        setScannersFilters: (filters: Partial<ScannersFilters>, replace: boolean = false) => ({ filters, replace }),
         clearFilters: true,
     }),
 
@@ -84,6 +182,32 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
                     state.map((l) => (l.id === id ? { ...l, enabled: !l.enabled } : l)),
             },
         ],
+        scannersTotal: [
+            0,
+            {
+                loadScannersSuccess: (_, { total }) => total,
+            },
+        ],
+        filters: [
+            DEFAULT_FILTERS,
+            {
+                setScannersFilters: (state, { filters, replace }) => {
+                    const next: ScannersFilters = replace
+                        ? { ...DEFAULT_FILTERS, ...filters }
+                        : { ...state, ...filters }
+                    const resets = !('page' in filters) && FILTER_RESET_KEYS.some((k) => k in filters)
+                    return resets ? { ...next, page: 1 } : next
+                },
+                clearFilters: (state) => ({
+                    ...state,
+                    search: '',
+                    enabledFilter: [],
+                    scannerTypeFilter: [],
+                    createdByFilter: [],
+                    page: 1,
+                }),
+            },
+        ],
         togglingIds: [
             [] as string[],
             {
@@ -92,33 +216,18 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
                 revertScannerEnabled: (state, { id }) => state.filter((i) => i !== id),
             },
         ],
+        creators: [
+            [] as UserBasicApi[],
+            {
+                loadCreatorsSuccess: (_, { creators }) => creators,
+            },
+        ],
         scannersLoading: [
             false,
             {
                 loadScanners: () => true,
                 loadScannersSuccess: () => false,
                 loadScannersFailure: () => false,
-            },
-        ],
-        search: [
-            '',
-            {
-                setSearch: (_, { search }) => search,
-                clearFilters: () => '',
-            },
-        ],
-        enabledFilter: [
-            [] as EnabledFilter[],
-            {
-                setEnabledFilter: (_, { values }) => values,
-                clearFilters: () => [],
-            },
-        ],
-        scannerTypeFilter: [
-            [] as ScannerType[],
-            {
-                setScannerTypeFilter: (_, { scannerTypes }) => scannerTypes,
-                clearFilters: () => [],
             },
         ],
         chartDateFrom: [
@@ -133,13 +242,6 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
                 setChartDateRange: (_, { dateTo }) => dateTo,
             },
         ],
-        createdByFilter: [
-            [] as string[],
-            {
-                setCreatedByFilter: (_, { userIds }) => userIds,
-                clearFilters: () => [],
-            },
-        ],
     }),
 
     listeners(({ actions, values }) => ({
@@ -149,13 +251,30 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
                 return
             }
             try {
-                const response = await visionScannersList(String(teamId))
-                actions.loadScannersSuccess(scannersFromApi(response.results ?? []))
+                const { filters } = values
+                const offset = (filters.page - 1) * SCANNERS_PAGE_SIZE
+                const params = buildScannerListParams(
+                    {
+                        search: filters.search,
+                        enabledFilter: filters.enabledFilter,
+                        scannerTypeFilter: filters.scannerTypeFilter,
+                        createdByFilter: filters.createdByFilter,
+                        scannersSort: filters.sort,
+                    },
+                    SCANNERS_PAGE_SIZE,
+                    offset
+                )
+                const response = await visionScannersList(String(teamId), params)
+                actions.loadScannersSuccess(scannersFromApi(response.results ?? []), response.count ?? 0)
             } catch (error) {
                 lemonToast.error(`Failed to load scanners: ${String(error)}`)
                 actions.loadScannersFailure(String(error))
             }
         },
+
+        // Any change that affects the result set has to refetch.
+        setScannersFilters: () => actions.loadScanners(),
+        clearFilters: () => actions.loadScanners(),
 
         deleteScanner: async ({ id }) => {
             const teamId = teamLogic.values.currentTeamId
@@ -202,6 +321,29 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
             }
         },
 
+        loadCreators: async () => {
+            const teamId = teamLogic.values.currentTeamId
+            if (!teamId) {
+                return
+            }
+            try {
+                const response = await visionScannersCreatorsRetrieve(String(teamId))
+                actions.loadCreatorsSuccess(response.creators ?? [])
+            } catch {
+                actions.loadCreatorsFailure()
+            }
+        },
+
+        // Refetch after a delete or duplicate so the paginated page + count + creator dropdown stay accurate.
+        deleteScannerSuccess: () => {
+            actions.loadScanners()
+            actions.loadCreators()
+        },
+        duplicateScannerSuccess: () => {
+            actions.loadScanners()
+            actions.loadCreators()
+        },
+
         toggleScannerEnabled: async ({ id }) => {
             // The reducer has already flipped `enabled` optimistically, so this reflects the new target state.
             const scanner = values.scanners.find((l) => l.id === id)
@@ -224,25 +366,25 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
     })),
 
     selectors({
+        search: [(s) => [s.filters], (filters: ScannersFilters) => filters.search],
+        enabledFilter: [(s) => [s.filters], (filters: ScannersFilters) => filters.enabledFilter],
+        scannerTypeFilter: [(s) => [s.filters], (filters: ScannersFilters) => filters.scannerTypeFilter],
+        createdByFilter: [(s) => [s.filters], (filters: ScannersFilters) => filters.createdByFilter],
+        scannersPage: [(s) => [s.filters], (filters: ScannersFilters) => filters.page],
+        scannersSort: [(s) => [s.filters], (filters: ScannersFilters) => filters.sort],
         hasActiveFilters: [
             (s) => [s.search, s.enabledFilter, s.scannerTypeFilter, s.createdByFilter],
             (search: string, enabled: EnabledFilter[], scannerTypes: ScannerType[], createdBy: string[]) =>
                 search.trim().length > 0 || enabled.length > 0 || scannerTypes.length > 0 || createdBy.length > 0,
         ],
         createdByOptions: [
-            (s) => [s.scanners, s.createdByFilter],
-            (scanners: ReplayScanner[], selectedIds: string[]): { value: string; label: string }[] => {
+            (s) => [s.creators, s.createdByFilter],
+            (creators: UserBasicApi[], selectedIds: string[]): { value: string; label: string }[] => {
                 const byId = new Map<string, string>()
-                for (const scanner of scanners) {
-                    if (scanner.created_by) {
-                        const id = String(scanner.created_by.id)
-                        if (!byId.has(id)) {
-                            byId.set(id, createdByLabel(scanner.created_by))
-                        }
-                    }
+                for (const user of creators) {
+                    byId.set(String(user.id), createdByLabel(user))
                 }
-                // Keep a selected creator visible (and so untickable) even when no loaded
-                // scanner has them — e.g. a shared URL or a refresh that dropped their scanners.
+                // Surface a selected-but-unknown id (e.g. shared URL) so the user can deselect it.
                 for (const id of selectedIds) {
                     if (!byId.has(id)) {
                         byId.set(id, `User ${id}`)
@@ -253,88 +395,60 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
                 )
             },
         ],
-        filteredScanners: [
-            (s) => [s.scanners, s.search, s.enabledFilter, s.scannerTypeFilter, s.createdByFilter],
-            (
-                scanners: ReplayScanner[],
-                search: string,
-                enabledValues: EnabledFilter[],
-                scannerTypes: ScannerType[],
-                createdBy: string[]
-            ): ReplayScanner[] => {
-                const q = search.trim().toLowerCase()
-                return scanners.filter((l) => {
-                    if (q) {
-                        const haystack = [l.name, l.description ?? '', l.scanner_config.prompt].join(' ').toLowerCase()
-                        if (!haystack.includes(q)) {
-                            return false
-                        }
-                    }
-                    if (enabledValues.length > 0) {
-                        const visible: EnabledFilter = l.enabled ? 'enabled' : 'disabled'
-                        if (!enabledValues.includes(visible)) {
-                            return false
-                        }
-                    }
-                    if (scannerTypes.length > 0 && !scannerTypes.includes(l.scanner_type)) {
-                        return false
-                    }
-                    if (createdBy.length > 0) {
-                        const id = l.created_by ? String(l.created_by.id) : null
-                        if (!id || !createdBy.includes(id)) {
-                            return false
-                        }
-                    }
-                    return true
-                })
-            },
-        ],
     }),
 
     tabAwareActionToUrl(({ values }) => {
-        const buildUrl = (): [string, Record<string, string | undefined>, undefined, { replace: true }] => [
-            urls.replayVision(),
-            {
-                ...router.values.searchParams,
-                search: values.search || undefined,
-                enabled: csv(values.enabledFilter),
-                type: csv(values.scannerTypeFilter),
-                created_by: csv(values.createdByFilter),
-            },
-            undefined,
-            { replace: true },
-        ]
+        const buildUrl = (): [string, Record<string, string | undefined>, undefined, { replace: true }] => {
+            const { filters } = values
+            const sortParam =
+                filters.sort &&
+                !(filters.sort.columnKey === DEFAULT_SORT.columnKey && filters.sort.order === DEFAULT_SORT.order)
+                    ? `${filters.sort.order === -1 ? '-' : ''}${filters.sort.columnKey}`
+                    : undefined
+            return [
+                urls.replayVision(),
+                {
+                    ...router.values.searchParams,
+                    search: filters.search || undefined,
+                    enabled: csv(filters.enabledFilter),
+                    type: csv(filters.scannerTypeFilter),
+                    created_by: csv(filters.createdByFilter),
+                    page: filters.page > 1 ? String(filters.page) : undefined,
+                    sort: sortParam,
+                },
+                undefined,
+                { replace: true },
+            ]
+        }
         return {
-            setSearch: buildUrl,
-            setEnabledFilter: buildUrl,
-            setScannerTypeFilter: buildUrl,
-            setCreatedByFilter: buildUrl,
+            setScannersFilters: buildUrl,
             clearFilters: buildUrl,
         }
     }),
 
-    tabAwareUrlToAction(({ actions, values }) => ({
+    tabAwareUrlToAction(({ actions, values, cache }) => ({
         [urls.replayVision()]: (_, searchParams) => {
-            const search = typeof searchParams.search === 'string' ? searchParams.search : ''
-            if (search !== values.search) {
-                actions.setSearch(search)
+            const pageRaw = Number(searchParams.page ?? 1)
+            const parsed: ScannersFilters = {
+                search: typeof searchParams.search === 'string' ? searchParams.search : '',
+                enabledFilter: fromCsv<EnabledFilter>(searchParams.enabled, ALL_ENABLED),
+                scannerTypeFilter: fromCsv<ScannerType>(searchParams.type, ALL_SCANNER_TYPES),
+                createdByFilter: splitCsv(searchParams.created_by),
+                page: Number.isFinite(pageRaw) ? Math.max(1, pageRaw) : 1,
+                sort: parseSortParam(searchParams.sort) ?? DEFAULT_SORT,
             }
-            const enabledValues = fromCsv<EnabledFilter>(searchParams.enabled, ALL_ENABLED)
-            if (csv(enabledValues) !== csv(values.enabledFilter)) {
-                actions.setEnabledFilter(enabledValues)
+            const changed = !equal(parsed, values.filters)
+            if (changed) {
+                actions.setScannersFilters(parsed, true)
+            } else if (!cache.initialLoad) {
+                // urlToAction always fires on mount; without URL params it short-circuits, so kick the first fetch here.
+                actions.loadScanners()
             }
-            const types = fromCsv<ScannerType>(searchParams.type, ALL_SCANNER_TYPES)
-            if (csv(types) !== csv(values.scannerTypeFilter)) {
-                actions.setScannerTypeFilter(types)
-            }
-            const createdBy = splitCsv(searchParams.created_by)
-            if (csv(createdBy) !== csv(values.createdByFilter)) {
-                actions.setCreatedByFilter(createdBy)
-            }
+            cache.initialLoad = true
         },
     })),
 
     afterMount(({ actions }) => {
-        actions.loadScanners()
+        actions.loadCreators()
     }),
 ])

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -121,7 +121,9 @@ export function scannerTypeLabel(scannerType: ScannerType | null | undefined): s
     return SCANNER_TYPE_OPTIONS.find((opt) => opt.value === scannerType)?.label ?? scannerType
 }
 
-export function createdByLabel(user: ReplayScanner['created_by']): string {
+export function createdByLabel(
+    user: { id: number; first_name?: string; last_name?: string; email?: string } | null
+): string {
     if (!user) {
         return ''
     }

--- a/products/replay_vision/mcp/tools.yaml
+++ b/products/replay_vision/mcp/tools.yaml
@@ -97,6 +97,9 @@ tools:
             - updated_at
         requires_ai_consent: true
         feature_flag: replay-vision
+    vision-scanners-creators-retrieve:
+        operation: vision_scanners_creators_retrieve
+        enabled: false
     vision-scanners-delete:
         operation: vision_scanners_destroy
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -36880,6 +36880,14 @@ export namespace Schemas {
       deleted?: boolean;
     }
 
+    /**
+     * Distinct creators across all scanners on the team — feeds the `Created by` filter dropdown.
+     */
+    export interface ScannerCreatorsResponse {
+      /** Users who created at least one scanner on this team. Returned regardless of pagination state so the dropdown stays stable across pages. */
+      creators: UserBasic[];
+    }
+
     export interface ScoreDefinitionCreate {
       /**
          * Human-readable scorer name.
@@ -44177,13 +44185,17 @@ export namespace Schemas {
 
     export type EnvironmentsVisionScannersListParams = {
     /**
+     * Filter to scanners created by the given user IDs (comma-separated).
+     */
+    created_by?: string;
+    /**
      * Filter to scanners that emit Signals.
      */
     emits_signals?: boolean;
     /**
-     * Filter to enabled vs disabled scanners.
+     * Filter by enabled state. Accepts a comma-separated list of `enabled`/`disabled`.
      */
-    enabled?: boolean;
+    enabled?: string;
     /**
      * Number of results to return per page.
      */
@@ -44193,29 +44205,18 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
+     * Sort scanners by name, created_at, updated_at, scanner_type, enabled, sampling_rate, or created_by. Prefix with `-` for descending.
      */
     order_by?: string;
     /**
-     * Filter by scanner type (monitor, classifier, scorer, summarizer).
-
-    * `monitor` - Monitor
-    * `classifier` - Classifier
-    * `scorer` - Scorer
-    * `summarizer` - Summarizer
+     * Filter by scanner type (monitor, classifier, scorer, summarizer). Accepts a comma-separated list.
      */
-    scanner_type?: EnvironmentsVisionScannersListScannerType;
+    scanner_type?: string;
+    /**
+     * Case-insensitive substring match across name, description, and the prompt in scanner_config.
+     */
+    search?: string;
     };
-
-    export type EnvironmentsVisionScannersListScannerType = typeof EnvironmentsVisionScannersListScannerType[keyof typeof EnvironmentsVisionScannersListScannerType];
-
-
-    export const EnvironmentsVisionScannersListScannerType = {
-      Classifier: 'classifier',
-      Monitor: 'monitor',
-      Scorer: 'scorer',
-      Summarizer: 'summarizer',
-    } as const;
 
     export type EnvironmentsVisionScannersObservationsListParams = {
     /**
@@ -50456,13 +50457,17 @@ export namespace Schemas {
 
     export type VisionScannersListParams = {
     /**
+     * Filter to scanners created by the given user IDs (comma-separated).
+     */
+    created_by?: string;
+    /**
      * Filter to scanners that emit Signals.
      */
     emits_signals?: boolean;
     /**
-     * Filter to enabled vs disabled scanners.
+     * Filter by enabled state. Accepts a comma-separated list of `enabled`/`disabled`.
      */
-    enabled?: boolean;
+    enabled?: string;
     /**
      * Number of results to return per page.
      */
@@ -50472,29 +50477,18 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.
+     * Sort scanners by name, created_at, updated_at, scanner_type, enabled, sampling_rate, or created_by. Prefix with `-` for descending.
      */
     order_by?: string;
     /**
-     * Filter by scanner type (monitor, classifier, scorer, summarizer).
-
-    * `monitor` - Monitor
-    * `classifier` - Classifier
-    * `scorer` - Scorer
-    * `summarizer` - Summarizer
+     * Filter by scanner type (monitor, classifier, scorer, summarizer). Accepts a comma-separated list.
      */
-    scanner_type?: VisionScannersListScannerType;
+    scanner_type?: string;
+    /**
+     * Case-insensitive substring match across name, description, and the prompt in scanner_config.
+     */
+    search?: string;
     };
-
-    export type VisionScannersListScannerType = typeof VisionScannersListScannerType[keyof typeof VisionScannersListScannerType];
-
-
-    export const VisionScannersListScannerType = {
-      Classifier: 'classifier',
-      Monitor: 'monitor',
-      Scorer: 'scorer',
-      Summarizer: 'summarizer',
-    } as const;
 
     export type VisionScannersObservationsListParams = {
     /**

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -63,20 +63,28 @@ export const VisionScannersListParams = /* @__PURE__ */ zod.object({
 })
 
 export const VisionScannersListQueryParams = /* @__PURE__ */ zod.object({
+    created_by: zod.string().optional().describe('Filter to scanners created by the given user IDs (comma-separated).'),
     emits_signals: zod.boolean().optional().describe('Filter to scanners that emit Signals.'),
-    enabled: zod.boolean().optional().describe('Filter to enabled vs disabled scanners.'),
+    enabled: zod
+        .string()
+        .optional()
+        .describe('Filter by enabled state. Accepts a comma-separated list of `enabled`/`disabled`.'),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     order_by: zod
         .string()
         .optional()
-        .describe('Sort scanners by name, created_at, updated_at, or scanner_type. Prefix with `-` for descending.'),
-    scanner_type: zod
-        .enum(['classifier', 'monitor', 'scorer', 'summarizer'])
-        .optional()
         .describe(
-            'Filter by scanner type (monitor, classifier, scorer, summarizer).\n\n* `monitor` - Monitor\n* `classifier` - Classifier\n* `scorer` - Scorer\n* `summarizer` - Summarizer'
+            'Sort scanners by name, created_at, updated_at, scanner_type, enabled, sampling_rate, or created_by. Prefix with `-` for descending.'
         ),
+    scanner_type: zod
+        .string()
+        .optional()
+        .describe('Filter by scanner type (monitor, classifier, scorer, summarizer). Accepts a comma-separated list.'),
+    search: zod
+        .string()
+        .optional()
+        .describe('Case-insensitive substring match across name, description, and the prompt in scanner_config.'),
 })
 
 /**

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -196,12 +196,14 @@ const visionScannersList = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/scanners/`,
             query: {
+                created_by: params.created_by,
                 emits_signals: params.emits_signals,
                 enabled: params.enabled,
                 limit: params.limit,
                 offset: params.offset,
                 order_by: params.order_by,
                 scanner_type: params.scanner_type,
+                search: params.search,
             },
         })
         return await withPostHogUrl(context, result, '/replay-vision')


### PR DESCRIPTION
## Problem

The Replay Vision scanner list paginates, filters and sorts client-side, and the `Created by` dropdown is scoped to whichever page is loaded.

## Changes

- Server-side pagination/sort/filter/search on `GET /vision/scanners/`.
- New `GET /vision/scanners/creators/` returns distinct creators for a stable filter dropdown.
- `created_by` sort mirrors the frontend `createdByLabel` fallback: `Coalesce(NullIf(first_name, ''), NullIf(last_name, ''), email)`.
- Filter primitives (`MultiChoiceFilter`, `OrderByFilter`, `validate_csv_choices`, `ordering_enum`) extracted into a shared `filters.py` and adopted by both viewsets.
- Frontend logic consolidated into a single `filters` reducer + `setScannersFilters(partial, replace?)` action.
- Controlled `LemonTable`; URL state stays in sync.

## How did you test this code?

Agent-authored, no manual UI testing.

- `pytest products/replay_vision/backend/tests/test_api.py` — 94 passed
- `hogli test products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts` — 30 passed

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.7).