### PR TITLE
chore(surveys): skip webkit-crashing survey story to unblock CI

### DIFF
--- a/frontend/src/scenes/surveys/Surveys.stories.tsx
+++ b/frontend/src/scenes/surveys/Surveys.stories.tsx
@@ -403,6 +403,8 @@ export const NewSurveyWithHTMLQuestionDescription: Story = {
 }
 
 export const NewSurveyWithTextQuestionDescriptionThatDoesNotRenderHTML: Story = {
+    // FIXME: Crashes webkit deterministically since the Playwright 1.60.0 bump (#60771). Fix tracked separately.
+    tags: ['test-skip-webkit'],
     render: () => {
         useDelayedOnMountEffect(() => {
             surveyLogic({ id: 'new' }).mount()


### PR DESCRIPTION
## Problem

The `Scenes-App/Surveys › NewSurveyWithTextQuestionDescriptionThatDoesNotRenderHTML › smoke-test` Storybook visual-regression test crashes the webkit browser deterministically (`page.evaluate: Target crashed` at `getStoryContext`) since #60771 bumped Playwright to 1.60.0. Playwright bundles its own browser binaries, so the bump also upgraded the webkit engine, which now crashes while rendering this story. This is failing the webkit shard on master and blocking the Storybook workflow for everyone.

## Changes

Add the `test-skip-webkit` tag to the offending story so it is skipped on webkit while still running on chromium. CI passes `STORYBOOK_SKIP_TAGS: 'test-skip,test-skip-${{ matrix.browser }}'` (see `.github/workflows/ci-storybook.yml`), so this tag skips the story only on the webkit shard — matching the existing precedent in `frontend/src/toolbar/Toolbar.stories.tsx`.

This is a targeted unblock so master CI stays green without reverting the dependency bump. The actual webkit/Playwright incompatibility is being fixed in a separate PR.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not run the webkit Storybook suite locally. The change is limited to adding a skip tag using the same mechanism already in use elsewhere in the repo; the webkit shard should skip this story and the chromium shards are unaffected.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by the PostHog Slack app at the request of a maintainer to unblock CI without reverting the Playwright 1.60.0 bump. Located the crashing story in `frontend/src/scenes/surveys/Surveys.stories.tsx`, confirmed the browser-specific skip mechanism via `STORYBOOK_SKIP_TAGS` in `ci-storybook.yml` and the `tags.skip` config in `common/storybook/.storybook/test-runner.ts`, and followed the existing `test-skip-webkit` precedent rather than introducing a new pattern. The root-cause fix for the webkit crash is being handled in a separate PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
