### PR TITLE
fix(retention): keep entity property out of events scan pre-filter

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -226,6 +226,23 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
     def return_entity_expr(self) -> ast.Expr:
         return entity_to_expr(self.return_event, self.team)
 
+    def relevant_event_type_expr(self, entity: RetentionEntity) -> ast.Expr:
+        """Event matcher with property filters stripped, for the scan-level pre-filter.
+
+        ``global_event_filters`` pre-filters the events scan to "relevant" events. Including an
+        entity's *property* filter here is redundant — the properties are re-applied inside the
+        per-actor aggregates that actually decide cohorting — and it is actively harmful: a
+        complex property predicate (e.g. a person-property map lookup wrapped in
+        ``parseDateTime64BestEffortOrNull``) in the events ``WHERE`` defeats ClickHouse's
+        primary-key analysis, dropping ``team_id`` pruning and forcing a full-table scan.
+        Restricting the pre-filter to the event *type* keeps the scan prunable.
+        """
+        if entity.type == EntityType.DATA_WAREHOUSE:
+            return ast.Constant(value=True)
+        clean_entity = entity.model_copy(deep=True)
+        clean_entity.properties = []
+        return entity_to_expr(clean_entity, self.team)
+
     @cached_property
     def aggregation_target_events_column(self) -> str:
         if self.group_type_index is not None:
@@ -239,8 +256,15 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         global_event_filters = self.events_where_clause(
             self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence
         )
-        # Pre-filter events to only those we care about
-        is_relevant_event = ast.Or(exprs=[self.start_entity_expr, self.return_entity_expr])
+        # Pre-filter events to only the relevant event *types*. Property filters are applied
+        # inside the per-actor aggregates, not here — see relevant_event_type_expr for why
+        # keeping them out of the scan WHERE preserves primary-key (team_id) pruning.
+        is_relevant_event = ast.Or(
+            exprs=[
+                self.relevant_event_type_expr(self.start_event),
+                self.relevant_event_type_expr(self.return_event),
+            ]
+        )
         if not self.is_first_ever_occurrence:
             global_event_filters.append(is_relevant_event)
 

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
@@ -28,7 +28,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('paid', 'posthog_test_warehouse_event_mix_signups')), or(equals(events.event, 'posthog_test_warehouse_event_mix_signups'), equals(events.event, 'paid')))
+        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('paid', 'posthog_test_warehouse_event_mix_signups')))
         GROUP BY actor_id) AS retention_events
      GROUP BY actor_id
      HAVING 1) AS actor_activity

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
@@ -635,7 +635,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), equals(events.event, 'returning_event')))
+     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(equals(events.event, 'target_event'), equals(events.event, 'returning_event')))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -5530,6 +5530,52 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
         # event property access should be present, not person property access
         self.assertIn("properties", sql)
 
+    def test_first_time_retention_entity_property_kept_out_of_scan_prefilter(self):
+        """An entity property on first-time retention must not leak into the events scan WHERE.
+
+        The scan pre-filter only needs the event *type*; the property is still applied inside the
+        per-actor aggregates. A complex property predicate in the scan WHERE (e.g. a person-property
+        map lookup) defeats ClickHouse's primary-key (team_id) analysis and forces a full-table scan,
+        so it must stay out of the pre-filter while results are unchanged.
+        """
+        from posthog.hogql.context import HogQLContext
+        from posthog.hogql.modifiers import create_default_modifiers_for_team
+        from posthog.hogql.printer import prepare_and_print_ast
+
+        runner = RetentionQueryRunner(
+            team=self.team,
+            query={
+                "dateRange": {"date_from": _date(0), "date_to": _date(5)},
+                "retentionFilter": {
+                    "totalIntervals": 5,
+                    "retentionType": "retention_first_time",
+                    "targetEntity": {
+                        "id": "target_event",
+                        "type": "events",
+                        "properties": [{"key": "prop", "value": "correct", "type": "event"}],
+                    },
+                    "returningEntity": {"id": "returning_event", "type": "events"},
+                },
+            },
+        )
+        base_query = runner._base_query()
+        context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            modifiers=create_default_modifiers_for_team(self.team),
+        )
+        sql, _ = prepare_and_print_ast(base_query, context, "clickhouse", pretty=True)
+
+        # The property filter is not dropped — it still gates the start-event aggregate.
+        self.assertIn("JSONExtractRaw(events.properties", sql)
+        # The events scan pre-filter is the final WHERE (the per-actor GROUP BY / HAVING follow it).
+        scan_where = sql.rsplit("WHERE", 1)[1]
+        # The pre-filter still restricts to the relevant event type...
+        self.assertIn("events.event", scan_where)
+        # ...but the property predicate must not appear there, or it would defeat team_id pruning.
+        self.assertNotIn("JSONExtractRaw", scan_where)
+        self.assertNotIn("events.properties", scan_where)
+
 
 class TestClickhouseRetentionGroupAggregation(
     RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixin, APIBaseTest


### PR DESCRIPTION
## Problem

Retention insights pre-filter the events scan to "relevant" events via `global_event_filters`. That pre-filter (`is_relevant_event`) carried the start/return entity's **property** predicate.

When that property predicate is complex — for example a person-property map lookup wrapped in `parseDateTime64BestEffortOrNull` — putting it in the events `WHERE` defeats ClickHouse's primary-key analysis. The scan then loses `team_id` pruning and reads the entire events table instead of a single team's rows, turning a retention query that should touch one team's data into a full-table scan.

This is most visible on "first time" retention with a property-based cohort definition, but applies to any retention whose entity carries a property filter that ClickHouse's key-condition analyzer can't simplify.

## Changes

- `RetentionQueryRunner.global_event_filters`: the relevant-event pre-filter now uses the event **type** only (`relevant_event_type_expr`), not the entity's property predicate.
- The property filter is unchanged where it actually decides cohorting — inside the per-actor aggregates (`groupUniqArrayIf` / `minIf`) — so **results are identical**.
- For the common case where the start and return events are the same, the old `or(and(event, prop), event)` collapsed to `event` anyway, so the property gave no selectivity there while still defeating pruning.
- Added a regression test asserting the entity property stays out of the events scan `WHERE`, and updated the one affected snapshot.

Verified against the query plan: with the property predicate present the events scan reports `PrimaryKey Condition: true` (no pruning, full scan); with the type-only pre-filter it prunes to the team's granules.

## How did you test this code?

I'm an agent (Claude Code); no manual testing. Automated only:

- New regression test `test_first_time_retention_entity_property_kept_out_of_scan_prefilter` — asserts the property predicate is absent from the events scan `WHERE`, while the event-type filter and the aggregate-level property filter remain.
- `hogli test posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py` — the result-asserting tests (e.g. `test_retention_first_time_vs_first_ever_occurrence`, which checks retention counts for a property-filtered cohort) pass; the one affected snapshot was updated. The remaining failures are pre-existing and reproduce identically on master with this change reverted (a `str` vs `UUID` comparison in actor-query tests, unrelated to this change).
- Confirmed the pruning behavior directly with ClickHouse `EXPLAIN indexes=1`: the property-laden predicate yields a full-table scan (`PrimaryKey Condition: true`); the type-only predicate prunes by `team_id`.
- **Benchmarked end-to-end** against a production-scale events dataset, running the generated SQL both ways. With the property predicate in the scan `WHERE` the query **did not complete within a 30s execution cap** (`TIMEOUT_EXCEEDED`) — it was still reading the full table; with the type-only pre-filter the **same query returned in ~2s**, with the events scan touching roughly 4–5 orders of magnitude fewer granules. Results matched — the property predicate still gates the per-actor aggregates, so this is a pure scan-pruning win.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing change — internal query generation only.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) while investigating high-cost retention queries in the ClickHouse query log. The cost turned out not to be an all-time event scan (the suspected cause) but a lost `team_id` primary-key prune: a complex entity-property predicate in the events `WHERE` made ClickHouse abandon key-condition analysis and full-scan the table.

Localized with `EXPLAIN indexes=1` (full predicate → `PrimaryKey Condition: true`; type-only predicate → pruned to the team's granules) plus a bounded reproduction against the live cluster. The property pre-filter is redundant with the aggregate-level property filter, so removing it preserves results while restoring pruning. Considered narrower alternatives (only stripping "complex" properties) but the property pre-filter provides no correctness value and, for same start/return events, no selectivity either, so a clean type-only pre-filter is the simplest safe fix.

Agent-authored; **requires human review**. Do not self-merge.

