### PR TITLE
fix(data-warehouse): stop capturing expected BigQuery cleanup errors

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/sources/bigquery/bigquery.py
@@ -22,7 +22,7 @@ from typing import Any
 
 import pyarrow as pa
 import structlog
-from google.api_core.exceptions import Forbidden
+from google.api_core.exceptions import Forbidden, NotFound
 from google.auth.transport.requests import AuthorizedSession
 from google.cloud import bigquery, bigquery_storage
 from google.cloud.bigquery.job import QueryJobConfig
@@ -201,6 +201,13 @@ def delete_all_temp_destination_tables(
                     bq.delete_table(table.reference)
                     if logger:
                         logger.debug(f"Deleted bigquery table {table.table_id}")
+        except (Forbidden, NotFound) as e:
+            # Best-effort cleanup. If the service account has lost permission to list/delete
+            # tables, or the dataset no longer exists, there's nothing to recover here — log
+            # quietly rather than capturing an expected, non-actionable condition that would
+            # otherwise fire on every sync for an affected source.
+            if logger:
+                logger.warning(f"Skipping temp table cleanup for dataset {dataset_id}: {e}")
         except Exception as e:
             capture_exception(e)
 

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -3,12 +3,14 @@ from freezegun import freeze_time
 from unittest import mock
 
 from dateutil import parser
+from google.api_core.exceptions import Forbidden, NotFound
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from posthog.temporal.data_imports.sources.bigquery.bigquery import (
     BigQueryImplementation,
     _bq_select_clause,
     _get_query,
+    delete_all_temp_destination_tables,
 )
 from posthog.temporal.data_imports.sources.bigquery.source import BigQuerySource
 from posthog.temporal.data_imports.sources.common.sql.identifiers import InvalidIdentifierError
@@ -189,3 +191,55 @@ def test_bigquery_select_clause_rejects_injection_attempts(malicious_column):
     """`enabled_columns` flows from user config — must be allowlisted before backtick quoting."""
     with pytest.raises(InvalidIdentifierError):
         _bq_select_clause([malicious_column], primary_keys=None, incremental_field=None)
+
+
+def _run_delete_all_temp_destination_tables(side_effect, logger):
+    bq = mock.MagicMock()
+    bq.list_tables.side_effect = side_effect
+    client_cm = mock.MagicMock()
+    client_cm.__enter__.return_value = bq
+
+    with (
+        mock.patch("posthog.temporal.data_imports.sources.bigquery.bigquery.bigquery_client", return_value=client_cm),
+        mock.patch("posthog.temporal.data_imports.sources.bigquery.bigquery.capture_exception") as mock_capture,
+    ):
+        delete_all_temp_destination_tables(
+            dataset_id="dataset-id",
+            table_prefix="prefix_",
+            project_id="project-id",
+            location=None,
+            dataset_project_id=None,
+            private_key="private-key",
+            private_key_id="private-key-id",
+            client_email="client-email",
+            token_uri="token-uri",
+            logger=logger,
+        )
+    return mock_capture
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        Forbidden("Access Denied: Permission bigquery.tables.list denied on dataset"),
+        NotFound("Dataset not found (or it may not exist)"),
+    ],
+)
+def test_delete_all_temp_destination_tables_swallows_expected_errors_quietly(exception):
+    """Lost permissions or a deleted dataset during best-effort cleanup must NOT be
+    captured to error tracking — it's expected and fires on every sync otherwise."""
+    logger = mock.MagicMock()
+
+    mock_capture = _run_delete_all_temp_destination_tables(exception, logger)
+
+    mock_capture.assert_not_called()
+    logger.warning.assert_called_once()
+
+
+def test_delete_all_temp_destination_tables_captures_unexpected_errors():
+    """Genuinely unexpected errors are still captured so we don't lose visibility."""
+    logger = mock.MagicMock()
+
+    mock_capture = _run_delete_all_temp_destination_tables(RuntimeError("boom"), logger)
+
+    mock_capture.assert_called_once()


### PR DESCRIPTION
## Problem

The BigQuery data warehouse source generated a very high volume of repeated `$exception` events under a single error-tracking group, all raised from `delete_all_temp_destination_tables`:

```
google.api_core.exceptions.Forbidden: ... Access Denied: Permission bigquery.tables.list denied on dataset ...
google.api_core.exceptions.Forbidden: ... Permission biglake.tables.list denied on namespace ... (or it may not exist).
```

Unlike a typical sync failure, this function is **best-effort temp-table cleanup** that runs at the start of every sync, and it already wraps its work in `try/except Exception` and swallows the error via `capture_exception(e)`. So the job neither fails nor retries from this — but every swallowed exception was still captured to error tracking. When a source's service account loses `bigquery.tables.list` / `biglake.tables.list` permission, or its dataset is deleted (note the "or it may not exist"), this fires on **every** scheduled sync, producing a large stream of non-actionable noise for a condition we can't recover from here.

## Changes

- In `delete_all_temp_destination_tables`, catch `Forbidden` and `NotFound` explicitly and log a warning instead of capturing them. This is the same pattern already used a few functions away in `get_columns` (line ~487), which catches `Forbidden` on `INFORMATION_SCHEMA.COLUMNS` and logs/continues.
- Genuinely unexpected errors still fall through to `capture_exception`, so we don't lose visibility into real bugs.

This is intentionally **not** a non-retryable classification: the cleanup is already non-fatal, so the only issue was error-tracking noise. The underlying user-facing cause (revoked permissions / deleted dataset) surfaces through the normal sync path if it actually blocks the import.

## How did you test this code?

I'm an agent. I ran the BigQuery source test suite (`tests/test_source.py`, 20 tests, all passing) and ran ruff check + format over the changed files. New automated coverage added:

- A parameterized test asserting that a `Forbidden` or `NotFound` from `list_tables` during cleanup is **not** sent to `capture_exception` and logs a warning instead.
- A test asserting an unexpected error (`RuntimeError`) is still captured.

No manual testing against live BigQuery was performed.

## 🤖 Agent context

Authored with Claude Code. Starting from an error-tracking group, I sampled its events via the PostHog MCP. Every occurrence was the same `Forbidden` from the cleanup path, across a handful of GCP projects/datasets.

Key decision: this case is different from the Meta/TikTok non-retryable work — the exception was already caught and swallowed, so the bug was purely that an expected, non-actionable condition was being captured on every run. The fix reuses the file's own established `Forbidden`-handling convention (log + continue) rather than introducing a new non-retryable pattern, and keeps capturing truly unexpected errors.
