### PR TITLE
fix(tasks): chunk long slack relay messages instead of truncating

### DIFF
--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -99,6 +99,109 @@ def _convert_tables(text: str) -> str:
     return "\n".join(result)
 
 
+# Slack renders text above ~4000 characters as a "Show more" affordance and silently truncates;
+# splitting at 3500 leaves comfortable headroom for the mention prefix and code-fence overhead.
+SLACK_MESSAGE_TEXT_LIMIT = 3500
+
+_FENCED_CODE_RE = re.compile(r"```([^\n]*)\n([\s\S]*?)\n```")
+
+
+def _split_text_for_slack(text: str, limit: int = SLACK_MESSAGE_TEXT_LIMIT) -> list[str]:
+    """Split text into Slack-sized chunks, preferring paragraph and line boundaries.
+
+    Fenced code blocks that cross a chunk boundary are closed at the end of one
+    chunk and reopened (with the same language hint) at the start of the next so
+    each posted chunk renders as valid mrkdwn on its own.
+    """
+    if len(text) <= limit:
+        return [text]
+
+    segments: list[tuple[str, str, str]] = []
+    pos = 0
+    for match in _FENCED_CODE_RE.finditer(text):
+        if match.start() > pos:
+            segments.append(("text", "", text[pos : match.start()]))
+        segments.append(("code", match.group(1), match.group(2)))
+        pos = match.end()
+    if pos < len(text):
+        segments.append(("text", "", text[pos:]))
+
+    chunks: list[str] = []
+    current = ""
+
+    def flush() -> None:
+        nonlocal current
+        stripped = current.rstrip()
+        if stripped:
+            chunks.append(stripped)
+        current = ""
+
+    def append_atom(atom: str, separator: str = "") -> None:
+        """Append ``atom`` to the current chunk, flushing first if it would overflow."""
+        nonlocal current
+        candidate = current + (separator if current else "") + atom
+        if len(candidate) <= limit:
+            current = candidate
+            return
+        flush()
+        current = atom
+
+    def split_long_line(line: str) -> None:
+        """Hard-split a single line that is itself longer than the limit."""
+        nonlocal current
+        remaining = line
+        while len(remaining) > limit:
+            flush()
+            chunks.append(remaining[:limit])
+            remaining = remaining[limit:]
+        if remaining:
+            append_atom(remaining, separator="\n")
+
+    for kind, lang, body in segments:
+        if kind == "text":
+            for paragraph_index, paragraph in enumerate(body.split("\n\n")):
+                separator = "\n\n" if paragraph_index > 0 or current else ""
+                if len(current) + len(separator) + len(paragraph) <= limit:
+                    current = current + separator + paragraph
+                    continue
+                if len(paragraph) <= limit:
+                    append_atom(paragraph, separator="\n\n")
+                    continue
+                # Paragraph alone overflows — fall back to per-line packing.
+                for line_index, line in enumerate(paragraph.split("\n")):
+                    sep = "\n" if line_index > 0 or current else ""
+                    if len(current) + len(sep) + len(line) <= limit:
+                        current = current + sep + line
+                    elif len(line) <= limit:
+                        append_atom(line, separator="\n")
+                    else:
+                        split_long_line(line)
+            continue
+
+        fence_open = f"```{lang}\n" if lang else "```\n"
+        fence_close = "\n```"
+        full_block = f"{fence_open}{body}{fence_close}"
+        if len(full_block) <= limit:
+            append_atom(full_block, separator="\n\n")
+            continue
+        # Block itself overflows — emit it across multiple fenced chunks, line-aligned.
+        flush()
+        overhead = len(fence_open) + len(fence_close)
+        room = max(1, limit - overhead)
+        cursor = 0
+        while cursor < len(body):
+            end = min(cursor + room, len(body))
+            if end < len(body):
+                newline = body.rfind("\n", cursor, end)
+                if newline > cursor:
+                    end = newline
+            chunks.append(f"{fence_open}{body[cursor:end]}{fence_close}")
+            cursor = end + 1 if end < len(body) and body[end] == "\n" else end
+
+    flush()
+    return chunks
+
+
 @dataclass
 class RelaySlackMessageInput:
     run_id: str
@@ -138,10 +241,7 @@ def relay_slack_message(input: RelaySlackMessageInput) -> None:
         return
 
     text = _markdown_to_slack_mrkdwn(text)
-
-    SLACK_MESSAGE_TEXT_LIMIT = 3900
-    if len(text) > SLACK_MESSAGE_TEXT_LIMIT:
-        text = f"{text[: SLACK_MESSAGE_TEXT_LIMIT - 3]}..."
+    chunks = _split_text_for_slack(text)
 
     context = SlackThreadContext(
         integration_id=mapping.integration_id,
@@ -155,7 +255,9 @@ def relay_slack_message(input: RelaySlackMessageInput) -> None:
     mention_prefix = f"<@{mapping.mentioning_slack_user_id}> " if mapping.mentioning_slack_user_id else ""
     if input.delete_progress:
         handler.delete_progress()
-    handler.post_thread_message(f"{mention_prefix}{text}")
+    for index, chunk in enumerate(chunks):
+        prefix = mention_prefix if index == 0 else ""
+        handler.post_thread_message(f"{prefix}{chunk}")
     if input.reaction_emoji is not None:
         handler.update_reaction(input.reaction_emoji)
 

--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -106,12 +106,17 @@ SLACK_MESSAGE_TEXT_LIMIT = 3500
 _FENCED_CODE_RE = re.compile(r"```([^\n]*)\n([\s\S]*?)\n```")
 
 
-def _split_text_for_slack(text: str, limit: int = SLACK_MESSAGE_TEXT_LIMIT) -> list[str]:
-    """Split text into Slack-sized chunks, preferring paragraph and line boundaries.
+def _split_markdown_for_slack(text: str, limit: int = SLACK_MESSAGE_TEXT_LIMIT) -> list[str]:
+    """Split raw markdown into Slack-sized chunks at safe structural boundaries.
 
-    Fenced code blocks that cross a chunk boundary are closed at the end of one
-    chunk and reopened (with the same language hint) at the start of the next so
-    each posted chunk renders as valid mrkdwn on its own.
+    Splits prefer paragraph (``\\n\\n``) and line (``\\n``) boundaries, then a hard
+    character break as a last resort. Fenced code blocks that cross a chunk
+    boundary are closed at the end of one chunk and reopened (with the same
+    language hint) at the start of the next so each chunk is a self-contained
+    markdown document. Callers convert each chunk to Slack mrkdwn independently;
+    that ordering means a hard char break inside an inline span like ``**bold**``
+    or ``[text](url)`` leaves the broken halves as literal text rather than
+    producing dangling unbalanced markers in the rendered output.
     """
     if len(text) <= limit:
         return [text]
@@ -240,8 +245,11 @@ def relay_slack_message(input: RelaySlackMessageInput) -> None:
         logger.info("slack_relay_empty_text", run_id=input.run_id, relay_id=input.relay_id)
         return
 
-    text = _markdown_to_slack_mrkdwn(text)
-    chunks = _split_text_for_slack(text)
+    # Split the raw markdown first, then convert each chunk independently. Converting
+    # per-chunk means an inline span broken by a hard char split (e.g. ``**bold**``
+    # halved) stays literal in the output instead of leaving dangling Slack-mrkdwn
+    # markers that would garble the rendering of surrounding text.
+    chunks = [_markdown_to_slack_mrkdwn(chunk) for chunk in _split_markdown_for_slack(text)]
 
     context = SlackThreadContext(
         integration_id=mapping.integration_id,

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -17,7 +17,7 @@ from products.tasks.backend.temporal.slack_relay.activities import (
     SLACK_MESSAGE_TEXT_LIMIT,
     RelaySlackMessageInput,
     _markdown_to_slack_mrkdwn,
-    _split_text_for_slack,
+    _split_markdown_for_slack,
     relay_slack_message,
 )
 
@@ -144,12 +144,12 @@ class TestMarkdownToSlackMrkdwn(TestCase):
 
 class TestSplitTextForSlack(TestCase):
     def test_short_text_returns_single_chunk(self):
-        assert _split_text_for_slack("hello world") == ["hello world"]
+        assert _split_markdown_for_slack("hello world") == ["hello world"]
 
     def test_each_chunk_under_limit(self):
         paragraph = ("word " * 200).strip()
         text = "\n\n".join([paragraph] * 10)
-        chunks = _split_text_for_slack(text)
+        chunks = _split_markdown_for_slack(text)
         assert len(chunks) > 1
         for chunk in chunks:
             assert len(chunk) <= SLACK_MESSAGE_TEXT_LIMIT
@@ -157,7 +157,7 @@ class TestSplitTextForSlack(TestCase):
     def test_split_prefers_paragraph_boundary(self):
         paragraph = ("alpha " * 400).strip()  # ~2400 chars per paragraph
         text = f"{paragraph}\n\n{paragraph}"
-        chunks = _split_text_for_slack(text)
+        chunks = _split_markdown_for_slack(text)
         assert len(chunks) == 2
         assert chunks[0] == paragraph
         assert chunks[1] == paragraph
@@ -165,7 +165,7 @@ class TestSplitTextForSlack(TestCase):
     def test_split_falls_back_to_line_within_paragraph(self):
         line = ("alpha " * 100).strip()  # ~600 chars
         text = "\n".join([line] * 10)  # single paragraph, ~6000 chars
-        chunks = _split_text_for_slack(text)
+        chunks = _split_markdown_for_slack(text)
         assert len(chunks) >= 2
         for chunk in chunks:
             for chunk_line in chunk.split("\n"):
@@ -173,7 +173,7 @@ class TestSplitTextForSlack(TestCase):
 
     def test_hard_breaks_single_long_line(self):
         line = "x" * (SLACK_MESSAGE_TEXT_LIMIT + 500)
-        chunks = _split_text_for_slack(line)
+        chunks = _split_markdown_for_slack(line)
         assert len(chunks) == 2
         assert all(len(chunk) <= SLACK_MESSAGE_TEXT_LIMIT for chunk in chunks)
         assert "".join(chunks) == line
@@ -182,7 +182,7 @@ class TestSplitTextForSlack(TestCase):
         body_lines = [f"line {i:04d}" for i in range(800)]
         body = "\n".join(body_lines)
         text = f"```python\n{body}\n```"
-        chunks = _split_text_for_slack(text)
+        chunks = _split_markdown_for_slack(text)
         assert len(chunks) >= 2
         for chunk in chunks:
             assert chunk.startswith("```python\n")
@@ -195,10 +195,44 @@ class TestSplitTextForSlack(TestCase):
         suffix = "\n\ntrailing paragraph"
         code = "```js\n" + "console.log('hi');\n" * 10 + "```"
         text = prefix + code + suffix
-        chunks = _split_text_for_slack(text)
+        chunks = _split_markdown_for_slack(text)
         joined = "\n\n".join(chunks)
         assert "```js\n" in joined
         assert joined.count("```") % 2 == 0
+
+    def test_paragraph_split_preserves_markdown_for_per_chunk_conversion(self):
+        # Each chunk must stay a valid markdown document on its own so that the
+        # per-chunk mrkdwn conversion produces correctly-rendered output.
+        paragraph_a = "This **bold** and [link](https://example.com) " * 50
+        paragraph_b = "Another **bold** and [link](https://example.com) " * 50
+        text = f"{paragraph_a.strip()}\n\n{paragraph_b.strip()}"
+        chunks = _split_markdown_for_slack(text)
+        assert len(chunks) == 2
+        for chunk in chunks:
+            converted = _markdown_to_slack_mrkdwn(chunk)
+            assert "*bold*" in converted
+            assert "<https://example.com|link>" in converted
+            assert "**" not in converted  # inline bold markers must be fully converted
+
+    def test_hard_char_break_leaves_broken_inline_span_as_literal(self):
+        # A single line longer than the limit forces a hard char break. Doing it
+        # before conversion means a halved ``**bold**`` simply fails to match the
+        # converter regex on either side, so both chunks keep the literal ``**``
+        # rather than ending up with a dangling unbalanced ``*`` in Slack mrkdwn.
+        prefix = "x" * (SLACK_MESSAGE_TEXT_LIMIT - 4)
+        line = prefix + "**bold**" + "y" * 100
+        chunks = _split_markdown_for_slack(line)
+        assert len(chunks) == 2
+        converted_first = _markdown_to_slack_mrkdwn(chunks[0])
+        converted_second = _markdown_to_slack_mrkdwn(chunks[1])
+        # Neither chunk should contain a valid Slack-mrkdwn ``*bold*`` because
+        # the span was halved; both should preserve the raw asterisks instead.
+        assert "*bold*" not in converted_first
+        assert "*bold*" not in converted_second
+        # And, critically, no chunk leaks a lone unbalanced ``*`` that would
+        # turn the rest of the message italic.
+        for chunk in (converted_first, converted_second):
+            assert chunk.count("*") % 2 == 0
 
 
 class TestRelaySlackMessageChunking(TestCase):

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -14,8 +14,10 @@ from posthog.models.user import User
 from products.slack_app.backend.models import SlackThreadTaskMapping
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.slack_relay.activities import (
+    SLACK_MESSAGE_TEXT_LIMIT,
     RelaySlackMessageInput,
     _markdown_to_slack_mrkdwn,
+    _split_text_for_slack,
     relay_slack_message,
 )
 
@@ -138,3 +140,139 @@ class TestMarkdownToSlackMrkdwn(TestCase):
         result = _markdown_to_slack_mrkdwn(md)
         assert "```python\n**not bold**\n```" in result
         assert "*this is bold*" in result
+
+
+class TestSplitTextForSlack(TestCase):
+    def test_short_text_returns_single_chunk(self):
+        assert _split_text_for_slack("hello world") == ["hello world"]
+
+    def test_each_chunk_under_limit(self):
+        paragraph = ("word " * 200).strip()
+        text = "\n\n".join([paragraph] * 10)
+        chunks = _split_text_for_slack(text)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert len(chunk) <= SLACK_MESSAGE_TEXT_LIMIT
+
+    def test_split_prefers_paragraph_boundary(self):
+        paragraph = ("alpha " * 400).strip()  # ~2400 chars per paragraph
+        text = f"{paragraph}\n\n{paragraph}"
+        chunks = _split_text_for_slack(text)
+        assert len(chunks) == 2
+        assert chunks[0] == paragraph
+        assert chunks[1] == paragraph
+
+    def test_split_falls_back_to_line_within_paragraph(self):
+        line = ("alpha " * 100).strip()  # ~600 chars
+        text = "\n".join([line] * 10)  # single paragraph, ~6000 chars
+        chunks = _split_text_for_slack(text)
+        assert len(chunks) >= 2
+        for chunk in chunks:
+            for chunk_line in chunk.split("\n"):
+                assert chunk_line == line
+
+    def test_hard_breaks_single_long_line(self):
+        line = "x" * (SLACK_MESSAGE_TEXT_LIMIT + 500)
+        chunks = _split_text_for_slack(line)
+        assert len(chunks) == 2
+        assert all(len(chunk) <= SLACK_MESSAGE_TEXT_LIMIT for chunk in chunks)
+        assert "".join(chunks) == line
+
+    def test_oversized_code_block_keeps_fences_balanced(self):
+        body_lines = [f"line {i:04d}" for i in range(800)]
+        body = "\n".join(body_lines)
+        text = f"```python\n{body}\n```"
+        chunks = _split_text_for_slack(text)
+        assert len(chunks) >= 2
+        for chunk in chunks:
+            assert chunk.startswith("```python\n")
+            assert chunk.endswith("\n```")
+            assert chunk.count("```") == 2
+            assert len(chunk) <= SLACK_MESSAGE_TEXT_LIMIT
+
+    def test_mixed_text_and_code_block_preserves_block(self):
+        prefix = "intro paragraph\n\n"
+        suffix = "\n\ntrailing paragraph"
+        code = "```js\n" + "console.log('hi');\n" * 10 + "```"
+        text = prefix + code + suffix
+        chunks = _split_text_for_slack(text)
+        joined = "\n\n".join(chunks)
+        assert "```js\n" in joined
+        assert joined.count("```") % 2 == 0
+
+
+class TestRelaySlackMessageChunking(TestCase):
+    org: ClassVar[Organization]
+    team: ClassVar[Team]
+    user: ClassVar[User]
+    integration: ClassVar[Integration]
+    task: ClassVar[Task]
+    task_run: ClassVar[TaskRun]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.org = Organization.objects.create(name="ChunkOrg")
+        cls.team = Team.objects.create(organization=cls.org, name="ChunkTeam")
+        cls.user = User.objects.create(email="bob@test.com")
+        cls.task = Task.objects.create(
+            team=cls.team,
+            title="Chunk task",
+            description="desc",
+            origin_product=Task.OriginProduct.SLACK,
+            created_by=cls.user,
+            repository="org/repo",
+        )
+        cls.task_run = TaskRun.objects.create(
+            task=cls.task,
+            team=cls.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            state={},
+        )
+        cls.integration = Integration.objects.create(
+            team=cls.team,
+            kind="slack",
+            integration_id="T456",
+            config={},
+        )
+        SlackThreadTaskMapping.objects.create(
+            team=cls.team,
+            integration=cls.integration,
+            slack_workspace_id="T456",
+            channel="C456",
+            thread_ts="2222.2",
+            task=cls.task,
+            task_run=cls.task_run,
+            mentioning_slack_user_id="U456",
+        )
+
+    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.update_reaction")
+    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.post_thread_message")
+    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.delete_progress")
+    def test_long_text_posts_multiple_chunks_with_prefix_only_on_first(
+        self,
+        mock_delete_progress,
+        mock_post,
+        mock_update,
+    ):
+        paragraph = ("alpha " * 400).strip()
+        text = "\n\n".join([paragraph] * 4)
+        relay_slack_message(
+            RelaySlackMessageInput(
+                run_id=str(self.task_run.id),
+                relay_id="relay-chunked",
+                text=text,
+                user_message_ts="1234.5",
+                reaction_emoji="hedgehog",
+            )
+        )
+
+        mock_delete_progress.assert_called_once()
+        assert mock_post.call_count >= 2
+        first_posted = mock_post.call_args_list[0].args[0]
+        assert first_posted.startswith("<@U456> ")
+        for call in mock_post.call_args_list[1:]:
+            assert not call.args[0].startswith("<@U456>")
+        mock_update.assert_called_once_with("hedgehog")
+
+        self.task_run.refresh_from_db()
+        assert "relay-chunked" in self.task_run.state.get("slack_sent_relay_ids", [])


### PR DESCRIPTION
## Problem

When a PostHog Code agent relays its task result back into a Slack thread, the Slack relay activity caps the message at 3900 characters with a `…` suffix. Anything past that is silently dropped, so the user in the thread only sees the head of a long answer with no obvious indicator that the rest was thrown away.

## Changes

Replace the truncation step in `relay_slack_message` with `_split_text_for_slack`, which splits the already-converted mrkdwn into chunks at most 3500 characters long. Splits prefer paragraph (`\n\n`) and line (`\n`) boundaries; oversized single lines fall back to a hard character break. Fenced code blocks that cross a chunk boundary are closed at the end of one chunk and reopened with their original language hint on the next, so each chunk is renderable on its own.

The relay activity now posts the chunks sequentially in the same thread. The user mention prefix is applied only to the first chunk; `delete_progress` runs once before the first chunk; `update_reaction` runs once after the last. The relay is still recorded as sent once after all chunks are posted, matching the existing best-effort semantics where `post_thread_message` swallows individual Slack failures.

## How did you test this code?

I am Claude (Opus 4.7, Claude Code). I did not perform manual end-to-end Slack testing.

Automated tests run locally:

- `hogli test products/tasks/backend/temporal/slack_relay/tests/test_activities.py` — 22 passed.

New tests cover:

- `_split_text_for_slack`: short-text passthrough, every chunk ≤ limit, paragraph-boundary preference, line-within-paragraph fallback, hard char break on a single long line, oversized code-block fence balance, and a mixed text + code-block scenario.
- `relay_slack_message`: long text produces multiple `post_thread_message` calls, mention prefix appears only on the first chunk, `delete_progress` and `update_reaction` are still called exactly once, and the relay id is recorded in `slack_sent_relay_ids`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs are affected.

## 🤖 Agent context

Authored by Claude Code (Opus 4.7, 1M context) in an interactive session with @VojtechBartos. Investigation traced the truncation to `relay_slack_message` in `products/tasks/backend/temporal/slack_relay/activities.py`. Considered tracking chunk-level idempotency to survive partial failure mid-batch, but rejected it: `post_thread_message` already swallows Slack errors, so the existing relay-id idempotency window is sufficient and avoids accidental duplicate posts on retry. Mention prefix and reaction/progress side effects are intentionally applied once per relay rather than per chunk.