### PR TITLE
fix(rbac): scope system.accounts to `account` resource

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -124,7 +124,10 @@ cohort_calculation_history: PostgresTable = PostgresTable(
 accounts: PostgresTable = PostgresTable(
     name="accounts",
     postgres_table_name="customer_analytics_account",
-    access_scope="customer_analytics",
+    # Object-level access control filters out ids directly off access_scope, so we use
+    # `account` here (where the per-object grants are stored) instead of the
+    # `customer_analytics` umbrella. Resource-level gating still works via RESOURCE_INHERITANCE_MAP.
+    access_scope="account",
     fields={
         "id": UUIDDatabaseField(name="id"),
         "team_id": IntegerDatabaseField(name="team_id"),

--- a/posthog/hogql/database/test/test_postgres_table.py
+++ b/posthog/hogql/database/test/test_postgres_table.py
@@ -1,6 +1,12 @@
+from functools import lru_cache
 from typing import Literal
 
 from posthog.test.base import BaseTest
+
+from django.test import SimpleTestCase
+from django.urls import get_resolver
+
+from parameterized import parameterized
 
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
@@ -14,9 +20,43 @@ from posthog.hogql.database.models import (
     TableNode,
 )
 from posthog.hogql.database.postgres_table import PostgresTable
+from posthog.hogql.database.schema.system import SystemTables
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import prepare_and_print_ast
 from posthog.hogql.query import create_default_modifiers_for_team
+
+from posthog.rbac.user_access_control import RESOURCE_INHERITANCE_MAP
+
+from ee.api.rbac.access_control import AccessControlViewSetMixin
+
+_SCOPED_SYSTEM_TABLES: dict[str, PostgresTable] = {
+    name: node.table
+    for name, node in SystemTables().children.items()
+    if isinstance(node.table, PostgresTable) and node.table.access_scope is not None
+}
+
+
+@lru_cache(maxsize=1)
+def _object_grant_scopes() -> frozenset[str]:
+    """Resources under which object-level access control grants can actually be stored,
+    i.e. every `scope_object` declared by an `AccessControlViewSetMixin` viewset. Loading
+    the full URLconf forces all viewsets (including product ones) to be imported and
+    registered as subclasses."""
+    _ = get_resolver().url_patterns
+
+    def all_subclasses(cls: type) -> set[type]:
+        subs: set[type] = set()
+        for sub in cls.__subclasses__():
+            subs.add(sub)
+            subs |= all_subclasses(sub)
+        return subs
+
+    scopes: set[str] = set()
+    for viewset in all_subclasses(AccessControlViewSetMixin):
+        scope = getattr(viewset, "scope_object", None)
+        if isinstance(scope, str) and scope != "INTERNAL":
+            scopes.add(scope)
+    return frozenset(scopes)
 
 
 class TestPostgresTable(BaseTest):
@@ -321,3 +361,32 @@ class TestPostgresTable(BaseTest):
             self._select("SELECT id FROM postgres_table LIMIT 10"),
             f"SELECT postgres_table.id AS id FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS postgres_table WHERE and(equals(postgres_table.team_id, {self.team.pk}), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(postgres_table.properties, %(hogql_val_15)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_16)s), 1)) LIMIT 10",
         )
+
+
+class TestSystemTableAccessScope(SimpleTestCase):
+    """A system table's `access_scope` must be the concrete resource under which object-level
+    access control grants are stored — never a pure umbrella parent.
+
+    Resource-level gating resolves an umbrella via RESOURCE_INHERITANCE_MAP, but object-level
+    deny lookups key directly off `access_scope` (`blocked_resource_ids_by_scope[access_scope]`).
+    If a table were scoped to an umbrella, those lookups would silently miss every grant stored
+    on the umbrella's children, leaking access-controlled objects through HogQL."""
+
+    @parameterized.expand(sorted(_SCOPED_SYSTEM_TABLES))
+    def test_access_scope_is_not_a_pure_umbrella(self, table_name: str) -> None:
+        access_scope = _SCOPED_SYSTEM_TABLES[table_name].access_scope
+
+        # A pure umbrella is a parent in the inheritance map that is never itself a
+        # `scope_object` — so object grants can only ever live on its children, not on it.
+        grant_scopes = _object_grant_scopes()
+        pure_umbrellas = {parent for parent in RESOURCE_INHERITANCE_MAP.values() if parent not in grant_scopes}
+
+        if access_scope in pure_umbrellas:
+            children = sorted(child for child, parent in RESOURCE_INHERITANCE_MAP.items() if parent == access_scope)
+            self.fail(
+                f"system.{table_name} has access_scope='{access_scope}', a pure umbrella resource "
+                f"that never stores object-level grants (they live on its children: "
+                f"{', '.join(children)}). Set access_scope to the concrete child resource this "
+                f"table's rows represent — resource-level gating still resolves the umbrella via "
+                f"RESOURCE_INHERITANCE_MAP."
+            )


### PR DESCRIPTION
## Problem

The `system.accounts` HogQL table was scoped to the `customer_analytics` umbrella resource, but object-level access control grants for accounts are stored under the `account` resource. 

Object-level deny lookups key directly off `access_scope`, so they looked up `customer_analytics` silently missed every per-object denial. A member explicitly denied access to a specific account could still read that row via HogQL.

This is a prerequisite cleanup for object-level access control in HogQL ([#49264](https://github.com/PostHog/posthog/pull/49264))

## Changes

- Set `system.accounts` `access_scope` to `account`
- Add a parameterized test (`TestSystemTableAccessScope`) asserting no system table's `access_scope` is a *pure umbrella* -- a parent in `RESOURCE_INHERITANCE_MAP` that is never itself a viewset `scope_object`. The authoritative set of object-grant scopes is derived from `AccessControlViewSetMixin` subclasses, so the check stays correct as viewsets are added.

This will be merged **before** object-level access control ([#49264](https://github.com/PostHog/posthog/pull/49264)). 

## How did you test this code?

I'm an agent. Automated tests I ran (via `uv run pytest`):

- `posthog/hogql/database/test/test_postgres_table.py` — full file, including the new `TestSystemTableAccessScope` (48 parameterized cases, all green).
- Verified the new test *fails loud* by temporarily reverting `accounts` to `customer_analytics` — it flags the umbrella with an actionable message, then reverted.
- `posthog/hogql/database/schema/test/test_system_tables.py` (account/access/resource subset) and `posthog/hogql/printer/test/test_hogql_access_control.py` — green, confirming resource-level gating behavior is unchanged.

## 🤖 Agent context

The key decision was how to fix the deny-key mismatch without a second `PostgresTable` field: rather than adding an `access_control_key`, we rely on the fact that `account` inherits from `customer_analytics`, so changing `access_scope` to the concrete child is a no-op for resource-level gating while fixing object-level lookups. We considered keeping the umbrella and resolving children at lookup time, but rejected it — it would union heterogeneous child deny-sets (safe only while PKs are UUIDs, an over-block footgun otherwise) for no benefit, since each table's rows map to exactly one concrete resource. The invariant test encodes that rule and is derived from the viewset registry rather than a hardcoded list.