### PR TITLE
fix(batch-exports): defer aioboto3 session creation to avoid import-time crash

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/file_download_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/file_download_batch_export.py
@@ -43,7 +43,17 @@ FILE_DOWNLOAD_PREFIX = (
 
 NON_RETRYABLE_ERROR_TYPES = ()
 
-SESSION = aioboto3.Session()
+# Created lazily rather than at module import time: instantiating a boto3 session eagerly
+# resolves botocore config (including the active AWS profile), which crashes Django startup
+# when a profile is set in the environment but absent from local AWS config.
+_SESSION: aioboto3.Session | None = None
+
+
+def get_session() -> aioboto3.Session:
+    global _SESSION
+    if _SESSION is None:
+        _SESSION = aioboto3.Session()
+    return _SESSION
 
 
 class Credentials(typing.NamedTuple):
@@ -100,7 +110,7 @@ async def _get_temporary_credentials_for_bucket_prefix(
     `_get_temporary_credentials_for_multipart_upload` or
     `_get_temporary_credentials_to_head_object` as needed.
     """
-    async with SESSION.client("sts") as sts:
+    async with get_session().client("sts") as sts:
         for attempt in range(1, max_attempts + 1):
             try:
                 response = await sts.assume_role(


### PR DESCRIPTION
## Problem

Local stack (and any environment with an AWS profile exported) fails to boot on master with:

```
botocore.exceptions.ProfileNotFound: The config profile (posthog) could not be found
```

The crash happens during Django startup, before the app can serve anything.

`products/batch_exports/backend/temporal/destinations/file_download_batch_export.py` instantiated `aioboto3.Session()` at **module import time**. That module is pulled into startup through a long but unavoidable chain:

`posthog/apps.py` `ready()` → `posthog.tasks` → `posthog.api` → batch_export API → `temporal/__init__.py` → `file_download_batch_export`.

`aioboto3.Session()` eagerly resolves botocore config — including the active AWS profile. Many devs export `AWS_PROFILE=posthog`, but no matching `[profile posthog]` exists in their local `~/.aws/config`, so botocore raises `ProfileNotFound` and granian/Django dies at boot.

## Changes

Create the boto3 session lazily behind a `get_session()` helper instead of at module scope. This matches the already-working pattern in the sibling `s3_batch_export.py`, which builds its session inside `__init__` rather than at import time. The session is still reused (cached in a module global) once first created inside an activity.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not run the local stack. I:

- Confirmed the import chain that drags this module into Django startup.
- Verified the edited module parses cleanly (`ast.parse`).
- Confirmed nothing else imports the old module-level `SESSION` symbol.

The change is a mechanical move of session creation from import time into a lazily-invoked accessor, mirroring the proven pattern in `s3_batch_export.py`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by the PostHog Slack app after a report that the local stack was broken on master. The traceback pointed at a module-level `aioboto3.Session()` in a newly added batch-exports destination. Diagnosed the import chain, compared against the lazy-session pattern in `s3_batch_export.py`, and applied the same deferral. Chose a cached lazy accessor over creating a fresh session per call to preserve the original single-session behavior.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
