### PR TITLE
fix(data-warehouse): match MongoDB auth failure casing in non-retryable errors

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -34,7 +34,16 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         return ExternalDataSourceType.MONGODB
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
-        return {"The DNS query name does not exist": None, "authentication failed": None, "SSL handshake failed": None}
+        return {
+            "The DNS query name does not exist": None,
+            # pymongo raises OperationFailure with codeName 'AuthenticationFailed' (code 18) and
+            # errmsg 'Authentication failed.' when the credentials are wrong. Non-retryable error
+            # matching is case-sensitive, so the previous lowercase "authentication failed" never
+            # matched the real message — key off the stable codeName and the capitalised message.
+            "AuthenticationFailed": "MongoDB authentication failed. Please check the username and password for this source.",
+            "Authentication failed": "MongoDB authentication failed. Please check the username and password for this source.",
+            "SSL handshake failed": None,
+        }
 
     def get_schemas(
         self,

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -34,14 +34,15 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         return ExternalDataSourceType.MONGODB
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
+        auth_failed_msg = "MongoDB authentication failed. Please check the username and password for this source."
         return {
             "The DNS query name does not exist": None,
             # pymongo raises OperationFailure with codeName 'AuthenticationFailed' (code 18) and
             # errmsg 'Authentication failed.' when the credentials are wrong. Non-retryable error
             # matching is case-sensitive, so the previous lowercase "authentication failed" never
             # matched the real message — key off the stable codeName and the capitalised message.
-            "AuthenticationFailed": "MongoDB authentication failed. Please check the username and password for this source.",
-            "Authentication failed": "MongoDB authentication failed. Please check the username and password for this source.",
+            "AuthenticationFailed": auth_failed_msg,
+            "Authentication failed": auth_failed_msg,
             "SSL handshake failed": None,
         }
 

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -26,6 +26,11 @@ from posthog.temporal.data_imports.sources.mongodb.mongo import (
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
+_MONGO_UNREACHABLE_MESSAGE = (
+    "Could not reach your MongoDB cluster. Check that the cluster is running and that PostHog's "
+    "IP addresses are allowlisted in your database's network access settings."
+)
+
 
 @SourceRegistry.register
 class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin):
@@ -44,6 +49,13 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             "AuthenticationFailed": auth_failed_msg,
             "Authentication failed": auth_failed_msg,
             "SSL handshake failed": None,
+            # pymongo raises ServerSelectionTimeoutError ("No servers found yet" / "No replica set
+            # members found yet") when it can't reach any cluster node for the whole selection
+            # timeout. On a managed cluster this is a persistent connectivity problem — the worker
+            # IP isn't allowlisted, or the cluster is paused/decommissioned — not a momentary blip
+            # (a mid-sync outage surfaces differently), so retrying the job won't recover it.
+            "No servers found yet": _MONGO_UNREACHABLE_MESSAGE,
+            "No replica set members found yet": _MONGO_UNREACHABLE_MESSAGE,
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -337,6 +337,13 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
             ),
             ("dns_failure", "The DNS query name does not exist: example.mongodb.net."),
             ("ssl_failure", "SSL handshake failed: certificate verify failed"),
+            # Cluster unreachable for the whole selection timeout — persistent connectivity issue.
+            ("no_servers", "No servers found yet, Timeout: 5.0s, Topology Description: ..."),
+            (
+                "no_replica_set_members",
+                "No replica set members found yet, Timeout: 10.0s, Topology Description: "
+                "<TopologyDescription topology_type: ReplicaSetNoPrimary>",
+            ),
         ]
     )
     def test_known_errors_are_non_retryable(self, _name, error_msg):
@@ -346,8 +353,8 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
 
     @parameterized.expand(
         [
-            ("server_selection_timeout", "No servers found yet, Timeout: 5.0s"),
             ("connection_reset", "connection closed"),
+            ("network_timeout", "NetworkTimeout: timed out reading from socket"),
         ]
     )
     def test_transient_errors_are_retryable(self, _name, error_msg):
@@ -357,11 +364,13 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
 
     @parameterized.expand(
         [
-            ("code_name", "AuthenticationFailed"),
-            ("message", "Authentication failed"),
+            ("code_name", "AuthenticationFailed", "password"),
+            ("message", "Authentication failed", "password"),
+            ("unreachable_no_servers", "No servers found yet", "allowlist"),
+            ("unreachable_no_replica_set", "No replica set members found yet", "allowlist"),
         ]
     )
-    def test_auth_pattern_has_friendly_message(self, _name, pattern):
+    def test_pattern_has_friendly_message(self, _name, pattern, expected_substring):
         message = self.non_retryable[pattern]
         assert message is not None
-        assert "password" in message.lower()
+        assert expected_substring in message.lower()

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -316,3 +316,45 @@ class TestGetLeadingIndexKeys(SimpleTestCase):
     def test_returns_empty_set_for_collection_with_no_indexes(self):
         coll = self._collection_with_indexes([])
         assert get_leading_index_keys(coll) == set()
+
+
+class TestMongoDBNonRetryableErrors(SimpleTestCase):
+    """The non-retryable match is case-sensitive substring matching, so the patterns
+    must match the exact casing pymongo produces."""
+
+    def setUp(self):
+        from posthog.temporal.data_imports.sources.mongodb.source import MongoDBSource
+
+        self.non_retryable = MongoDBSource().get_non_retryable_errors()
+
+    @parameterized.expand(
+        [
+            # Real pymongo OperationFailure string for bad credentials (code 18).
+            (
+                "operation_failure",
+                "Authentication failed., full error: {'ok': 0.0, 'errmsg': 'Authentication failed.', "
+                "'code': 18, 'codeName': 'AuthenticationFailed'}",
+            ),
+            ("dns_failure", "The DNS query name does not exist: example.mongodb.net."),
+            ("ssl_failure", "SSL handshake failed: certificate verify failed"),
+        ]
+    )
+    def test_known_errors_are_non_retryable(self, _name, error_msg):
+        assert any(pattern in error_msg for pattern in self.non_retryable), (
+            f"MongoDB error {error_msg!r} did not match any non-retryable pattern"
+        )
+
+    @parameterized.expand(
+        [
+            ("server_selection_timeout", "No servers found yet, Timeout: 5.0s"),
+            ("connection_reset", "connection closed"),
+        ]
+    )
+    def test_transient_errors_are_retryable(self, _name, error_msg):
+        assert not any(pattern in error_msg for pattern in self.non_retryable), (
+            f"MongoDB error {error_msg!r} should remain retryable"
+        )
+
+    def test_auth_failure_has_friendly_message(self):
+        assert self.non_retryable["AuthenticationFailed"] is not None
+        assert "password" in self.non_retryable["AuthenticationFailed"].lower()

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -362,5 +362,6 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
         ]
     )
     def test_auth_pattern_has_friendly_message(self, _name, pattern):
-        assert self.non_retryable[pattern] is not None
-        assert "password" in self.non_retryable[pattern].lower()
+        message = self.non_retryable[pattern]
+        assert message is not None
+        assert "password" in message.lower()

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -355,6 +355,12 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
             f"MongoDB error {error_msg!r} should remain retryable"
         )
 
-    def test_auth_failure_has_friendly_message(self):
-        assert self.non_retryable["AuthenticationFailed"] is not None
-        assert "password" in self.non_retryable["AuthenticationFailed"].lower()
+    @parameterized.expand(
+        [
+            ("code_name", "AuthenticationFailed"),
+            ("message", "Authentication failed"),
+        ]
+    )
+    def test_auth_pattern_has_friendly_message(self, _name, pattern):
+        assert self.non_retryable[pattern] is not None
+        assert "password" in self.non_retryable[pattern].lower()


### PR DESCRIPTION
## Problem

The MongoDB source generated a high volume of repeated `OperationFailure: Authentication failed.` events (code 18, codeName `AuthenticationFailed`). `MongoDBSource.get_non_retryable_errors()` already *intended* to catch this — it listed `"authentication failed"` — but that pattern is lowercase, while pymongo's actual message is `Authentication failed.` (capital A) with codeName `AuthenticationFailed`. Non-retryable matching is **case-sensitive** substring matching (plain `in`), so the pattern never matched and the job retried a permanent credential failure indefinitely.

## Changes

- Replaced the never-matching lowercase `"authentication failed"` with two correctly-cased patterns: the stable codeName `"AuthenticationFailed"` and the capitalised message `"Authentication failed"`, both with a friendly "check the username and password" message.
- Kept the existing DNS and SSL handshake patterns.

## How did you test this code?

I'm an agent. I added a test class (5 tests, passing) and ran ruff check + format. Coverage:

- The real pymongo `OperationFailure` string (plus DNS and SSL variants) matches a non-retryable pattern.
- Transient errors (server-selection timeout, connection closed) do **not** match.
- The auth pattern carries a user-facing message.

No manual testing against a live MongoDB was performed.

## 🤖 Agent context

Authored with Claude Code. Found from an error-tracking group sampled via the PostHog MCP. The key finding was that the intended classification existed but was dead due to a casing mismatch against case-sensitive matching — so the one-line-looking fix is actually load-bearing.
