### PR TITLE
fix(data-warehouse): mark Snapchat Ads client errors as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/snapchat_ads/source.py
+++ b/posthog/temporal/data_imports/sources/snapchat_ads/source.py
@@ -33,6 +33,16 @@ class SnapchatAdsSource(ResumableSource[SnapchatAdsSourceConfig, SnapchatResumeC
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.SNAPCHATADS
 
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        # Snapchat's Marketing API surfaces these as requests HTTPError "<code> Client Error".
+        # They're all permanent for a given config — a deleted/inaccessible ad account (404),
+        # revoked auth (401), or insufficient permissions (403) — so retrying cannot recover.
+        return {
+            "401 Client Error": "Snapchat Ads authentication failed. Please reconnect your Snapchat account.",
+            "403 Client Error": "Snapchat Ads access forbidden. Please check your account permissions.",
+            "404 Client Error": "Snapchat Ads resource not found. Please check that the ad account still exists and is accessible.",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/posthog/temporal/data_imports/sources/snapchat_ads/tests/test_snapchat_ads.py
+++ b/posthog/temporal/data_imports/sources/snapchat_ads/tests/test_snapchat_ads.py
@@ -331,3 +331,35 @@ class TestIterRowsMultiChunkStats:
         assert captured_calls[0]["initial_paginator_state"] == {
             "next_link": "https://adsapi.snapchat.com/v1/stats?chunk=1&cursor=midchunk",
         }
+
+
+class TestNonRetryableErrors:
+    @parameterized.expand(
+        [
+            # Real requests HTTPError strings from Snapchat's Marketing API.
+            "404 Client Error: Not Found for url: https://adsapi.snapchat.com/v1/adaccounts/abc/stats",
+            "401 Client Error: Unauthorized for url: https://adsapi.snapchat.com/v1/adaccounts/abc/stats",
+            "403 Client Error: Forbidden for url: https://adsapi.snapchat.com/v1/adaccounts/abc/stats",
+        ]
+    )
+    def test_permanent_client_errors_are_non_retryable(self, error_msg: str) -> None:
+        from posthog.temporal.data_imports.sources.snapchat_ads.source import SnapchatAdsSource
+
+        patterns = SnapchatAdsSource().get_non_retryable_errors()
+        assert any(pattern in error_msg for pattern in patterns), (
+            f"Snapchat error '{error_msg}' did not match any non-retryable pattern"
+        )
+
+    @parameterized.expand(
+        [
+            "500 Server Error: Internal Server Error for url: https://adsapi.snapchat.com/v1/stats",
+            "429 Client Error: Too Many Requests for url: https://adsapi.snapchat.com/v1/stats",
+        ]
+    )
+    def test_transient_errors_stay_retryable(self, error_msg: str) -> None:
+        from posthog.temporal.data_imports.sources.snapchat_ads.source import SnapchatAdsSource
+
+        patterns = SnapchatAdsSource().get_non_retryable_errors()
+        assert not any(pattern in error_msg for pattern in patterns), (
+            f"Snapchat error '{error_msg}' should remain retryable"
+        )

--- a/posthog/temporal/data_imports/sources/snapchat_ads/tests/test_snapchat_ads.py
+++ b/posthog/temporal/data_imports/sources/snapchat_ads/tests/test_snapchat_ads.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.snapchat_ads.snapchat_ads import SnapchatResumeConfig, _iter_rows
+from posthog.temporal.data_imports.sources.snapchat_ads.source import SnapchatAdsSource
 
 
 class _FakeResource:
@@ -334,6 +335,8 @@ class TestIterRowsMultiChunkStats:
 
 
 class TestNonRetryableErrors:
+    _patterns = SnapchatAdsSource().get_non_retryable_errors()
+
     @parameterized.expand(
         [
             # Real requests HTTPError strings from Snapchat's Marketing API.
@@ -343,10 +346,7 @@ class TestNonRetryableErrors:
         ]
     )
     def test_permanent_client_errors_are_non_retryable(self, error_msg: str) -> None:
-        from posthog.temporal.data_imports.sources.snapchat_ads.source import SnapchatAdsSource
-
-        patterns = SnapchatAdsSource().get_non_retryable_errors()
-        assert any(pattern in error_msg for pattern in patterns), (
+        assert any(pattern in error_msg for pattern in self._patterns), (
             f"Snapchat error '{error_msg}' did not match any non-retryable pattern"
         )
 
@@ -357,9 +357,6 @@ class TestNonRetryableErrors:
         ]
     )
     def test_transient_errors_stay_retryable(self, error_msg: str) -> None:
-        from posthog.temporal.data_imports.sources.snapchat_ads.source import SnapchatAdsSource
-
-        patterns = SnapchatAdsSource().get_non_retryable_errors()
-        assert not any(pattern in error_msg for pattern in patterns), (
+        assert not any(pattern in error_msg for pattern in self._patterns), (
             f"Snapchat error '{error_msg}' should remain retryable"
         )


### PR DESCRIPTION
## Problem

The Snapchat Ads source generated a high volume of repeated `HTTPError: 404 Client Error: Not Found for url: https://adsapi.snapchat.com/v1/adaccounts/<id>/stats` events, raised in the REST pipeline. A 404 on the ad account stats endpoint means the ad account was deleted or is no longer accessible — retrying cannot recover. The source had no `get_non_retryable_errors()` at all, so the job retried these permanent failures indefinitely.

## Changes

- Added `get_non_retryable_errors()` to `SnapchatAdsSource` matching `401`/`403`/`404 Client Error` with friendly messages, following the same convention already used by the Pinterest and Reddit ad sources (which use the same REST client and `requests` HTTPError shape).

Transient errors (5xx, 429) do not match and stay retryable.

## How did you test this code?

I'm an agent. I added a test class (12 tests in the module, all passing) and ran ruff check + format. Coverage:

- Parameterized tests that real 401/403/404 Snapchat HTTPError strings match a non-retryable pattern.
- Parameterized tests that 500/429 strings do **not** match (stay retryable).

No manual testing against the live Snapchat API was performed.

## 🤖 Agent context

Authored with Claude Code. Found via the PostHog MCP error-tracking group. Reused the established Pinterest/Reddit REST ad-source convention (`"40x Client Error"` substring) rather than inventing a new scheme, and kept 5xx/429 retryable.
