### PR TITLE
fix(data-warehouse): skip schema discovery on non-retryable source errors

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -58,7 +58,21 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
 
         new_source = SourceRegistry.get_source(source_type_enum)
         config = new_source.parse_config(source.job_inputs)
-        schemas = new_source.get_schemas(config, inputs.team_id)
+        try:
+            schemas = new_source.get_schemas(config, inputs.team_id)
+        except Exception as e:
+            # Schema discovery is best-effort and runs on its own ~6h cadence. If the source's
+            # credentials are broken (expired/revoked tokens, permission denied, deleted account,
+            # etc.) discovery will keep failing until the user reconnects — there is nothing to
+            # retry here, and the per-schema sync path surfaces and disables the source on the
+            # same error. Skip quietly on known non-retryable source errors rather than spamming
+            # retries and error tracking on every discovery run. Other errors still propagate.
+            error_msg = str(e)
+            non_retryable_errors = new_source.get_non_retryable_errors()
+            if any(pattern in error_msg for pattern in non_retryable_errors):
+                logger.warning(f"Skipping schema discovery due to non-retryable source error: {error_msg}")
+                return
+            raise
 
         schemas_to_sync = {s.name: s.label for s in schemas}
     else:

--- a/posthog/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
+++ b/posthog/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
@@ -31,25 +31,30 @@ def _run_activity(source_mock):
         sync_new_schemas_activity(SyncNewSchemasActivityInputs(source_id="src", team_id=1))
 
 
-def test_non_retryable_get_schemas_error_is_skipped():
-    """A non-retryable source error during discovery must be swallowed, not retried."""
+@pytest.mark.parametrize(
+    "error_msg,non_retryable,expected_exc",
+    [
+        (
+            "('invalid_grant: Bad Request', {'error': 'invalid_grant', 'error_description': 'Bad Request'})",
+            {"invalid_grant": None},
+            None,
+        ),
+        (
+            "UNAVAILABLE: transient network blip",
+            {"invalid_grant": None},
+            "transient network blip",
+        ),
+    ],
+    ids=["non_retryable_error_is_skipped", "unknown_error_propagates"],
+)
+def test_get_schemas_error_handling(error_msg, non_retryable, expected_exc):
     source_mock = mock.MagicMock()
     source_mock.parse_config.return_value = {}
-    source_mock.get_schemas.side_effect = Exception(
-        "('invalid_grant: Bad Request', {'error': 'invalid_grant', 'error_description': 'Bad Request'})"
-    )
-    source_mock.get_non_retryable_errors.return_value = {"invalid_grant": None}
+    source_mock.get_schemas.side_effect = Exception(error_msg)
+    source_mock.get_non_retryable_errors.return_value = non_retryable
 
-    # Should not raise — the error matches a non-retryable pattern and is skipped.
-    _run_activity(source_mock)
-
-
-def test_unknown_get_schemas_error_propagates():
-    """An error that is not classified as non-retryable must still propagate (and retry)."""
-    source_mock = mock.MagicMock()
-    source_mock.parse_config.return_value = {}
-    source_mock.get_schemas.side_effect = Exception("UNAVAILABLE: transient network blip")
-    source_mock.get_non_retryable_errors.return_value = {"invalid_grant": None}
-
-    with pytest.raises(Exception, match="transient network blip"):
+    if expected_exc is None:
         _run_activity(source_mock)
+    else:
+        with pytest.raises(Exception, match=expected_exc):
+            _run_activity(source_mock)

--- a/posthog/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
+++ b/posthog/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.workflow_activities import sync_new_schemas as module
+from posthog.temporal.data_imports.workflow_activities.sync_new_schemas import (
+    SyncNewSchemasActivityInputs,
+    sync_new_schemas_activity,
+)
+
+
+def _patch_common(source_mock):
+    """Patch DB + registry so the activity runs without a database or real source."""
+    existing_source = mock.MagicMock(source_type="GoogleAds", job_inputs={"k": "v"}, deleted=False)
+    objects = mock.MagicMock()
+    objects.filter.return_value.exclude.return_value.exists.return_value = True
+    objects.get.return_value = existing_source
+
+    return (
+        mock.patch.object(module, "close_old_connections"),
+        mock.patch.object(module.ExternalDataSource, "objects", objects),
+        mock.patch.object(module, "ExternalDataSourceType", return_value="GoogleAds"),
+        mock.patch.object(module.SourceRegistry, "is_registered", return_value=True),
+        mock.patch.object(module.SourceRegistry, "get_source", return_value=source_mock),
+        mock.patch.object(module, "sync_old_schemas_with_new_schemas", return_value=([], [])),
+    )
+
+
+def _run_activity(source_mock):
+    patches = _patch_common(source_mock)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        sync_new_schemas_activity(SyncNewSchemasActivityInputs(source_id="src", team_id=1))
+
+
+def test_non_retryable_get_schemas_error_is_skipped():
+    """A non-retryable source error during discovery must be swallowed, not retried."""
+    source_mock = mock.MagicMock()
+    source_mock.parse_config.return_value = {}
+    source_mock.get_schemas.side_effect = Exception(
+        "('invalid_grant: Bad Request', {'error': 'invalid_grant', 'error_description': 'Bad Request'})"
+    )
+    source_mock.get_non_retryable_errors.return_value = {"invalid_grant": None}
+
+    # Should not raise — the error matches a non-retryable pattern and is skipped.
+    _run_activity(source_mock)
+
+
+def test_unknown_get_schemas_error_propagates():
+    """An error that is not classified as non-retryable must still propagate (and retry)."""
+    source_mock = mock.MagicMock()
+    source_mock.parse_config.return_value = {}
+    source_mock.get_schemas.side_effect = Exception("UNAVAILABLE: transient network blip")
+    source_mock.get_non_retryable_errors.return_value = {"invalid_grant": None}
+
+    with pytest.raises(Exception, match="transient network blip"):
+        _run_activity(source_mock)


### PR DESCRIPTION
## Problem

The Google Ads source generated a very high volume of repeated `RefreshError: invalid_grant` events. Curiously, `invalid_grant` is **already** in `GoogleAdsSource.get_non_retryable_errors()` — so why does it keep firing?

The stack traces show these are raised inside `sync_new_schemas_activity` (the periodic schema-discovery pass), **not** `import_data_activity` (the per-schema sync). The non-retryable classification (`get_non_retryable_errors()`) is only consulted by the import activity. Schema discovery had no non-retryable handling at all: it re-ran `get_schemas` every ~6h, the broken-credential source threw the same auth `RefreshError` every time, Temporal retried it 3× per run, and it repeated indefinitely. This is a shared-activity gap that affects every source — Google Ads `invalid_grant` is just the loudest instance.

## Changes

- `sync_new_schemas_activity` now wraps the `get_schemas` call. If it raises an error that matches the source's `get_non_retryable_errors()` patterns, the discovery pass logs a warning and returns instead of retrying/propagating. Unknown errors still propagate and retry as before.

Schema discovery is best-effort and inherently safe to skip: there is nothing to discover while credentials are broken, and the per-schema sync path still surfaces the auth failure and disables the source through its existing handling. This mirrors the "skip the best-effort pass quietly on expected, non-actionable errors" pattern.

## How did you test this code?

I'm an agent. I added a focused unit-test module (2 tests, passing) and ran ruff check + format. Coverage:

- A non-retryable error from `get_schemas` (the production `invalid_grant` RefreshError string) is swallowed — the activity returns without raising.
- An unclassified error (transient `UNAVAILABLE`) still propagates so Temporal retries it.

No manual testing against the live Google Ads API or Temporal was performed.

## 🤖 Agent context

Authored with Claude Code. Started from the error-tracking group; the stack traces revealed the errors originate in `sync_new_schemas_activity`, which bypassed the non-retryable machinery that already exists for imports. Rather than duplicating per-source lists, the fix teaches the shared discovery activity to honor each source's existing `get_non_retryable_errors()`, so it benefits all sources (Salesforce, MySQL, MongoDB, etc.) whose credentials can break, not just Google Ads.
