### PR TITLE
fix(data-warehouse): mark HubSpot missing refresh token as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -88,6 +88,8 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
             # Raised by source_for_pipeline when the source config carries no refresh token at all
             # (integration never connected or lost its token). Retrying cannot recover.
             "Hubspot refresh token not found": "Your HubSpot connection is missing its refresh token. Please reconnect it.",
+            # Raised by source_for_pipeline (OAuth path) when the integration is missing its access or refresh token.
+            "Hubspot refresh or access token not found": "Your HubSpot connection is missing its refresh token. Please reconnect it.",
         }
 
     # TODO: clean up hubspot job inputs to not have two auth config options

--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -85,6 +85,9 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
         return {
             "missing or invalid refresh token": "Your HubSpot connection is invalid or expired. Please reconnect it.",
             "missing or unknown hub id": None,
+            # Raised by source_for_pipeline when the source config carries no refresh token at all
+            # (integration never connected or lost its token). Retrying cannot recover.
+            "Hubspot refresh token not found": "Your HubSpot connection is missing its refresh token. Please reconnect it.",
         }
 
     # TODO: clean up hubspot job inputs to not have two auth config options

--- a/posthog/temporal/data_imports/sources/hubspot/test/test_source_routing.py
+++ b/posthog/temporal/data_imports/sources/hubspot/test/test_source_routing.py
@@ -219,10 +219,18 @@ class TestSettingsShape:
         assert field["type"] == IncrementalFieldType.DateTime
 
 
-def test_missing_refresh_token_error_is_non_retryable():
-    """The ValueError raised when the config has no refresh token must match a non-retryable
-    pattern, otherwise the job retries a permanent misconfiguration forever."""
-    error_msg = "Hubspot refresh token not found for job 019cdc50-67a5-0000-c023-0d6a4e057e9b"
+@pytest.mark.parametrize(
+    "error_msg",
+    [
+        # HubspotSourceOldConfig path
+        "Hubspot refresh token not found for job 019cdc50-67a5-0000-c023-0d6a4e057e9b",
+        # HubspotSourceConfig OAuth path
+        "Hubspot refresh or access token not found for job 019cdc50-67a5-0000-c023-0d6a4e057e9b",
+    ],
+)
+def test_missing_token_error_is_non_retryable(error_msg: str) -> None:
+    """Each ValueError raised when a token is missing must match a non-retryable pattern,
+    otherwise the job retries a permanent misconfiguration forever."""
     patterns = HubspotSource().get_non_retryable_errors()
     assert any(pattern in error_msg for pattern in patterns), (
         f"HubSpot error {error_msg!r} did not match any non-retryable pattern"

--- a/posthog/temporal/data_imports/sources/hubspot/test/test_source_routing.py
+++ b/posthog/temporal/data_imports/sources/hubspot/test/test_source_routing.py
@@ -217,3 +217,13 @@ class TestSettingsShape:
         field = config.incremental_fields[0]
         assert field["field"] == config.cursor_filter_property_field
         assert field["type"] == IncrementalFieldType.DateTime
+
+
+def test_missing_refresh_token_error_is_non_retryable():
+    """The ValueError raised when the config has no refresh token must match a non-retryable
+    pattern, otherwise the job retries a permanent misconfiguration forever."""
+    error_msg = "Hubspot refresh token not found for job 019cdc50-67a5-0000-c023-0d6a4e057e9b"
+    patterns = HubspotSource().get_non_retryable_errors()
+    assert any(pattern in error_msg for pattern in patterns), (
+        f"HubSpot error {error_msg!r} did not match any non-retryable pattern"
+    )


### PR DESCRIPTION
## Problem

The HubSpot source generated a high volume of repeated `ValueError: Hubspot refresh token not found for job <id>` events, raised from `source_for_pipeline` when the source config carries no refresh token (the integration was never connected or lost its token). The source's `get_non_retryable_errors()` had a `"missing or invalid refresh token"` pattern, but that wording differs from the actual message, so it never matched and the job retried a permanent misconfiguration indefinitely.

## Changes

- Added `"Hubspot refresh token not found"` (the stable part of the raised message, minus the per-job id) to `get_non_retryable_errors()`, with a friendly "reconnect" message.

## How did you test this code?

I'm an agent. I added a test (33 in the module, all passing) and ran ruff check + format. The test asserts the real raised message (with a job id) matches a non-retryable pattern.

No manual testing against live HubSpot was performed.

## 🤖 Agent context

Authored with Claude Code. Found via the PostHog MCP error-tracking group. The existing pattern looked like it covered this but used different wording than the actual `ValueError`, so matching the real message text is the fix.
