### PR TITLE
fix(data-warehouse): mark Salesforce expired refresh token as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/salesforce/source.py
+++ b/posthog/temporal/data_imports/sources/salesforce/source.py
@@ -32,6 +32,11 @@ class SalesforceSource(ResumableSource[SalesforceSourceConfig, SalesforceResumeC
             "400 Client Error: Bad Request for url": None,
             "403 Client Error: Forbidden for url": None,
             "inactive organization": None,
+            # SalesforceAuthRequestError.raise_from_response formats token-refresh failures as
+            # "<code> Client Error: <reason>: <error_description>", so the "... for url" patterns
+            # above never match it. Key off the stable error_description returned by Salesforce
+            # when the refresh token is expired/revoked — reconnecting is the only fix.
+            "expired access/refresh token": "Your Salesforce connection has expired or been revoked. Please reconnect the source.",
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/salesforce/test/test_auth.py
+++ b/posthog/temporal/data_imports/sources/salesforce/test/test_auth.py
@@ -98,3 +98,28 @@ def test_get_salesforce_access_token_from_code_raises_on_server_failure():
     assert exc.value.response == response
     assert "Server Error" in str(exc.value)
     assert response_body in str(exc.value)
+
+
+def test_expired_refresh_token_error_is_non_retryable():
+    """The SalesforceAuthRequestError raised for an expired refresh token must match a
+    non-retryable pattern, otherwise the job retries a permanent auth failure forever."""
+    from posthog.temporal.data_imports.sources.salesforce.source import SalesforceSource
+
+    response = requests.Response()
+    response.status_code = 400
+    response._content = json.dumps({"error_description": "expired access/refresh token"}).encode("utf-8")
+
+    with (
+        unittest.mock.patch(
+            "posthog.temporal.data_imports.sources.salesforce.auth.make_tracked_session",
+            return_value=type("_S", (), {"post": staticmethod(lambda *a, **k: response)})(),
+        ),
+        pytest.raises(auth.SalesforceAuthRequestError) as exc,
+    ):
+        _ = auth.salesforce_refresh_access_token("something", "https://login.salesforce.com")
+
+    error_message = str(exc.value)
+    patterns = SalesforceSource().get_non_retryable_errors()
+    assert any(pattern in error_message for pattern in patterns), (
+        f"Salesforce auth error {error_message!r} did not match any non-retryable pattern"
+    )


### PR DESCRIPTION
## Problem

The Salesforce source generated a high volume of repeated `SalesforceAuthRequestError: 400 Client Error: Bad Request: expired access/refresh token` events. The source's `get_non_retryable_errors()` lists `"400 Client Error: Bad Request for url"` — but that is the `requests` library `HTTPError` shape. `SalesforceAuthRequestError.raise_from_response` formats its message as `"<code> Client Error: <reason>: <error_description>"` (no *"for url"*), so the existing pattern never matched this token-refresh failure and the job retried a permanent, expired/revoked refresh token indefinitely.

## Changes

- Added `"expired access/refresh token"` (the stable `error_description` Salesforce returns when the refresh token is expired/revoked) to `get_non_retryable_errors()`, with a friendly "reconnect the source" message.

## How did you test this code?

I'm an agent. I added a test (5 in the module, all passing) and ran ruff check + format. The new test drives the real `salesforce_refresh_access_token` path with an `expired access/refresh token` response and asserts the resulting `SalesforceAuthRequestError` matches a non-retryable pattern — tying the producer to the matcher.

No manual testing against live Salesforce was performed.

## 🤖 Agent context

Authored with Claude Code. Found via the PostHog MCP error-tracking group. The existing pattern looked like it should cover this but assumed the `requests` HTTPError string format, which the custom auth exception does not use — so matching on the Salesforce-provided `error_description` is the robust fix.
