### PR TITLE
feat(mcp): render bar charts with hog-charts TimeSeriesBarChart

### DIFF
--- a/services/mcp/src/ui-apps/components/RetentionVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/RetentionVisualizer.tsx
@@ -123,9 +123,9 @@ export function RetentionVisualizer({ query, results }: RetentionVisualizerProps
 
     const [chartMode, setChartMode] = useState<ChartMode>('line')
 
-    const { series, labels, maxValue, totalCohorts } = useMemo(() => {
+    const { series, labels, totalCohorts } = useMemo(() => {
         if (!results || results.length === 0) {
-            return { series: [] as Series[], labels: [] as string[], maxValue: 0, totalCohorts: 0 }
+            return { series: [] as Series[], labels: [] as string[], totalCohorts: 0 }
         }
         const sorted = sortCohorts(results)
         // Cap to MAX_COHORTS so each line gets a distinct palette color rather than wrapping back
@@ -133,14 +133,10 @@ export function RetentionVisualizer({ query, results }: RetentionVisualizerProps
         const limited = sorted.slice(0, MAX_COHORTS)
         const numIntervals = limited.reduce((m, c) => Math.max(m, c.values.length), 0)
         const xLabels = buildXAxisLabels(numIntervals, period)
-        let computedMax = 0
 
         const built: Series[] = limited.map((cohort, idx) => {
             const points = Array.from({ length: numIntervals }, (_, i) => {
                 const y = computeSeriesValue(cohort.values, i, aggregationType, reference)
-                if (y > computedMax) {
-                    computedMax = y
-                }
                 return { x: i, y, label: xLabels[i] ?? `${i}` }
             })
             return {
@@ -152,7 +148,6 @@ export function RetentionVisualizer({ query, results }: RetentionVisualizerProps
         return {
             series: built,
             labels: xLabels,
-            maxValue: computedMax || 1,
             totalCohorts: sorted.length,
         }
     }, [results, aggregationType, reference, period])
@@ -189,9 +184,9 @@ export function RetentionVisualizer({ query, results }: RetentionVisualizerProps
                 <Select value={chartMode} onChange={setChartMode} options={CHART_MODE_OPTIONS} />
             </div>
             {chartMode === 'bar' ? (
-                <BarChart series={series} labels={labels} maxValue={maxValue} yAxisLabel={yAxisLabel} />
+                <BarChart series={series} labels={labels} yAxisLabel={yAxisLabel} />
             ) : (
-                <LineChart series={series} labels={labels} maxValue={maxValue} yAxisLabel={yAxisLabel} />
+                <LineChart series={series} labels={labels} yAxisLabel={yAxisLabel} />
             )}
         </div>
     )

--- a/services/mcp/src/ui-apps/components/TableVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TableVisualizer.tsx
@@ -3,9 +3,9 @@ import type { ReactElement } from 'react'
 import { emptyStateIllustration } from '@posthog/mcp-ui'
 import { DataTable, type DataTableProps, Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@posthog/quill'
 
-import { formatNumber } from './utils'
 import { BigNumber, LineChart, type Series } from './charts'
 import type { TableVisualizerProps } from './types'
+import { formatNumber } from './utils'
 
 // Query results are truncated client-side; sorting a truncated view would
 // mislead, so columns are non-sortable.
@@ -97,22 +97,19 @@ function transformToSeries(
     timeIdx: number,
     valueIdx: number,
     valueLabel: string
-): { series: Series[]; labels: string[]; maxValue: number } {
+): { series: Series[]; labels: string[] } {
     const labels: string[] = []
-    let maxValue = 0
 
     const points = rows.map((row, i) => {
         const label = String(row[timeIdx])
         const value = row[valueIdx] as number
         labels.push(label)
-        maxValue = Math.max(maxValue, value)
         return { x: i, y: value, label }
     })
 
     return {
         series: [{ label: valueLabel, points }],
         labels,
-        maxValue: maxValue || 1,
     }
 }
 
@@ -132,13 +129,8 @@ export function TableVisualizer({ results }: TableVisualizerProps): ReactElement
         format.valueColumnIndex !== undefined
     ) {
         const valueLabel = columns[format.valueColumnIndex] || 'Value'
-        const { series, labels, maxValue } = transformToSeries(
-            rows,
-            format.timeColumnIndex,
-            format.valueColumnIndex,
-            valueLabel
-        )
-        return <LineChart series={series} labels={labels} maxValue={maxValue} showLegend={false} />
+        const { series, labels } = transformToSeries(rows, format.timeColumnIndex, format.valueColumnIndex, valueLabel)
+        return <LineChart series={series} labels={labels} showLegend={false} />
     }
 
     if (rows.length === 0) {

--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -94,6 +94,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
                     labels={labels}
                     maxValue={maxValue}
                     yAxisLabel={series.length === 1 ? series[0]?.label : undefined}
+                    yAxisFormat={query?.trendsFilter?.aggregationAxisFormat}
                 />
             ) : (
                 <LineChart

--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -17,32 +17,27 @@ const CHART_MODE_OPTIONS = [
 function prepareChartData(results: TrendsResultItem[]): {
     series: Series[]
     labels: string[]
-    maxValue: number
 } {
     if (!results || results.length === 0) {
-        return { series: [], labels: [], maxValue: 0 }
+        return { series: [], labels: [] }
     }
 
     const labels = results[0]?.days || results[0]?.labels || []
-    let maxValue = 0
 
     const series = results.map((item, seriesIndex) => {
         const data = item.data || []
-        const points = data.map((value, i) => {
-            maxValue = Math.max(maxValue, value)
-            return {
-                x: i,
-                y: value,
-                label: labels[i] || `${i}`,
-            }
-        })
+        const points = data.map((value, i) => ({
+            x: i,
+            y: value,
+            label: labels[i] || `${i}`,
+        }))
         return {
             label: getSeriesLabel(item, seriesIndex),
             points,
         }
     })
 
-    return { series, labels, maxValue: maxValue || 1 }
+    return { series, labels }
 }
 
 function calculateTotal(results: TrendsResultItem[]): number {
@@ -63,7 +58,7 @@ function calculateTotal(results: TrendsResultItem[]): number {
 export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): ReactElement {
     const displayType = getDisplayType(query)
     const [chartMode, setChartMode] = useState<ChartMode>(isBarChart(displayType) ? 'bar' : 'line')
-    const { series, labels, maxValue } = prepareChartData(results)
+    const { series, labels } = prepareChartData(results)
 
     if (!results || results.length === 0 || series.length === 0) {
         return (
@@ -92,7 +87,6 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
                 <BarChart
                     series={series}
                     labels={labels}
-                    maxValue={maxValue}
                     yAxisLabel={series.length === 1 ? series[0]?.label : undefined}
                     yAxisFormat={query?.trendsFilter?.aggregationAxisFormat}
                 />
@@ -100,7 +94,6 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
                 <LineChart
                     series={series}
                     labels={labels}
-                    maxValue={maxValue}
                     yAxisLabel={series.length === 1 ? series[0]?.label : undefined}
                     yAxisFormat={query?.trendsFilter?.aggregationAxisFormat}
                 />

--- a/services/mcp/src/ui-apps/components/charts/BarChart.tsx
+++ b/services/mcp/src/ui-apps/components/charts/BarChart.tsx
@@ -1,28 +1,20 @@
-import type { ReactElement } from 'react'
+import { type ReactElement } from 'react'
 
-import { formatDate, formatNumber } from '../utils'
+import {
+    type ChartTheme,
+    type Series as ChartSeries,
+    type YAxisFormat,
+    TimeSeriesBarChart,
+} from '@posthog/quill-charts'
 
-// TODO(quill): replace with a Quill chart primitive (e.g. `BarChart` /
-// `Charts.Bar`) once Quill ships one. Quill currently has no chart layer —
-// it stops at primitives/components/blocks, none of which render data viz.
-// This bespoke SVG renderer uses Quill design tokens (`--text-secondary`
-// via the host bridge, `--posthog-chart-*` palette declared in base.css)
-// so the visual language already matches.
+import { formatDate } from '../utils'
 
-const CHART_HEIGHT = 200
-const CHART_WIDTH = 400
-const PADDING = { top: 20, right: 20, bottom: 40, left: 50 }
+// Series palette mirroring base.css `--posthog-chart-*`. Canvas can't read CSS
+// custom properties, so we hand the chart concrete hexes. The chart picks one
+// per series by index; the legend uses the same array to stay in sync.
+const CHART_COLORS = ['#1d4aff', '#621da6', '#42827e', '#ce0e74', '#f14f58', '#7c440e', '#529a0a', '#0476fb']
 
-const COLORS = [
-    'var(--posthog-chart-1, #1d4aff)',
-    'var(--posthog-chart-2, #621da6)',
-    'var(--posthog-chart-3, #42827e)',
-    'var(--posthog-chart-4, #ce0e74)',
-    'var(--posthog-chart-5, #f14f58)',
-    'var(--posthog-chart-6, #7c440e)',
-    'var(--posthog-chart-7, #529a0a)',
-    'var(--posthog-chart-8, #0476fb)',
-]
+const THEME: ChartTheme = { colors: CHART_COLORS }
 
 export interface DataPoint {
     x: number
@@ -41,104 +33,41 @@ export interface BarChartProps {
     maxValue: number
     showLegend?: boolean
     yAxisLabel?: string | undefined
+    /** Y-axis value format. Mirrors a trends insight's `aggregationAxisFormat`; defaults to `numeric`. */
+    yAxisFormat?: YAxisFormat | undefined
 }
 
-export function BarChart({ series, labels, maxValue, showLegend = true, yAxisLabel }: BarChartProps): ReactElement {
-    const innerWidth = CHART_WIDTH - PADDING.left - PADDING.right
-    const innerHeight = CHART_HEIGHT - PADDING.top - PADDING.bottom
-
-    const numBars = labels.length
-    const numSeries = series.length
-    const barGroupWidth = innerWidth / numBars
-    const barWidth = Math.min(barGroupWidth * 0.8, 40) / numSeries
-    const barGap = barWidth * 0.1
+export function BarChart({
+    series,
+    labels,
+    showLegend = true,
+    yAxisLabel,
+    yAxisFormat = 'numeric',
+}: BarChartProps): ReactElement {
+    // Color omitted so the chart assigns one per series from THEME.colors by index.
+    const chartSeries: ChartSeries[] = series.map((s, i) => ({
+        key: s.label || `series-${i}`,
+        label: s.label,
+        data: s.points.map((p) => p.y),
+    }))
 
     return (
         <div>
-            <svg viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`} style={{ width: '100%', height: '400px' }}>
-                {yAxisLabel && (
-                    <text
-                        x={12}
-                        y={PADDING.top + innerHeight / 2}
-                        textAnchor="middle"
-                        fontSize="11"
-                        fill="var(--color-text-secondary, #6b7280)"
-                        transform={`rotate(-90, 12, ${PADDING.top + innerHeight / 2})`}
-                    >
-                        {yAxisLabel}
-                    </text>
-                )}
-
-                {/* Y-axis labels */}
-                {[0, 0.5, 1].map((ratio) => {
-                    const value = maxValue * ratio
-                    const y = PADDING.top + innerHeight - (value / maxValue) * innerHeight
-                    return (
-                        <g key={ratio}>
-                            <line
-                                x1={PADDING.left}
-                                y1={y}
-                                x2={CHART_WIDTH - PADDING.right}
-                                y2={y}
-                                stroke="var(--color-border-primary, #e5e7eb)"
-                                strokeDasharray={ratio === 0 ? '0' : '4,4'}
-                            />
-                            <text
-                                x={PADDING.left - 8}
-                                y={y + 4}
-                                textAnchor="end"
-                                fontSize="10"
-                                fill="var(--color-text-secondary, #6b7280)"
-                            >
-                                {formatNumber(value)}
-                            </text>
-                        </g>
-                    )
-                })}
-
-                {/* X-axis labels */}
-                {labels.map((label, i) => {
-                    if (labels.length > 7 && i % Math.ceil(labels.length / 7) !== 0) {
-                        return null
-                    }
-                    const x = PADDING.left + (i + 0.5) * barGroupWidth
-                    return (
-                        <text
-                            key={i}
-                            x={x}
-                            y={CHART_HEIGHT - 8}
-                            textAnchor="middle"
-                            fontSize="10"
-                            fill="var(--color-text-secondary, #6b7280)"
-                        >
-                            {formatDate(label)}
-                        </text>
-                    )
-                })}
-
-                {/* Bars */}
-                {series.map((s, seriesIndex) =>
-                    s.points.map((p, i) => {
-                        const barHeight = (p.y / maxValue) * innerHeight
-                        const groupX = PADDING.left + i * barGroupWidth
-                        const barX = groupX + (barGroupWidth - numSeries * barWidth - (numSeries - 1) * barGap) / 2
-                        const x = barX + seriesIndex * (barWidth + barGap)
-                        const y = PADDING.top + innerHeight - barHeight
-
-                        return (
-                            <rect
-                                key={`${seriesIndex}-${i}`}
-                                x={x}
-                                y={y}
-                                width={barWidth}
-                                height={barHeight}
-                                fill={COLORS[seriesIndex % COLORS.length]}
-                                rx="2"
-                            />
-                        )
-                    })
-                )}
-            </svg>
+            <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '400px' }}>
+                <TimeSeriesBarChart
+                    series={chartSeries}
+                    labels={labels}
+                    theme={THEME}
+                    config={{
+                        xAxis: { tickFormatter: (value) => formatDate(value) },
+                        yAxis: {
+                            ...(yAxisLabel ? { label: yAxisLabel } : {}),
+                            format: yAxisFormat,
+                            showGrid: true,
+                        },
+                    }}
+                />
+            </div>
 
             {showLegend && series.length > 1 && (
                 <div
@@ -158,7 +87,7 @@ export function BarChart({ series, labels, maxValue, showLegend = true, yAxisLab
                                     width: '12px',
                                     height: '12px',
                                     borderRadius: '2px',
-                                    backgroundColor: COLORS[i % COLORS.length],
+                                    backgroundColor: CHART_COLORS[i % CHART_COLORS.length],
                                 }}
                             />
                             <span style={{ color: 'var(--color-text-secondary, #6b7280)' }}>{s.label}</span>

--- a/services/mcp/src/ui-apps/components/charts/BarChart.tsx
+++ b/services/mcp/src/ui-apps/components/charts/BarChart.tsx
@@ -4,22 +4,11 @@ import { type Series as ChartSeries, type YAxisFormat, TimeSeriesBarChart } from
 
 import { formatDate } from '../utils'
 import { CHART_COLORS, CHART_THEME } from './theme'
-
-export interface DataPoint {
-    x: number
-    y: number
-    label: string
-}
-
-export interface Series {
-    label: string
-    points: DataPoint[]
-}
+import type { Series } from './types'
 
 export interface BarChartProps {
     series: Series[]
     labels: string[]
-    maxValue: number
     showLegend?: boolean
     yAxisLabel?: string | undefined
     /** Y-axis value format. Mirrors a trends insight's `aggregationAxisFormat`; defaults to `numeric`. */

--- a/services/mcp/src/ui-apps/components/charts/BarChart.tsx
+++ b/services/mcp/src/ui-apps/components/charts/BarChart.tsx
@@ -1,20 +1,9 @@
 import { type ReactElement } from 'react'
 
-import {
-    type ChartTheme,
-    type Series as ChartSeries,
-    type YAxisFormat,
-    TimeSeriesBarChart,
-} from '@posthog/quill-charts'
+import { type Series as ChartSeries, type YAxisFormat, TimeSeriesBarChart } from '@posthog/quill-charts'
 
 import { formatDate } from '../utils'
-
-// Series palette mirroring base.css `--posthog-chart-*`. Canvas can't read CSS
-// custom properties, so we hand the chart concrete hexes. The chart picks one
-// per series by index; the legend uses the same array to stay in sync.
-const CHART_COLORS = ['#1d4aff', '#621da6', '#42827e', '#ce0e74', '#f14f58', '#7c440e', '#529a0a', '#0476fb']
-
-const THEME: ChartTheme = { colors: CHART_COLORS }
+import { CHART_COLORS, CHART_THEME } from './theme'
 
 export interface DataPoint {
     x: number
@@ -57,7 +46,7 @@ export function BarChart({
                 <TimeSeriesBarChart
                     series={chartSeries}
                     labels={labels}
-                    theme={THEME}
+                    theme={CHART_THEME}
                     config={{
                         xAxis: { tickFormatter: (value) => formatDate(value) },
                         yAxis: {

--- a/services/mcp/src/ui-apps/components/charts/LineChart.tsx
+++ b/services/mcp/src/ui-apps/components/charts/LineChart.tsx
@@ -4,22 +4,11 @@ import { type Series as ChartSeries, type YAxisFormat, TimeSeriesLineChart } fro
 
 import { formatDate } from '../utils'
 import { CHART_COLORS, CHART_THEME } from './theme'
-
-export interface DataPoint {
-    x: number
-    y: number
-    label: string
-}
-
-export interface Series {
-    label: string
-    points: DataPoint[]
-}
+import type { Series } from './types'
 
 export interface LineChartProps {
     series: Series[]
     labels: string[]
-    maxValue: number
     showLegend?: boolean
     yAxisLabel?: string | undefined
     /** Y-axis value format. Mirrors a trends insight's `aggregationAxisFormat`; defaults to `numeric`. */

--- a/services/mcp/src/ui-apps/components/charts/LineChart.tsx
+++ b/services/mcp/src/ui-apps/components/charts/LineChart.tsx
@@ -1,20 +1,9 @@
 import { type ReactElement } from 'react'
 
-import {
-    type ChartTheme,
-    type Series as ChartSeries,
-    type YAxisFormat,
-    TimeSeriesLineChart,
-} from '@posthog/quill-charts'
+import { type Series as ChartSeries, type YAxisFormat, TimeSeriesLineChart } from '@posthog/quill-charts'
 
 import { formatDate } from '../utils'
-
-// Series palette mirroring base.css `--posthog-chart-*`. Canvas can't read CSS
-// custom properties, so we hand the chart concrete hexes. The chart picks one
-// per series by index; the legend uses the same array to stay in sync.
-const CHART_COLORS = ['#1d4aff', '#621da6', '#42827e', '#ce0e74', '#f14f58', '#7c440e', '#529a0a', '#0476fb']
-
-const THEME: ChartTheme = { colors: CHART_COLORS }
+import { CHART_COLORS, CHART_THEME } from './theme'
 
 export interface DataPoint {
     x: number
@@ -57,7 +46,7 @@ export function LineChart({
                 <TimeSeriesLineChart
                     series={chartSeries}
                     labels={labels}
-                    theme={THEME}
+                    theme={CHART_THEME}
                     config={{
                         xAxis: { tickFormatter: (value) => formatDate(value) },
                         yAxis: {

--- a/services/mcp/src/ui-apps/components/charts/index.ts
+++ b/services/mcp/src/ui-apps/components/charts/index.ts
@@ -1,5 +1,6 @@
 export { BigNumber, type BigNumberProps } from './BigNumber'
-export { LineChart, type LineChartProps, type Series, type DataPoint } from './LineChart'
+export { LineChart, type LineChartProps } from './LineChart'
 export { BarChart, type BarChartProps } from './BarChart'
 export { HorizontalBarChart, type HorizontalBarChartProps, type HorizontalBar } from './HorizontalBarChart'
 export { Select, type SelectProps, type SelectOption } from './Select'
+export { type Series, type DataPoint } from './types'

--- a/services/mcp/src/ui-apps/components/charts/theme.ts
+++ b/services/mcp/src/ui-apps/components/charts/theme.ts
@@ -1,0 +1,26 @@
+import { type ChartTheme } from '@posthog/quill-charts'
+
+// PostHog brand palette. Canvas can't read CSS custom properties, so we hand the
+// chart concrete hexes. The chart picks one per series by index; legends use the
+// same array to stay in sync.
+export const CHART_COLORS = [
+    '#1d4aff', // PostHog blue
+    '#621da6', // PostHog purple
+    '#00d683', // PostHog green
+    '#f54e00', // PostHog orange
+    '#f7a501', // PostHog yellow
+    '#dc2626', // red
+]
+
+// Single mid-gray for axis labels — readable on both light and dark hosts. Claude
+// Desktop's iframe doesn't set `prefers-color-scheme`, so we can't detect the host
+// theme and adapt at runtime.
+export const CHART_THEME: ChartTheme = {
+    colors: CHART_COLORS,
+    backgroundColor: '#ffffff',
+    axisColor: '#9ca3af',
+    gridColor: 'rgba(128, 128, 128, 0.2)',
+    crosshairColor: 'rgba(128, 128, 128, 0.5)',
+    tooltipBackground: '#ffffff',
+    tooltipColor: '#111827',
+}

--- a/services/mcp/src/ui-apps/components/charts/types.ts
+++ b/services/mcp/src/ui-apps/components/charts/types.ts
@@ -1,0 +1,10 @@
+export interface DataPoint {
+    x: number
+    y: number
+    label: string
+}
+
+export interface Series {
+    label: string
+    points: DataPoint[]
+}


### PR DESCRIPTION
## Problem

The MCP UI app rendered bar charts with a bespoke hand-rolled SVG renderer. The sibling line chart was just migrated to the shared hog-charts (`@posthog/quill-charts`) library; this brings bars onto the same library so they match in-app trends rendering.

Stacked on top of #61558 — base this against `sam/mcp-quill-charts-line-chart`, not master.

## Changes

https://github.com/user-attachments/assets/406d949a-9886-4d01-939f-283b923af1ab


- Replace the bespoke SVG bar renderer in `services/mcp/src/ui-apps/components/charts/BarChart.tsx` with hog-charts' `TimeSeriesBarChart`.
- Use a static color palette (concrete hexes; canvas can't read CSS vars) and let the chart assign series colors by index.
- Add a `yAxisFormat` prop that defaults to `numeric` and is wired from a trends insight's `aggregationAxisFormat` in `TrendsVisualizer`.
- Format the x-axis dates via the existing `formatDate` util; bars use hog-charts' default stacked layout (matching a normal trends bar insight).

## How did you test this code?

I'm an agent. I ran the automated checks locally:

- `pnpm typecheck` (tsc) — passes
- `oxlint` on the changed files — clean
- `pnpm build` (UI apps) — builds successfully

No manual/visual testing. The storybook visual-regression snapshots will shift (canvas vs the old SVG) and need regenerating.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Sam's direction. This is the second of a stacked pair: the line chart migration (#61558) added the `@posthog/quill-charts` build + MCP tsconfig path plumbing; this PR mirrors that approach for bars.

Decisions: kept the y-axis on hog-charts' declarative `format` (default `numeric`) to match a normal trends insight rather than the previous compact formatter; chose stacked bar layout (hog-charts/trends default) over the old grouped layout; left the x-axis on the existing `formatDate` util since the MCP UI-app data model carries neither `interval` nor `timezone` needed for hog-charts' native date formatter.