### PR TITLE
fix(batch-exports): return clear error when Redshift can't read staged S3 files

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1227,8 +1227,6 @@ async def check_and_raise_redshift_copy_error(
             raise InsufficientS3PermissionsError(bucket) from err
         return
 
-    # Redshift reports a missing read permission as the misleading "requires full path of an S3
-    # object" rather than a clean access-denied, so match those markers as well.
     markers = (
         "requires full path of an S3 object",
         "Access Denied",

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1167,28 +1167,33 @@ async def is_s3_read_access_denied(
     credentials: AWSCredentials,
     keys: collections.abc.Sequence[str],
 ) -> bool:
-    """Return True if reading any of `keys` is denied with the given credentials.
+    """Return True only if a HEAD positively confirms read access is denied for any of `keys`.
 
     We `head_object` each key with the same credentials Redshift uses for the COPY. A 403 / Access
     Denied / Forbidden confirms a read-permission problem (including the SSE-KMS 'kms:Decrypt' case,
-    which also fails the HEAD). Non-permission errors (e.g. a 404) are treated as not-denied so we
-    don't mask an unrelated failure.
+    which also fails the HEAD). Anything else returns False — a successful HEAD, a non-permission
+    error (e.g. a 404), or an unexpected probe failure (e.g. a connection error). This is best-effort
+    by design: callers should only escalate to a hard error on a confirmed denial, and never mask an
+    original failure just because the probe itself couldn't run.
     """
-    session = aioboto3.Session()
-    async with session.client(
-        "s3",
-        region_name=region_name,
-        aws_access_key_id=credentials.aws_access_key_id,
-        aws_secret_access_key=credentials.aws_secret_access_key,
-    ) as client:
-        for key in keys:
-            try:
-                await client.head_object(Bucket=bucket, Key=key)
-            except botocore.exceptions.ClientError as err:
-                status = err.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
-                code = err.response.get("Error", {}).get("Code")
-                if status == 403 or code in ("403", "AccessDenied", "Forbidden"):
-                    return True
+    try:
+        session = aioboto3.Session()
+        async with session.client(
+            "s3",
+            region_name=region_name,
+            aws_access_key_id=credentials.aws_access_key_id,
+            aws_secret_access_key=credentials.aws_secret_access_key,
+        ) as client:
+            for key in keys:
+                try:
+                    await client.head_object(Bucket=bucket, Key=key)
+                except botocore.exceptions.ClientError as err:
+                    status = err.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+                    code = err.response.get("Error", {}).get("Code")
+                    if status == 403 or code in ("403", "AccessDenied", "Forbidden"):
+                        return True
+    except Exception:
+        LOGGER.warning("S3 read-access probe failed; treating as not confirmed", exc_info=True)
     return False
 
 
@@ -1216,15 +1221,9 @@ async def check_and_raise_redshift_copy_error(
     """
     if isinstance(authorization, AWSCredentials):
         probe_keys = [manifest_key, *files_uploaded[:1]]
-        try:
-            access_denied = await is_s3_read_access_denied(
-                bucket=bucket, region_name=region_name, credentials=authorization, keys=probe_keys
-            )
-        except Exception:
-            # The probe itself failed (e.g. a connection error); let the caller re-raise the
-            # original COPY error rather than masking it with an unrelated probe failure.
-            return
-        if access_denied:
+        if await is_s3_read_access_denied(
+            bucket=bucket, region_name=region_name, credentials=authorization, keys=probe_keys
+        ):
             raise InsufficientS3PermissionsError(bucket) from err
         return
 

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1216,9 +1216,15 @@ async def check_and_raise_redshift_copy_error(
     """
     if isinstance(authorization, AWSCredentials):
         probe_keys = [manifest_key, *files_uploaded[:1]]
-        if await is_s3_read_access_denied(
-            bucket=bucket, region_name=region_name, credentials=authorization, keys=probe_keys
-        ):
+        try:
+            access_denied = await is_s3_read_access_denied(
+                bucket=bucket, region_name=region_name, credentials=authorization, keys=probe_keys
+            )
+        except Exception:
+            # The probe itself failed (e.g. a connection error); let the caller re-raise the
+            # original COPY error rather than masking it with an unrelated probe failure.
+            return
+        if access_denied:
             raise InsufficientS3PermissionsError(bucket) from err
         return
 

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -101,6 +101,11 @@ NON_RETRYABLE_ERROR_TYPES = (
     "InvalidCredentialsError",
     # Raised by Redshift client when the cluster has insufficient system resources.
     "InsufficientSystemResourcesError",
+    # The S3 credentials provided for the COPY can't read the staged files.
+    "InsufficientS3PermissionsError",
+    # Redshift failed to COPY the staged files from S3 (IAM role auth, cause not locally confirmable).
+    # These (read access, region, manifest) don't self-heal, so retrying is pointless.
+    "RedshiftS3CopyError",
 )
 
 
@@ -129,6 +134,41 @@ class InsufficientSystemResourcesError(Exception):
     """
 
     pass
+
+
+class InsufficientS3PermissionsError(Exception):
+    """Error raised when Redshift cannot read the staged files from S3 during COPY.
+
+    Redshift surfaces a missing read permission as the misleading "COPY with MANIFEST parameter
+    requires full path of an S3 object" error rather than a clean access-denied. We translate it
+    into something actionable once we've confirmed S3 read is denied with the same credentials.
+    """
+
+    def __init__(self, bucket: str):
+        super().__init__(
+            f"Redshift could not read the staged files from S3 bucket '{bucket}'."
+            " The S3 credentials provided for the Redshift COPY are missing read access"
+            " (Redshift requires both 's3:GetObject' and 's3:ListBucket')."
+            " If the bucket uses SSE-KMS encryption, 'kms:Decrypt' on the key is also required."
+            " Grant read access and retry."
+        )
+
+
+class RedshiftS3CopyError(Exception):
+    """Error raised when Redshift fails to COPY the staged files from S3 and we can't pin down why.
+
+    Used for IAM role auth, which we can't probe locally to confirm a read denial. The message points
+    at the common causes of a failed COPY so the user knows where to look.
+    """
+
+    def __init__(self, bucket: str):
+        super().__init__(
+            f"Redshift could not COPY the staged files from S3 bucket '{bucket}'."
+            " Common causes: the IAM role provided for the Redshift COPY lacks read access to the"
+            " bucket (Redshift requires 's3:GetObject' and 's3:ListBucket', plus 'kms:Decrypt' if the"
+            " bucket uses SSE-KMS encryption), or the bucket is in a different AWS region than the"
+            " Redshift cluster. Verify the role's permissions and the bucket region, then retry."
+        )
 
 
 class ClientErrorGroup(ExceptionGroup):
@@ -1121,6 +1161,80 @@ async def delete_uploaded_files(
             tg.create_task(delete_key(manifest_key))
 
 
+async def is_s3_read_access_denied(
+    bucket: str,
+    region_name: str,
+    credentials: AWSCredentials,
+    keys: collections.abc.Sequence[str],
+) -> bool:
+    """Return True if reading any of `keys` is denied with the given credentials.
+
+    We `head_object` each key with the same credentials Redshift uses for the COPY. A 403 / Access
+    Denied / Forbidden confirms a read-permission problem (including the SSE-KMS 'kms:Decrypt' case,
+    which also fails the HEAD). Non-permission errors (e.g. a 404) are treated as not-denied so we
+    don't mask an unrelated failure.
+    """
+    session = aioboto3.Session()
+    async with session.client(
+        "s3",
+        region_name=region_name,
+        aws_access_key_id=credentials.aws_access_key_id,
+        aws_secret_access_key=credentials.aws_secret_access_key,
+    ) as client:
+        for key in keys:
+            try:
+                await client.head_object(Bucket=bucket, Key=key)
+            except botocore.exceptions.ClientError as err:
+                status = err.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+                code = err.response.get("Error", {}).get("Code")
+                if status == 403 or code in ("403", "AccessDenied", "Forbidden"):
+                    return True
+    return False
+
+
+async def check_and_raise_redshift_copy_error(
+    err: psycopg.errors.InternalError_,
+    *,
+    authorization: IAMRole | AWSCredentials,
+    bucket: str,
+    region_name: str,
+    manifest_key: str,
+    files_uploaded: collections.abc.Sequence[str],
+) -> None:
+    """Translate a failed Redshift COPY into an actionable error.
+
+    Redshift reports a missing read permission as the misleading "requires full path of an S3 object"
+    error. We always generate a well-formed manifest, so for credential auth we confirm the real
+    cause by probing S3 read access (HEAD on the manifest + a staged file) with the same credentials
+    Redshift uses for the COPY: a confirmed denial raises `InsufficientS3PermissionsError`, otherwise
+    we return so the caller re-raises the original (it's some other COPY problem).
+
+    IAM role auth can't be probed locally, so we can't confirm the cause. We only translate when the
+    error matches a known S3 read/access marker, raising the more generic `RedshiftS3CopyError` that
+    points at the likely culprits (role read access or bucket region). Any other COPY error returns
+    unchanged so it keeps its original message and retry behaviour.
+    """
+    if isinstance(authorization, AWSCredentials):
+        probe_keys = [manifest_key, *files_uploaded[:1]]
+        if await is_s3_read_access_denied(
+            bucket=bucket, region_name=region_name, credentials=authorization, keys=probe_keys
+        ):
+            raise InsufficientS3PermissionsError(bucket) from err
+        return
+
+    # Redshift reports a missing read permission as the misleading "requires full path of an S3
+    # object" rather than a clean access-denied, so match those markers as well.
+    markers = (
+        "requires full path of an S3 object",
+        "Access Denied",
+        "S3ServiceException",
+        "Forbidden",
+    )
+    diagnostics = (str(err), err.diag.message_primary or "", err.diag.message_detail or "")
+    if any(marker in text for text in diagnostics for marker in markers):
+        raise RedshiftS3CopyError(bucket) from err
+
+
 @activity.defn
 @handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInputs) -> BatchExportResult:
@@ -1331,14 +1445,25 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                 try:
                     external_logger.info(f"Copying {len(consumer.files_uploaded)} file/s into Redshift")
 
-                    await redshift_client.acopy_from_s3_bucket(
-                        table_name=redshift_stage_table,
-                        parquet_fields=[field.name for field in transformer.schema],
-                        schema_name=inputs.table.schema_name,
-                        s3_bucket=inputs.copy.s3_bucket.name,
-                        manifest_key=manifest_key,
-                        authorization=inputs.copy.authorization,
-                    )
+                    try:
+                        await redshift_client.acopy_from_s3_bucket(
+                            table_name=redshift_stage_table,
+                            parquet_fields=[field.name for field in transformer.schema],
+                            schema_name=inputs.table.schema_name,
+                            s3_bucket=inputs.copy.s3_bucket.name,
+                            manifest_key=manifest_key,
+                            authorization=inputs.copy.authorization,
+                        )
+                    except psycopg.errors.InternalError_ as err:
+                        await check_and_raise_redshift_copy_error(
+                            err,
+                            authorization=inputs.copy.authorization,
+                            bucket=inputs.copy.s3_bucket.name,
+                            region_name=inputs.copy.s3_bucket.region_name,
+                            manifest_key=manifest_key,
+                            files_uploaded=consumer.files_uploaded,
+                        )
+                        raise
 
                     if merge_settings.requires_merge is True:
                         await redshift_client.amerge_tables(

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from typing import Any
 
 import pytest
 from unittest import mock
@@ -166,37 +167,23 @@ def _mock_s3_session_with_head_object(head_object: mock.AsyncMock) -> mock.Magic
 
 
 @pytest.mark.parametrize(
-    "head_object,expected",
+    "error_code,status_code,expected",
     [
-        (
-            mock.AsyncMock(
-                side_effect=botocore.exceptions.ClientError(
-                    {"Error": {"Code": "AccessDenied"}, "ResponseMetadata": {"HTTPStatusCode": 403}}, "HeadObject"
-                )
-            ),
-            True,
-        ),
-        (
-            mock.AsyncMock(
-                side_effect=botocore.exceptions.ClientError(
-                    {"Error": {"Code": "403"}, "ResponseMetadata": {"HTTPStatusCode": 403}}, "HeadObject"
-                )
-            ),
-            True,
-        ),
-        (mock.AsyncMock(return_value={}), False),
-        (
-            mock.AsyncMock(
-                side_effect=botocore.exceptions.ClientError(
-                    {"Error": {"Code": "404"}, "ResponseMetadata": {"HTTPStatusCode": 404}}, "HeadObject"
-                )
-            ),
-            False,
-        ),
+        ("AccessDenied", 403, True),
+        ("403", 403, True),
+        (None, None, False),
+        ("404", 404, False),
     ],
 )
-async def test_is_s3_read_access_denied(head_object, expected):
+async def test_is_s3_read_access_denied(error_code, status_code, expected):
     """Test we report read access as denied only on a 403/AccessDenied HEAD."""
+    if error_code is None:
+        head_object = mock.AsyncMock(return_value={})
+    else:
+        # Typed as Any to skip the botocore response TypedDict's required-key checks.
+        response: Any = {"Error": {"Code": error_code}, "ResponseMetadata": {"HTTPStatusCode": status_code}}
+        head_object = mock.AsyncMock(side_effect=botocore.exceptions.ClientError(response, "HeadObject"))
+
     with mock.patch(
         "products.batch_exports.backend.temporal.destinations.redshift_batch_export.aioboto3.Session"
     ) as mock_session_class:
@@ -227,7 +214,7 @@ class _FakeInternalError(psycopg.errors.InternalError_):
         self._fake_diag = _FakeDiag(primary, detail)
 
     @property
-    def diag(self):  # type: ignore[override]
+    def diag(self) -> Any:
         return self._fake_diag
 
 
@@ -252,7 +239,26 @@ async def test_check_and_raise_redshift_copy_error_credentials(denied):
             with pytest.raises(InsufficientS3PermissionsError):
                 await call
         else:
-            assert await call is None
+            await call  # should not raise
+
+
+async def test_check_and_raise_redshift_copy_error_swallows_probe_failure():
+    """If the S3 probe itself fails, we don't mask the original COPY error (caller re-raises it)."""
+    credentials = AWSCredentials(aws_access_key_id="key", aws_secret_access_key="secret")
+
+    with mock.patch(
+        "products.batch_exports.backend.temporal.destinations.redshift_batch_export.is_s3_read_access_denied",
+        new=mock.AsyncMock(side_effect=botocore.exceptions.EndpointConnectionError(endpoint_url="https://s3")),
+    ):
+        # Should not raise — the unexpected probe failure is swallowed so the caller re-raises.
+        await check_and_raise_redshift_copy_error(
+            _FakeInternalError("COPY failed"),
+            authorization=credentials,
+            bucket="test-bucket",
+            region_name="us-east-1",
+            manifest_key="prefix/manifest.json",
+            files_uploaded=["prefix/file-0.parquet.zst"],
+        )
 
 
 @pytest.mark.parametrize(
@@ -277,4 +283,4 @@ async def test_check_and_raise_redshift_copy_error_iam_role(error, should_raise)
         with pytest.raises(RedshiftS3CopyError):
             await call
     else:
-        assert await call is None
+        await call  # should not raise

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
@@ -6,12 +6,18 @@ from unittest import mock
 
 from django.conf import settings
 
+import psycopg
 import aioboto3
 import pytest_asyncio
 import botocore.exceptions
 
+from products.batch_exports.backend.service import AWSCredentials
 from products.batch_exports.backend.temporal.destinations.redshift_batch_export import (
     ClientErrorGroup,
+    InsufficientS3PermissionsError,
+    RedshiftS3CopyError,
+    check_and_raise_redshift_copy_error,
+    is_s3_read_access_denied,
     upload_manifest_file,
 )
 from products.batch_exports.backend.temporal.temporary_file import remove_escaped_whitespace_recursive
@@ -143,3 +149,132 @@ async def test_upload_manifest_file_raises_on_client_error(minio_client, bucket_
             )
         assert all(isinstance(exc, botocore.exceptions.ClientError) for exc in exc_info.value.exceptions)
         assert exc_info.value.ops == {"list_objects_v2": {"AccessDenied"}}  # type: ignore
+
+
+def _mock_s3_session_with_head_object(head_object: mock.AsyncMock) -> mock.MagicMock:
+    """Build a mocked aioboto3 Session whose S3 client uses the given head_object mock."""
+    mock_client = mock.MagicMock()
+    mock_client.head_object = head_object
+
+    mock_context_manager = mock.MagicMock()
+    mock_context_manager.__aenter__.return_value = mock_client
+    mock_context_manager.__aexit__.return_value = None
+
+    mock_session_instance = mock.MagicMock()
+    mock_session_instance.client.return_value = mock_context_manager
+    return mock_session_instance
+
+
+@pytest.mark.parametrize(
+    "head_object,expected",
+    [
+        (
+            mock.AsyncMock(
+                side_effect=botocore.exceptions.ClientError(
+                    {"Error": {"Code": "AccessDenied"}, "ResponseMetadata": {"HTTPStatusCode": 403}}, "HeadObject"
+                )
+            ),
+            True,
+        ),
+        (
+            mock.AsyncMock(
+                side_effect=botocore.exceptions.ClientError(
+                    {"Error": {"Code": "403"}, "ResponseMetadata": {"HTTPStatusCode": 403}}, "HeadObject"
+                )
+            ),
+            True,
+        ),
+        (mock.AsyncMock(return_value={}), False),
+        (
+            mock.AsyncMock(
+                side_effect=botocore.exceptions.ClientError(
+                    {"Error": {"Code": "404"}, "ResponseMetadata": {"HTTPStatusCode": 404}}, "HeadObject"
+                )
+            ),
+            False,
+        ),
+    ],
+)
+async def test_is_s3_read_access_denied(head_object, expected):
+    """Test we report read access as denied only on a 403/AccessDenied HEAD."""
+    with mock.patch(
+        "products.batch_exports.backend.temporal.destinations.redshift_batch_export.aioboto3.Session"
+    ) as mock_session_class:
+        mock_session_class.return_value = _mock_s3_session_with_head_object(head_object)
+
+        denied = await is_s3_read_access_denied(
+            bucket="test-bucket",
+            region_name="us-east-1",
+            credentials=AWSCredentials(aws_access_key_id="key", aws_secret_access_key="secret"),
+            keys=["some/manifest.json", "some/file-0.parquet.zst"],
+        )
+
+    assert denied is expected
+
+
+class _FakeDiag:
+    def __init__(self, primary: str | None = None, detail: str | None = None):
+        self.message_primary = primary
+        self.message_detail = detail
+
+
+class _FakeInternalError(psycopg.errors.InternalError_):
+    """Stand-in for a Redshift COPY error. psycopg builds `diag` from driver state we can't fake, so
+    we override it to expose the message fields the code inspects."""
+
+    def __init__(self, message: str = "", *, primary: str | None = None, detail: str | None = None):
+        super().__init__(message)
+        self._fake_diag = _FakeDiag(primary, detail)
+
+    @property
+    def diag(self):  # type: ignore[override]
+        return self._fake_diag
+
+
+@pytest.mark.parametrize("denied", [True, False])
+async def test_check_and_raise_redshift_copy_error_credentials(denied):
+    """With credential auth we probe S3 and only raise the specific error when read is denied."""
+    credentials = AWSCredentials(aws_access_key_id="key", aws_secret_access_key="secret")
+
+    with mock.patch(
+        "products.batch_exports.backend.temporal.destinations.redshift_batch_export.is_s3_read_access_denied",
+        new=mock.AsyncMock(return_value=denied),
+    ):
+        call = check_and_raise_redshift_copy_error(
+            _FakeInternalError("COPY failed"),
+            authorization=credentials,
+            bucket="test-bucket",
+            region_name="us-east-1",
+            manifest_key="prefix/manifest.json",
+            files_uploaded=["prefix/file-0.parquet.zst"],
+        )
+        if denied:
+            with pytest.raises(InsufficientS3PermissionsError):
+                await call
+        else:
+            assert await call is None
+
+
+@pytest.mark.parametrize(
+    "error,should_raise",
+    [
+        (_FakeInternalError("COPY with MANIFEST parameter requires full path of an S3 object"), True),
+        (_FakeInternalError("copy failed", detail="S3ServiceException: Access Denied"), True),
+        (_FakeInternalError("syntax error at or near 'foo'"), False),
+    ],
+)
+async def test_check_and_raise_redshift_copy_error_iam_role(error, should_raise):
+    """IAM role auth can't be probed, so we translate only recognised S3 read/access failures."""
+    call = check_and_raise_redshift_copy_error(
+        error,
+        authorization="arn:aws:iam::123456789012:role/redshift-copy",
+        bucket="test-bucket",
+        region_name="us-east-1",
+        manifest_key="prefix/manifest.json",
+        files_uploaded=["prefix/file-0.parquet.zst"],
+    )
+    if should_raise:
+        with pytest.raises(RedshiftS3CopyError):
+            await call
+    else:
+        assert await call is None

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
@@ -199,6 +199,25 @@ async def test_is_s3_read_access_denied(error_code, status_code, expected):
     assert denied is expected
 
 
+async def test_is_s3_read_access_denied_swallows_unexpected_error():
+    """An unexpected probe failure (e.g. a connection error) is treated as 'not confirmed' (False)."""
+    head_object = mock.AsyncMock(side_effect=botocore.exceptions.EndpointConnectionError(endpoint_url="https://s3"))
+
+    with mock.patch(
+        "products.batch_exports.backend.temporal.destinations.redshift_batch_export.aioboto3.Session"
+    ) as mock_session_class:
+        mock_session_class.return_value = _mock_s3_session_with_head_object(head_object)
+
+        denied = await is_s3_read_access_denied(
+            bucket="test-bucket",
+            region_name="us-east-1",
+            credentials=AWSCredentials(aws_access_key_id="key", aws_secret_access_key="secret"),
+            keys=["some/manifest.json"],
+        )
+
+    assert denied is False
+
+
 class _FakeDiag:
     def __init__(self, primary: str | None = None, detail: str | None = None):
         self.message_primary = primary
@@ -240,25 +259,6 @@ async def test_check_and_raise_redshift_copy_error_credentials(denied):
                 await call
         else:
             await call  # should not raise
-
-
-async def test_check_and_raise_redshift_copy_error_swallows_probe_failure():
-    """If the S3 probe itself fails, we don't mask the original COPY error (caller re-raises it)."""
-    credentials = AWSCredentials(aws_access_key_id="key", aws_secret_access_key="secret")
-
-    with mock.patch(
-        "products.batch_exports.backend.temporal.destinations.redshift_batch_export.is_s3_read_access_denied",
-        new=mock.AsyncMock(side_effect=botocore.exceptions.EndpointConnectionError(endpoint_url="https://s3")),
-    ):
-        # Should not raise — the unexpected probe failure is swallowed so the caller re-raises.
-        await check_and_raise_redshift_copy_error(
-            _FakeInternalError("COPY failed"),
-            authorization=credentials,
-            bucket="test-bucket",
-            region_name="us-east-1",
-            manifest_key="prefix/manifest.json",
-            files_uploaded=["prefix/file-0.parquet.zst"],
-        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

A Redshift batch export running in COPY mode fails with the cryptic, misleading error `COPY with MANIFEST parameter requires full path of an S3 object` (Redshift error code 8001).

In some cases, the actual cause is a **read-permission gap on the staging bucket**: the S3 credentials provided for the export can *write* and *list* the bucket (`s3:PutObject` + `s3:ListBucket`) but cannot *read* it (`s3:GetObject` missing, or `kms:Decrypt` missing for an SSE-KMS bucket). So our pipeline uploads the parquet files and the manifest fine, but Redshift's COPY — which uses those same credentials to *read* the manifest and data files — gets a 403 that it reports as the misleading "requires full path" error instead of a clean access-denied. The export then retries pointlessly as it surfaces a generic retryable error, with nothing actionable surfaced to the user.

## Changes

When a Redshift COPY raises an `InternalError`, we now attempt to translate it into an actionable, non-retryable error instead of letting the raw message propagate:

- **Credential auth** — confirm the cause by probing S3 read access with the *same* credentials Redshift uses for the COPY (`HEAD` on the manifest key + the first staged file). A real 403 / `AccessDenied` raises `InsufficientS3PermissionsError`, naming the bucket and the required permissions (`s3:GetObject`, `s3:ListBucket`, and `kms:Decrypt` for SSE-KMS). The probe runs only on the failure path, so there's no overhead on healthy runs, and it's authoritative rather than relying on message string-matching.
- **IAM-role auth** — we can't impersonate the role locally to probe it, so we don't over-claim. We raise the more generic `RedshiftS3CopyError` (pointing at the likely culprits: role read access *or* bucket region) only when the error matches a known S3 read/access marker.
- **Anything else** — re-raised unchanged, keeping its original message and existing retry behaviour. So only the recognised, non-self-healing failures become non-retryable.

Both new exceptions are registered as non-retryable so they surface to the user immediately rather than burning retries.

## How did you test this code?

- Unit tests in `products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed — this only improves an internal error message surfaced on failed batch export runs.

## 🤖 Agent context

Authored with PostHog Code (Claude). The work started from a support investigation into the "requires full path of an S3 object" failure. The first hypothesis was a cross-region bucket/cluster mismatch (the COPY emits no `REGION` clause); that was ruled out after confirming the bucket and cluster were both in the same region. The cause was then pinned to a missing `s3:GetObject` on the provided credentials, reproduced via a 403 on a `HeadObject` with those keys.

Key decisions:
- **Catch-then-probe** rather than a pre-flight check — zero overhead on healthy runs, and a real 403 confirms the diagnosis instead of guessing from Redshift's wording.
- **Two error types**: a specific `InsufficientS3PermissionsError` only when the probe *confirms* a denial (credential auth), and a generic, marker-gated `RedshiftS3CopyError` for IAM-role auth, which we can't probe locally without assuming the role. We deliberately avoid over-claiming a permissions cause we can't verify.
- Non-permission COPY errors are left untouched to preserve their retry semantics.

A follow-up PR will add cross-region support (emitting a `REGION` clause from the configured bucket region).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*