### PR TITLE
feat(error-tracking): add cymbal temporal worker

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -239,6 +239,16 @@ procs:
             layer: Product services
             tech: Rust
 
+    cymbal-worker:
+        shell: |-
+            bin/wait-for-docker temporal && \
+            bin/start-rust-service cymbal-worker
+        capability: cymbal_temporal_worker
+        ready_pattern: 'starting cymbal Temporal worker'
+        groups:
+            layer: Product services
+            tech: Rust
+
     embedding-worker:
         shell: |-
             bin/wait-for-docker && \

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -174,6 +174,15 @@ case "$RS_SVC" in
     export SUBSCRIBE_TICK_INTERVAL_MS="${SUBSCRIBE_TICK_INTERVAL_MS:-500}"
     ;;
 
+  cymbal-worker)
+    export RUST_LOG=info,cymbal_worker=debug
+    export RUST_BACKTRACE=1
+    export TEMPORAL_ADDRESS="${TEMPORAL_ADDRESS:-http://localhost:7233}"
+    export TEMPORAL_NAMESPACE="${TEMPORAL_NAMESPACE:-default}"
+    export TEMPORAL_TASK_QUEUE="${TEMPORAL_TASK_QUEUE:-cymbal-worker}"
+    export TEMPORAL_CLIENT_IDENTITY="${TEMPORAL_CLIENT_IDENTITY:-cymbal-worker-local}"
+    ;;
+
   embedding-worker)
     export RUST_LOG=debug,rdkafka=warn
     export RUST_BACKTRACE=1

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -43,6 +43,11 @@ capabilities:
         requires: [event_ingestion]
         docker_profiles: []
 
+    cymbal_temporal_worker:
+        description: 'Rust Temporal worker for Cymbal workflows and activities'
+        requires: [core_infra]
+        docker_profiles: [temporal]
+
     flag_evaluation:
         description: 'Fast feature flag evaluation service'
         requires: [core_infra]
@@ -222,6 +227,7 @@ intents:
             [
                 event_ingestion,
                 error_symbolication,
+                cymbal_temporal_worker,
                 embedding_service,
                 property_definitions,
                 property_values,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -474,6 +474,7 @@ services:
                 # startup for every output it produces to (see analytics/outputs/registry.ts).
                 # Auto-create only fires on producer-first writes, so pre-create them here.
                 TOPICS="document_embeddings_input \
+                    document_embedding_results \
                     clickhouse_events_json \
                     clickhouse_ai_events_json \
                     clickhouse_heatmap_events \

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
- "lru",
+ "lru 0.12.5",
  "percent-encoding",
  "regex-lite",
  "sha2",
@@ -1752,7 +1752,7 @@ dependencies = [
  "multer",
  "once_cell",
  "opentelemetry 0.22.0",
- "opentelemetry-otlp",
+ "opentelemetry-otlp 0.15.0",
  "opentelemetry-proto 0.29.0",
  "opentelemetry_sdk 0.22.1",
  "prost 0.13.5",
@@ -2333,6 +2333,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,6 +2722,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cymbal-worker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "common-kafka",
+ "common-types",
+ "envconfig",
+ "serde",
+ "serde_json",
+ "squads-temporal-sdk",
+ "squads-temporal-sdk-core",
+ "squads-temporal-sdk-core-api",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,6 +2979,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3160,6 +3211,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "enum-iterator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3174,6 +3245,18 @@ version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3243,6 +3326,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -3413,7 +3507,7 @@ dependencies = [
  "envconfig",
  "fancy-regex 0.17.0",
  "futures",
- "governor",
+ "governor 0.5.1",
  "hex",
  "http-body-util",
  "json5",
@@ -3425,7 +3519,7 @@ dependencies = [
  "moka",
  "once_cell",
  "opentelemetry 0.22.0",
- "opentelemetry-otlp",
+ "opentelemetry-otlp 0.15.0",
  "opentelemetry_sdk 0.22.1",
  "percent-encoding",
  "petgraph 0.8.3",
@@ -3868,6 +3962,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-retry"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde5a672a61f96552aa5ed9fd9c81c3fbdae4be9b1e205d6eaf17c83705adc0f"
+dependencies = [
+ "futures",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3910,6 +4015,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -4007,6 +4122,29 @@ dependencies = [
  "quanta 0.9.3",
  "rand 0.8.5",
  "smallvec",
+]
+
+[[package]]
+name = "governor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+dependencies = [
+ "cfg-if",
+ "dashmap 6.1.0",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta 0.12.6",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -4545,7 +4683,7 @@ dependencies = [
  "health",
  "http-body-util",
  "opentelemetry 0.22.0",
- "opentelemetry-otlp",
+ "opentelemetry-otlp 0.15.0",
  "opentelemetry_sdk 0.22.1",
  "regex",
  "reqwest 0.12.28",
@@ -4589,7 +4727,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4867,6 +5005,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -5230,7 +5377,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "object_store",
  "opentelemetry 0.22.0",
- "opentelemetry-otlp",
+ "opentelemetry-otlp 0.15.0",
  "opentelemetry_sdk 0.22.1",
  "rand 0.8.5",
  "rayon",
@@ -5568,7 +5715,7 @@ dependencies = [
  "criterion",
  "dashmap 6.1.0",
  "futures",
- "governor",
+ "governor 0.5.1",
  "metrics",
  "metrics-util",
  "moka",
@@ -5639,6 +5786,15 @@ name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.5",
 ]
@@ -6134,6 +6290,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6434,6 +6599,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry 0.30.0",
+ "reqwest 0.12.28",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6450,6 +6642,25 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.11.0",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry 0.30.0",
+ "opentelemetry-http",
+ "opentelemetry-proto 0.30.0",
+ "opentelemetry_sdk 0.30.0",
+ "prost 0.13.5",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.13.1",
+ "tracing",
 ]
 
 [[package]]
@@ -6478,6 +6689,18 @@ dependencies = [
  "serde",
  "tonic 0.12.3",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+dependencies = [
+ "opentelemetry 0.30.0",
+ "opentelemetry_sdk 0.30.0",
+ "prost 0.13.5",
+ "tonic 0.13.1",
 ]
 
 [[package]]
@@ -6523,6 +6746,24 @@ dependencies = [
  "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.30.0",
+ "percent-encoding",
+ "rand 0.9.2",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -7010,6 +7251,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
+name = "pid"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c931ef9756cd5e3fa3d395bfe09df4dfa6f0612c6ca8f6b12927d17ca34e36"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7357,6 +7607,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "property-defs-rs"
 version = "0.1.0"
 dependencies = [
@@ -7585,6 +7850,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost 0.14.3",
+]
+
+[[package]]
+name = "prost-wkt"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497e1e938f0c09ef9cabe1d49437b4016e03e8f82fbbe5d1c62a9b61b9decae1"
+dependencies = [
+ "chrono",
+ "inventory",
+ "prost 0.13.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "typetag",
+]
+
+[[package]]
+name = "prost-wkt-build"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b8bf115b70a7aa5af1fd5d6e9418492e9ccb6e4785e858c938e28d132a884b"
+dependencies = [
+ "heck",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "quote",
+]
+
+[[package]]
+name = "prost-wkt-types"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cdde6df0a98311c839392ca2f2f0bcecd545f86a62b4e3c6a49c336e970fe5"
+dependencies = [
+ "chrono",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "prost-wkt",
+ "prost-wkt-build",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -8372,6 +8683,17 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ringbuf"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c"
+dependencies = [
+ "crossbeam-utils",
+ "portable-atomic",
+ "portable-atomic-util",
 ]
 
 [[package]]
@@ -9204,6 +9526,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "small_ctor"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9287,6 +9618,15 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]
@@ -9508,6 +9848,192 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+ "uuid",
+]
+
+[[package]]
+name = "squads-rustfsm"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c382048e58d5c56d6a23fae9eef2ffc01baadf47efbb83306d964a7b890d7ca1"
+dependencies = [
+ "squads-rustfsm-procmacro",
+ "squads-rustfsm-trait",
+]
+
+[[package]]
+name = "squads-rustfsm-procmacro"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef7bb646d98c3e88041c3b964579a673fdc9c946e7ea2210a90af92a1da7160"
+dependencies = [
+ "derive_more",
+ "proc-macro2",
+ "quote",
+ "squads-rustfsm-trait",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "squads-rustfsm-trait"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68cc72136ed00a44984a99c2a60dab53d0e94b900308c9aa2a933f397f50696"
+
+[[package]]
+name = "squads-temporal-client"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75bf1407c114448b05bed51cdc80350fd86815e889a27befc202068d7b4564ef"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backoff",
+ "base64 0.22.1",
+ "bytes",
+ "derive_builder",
+ "derive_more",
+ "futures",
+ "futures-retry",
+ "futures-util",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "parking_lot",
+ "slotmap",
+ "squads-temporal-sdk-core-api",
+ "squads-temporal-sdk-core-protos",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.13.1",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "squads-temporal-sdk"
+version = "0.1.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84622bd901ccd47ae480d4e2c94b55d44afbe6b8519712ee0ad9d4aecc1d0830"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "derive_more",
+ "futures",
+ "futures-util",
+ "parking_lot",
+ "prost-wkt-types",
+ "serde",
+ "squads-temporal-client",
+ "squads-temporal-sdk-core",
+ "squads-temporal-sdk-core-api",
+ "squads-temporal-sdk-core-protos",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "squads-temporal-sdk-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4ef72eb91b769358bd5f4c0026c36edf3c37f3e4b83238d09ccb972bbf422f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "crossbeam-channel",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "dashmap 6.1.0",
+ "derive_builder",
+ "derive_more",
+ "enum-iterator",
+ "enum_dispatch",
+ "futures-channel",
+ "futures-util",
+ "gethostname",
+ "governor 0.8.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "itertools 0.14.0",
+ "lru 0.13.0",
+ "mockall",
+ "opentelemetry 0.30.0",
+ "opentelemetry-otlp 0.30.0",
+ "opentelemetry_sdk 0.30.0",
+ "parking_lot",
+ "pid",
+ "pin-project",
+ "prometheus",
+ "prost 0.13.5",
+ "prost-wkt-types",
+ "rand 0.9.2",
+ "ringbuf",
+ "serde",
+ "serde_json",
+ "siphasher 1.0.2",
+ "slotmap",
+ "squads-rustfsm",
+ "squads-temporal-client",
+ "squads-temporal-sdk-core-api",
+ "squads-temporal-sdk-core-protos",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic 0.13.1",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "squads-temporal-sdk-core-api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161dddd0f4e8d0c5a90c13bbab6e62822e07db65c87bc751eed911075510c8ba"
+dependencies = [
+ "async-trait",
+ "derive_builder",
+ "derive_more",
+ "opentelemetry 0.30.0",
+ "prost 0.13.5",
+ "serde_json",
+ "squads-temporal-sdk-core-protos",
+ "thiserror 2.0.18",
+ "tonic 0.13.1",
+ "tracing",
+ "tracing-core",
+ "url",
+]
+
+[[package]]
+name = "squads-temporal-sdk-core-protos"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e3c50bf2b44b6a4c9e953c7edb9a4a96d098b0ddfe14e303317e1f525d4243"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "derive_more",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "prost-wkt",
+ "prost-wkt-build",
+ "prost-wkt-types",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
  "uuid",
 ]
 
@@ -9968,6 +10494,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows",
 ]
 
 [[package]]
@@ -10509,6 +11048,37 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "axum 0.8.8",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "rustls-native-certs 0.8.3",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
@@ -10541,6 +11111,20 @@ name = "tonic-build"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -10777,6 +11361,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
+ "parking_lot",
  "regex-automata",
  "serde",
  "serde_json",
@@ -10821,10 +11406,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typetag"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -10876,6 +11491,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -11316,16 +11937,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11333,6 +11987,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11363,8 +12028,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,6 +37,7 @@ members = [
   "cymbal",
   "cymbal-proto",
   "cymbal-resolution",
+  "cymbal-worker",
   "embedding-worker",
   "common/geoip",
   "common/hogvm",

--- a/rust/cymbal-worker/Cargo.toml
+++ b/rust/cymbal-worker/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "cymbal-worker"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+common-kafka = { path = "../common/kafka" }
+common-types = { path = "../common/types" }
+envconfig = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+temporal-sdk = { package = "squads-temporal-sdk", version = "0.1.0-alpha.1" }
+squads-temporal-sdk-core = "0.1.0-alpha.1"
+squads-temporal-sdk-core-api = "0.1.0-alpha.1"
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/cymbal-worker/README.md
+++ b/rust/cymbal-worker/README.md
@@ -1,0 +1,43 @@
+# Cymbal worker
+
+Rust Temporal worker skeleton for Cymbal workflows and activities.
+It also subscribes to the embedding worker result topic and starts a sample Temporal workflow for Error tracking stacktrace/fingerprint embedding results.
+The sample processing activity prints the raw Kafka message.
+
+## Local development
+
+`hogli start` runs this worker when the Error tracking intent is enabled.
+The worker runs locally via `bin/start-rust-service cymbal-worker`; only Temporal itself runs in Docker through the `temporal` compose profile.
+
+To configure your dev environment for Error tracking:
+
+```bash
+hogli dev:setup
+hogli start
+```
+
+For a direct smoke test without the full dev environment, start Temporal and the worker separately:
+
+```bash
+docker compose -f docker-compose.dev.yml --profile temporal up -d temporal temporal-ui
+bin/wait-for-docker temporal
+bin/start-rust-service cymbal-worker
+```
+
+Then start the sample workflow from the Temporal admin tools container:
+
+```bash
+docker compose -f docker-compose.dev.yml run --rm temporal-admin-tools \
+    temporal workflow start \
+    --namespace default \
+    --task-queue cymbal-worker \
+    --type cymbal_echo_workflow \
+    --workflow-id cymbal-echo-test \
+    --input '{"message":"hello from cymbal-worker"}'
+```
+
+The workflow calls `cymbal_echo_activity` and returns the message unchanged.
+Temporal UI is available at http://localhost:8081.
+
+Embedding result handling listens to `document_embedding_results` using the `cymbal-worker` consumer group.
+Only messages with `product: "error_tracking"` and `document_type: "stacktrace"` or `"fingerprint"` start `cymbal_process_embedding_result_workflow`.

--- a/rust/cymbal-worker/src/activities.rs
+++ b/rust/cymbal-worker/src/activities.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+use temporal_sdk::{ActContext, ActivityError};
+
+pub const ECHO_ACTIVITY_TYPE: &str = "cymbal_echo_activity";
+pub const PRINT_EMBEDDING_RESULT_ACTIVITY_TYPE: &str = "cymbal_print_embedding_result_activity";
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct EchoActivityInput {
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct EchoActivityOutput {
+    pub message: String,
+}
+
+pub async fn echo_activity(
+    _ctx: ActContext,
+    input: EchoActivityInput,
+) -> Result<EchoActivityOutput, ActivityError> {
+    Ok(EchoActivityOutput {
+        message: input.message,
+    })
+}
+
+pub async fn print_embedding_result_activity(
+    _ctx: ActContext,
+    raw_message: String,
+) -> Result<(), ActivityError> {
+    println!("{raw_message}");
+    Ok(())
+}

--- a/rust/cymbal-worker/src/config.rs
+++ b/rust/cymbal-worker/src/config.rs
@@ -1,0 +1,31 @@
+use common_kafka::config::{ConsumerConfig, KafkaConfig};
+use envconfig::Envconfig;
+
+#[derive(Clone, Envconfig)]
+pub struct Config {
+    #[envconfig(from = "TEMPORAL_ADDRESS", default = "http://localhost:7233")]
+    pub temporal_address: String,
+
+    #[envconfig(from = "TEMPORAL_NAMESPACE", default = "default")]
+    pub temporal_namespace: String,
+
+    #[envconfig(from = "TEMPORAL_TASK_QUEUE", default = "cymbal-worker")]
+    pub temporal_task_queue: String,
+
+    #[envconfig(from = "TEMPORAL_CLIENT_IDENTITY", default = "cymbal-worker")]
+    pub temporal_client_identity: String,
+
+    #[envconfig(nested = true)]
+    pub kafka: KafkaConfig,
+
+    #[envconfig(nested = true)]
+    pub consumer: ConsumerConfig,
+}
+
+impl Config {
+    pub fn init_with_defaults() -> Result<Self, envconfig::Error> {
+        ConsumerConfig::set_defaults("cymbal-worker", "document_embedding_results", true);
+
+        Self::init_from_env()
+    }
+}

--- a/rust/cymbal-worker/src/embedding_results.rs
+++ b/rust/cymbal-worker/src/embedding_results.rs
@@ -1,0 +1,145 @@
+use std::str::FromStr;
+
+use anyhow::Context;
+use common_kafka::kafka_consumer::{RecvErr, SingleTopicConsumer};
+use common_types::embedding::EmbeddingResponse;
+use temporal_sdk::prelude::client::{sdk_client_options, WorkflowClientTrait, WorkflowOptions};
+use temporal_sdk::prelude::worker::Url;
+use temporal_sdk::prelude::workflow::AsJsonPayloadExt;
+use tracing::{info, warn};
+
+use crate::{config::Config, workflows::PROCESS_EMBEDDING_RESULT_WORKFLOW_TYPE};
+
+pub async fn run_embedding_result_consumer(config: Config) -> anyhow::Result<()> {
+    let consumer = SingleTopicConsumer::new(config.kafka.clone(), config.consumer.clone())
+        .context("failed to initialize embedding result Kafka consumer")?;
+    let temporal_client = sdk_client_options(Url::from_str(&config.temporal_address)?)
+        .build()
+        .context("failed to build Temporal client options")?
+        .connect(&config.temporal_namespace, None)
+        .await
+        .context("failed to connect Temporal client for embedding result consumer")?;
+
+    info!(
+        topic = %config.consumer.kafka_consumer_topic,
+        group = %config.consumer.kafka_consumer_group,
+        "subscribing to embedding result topic"
+    );
+
+    loop {
+        match consumer.json_recv::<EmbeddingResponse>().await {
+            Ok((response, offset)) => {
+                if !is_stacktrace_embedding_response(&response) {
+                    offset
+                        .store()
+                        .context("failed to store ignored embedding result offset")?;
+                    consumer
+                        .commit()
+                        .context("failed to commit ignored embedding result offset")?;
+                    continue;
+                }
+
+                let workflow_id = format!(
+                    "cymbal-embedding-result-{}-{}",
+                    offset.partition(),
+                    offset.get_value()
+                );
+                let raw_message = serde_json::to_string(&response)
+                    .context("failed to serialize embedding result for workflow input")?;
+                let input = vec![raw_message.as_json_payload()?];
+
+                temporal_client
+                    .start_workflow(
+                        input,
+                        config.temporal_task_queue.clone(),
+                        workflow_id.clone(),
+                        PROCESS_EMBEDDING_RESULT_WORKFLOW_TYPE.to_string(),
+                        None,
+                        WorkflowOptions::default(),
+                    )
+                    .await
+                    .with_context(|| format!("failed to start workflow {workflow_id}"))?;
+
+                info!(
+                    workflow_id,
+                    team_id = response.request.team_id,
+                    product = %response.request.product,
+                    document_type = %response.request.document_type,
+                    document_id = %response.request.document_id,
+                    "started Cymbal embedding result workflow"
+                );
+
+                offset
+                    .store()
+                    .context("failed to store embedding result offset")?;
+                consumer
+                    .commit()
+                    .context("failed to commit embedding result offset")?;
+            }
+            Err(RecvErr::Kafka(error)) => {
+                return Err(error).context("failed to receive embedding result from Kafka");
+            }
+            Err(RecvErr::Serde(error)) => {
+                warn!(?error, "skipping malformed embedding result message");
+            }
+            Err(RecvErr::Empty) => {
+                warn!("skipping empty embedding result message");
+            }
+        }
+    }
+}
+
+fn is_stacktrace_embedding_response(response: &EmbeddingResponse) -> bool {
+    response.request.product == "error_tracking"
+        && matches!(
+            response.request.document_type.as_str(),
+            "stacktrace" | "fingerprint"
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use chrono::Utc;
+    use common_types::embedding::{EmbeddingModel, EmbeddingRequest, EmbeddingResponse};
+
+    use super::is_stacktrace_embedding_response;
+
+    fn response(product: &str, document_type: &str) -> EmbeddingResponse {
+        EmbeddingResponse {
+            request: EmbeddingRequest {
+                team_id: 1,
+                product: product.to_string(),
+                document_type: document_type.to_string(),
+                rendering: "text".to_string(),
+                document_id: "document-id".to_string(),
+                timestamp: Utc::now(),
+                content: "content".to_string(),
+                models: vec![EmbeddingModel::OpenAITextEmbeddingSmall],
+                metadata: HashMap::new(),
+            },
+            results: vec![],
+        }
+    }
+
+    #[test]
+    fn identifies_error_tracking_stacktrace_embedding_results() {
+        assert!(is_stacktrace_embedding_response(&response(
+            "error_tracking",
+            "stacktrace"
+        )));
+        assert!(is_stacktrace_embedding_response(&response(
+            "error_tracking",
+            "fingerprint"
+        )));
+        assert!(!is_stacktrace_embedding_response(&response(
+            "error_tracking",
+            "session_summary"
+        )));
+        assert!(!is_stacktrace_embedding_response(&response(
+            "other_product",
+            "stacktrace"
+        )));
+    }
+}

--- a/rust/cymbal-worker/src/lib.rs
+++ b/rust/cymbal-worker/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod activities;
+pub mod config;
+pub mod embedding_results;
+pub mod temporal;
+pub mod workflows;
+
+pub use temporal::build_worker;

--- a/rust/cymbal-worker/src/main.rs
+++ b/rust/cymbal-worker/src/main.rs
@@ -1,0 +1,43 @@
+use cymbal_worker::{
+    build_worker, config::Config, embedding_results::run_embedding_result_consumer,
+};
+use tracing::level_filters::LevelFilter;
+use tracing::{error, info};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
+
+fn setup_tracing() {
+    let log_layer = tracing_subscriber::fmt::layer().with_filter(
+        EnvFilter::builder()
+            .with_default_directive(LevelFilter::INFO.into())
+            .from_env_lossy(),
+    );
+    tracing_subscriber::registry().with(log_layer).init();
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    setup_tracing();
+
+    let config = Config::init_with_defaults()?;
+    info!(
+        namespace = %config.temporal_namespace,
+        task_queue = %config.temporal_task_queue,
+        "starting cymbal Temporal worker"
+    );
+
+    let mut worker = build_worker(&config).await?;
+    let worker_config = config.clone();
+
+    tokio::try_join!(
+        async move {
+            if let Err(error) = worker.run().await {
+                error!(?error, "cymbal Temporal worker stopped with an error");
+                return Err(error);
+            }
+            Ok(())
+        },
+        run_embedding_result_consumer(worker_config),
+    )?;
+
+    Ok(())
+}

--- a/rust/cymbal-worker/src/temporal.rs
+++ b/rust/cymbal-worker/src/temporal.rs
@@ -1,0 +1,61 @@
+use std::{str::FromStr, sync::Arc};
+
+use anyhow::Context;
+use temporal_sdk::{prelude::registry::into_workflow, prelude::worker::*, Worker};
+
+use crate::{
+    activities::{
+        echo_activity, print_embedding_result_activity, ECHO_ACTIVITY_TYPE,
+        PRINT_EMBEDDING_RESULT_ACTIVITY_TYPE,
+    },
+    config::Config,
+    workflows::{
+        echo_workflow, process_embedding_result_workflow, ECHO_WORKFLOW_TYPE,
+        PROCESS_EMBEDDING_RESULT_WORKFLOW_TYPE,
+    },
+};
+
+pub async fn build_worker(config: &Config) -> anyhow::Result<Worker> {
+    let temporal_url = Url::from_str(&config.temporal_address)
+        .with_context(|| format!("invalid Temporal address: {}", config.temporal_address))?;
+    let server_options = sdk_client_options(temporal_url)
+        .build()
+        .context("failed to build Temporal client options")?;
+    let client = server_options
+        .connect(&config.temporal_namespace, None)
+        .await
+        .context("failed to connect Temporal client")?;
+
+    let telemetry_options = TelemetryOptionsBuilder::default()
+        .build()
+        .context("failed to build Temporal telemetry options")?;
+    let runtime = CoreRuntime::new_assume_tokio(telemetry_options)
+        .context("failed to initialize Temporal runtime")?;
+
+    let task_queue = config.temporal_task_queue.clone();
+    let worker_config = WorkerConfigBuilder::default()
+        .namespace(config.temporal_namespace.clone())
+        .task_queue(task_queue.clone())
+        .client_identity_override(Some(config.temporal_client_identity.clone()))
+        .versioning_strategy(WorkerVersioningStrategy::None {
+            build_id: "cymbal-worker".to_string(),
+        })
+        .build()
+        .context("failed to build Temporal worker config")?;
+    let core_worker = init_worker(&runtime, worker_config, client)
+        .context("failed to initialize Temporal worker")?;
+
+    let mut worker = Worker::new_from_core(Arc::new(core_worker), task_queue);
+    worker.register_activity(ECHO_ACTIVITY_TYPE, echo_activity);
+    worker.register_activity(
+        PRINT_EMBEDDING_RESULT_ACTIVITY_TYPE,
+        print_embedding_result_activity,
+    );
+    worker.register_wf(ECHO_WORKFLOW_TYPE, into_workflow(echo_workflow));
+    worker.register_wf(
+        PROCESS_EMBEDDING_RESULT_WORKFLOW_TYPE,
+        into_workflow(process_embedding_result_workflow),
+    );
+
+    Ok(worker)
+}

--- a/rust/cymbal-worker/src/workflows.rs
+++ b/rust/cymbal-worker/src/workflows.rs
@@ -1,0 +1,64 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use temporal_sdk::prelude::workflow::{execute_activity, ActivityOptions, WfContext};
+
+use crate::activities::{
+    echo_activity, print_embedding_result_activity, EchoActivityInput, ECHO_ACTIVITY_TYPE,
+    PRINT_EMBEDDING_RESULT_ACTIVITY_TYPE,
+};
+
+pub const ECHO_WORKFLOW_TYPE: &str = "cymbal_echo_workflow";
+pub const PROCESS_EMBEDDING_RESULT_WORKFLOW_TYPE: &str = "cymbal_process_embedding_result_workflow";
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct EchoWorkflowInput {
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct EchoWorkflowOutput {
+    pub message: String,
+}
+
+pub async fn echo_workflow(
+    ctx: WfContext,
+    input: EchoWorkflowInput,
+) -> Result<EchoWorkflowOutput, anyhow::Error> {
+    let activity_output = execute_activity(
+        &ctx,
+        ActivityOptions {
+            activity_type: ECHO_ACTIVITY_TYPE.to_string(),
+            schedule_to_close_timeout: Some(Duration::from_secs(10)),
+            ..Default::default()
+        },
+        echo_activity,
+        EchoActivityInput {
+            message: input.message,
+        },
+    )
+    .await?;
+
+    Ok(EchoWorkflowOutput {
+        message: activity_output.message,
+    })
+}
+
+pub async fn process_embedding_result_workflow(
+    ctx: WfContext,
+    raw_message: String,
+) -> Result<(), anyhow::Error> {
+    execute_activity(
+        &ctx,
+        ActivityOptions {
+            activity_type: PRINT_EMBEDDING_RESULT_ACTIVITY_TYPE.to_string(),
+            schedule_to_close_timeout: Some(Duration::from_secs(10)),
+            ..Default::default()
+        },
+        print_embedding_result_activity,
+        raw_message,
+    )
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

Cymbal needs a Rust-owned place to begin experimenting with Temporal workflows and activities without running the worker as a Docker Compose service. The initial worker also needs a local path for reacting to stacktrace-related embedding results emitted by the existing embedding worker.

## Changes

- Add a new `rust/cymbal-worker` crate using the Temporal Rust SDK.
- Register sample Temporal workflows and activities, including a workflow for stacktrace embedding results that prints the raw Kafka message.
- Subscribe locally to the `document_embedding_results` Kafka topic and filter to Error tracking stacktrace/fingerprint embedding responses before starting the sample workflow.
- Wire the worker into `hogli start` for the Error tracking intent, with Temporal still provided by the local Docker profile.
- Pre-create the embedding result topic in local Docker setup.

## How did you test this code?

Agent-authored change. Automated checks run:

```bash
cd rust && cargo check -p cymbal-worker
cd rust && cargo test -p cymbal-worker
./bin/hogli dev:explain error_tracking
./bin/hogli test tools/hogli-commands/hogli_commands/tests/test_devenv.py
```

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No public docs update expected; this is local developer infrastructure and an initial Rust worker skeleton.

## 🤖 Agent context

Implemented with the pi coding agent using shell/file-editing tools. The main design choice was to run `cymbal-worker` as a local `hogli start` process for the Error tracking intent, while keeping Temporal itself in Docker via the existing local Temporal profile.

The Kafka subscription is intentionally narrow: it consumes the generic embedding result topic but only starts the sample workflow for Error tracking stacktrace/fingerprint documents. The workflow currently just prints the raw Kafka message so the wiring can be validated before adding product behavior.