### PR TITLE
fix(cli): warn and fall back when --env-file is missing

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.7.17
+
+- fix: treat a missing `--env-file` as a warning instead of a fatal error — the CLI logs that the file wasn't found and falls back to the other credential sources (process env, then stored credentials). A file that exists but can't be read still errors.
+
 # 0.7.16
 
 - feat: add `--dry-run` flag (and `POSTHOG_CLI_DRY_RUN` env var) to skip artifact uploads (sourcemap, dSYM, Hermes, ProGuard) without contacting PostHog or requiring credentials — for CI gates that bundle to catch regressions but must not upload.

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -14,7 +14,7 @@ git checkout -b "cli/release-v0.1.0-pre1"
 ```bash
 git add .
 git commit -m "Bump version number"
-git tag "posthog-cli-v0.1.0-prerelease.1"
+git tag "posthog-cli/v0.1.0-prerelease.1"
 git push
 git push --tags
 # Optional - also publish to crates.io

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-cli"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.7.16"
+version = "0.7.17"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/utils/auth.rs
+++ b/cli/src/utils/auth.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Error};
 use inquire::{validator::Validation, CustomUserError};
 use reqwest::Url;
 use std::path::PathBuf;
-use tracing::info;
+use tracing::{info, warn};
 
 use serde::{Deserialize, Serialize};
 
@@ -63,7 +63,9 @@ impl CredentialProvider for HomeDirProvider {
 
 /// Reads credentials atomically from a single source. Tries the process env first; if the
 /// required variables aren't there and an explicit `--env-file` path was supplied, tries that
-/// file next. `host` is optional and is only read from the same source that supplied the rest.
+/// file next. A missing `--env-file` is a warning, not a fatal error — we skip it and let the
+/// caller fall back to other credential sources. `host` is optional and is only read from the
+/// same source that supplied the rest.
 pub struct EnvVarProvider {
     pub env_file: Option<PathBuf>,
 }
@@ -85,14 +87,20 @@ impl CredentialProvider for EnvVarProvider {
             return Ok(t);
         }
         if let Some(path) = &self.env_file {
-            let file = load_dotenv(path)?;
-            if let Some(t) = try_source(|n| file.get(n).cloned()) {
-                return Ok(t);
+            if path.exists() {
+                let file = load_dotenv(path)?;
+                if let Some(t) = try_source(|n| file.get(n).cloned()) {
+                    return Ok(t);
+                }
+                anyhow::bail!(
+                    "Couldn't find POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID in process env or {}",
+                    path.display()
+                )
             }
-            anyhow::bail!(
-                "Couldn't find POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID in process env or {}",
+            warn!(
+                "Env file {} not found; falling back to default credential sources",
                 path.display()
-            )
+            );
         }
         anyhow::bail!("Couldn't find POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID in process env")
     }
@@ -330,5 +338,20 @@ mod tests {
         let token = provider.get_credentials().unwrap();
         assert_eq!(token.token, "phx_from_file");
         assert_eq!(token.env_id, "222");
+    }
+
+    #[test]
+    fn provider_skips_missing_env_file_without_read_error() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        clear_env();
+
+        let provider = EnvVarProvider {
+            env_file: Some(PathBuf::from("/definitely/not/a/real/path/.env")),
+        };
+        // A missing env file must not surface a file-read error — it falls through to the
+        // generic "not in process env" message so the caller can try other sources.
+        let err = provider.get_credentials().unwrap_err().to_string();
+        assert!(err.contains("in process env"));
+        assert!(!err.contains("env file"));
     }
 }

--- a/cli/src/utils/auth.rs
+++ b/cli/src/utils/auth.rs
@@ -87,20 +87,29 @@ impl CredentialProvider for EnvVarProvider {
             return Ok(t);
         }
         if let Some(path) = &self.env_file {
-            if path.exists() {
-                let file = load_dotenv(path)?;
-                if let Some(t) = try_source(|n| file.get(n).cloned()) {
-                    return Ok(t);
+            match load_dotenv(path) {
+                Ok(file) => {
+                    if let Some(t) = try_source(|n| file.get(n).cloned()) {
+                        return Ok(t);
+                    }
+                    anyhow::bail!(
+                        "Couldn't find POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID in process env or {}",
+                        path.display()
+                    )
                 }
-                anyhow::bail!(
-                    "Couldn't find POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID in process env or {}",
-                    path.display()
-                )
+                // A missing file is non-fatal: warn and fall back to other sources. Any other
+                // read failure (e.g. permissions) is a real problem and still propagates.
+                Err(e)
+                    if e.downcast_ref::<std::io::Error>()
+                        .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound) =>
+                {
+                    warn!(
+                        "Env file {} not found; falling back to default credential sources",
+                        path.display()
+                    );
+                }
+                Err(e) => return Err(e),
             }
-            warn!(
-                "Env file {} not found; falling back to default credential sources",
-                path.display()
-            );
         }
         anyhow::bail!("Couldn't find POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID in process env")
     }


### PR DESCRIPTION
## Problem

Passing `--env-file` with a path that doesn't exist made the CLI surface a hard file-read error instead of falling back to the other credential sources.

## Changes

A missing `--env-file` now logs a warning and falls through to the normal fallback chain (process env, then home-dir credentials). A file that exists but is malformed still errors.

## How did you test this code?

Agent-authored. Added and ran a unit test (`provider_skips_missing_env_file_without_read_error`) covering the missing-file path; the full `auth` test module passes via `cargo test`.

## 🤖 Agent context

Authored with Claude Code. Considered also adding value-naming warnings for loaded host/key/project-id, but skipped that since `InvocationConfig::validate()` already enforces those. Scoped to making a missing `--env-file` non-fatal; kept the error for a present-but-malformed file.
