### PR TITLE
fix(ws): bound load-consumer batch processing with a timeout

### DIFF
--- a/posthog/management/commands/run_warehouse_sources_load.py
+++ b/posthog/management/commands/run_warehouse_sources_load.py
@@ -56,6 +56,13 @@ class Command(BaseCommand):
             help="Maximum processing attempts per batch before failing the run (default: 3)",
         )
         parser.add_argument(
+            "--batch-timeout-seconds",
+            type=float,
+            default=1800.0,
+            help="Hard ceiling on a single batch's loader before it is failed and retried, "
+            "so a hung loader cannot wedge the consumer indefinitely (default: 1800)",
+        )
+        parser.add_argument(
             "--health-port",
             type=int,
             default=8080,
@@ -78,6 +85,7 @@ class Command(BaseCommand):
             poll_interval_seconds=options["poll_interval"],
             poll_limit=options["poll_limit"],
             max_attempts=options["max_attempts"],
+            batch_processing_timeout_seconds=options["batch_timeout_seconds"],
             health_port=health_port,
             health_timeout_seconds=health_timeout,
         )
@@ -88,6 +96,7 @@ class Command(BaseCommand):
             poll_interval=config.poll_interval_seconds,
             poll_limit=config.poll_limit,
             max_attempts=config.max_attempts,
+            batch_processing_timeout_seconds=config.batch_processing_timeout_seconds,
             health_port=health_port,
         )
 

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -46,6 +46,24 @@ RECOVERY_INTERVAL_SECONDS = 30.0
 RETRY_BACKOFF_BASE_SECONDS = 15
 HEARTBEAT_INTERVAL_SECONDS = 5.0
 
+# Hard ceiling on a single batch's loader. A hung loader (e.g. a Delta write that never
+# returns) would otherwise block the run loop on `asyncio.gather` indefinitely, never
+# release the (team_id, schema_id) advisory lock — which the recovery sweep cannot reclaim
+# while this process is alive — and head-of-line-block the whole queue. Bounding it turns an
+# indefinite wedge into an ordinary retry (the lock is released in `_process_group`'s finally,
+# letting other groups drain). Keep this comfortably above the legitimate batch p99.9; tune via
+# `--batch-timeout-seconds`.
+BATCH_PROCESSING_TIMEOUT_SECONDS = 1800.0
+
+
+class BatchProcessingTimeoutError(Exception):
+    """A single batch's loader exceeded ``batch_processing_timeout_seconds``.
+
+    Surfaced as an ordinary processing failure so it flows through the normal retry /
+    fail_run path. The point is to release the advisory lock instead of wedging the
+    consumer (and the queue behind it) on a loader that never returns.
+    """
+
 
 @dataclass
 class ConsumerConfig:
@@ -61,6 +79,7 @@ class ConsumerConfig:
     heartbeat_interval_seconds: float = HEARTBEAT_INTERVAL_SECONDS
     recovery_interval_seconds: float = RECOVERY_INTERVAL_SECONDS
     retry_backoff_base_seconds: int = RETRY_BACKOFF_BASE_SECONDS
+    batch_processing_timeout_seconds: float = BATCH_PROCESSING_TIMEOUT_SECONDS
     recovery_grace_seconds: int | None = None
 
     def __post_init__(self) -> None:
@@ -288,7 +307,19 @@ class BatchConsumer:
 
         try:
             start = time.monotonic()
-            await self._process_batch(batch)
+            try:
+                await asyncio.wait_for(
+                    self._process_batch(batch),
+                    timeout=self._config.batch_processing_timeout_seconds,
+                )
+            except TimeoutError as e:
+                # Abandon the await so `_process_group`'s finally releases the advisory lock
+                # and the queue can drain. The orphaned worker thread is harmless: the Delta
+                # commit is idempotent on (run_uuid, batch_index).
+                raise BatchProcessingTimeoutError(
+                    f"loader exceeded {self._config.batch_processing_timeout_seconds:.0f}s "
+                    f"(run_uuid={batch.run_uuid} batch_index={batch.batch_index})"
+                ) from e
             duration = time.monotonic() - start
             BATCH_PROCESSING_DURATION_SECONDS.labels(team_id=team_id, schema_id=schema_id).observe(duration)
 

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -95,6 +95,55 @@ class TestProcessSingle:
         assert states == [SourceBatchStatus.State.EXECUTING, SourceBatchStatus.State.WAITING_RETRY]
 
     @pytest.mark.asyncio
+    async def test_hung_loader_times_out_and_sets_waiting_retry(self):
+        # A loader that never returns must not wedge the consumer: it is bounded by
+        # batch_processing_timeout_seconds, surfaced as a failure, and retried — which is
+        # what lets _process_group release its advisory lock so the queue can drain.
+        consumer = _make_consumer(max_attempts=3, batch_processing_timeout_seconds=0.01)
+        batch = _make_batch(latest_attempt=0)
+        states: list[str] = []
+        errors: list[str] = []
+
+        async def track_status(conn, *, batch_id, job_state, attempt, error_response=None):
+            states.append(job_state)
+            if error_response is not None:
+                errors.append(error_response["error"])
+
+        async def hang(_batch):
+            await asyncio.sleep(60)
+
+        consumer._process_batch = hang
+        with patch(
+            "posthog.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status",
+            side_effect=track_status,
+        ):
+            await consumer._process_single(batch)
+
+        assert states == [SourceBatchStatus.State.EXECUTING, SourceBatchStatus.State.WAITING_RETRY]
+        assert errors and "exceeded" in errors[0]
+
+    @pytest.mark.asyncio
+    async def test_hung_loader_at_max_attempts_fails_run(self):
+        consumer = _make_consumer(max_attempts=2, batch_processing_timeout_seconds=0.01)
+        batch = _make_batch(latest_attempt=1)
+
+        async def hang(_batch):
+            await asyncio.sleep(60)
+
+        consumer._process_batch = hang
+        with (
+            patch(
+                "posthog.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status",
+                new_callable=AsyncMock,
+            ),
+            patch.object(consumer, "_fail_run", new_callable=AsyncMock) as mock_fail,
+        ):
+            await consumer._process_single(batch)
+
+        mock_fail.assert_called_once()
+        assert "exceeded" in mock_fail.call_args[1]["reason"]
+
+    @pytest.mark.asyncio
     async def test_max_attempts_exceeded_fails_run(self):
         consumer = _make_consumer(max_attempts=3)
         batch = _make_batch(latest_attempt=3)


### PR DESCRIPTION
## Problem

The warehouse-sources V3 load consumer processes batches grouped by `(team_id, schema_id)` under Postgres advisory locks. If a single batch's loader hangs (e.g. a Delta write that never returns), the consumer's `run()` loop stays blocked on `asyncio.gather` indefinitely:

- the group's advisory lock is released only in `_process_group`'s `finally`, so it is never freed;
- the recovery sweep can't reclaim a lock held by a *live* process (`get_stale_executing` probes `pg_try_advisory_lock`);
- the poll query applies `LIMIT` to candidates *before* the advisory-lock probe, so the stuck group's oldest rows head-of-line-block other consumers.

Net effect: a single hung batch can stall warehouse loads with no automatic recovery — every job with new rows sits in `Running` while only zero-row syncs complete.

## Changes

- Bound `_process_batch` with `asyncio.wait_for(timeout=batch_processing_timeout_seconds)`. On timeout it raises `BatchProcessingTimeoutError`, which flows through the **existing** retry / `fail_run` path, so `_process_group`'s `finally` releases the advisory lock and other groups drain.
- New `batch_processing_timeout_seconds` config (default `1800`s) and a `--batch-timeout-seconds` CLI flag on `run_warehouse_sources_load`.
- The orphaned worker thread that `wait_for` leaves behind is harmless: the Delta commit is idempotent on `(run_uuid, batch_index)`.

Deliberately **out of scope** (suggested follow-ups):

- **Blast-radius containment:** make the poll skip locked groups (resolve lockable groups before selecting their batches) so one stuck schema can't head-of-line-block the queue at all. This is a concurrency-sensitive SQL change with a phantom-advisory-lock pitfall and wants the real queue DB to validate.
- **Tighter default:** the `batch_processing_duration_seconds` histogram saturates at its top bucket (`le=600`), hiding the true legitimate tail. Extend the buckets, then lower the default timeout toward p99.9 + margin.

## How did you test this code?

I'm an agent — automated tests only, no manual or production testing.

- Added two unit tests in `test_consumer.py`: a hung loader times out → `WAITING_RETRY`; a hung loader at max attempts → `fail_run`.
- Ran the full `test_consumer.py` suite (21 tests) — all pass.
- `ruff check` and `ruff format` clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal ingestion-pipeline change; no user-facing docs. Add `skip-inkeep-docs` if the bot proposes one.

## 🤖 Agent context

Authored with Claude Code (Read / Grep / Bash / Edit, plus the Grafana MCP for consumer metrics). The wedge was diagnosed from the consumer + queue code and prod consumer metrics — polling kept running while batch throughput sat at zero with a single group stuck "active" and the recovery sweep unable to reclaim it.

I considered rewriting the head-of-line poll query directly but rejected it for this PR: it's concurrency-sensitive and risks phantom advisory locks, and it can't be validated without the real queue DB. The bounded timeout is the safe, self-healing first step; the poll-query containment is filed as a follow-up above. The `1800`s default is intentionally conservative because the duration histogram saturates at `600`s, so the real legitimate ceiling isn't observable yet.
