### PR TITLE
fix(data-warehouse): mark MongoDB unreachable-cluster timeouts as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -26,6 +26,11 @@ from posthog.temporal.data_imports.sources.mongodb.mongo import (
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
+_MONGO_UNREACHABLE_MESSAGE = (
+    "Could not reach your MongoDB cluster. Check that the cluster is running and that PostHog's "
+    "IP addresses are allowlisted in your database's network access settings."
+)
+
 
 @SourceRegistry.register
 class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin):
@@ -43,6 +48,13 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             "AuthenticationFailed": "MongoDB authentication failed. Please check the username and password for this source.",
             "Authentication failed": "MongoDB authentication failed. Please check the username and password for this source.",
             "SSL handshake failed": None,
+            # pymongo raises ServerSelectionTimeoutError ("No servers found yet" / "No replica set
+            # members found yet") when it can't reach any cluster node for the whole selection
+            # timeout. On a managed cluster this is a persistent connectivity problem — the worker
+            # IP isn't allowlisted, or the cluster is paused/decommissioned — not a momentary blip
+            # (a mid-sync outage surfaces differently), so retrying the job won't recover it.
+            "No servers found yet": _MONGO_UNREACHABLE_MESSAGE,
+            "No replica set members found yet": _MONGO_UNREACHABLE_MESSAGE,
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -39,14 +39,15 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         return ExternalDataSourceType.MONGODB
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
+        auth_failed_msg = "MongoDB authentication failed. Please check the username and password for this source."
         return {
             "The DNS query name does not exist": None,
             # pymongo raises OperationFailure with codeName 'AuthenticationFailed' (code 18) and
             # errmsg 'Authentication failed.' when the credentials are wrong. Non-retryable error
             # matching is case-sensitive, so the previous lowercase "authentication failed" never
             # matched the real message — key off the stable codeName and the capitalised message.
-            "AuthenticationFailed": "MongoDB authentication failed. Please check the username and password for this source.",
-            "Authentication failed": "MongoDB authentication failed. Please check the username and password for this source.",
+            "AuthenticationFailed": auth_failed_msg,
+            "Authentication failed": auth_failed_msg,
             "SSL handshake failed": None,
             # pymongo raises ServerSelectionTimeoutError ("No servers found yet" / "No replica set
             # members found yet") when it can't reach any cluster node for the whole selection

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -362,10 +362,15 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
             f"MongoDB error {error_msg!r} should remain retryable"
         )
 
-    def test_auth_failure_has_friendly_message(self):
-        assert self.non_retryable["AuthenticationFailed"] is not None
-        assert "password" in self.non_retryable["AuthenticationFailed"].lower()
-
-    def test_unreachable_cluster_has_friendly_message(self):
-        assert self.non_retryable["No servers found yet"] is not None
-        assert "allowlist" in self.non_retryable["No servers found yet"].lower()
+    @parameterized.expand(
+        [
+            ("code_name", "AuthenticationFailed", "password"),
+            ("message", "Authentication failed", "password"),
+            ("unreachable_no_servers", "No servers found yet", "allowlist"),
+            ("unreachable_no_replica_set", "No replica set members found yet", "allowlist"),
+        ]
+    )
+    def test_pattern_has_friendly_message(self, _name, pattern, expected_substring):
+        message = self.non_retryable[pattern]
+        assert message is not None
+        assert expected_substring in message.lower()

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -337,6 +337,13 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
             ),
             ("dns_failure", "The DNS query name does not exist: example.mongodb.net."),
             ("ssl_failure", "SSL handshake failed: certificate verify failed"),
+            # Cluster unreachable for the whole selection timeout — persistent connectivity issue.
+            ("no_servers", "No servers found yet, Timeout: 5.0s, Topology Description: ..."),
+            (
+                "no_replica_set_members",
+                "No replica set members found yet, Timeout: 10.0s, Topology Description: "
+                "<TopologyDescription topology_type: ReplicaSetNoPrimary>",
+            ),
         ]
     )
     def test_known_errors_are_non_retryable(self, _name, error_msg):
@@ -346,8 +353,8 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
 
     @parameterized.expand(
         [
-            ("server_selection_timeout", "No servers found yet, Timeout: 5.0s"),
             ("connection_reset", "connection closed"),
+            ("network_timeout", "NetworkTimeout: timed out reading from socket"),
         ]
     )
     def test_transient_errors_are_retryable(self, _name, error_msg):
@@ -358,3 +365,7 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
     def test_auth_failure_has_friendly_message(self):
         assert self.non_retryable["AuthenticationFailed"] is not None
         assert "password" in self.non_retryable["AuthenticationFailed"].lower()
+
+    def test_unreachable_cluster_has_friendly_message(self):
+        assert self.non_retryable["No servers found yet"] is not None
+        assert "allowlist" in self.non_retryable["No servers found yet"].lower()


### PR DESCRIPTION
## Problem

A second MongoDB error-tracking group is dominated by `ServerSelectionTimeoutError: No servers found yet` / `No replica set members found yet` (all cluster nodes shown as `server_type: Unknown`). This means pymongo could not reach **any** node of the cluster for the entire server-selection timeout. The same clusters have been failing this way continuously since October 2025 (~8 months) — that is not a momentary network blip, it's a persistent connectivity problem: the worker IP isn't allowlisted in the cluster's network-access settings, or the cluster has been paused/decommissioned. Retrying cannot recover it, but it was retried on every scheduled run.

## Changes

- Added the two stable connection-establishment timeout messages (`"No servers found yet"`, `"No replica set members found yet"`) to `MongoDBSource.get_non_retryable_errors()`, with a shared message telling the user to check the cluster is running and that PostHog's IPs are allowlisted. This is consistent with how the source already treats DNS and SSL connection failures as non-retryable.

### Tradeoff
I deliberately matched the specific "cannot reach any node at selection time" phrases rather than the whole `ServerSelectionTimeoutError` type. A genuinely transient mid-sync outage surfaces as a different error (e.g. `NetworkTimeout` on an established connection), which stays retryable. The risk of a false positive on a brief outage at connect time is low and recoverable (the user re-enables and gets a clear message), and it's outweighed by stopping the indefinite retry/noise on the many sources that are persistently misconfigured.

## How did you test this code?

I'm an agent. I extended the MongoDB non-retryable test class (44 tests in the module, all passing) and ran ruff check + format. Coverage:

- The two unreachable-cluster messages match a non-retryable pattern.
- A `NetworkTimeout`/`connection closed` (transient) does **not** match.
- The unreachable message mentions allowlisting.

No manual testing against a live MongoDB cluster was performed.

> Note: this PR is stacked on `tom/mongodb-fix-auth-nonretryable-casing` (the auth-casing fix) because both edit the same `get_non_retryable_errors` dict. It targets that branch to keep the diff clean; it can be retargeted to master once the base merges.

## 🤖 Agent context

Authored with Claude Code. Found via the PostHog MCP error-tracking group. The decisive signal was the 8-month persistence on the same clusters, which rules out transience and matches the well-known Atlas IP-allowlist / paused-cluster failure mode.
