### PR TITLE
fix(data-warehouse): mark MSSQL unreachable-server errors as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -42,6 +42,11 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
             "Adaptive Server connection failed": None,
+            # pymssql DB-Lib error 20009 — the server host can't be reached for the whole
+            # connection attempt. On a managed instance this is a persistent connectivity issue
+            # (security group doesn't allow PostHog's IPs, the instance is stopped, or the
+            # hostname is wrong), not a momentary blip, so retrying the job won't recover it.
+            "Adaptive Server is unavailable or does not exist": "Could not reach your SQL Server. Check that the server is running and reachable, and that PostHog's IP addresses are allowed through its firewall / security group.",
             "Login failed for user": None,
             "Cannot find the CREDENTIAL": "Cannot find the credential - check that it exists and you have permission to access it",
             # Raised from the shared `_decimal_array_from_values` fallback in

--- a/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -432,3 +432,16 @@ class TestMSSQLSourceNonRetryableErrors:
     def test_data_shape_errors_are_non_retryable(self, error_msg):
         non_retryable = MSSQLSource().get_non_retryable_errors()
         assert any(pattern in error_msg for pattern in non_retryable.keys()), error_msg
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Real pymssql DB-Lib error 20009 for an unreachable host.
+            "DB-Lib error message 20009, severity 9:\nUnable to connect: Adaptive Server is "
+            "unavailable or does not exist (cplapps.example.us-east-2.rds.amazonaws.com)",
+            "Login failed for user 'reporting'.",
+        ],
+    )
+    def test_connection_errors_are_non_retryable(self, error_msg):
+        non_retryable = MSSQLSource().get_non_retryable_errors()
+        assert any(pattern in error_msg for pattern in non_retryable.keys()), error_msg


### PR DESCRIPTION
## Problem

The MSSQL source generated a high volume of repeated `MSSQLDatabaseException: ... Unable to connect: Adaptive Server is unavailable or does not exist (...rds.amazonaws.com)` events (pymssql DB-Lib error 20009), raised at connect time. The source's `get_non_retryable_errors()` already treats `"Adaptive Server connection failed"` as non-retryable — i.e. the author already decided unreachable-server failures shouldn't be retried — but the actual error uses different wording (`"is unavailable or does not exist"`), so it never matched and the job retried indefinitely.

## Changes

- Added `"Adaptive Server is unavailable or does not exist"` (the stable DB-Lib 20009 message) to `get_non_retryable_errors()`, with a message telling the user to check the server is reachable and that PostHog's IPs are allowed through its firewall / security group. This is consistent with the existing `"Adaptive Server connection failed"` / `"Login failed for user"` entries.

### Tradeoff
This is a connection-establishment failure that is *usually* permanent on a managed instance (security group, stopped instance, wrong hostname). A genuinely brief outage could be classified after repeated occurrences, but that's recoverable (re-enable) and is consistent with how the source already treats the sibling connection-failure message.

## How did you test this code?

I'm an agent. I extended the MSSQL non-retryable test class (49 tests in the module, all passing) and ran ruff check + format. The new test asserts the real DB-Lib 20009 string (and a `Login failed for user` string) match a non-retryable pattern.

No manual testing against a live SQL Server was performed.

## 🤖 Agent context

Authored with Claude Code. Found via the PostHog MCP error-tracking group. The source already intended to classify unreachable-server failures as non-retryable; this just adds the actual pymssql 20009 wording the existing pattern missed.
