### PR TITLE
fix(data-warehouse): mark Google Sheets 404 not found as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/google_sheets/source.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/source.py
@@ -39,6 +39,9 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
             "SpreadsheetNotFound": None,
             "must be real number, not str": "Import failed: a numeric column contains a non-numeric value. Ensure every cell in numeric columns is stored as a plain number.",
             "Spreadsheet access denied": "Import failed: PostHog does not have access to this spreadsheet. Please share it with our service account as described at https://posthog.com/docs/cdp/sources/google-sheets",
+            # gspread raises APIError "[404]: Requested entity was not found." when the
+            # spreadsheet has been deleted or is otherwise unreachable. Retrying cannot recover.
+            "Requested entity was not found": "Import failed: the Google Sheet could not be found. It may have been deleted or moved. Please check the spreadsheet URL and that it is shared with our service account.",
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -101,3 +101,18 @@ def test_permission_error_is_non_retryable():
     error_msg = str(raised)
 
     assert any(key in error_msg for key in non_retryable_errors)
+
+
+def test_not_found_api_error_is_non_retryable():
+    """gspread raises a 404 APIError when the spreadsheet has been deleted/moved — it
+    must match a non-retryable pattern so we stop retrying a permanent failure."""
+    mock_response = mock.MagicMock()
+    mock_response.json.return_value = {
+        "error": {"code": 404, "message": "Requested entity was not found.", "status": "NOT_FOUND"}
+    }
+    error_msg = str(gspread.exceptions.APIError(mock_response))
+
+    non_retryable_errors = GoogleSheetsSource().get_non_retryable_errors()
+    assert any(key in error_msg for key in non_retryable_errors), (
+        f"Google Sheets 404 error {error_msg!r} did not match any non-retryable pattern"
+    )


### PR DESCRIPTION
## Problem

The Google Sheets source generated a high volume of repeated `APIError: [404]: Requested entity was not found.` events, raised from `get_schemas` when opening the spreadsheet. gspread returns a 404 when the spreadsheet has been deleted, moved, or is otherwise unreachable — retrying cannot recover. The source's `get_non_retryable_errors()` had patterns for permission denied, not-found-by-title, duplicate headers, etc., but none matched this gspread 404 message, so the job retried indefinitely.

## Changes

- Added `"Requested entity was not found"` (the stable gspread 404 message) to `get_non_retryable_errors()`, with a friendly message prompting the user to check the URL / sharing.

Because the same error also surfaces during schema discovery, this additionally lets the discover-schemas activity skip it (see the companion change that teaches schema discovery to honor `get_non_retryable_errors()`).

## How did you test this code?

I'm an agent. I added a test (6 in the module, all passing) and ran ruff check + format. The new test constructs a real gspread `APIError` from a 404 response and asserts its string matches a non-retryable pattern.

No manual testing against live Google Sheets was performed.

## 🤖 Agent context

Authored with Claude Code. Found via the PostHog MCP error-tracking group. Matched on the stable gspread 404 message string rather than the HTTP code so it's robust to gspread's formatting.
