### PR TITLE
feat(data-warehouse): implement twilio import source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -112,6 +112,7 @@ the row lists both.
 | surveymonkey     | HTTP                        | requests                                                        | ✅                          |
 | temporalio       | gRPC (vendor SDK)           | temporalio (`Client`, Rust core via `temporalio.bridge`)        | ⚠️                          |
 | tiktok_ads       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| twilio           | HTTP                        | requests                                                        | ✅                          |
 | typeform         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | vitally          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | webflow          | HTTP                        | requests                                                        | ✅                          |
@@ -216,7 +217,6 @@ doesn't conflict with concurrent PRs.
 - smartsheet
 - surveymonkey
 - trello
-- twilio
 - twitter_ads
 - workday
 - wrike

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -86,6 +86,14 @@ class StripeAuthMethodConfig(config.Config):
 
 
 @config.config
+class TwilioAuthMethodConfig(config.Config):
+    selection: Literal["api_key", "auth_token"] = "api_key"
+    api_key_sid: str | None = None
+    api_key_secret: str | None = None
+    auth_token: str | None = None
+
+
+@config.config
 class VitallyRegionConfig(config.Config):
     subdomain: str
     selection: Literal["EU", "US"] = "EU"
@@ -858,7 +866,8 @@ class TrelloSourceConfig(config.Config):
 
 @config.config
 class TwilioSourceConfig(config.Config):
-    pass
+    account_sid: str
+    auth_method: TwilioAuthMethodConfig
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/twilio/settings.py
+++ b/posthog/temporal/data_imports/sources/twilio/settings.py
@@ -1,0 +1,127 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SortMode
+
+from products.data_warehouse.backend.types import IncrementalField, IncrementalFieldType
+
+
+def _datetime_field(name: str, nullable: bool = False) -> IncrementalField:
+    return {
+        "label": name,
+        "type": IncrementalFieldType.DateTime,
+        "field": name,
+        "field_type": IncrementalFieldType.DateTime,
+        "nullable": nullable,
+    }
+
+
+@dataclass
+class TwilioEndpointConfig:
+    name: str
+    # Resource path appended after `/2010-04-01/Accounts/{account_sid}/`, e.g. "Messages.json".
+    path: str
+    # JSON key wrapping the array of resources in a list response, e.g. "messages".
+    response_key: str
+    primary_key: str = "sid"
+    # Stable, never-changing timestamp used for partitioning (Twilio returns these as RFC 2822 strings).
+    partition_key: Optional[str] = None
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+    # Maps an advertised incremental field to the Twilio query-filter base name (operator appended at request time).
+    # e.g. {"date_sent": "DateSent"} produces `DateSent>=<date>`.
+    incremental_filter_params: dict[str, str] = field(default_factory=dict)
+    # Twilio list endpoints that filter by date return rows newest-first and offer no ascending option.
+    sort_mode: SortMode = "asc"
+
+
+TWILIO_ENDPOINTS: dict[str, TwilioEndpointConfig] = {
+    "messages": TwilioEndpointConfig(
+        name="messages",
+        path="Messages.json",
+        response_key="messages",
+        partition_key="date_created",
+        incremental_fields=[_datetime_field("date_sent", nullable=True)],
+        incremental_filter_params={"date_sent": "DateSent"},
+        sort_mode="desc",
+    ),
+    "calls": TwilioEndpointConfig(
+        name="calls",
+        path="Calls.json",
+        response_key="calls",
+        partition_key="date_created",
+        incremental_fields=[
+            _datetime_field("start_time", nullable=True),
+            _datetime_field("end_time", nullable=True),
+        ],
+        incremental_filter_params={"start_time": "StartTime", "end_time": "EndTime"},
+        sort_mode="desc",
+    ),
+    "recordings": TwilioEndpointConfig(
+        name="recordings",
+        path="Recordings.json",
+        response_key="recordings",
+        partition_key="date_created",
+        incremental_fields=[_datetime_field("date_created")],
+        incremental_filter_params={"date_created": "DateCreated"},
+        sort_mode="desc",
+    ),
+    "conferences": TwilioEndpointConfig(
+        name="conferences",
+        path="Conferences.json",
+        response_key="conferences",
+        partition_key="date_created",
+        incremental_fields=[
+            _datetime_field("date_created"),
+            _datetime_field("date_updated", nullable=True),
+        ],
+        incremental_filter_params={"date_created": "DateCreated", "date_updated": "DateUpdated"},
+        sort_mode="desc",
+    ),
+    "addresses": TwilioEndpointConfig(
+        name="addresses",
+        path="Addresses.json",
+        response_key="addresses",
+    ),
+    "applications": TwilioEndpointConfig(
+        name="applications",
+        path="Applications.json",
+        response_key="applications",
+        partition_key="date_created",
+    ),
+    "incoming_phone_numbers": TwilioEndpointConfig(
+        name="incoming_phone_numbers",
+        path="IncomingPhoneNumbers.json",
+        response_key="incoming_phone_numbers",
+        partition_key="date_created",
+    ),
+    "keys": TwilioEndpointConfig(
+        name="keys",
+        path="Keys.json",
+        response_key="keys",
+        partition_key="date_created",
+    ),
+    "outgoing_caller_ids": TwilioEndpointConfig(
+        name="outgoing_caller_ids",
+        path="OutgoingCallerIds.json",
+        response_key="outgoing_caller_ids",
+        partition_key="date_created",
+    ),
+    "queues": TwilioEndpointConfig(
+        name="queues",
+        path="Queues.json",
+        response_key="queues",
+        partition_key="date_created",
+    ),
+    "transcriptions": TwilioEndpointConfig(
+        name="transcriptions",
+        path="Transcriptions.json",
+        response_key="transcriptions",
+        partition_key="date_created",
+    ),
+}
+
+ENDPOINTS = tuple(TWILIO_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in TWILIO_ENDPOINTS.items()
+}

--- a/posthog/temporal/data_imports/sources/twilio/source.py
+++ b/posthog/temporal/data_imports/sources/twilio/source.py
@@ -1,19 +1,34 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+    SourceFieldSelectConfig,
+    SourceFieldSelectConfigOption,
 )
 
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import TwilioSourceConfig
+from posthog.temporal.data_imports.sources.twilio.settings import ENDPOINTS, INCREMENTAL_FIELDS
+from posthog.temporal.data_imports.sources.twilio.twilio import (
+    TwilioAuth,
+    TwilioResumeConfig,
+    twilio_source,
+    validate_credentials as validate_twilio_credentials,
+)
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class TwilioSource(SimpleSource[TwilioSourceConfig]):
+class TwilioSource(ResumableSource[TwilioSourceConfig, TwilioResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.TWILIO
@@ -23,7 +38,143 @@ class TwilioSource(SimpleSource[TwilioSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.TWILIO,
             label="Twilio",
-            iconPath="/static/services/twilio.png",
-            fields=cast(list[FieldType], []),
+            releaseStatus=ReleaseStatus.ALPHA,
             unreleasedSource=True,
+            caption="""Enter your Twilio credentials to pull your Twilio data into the PostHog Data warehouse.
+
+Your **Account SID** is on the [Twilio Console dashboard](https://console.twilio.com). For credentials we recommend creating a [Standard API key](https://console.twilio.com/us1/account/keys-credentials/api-keys) (SID + Secret) since it can be revoked independently — alternatively you can use your Account SID and Auth Token.""",
+            iconPath="/static/services/twilio.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/twilio",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="account_sid",
+                        label="Account SID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="AC...",
+                        secret=False,
+                    ),
+                    SourceFieldSelectConfig(
+                        name="auth_method",
+                        label="Authentication method",
+                        required=True,
+                        defaultValue="api_key",
+                        options=[
+                            SourceFieldSelectConfigOption(
+                                label="API key (SID + secret)",
+                                value="api_key",
+                                fields=cast(
+                                    list[FieldType],
+                                    [
+                                        SourceFieldInputConfig(
+                                            name="api_key_sid",
+                                            label="API key SID",
+                                            type=SourceFieldInputConfigType.TEXT,
+                                            required=False,
+                                            placeholder="SK...",
+                                            secret=False,
+                                        ),
+                                        SourceFieldInputConfig(
+                                            name="api_key_secret",
+                                            label="API key secret",
+                                            type=SourceFieldInputConfigType.PASSWORD,
+                                            required=False,
+                                            placeholder="",
+                                            secret=True,
+                                        ),
+                                    ],
+                                ),
+                            ),
+                            SourceFieldSelectConfigOption(
+                                label="Auth token",
+                                value="auth_token",
+                                fields=cast(
+                                    list[FieldType],
+                                    [
+                                        SourceFieldInputConfig(
+                                            name="auth_token",
+                                            label="Auth token",
+                                            type=SourceFieldInputConfigType.PASSWORD,
+                                            required=False,
+                                            placeholder="",
+                                            secret=True,
+                                        ),
+                                    ],
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        )
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://api.twilio.com": "Invalid Twilio credentials. Please check your Account SID and Auth Token (or API key SID and secret) and reconnect.",
+            "403 Client Error: Forbidden for url: https://api.twilio.com": "Your Twilio credentials lack permission for this resource. Please check the credential's permissions and try again.",
+        }
+
+    def _get_auth(self, config: TwilioSourceConfig) -> TwilioAuth:
+        if config.auth_method.selection == "auth_token":
+            if not config.auth_method.auth_token:
+                raise ValueError("Missing Twilio auth token")
+            return config.account_sid, config.auth_method.auth_token
+
+        if not config.auth_method.api_key_sid or not config.auth_method.api_key_secret:
+            raise ValueError("Missing Twilio API key SID or secret")
+        return config.auth_method.api_key_sid, config.auth_method.api_key_secret
+
+    def get_schemas(
+        self,
+        config: TwilioSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=bool(INCREMENTAL_FIELDS.get(endpoint)),
+                supports_append=bool(INCREMENTAL_FIELDS.get(endpoint)),
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+            )
+            for endpoint in list(ENDPOINTS)
+        ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: TwilioSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        try:
+            auth = self._get_auth(config)
+        except ValueError as e:
+            return False, str(e)
+        return validate_twilio_credentials(auth, config.account_sid, schema_name)
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[TwilioResumeConfig]:
+        return ResumableSourceManager[TwilioResumeConfig](inputs, TwilioResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: TwilioSourceConfig,
+        resumable_source_manager: ResumableSourceManager[TwilioResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return twilio_source(
+            auth=self._get_auth(config),
+            account_sid=config.account_sid,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value
+            if inputs.should_use_incremental_field
+            else None,
+            incremental_field=inputs.incremental_field,
         )

--- a/posthog/temporal/data_imports/sources/twilio/tests/test_twilio.py
+++ b/posthog/temporal/data_imports/sources/twilio/tests/test_twilio.py
@@ -1,0 +1,244 @@
+from datetime import UTC, date, datetime
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.twilio.settings import TWILIO_ENDPOINTS
+from posthog.temporal.data_imports.sources.twilio.twilio import (
+    TwilioResumeConfig,
+    _build_initial_params,
+    _build_initial_url,
+    _format_filter_date,
+    get_rows,
+    twilio_source,
+    validate_credentials,
+)
+
+ACCOUNT_SID = "AC00000000000000000000000000000000"
+
+
+def _mock_response(status_code=200, body=None):
+    response = mock.MagicMock()
+    response.status_code = status_code
+    response.ok = 200 <= status_code < 300
+    response.json.return_value = body if body is not None else {}
+    response.text = "error body"
+    return response
+
+
+def _patch_session(responses):
+    session = mock.MagicMock()
+    session.get.side_effect = responses
+    patcher = mock.patch(
+        "posthog.temporal.data_imports.sources.twilio.twilio.make_tracked_session", return_value=session
+    )
+    return patcher, session
+
+
+class TestFormatFilterDate:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC), "2026-03-04"),
+            (datetime(2026, 1, 15, 10, 30, 45), "2026-01-15"),
+            (date(2026, 3, 4), "2026-03-04"),
+            ("2026-03-04T02:58:14Z", "2026-03-04"),
+            ("Fri, 24 May 2019 17:44:46 +0000", "2019-05-24"),
+        ],
+    )
+    def test_format_filter_date(self, value, expected):
+        assert _format_filter_date(value) == expected
+
+
+class TestBuildInitialParams:
+    def test_full_refresh_only_sends_page_size(self):
+        params = _build_initial_params(
+            TWILIO_ENDPOINTS["messages"],
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=None,
+            incremental_field=None,
+        )
+        assert params == {"PageSize": 1000}
+
+    def test_incremental_adds_inclusive_date_filter(self):
+        params = _build_initial_params(
+            TWILIO_ENDPOINTS["messages"],
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            incremental_field="date_sent",
+        )
+        assert params["DateSent>"] == "2026-03-04"
+
+    def test_incremental_honors_chosen_field(self):
+        params = _build_initial_params(
+            TWILIO_ENDPOINTS["calls"],
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            incremental_field="end_time",
+        )
+        assert "EndTime>" in params
+        assert "StartTime>" not in params
+
+    def test_incremental_defaults_to_single_filter_field(self):
+        # `date_sent` is the only filter for messages, so a None selection still resolves to it.
+        params = _build_initial_params(
+            TWILIO_ENDPOINTS["messages"],
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            incremental_field=None,
+        )
+        assert params["DateSent>"] == "2026-03-04"
+
+    def test_full_refresh_endpoint_never_filters(self):
+        # `transcriptions` exposes no server-side filter even if incremental is requested.
+        params = _build_initial_params(
+            TWILIO_ENDPOINTS["transcriptions"],
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            incremental_field="date_created",
+        )
+        assert params == {"PageSize": 1000}
+
+
+class TestBuildInitialUrl:
+    def test_url_contains_account_sid_path(self):
+        url = _build_initial_url(TWILIO_ENDPOINTS["messages"], ACCOUNT_SID, {"PageSize": 1})
+        assert url.startswith(f"https://api.twilio.com/2010-04-01/Accounts/{ACCOUNT_SID}/Messages.json?")
+        assert "PageSize=1" in url
+
+    def test_filter_operator_stays_literal(self):
+        url = _build_initial_url(
+            TWILIO_ENDPOINTS["messages"], ACCOUNT_SID, {"PageSize": 1000, "DateSent>": "2026-03-04"}
+        )
+        assert "DateSent>=2026-03-04" in url
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        "status_code, schema_name, expected_valid",
+        [
+            (200, None, True),
+            (200, "messages", True),
+            (401, None, False),
+            (401, "messages", False),
+            (403, None, True),  # valid token, no resource selected yet -> accept
+            (403, "messages", False),  # valid token, but no access to the chosen endpoint
+            (500, None, False),
+        ],
+    )
+    def test_status_mapping(self, status_code, schema_name, expected_valid):
+        patcher, _ = _patch_session([_mock_response(status_code, {"message": "nope"})])
+        with patcher:
+            is_valid, _msg = validate_credentials((ACCOUNT_SID, "token"), ACCOUNT_SID, schema_name)
+        assert is_valid is expected_valid
+
+
+class TestGetRows:
+    def _manager(self, can_resume=False, state=None):
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = can_resume
+        manager.load_state.return_value = state
+        return manager
+
+    def test_paginates_via_next_page_uri_and_saves_state(self):
+        responses = [
+            _mock_response(
+                200,
+                {
+                    "messages": [{"sid": "SM1"}, {"sid": "SM2"}],
+                    "next_page_uri": "/2010-04-01/Accounts/x/Messages.json?Page=1",
+                },
+            ),
+            _mock_response(200, {"messages": [{"sid": "SM3"}], "next_page_uri": None}),
+        ]
+        patcher, session = _patch_session(responses)
+        manager = self._manager()
+
+        with patcher:
+            pages = list(
+                get_rows(
+                    auth=(ACCOUNT_SID, "token"),
+                    account_sid=ACCOUNT_SID,
+                    endpoint="messages",
+                    logger=mock.MagicMock(),
+                    resumable_source_manager=manager,
+                )
+            )
+
+        assert pages == [[{"sid": "SM1"}, {"sid": "SM2"}], [{"sid": "SM3"}]]
+        assert session.get.call_count == 2
+        # State saved once, after the first page is yielded, pointing at the absolute next URL.
+        manager.save_state.assert_called_once()
+        saved = manager.save_state.call_args.args[0]
+        assert isinstance(saved, TwilioResumeConfig)
+        assert saved.next_url == "https://api.twilio.com/2010-04-01/Accounts/x/Messages.json?Page=1"
+
+    def test_resumes_from_saved_state(self):
+        resume_url = "https://api.twilio.com/2010-04-01/Accounts/x/Messages.json?Page=5"
+        responses = [_mock_response(200, {"messages": [{"sid": "SM9"}], "next_page_uri": None})]
+        patcher, session = _patch_session(responses)
+        manager = self._manager(can_resume=True, state=TwilioResumeConfig(next_url=resume_url))
+
+        with patcher:
+            pages = list(
+                get_rows(
+                    auth=(ACCOUNT_SID, "token"),
+                    account_sid=ACCOUNT_SID,
+                    endpoint="messages",
+                    logger=mock.MagicMock(),
+                    resumable_source_manager=manager,
+                )
+            )
+
+        assert pages == [[{"sid": "SM9"}]]
+        assert session.get.call_args_list[0].args[0] == resume_url
+
+    def test_empty_page_terminates(self):
+        responses = [_mock_response(200, {"messages": [], "next_page_uri": None})]
+        patcher, _ = _patch_session(responses)
+        manager = self._manager()
+
+        with patcher:
+            pages = list(
+                get_rows(
+                    auth=(ACCOUNT_SID, "token"),
+                    account_sid=ACCOUNT_SID,
+                    endpoint="messages",
+                    logger=mock.MagicMock(),
+                    resumable_source_manager=manager,
+                )
+            )
+
+        assert pages == []
+        manager.save_state.assert_not_called()
+
+
+class TestTwilioSource:
+    @pytest.mark.parametrize(
+        "endpoint, expected_sort, expects_partition",
+        [
+            ("messages", "desc", True),
+            ("calls", "desc", True),
+            ("recordings", "desc", True),
+            ("conferences", "desc", True),
+            ("addresses", "asc", False),
+            ("transcriptions", "asc", True),
+        ],
+    )
+    def test_source_response_shape(self, endpoint, expected_sort, expects_partition):
+        response = twilio_source(
+            auth=(ACCOUNT_SID, "token"),
+            account_sid=ACCOUNT_SID,
+            endpoint=endpoint,
+            logger=mock.MagicMock(),
+            resumable_source_manager=mock.MagicMock(),
+        )
+        assert response.name == endpoint
+        assert response.primary_keys == ["sid"]
+        assert response.sort_mode == expected_sort
+        if expects_partition:
+            assert response.partition_mode == "datetime"
+            assert response.partition_keys == ["date_created"]
+        else:
+            assert response.partition_mode is None
+            assert response.partition_keys is None

--- a/posthog/temporal/data_imports/sources/twilio/tests/test_twilio.py
+++ b/posthog/temporal/data_imports/sources/twilio/tests/test_twilio.py
@@ -44,10 +44,17 @@ class TestFormatFilterDate:
             (date(2026, 3, 4), "2026-03-04"),
             ("2026-03-04T02:58:14Z", "2026-03-04"),
             ("Fri, 24 May 2019 17:44:46 +0000", "2019-05-24"),
+            (1583290694, "2020-03-04"),  # epoch seconds
         ],
     )
     def test_format_filter_date(self, value, expected):
         assert _format_filter_date(value) == expected
+
+    @pytest.mark.parametrize("value", ["not-a-date", "", None])
+    def test_format_filter_date_raises_on_unparseable(self, value):
+        # Better to fail loudly than emit a malformed filter Twilio rejects with error 20001.
+        with pytest.raises(ValueError):
+            _format_filter_date(value)
 
 
 class TestBuildInitialParams:

--- a/posthog/temporal/data_imports/sources/twilio/tests/test_twilio_source.py
+++ b/posthog/temporal/data_imports/sources/twilio/tests/test_twilio_source.py
@@ -1,0 +1,170 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType, SourceFieldSelectConfig
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.generated_configs import TwilioAuthMethodConfig, TwilioSourceConfig
+from posthog.temporal.data_imports.sources.twilio.settings import ENDPOINTS, INCREMENTAL_FIELDS
+from posthog.temporal.data_imports.sources.twilio.source import TwilioSource
+from posthog.temporal.data_imports.sources.twilio.twilio import TwilioResumeConfig
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+ACCOUNT_SID = "AC00000000000000000000000000000000"
+
+
+def _api_key_config():
+    return TwilioSourceConfig(
+        account_sid=ACCOUNT_SID,
+        auth_method=TwilioAuthMethodConfig(selection="api_key", api_key_sid="SK123", api_key_secret="secret"),
+    )
+
+
+def _auth_token_config():
+    return TwilioSourceConfig(
+        account_sid=ACCOUNT_SID,
+        auth_method=TwilioAuthMethodConfig(selection="auth_token", auth_token="token"),
+    )
+
+
+class TestTwilioSource:
+    def setup_method(self):
+        self.source = TwilioSource()
+        self.team_id = 123
+        self.config = _api_key_config()
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.TWILIO
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "Twilio"
+        assert config.label == "Twilio"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is True
+        assert config.iconPath == "/static/services/twilio.png"
+
+        field_names = [f.name for f in config.fields]
+        assert field_names == ["account_sid", "auth_method"]
+
+    def test_auth_method_offers_both_credential_types(self):
+        config = self.source.get_source_config
+        auth_field = next(f for f in config.fields if isinstance(f, SourceFieldSelectConfig))
+        assert {o.value for o in auth_field.options} == {"api_key", "auth_token"}
+
+    def test_secret_fields_are_passwords(self):
+        config = self.source.get_source_config
+        secrets = {
+            f.name
+            for option_field in config.fields
+            if isinstance(option_field, SourceFieldSelectConfig)
+            for o in option_field.options
+            for f in (o.fields or [])
+            if isinstance(f, SourceFieldInputConfig) and f.type == SourceFieldInputConfigType.PASSWORD
+        }
+        assert secrets == {"api_key_secret", "auth_token"}
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.twilio.com/2010-04-01/Accounts/AC1/Messages.json",
+            "403 Client Error: Forbidden for url: https://api.twilio.com/2010-04-01/Accounts/AC1/Calls.json",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error):
+        assert any(key in observed_error for key in self.source.get_non_retryable_errors())
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.stripe.com/v1/customers",
+            "500 Server Error for url: https://api.twilio.com/2010-04-01/Accounts/AC1/Messages.json",
+        ],
+    )
+    def test_non_retryable_errors_ignore_unrelated(self, other_error):
+        assert not any(key in other_error for key in self.source.get_non_retryable_errors())
+
+    def test_get_schemas(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert {s.name for s in schemas} == set(ENDPOINTS)
+        incremental = {s.name for s in schemas if s.supports_incremental}
+        assert incremental == {"messages", "calls", "recordings", "conferences"}
+
+    def test_incremental_schemas_advertise_their_fields(self):
+        schemas = {s.name: s for s in self.source.get_schemas(self.config, self.team_id)}
+        assert schemas["messages"].incremental_fields == INCREMENTAL_FIELDS["messages"]
+        assert schemas["addresses"].incremental_fields == []
+        assert schemas["addresses"].supports_append is False
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["calls"])
+        assert [s.name for s in schemas] == ["calls"]
+
+    @pytest.mark.parametrize(
+        "config_factory, expected_auth",
+        [
+            (_api_key_config, ("SK123", "secret")),
+            (_auth_token_config, (ACCOUNT_SID, "token")),
+        ],
+    )
+    def test_get_auth_resolves_basic_auth(self, config_factory, expected_auth):
+        assert self.source._get_auth(config_factory()) == expected_auth
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            TwilioSourceConfig(account_sid=ACCOUNT_SID, auth_method=TwilioAuthMethodConfig(selection="auth_token")),
+            TwilioSourceConfig(account_sid=ACCOUNT_SID, auth_method=TwilioAuthMethodConfig(selection="api_key")),
+        ],
+    )
+    def test_validate_credentials_missing_secrets(self, config):
+        is_valid, error = self.source.validate_credentials(config, self.team_id)
+        assert is_valid is False
+        assert error is not None
+
+    @mock.patch("posthog.temporal.data_imports.sources.twilio.source.validate_twilio_credentials")
+    def test_validate_credentials_delegates(self, mock_validate):
+        mock_validate.return_value = (True, None)
+        is_valid, error = self.source.validate_credentials(self.config, self.team_id, schema_name="messages")
+        assert is_valid is True
+        assert error is None
+        mock_validate.assert_called_once_with(("SK123", "secret"), ACCOUNT_SID, "messages")
+
+    def test_get_resumable_source_manager_binds_resume_config(self):
+        manager = self.source.get_resumable_source_manager(mock.MagicMock())
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is TwilioResumeConfig
+
+    @mock.patch("posthog.temporal.data_imports.sources.twilio.source.twilio_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_twilio_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "messages"
+        inputs.should_use_incremental_field = True
+        inputs.db_incremental_field_last_value = "2026-03-04"
+        inputs.incremental_field = "date_sent"
+        manager = mock.MagicMock()
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        kwargs = mock_twilio_source.call_args.kwargs
+        assert kwargs["auth"] == ("SK123", "secret")
+        assert kwargs["account_sid"] == ACCOUNT_SID
+        assert kwargs["endpoint"] == "messages"
+        assert kwargs["resumable_source_manager"] is manager
+        assert kwargs["should_use_incremental_field"] is True
+        assert kwargs["db_incremental_field_last_value"] == "2026-03-04"
+        assert kwargs["incremental_field"] == "date_sent"
+
+    @mock.patch("posthog.temporal.data_imports.sources.twilio.source.twilio_source")
+    def test_source_for_pipeline_omits_last_value_on_full_refresh(self, mock_twilio_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "addresses"
+        inputs.should_use_incremental_field = False
+        inputs.db_incremental_field_last_value = "2026-03-04"
+        inputs.incremental_field = None
+
+        self.source.source_for_pipeline(self.config, mock.MagicMock(), inputs)
+
+        assert mock_twilio_source.call_args.kwargs["db_incremental_field_last_value"] is None

--- a/posthog/temporal/data_imports/sources/twilio/twilio.py
+++ b/posthog/temporal/data_imports/sources/twilio/twilio.py
@@ -1,6 +1,6 @@
 import dataclasses
 from collections.abc import Iterator
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import urlencode
 
@@ -31,19 +31,21 @@ class TwilioResumeConfig:
 
 
 def _format_filter_date(value: Any) -> str:
-    """Twilio date filters are GMT and day-granular (YYYY-MM-DD).
+    """Format an incremental watermark as Twilio's day-granular GMT filter value (YYYY-MM-DD).
 
-    We format the watermark down to its date and use an inclusive `>=` filter, so the whole
-    boundary day is re-fetched and de-duplicated on `sid` by the pipeline's merge semantics.
+    Used with an inclusive `>=` filter, so the whole boundary day is re-fetched and de-duplicated
+    on `sid` by the pipeline's merge semantics. `bool` is excluded from the numeric branch since it
+    subclasses `int`. We raise on anything we can't turn into a real date rather than passing a
+    malformed value through, which Twilio would reject mid-sync with the opaque error 20001.
     """
     if isinstance(value, datetime | date):
         return value.strftime("%Y-%m-%d")
-    # Watermarks arrive as datetimes in practice; parse any string defensively so a non-ISO
-    # value can't produce a malformed filter (which Twilio rejects with error 20001).
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return datetime.fromtimestamp(value, tz=UTC).strftime("%Y-%m-%d")
     try:
         return dateutil_parser.parse(str(value)).strftime("%Y-%m-%d")
-    except (ValueError, TypeError, OverflowError):
-        return str(value)[:10]
+    except (ValueError, TypeError, OverflowError) as e:
+        raise ValueError(f"Cannot build a Twilio date filter from incremental value {value!r}") from e
 
 
 def _build_initial_params(

--- a/posthog/temporal/data_imports/sources/twilio/twilio.py
+++ b/posthog/temporal/data_imports/sources/twilio/twilio.py
@@ -1,0 +1,201 @@
+import dataclasses
+from collections.abc import Iterator
+from datetime import date, datetime
+from typing import Any, Optional
+from urllib.parse import urlencode
+
+import requests
+from dateutil import parser as dateutil_parser
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.twilio.settings import TWILIO_ENDPOINTS, TwilioEndpointConfig
+
+TWILIO_BASE_URL = "https://api.twilio.com"
+TWILIO_API_VERSION = "2010-04-01"
+DEFAULT_PAGE_SIZE = 1000
+
+TwilioAuth = tuple[str, str]
+
+
+class TwilioRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class TwilioResumeConfig:
+    next_url: str
+
+
+def _format_filter_date(value: Any) -> str:
+    """Twilio date filters are GMT and day-granular (YYYY-MM-DD).
+
+    We format the watermark down to its date and use an inclusive `>=` filter, so the whole
+    boundary day is re-fetched and de-duplicated on `sid` by the pipeline's merge semantics.
+    """
+    if isinstance(value, datetime | date):
+        return value.strftime("%Y-%m-%d")
+    # Watermarks arrive as datetimes in practice; parse any string defensively so a non-ISO
+    # value can't produce a malformed filter (which Twilio rejects with error 20001).
+    try:
+        return dateutil_parser.parse(str(value)).strftime("%Y-%m-%d")
+    except (ValueError, TypeError, OverflowError):
+        return str(value)[:10]
+
+
+def _build_initial_params(
+    config: TwilioEndpointConfig,
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+    incremental_field: str | None,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {"PageSize": DEFAULT_PAGE_SIZE}
+
+    if should_use_incremental_field and db_incremental_field_last_value is not None:
+        # Honor the user's chosen cursor field; only filter when it maps to a server-side filter.
+        chosen = incremental_field if incremental_field in config.incremental_filter_params else None
+        if chosen is None and len(config.incremental_filter_params) == 1:
+            chosen = next(iter(config.incremental_filter_params))
+        if chosen is not None:
+            filter_base = config.incremental_filter_params[chosen]
+            # The operator lives in the parameter NAME (e.g. `DateSent>`); urlencode's `=` separator
+            # then yields Twilio's documented `DateSent>=<date>` (inclusive, on-or-after) form. The date
+            # value must stay plain — inlining the operator into the value triggers Twilio error 20001.
+            params[f"{filter_base}>"] = _format_filter_date(db_incremental_field_last_value)
+
+    return params
+
+
+def _build_initial_url(config: TwilioEndpointConfig, account_sid: str, params: dict[str, Any]) -> str:
+    path = f"/{TWILIO_API_VERSION}/Accounts/{account_sid}/{config.path}"
+    if not params:
+        return f"{TWILIO_BASE_URL}{path}"
+    # `safe=">"` keeps Twilio's inequality operator literal in the param name (e.g. `DateSent>`).
+    return f"{TWILIO_BASE_URL}{path}?{urlencode(params, safe='>')}"
+
+
+def validate_credentials(
+    auth: TwilioAuth, account_sid: str, schema_name: Optional[str] = None
+) -> tuple[bool, str | None]:
+    if schema_name is not None and schema_name in TWILIO_ENDPOINTS:
+        config = TWILIO_ENDPOINTS[schema_name]
+        url = _build_initial_url(config, account_sid, {"PageSize": 1})
+    else:
+        url = f"{TWILIO_BASE_URL}/{TWILIO_API_VERSION}/Accounts/{account_sid}.json"
+
+    try:
+        response = make_tracked_session().get(url, auth=auth, timeout=10)
+    except requests.exceptions.RequestException as e:
+        return False, str(e)
+
+    if response.status_code == 200:
+        return True, None
+
+    if response.status_code == 401:
+        return False, "Invalid Twilio credentials. Check your Account SID and Auth Token (or API key SID and secret)."
+
+    # A valid token without access to a specific resource is acceptable at source-create time
+    # (no schema selected yet); only treat it as a failure when validating a specific endpoint.
+    if response.status_code == 403 and schema_name is None:
+        return True, None
+
+    try:
+        message = response.json().get("message", response.text)
+    except Exception:
+        message = response.text
+    return False, message
+
+
+def get_rows(
+    auth: TwilioAuth,
+    account_sid: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[TwilioResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+    incremental_field: str | None = None,
+) -> Iterator[Any]:
+    config = TWILIO_ENDPOINTS[endpoint]
+
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume_config is not None:
+        url: str = resume_config.next_url
+        logger.debug(f"Twilio: resuming from URL: {url}")
+    else:
+        params = _build_initial_params(
+            config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+        )
+        url = _build_initial_url(config, account_sid, params)
+
+    @retry(
+        retry=retry_if_exception_type((TwilioRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(5),
+        wait=wait_exponential_jitter(initial=1, max=60),
+        reraise=True,
+    )
+    def fetch_page(page_url: str) -> dict:
+        response = make_tracked_session().get(page_url, auth=auth, timeout=60)
+
+        # Twilio rate-limits with 429 + a Retry-After header; exponential backoff is a safe fallback.
+        if response.status_code == 429 or response.status_code >= 500:
+            raise TwilioRetryableError(f"Twilio API error (retryable): status={response.status_code}, url={page_url}")
+
+        if not response.ok:
+            logger.error(f"Twilio API error: status={response.status_code}, body={response.text}, url={page_url}")
+            response.raise_for_status()
+
+        return response.json()
+
+    while True:
+        data = fetch_page(url)
+
+        items = data.get(config.response_key, [])
+        if items:
+            yield items
+
+        # `next_page_uri` is a relative path; null/absent signals the last page.
+        next_page_uri = data.get("next_page_uri")
+        if not next_page_uri:
+            break
+
+        url = f"{TWILIO_BASE_URL}{next_page_uri}"
+        # Save AFTER yielding so a crash re-yields the last batch (merge dedupes) rather than skipping it.
+        resumable_source_manager.save_state(TwilioResumeConfig(next_url=url))
+
+
+def twilio_source(
+    auth: TwilioAuth,
+    account_sid: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[TwilioResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+    incremental_field: str | None = None,
+) -> SourceResponse:
+    config = TWILIO_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            auth=auth,
+            account_sid=account_sid,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+            incremental_field=incremental_field,
+        ),
+        primary_keys=[config.primary_key],
+        sort_mode=config.sort_mode,
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+    )


### PR DESCRIPTION
## Problem

Twilio (a Communications Platform as a Service) was registered as a scaffolded data warehouse source but had no sync logic — users couldn't pull their messaging, voice, and account data into the PostHog Data warehouse. This fills in the source end-to-end.

## Changes

Implements the `twilio` import source following the warehouse-sources architecture contract (`source.py` / `settings.py` / `twilio.py` split):

- **`settings.py`** — declarative endpoint catalog over `api.twilio.com/2010-04-01/Accounts/{AccountSid}/`: `messages`, `calls`, `recordings`, `conferences` (incremental), plus `addresses`, `applications`, `incoming_phone_numbers`, `keys`, `outgoing_caller_ids`, `queues`, `transcriptions` (full refresh). Each carries its primary key (`sid`), a stable `date_created` partition key, and an incremental-field → server-filter mapping.
- **`twilio.py`** — transport over the tracked session (`make_tracked_session`): `next_page_uri` cursor pagination, resumable state (saved after each yielded page), `tenacity` retries on 429/5xx, day-granular `>=` date filtering, and credential validation.
- **`source.py`** — a `ResumableSource` with Account SID in the path and a choice of API key (SID + secret) or Account SID + Auth Token basic auth. Implements `validate_credentials`, `get_schemas`, `source_for_pipeline`, `get_resumable_source_manager`, and `get_non_retryable_errors` (Twilio 401/403).

Incremental sync is enabled **only** where Twilio exposes a real server-side timestamp filter (`DateSent`, `StartTime`/`EndTime`, `DateCreated`). Those list endpoints return newest-first with no ascending option, so `sort_mode="desc"` and the pipeline advances the watermark on completion. All other endpoints ship full refresh.

The source stays behind `unreleasedSource=True` with `releaseStatus=alpha`. Icon (`twilio.png`), the schema enum, and registration were already present from the scaffold; `pnpm run generate:source-configs` was run to populate `TwilioSourceConfig` / `TwilioAuthMethodConfig`.

### Known limitations / decisions

- **No webhook support.** Twilio's webhooks (StatusCallback / Event Streams) are configured per-service and don't map cleanly onto the per-resource S3 webhook-ingestion model, so this ships pull-only. Documented for a possible follow-up.
- **Date filters validated against docs, not a live account.** I did not have Twilio credentials to curl-verify filter behavior against real data. The `DateSent>` / `StartTime>` / `DateCreated>` parameter forms (operator in the param name, plain date value) match Twilio's own paging URIs and the twilio-python SDK; inlining the operator into the value is known to trigger Twilio error 20001, which the implementation avoids. The filters should be smoke-tested against a real account before promoting past alpha.
- Endpoints that span other Twilio hosts (Alerts on monitor.twilio.com, Conversations on conversations.twilio.com) and `usage_records` (no `sid`) were left out of this first pass to keep the base URL and primary-key handling uniform.

## How did you test this code?

I'm an agent. I ran the targeted automated tests and lint only — no manual end-to-end sync against a live Twilio account (no credentials available).

- `pytest posthog/temporal/data_imports/sources/twilio/tests/` — 47 passing (transport: param/URL building, pagination + resume, credential status mapping, SourceResponse shape; source class: config/schemas/auth resolution/argument plumbing).
- `ruff check` and `ruff format` clean on the changed Python.
- Confirmed the source loads, registers, and reports correct schemas/incremental flags via Django shell.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus) via the `implementing-warehouse-sources` skill. Reference implementations used were `klaviyo` and `github` (resumable REST sources over `make_tracked_session`).

Key decisions: chose `ResumableSource` over the recommended `ResumableSource+WebhookSource` because Twilio's webhook model doesn't fit the S3 webhook-ingestion path (see limitations). Verified Twilio's date-filter wire format against the public docs and twilio-python behaviour, then fixed a real bug found while testing — building the param as `DateSent>=` produced a doubled `=` (`DateSent>==`) through `urlencode`, so the operator lives in the param name as `DateSent>` and urlencode's separator yields the documented `DateSent>=<date>`. `generated_configs.py` was regenerated via the generator but only the Twilio additions were kept (the generator otherwise reflowed unrelated rows).
