### PR TITLE
fix(error-tracking): tune cymbal frame cache ttl

### DIFF
--- a/rust/cymbal-resolution/README.md
+++ b/rust/cymbal-resolution/README.md
@@ -134,7 +134,7 @@ All variables are prefixed `CYMBAL_REMOTE_RESOLUTION_` and live on `cymbal::conf
 | `SUBSCRIBE_MIN_TICK_MS` | `100` | Lower bound for the Subscribe tick cadence. |
 | `SUBSCRIBE_MAX_TICK_MS` | `10000` | Upper bound for the Subscribe tick cadence. |
 
-The server inherits the narrow subset of cymbal's env-var surface needed by `build_symbol_resolver` and internal gRPC authentication: `INTERNAL_API_SECRET`, Postgres, object storage, symbol-store cache/resolver tuning, and outbound HTTP controls. It does not connect to Kafka, Redis, or the signals API.
+The server inherits the narrow subset of cymbal's env-var surface needed by `build_symbol_resolver` and internal gRPC authentication: `INTERNAL_API_SECRET`, Postgres, object storage, symbol-store cache/resolver tuning, and outbound HTTP controls. Frame result cache knobs such as `FRAME_RESOLVED_TTL_SECONDS` and `FRAME_UNRESOLVED_TTL_SECONDS` are read through cymbal's shared symbol resolver config, not duplicated in `cymbal-resolution`'s own `Config`. It does not connect to Kafka, Redis, or the signals API.
 
 Shared-secret callers are service-scoped today, so authenticated cymbal pods are permitted to resolve all teams. If future callers carry a team-scoped identity, the `Resolve` handler must reject any `ResolveItem.team_id` outside the caller's allowed team set before scheduling resolution work.
 

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -98,16 +98,14 @@ pub struct Config {
     #[envconfig(default = "100000")]
     pub frame_cache_size: u64,
 
-    #[envconfig(default = "600")]
-    pub frame_cache_ttl_seconds: u64,
+    // Used by cymbal and cymbal-resolution through the shared symbol resolver config.
+    // Resolved frame results are relatively stable, while unresolved results can become
+    // resolvable after a user uploads missing symbols, so keep them shorter.
+    #[envconfig(default = "1800")]
+    pub frame_resolved_ttl_seconds: u64,
 
-    // When we resolve a frame, we put it in PG, so other instances of cymbal can
-    // use it, or so we can re-use it after a restart. This is the TTL for that,
-    // after this many minutes we'll discard saved resolution results and re-resolve
-    // TODO - 10 minutes is too short for production use, it's only twice as long as
-    // our in-memory caching. We should do at least an hour once we release
-    #[envconfig(default = "10")]
-    pub frame_result_ttl_minutes: u32,
+    #[envconfig(default = "300")]
+    pub frame_unresolved_ttl_seconds: u64,
 
     // Maximum number of lines of pre and post context to get per frame
     #[envconfig(default = "15")]

--- a/rust/cymbal/src/frames/records.rs
+++ b/rust/cymbal/src/frames/records.rs
@@ -1,8 +1,3 @@
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-};
-
 use chrono::{DateTime, Duration, Utc};
 use common_types::error_tracking::RawFrameId;
 use serde::{Deserialize, Serialize};
@@ -62,10 +57,22 @@ impl FrameResultTtlPolicy {
             return Duration::zero();
         }
 
-        let mut hasher = DefaultHasher::new();
-        id.hash(&mut hasher);
-        Duration::milliseconds((hasher.finish() % (max_jitter_millis + 1)) as i64)
+        Duration::milliseconds((stable_jitter_hash(id) % (max_jitter_millis + 1)) as i64)
     }
+}
+
+fn stable_jitter_hash(id: &RawFrameId) -> u64 {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in id
+        .hash_id
+        .as_bytes()
+        .iter()
+        .chain(id.team_id.to_le_bytes().iter())
+    {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/rust/cymbal/src/frames/records.rs
+++ b/rust/cymbal/src/frames/records.rs
@@ -215,28 +215,45 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ttl_policy_uses_resolved_and_unresolved_ttls() {
-        let policy = FrameResultTtlPolicy::new(Duration::seconds(1800), Duration::seconds(300));
-        let id = RawFrameId::new("frame".to_string(), 1);
+    fn ttl_policy_applies_expected_ttl_with_deterministic_jitter() {
+        for (name, resolved_ttl, unresolved_ttl, all_resolved, min_ttl, max_ttl) in [
+            (
+                "resolved",
+                Duration::seconds(1800),
+                Duration::seconds(300),
+                true,
+                Duration::seconds(1800),
+                Duration::seconds(1980),
+            ),
+            (
+                "unresolved",
+                Duration::seconds(1800),
+                Duration::seconds(300),
+                false,
+                Duration::seconds(300),
+                Duration::seconds(330),
+            ),
+            (
+                "deterministic jitter",
+                Duration::seconds(100),
+                Duration::seconds(100),
+                true,
+                Duration::seconds(100),
+                Duration::seconds(110),
+            ),
+        ] {
+            let policy = FrameResultTtlPolicy::new(resolved_ttl, unresolved_ttl);
+            let id = RawFrameId::new("frame".to_string(), 1);
 
-        let resolved_ttl = policy.ttl_for_resolved_status(&id, true);
-        let unresolved_ttl = policy.ttl_for_resolved_status(&id, false);
+            let ttl = policy.ttl_for_resolved_status(&id, all_resolved);
 
-        assert!(resolved_ttl >= Duration::seconds(1800));
-        assert!(resolved_ttl <= Duration::seconds(1980));
-        assert!(unresolved_ttl >= Duration::seconds(300));
-        assert!(unresolved_ttl <= Duration::seconds(330));
-    }
-
-    #[test]
-    fn ttl_policy_adds_deterministic_jitter() {
-        let policy = FrameResultTtlPolicy::new(Duration::seconds(100), Duration::seconds(100));
-        let id = RawFrameId::new("frame".to_string(), 1);
-
-        let ttl = policy.ttl_for_resolved_status(&id, true);
-
-        assert_eq!(ttl, policy.ttl_for_resolved_status(&id, true));
-        assert!(ttl >= Duration::seconds(100));
-        assert!(ttl <= Duration::seconds(110));
+            assert_eq!(
+                ttl,
+                policy.ttl_for_resolved_status(&id, all_resolved),
+                "{name}"
+            );
+            assert!(ttl >= min_ttl, "{name}");
+            assert!(ttl <= max_ttl, "{name}");
+        }
     }
 }

--- a/rust/cymbal/src/frames/records.rs
+++ b/rust/cymbal/src/frames/records.rs
@@ -1,3 +1,8 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
 use chrono::{DateTime, Duration, Utc};
 use common_types::error_tracking::RawFrameId;
 use serde::{Deserialize, Serialize};
@@ -11,6 +16,57 @@ use crate::{
 };
 
 use super::{Context, Frame};
+
+const FRAME_TTL_JITTER_PERCENT: u32 = 10;
+
+#[derive(Debug, Clone, Copy)]
+pub struct FrameResultTtlPolicy {
+    resolved_ttl: Duration,
+    unresolved_ttl: Duration,
+}
+
+impl FrameResultTtlPolicy {
+    pub fn new(resolved_ttl: Duration, unresolved_ttl: Duration) -> Self {
+        Self {
+            resolved_ttl,
+            unresolved_ttl,
+        }
+    }
+
+    pub fn ttl_for_records(
+        &self,
+        id: &RawFrameId,
+        records: &[ErrorTrackingStackFrame],
+    ) -> Duration {
+        self.ttl_for_resolved_status(id, records.iter().all(|record| record.resolved))
+    }
+
+    pub fn ttl_for_resolved_status(&self, id: &RawFrameId, all_resolved: bool) -> Duration {
+        let base_ttl = if all_resolved {
+            self.resolved_ttl
+        } else {
+            self.unresolved_ttl
+        };
+
+        base_ttl + self.jitter_for(id, base_ttl)
+    }
+
+    fn jitter_for(&self, id: &RawFrameId, base_ttl: Duration) -> Duration {
+        if base_ttl <= Duration::zero() {
+            return Duration::zero();
+        }
+
+        let base_millis = base_ttl.num_milliseconds() as u64;
+        let max_jitter_millis = base_millis * u64::from(FRAME_TTL_JITTER_PERCENT) / 100;
+        if max_jitter_millis == 0 {
+            return Duration::zero();
+        }
+
+        let mut hasher = DefaultHasher::new();
+        id.hash(&mut hasher);
+        Duration::milliseconds((hasher.finish() % (max_jitter_millis + 1)) as i64)
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ErrorTrackingStackFrame {
@@ -76,7 +132,7 @@ impl ErrorTrackingStackFrame {
     pub async fn load_all<'c, E>(
         e: E,
         id: &RawFrameId,
-        result_ttl: Duration,
+        ttl_policy: FrameResultTtlPolicy,
     ) -> Result<Vec<Self>, UnhandledError>
     where
         E: Executor<'c, Database = sqlx::Postgres> + Clone,
@@ -109,6 +165,7 @@ impl ErrorTrackingStackFrame {
         }
 
         let mut results = Vec::new();
+        let result_ttl = ttl_policy.ttl_for_resolved_status(id, res.iter().all(|f| f.resolved));
         if res.iter().any(|f| f.created_at < Utc::now() - result_ttl) {
             // If any resultant frame is too old, we should recalculate all of them
             return Ok(Vec::new());
@@ -150,5 +207,36 @@ impl ErrorTrackingStackFrame {
         }
 
         Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ttl_policy_uses_resolved_and_unresolved_ttls() {
+        let policy = FrameResultTtlPolicy::new(Duration::seconds(1800), Duration::seconds(300));
+        let id = RawFrameId::new("frame".to_string(), 1);
+
+        let resolved_ttl = policy.ttl_for_resolved_status(&id, true);
+        let unresolved_ttl = policy.ttl_for_resolved_status(&id, false);
+
+        assert!(resolved_ttl >= Duration::seconds(1800));
+        assert!(resolved_ttl <= Duration::seconds(1980));
+        assert!(unresolved_ttl >= Duration::seconds(300));
+        assert!(unresolved_ttl <= Duration::seconds(330));
+    }
+
+    #[test]
+    fn ttl_policy_adds_deterministic_jitter() {
+        let policy = FrameResultTtlPolicy::new(Duration::seconds(100), Duration::seconds(100));
+        let id = RawFrameId::new("frame".to_string(), 1);
+
+        let ttl = policy.ttl_for_resolved_status(&id, true);
+
+        assert_eq!(ttl, policy.ttl_for_resolved_status(&id, true));
+        assert!(ttl >= Duration::seconds(100));
+        assert!(ttl <= Duration::seconds(110));
     }
 }

--- a/rust/cymbal/src/stages/resolution/symbol/local.rs
+++ b/rust/cymbal/src/stages/resolution/symbol/local.rs
@@ -1,16 +1,26 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use async_trait::async_trait;
 
 use common_types::error_tracking::RawFrameId;
-use moka::future::{Cache, CacheBuilder};
+use moka::{
+    future::{Cache, CacheBuilder},
+    Expiry,
+};
 
 use sqlx::PgPool;
 
 use crate::{
     config::Config,
     error::{JsResolveErr, ProguardError, ResolveError, UnhandledError},
-    frames::{records::ErrorTrackingStackFrame, releases::ReleaseRecord, Frame, RawFrame},
+    frames::{
+        records::{ErrorTrackingStackFrame, FrameResultTtlPolicy},
+        releases::ReleaseRecord,
+        Frame, RawFrame,
+    },
     langs::apple::AppleDebugImage,
     metric_consts::{
         FRAME_CACHE_HITS, FRAME_CACHE_MISSES, FRAME_DB_HITS, FRAME_DB_MISSES,
@@ -32,22 +42,45 @@ pub struct LocalSymbolResolver {
     catalog: Arc<Catalog>,
     cache: Cache<RawFrameId, Vec<ErrorTrackingStackFrame>>,
     pool: PgPool,
-    result_ttl: chrono::Duration,
+    ttl_policy: FrameResultTtlPolicy,
+}
+
+impl Expiry<RawFrameId, Vec<ErrorTrackingStackFrame>> for FrameResultTtlPolicy {
+    fn expire_after_create(
+        &self,
+        key: &RawFrameId,
+        value: &Vec<ErrorTrackingStackFrame>,
+        _created_at: Instant,
+    ) -> Option<Duration> {
+        self.ttl_for_records(key, value).to_std().ok()
+    }
+
+    fn expire_after_update(
+        &self,
+        key: &RawFrameId,
+        value: &Vec<ErrorTrackingStackFrame>,
+        _updated_at: Instant,
+        _duration_until_expiry: Option<Duration>,
+    ) -> Option<Duration> {
+        self.ttl_for_records(key, value).to_std().ok()
+    }
 }
 
 impl LocalSymbolResolver {
     pub fn new(config: &Config, catalog: Arc<Catalog>, pool: PgPool) -> Self {
+        let ttl_policy = FrameResultTtlPolicy::new(
+            chrono::Duration::seconds(config.frame_resolved_ttl_seconds as i64),
+            chrono::Duration::seconds(config.frame_unresolved_ttl_seconds as i64),
+        );
         let cache = CacheBuilder::new(config.frame_cache_size)
-            .time_to_live(Duration::from_secs(config.frame_cache_ttl_seconds))
+            .expire_after(ttl_policy)
             .build();
-
-        let result_ttl = chrono::Duration::minutes(config.frame_result_ttl_minutes as i64);
 
         Self {
             catalog,
             pool,
             cache,
-            result_ttl,
+            ttl_policy,
         }
     }
 
@@ -87,7 +120,7 @@ impl LocalSymbolResolver {
         debug_images: &[AppleDebugImage],
     ) -> Result<Vec<ErrorTrackingStackFrame>, UnhandledError> {
         let loaded =
-            ErrorTrackingStackFrame::load_all(&self.pool, &raw_id, self.result_ttl).await?;
+            ErrorTrackingStackFrame::load_all(&self.pool, &raw_id, self.ttl_policy).await?;
         if !loaded.is_empty() {
             metrics::counter!(FRAME_DB_HITS).increment(1);
             return Ok(loaded);
@@ -397,12 +430,11 @@ mod test {
 
         // get the frame
         let frame_id = frame.raw_id(0);
-        let frame =
-            ErrorTrackingStackFrame::load_all(&pool, &frame_id, chrono::Duration::minutes(30))
-                .await
-                .unwrap()
-                .pop()
-                .unwrap();
+        let frame = ErrorTrackingStackFrame::load_all(&pool, &frame_id, resolver.ttl_policy)
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
 
         assert_eq!(frame.symbol_set_id.unwrap(), set.id);
 

--- a/rust/cymbal/src/stages/resolution/symbol/local.rs
+++ b/rust/cymbal/src/stages/resolution/symbol/local.rs
@@ -37,6 +37,8 @@ use crate::{
     types::operator::TeamId,
 };
 
+const FRAME_EXPIRY_FALLBACK_SECONDS: u64 = 300;
+
 #[derive(Clone)]
 pub struct LocalSymbolResolver {
     catalog: Arc<Catalog>,
@@ -52,7 +54,7 @@ impl Expiry<RawFrameId, Vec<ErrorTrackingStackFrame>> for FrameResultTtlPolicy {
         value: &Vec<ErrorTrackingStackFrame>,
         _created_at: Instant,
     ) -> Option<Duration> {
-        self.ttl_for_records(key, value).to_std().ok()
+        Some(expiration_duration(self, key, value))
     }
 
     fn expire_after_update(
@@ -62,8 +64,22 @@ impl Expiry<RawFrameId, Vec<ErrorTrackingStackFrame>> for FrameResultTtlPolicy {
         _updated_at: Instant,
         _duration_until_expiry: Option<Duration>,
     ) -> Option<Duration> {
-        self.ttl_for_records(key, value).to_std().ok()
+        Some(expiration_duration(self, key, value))
     }
+}
+
+fn expiration_duration(
+    policy: &FrameResultTtlPolicy,
+    key: &RawFrameId,
+    value: &[ErrorTrackingStackFrame],
+) -> Duration {
+    policy
+        .ttl_for_records(key, value)
+        .to_std()
+        .unwrap_or_else(|err| {
+            tracing::warn!(error = %err, "invalid frame cache ttl, using fallback");
+            Duration::from_secs(FRAME_EXPIRY_FALLBACK_SECONDS)
+        })
 }
 
 impl LocalSymbolResolver {


### PR DESCRIPTION
## Problem

Cymbal uses the same frame-cache freshness window for resolved and unresolved frame results. This keeps stale unresolved results around as long as stable resolved results, and fixed TTLs can cause many entries created around the same time to expire together.

## Changes

- Add separate resolved and unresolved frame result TTL config values for the shared Cymbal symbol resolver.
- Apply the same TTL policy to both Moka in-memory cache entries and Postgres-backed frame reuse.
- Add deterministic per-frame 10% TTL jitter to spread expirations while keeping behavior stable for each raw frame id.
- Document how `cymbal-resolution` inherits these resolver cache knobs through Cymbal's shared config.

## How did you test this code?

- Agent-authored change; automated checks only.
- `cd rust/cymbal && flox activate -- bash -c "cargo fmt"`
- `cd rust/cymbal && flox activate -- bash -c "cargo test -p cymbal frames::records::tests"`
- `cd rust/cymbal && flox activate -- bash -c "cargo clippy -p cymbal --all-targets -- -D warnings"`
- `cd rust/cymbal && flox activate -- bash -c "cargo check -p cymbal -p cymbal-resolution"`
- `cd rust/cymbal && flox activate -- bash -c "cargo shear"` was attempted and failed on existing unrelated `capture` and `personhog-replica` dependency/file findings.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated the `cymbal-resolution` README to clarify that frame result cache TTL knobs are inherited through Cymbal's shared symbol resolver config.

## 🤖 Agent context

Implemented with the pi coding agent using repo-local file edits and Rust cargo checks. The TTL policy is intentionally small: resolved and unresolved result TTLs are configurable, while jitter is a fixed 10% deterministic spread per raw frame id to avoid adding another config knob.

The policy is shared between the Moka frame cache and Postgres frame reuse so a Moka miss does not revive stale unresolved results from the persisted cache.