### PR TITLE
feat(taxonomic-filter): aggregate cross-tab top matches in Suggested tab

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/headless/Root.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/Root.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react'
 
 import { useTaxonomicFilter, UseTaxonomicFilterOptions } from '../hooks/useTaxonomicFilter'
 import { TaxonomicFilterContext } from './context'
+import { SuggestedTopMatchCollector } from './SuggestedTopMatchCollector'
 
 export interface TaxonomicFilterRootProps extends UseTaxonomicFilterOptions {
     children: ReactNode
@@ -21,6 +22,7 @@ export function TaxonomicFilterRoot({
         <TaxonomicFilterContext.Provider value={api} data-quill>
             <div className={className} {...(bindRootProps ? api.rootProps : {})}>
                 {children}
+                <SuggestedTopMatchCollector />
             </div>
         </TaxonomicFilterContext.Provider>
     )

--- a/frontend/src/lib/components/TaxonomicFilter/headless/SuggestedTopMatchCollector.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/SuggestedTopMatchCollector.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from 'react'
+
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { TopMatchItem } from 'lib/components/TaxonomicFilter/utils/redistributeTopMatches'
+
+import { useGroupList } from '../hooks/useGroupList'
+import { TaxonomicFilterGroup } from '../types'
+import { useTaxonomicFilterContext } from './context'
+
+/**
+ * Headless, render-nothing collector that feeds the SuggestedFilters tab's
+ * cross-tab aggregation. Mounts one invisible probe per content group while a
+ * query is active; each probe runs the same `useGroupList` the tab counts
+ * already run (so the fetch is shared via the resource cache) and publishes its
+ * top matches into the orchestrator's registry.
+ *
+ * Why a child-per-group component rather than a `.map` of `useGroupList`: the
+ * visible group set can change between renders, and a bare hook-in-a-loop would
+ * violate the Rules of Hooks. One component instance per group (keyed by type)
+ * makes each hook's lifecycle independent — the same pattern `Categories` uses.
+ */
+export function SuggestedTopMatchCollector(): JSX.Element | null {
+    const { groups, groupTypes, metaGroupTypes, searchQuery } = useTaxonomicFilterContext()
+
+    if (!searchQuery.trim() || !groupTypes.includes(TaxonomicFilterGroupType.SuggestedFilters)) {
+        return null
+    }
+
+    const contentGroups = groups.filter((g) => !metaGroupTypes.has(g.type))
+    return (
+        <>
+            {contentGroups.map((group) => (
+                <GroupTopMatchProbe key={group.type} group={group} />
+            ))}
+        </>
+    )
+}
+
+function GroupTopMatchProbe({ group }: { group: TaxonomicFilterGroup }): null {
+    const { getGroupListInput, reportTopMatches } = useTaxonomicFilterContext()
+    const list = useGroupList(getGroupListInput(group))
+    const matches = list.topMatchesForQuery
+    const isFetching = list.isFetching
+
+    useEffect(() => {
+        const tagged: TopMatchItem[] = matches.map((item) => ({ ...item, group: group.type }) as TopMatchItem)
+        reportTopMatches(group.type, tagged, isFetching)
+    }, [group.type, matches, isFetching, reportTopMatches])
+
+    return null
+}

--- a/frontend/src/lib/components/TaxonomicFilter/headless/TaxonomicFilterHeadless.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/TaxonomicFilterHeadless.stories.tsx
@@ -184,3 +184,19 @@ export const SuggestedWithRecents: Story = {
         },
     },
 }
+
+export const SuggestedAggregatedSearch: Story = {
+    render: () => (
+        <Container
+            taxonomicGroupTypes={[TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.EventProperties]}
+            initialSearchQuery="n"
+        />
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Searching from the Suggested tab surfaces the best matches from every content group at once — events and properties interleaved here — slot-distributed across groups and deduped against any recents/pinned. This is the cross-tab aggregation that makes the Suggested tab the one-stop search surface.',
+            },
+        },
+    },
+}

--- a/frontend/src/lib/components/TaxonomicFilter/headless/headless.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/headless.test.tsx
@@ -125,6 +125,36 @@ describe('TaxonomicFilterHeadless integration', () => {
         )
     })
 
+    it('aggregates cross-tab top matches into the Suggested tab when searching', async () => {
+        recentTaxonomicFiltersLogic.mount()
+        act(() => recentTaxonomicFiltersLogic.actions.clearRecentFilters())
+        apiGet.mockImplementation((url: string) => {
+            if (url.includes('event_definitions')) {
+                return Promise.resolve({ results: [{ id: 1, name: 'click_event' }], count: 1 })
+            }
+            if (url.includes('property_definitions')) {
+                return Promise.resolve({ results: [{ id: 2, name: 'click_prop' }], count: 1 })
+            }
+            return Promise.resolve({ results: [], count: 0 })
+        })
+        render(
+            <Provider>
+                <TaxonomicFilterHeadless.Root
+                    taxonomicGroupTypes={[TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.EventProperties]}
+                    onChange={onChangeMock}
+                >
+                    <TaxonomicFilterHeadless.Input />
+                    <TaxonomicFilterHeadless.Categories />
+                    <TaxonomicFilterHeadless.Panel />
+                </TaxonomicFilterHeadless.Root>
+            </Provider>
+        )
+        await user.type(screen.getByTestId('taxonomic-filter-searchfield'), 'click')
+        // Both groups' matches surface in the (default, active) Suggested tab.
+        await waitFor(() => expect(screen.getByText('click_event')).toBeInTheDocument())
+        expect(screen.getByText('click_prop')).toBeInTheDocument()
+    })
+
     it('mounts Root, Input, Categories and Panel without throwing', () => {
         apiGet.mockResolvedValue({ results: [{ id: 1, name: 'pageview' }], count: 1 })
         renderHeadless()

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.ts
@@ -32,6 +32,8 @@ import {
     TaxonomicFilterGroupType,
 } from 'lib/components/TaxonomicFilter/types'
 import { composeSuggestedItems } from 'lib/components/TaxonomicFilter/utils/composeSuggestedItems'
+import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
+import { MAX_TOP_MATCHES_PER_GROUP } from 'lib/components/TaxonomicFilter/utils/redistributeTopMatches'
 import { createFuse } from 'lib/utils/fuseSearch'
 
 import { getCoreFilterDefinition } from '~/taxonomy/helpers'
@@ -75,11 +77,20 @@ export interface UseGroupListInput {
     suggestedPinned?: TaxonomicDefinitionTypes[]
     suggestedRecentMatches?: TaxonomicDefinitionTypes[]
     suggestedPinnedMatches?: TaxonomicDefinitionTypes[]
+    /** SuggestedFilters only: aggregated cross-tab top matches to append. */
+    suggestedTopMatches?: TaxonomicDefinitionTypes[]
+    /** SuggestedFilters only: content-group top-match collectors still loading,
+     *  so show a loading state rather than "no results". */
+    suggestedLoading?: boolean
 }
 
 export interface UseGroupListResult {
     /** Combined items (local + remote + keyword shortcuts), with QuickFilterItems first when enabled. */
     items: TaxonomicDefinitionTypes[]
+    /** This group's contribution to the aggregated SuggestedFilters tab: keyword
+     *  shortcuts then promoted query matches, capped per group. Empty with no
+     *  query. Read by the SuggestedFilters top-match collector. */
+    topMatchesForQuery: TaxonomicDefinitionTypes[]
     /** items.length plus synthetic rows like the expand button. */
     rowCount: number
     /** Number of "real" results (excluding synthetic rows). */
@@ -127,6 +138,8 @@ export function useGroupList(input: UseGroupListInput): UseGroupListResult {
         suggestedPinned,
         suggestedRecentMatches,
         suggestedPinnedMatches,
+        suggestedTopMatches,
+        suggestedLoading = false,
     } = input
 
     const [isExpanded, setIsExpanded] = useState(false)
@@ -366,6 +379,7 @@ export function useGroupList(input: UseGroupListInput): UseGroupListResult {
                       contextPinned: suggestedPinned ?? [],
                       recentMatches: suggestedRecentMatches ?? [],
                       pinnedMatches: suggestedPinnedMatches ?? [],
+                      topMatches: suggestedTopMatches ?? [],
                   })
                 : null,
         [
@@ -376,10 +390,25 @@ export function useGroupList(input: UseGroupListInput): UseGroupListResult {
             suggestedPinned,
             suggestedRecentMatches,
             suggestedPinnedMatches,
+            suggestedTopMatches,
         ]
     )
 
     const items = suggested ? suggested.items : mergedItems
+
+    // This group's slice for the aggregated SuggestedFilters tab. Mirrors the
+    // legacy per-group `topMatchesForQuery`: keyword shortcuts lead, then the
+    // promoted real matches, capped per group. Remote results only count once
+    // they're fresh for the current query (no stale-keystroke contributions).
+    const topMatchesForQuery = useMemo<TaxonomicDefinitionTypes[]>(() => {
+        if (!trimmedSearch) {
+            return []
+        }
+        const remoteIsFresh = remoteItems.searchQuery === searchQuery
+        const realResults = hasRemoteDataSource ? (remoteIsFresh ? remoteItems.results : []) : localItems.results
+        const realMatches = promoteMatchingProperties(realResults, searchQuery).slice(0, MAX_TOP_MATCHES_PER_GROUP)
+        return [...keywordShortcuts, ...realMatches]
+    }, [trimmedSearch, hasRemoteDataSource, remoteItems, localItems, searchQuery, keywordShortcuts])
 
     const isExpandable = !!(
         group.endpoint &&
@@ -419,12 +448,18 @@ export function useGroupList(input: UseGroupListInput): UseGroupListResult {
 
     // Empty / loading state checks read array length, not the API-reported
     // total — a remote tab can have count > 0 while still loading its first
-    // page, and we don't want to flash an empty state during that window.
+    // page, and we don't want to flash an empty state during that window. For
+    // the Suggested tab, also stay in the loading state while its cross-tab
+    // collectors are still resolving, so it doesn't flash "no results".
+    const effectiveLoading = isLoading || (isSuggested && suggestedLoading)
     const showEmptyState =
-        (items.length === 0 && !isLoading && (!!searchQuery || !hasRemoteDataSource) && !showNonCapturedEventOption) ||
+        (items.length === 0 &&
+            !effectiveLoading &&
+            (!!searchQuery || !hasRemoteDataSource) &&
+            !showNonCapturedEventOption) ||
         needsMoreSearchCharacters
 
-    const showLoadingState = isLoading && items.length === 0
+    const showLoadingState = effectiveLoading && items.length === 0
 
     // ---- Index / keyboard nav ----------------------------------------------
     const moveUp = (): void => {
@@ -454,6 +489,7 @@ export function useGroupList(input: UseGroupListInput): UseGroupListResult {
 
     return {
         items,
+        topMatchesForQuery,
         rowCount,
         totalResultCount,
         index,

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
@@ -322,6 +322,7 @@ describe('useTaxonomicFilter', () => {
         const fakeItem = { id: 42, name: 'pageview' }
         const fakeApi = {
             items: [fakeItem] as any,
+            topMatchesForQuery: [],
             rowCount: 1,
             totalResultCount: 1,
             index: 0,

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
@@ -37,6 +37,7 @@ import {
     ExcludedOperators,
     ExcludedProperties,
     SelectedProperties,
+    SelectingKeyOnly,
     SimpleOption,
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
@@ -45,6 +46,8 @@ import {
 } from 'lib/components/TaxonomicFilter/types'
 import { isQuickFilterItem } from 'lib/components/TaxonomicFilter/types'
 import { buildTaxonomicGroups } from 'lib/components/TaxonomicFilter/utils/buildTaxonomicGroups'
+import { dedupeTopMatches } from 'lib/components/TaxonomicFilter/utils/composeSuggestedItems'
+import { redistributeTopMatches, TopMatchItem } from 'lib/components/TaxonomicFilter/utils/redistributeTopMatches'
 import { resolveItemGroup } from 'lib/components/TaxonomicFilter/utils/resolveSourceGroup'
 import {
     filterPinnedForContext,
@@ -91,7 +94,7 @@ export interface UseTaxonomicFilterOptions {
     excludedOperators?: ExcludedOperators
     /** When the picker only selects a property key (no operator/value), recents
      *  are deduped by storage key. */
-    selectingKeyOnly?: boolean
+    selectingKeyOnly?: SelectingKeyOnly
     maxContextOptions?: MaxContextTaxonomicFilterOption[]
     hideBehavioralCohorts?: boolean
     endpointFilters?: Record<string, any>
@@ -144,6 +147,13 @@ export interface TaxonomicFilterApi {
     // factory for per-tab consumers
     /** Build the input object for `useGroupList`, for a given group. */
     getGroupListInput: (group: TaxonomicFilterGroup) => UseGroupListInput
+
+    // SuggestedFilters cross-tab aggregation
+    /** Per-group top-match collectors call this to publish their slice and
+     *  whether they're still fetching for the current query. */
+    reportTopMatches: (groupType: TaxonomicFilterGroupType, items: TopMatchItem[], isLoading: boolean) => void
+    /** Redistributed + ordered top matches across all content groups. */
+    aggregatedTopMatches: TopMatchItem[]
 
     // value passthroughs
     value?: TaxonomicFilterValue
@@ -353,7 +363,7 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
     const contextRecents = useMemo(
         () =>
             hasSuggestedTab
-                ? filterRecentsForContext(recentFilterItems, groupTypes, excludedOperators, selectingKeyOnly)
+                ? filterRecentsForContext(recentFilterItems, groupTypes, excludedOperators, !!selectingKeyOnly)
                 : [],
         [hasSuggestedTab, recentFilterItems, groupTypes, excludedOperators, selectingKeyOnly]
     )
@@ -370,6 +380,71 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         () => (trimmedQuery ? contextPinned.filter((i) => pinnedItemMatchesSearch(i, trimmedQuery, groups)) : []),
         [trimmedQuery, contextPinned, groups]
     )
+
+    // ---- Suggested tab: cross-tab top-match aggregation ---------------------
+    // Per-group collectors publish their slice into this registry; the Suggested
+    // tab redistributes + dedupes the union. Mirrors the legacy parent-logic
+    // `appendTopMatches` -> `redistributedTopMatchItems` -> `dedupedTopMatches`.
+    const [topMatchRegistry, setTopMatchRegistry] = useState<
+        Record<string, { items: TopMatchItem[]; isLoading: boolean }>
+    >({})
+    const reportTopMatches = useCallback(
+        (groupType: TaxonomicFilterGroupType, items: TopMatchItem[], isLoading: boolean) => {
+            setTopMatchRegistry((prev) => {
+                const existing = prev[groupType]
+                if (
+                    existing &&
+                    existing.isLoading === isLoading &&
+                    existing.items.length === items.length &&
+                    existing.items.every((it, i) => it === items[i])
+                ) {
+                    return prev
+                }
+                return { ...prev, [groupType]: { items, isLoading } }
+            })
+        },
+        []
+    )
+    // Reset on every query change so stale matches don't linger (mirrors the
+    // legacy `setSearchQuery: () => []` reducer on topMatchItems).
+    useEffect(() => {
+        setTopMatchRegistry({})
+    }, [trimmedQuery])
+
+    const nonMetaGroupTypes = useMemo(
+        () => groupTypes.filter((t) => !metaGroupTypes.has(t)),
+        [groupTypes, metaGroupTypes]
+    )
+    const aggregatedTopMatches = useMemo(() => {
+        const all: TopMatchItem[] = []
+        for (const groupType of nonMetaGroupTypes) {
+            const entry = topMatchRegistry[groupType]
+            if (entry?.items.length) {
+                all.push(...entry.items)
+            }
+        }
+        return redistributeTopMatches(all, nonMetaGroupTypes.length, nonMetaGroupTypes)
+    }, [topMatchRegistry, nonMetaGroupTypes])
+
+    const suggestedTopMatches = useMemo(
+        () =>
+            hasSuggestedTab && trimmedQuery
+                ? dedupeTopMatches(aggregatedTopMatches, suggestedRecentMatches, suggestedPinnedMatches, groups)
+                : [],
+        [hasSuggestedTab, trimmedQuery, aggregatedTopMatches, suggestedRecentMatches, suggestedPinnedMatches, groups]
+    )
+
+    // Suggested tab shows a loading state (not "no results") until every content
+    // group's probe has reported a settled, non-loading slice for this query.
+    const suggestedTopMatchesLoading = useMemo(() => {
+        if (!hasSuggestedTab || !trimmedQuery) {
+            return false
+        }
+        return nonMetaGroupTypes.some((t) => {
+            const entry = topMatchRegistry[t]
+            return !entry || entry.isLoading
+        })
+    }, [hasSuggestedTab, trimmedQuery, nonMetaGroupTypes, topMatchRegistry])
 
     // ---- active group (controlled by initial prop, then internal) -----------
     const defaultActiveGroup = useMemo<TaxonomicFilterGroupType>(() => {
@@ -538,6 +613,8 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
                       suggestedPinned: contextPinned,
                       suggestedRecentMatches,
                       suggestedPinnedMatches,
+                      suggestedTopMatches,
+                      suggestedLoading: suggestedTopMatchesLoading,
                   }
                 : {}),
         }),
@@ -556,6 +633,8 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
             contextPinned,
             suggestedRecentMatches,
             suggestedPinnedMatches,
+            suggestedTopMatches,
+            suggestedTopMatchesLoading,
         ]
     )
 
@@ -605,6 +684,8 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         selectSelected,
         registerActiveList,
         getGroupListInput,
+        reportTopMatches,
+        aggregatedTopMatches,
         value,
         rootProps: { onKeyDown },
         inputProps: {

--- a/frontend/src/lib/components/TaxonomicFilter/utils/composeSuggestedItems.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/composeSuggestedItems.test.ts
@@ -1,9 +1,15 @@
-import { TaxonomicDefinitionTypes } from 'lib/components/TaxonomicFilter/types'
+import {
+    TaxonomicDefinitionTypes,
+    TaxonomicFilterGroup,
+    TaxonomicFilterGroupType,
+} from 'lib/components/TaxonomicFilter/types'
+import { TopMatchItem } from 'lib/components/TaxonomicFilter/utils/redistributeTopMatches'
 
-import { composeSuggestedItems } from './composeSuggestedItems'
+import { composeSuggestedItems, dedupeTopMatches } from './composeSuggestedItems'
 
 const named = (name: string): TaxonomicDefinitionTypes => ({ name }) as TaxonomicDefinitionTypes
 const names = (items: TaxonomicDefinitionTypes[]): string[] => items.map((i) => ('name' in i ? (i.name as string) : ''))
+const topMatch = (name: string, group: TaxonomicFilterGroupType): TopMatchItem => ({ name, group }) as TopMatchItem
 
 describe('composeSuggestedItems', () => {
     const recents = [named('r1'), named('r2'), named('r3'), named('r4')]
@@ -65,5 +71,53 @@ describe('composeSuggestedItems', () => {
             pinnedMatches: [named('pm')],
         })
         expect(count).toBe(expected)
+    })
+
+    it('appends top matches after the local options and counts them', () => {
+        const { items, count } = composeSuggestedItems({
+            searchQuery: 'q',
+            localResults: [named('local')],
+            localCount: 1,
+            contextRecents: [],
+            contextPinned: [],
+            recentMatches: [named('rm')],
+            pinnedMatches: [],
+            topMatches: [named('tm1'), named('tm2')],
+        })
+        expect(names(items)).toEqual(['rm', 'local', 'tm1', 'tm2'])
+        expect(count).toBe(1 + 0 + 1 + 2)
+    })
+})
+
+describe('dedupeTopMatches', () => {
+    const groups = [{ type: TaxonomicFilterGroupType.Events, getValue: (i: any) => i.name } as TaxonomicFilterGroup]
+    const recentRow = (sourceValue: string): TaxonomicDefinitionTypes =>
+        ({
+            name: sourceValue,
+            _recentContext: { sourceGroupType: TaxonomicFilterGroupType.Events, sourceValue },
+        }) as unknown as TaxonomicDefinitionTypes
+    const pinnedRow = (value: string): TaxonomicDefinitionTypes =>
+        ({
+            name: value,
+            _pinnedContext: { sourceGroupType: TaxonomicFilterGroupType.Events, value },
+        }) as unknown as TaxonomicDefinitionTypes
+
+    const top = [
+        topMatch('pageview', TaxonomicFilterGroupType.Events),
+        topMatch('click', TaxonomicFilterGroupType.Events),
+    ]
+
+    it('drops a top match that duplicates a shown recent', () => {
+        const result = dedupeTopMatches(top, [recentRow('pageview')], [], groups)
+        expect(result.map((i) => ('name' in i ? i.name : ''))).toEqual(['click'])
+    })
+
+    it('drops a top match that duplicates a shown pinned', () => {
+        const result = dedupeTopMatches(top, [], [pinnedRow('click')], groups)
+        expect(result.map((i) => ('name' in i ? i.name : ''))).toEqual(['pageview'])
+    })
+
+    it('returns all top matches when nothing is shown to dedupe against', () => {
+        expect(dedupeTopMatches(top, [], [], groups)).toHaveLength(2)
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/utils/composeSuggestedItems.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/composeSuggestedItems.ts
@@ -1,5 +1,8 @@
-import { TaxonomicDefinitionTypes } from 'lib/components/TaxonomicFilter/types'
+import { hasRecentContext } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
+import { hasPinnedContext } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
+import { TaxonomicDefinitionTypes, TaxonomicFilterGroup } from 'lib/components/TaxonomicFilter/types'
 import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
+import { TopMatchItem } from 'lib/components/TaxonomicFilter/utils/redistributeTopMatches'
 
 export const RECENT_PINNED_PREFIX_LIMIT = 3
 
@@ -16,6 +19,9 @@ export interface ComposeSuggestedItemsInput {
      *  when a query is present. */
     recentMatches: TaxonomicDefinitionTypes[]
     pinnedMatches: TaxonomicDefinitionTypes[]
+    /** Aggregated cross-tab top matches (already redistributed + deduped),
+     *  appended after the local options. Only present with a query. */
+    topMatches?: TaxonomicDefinitionTypes[]
 }
 
 export interface ComposedSuggestedItems {
@@ -39,13 +45,49 @@ export function composeSuggestedItems({
     contextPinned,
     recentMatches,
     pinnedMatches,
+    topMatches = [],
 }: ComposeSuggestedItemsInput): ComposedSuggestedItems {
     const hasQuery = !!searchQuery.trim()
     const recentSegment = hasQuery ? recentMatches : contextRecents.slice(0, RECENT_PINNED_PREFIX_LIMIT)
     const pinnedSegment = hasQuery ? pinnedMatches : contextPinned.slice(0, RECENT_PINNED_PREFIX_LIMIT)
-    const combined = [...recentSegment, ...pinnedSegment, ...localResults]
+    const combined = [...recentSegment, ...pinnedSegment, ...localResults, ...topMatches]
     return {
         items: hasQuery ? promoteMatchingProperties(combined, searchQuery) : combined,
-        count: recentSegment.length + pinnedSegment.length + localCount,
+        count: recentSegment.length + pinnedSegment.length + localCount + topMatches.length,
     }
+}
+
+/**
+ * Drop top-match rows that duplicate a recent/pinned row already shown, keyed
+ * by the row's source group + value (so "Recent · pageview" doesn't stack above
+ * "Events · pageview"). Mirrors the legacy `infiniteListLogic.dedupedTopMatches`.
+ */
+export function dedupeTopMatches(
+    topMatches: TopMatchItem[],
+    shownRecents: TaxonomicDefinitionTypes[],
+    shownPinned: TaxonomicDefinitionTypes[],
+    groups: TaxonomicFilterGroup[]
+): TopMatchItem[] {
+    if (topMatches.length === 0) {
+        return []
+    }
+    const dedupeKeys = new Set<string>()
+    for (const item of shownRecents) {
+        if (hasRecentContext(item) && item._recentContext.sourceValue != null) {
+            dedupeKeys.add(`${item._recentContext.sourceGroupType}::${item._recentContext.sourceValue}`)
+        }
+    }
+    for (const item of shownPinned) {
+        if (hasPinnedContext(item) && item._pinnedContext.value != null) {
+            dedupeKeys.add(`${item._pinnedContext.sourceGroupType}::${item._pinnedContext.value}`)
+        }
+    }
+    if (dedupeKeys.size === 0) {
+        return topMatches
+    }
+    const groupsByType = new Map(groups.map((g) => [g.type, g]))
+    return topMatches.filter((item) => {
+        const value = groupsByType.get(item.group)?.getValue?.(item) ?? null
+        return value == null || !dedupeKeys.has(`${item.group}::${value}`)
+    })
 }


### PR DESCRIPTION
## Problem

Final step of bringing the headless TaxonomicFilter rebuild's **Suggested filters** tab to parity with the legacy picker. In legacy, searching from the Suggested tab surfaces the best matches from every other tab, slot-distributed across groups and deduped against recents/pinned — this is the core "suggestions" experience. The rebuild had no cross-tab aggregation, so a search on the Suggested tab showed almost nothing.

Stacked on #61637.

## Changes

- Add a hidden, render-nothing `SuggestedTopMatchCollector` that — while a query is active and a Suggested tab is present — mounts one probe per content group. Each probe runs the same `useGroupList` the tab counts already run (so the resource cache shares the fetch rather than duplicating it) and publishes that group's top matches into a registry on the orchestrator.
- The orchestrator redistributes the union across groups (reusing the existing pure `redistributeTopMatches`) and the Suggested tab dedupes rows already shown as a recent/pinned (new pure `dedupeTopMatches`) before appending them after the promoted options.
- The Suggested tab stays in a loading state until every content group's probe settles for the current query, so it doesn't flash "no results" while matches stream in. The legacy 5s anti-jump timer is intentionally left as a follow-up.

A per-group child-component pattern (mirroring `Categories`) is used rather than a `.map` of `useGroupList`, so the hook lifecycle stays valid when the visible group set changes (Rules of Hooks).

## How did you test this code?

I'm an agent (PostHog Code); no manual testing. Automated RTL + unit tests added and run (`hogli test`, all green):
- `composeSuggestedItems.test.ts`: top matches appended after local options + counted; `dedupeTopMatches` drops a top match duplicating a shown recent and a shown pinned, and is a no-op when nothing is shown.
- `headless.test.tsx`: typing a query on the Suggested tab surfaces matching rows aggregated from two different content groups (events + properties).

`tsc --noEmit` clean for these files.

## 🤖 Agent context

Authored with PostHog Code (Claude). Key design decision: the rebuild has no central per-tab store, so aggregation is done via a probe-per-group collector that reuses the shared `useTaxonomicResource` cache (verified the cache dedupes identical in-flight fetches) — chosen over lifting a results registry that display lists publish into (couples render to publication timing) and over a bare hook-in-a-loop (Rules of Hooks violation when the group set changes). Per-group top matches encapsulate the legacy "remote must be fresh for the current query" guard inside `useGroupList.topMatchesForQuery`. Ordering/dedup are locked by tests against the legacy behavior. This completes the staff-only parity work needed before the rebuild can become the default.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
