### PR TITLE
fix(data-warehouse): mark Shopify access token 4xx as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/shopify/shopify.py
+++ b/posthog/temporal/data_imports/sources/shopify/shopify.py
@@ -32,6 +32,14 @@ PHASE_ALL = "all"
 PHASE_EARLIEST = "earliest"
 PHASE_LATEST = "latest"
 
+# Raised when Shopify's OAuth token endpoint returns a 4xx — the app credentials are
+# invalid or the app was uninstalled, so re-auth is the only fix. `ShopifySource.
+# get_non_retryable_errors` matches on this exact text to fail the job fast.
+SHOPIFY_ACCESS_TOKEN_AUTH_ERROR = (
+    "Failed to retrieve Shopify access token: the app credentials are invalid or the "
+    "app was uninstalled. Please reconnect your Shopify integration."
+)
+
 
 @dataclasses.dataclass
 class ShopifyResumeConfig:
@@ -156,6 +164,11 @@ def _get_shopify_access_token(shopify_store_id: str, shopify_client_id: str, sho
     }
     access_res = make_tracked_session().post(access_token_url, data=access_data)
     if not access_res.ok:
+        # A 4xx means the app credentials are invalid/revoked (e.g. the app was
+        # uninstalled) — re-auth is the only fix, so surface a non-retryable message.
+        # 5xx is transient and stays retryable via the generic message.
+        if 400 <= access_res.status_code < 500:
+            raise Exception(f"{SHOPIFY_ACCESS_TOKEN_AUTH_ERROR} (HTTP {access_res.status_code})")
         raise Exception(f"Failed to retrieve Shopify access token: {access_res}")
     return access_res.json()["access_token"]
 

--- a/posthog/temporal/data_imports/sources/shopify/shopify.py
+++ b/posthog/temporal/data_imports/sources/shopify/shopify.py
@@ -166,8 +166,8 @@ def _get_shopify_access_token(shopify_store_id: str, shopify_client_id: str, sho
     if not access_res.ok:
         # A 4xx means the app credentials are invalid/revoked (e.g. the app was
         # uninstalled) — re-auth is the only fix, so surface a non-retryable message.
-        # 5xx is transient and stays retryable via the generic message.
-        if 400 <= access_res.status_code < 500:
+        # 429 (rate limit) and 5xx are transient and stay retryable via the generic message.
+        if 400 <= access_res.status_code < 500 and access_res.status_code != 429:
             raise Exception(f"{SHOPIFY_ACCESS_TOKEN_AUTH_ERROR} (HTTP {access_res.status_code})")
         raise Exception(f"Failed to retrieve Shopify access token: {access_res}")
     return access_res.json()["access_token"]

--- a/posthog/temporal/data_imports/sources/shopify/source.py
+++ b/posthog/temporal/data_imports/sources/shopify/source.py
@@ -16,6 +16,7 @@ from posthog.temporal.data_imports.sources.generated_configs import ShopifySourc
 from posthog.temporal.data_imports.sources.shopify.constants import SHOPIFY_GRAPHQL_OBJECTS
 from posthog.temporal.data_imports.sources.shopify.settings import ENDPOINT_CONFIGS
 from posthog.temporal.data_imports.sources.shopify.shopify import (
+    SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
     ShopifyPermissionError,
     ShopifyResumeConfig,
     shopify_source,
@@ -30,6 +31,13 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.SHOPIFY
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            # 4xx from Shopify's OAuth token endpoint — invalid/revoked app credentials.
+            # Retrying cannot recover; the user must reconnect the integration.
+            SHOPIFY_ACCESS_TOKEN_AUTH_ERROR: SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
+        }
 
     @property
     def get_source_config(self) -> SourceConfig:

--- a/posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py
@@ -37,8 +37,8 @@ def test_get_access_token_4xx_is_non_retryable(status_code):
     )
 
 
-@pytest.mark.parametrize("status_code", [500, 502, 503])
-def test_get_access_token_5xx_stays_retryable(status_code):
+@pytest.mark.parametrize("status_code", [429, 500, 502, 503])
+def test_get_access_token_transient_stays_retryable(status_code):
     with _patched_token_call(_mock_response(status_code, ok=False)):
         with pytest.raises(Exception) as exc_info:
             _get_shopify_access_token("store", "client-id", "client-secret")
@@ -46,7 +46,7 @@ def test_get_access_token_5xx_stays_retryable(status_code):
     error_message = str(exc_info.value)
     patterns = ShopifySource().get_non_retryable_errors()
     assert not any(pattern in error_message for pattern in patterns), (
-        f"5xx token error '{error_message}' should remain retryable"
+        f"transient token error '{error_message}' should remain retryable"
     )
 
 

--- a/posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.shopify.shopify import (
+    SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
+    _get_shopify_access_token,
+)
+from posthog.temporal.data_imports.sources.shopify.source import ShopifySource
+
+
+def _mock_response(status_code: int, ok: bool, json_data: dict | None = None) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.status_code = status_code
+    response.ok = ok
+    response.json.return_value = json_data or {}
+    return response
+
+
+def _patched_token_call(response: mock.MagicMock):
+    return mock.patch(
+        "posthog.temporal.data_imports.sources.shopify.shopify.make_tracked_session",
+        return_value=mock.MagicMock(post=mock.MagicMock(return_value=response)),
+    )
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404])
+def test_get_access_token_4xx_is_non_retryable(status_code):
+    with _patched_token_call(_mock_response(status_code, ok=False)):
+        with pytest.raises(Exception) as exc_info:
+            _get_shopify_access_token("store", "client-id", "client-secret")
+
+    error_message = str(exc_info.value)
+    assert SHOPIFY_ACCESS_TOKEN_AUTH_ERROR in error_message
+    patterns = ShopifySource().get_non_retryable_errors()
+    assert any(pattern in error_message for pattern in patterns), (
+        f"4xx token error '{error_message}' should match a non-retryable pattern"
+    )
+
+
+@pytest.mark.parametrize("status_code", [500, 502, 503])
+def test_get_access_token_5xx_stays_retryable(status_code):
+    with _patched_token_call(_mock_response(status_code, ok=False)):
+        with pytest.raises(Exception) as exc_info:
+            _get_shopify_access_token("store", "client-id", "client-secret")
+
+    error_message = str(exc_info.value)
+    patterns = ShopifySource().get_non_retryable_errors()
+    assert not any(pattern in error_message for pattern in patterns), (
+        f"5xx token error '{error_message}' should remain retryable"
+    )
+
+
+def test_get_access_token_success_returns_token():
+    with _patched_token_call(_mock_response(200, ok=True, json_data={"access_token": "tok"})):
+        assert _get_shopify_access_token("store", "client-id", "client-secret") == "tok"


### PR DESCRIPTION
## Problem

The Shopify data warehouse source generated a high volume of repeated `$exception` events: `Failed to retrieve Shopify access token: <Response [400]>`, raised from `_get_shopify_access_token`. A 400 from Shopify's OAuth token endpoint means the app credentials are invalid or the app was uninstalled — re-authorization is the only fix. But the function raised the same generic error for any non-OK response and the source had no non-retryable classification, so the job retried it on every schedule indefinitely.

## Changes

- `_get_shopify_access_token` now distinguishes a 4xx (invalid/revoked credentials) from a 5xx (transient). For 4xx it raises a clear, user-actionable message (shared constant `SHOPIFY_ACCESS_TOKEN_AUTH_ERROR`, with the HTTP status appended); 5xx keeps the generic message and stays retryable.
- Added `ShopifySource.get_non_retryable_errors()` keyed on that message, with the same string as the user-facing error, so these jobs fail fast and prompt the user to reconnect.

## How did you test this code?

I'm an agent. I ran the new test module (8 tests, all passing) and ruff check + format over the changed files. New coverage:

- Parameterized tests that 4xx responses (400/401/403/404) raise the non-retryable message and match `get_non_retryable_errors()`.
- Parameterized tests that 5xx responses (500/502/503) do **not** match (stay retryable).
- A success-path test returning the token.

No manual testing against the live Shopify API was performed.

## 🤖 Agent context

Authored with Claude Code. Identified from an error-tracking group sampled via the PostHog MCP. Decision: split on status-code class rather than blanket-classifying all token failures, so transient 5xx errors keep retrying while permanent credential failures fail fast.
