### PR TITLE
feat(dashboards): add dashboard-update-tile MCP tool

### DIFF
--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -2494,9 +2494,9 @@ class DashboardsViewSet(
             dashboard=dashboard,
             dashboard__team__project_id=self.team.project_id,
         )
-        if tile.text is not None:
+        if tile.insight_id is None and tile.widget_id is None:
             raise exceptions.ValidationError(
-                "Text tiles are not supported here — use the update text tile endpoint to edit a text tile."
+                "Only insight and widget tiles can be updated here — use the update text tile endpoint for text tiles."
             )
 
         tile_updates: list[str] = []

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -483,6 +483,12 @@ class UpdateTileRequestSerializer(serializers.Serializer):
     )
 
 
+class TilePresentationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DashboardTile
+        fields = ["id", "dashboard_id", "show_description", "color", "layouts"]
+
+
 class DeleteTileRequestSerializer(serializers.Serializer):
     tile_id = serializers.IntegerField(
         required=True,
@@ -2473,7 +2479,7 @@ class DashboardsViewSet(
 
     @extend_schema(
         request=UpdateTileRequestSerializer,
-        responses={200: DashboardTileSerializer},
+        responses={200: TilePresentationSerializer},
     )
     @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
     def update_tile(self, request: Request, *args: Any, **kwargs: Any) -> Response:
@@ -2513,7 +2519,7 @@ class DashboardsViewSet(
             tile.save(update_fields=tile_updates)
 
         tile.refresh_from_db()
-        return Response(DashboardTileSerializer(tile, context=self.get_serializer_context()).data)
+        return Response(TilePresentationSerializer(tile).data)
 
     @extend_schema(
         operation_id="dashboards_delete_tile",

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -457,6 +457,32 @@ class UpdateTextTileRequestSerializer(serializers.Serializer):
     )
 
 
+class UpdateTileRequestSerializer(serializers.Serializer):
+    tile_id = serializers.IntegerField(
+        required=True,
+        help_text="ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.",
+    )
+    show_description = serializers.BooleanField(
+        required=False,
+        help_text=(
+            "Whether the tile's description is shown on the dashboard. "
+            "Set false to hide it, true to show it. Omit to leave unchanged."
+        ),
+    )
+    color = serializers.CharField(
+        max_length=400,
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        help_text="New accent color name, empty string or null to clear. Omit to leave unchanged.",
+        error_messages={"max_length": "Color cannot exceed 400 characters"},
+    )
+    layouts = TileLayoutsSerializer(
+        required=False,
+        help_text="New grid layout per breakpoint. Omit to leave the layout unchanged.",
+    )
+
+
 class DeleteTileRequestSerializer(serializers.Serializer):
     tile_id = serializers.IntegerField(
         required=True,
@@ -2441,6 +2467,50 @@ class DashboardsViewSet(
                 tile_updates.append("color")
             if tile_updates:
                 tile.save(update_fields=tile_updates)
+
+        tile.refresh_from_db()
+        return Response(DashboardTileSerializer(tile, context=self.get_serializer_context()).data)
+
+    @extend_schema(
+        request=UpdateTileRequestSerializer,
+        responses={200: DashboardTileSerializer},
+    )
+    @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
+    def update_tile(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Update the description visibility, color, or layout of an existing insight or widget tile on a dashboard."""
+        dashboard = self.get_object()
+        if dashboard.deleted:
+            raise exceptions.NotFound()
+        if not self.user_permissions.dashboard(dashboard).can_edit:
+            raise exceptions.PermissionDenied("You don't have edit permissions for this dashboard.")
+
+        serializer = UpdateTileRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        validated = serializer.validated_data
+
+        tile = get_object_or_404(
+            DashboardTile,
+            id=validated["tile_id"],
+            dashboard=dashboard,
+            dashboard__team__project_id=self.team.project_id,
+        )
+        if tile.text is not None:
+            raise exceptions.ValidationError(
+                "Text tiles are not supported here — use the update text tile endpoint to edit a text tile."
+            )
+
+        tile_updates: list[str] = []
+        if "show_description" in validated:
+            tile.show_description = validated["show_description"]
+            tile_updates.append("show_description")
+        if "color" in validated:
+            tile.color = validated["color"]
+            tile_updates.append("color")
+        if "layouts" in validated:
+            tile.layouts = validated["layouts"]
+            tile_updates.append("layouts")
+        if tile_updates:
+            tile.save(update_fields=tile_updates)
 
         tile.refresh_from_db()
         return Response(DashboardTileSerializer(tile, context=self.get_serializer_context()).data)

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -28,6 +28,7 @@ import posthoganalytics
 from asgiref.sync import sync_to_async
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
+from loginas.utils import is_impersonated_session
 from opentelemetry import trace
 from pydantic import BaseModel
 from rest_framework import exceptions, serializers, status, viewsets
@@ -61,7 +62,7 @@ from posthog.helpers.trigram_search import (
     normalize_search_term,
 )
 from posthog.hogql_queries.query_runner import ExecutionMode
-from posthog.models.activity_logging.activity_log import ActivityScope, Detail, changes_between, log_activity
+from posthog.models.activity_logging.activity_log import ActivityScope, Change, Detail, changes_between, log_activity
 from posthog.models.file_system.file_system import create_or_update_file, delete_file
 from posthog.models.quick_filter import QuickFilter
 from posthog.models.signals import model_activity_signal, mutable_receiver
@@ -2429,36 +2430,61 @@ class DashboardsViewSet(
             status=status.HTTP_201_CREATED,
         )
 
-    @extend_schema(
-        request=UpdateTextTileRequestSerializer,
-        responses={200: DashboardTileSerializer},
-    )
-    @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
-    def update_text_tile(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        """Update the markdown body, layout, or color of an existing text tile on a dashboard."""
+    def _get_editable_tile(self, tile_id: int) -> tuple[Dashboard, DashboardTile]:
         dashboard = self.get_object()
         if dashboard.deleted:
             raise exceptions.NotFound()
         if not self.user_permissions.dashboard(dashboard).can_edit:
             raise exceptions.PermissionDenied("You don't have edit permissions for this dashboard.")
+        tile = get_object_or_404(
+            DashboardTile,
+            id=tile_id,
+            dashboard=dashboard,
+            dashboard__team__project_id=self.team.project_id,
+        )
+        return dashboard, tile
 
+    def _log_tile_activity(self, dashboard: Dashboard, changes: list[Change], request: Request) -> None:
+        if not changes:
+            return
+        log_activity(
+            organization_id=dashboard.team.organization_id,
+            team_id=dashboard.team_id,
+            user=cast(User, request.user),
+            was_impersonated=is_impersonated_session(request),
+            item_id=dashboard.id,
+            scope="Dashboard",
+            activity="updated",
+            detail=Detail(
+                changes=changes,
+                name=dashboard.name,
+                type="dashboard",
+            ),
+        )
+
+    @extend_schema(
+        request=UpdateTextTileRequestSerializer,
+        responses={200: TilePresentationSerializer},
+    )
+    @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
+    def update_text_tile(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Update the markdown body, layout, or color of an existing text tile on a dashboard."""
         serializer = UpdateTextTileRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         validated = serializer.validated_data
 
-        tile = get_object_or_404(
-            DashboardTile,
-            id=validated["tile_id"],
-            dashboard=dashboard,
-            dashboard__team__project_id=self.team.project_id,
-        )
+        dashboard, tile = self._get_editable_tile(validated["tile_id"])
         if tile.text is None:
             raise exceptions.ValidationError("Tile is not a text tile.")
 
         user = cast(User, request.user)
+        changes: list[Change] = []
         with transaction.atomic():
             text = tile.text
             if "body" in validated:
+                changes.append(
+                    Change(type="Dashboard", action="changed", field="body", before=text.body, after=validated["body"])
+                )
                 text.body = validated["body"]
             text.last_modified_by = user
             text.last_modified_at = now()
@@ -2466,16 +2492,31 @@ class DashboardsViewSet(
 
             tile_updates: list[str] = []
             if "layouts" in validated:
+                changes.append(
+                    Change(
+                        type="Dashboard",
+                        action="changed",
+                        field="layouts",
+                        before=tile.layouts,
+                        after=validated["layouts"],
+                    )
+                )
                 tile.layouts = validated["layouts"]
                 tile_updates.append("layouts")
             if "color" in validated:
+                changes.append(
+                    Change(
+                        type="Dashboard", action="changed", field="color", before=tile.color, after=validated["color"]
+                    )
+                )
                 tile.color = validated["color"]
                 tile_updates.append("color")
             if tile_updates:
                 tile.save(update_fields=tile_updates)
 
+        self._log_tile_activity(dashboard, changes, request)
         tile.refresh_from_db()
-        return Response(DashboardTileSerializer(tile, context=self.get_serializer_context()).data)
+        return Response(TilePresentationSerializer(tile).data)
 
     @extend_schema(
         request=UpdateTileRequestSerializer,
@@ -2484,40 +2525,48 @@ class DashboardsViewSet(
     @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
     def update_tile(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Update the description visibility, color, or layout of an existing insight or widget tile on a dashboard."""
-        dashboard = self.get_object()
-        if dashboard.deleted:
-            raise exceptions.NotFound()
-        if not self.user_permissions.dashboard(dashboard).can_edit:
-            raise exceptions.PermissionDenied("You don't have edit permissions for this dashboard.")
-
         serializer = UpdateTileRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         validated = serializer.validated_data
 
-        tile = get_object_or_404(
-            DashboardTile,
-            id=validated["tile_id"],
-            dashboard=dashboard,
-            dashboard__team__project_id=self.team.project_id,
-        )
+        dashboard, tile = self._get_editable_tile(validated["tile_id"])
         if tile.insight_id is None and tile.widget_id is None:
             raise exceptions.ValidationError(
                 "Only insight and widget tiles can be updated here — use the update text tile endpoint for text tiles."
             )
 
         tile_updates: list[str] = []
+        changes: list[Change] = []
         if "show_description" in validated:
+            changes.append(
+                Change(
+                    type="Dashboard",
+                    action="changed",
+                    field="show_description",
+                    before=tile.show_description,
+                    after=validated["show_description"],
+                )
+            )
             tile.show_description = validated["show_description"]
             tile_updates.append("show_description")
         if "color" in validated:
+            changes.append(
+                Change(type="Dashboard", action="changed", field="color", before=tile.color, after=validated["color"])
+            )
             tile.color = validated["color"]
             tile_updates.append("color")
         if "layouts" in validated:
+            changes.append(
+                Change(
+                    type="Dashboard", action="changed", field="layouts", before=tile.layouts, after=validated["layouts"]
+                )
+            )
             tile.layouts = validated["layouts"]
             tile_updates.append("layouts")
         if tile_updates:
             tile.save(update_fields=tile_updates)
 
+        self._log_tile_activity(dashboard, changes, request)
         tile.refresh_from_db()
         return Response(TilePresentationSerializer(tile).data)
 

--- a/products/dashboards/backend/api/test/test_dashboard_update_tile.py
+++ b/products/dashboards/backend/api/test/test_dashboard_update_tile.py
@@ -6,7 +6,10 @@ from rest_framework import status
 from posthog.schema import DateRange, EventsNode, InsightVizNode, TrendsFilter, TrendsQuery
 
 from posthog.api.test.dashboards import DashboardAPI
+from posthog.models.organization import Organization
+from posthog.models.team import Team
 
+from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile, Text
 from products.dashboards.backend.models.dashboard_widget import DashboardWidget
 
@@ -71,6 +74,14 @@ class TestDashboardUpdateTile(APIBaseTest):
 
         assert DashboardTile.objects.get(id=tile_id).color == "blue"
 
+    def test_sets_layouts(self) -> None:
+        dashboard_id, tile_id = self._make_tile("insight")
+        layouts = {"sm": {"x": 0, "y": 0, "w": 6, "h": 5}}
+
+        self._update(dashboard_id, {"tile_id": tile_id, "layouts": layouts})
+
+        assert DashboardTile.objects.get(id=tile_id).layouts == layouts
+
     def test_only_updates_provided_fields(self) -> None:
         dashboard_id, tile_id = self._make_tile("insight")
         DashboardTile.objects.filter(id=tile_id).update(color="green")
@@ -99,5 +110,15 @@ class TestDashboardUpdateTile(APIBaseTest):
         self._update(
             dashboard_id,
             {"tile_id": other_tile_id, "show_description": False},
+            expected_status=status.HTTP_404_NOT_FOUND,
+        )
+
+    def test_rejects_dashboard_from_other_team(self) -> None:
+        other_team = Team.objects.create(organization=Organization.objects.create(name="other"), name="other")
+        other_dashboard = Dashboard.objects.create(team=other_team, name="other")
+
+        self._update(
+            other_dashboard.id,
+            {"tile_id": 1, "show_description": False},
             expected_status=status.HTTP_404_NOT_FOUND,
         )

--- a/products/dashboards/backend/api/test/test_dashboard_update_tile.py
+++ b/products/dashboards/backend/api/test/test_dashboard_update_tile.py
@@ -1,0 +1,103 @@
+from posthog.test.base import APIBaseTest
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.schema import DateRange, EventsNode, InsightVizNode, TrendsFilter, TrendsQuery
+
+from posthog.api.test.dashboards import DashboardAPI
+
+from products.dashboards.backend.models.dashboard_tile import DashboardTile, Text
+from products.dashboards.backend.models.dashboard_widget import DashboardWidget
+
+
+def _trends_query_dict(event: str = "$pageview") -> dict:
+    return InsightVizNode(
+        source=TrendsQuery(
+            series=[EventsNode(event=event)],
+            dateRange=DateRange(date_from="-7d"),
+            trendsFilter=TrendsFilter(display="ActionsLineGraph"),
+        ),
+    ).model_dump()
+
+
+class TestDashboardUpdateTile(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
+
+    def _make_tile(self, kind: str) -> tuple[int, int]:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
+        if kind == "insight":
+            insight_id, _ = self.dashboard_api.create_insight(
+                {"name": "A", "query": _trends_query_dict(), "dashboards": [dashboard_id]}
+            )
+            tile = DashboardTile.objects.get(dashboard_id=dashboard_id, insight_id=insight_id)
+        else:
+            widget = DashboardWidget.all_teams.create(
+                team=self.team, widget_type="error_tracking_list", config={"limit": 10}
+            )
+            tile = DashboardTile.objects.create(dashboard_id=dashboard_id, widget=widget)
+        return dashboard_id, tile.id
+
+    def _update(self, dashboard_id: int, payload: dict, expected_status: int = status.HTTP_200_OK) -> dict:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{dashboard_id}/update_tile/",
+            payload,
+        )
+        assert response.status_code == expected_status, response.content
+        return response.json()
+
+    @parameterized.expand(
+        [
+            ("insight_hide", "insight", False),
+            ("insight_show", "insight", True),
+            ("widget_hide", "widget", False),
+            ("widget_show", "widget", True),
+        ]
+    )
+    def test_sets_show_description(self, _name: str, kind: str, value: bool) -> None:
+        dashboard_id, tile_id = self._make_tile(kind)
+
+        body = self._update(dashboard_id, {"tile_id": tile_id, "show_description": value})
+
+        assert body["show_description"] == value
+        assert DashboardTile.objects.get(id=tile_id).show_description == value
+
+    def test_sets_color(self) -> None:
+        dashboard_id, tile_id = self._make_tile("insight")
+
+        self._update(dashboard_id, {"tile_id": tile_id, "color": "blue"})
+
+        assert DashboardTile.objects.get(id=tile_id).color == "blue"
+
+    def test_only_updates_provided_fields(self) -> None:
+        dashboard_id, tile_id = self._make_tile("insight")
+        DashboardTile.objects.filter(id=tile_id).update(color="green")
+
+        self._update(dashboard_id, {"tile_id": tile_id, "show_description": False})
+
+        tile = DashboardTile.objects.get(id=tile_id)
+        assert tile.show_description is False
+        assert tile.color == "green"
+
+    def test_rejects_text_tile(self) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
+        text = Text.objects.create(body="hi", team=self.team)
+        tile = DashboardTile.objects.create(dashboard_id=dashboard_id, text=text)
+
+        self._update(
+            dashboard_id,
+            {"tile_id": tile.id, "show_description": False},
+            expected_status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    def test_rejects_tile_from_other_dashboard(self) -> None:
+        dashboard_id, _ = self._make_tile("insight")
+        _, other_tile_id = self._make_tile("insight")
+
+        self._update(
+            dashboard_id,
+            {"tile_id": other_tile_id, "show_description": False},
+            expected_status=status.HTTP_404_NOT_FOUND,
+        )

--- a/products/dashboards/backend/api/test/test_dashboard_update_tile.py
+++ b/products/dashboards/backend/api/test/test_dashboard_update_tile.py
@@ -6,6 +6,7 @@ from rest_framework import status
 from posthog.schema import DateRange, EventsNode, InsightVizNode, TrendsFilter, TrendsQuery
 
 from posthog.api.test.dashboards import DashboardAPI
+from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.organization import Organization
 from posthog.models.team import Team
 
@@ -122,3 +123,49 @@ class TestDashboardUpdateTile(APIBaseTest):
             {"tile_id": 1, "show_description": False},
             expected_status=status.HTTP_404_NOT_FOUND,
         )
+
+    def _dashboard_activity(self, dashboard_id: int) -> list[ActivityLog]:
+        return list(ActivityLog.objects.filter(scope="Dashboard", item_id=str(dashboard_id), activity="updated"))
+
+    @parameterized.expand(
+        [
+            ("show_description", {"show_description": True}, "show_description", True),
+            ("color", {"color": "blue"}, "color", "blue"),
+            (
+                "layouts",
+                {"layouts": {"sm": {"x": 0, "y": 0, "w": 6, "h": 5}}},
+                "layouts",
+                {"sm": {"x": 0, "y": 0, "w": 6, "h": 5}},
+            ),
+        ]
+    )
+    def test_update_tile_logs_activity(self, _name: str, payload: dict, field: str, expected_after: object) -> None:
+        dashboard_id, tile_id = self._make_tile("insight")
+
+        self._update(dashboard_id, {"tile_id": tile_id, **payload})
+
+        logs = self._dashboard_activity(dashboard_id)
+        assert len(logs) == 1
+        log = logs[0]
+        assert log.activity == "updated"
+        assert log.item_id == str(dashboard_id)
+        changed_fields = {change["field"]: change["after"] for change in log.detail["changes"]}
+        assert field in changed_fields
+        assert changed_fields[field] == expected_after
+
+    def test_update_text_tile_logs_activity(self) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
+        text = Text.objects.create(body="hi", team=self.team)
+        tile = DashboardTile.objects.create(dashboard_id=dashboard_id, text=text)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{dashboard_id}/update_text_tile/",
+            {"tile_id": tile.id, "body": "updated body", "color": "purple"},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+
+        logs = self._dashboard_activity(dashboard_id)
+        assert len(logs) == 1
+        changed_fields = {change["field"]: change["after"] for change in logs[0].detail["changes"]}
+        assert changed_fields["body"] == "updated body"
+        assert changed_fields["color"] == "purple"

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -7757,6 +7757,19 @@ export interface UpdateTextTileRequestApi {
     color?: string | null
 }
 
+export interface TilePresentationApi {
+    readonly id: number
+    readonly dashboard_id: number
+    /** @nullable */
+    show_description?: boolean | null
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    color?: string | null
+    layouts?: unknown
+}
+
 export interface UpdateTileRequestApi {
     /** ID of the dashboard tile to update. Use dashboard-get to look up tile IDs. */
     tile_id: number
@@ -7770,19 +7783,6 @@ export interface UpdateTileRequestApi {
     color?: string | null
     /** New grid layout per breakpoint. Omit to leave the layout unchanged. */
     layouts?: TileLayoutsApi
-}
-
-export interface TilePresentationApi {
-    readonly id: number
-    readonly dashboard_id: number
-    /** @nullable */
-    show_description?: boolean | null
-    /**
-     * @maxLength 400
-     * @nullable
-     */
-    color?: string | null
-    layouts?: unknown
 }
 
 export interface AddDashboardWidgetRequestApi {

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -7757,6 +7757,21 @@ export interface UpdateTextTileRequestApi {
     color?: string | null
 }
 
+export interface UpdateTileRequestApi {
+    /** ID of the dashboard tile to update. Use dashboard-get to look up tile IDs. */
+    tile_id: number
+    /** Whether the tile's description is shown on the dashboard. Set false to hide it, true to show it. Omit to leave unchanged. */
+    show_description?: boolean
+    /**
+     * New accent color name, empty string or null to clear. Omit to leave unchanged.
+     * @maxLength 400
+     * @nullable
+     */
+    color?: string | null
+    /** New grid layout per breakpoint. Omit to leave the layout unchanged. */
+    layouts?: TileLayoutsApi
+}
+
 export interface AddDashboardWidgetRequestApi {
     /**
      * Widget type identifier. Supported values: error_tracking_list, session_replay_list. Use dashboard-widget-catalog-list for config_schema_hints per type.
@@ -8207,6 +8222,18 @@ export type DashboardsUpdateTextTileCreateFormat =
     (typeof DashboardsUpdateTextTileCreateFormat)[keyof typeof DashboardsUpdateTextTileCreateFormat]
 
 export const DashboardsUpdateTextTileCreateFormat = {
+    Json: 'json',
+    Txt: 'txt',
+} as const
+
+export type DashboardsUpdateTileCreateParams = {
+    format?: DashboardsUpdateTileCreateFormat
+}
+
+export type DashboardsUpdateTileCreateFormat =
+    (typeof DashboardsUpdateTileCreateFormat)[keyof typeof DashboardsUpdateTileCreateFormat]
+
+export const DashboardsUpdateTileCreateFormat = {
     Json: 'json',
     Txt: 'txt',
 } as const

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -7772,6 +7772,19 @@ export interface UpdateTileRequestApi {
     layouts?: TileLayoutsApi
 }
 
+export interface TilePresentationApi {
+    readonly id: number
+    readonly dashboard_id: number
+    /** @nullable */
+    show_description?: boolean | null
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    color?: string | null
+    layouts?: unknown
+}
+
 export interface AddDashboardWidgetRequestApi {
     /**
      * Widget type identifier. Supported values: error_tracking_list, session_replay_list. Use dashboard-widget-catalog-list for config_schema_hints per type.

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -59,6 +59,7 @@ import type {
     ReorderTilesRequestApi,
     RunInsightsResponseApi,
     RunWidgetsResponseApi,
+    TilePresentationApi,
     UpdateTextTileRequestApi,
     UpdateTileRequestApi,
     WidgetCatalogResponseApi,
@@ -926,8 +927,8 @@ export const dashboardsUpdateTileCreate = async (
     updateTileRequestApi: UpdateTileRequestApi,
     params?: DashboardsUpdateTileCreateParams,
     options?: RequestInit
-): Promise<DashboardTileApi> => {
-    return apiMutator<DashboardTileApi>(getDashboardsUpdateTileCreateUrl(projectId, id, params), {
+): Promise<TilePresentationApi> => {
+    return apiMutator<TilePresentationApi>(getDashboardsUpdateTileCreateUrl(projectId, id, params), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -42,6 +42,7 @@ import type {
     DashboardsStreamTilesRetrieveParams,
     DashboardsUpdateParams,
     DashboardsUpdateTextTileCreateParams,
+    DashboardsUpdateTileCreateParams,
     DashboardsWidgetCatalogRetrieveParams,
     DashboardsWidgetsBatchCreateParams,
     DataColorThemeApi,
@@ -59,6 +60,7 @@ import type {
     RunInsightsResponseApi,
     RunWidgetsResponseApi,
     UpdateTextTileRequestApi,
+    UpdateTileRequestApi,
     WidgetCatalogResponseApi,
 } from './api.schemas'
 
@@ -892,6 +894,44 @@ export const dashboardsUpdateTextTileCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(updateTextTileRequestApi),
+    })
+}
+
+export const getDashboardsUpdateTileCreateUrl = (
+    projectId: string,
+    id: number,
+    params?: DashboardsUpdateTileCreateParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/dashboards/${id}/update_tile/?${stringifiedParams}`
+        : `/api/projects/${projectId}/dashboards/${id}/update_tile/`
+}
+
+/**
+ * Update the description visibility, color, or layout of an existing insight or widget tile on a dashboard.
+ */
+export const dashboardsUpdateTileCreate = async (
+    projectId: string,
+    id: number,
+    updateTileRequestApi: UpdateTileRequestApi,
+    params?: DashboardsUpdateTileCreateParams,
+    options?: RequestInit
+): Promise<DashboardTileApi> => {
+    return apiMutator<DashboardTileApi>(getDashboardsUpdateTileCreateUrl(projectId, id, params), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(updateTileRequestApi),
     })
 }
 

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -889,8 +889,8 @@ export const dashboardsUpdateTextTileCreate = async (
     updateTextTileRequestApi: UpdateTextTileRequestApi,
     params?: DashboardsUpdateTextTileCreateParams,
     options?: RequestInit
-): Promise<DashboardTileApi> => {
-    return apiMutator<DashboardTileApi>(getDashboardsUpdateTextTileCreateUrl(projectId, id, params), {
+): Promise<TilePresentationApi> => {
+    return apiMutator<TilePresentationApi>(getDashboardsUpdateTextTileCreateUrl(projectId, id, params), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -480,6 +480,49 @@ export const DashboardsUpdateTextTileCreateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * Update the description visibility, color, or layout of an existing insight or widget tile on a dashboard.
+ */
+export const dashboardsUpdateTileCreateBodyColorMax = 400
+
+export const DashboardsUpdateTileCreateBody = /* @__PURE__ */ zod.object({
+    tile_id: zod.number().describe('ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.'),
+    show_description: zod
+        .boolean()
+        .optional()
+        .describe(
+            "Whether the tile's description is shown on the dashboard. Set false to hide it, true to show it. Omit to leave unchanged."
+        ),
+    color: zod
+        .string()
+        .max(dashboardsUpdateTileCreateBodyColorMax)
+        .nullish()
+        .describe('New accent color name, empty string or null to clear. Omit to leave unchanged.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+            xs: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+        })
+        .optional()
+        .describe('New grid layout per breakpoint. Omit to leave the layout unchanged.'),
+})
+
+/**
  * Add multiple widget tiles to a dashboard in one atomic request.
  */
 export const dashboardsWidgetsBatchCreateBodyWidgetsItemWidgetTypeMax = 64

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -355,6 +355,26 @@ tools:
         param_overrides:
             id:
                 cast: string-int
+    dashboard-update-tile:
+        operation: dashboards_update_tile_create
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: '{params.id}'
+        title: Update dashboard tile
+        description: >
+            Update an existing insight or widget tile on a dashboard — toggle whether the tile's description is shown
+            (`show_description`), set its accent `color`, or change its `layouts`. Pass the DashboardTile id as
+            `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are updated; omitted fields
+            are left unchanged. Use this to hide or show the description text under an insight or widget on a dashboard.
+            To edit a text tile's body, use dashboard-update-text-tile instead.
+        param_overrides:
+            id:
+                cast: string-int
     dashboard-widget-catalog-list:
         operation: dashboards_widget_catalog_retrieve
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1106,6 +1106,20 @@
             "readOnlyHint": false
         }
     },
+    "dashboard-update-tile": {
+        "description": "Update an existing insight or widget tile on a dashboard — toggle whether the tile's description is shown (`show_description`), set its accent `color`, or change its `layouts`. Pass the DashboardTile id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are updated; omitted fields are left unchanged. Use this to hide or show the description text under an insight or widget on a dashboard. To edit a text tile's body, use dashboard-update-text-tile instead.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Update dashboard tile",
+        "title": "Update dashboard tile",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "dashboard-widget-catalog-list": {
         "description": "List registered dashboard widget types with labels, descriptions, and config_schema_hints. Use before dashboard-widgets-batch-add to pick a widget_type and shape config.",
         "category": "Dashboards",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1122,6 +1122,20 @@
             "readOnlyHint": false
         }
     },
+    "dashboard-update-tile": {
+        "description": "Update an existing insight or widget tile on a dashboard — toggle whether the tile's description is shown (`show_description`), set its accent `color`, or change its `layouts`. Pass the DashboardTile id as `tile_id` (use dashboard-get to look up tile IDs). Only the fields you provide are updated; omitted fields are left unchanged. Use this to hide or show the description text under an insight or widget on a dashboard. To edit a text tile's body, use dashboard-update-text-tile instead.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Update dashboard tile",
+        "title": "Update dashboard tile",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "dashboard-widget-catalog-list": {
         "description": "List registered dashboard widget types with labels, descriptions, and config_schema_hints. Use before dashboard-widgets-batch-add to pick a widget_type and shape config.",
         "category": "Dashboards",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39249,6 +39249,19 @@ export namespace Schemas {
       metadata: TextReprMetadata;
     }
 
+    export interface TilePresentation {
+      readonly id: number;
+      readonly dashboard_id: number;
+      /** @nullable */
+      show_description?: boolean | null;
+      /**
+         * @maxLength 400
+         * @nullable
+         */
+      color?: string | null;
+      layouts?: unknown;
+    }
+
     export interface TopPage {
       /** Host for the page, if recorded. */
       host: string;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39321,6 +39321,21 @@ export namespace Schemas {
       color?: string | null;
     }
 
+    export interface UpdateTileRequest {
+      /** ID of the dashboard tile to update. Use dashboard-get to look up tile IDs. */
+      tile_id: number;
+      /** Whether the tile's description is shown on the dashboard. Set false to hide it, true to show it. Omit to leave unchanged. */
+      show_description?: boolean;
+      /**
+         * New accent color name, empty string or null to clear. Omit to leave unchanged.
+         * @maxLength 400
+         * @nullable
+         */
+      color?: string | null;
+      /** New grid layout per breakpoint. Omit to leave the layout unchanged. */
+      layouts?: TileLayouts;
+    }
+
     /**
      * Optional structured plan of events the wizard intends to instrument. Schema is workflow-specific.
      * @nullable
@@ -40874,6 +40889,18 @@ export namespace Schemas {
 
 
     export const EnvironmentsDashboardsUpdateTextTileCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type EnvironmentsDashboardsUpdateTileCreateParams = {
+    format?: EnvironmentsDashboardsUpdateTileCreateFormat;
+    };
+
+    export type EnvironmentsDashboardsUpdateTileCreateFormat = typeof EnvironmentsDashboardsUpdateTileCreateFormat[keyof typeof EnvironmentsDashboardsUpdateTileCreateFormat];
+
+
+    export const EnvironmentsDashboardsUpdateTileCreateFormat = {
       Json: 'json',
       Txt: 'txt',
     } as const;
@@ -46098,6 +46125,18 @@ export namespace Schemas {
 
 
     export const DashboardsUpdateTextTileCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type DashboardsUpdateTileCreateParams = {
+    format?: DashboardsUpdateTileCreateFormat;
+    };
+
+    export type DashboardsUpdateTileCreateFormat = typeof DashboardsUpdateTileCreateFormat[keyof typeof DashboardsUpdateTileCreateFormat];
+
+
+    export const DashboardsUpdateTileCreateFormat = {
       Json: 'json',
       Txt: 'txt',
     } as const;

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 15 enabled ops
+ * PostHog API - MCP 16 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -430,6 +430,62 @@ export const DashboardsUpdateTextTileCreateBody = /* @__PURE__ */ zod.object({
         .max(dashboardsUpdateTextTileCreateBodyColorMax)
         .nullish()
         .describe('New accent color name, empty string or null to clear. Omit to leave unchanged.'),
+})
+
+/**
+ * Update the description visibility, color, or layout of an existing insight or widget tile on a dashboard.
+ */
+export const DashboardsUpdateTileCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const DashboardsUpdateTileCreateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const dashboardsUpdateTileCreateBodyColorMax = 400
+
+export const DashboardsUpdateTileCreateBody = /* @__PURE__ */ zod.object({
+    tile_id: zod.number().describe('ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.'),
+    show_description: zod
+        .boolean()
+        .optional()
+        .describe(
+            "Whether the tile's description is shown on the dashboard. Set false to hide it, true to show it. Omit to leave unchanged."
+        ),
+    color: zod
+        .string()
+        .max(dashboardsUpdateTileCreateBodyColorMax)
+        .nullish()
+        .describe('New accent color name, empty string or null to clear. Omit to leave unchanged.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+            xs: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+        })
+        .optional()
+        .describe('New grid layout per breakpoint. Omit to leave the layout unchanged.'),
 })
 
 /**

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -26,6 +26,8 @@ import {
     DashboardsRunWidgetsRetrieveQueryParams,
     DashboardsUpdateTextTileCreateBody,
     DashboardsUpdateTextTileCreateParams,
+    DashboardsUpdateTileCreateBody,
+    DashboardsUpdateTileCreateParams,
     DashboardsWidgetsBatchCreateBody,
     DashboardsWidgetsBatchCreateParams,
 } from '@/generated/dashboards/api'
@@ -478,6 +480,37 @@ const dashboardUpdateTextTile = (): ToolBase<
     },
 })
 
+const DashboardUpdateTileSchema = DashboardsUpdateTileCreateParams.omit({ project_id: true })
+    .extend(DashboardsUpdateTileCreateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsUpdateTileCreateParams.shape['id']) })
+
+const dashboardUpdateTile = (): ToolBase<typeof DashboardUpdateTileSchema, WithPostHogUrl<Schemas.DashboardTile>> => ({
+    name: 'dashboard-update-tile',
+    schema: DashboardUpdateTileSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardUpdateTileSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.tile_id !== undefined) {
+            body['tile_id'] = params.tile_id
+        }
+        if (params.show_description !== undefined) {
+            body['show_description'] = params.show_description
+        }
+        if (params.color !== undefined) {
+            body['color'] = params.color
+        }
+        if (params.layouts !== undefined) {
+            body['layouts'] = params.layouts
+        }
+        const result = await context.api.request<Schemas.DashboardTile>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/update_tile/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/dashboard/${params.id}`)
+    },
+})
+
 const DashboardWidgetCatalogListSchema = z.object({})
 
 const dashboardWidgetCatalogList = (): ToolBase<
@@ -619,6 +652,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'dashboard-tile-copy': dashboardTileCopy,
     'dashboard-update': dashboardUpdate,
     'dashboard-update-text-tile': dashboardUpdateTextTile,
+    'dashboard-update-tile': dashboardUpdateTile,
     'dashboard-widget-catalog-list': dashboardWidgetCatalogList,
     'dashboard-widgets-batch-add': dashboardWidgetsBatchAdd,
     'dashboard-widgets-run': dashboardWidgetsRun,

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -484,7 +484,10 @@ const DashboardUpdateTileSchema = DashboardsUpdateTileCreateParams.omit({ projec
     .extend(DashboardsUpdateTileCreateBody.shape)
     .extend({ id: z.preprocess(castStringToInt, DashboardsUpdateTileCreateParams.shape['id']) })
 
-const dashboardUpdateTile = (): ToolBase<typeof DashboardUpdateTileSchema, WithPostHogUrl<Schemas.DashboardTile>> => ({
+const dashboardUpdateTile = (): ToolBase<
+    typeof DashboardUpdateTileSchema,
+    WithPostHogUrl<Schemas.TilePresentation>
+> => ({
     name: 'dashboard-update-tile',
     schema: DashboardUpdateTileSchema,
     handler: async (context: Context, params: z.infer<typeof DashboardUpdateTileSchema>) => {
@@ -502,7 +505,7 @@ const dashboardUpdateTile = (): ToolBase<typeof DashboardUpdateTileSchema, WithP
         if (params.layouts !== undefined) {
             body['layouts'] = params.layouts
         }
-        const result = await context.api.request<Schemas.DashboardTile>({
+        const result = await context.api.request<Schemas.TilePresentation>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/update_tile/`,
             body,

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -452,7 +452,7 @@ const DashboardUpdateTextTileSchema = DashboardsUpdateTextTileCreateParams.omit(
 
 const dashboardUpdateTextTile = (): ToolBase<
     typeof DashboardUpdateTextTileSchema,
-    WithPostHogUrl<Schemas.DashboardTile>
+    WithPostHogUrl<Schemas.TilePresentation>
 > => ({
     name: 'dashboard-update-text-tile',
     schema: DashboardUpdateTextTileSchema,
@@ -471,7 +471,7 @@ const dashboardUpdateTextTile = (): ToolBase<
         if (params.color !== undefined) {
             body['color'] = params.color
         }
-        const result = await context.api.request<Schemas.DashboardTile>({
+        const result = await context.api.request<Schemas.TilePresentation>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/update_text_tile/`,
             body,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update-tile.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "color": {
+            "anyOf": [
+                {
+                    "maxLength": 400,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "New accent color name, empty string or null to clear. Omit to leave unchanged."
+        },
+        "id": {
+            "description": "A unique integer value identifying this dashboard.",
+            "type": "number"
+        },
+        "layouts": {
+            "description": "New grid layout per breakpoint. Omit to leave the layout unchanged.",
+            "properties": {
+                "sm": {
+                    "description": "Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.",
+                    "properties": {
+                        "h": {
+                            "description": "Height in grid rows.",
+                            "type": "number"
+                        },
+                        "w": {
+                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                            "type": "number"
+                        },
+                        "x": {
+                            "description": "Column position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        },
+                        "y": {
+                            "description": "Row position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                "xs": {
+                    "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
+                    "properties": {
+                        "h": {
+                            "description": "Height in grid rows.",
+                            "type": "number"
+                        },
+                        "w": {
+                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                            "type": "number"
+                        },
+                        "x": {
+                            "description": "Column position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        },
+                        "y": {
+                            "description": "Row position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "show_description": {
+            "description": "Whether the tile's description is shown on the dashboard. Set false to hide it, true to show it. Omit to leave unchanged.",
+            "type": "boolean"
+        },
+        "tile_id": {
+            "description": "ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.",
+            "type": "number"
+        }
+    },
+    "required": ["id", "tile_id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

PostHog dashboards expose per-tile presentation settings — whether a tile's description is shown, its accent color, and its layout — but the only dedicated tile-update endpoint was for **text** tiles. There was no API/MCP path to toggle `show_description` (or color/layout) on **insight or widget** tiles: the dashboard `PATCH ... {tiles: [...]}` payload the frontend uses isn't represented in the OpenAPI schema, so it never surfaced as an MCP tool. Agents and MCP clients therefore couldn't hide a tile's description on a dashboard.

## Changes

- New `update_tile` action on the dashboard viewset (`POST .../dashboards/:id/update_tile/`) that updates `show_description`, `color`, and `layouts` on an existing **insight or widget** tile. Text tiles are rejected with a pointer to the existing text-tile endpoint.
- New `UpdateTileRequestSerializer` with `help_text` on every field, so the descriptions flow through to the generated Zod schema and MCP tool.
- New MCP tool **`dashboard-update-tile`** (`dashboard:write`, non-destructive, idempotent). The handler returns the updated tile (including `show_description`) so callers can verify the change in one round-trip.
- Regenerated OpenAPI spec, MCP tool definitions/handlers/schemas, and frontend API types.

No DB migration — the `show_description` column already exists.

## How did you test this code?

I'm an agent (PostHog Code) — automated tests only, no manual UI clickthrough.

- New `products/dashboards/backend/api/test/test_dashboard_update_tile.py`: parameterized `show_description` toggle across **insight × {hide, show}** and **widget × {hide, show}**, plus color update, only-provided-fields-change, reject-text-tile (400), and reject-cross-dashboard-tile (404). 8/8 pass.
- MCP: `lint-tool-names` passes; `tool-schema-snapshots` and `tool-filtering` vitest suites pass (new tool snapshot committed).

## 🤖 Agent context

Authored by PostHog Code (Claude) at Paul's request. Trigger: the MCP couldn't hide per-tile descriptions — `dashboard-update` documents a `tiles` param but its input schema omits it, so the operation was unreachable. Rather than patch the generic endpoint, I mirrored the existing `update_text_tile` action for consistency. Initially scoped to insight tiles, then broadened to insight **and** widget tiles (rejecting only text tiles) on review feedback. Generated artifacts were rebuilt with `hogli build:openapi`; the branch was rebased onto current master, resolving generated-file conflicts by regenerating rather than hand-merging.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
