### PR TITLE
feat(taxonomic-filter): scope recents and pinned to the picker's groups

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -45,6 +45,7 @@ import { useTaxonomicFilterContext } from '../headless/context'
 import { recentTaxonomicFiltersLogic } from '../recentTaxonomicFiltersLogic'
 import { taxonomicFilterPinnedPropertiesLogic } from '../taxonomicFilterPinnedPropertiesLogic'
 import { META_GROUP_TYPES, TaxonomicDefinitionTypes, TaxonomicFilterGroupType } from '../types'
+import { filterPinnedForContext, filterRecentsForContext } from '../utils/suggestedContextFilters'
 import { MenuFilterCombobox } from './Combobox'
 import { MenuFilterDwhConfig } from './DwhFlow'
 import { MenuFilterHogQLEditor } from './HogQLEditor'
@@ -235,13 +236,32 @@ export function TaxonomicFilterMenu({
     const { recentFilterItems } = useValues(recentTaxonomicFiltersLogic)
     const { pinnedFilterItems } = useValues(taxonomicFilterPinnedPropertiesLogic)
 
+    // Only recents/pinned whose source group is one of this picker's groups —
+    // a global recent from a different picker (e.g. a cohort in an events-only
+    // picker) would otherwise be remapped onto a fallback group and shown under
+    // the wrong category.
+    const taxonomicGroupTypes = useMemo(() => groups.map((g) => g.type), [groups])
     const recentEntries = useMemo<MenuFilterEntry[]>(
-        () => mapShortcutItems(recentFilterItems as ShortcutItem[], groups),
-        [recentFilterItems, groups]
+        () =>
+            mapShortcutItems(
+                filterRecentsForContext(
+                    recentFilterItems as TaxonomicDefinitionTypes[],
+                    taxonomicGroupTypes
+                ) as ShortcutItem[],
+                groups
+            ),
+        [recentFilterItems, taxonomicGroupTypes, groups]
     )
     const pinnedEntries = useMemo<MenuFilterEntry[]>(
-        () => mapShortcutItems(pinnedFilterItems as ShortcutItem[], groups),
-        [pinnedFilterItems, groups]
+        () =>
+            mapShortcutItems(
+                filterPinnedForContext(
+                    pinnedFilterItems as TaxonomicDefinitionTypes[],
+                    taxonomicGroupTypes
+                ) as ShortcutItem[],
+                groups
+            ),
+        [pinnedFilterItems, taxonomicGroupTypes, groups]
     )
 
     const hasDwh = groups.some((g) => g.type === TaxonomicFilterGroupType.DataWarehouse)

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.test.ts
@@ -1,0 +1,75 @@
+import { PropertyOperator } from '~/types'
+
+import { TaxonomicDefinitionTypes, TaxonomicFilterGroupType } from '../types'
+import { filterPinnedForContext, filterRecentsForContext } from './suggestedContextFilters'
+
+const { Events, EventProperties, Cohorts } = TaxonomicFilterGroupType
+
+function recent(
+    sourceGroupType: TaxonomicFilterGroupType,
+    name: string,
+    extra: Record<string, unknown> = {}
+): TaxonomicDefinitionTypes {
+    return {
+        name,
+        _recentContext: { sourceGroupType, sourceValue: name, ...extra },
+    } as unknown as TaxonomicDefinitionTypes
+}
+
+function pinned(sourceGroupType: TaxonomicFilterGroupType, name: string): TaxonomicDefinitionTypes {
+    return { name, _pinnedContext: { sourceGroupType, value: name } } as unknown as TaxonomicDefinitionTypes
+}
+
+const names = (items: TaxonomicDefinitionTypes[]): string[] => items.map((i) => (i as { name: string }).name)
+
+describe('suggestedContextFilters', () => {
+    describe.each([
+        ['only in-scope kept', [recent(Events, 'a'), recent(Cohorts, 'c')], [Events], ['a']],
+        ['all out-of-scope dropped', [recent(Cohorts, 'c')], [Events], []],
+        [
+            'multiple in-scope kept in order',
+            [recent(Events, 'a'), recent(EventProperties, 'b')],
+            [Events, EventProperties],
+            ['a', 'b'],
+        ],
+        ['empty input', [], [Events], []],
+    ])('filterRecentsForContext — %s', (_label, items, types, expected) => {
+        it('matches the expected in-scope set', () => {
+            expect(names(filterRecentsForContext(items, types))).toEqual(expected)
+        })
+    })
+
+    describe('filterRecentsForContext operators + key-only dedup', () => {
+        it('drops a recent whose operator is excluded for its group', () => {
+            const items = [recent(EventProperties, 'p', { propertyFilter: { operator: PropertyOperator.IContains } })]
+            expect(
+                filterRecentsForContext(items, [EventProperties], { [EventProperties]: [PropertyOperator.IContains] })
+            ).toHaveLength(0)
+            expect(
+                filterRecentsForContext(items, [EventProperties], { [EventProperties]: [PropertyOperator.Exact] })
+            ).toHaveLength(1)
+        })
+
+        it('dedups by storage key and strips the property filter when selecting a key only', () => {
+            const items = [
+                recent(EventProperties, 'plan', { propertyFilter: { operator: PropertyOperator.Exact } }),
+                recent(EventProperties, 'plan', { propertyFilter: { operator: PropertyOperator.IContains } }),
+            ]
+            const out = filterRecentsForContext(items, [EventProperties], undefined, true)
+            expect(out).toHaveLength(1)
+            expect(
+                (out[0] as unknown as { _recentContext: { propertyFilter?: unknown } })._recentContext.propertyFilter
+            ).toBeUndefined()
+        })
+    })
+
+    describe.each([
+        ['only in-scope kept', [pinned(Events, 'a'), pinned(Cohorts, 'c')], [Events], ['a']],
+        ['all out-of-scope dropped', [pinned(Cohorts, 'c')], [Events], []],
+        ['empty input', [], [Events], []],
+    ])('filterPinnedForContext — %s', (_label, items, types, expected) => {
+        it('matches the expected in-scope set', () => {
+            expect(names(filterPinnedForContext(items, types))).toEqual(expected)
+        })
+    })
+})

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
@@ -1,0 +1,81 @@
+import { hasRecentContext } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
+import { hasPinnedContext } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
+import {
+    ExcludedOperators,
+    TaxonomicDefinitionTypes,
+    TaxonomicFilterGroupType,
+} from 'lib/components/TaxonomicFilter/types'
+
+/*
+ * These mirror the legacy `infiniteListLogic` context-filter selectors
+ * (`contextFilteredRecentItems` / `contextFilteredPinnedItems`). It's a
+ * deliberate fork, not a shared util: the rebuild and the legacy kea picker
+ * are independent code paths, and the legacy one is being retired with the
+ * rest of `infiniteListLogic`. Until then, behaviour changes here that should
+ * also apply to the legacy picker must be made in both places.
+ */
+
+/** Recents whose source group is one of the picker's groups, with operators the
+ *  host can't represent filtered out, and (when selecting a key only) deduped by
+ *  storage key, so the picker stops surfacing recents that belong to a
+ *  different picker. */
+export function filterRecentsForContext(
+    recentFilterItems: TaxonomicDefinitionTypes[],
+    taxonomicGroupTypes: TaxonomicFilterGroupType[],
+    excludedOperators?: ExcludedOperators,
+    selectingKeyOnly?: boolean
+): TaxonomicDefinitionTypes[] {
+    if (!recentFilterItems?.length) {
+        return []
+    }
+    const availableTypes = new Set(taxonomicGroupTypes)
+    const inScope = recentFilterItems.filter((item) => {
+        if (!hasRecentContext(item) || !availableTypes.has(item._recentContext.sourceGroupType)) {
+            return false
+        }
+        const excludedForGroup = excludedOperators?.[item._recentContext.sourceGroupType]
+        if (excludedForGroup?.length) {
+            const propertyFilter = item._recentContext.propertyFilter
+            const operator = propertyFilter && 'operator' in propertyFilter ? propertyFilter.operator : undefined
+            if (operator && excludedForGroup.includes(operator)) {
+                return false
+            }
+        }
+        return true
+    })
+    if (!selectingKeyOnly) {
+        return inScope
+    }
+    const seen = new Set<string>()
+    const dedupedItems: TaxonomicDefinitionTypes[] = []
+    for (const item of inScope) {
+        if (!hasRecentContext(item)) {
+            continue
+        }
+        // Dedup by the persisted storage key (source group + value), not by
+        // item.name — for groups like Cohorts/Actions the name is a display
+        // label that can be unstable, while the stored value is canonical.
+        const dedupKey = `${item._recentContext.sourceGroupType}::${item._recentContext.sourceValue ?? ''}`
+        if (seen.has(dedupKey)) {
+            continue
+        }
+        seen.add(dedupKey)
+        const { propertyFilter: _propertyFilter, ...restContext } = item._recentContext
+        dedupedItems.push({ ...item, _recentContext: restContext } as unknown as TaxonomicDefinitionTypes)
+    }
+    return dedupedItems
+}
+
+/** Pinned items whose source group is one of the picker's groups. */
+export function filterPinnedForContext(
+    pinnedFilterItems: TaxonomicDefinitionTypes[],
+    taxonomicGroupTypes: TaxonomicFilterGroupType[]
+): TaxonomicDefinitionTypes[] {
+    if (!pinnedFilterItems?.length) {
+        return []
+    }
+    const availableTypes = new Set(taxonomicGroupTypes)
+    return pinnedFilterItems.filter(
+        (item) => hasPinnedContext(item) && availableTypes.has(item._pinnedContext.sourceGroupType)
+    )
+}


### PR DESCRIPTION
we shouldn't show a recent or a pinned item if it can't be chosen in the current context

## Problem

Recents and pinned items are stored globally across every TaxonomicFilter. In the rebuild's menu Combobox, a recent/pinned item whose source group wasn't part of the current picker was remapped onto a fallback group and shown under the wrong category — e.g. a recent cohort surfacing (mislabelled) in an events-only picker. The pill variant drops these out-of-scope shortcuts.

## Changes

Filter the raw `recentFilterItems` / `pinnedFilterItems` to the picker's group types _before_ mapping them into menu entries, so only in-scope shortcuts surface. This ports the pill variant's `contextFilteredRecentItems` / `contextFilteredPinnedItems` as small pure helpers (`filterRecentsForContext` / `filterPinnedForContext`).

The helper also supports operator-exclusion and key-only dedup (both pill behaviours); the menu currently passes only the group types, so threading `excludedOperators` / `selectingKeyOnly` through is a follow-up.

## How did you test this code?

I'm an agent (PostHog Code) — no manual QA. Parameterized unit tests (`suggestedContextFilters.test.ts`): in-scope kept, out-of-scope dropped, operator exclusion, and key-only dedup + property-filter strip. Full `TaxonomicFilter/` jest suite green; `tsc` clean on the changed files.

## 🤖 Agent context

This PR was originally "port recents + pinned into the headless Suggested tab" (one of a stack layering the Suggested composition onto the headless `Panel`). That surface isn't rendered in production — the menu Combobox is, and it has its own recents/pinned handling. The base PR now surfaces recents/pinned directly in the menu, so this PR was **repointed** to the one piece of its logic the menu still lacked versus pill: dropping out-of-scope recents/pinned. The headless composition was removed.

The two PRs that previously stacked on top of this one were detached from the Graphite stack pending their own assessment.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)