### PR TITLE
fix(data-warehouse): mark Google Ads access_not_configured as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -51,6 +51,10 @@ class GoogleAdsSource(
             # has been revoked, expired, or is otherwise rejected by Google's token endpoint.
             # Retrying cannot recover — the user must reconnect their Google Ads account.
             "invalid_grant": "Your Google Ads connection has expired or been revoked. Please reconnect your Google Ads account.",
+            # google.auth.exceptions.RefreshError raised when the user's Google Workspace admin
+            # has restricted third-party API access for this app (org policy / app not approved).
+            # Retrying cannot recover — an admin must grant access before the user reconnects.
+            "access_not_configured": "Your Google Workspace administrator has restricted API access for this app. Ask your admin to approve it, then reconnect your Google Ads account.",
         }
 
     # TODO: clean up google ads source to not have two auth config options

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -27,6 +27,30 @@ class TestGoogleAdsNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Real RefreshError strings observed in production when a Google Workspace
+            # admin has restricted third-party API access for the app. Reported by
+            # `str(e)` on google.auth.exceptions.RefreshError.
+            (
+                "('access_not_configured: Access to your account data (which may include HIPAA and PHI data) is "
+                "restricted by policies within your organization. Please contact the administrator of your "
+                "organization for more information regarding API access from third-party applications.', "
+                "{'error': 'access_not_configured', 'error_description': 'Access to your account data ...'})"
+            ),
+            (
+                "('access_not_configured: You can't access this app until an admin at your institution reviews "
+                "and configures access for it. If you need access to this app,', {'error': 'access_not_configured', "
+                "'error_description': 'You can't access this app ...'})"
+            ),
+        ],
+    )
+    def test_access_not_configured_is_non_retryable(self, error_msg):
+        assert any(pattern in error_msg for pattern in self.non_retryable), (
+            f"RefreshError message {error_msg!r} did not match any non-retryable pattern"
+        )
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Observed in production: requesting metrics against a manager (MCC) account.
             (
                 "errors {\n  error_code {\n    query_error: REQUESTED_METRICS_FOR_MANAGER\n  }\n  "
@@ -53,6 +77,9 @@ class TestGoogleAdsNonRetryableErrors:
             "UNAVAILABLE: The service is currently unavailable",
             "ConnectionError: Connection reset by peer",
             "INTERNAL: Internal server error",
+            # A RefreshError wrapping a transient 502 from Google's token endpoint shares the
+            # same error-tracking group as access_not_configured but must remain retryable.
+            "('<!DOCTYPE html><title>Error 502 (Server Error)!!1</title>', None)",
         ],
     )
     def test_transient_errors_are_retryable(self, error_msg):
@@ -69,6 +96,7 @@ class TestGoogleAdsNonRetryableErrors:
             "INVALID_CUSTOMER_ID",
             "REQUESTED_METRICS_FOR_MANAGER",
             "invalid_grant",
+            "access_not_configured",
         ],
     )
     def test_documented_patterns_present(self, pattern):
@@ -83,3 +111,8 @@ class TestGoogleAdsNonRetryableErrors:
         friendly = self.non_retryable["invalid_grant"]
         assert friendly is not None
         assert "reconnect" in friendly.lower()
+
+    def test_access_not_configured_has_friendly_message(self):
+        friendly = self.non_retryable["access_not_configured"]
+        assert friendly is not None
+        assert "admin" in friendly.lower()


### PR DESCRIPTION
## Problem

The Google Ads data warehouse source generated a high volume of repeated `$exception` events under a single error-tracking group. Sampling the group showed they're `google.auth.exceptions.RefreshError`s raised during OAuth token refresh in `google_ads_client`, with `error: 'access_not_configured'` and one of two messages:

- *"Access to your account data (which may include HIPAA and PHI data) is restricted by policies within your organization..."*
- *"You can't access this app until an admin at your institution reviews and configures access for it..."*

Both mean the user's Google Workspace administrator has blocked third-party API access for the app. Retrying cannot recover — an admin has to approve access before the connection works. The source already classifies the sibling `RefreshError` variant (`invalid_grant`) as non-retryable, but `access_not_configured` was missing, so the job retried it on every schedule indefinitely.

## Changes

- Added `access_not_configured` to `GoogleAdsSource.get_non_retryable_errors()`, following the exact pattern of the existing `invalid_grant` entry, with an admin-facing friendly message ("Ask your admin to approve it, then reconnect your Google Ads account").

The match is on the stable `access_not_configured` token that appears in `str(RefreshError)`. A transient `502` from Google's token endpoint (also surfaced as a `RefreshError` and sharing this error-tracking group) does **not** contain that token, so it correctly stays retryable.

## How did you test this code?

I'm an agent. I ran the Google Ads source test suite (`tests/test_google_ads_source.py`, 27 tests, all passing) and ran ruff check + format over the changed files. New automated coverage added:

- A parameterized test that both production `access_not_configured` RefreshError strings match a non-retryable pattern.
- Added `access_not_configured` to the documented-patterns test and a friendly-message assertion.
- Added the transient `502` RefreshError to the retryable test set to lock in that it is **not** swept up as non-retryable.

No manual testing against the live Google Ads API was performed.

## 🤖 Agent context

Authored with Claude Code. Starting from the error-tracking group, I sampled events via the PostHog MCP. All sampled occurrences were `access_not_configured` RefreshErrors from token refresh; the group's representative also showed a transient 502.

Key decision: match the narrow `access_not_configured` token rather than broadly classifying all `RefreshError`s, so the genuinely transient 502 sharing the same group remains retryable. Reused the source's existing `invalid_grant` convention (pattern + friendly message) rather than introducing new machinery.
