### PR TITLE
fix: Show correct tab state when viewing syncs from schema

### DIFF
--- a/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
@@ -14,6 +14,8 @@ import {
 import { actionToUrl, urlToAction } from 'kea-router'
 import { useEffect } from 'react'
 
+import { LemonSkeleton } from '@posthog/lemon-ui'
+
 import { NotFound } from 'lib/components/NotFound'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
@@ -217,7 +219,7 @@ function ManagedSourceTabs({
 }): JSX.Element {
     const settingsLogic = sourceSettingsLogic({ id: sourceId, availableSources: {} })
     const { featureFlags } = useValues(featureFlagLogic)
-    const { source } = useValues(settingsLogic)
+    const { source, sourceLoading } = useValues(settingsLogic)
 
     useAttachedLogic(settingsLogic, attachTo)
 
@@ -236,6 +238,10 @@ function ManagedSourceTabs({
             setCurrentTab('schemas')
         }
     }, [showSyncsTab, showWebhookTab, showMetricsTab, currentTab, setCurrentTab])
+
+    if (sourceLoading && !source) {
+        return <LemonSkeleton className="w-full h-12" />
+    }
 
     const tabs: LemonTab<SourceSceneTab>[] = [
         { label: 'Schemas', key: 'schemas', content: <SchemasTab id={sourceId} /> },


### PR DESCRIPTION
## Problem

Clicking 'view sync history' showed the wrong tab state when you landed on the syncs page:

https://github.com/user-attachments/assets/82b1576a-a2fa-49b2-ad9a-d28ad3bb2570

## Changes

Wait for sourceLoading to complete before rendering tab state


https://github.com/user-attachments/assets/4e595881-dbf7-4fc2-83de-a48547152cc6

## How did you test this code?

Verified the fix locally