### PR TITLE
fix(ws): remove sibilings of executed jobs before try to lock

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -195,6 +195,12 @@ class BatchQueue:
         batches that are unprocessed (NULL status) or ``waiting_retry`` with
         backoff met are treated as siblings that will be returned alongside
         in the same poll and processed sequentially by the consumer.
+
+        In-flight schema gating: a batch is also excluded if its
+        ``(team_id, schema_id)`` already has an ``executing`` batch (i.e. the
+        per-schema advisory lock is held by the pod processing it). This keeps a
+        schema's other queued runs from consuming the ``LIMIT`` window ahead of
+        the advisory-lock filter and starving other schemas' claimable work.
         """
         async with conn.cursor(row_factory=dict_row) as cur:
             await cur.execute(
@@ -244,6 +250,15 @@ class BatchQueue:
                             JOIN {STATUS_VIEW} s2 ON b2.id = s2.batch_id
                             WHERE b2.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                                 AND s2.job_state = 'failed'
+                        )
+                        AND NOT EXISTS (
+                            SELECT 1
+                            FROM {BATCH_TABLE} b_busy
+                            JOIN {STATUS_VIEW} s_busy ON b_busy.id = s_busy.batch_id
+                            WHERE b_busy.team_id = b.team_id
+                                AND b_busy.schema_id = b.schema_id
+                                AND b_busy.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+                                AND s_busy.job_state = 'executing'
                         )
                     ORDER BY b.created_at ASC, b.batch_index ASC
                     LIMIT %(limit)s

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -196,6 +196,58 @@ class TestBatchQueueGetUnprocessed:
 
         assert len(batches) == 3
 
+    @pytest.mark.asyncio
+    async def test_excludes_schema_with_in_flight_batch(self, conn):
+        # A schema with an executing batch contributes no candidates, even for
+        # NULL-status batches from a different (later) run of the same schema.
+        executing_bid = await _insert_batch(conn, schema_id="busy", run_uuid="run-a", batch_index=0)
+        await _insert_batch(conn, schema_id="busy", run_uuid="run-b", batch_index=0)
+        await BatchQueue.update_status(conn, batch_id=executing_bid, job_state="executing", attempt=1)
+
+        batches = await BatchQueue.get_unprocessed_and_lock(conn)
+
+        assert batches == []
+
+    @pytest.mark.asyncio
+    async def test_in_flight_schema_does_not_starve_other_schemas(self, conn):
+        # Regression: a busy schema's older backlog (from a later run) must not fill
+        # the LIMIT window ahead of a different schema's claimable work.
+        a_exec = await _insert_batch(conn, schema_id="A", run_uuid="a-run-1", batch_index=0)
+        await BatchQueue.update_status(conn, batch_id=a_exec, job_state="executing", attempt=1)
+        for i in range(5):  # older than B, would fill limit=3 if not excluded
+            await _insert_batch(conn, schema_id="A", run_uuid="a-run-2", batch_index=i)
+        await _insert_batch(conn, schema_id="B", run_uuid="b-run-1", batch_index=0)  # newest
+
+        batches = await BatchQueue.get_unprocessed_and_lock(conn, limit=3)
+
+        assert [b.schema_id for b in batches] == ["B"]
+        await BatchQueue.unlock_for_batches(conn, batches=batches)
+
+    @pytest.mark.asyncio
+    async def test_in_flight_gating_clears_after_terminal_status(self, conn):
+        # Once the executing batch is superseded by a terminal status, the schema's
+        # queued batches become selectable again.
+        exec_bid = await _insert_batch(conn, schema_id="S", run_uuid="run-1", batch_index=0)
+        await _insert_batch(conn, schema_id="S", run_uuid="run-2", batch_index=0)
+        # Explicit timestamps so the latest-status view is deterministic (ids are random uuids).
+        await conn.execute(
+            f"INSERT INTO {STATUS_TABLE} (batch_id, job_state, attempt, created_at) "
+            f"VALUES (%s, 'executing', 1, now() - interval '5 seconds')",
+            [exec_bid],
+        )
+
+        assert await BatchQueue.get_unprocessed_and_lock(conn) == []
+
+        await conn.execute(
+            f"INSERT INTO {STATUS_TABLE} (batch_id, job_state, attempt, created_at) VALUES (%s, 'succeeded', 1, now())",
+            [exec_bid],
+        )
+
+        batches = await BatchQueue.get_unprocessed_and_lock(conn)
+
+        assert [b.run_uuid for b in batches] == ["run-2"]
+        await BatchQueue.unlock_for_batches(conn, batches=batches)
+
 
 @pytest.mark.django_db(transaction=True)
 class TestBatchQueueUpdateStatus:


### PR DESCRIPTION
## Problem

When getting batch-candidates we weren't excluding those whose sibilings where already executing, these batches failed to adquired logs, they weren't being executed (it was safe) but they were wasting positions on the 50 limit window

## Changes

 - Add subquery to filter out sibilings of running batches

## How did you test this code?

Test pass
Added tests

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

