### PR TITLE
fix(data-warehouse): mark TikTok Ads client errors as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/source.py
@@ -23,6 +23,7 @@ from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import TikTokAdsSourceConfig
 from posthog.temporal.data_imports.sources.tiktok_ads.settings import TIKTOK_ADS_CONFIG
 from posthog.temporal.data_imports.sources.tiktok_ads.tiktok_ads import TikTokAdsResumeConfig, tiktok_ads_source
+from posthog.temporal.data_imports.sources.tiktok_ads.utils import TIKTOK_NON_RETRYABLE_ERROR_PREFIX
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
@@ -32,6 +33,15 @@ class TikTokAdsSource(ResumableSource[TikTokAdsSourceConfig, TikTokAdsResumeConf
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.TIKTOKADS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            # TikTok client errors not in the retryable code set (e.g. 40001 — the advertiser
+            # doesn't exist or has been deleted). The paginator raises these with this exact
+            # prefix; retrying cannot recover, so fail the job fast. The raw message is kept as
+            # the user-facing error since it names the specific advertiser and TikTok error code.
+            TIKTOK_NON_RETRYABLE_ERROR_PREFIX: None,
+        }
 
     @property
     def get_source_config(self) -> SourceConfig:

--- a/posthog/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
@@ -14,6 +14,7 @@ from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInput
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.generated_configs import TikTokAdsSourceConfig
 from posthog.temporal.data_imports.sources.tiktok_ads.source import TikTokAdsSource
+from posthog.temporal.data_imports.sources.tiktok_ads.utils import TikTokAdsPaginator
 
 from products.data_warehouse.backend.types import ExternalDataSourceType, IncrementalFieldType
 
@@ -38,6 +39,44 @@ class TestTikTokAdsSource:
     def test_source_type(self):
         """Test that source type is correctly identified."""
         assert self.source.source_type == ExternalDataSourceType.TIKTOKADS
+
+    @parameterized.expand(
+        [
+            ("advertiser_deleted", 40001, "The advertiser 123 doesn't exist or has been deleted."),
+            ("invalid_parameter", 40002, "Invalid parameter"),
+        ]
+    )
+    def test_non_retryable_paginator_error_matches_source_pattern(self, name, api_code, message):
+        """The ValueError the paginator raises for non-retryable codes must match a
+        pattern in get_non_retryable_errors, otherwise the job retries forever."""
+        paginator = TikTokAdsPaginator()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"code": api_code, "message": message, "data": {}}
+
+        with pytest.raises(ValueError) as exc_info:
+            paginator.update_state(mock_response)
+
+        error_message = str(exc_info.value)
+        patterns = self.source.get_non_retryable_errors()
+        assert any(pattern in error_message for pattern in patterns), (
+            f"TikTok non-retryable error '{error_message}' does not match any non-retryable pattern"
+        )
+
+    def test_retryable_paginator_error_does_not_match_source_pattern(self):
+        """Retryable rate-limit/server errors must NOT be classified as non-retryable."""
+        paginator = TikTokAdsPaginator()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"code": 50000, "message": "Internal server error", "data": {}}
+
+        # Retryable codes raise TikTokAdsAPIError, not ValueError; capture its message.
+        with pytest.raises(Exception) as exc_info:
+            paginator.update_state(mock_response)
+
+        error_message = str(exc_info.value)
+        patterns = self.source.get_non_retryable_errors()
+        assert not any(pattern in error_message for pattern in patterns)
 
     def test_get_source_config(self):
         """Test source configuration generation."""

--- a/posthog/temporal/data_imports/sources/tiktok_ads/utils.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/utils.py
@@ -18,6 +18,12 @@ from posthog.temporal.data_imports.sources.tiktok_ads.settings import (
 
 logger = structlog.get_logger(__name__)
 
+# Prefix for the ValueError raised when TikTok returns a client error code that
+# is not in the retryable set (e.g. 40001 "advertiser doesn't exist or has been
+# deleted"). Retrying these never succeeds, so `TikTokAdsSource.get_non_retryable_errors`
+# matches on this exact prefix to fail the job fast instead of looping forever.
+TIKTOK_NON_RETRYABLE_ERROR_PREFIX = "TikTok API client error (non-retryable):"
+
 
 class TikTokAdsAPIError(Exception):
     """Custom exception for TikTok Ads API errors that should trigger retries."""
@@ -404,7 +410,7 @@ class TikTokAdsPaginator(BasePaginator):
                         f"TikTok API error: {error_message} (code: {api_code})", api_code=api_code, response=response
                     )
                 else:
-                    raise ValueError(f"TikTok API client error (non-retryable): {error_message} (code: {api_code})")
+                    raise ValueError(f"{TIKTOK_NON_RETRYABLE_ERROR_PREFIX} {error_message} (code: {api_code})")
         except TikTokAdsAPIError:
             raise
         except ValueError:


### PR DESCRIPTION
## Problem

The TikTok Ads data warehouse source generated a very high volume of repeated `$exception` events under a single error-tracking group, all of the form:

```
ValueError: TikTok API client error (non-retryable): The advertiser <id> doesn't exist or has been deleted. (code: 40001)
```

The paginator already classifies error codes correctly — codes outside the known retryable set (rate limits, task/system errors) are raised as a `ValueError` explicitly tagged `(non-retryable)`. But `TikTokAdsSource` never overrode `get_non_retryable_errors()`, so that message was never matched against any non-retryable pattern. As a result the job retried these terminal failures indefinitely (a deleted/inaccessible advertiser will never come back), producing the large occurrence count for a small set of advertiser IDs.

## Changes

- Extracted the `"TikTok API client error (non-retryable):"` message prefix into a shared constant (`TIKTOK_NON_RETRYABLE_ERROR_PREFIX`) in `utils.py`, used both where the paginator raises and where the source matches — so the match key can't drift from the raised message.
- Added a `get_non_retryable_errors()` override to `TikTokAdsSource` keyed on that prefix. The prefix covers the whole non-retryable client-error class (40001 and any other code not in the retryable set), so the job now fails fast instead of looping. The raw message is kept as the user-facing error since it names the specific advertiser and TikTok error code, which is more actionable than a static string.

## How did you test this code?

I'm an agent. I ran the TikTok source + utils test suites (`test_tiktok_ads_source.py`, `test_tiktok_ads_utils.py`, 89 tests, all passing) and ran ruff check + format over the changed files. New automated coverage added:

- An end-to-end test that drives the real paginator (`update_state`) for non-retryable codes (40001, 40002) and asserts the resulting `ValueError` message matches a pattern returned by `get_non_retryable_errors()` — tying the producer and the matcher together so they can't silently drift apart.
- A companion test asserting a retryable code (50000) does **not** match the non-retryable patterns.

No manual testing against the live TikTok API was performed.

## 🤖 Agent context

Authored with Claude Code. Starting from an error-tracking group, I sampled its events via the PostHog MCP and found every occurrence shared the same `(non-retryable)`-tagged `ValueError`. Tracing it to `tiktok_ads/utils.py` showed the paginator was correctly identifying the error as non-retryable, but `source.py` had no `get_non_retryable_errors()` override, so the classification was never honoured at the activity layer.

Key decision: match on the shared message prefix rather than enumerating individual error codes in the source, since the paginator already encodes the retryable/non-retryable split and the prefix is the single stable contract between the two layers. Kept `value = None` so the user-facing error preserves the specific advertiser ID and code instead of a generic static string.
