### PR TITLE
fix: support double liner

### DIFF
--- a/products/conversations/backend/api/tests/test_formatting.py
+++ b/products/conversations/backend/api/tests/test_formatting.py
@@ -154,9 +154,44 @@ class TestSlackFormatting(SimpleTestCase):
         slack_text, slack_blocks = rich_content_to_slack_payload(rich_content, "")
         content, parsed_rich_content = slack_to_content_and_rich_content(slack_text, slack_blocks)
 
-        assert content == "line1  \nline2\n\nline3"
+        assert content == "line1  \nline2\n\n\n\nline3"
         assert parsed_rich_content is not None
-        assert len(parsed_rich_content["content"]) == 2
+        # 3 paragraphs: original 2 + spacer section between them
+        assert len(parsed_rich_content["content"]) == 3
+
+    def test_outbound_multi_paragraph_produces_spacer_sections(self) -> None:
+        rich_content = {
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "para1"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": "para2"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": "para3"}]},
+            ],
+        }
+
+        _, slack_blocks = rich_content_to_slack_payload(rich_content, "")
+        assert slack_blocks is not None
+
+        elements = slack_blocks[0]["elements"]
+        # 3 content sections + 2 spacer sections = 5
+        assert len(elements) == 5
+        assert elements[0]["elements"][0]["text"] == "para1"
+        assert elements[1]["elements"][0]["text"] == "\n"
+        assert elements[2]["elements"][0]["text"] == "para2"
+        assert elements[3]["elements"][0]["text"] == "\n"
+        assert elements[4]["elements"][0]["text"] == "para3"
+
+    def test_single_paragraph_has_no_spacer(self) -> None:
+        rich_content = {
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "only one"}]},
+            ],
+        }
+
+        _, slack_blocks = rich_content_to_slack_payload(rich_content, "")
+        assert slack_blocks is not None
+        assert len(slack_blocks[0]["elements"]) == 1
 
     def test_outbound_excludes_images_from_text_when_requested(self) -> None:
         rich_content = {

--- a/products/conversations/backend/api/tests/test_formatting.py
+++ b/products/conversations/backend/api/tests/test_formatting.py
@@ -154,18 +154,23 @@ class TestSlackFormatting(SimpleTestCase):
         slack_text, slack_blocks = rich_content_to_slack_payload(rich_content, "")
         content, parsed_rich_content = slack_to_content_and_rich_content(slack_text, slack_blocks)
 
-        assert content == "line1  \nline2\n\n\n\nline3"
+        assert content == "line1  \nline2\n\n  \n\n\nline3"
         assert parsed_rich_content is not None
         # 3 paragraphs: original 2 + spacer section between them
         assert len(parsed_rich_content["content"]) == 3
 
-    def test_outbound_multi_paragraph_produces_spacer_sections(self) -> None:
+    @parameterized.expand(
+        [
+            ("single_paragraph", 1, 1),
+            ("two_paragraphs", 2, 3),
+            ("three_paragraphs", 3, 5),
+        ]
+    )
+    def test_outbound_paragraph_spacer_sections(self, _name: str, para_count: int, expected_elements: int) -> None:
         rich_content = {
             "type": "doc",
             "content": [
-                {"type": "paragraph", "content": [{"type": "text", "text": "para1"}]},
-                {"type": "paragraph", "content": [{"type": "text", "text": "para2"}]},
-                {"type": "paragraph", "content": [{"type": "text", "text": "para3"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": f"para{i + 1}"}]} for i in range(para_count)
             ],
         }
 
@@ -173,25 +178,12 @@ class TestSlackFormatting(SimpleTestCase):
         assert slack_blocks is not None
 
         elements = slack_blocks[0]["elements"]
-        # 3 content sections + 2 spacer sections = 5
-        assert len(elements) == 5
-        assert elements[0]["elements"][0]["text"] == "para1"
-        assert elements[1]["elements"][0]["text"] == "\n"
-        assert elements[2]["elements"][0]["text"] == "para2"
-        assert elements[3]["elements"][0]["text"] == "\n"
-        assert elements[4]["elements"][0]["text"] == "para3"
-
-    def test_single_paragraph_has_no_spacer(self) -> None:
-        rich_content = {
-            "type": "doc",
-            "content": [
-                {"type": "paragraph", "content": [{"type": "text", "text": "only one"}]},
-            ],
-        }
-
-        _, slack_blocks = rich_content_to_slack_payload(rich_content, "")
-        assert slack_blocks is not None
-        assert len(slack_blocks[0]["elements"]) == 1
+        assert len(elements) == expected_elements
+        for i, el in enumerate(elements):
+            if i % 2 == 0:
+                assert el["elements"][0]["text"] == f"para{i // 2 + 1}"
+            else:
+                assert el["elements"][0]["text"] == "\n"
 
     def test_outbound_excludes_images_from_text_when_requested(self) -> None:
         rich_content = {

--- a/products/conversations/backend/formatting.py
+++ b/products/conversations/backend/formatting.py
@@ -511,6 +511,10 @@ def rich_content_to_slack_blocks(rich_content: JSON | None, include_images: bool
                         section_elements.append({"type": "link", "url": src, "text": alt})
 
             if section_elements:
+                if rich_text_elements:
+                    rich_text_elements.append(
+                        {"type": "rich_text_section", "elements": [{"type": "text", "text": "\n"}]}
+                    )
                 rich_text_elements.append({"type": "rich_text_section", "elements": section_elements})
             continue
 


### PR DESCRIPTION
Fix double-linebreaks in Slack