### PR TITLE
fix(workflows): allow blank HTML field in EmailTemplateSerializer when the template is saved on plain text mode

### DIFF
--- a/products/messaging/backend/api/test/test_message_templates.py
+++ b/products/messaging/backend/api/test/test_message_templates.py
@@ -333,3 +333,5 @@ class TestMessageTemplatesAPI(APIBaseTest):
             format="json",
         )
         assert response.status_code == status.HTTP_200_OK
+        self.message_template.refresh_from_db()
+        assert self.message_template.content["email"]["html"] == ""

--- a/products/messaging/backend/api/test/test_message_templates.py
+++ b/products/messaging/backend/api/test/test_message_templates.py
@@ -317,3 +317,19 @@ class TestMessageTemplatesAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         self.message_template.refresh_from_db()
         assert self.message_template.message_category_id == own_category.id
+
+    def test_update_template_with_plaintext_only_email(self):
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/messaging_templates/{self.message_template.id}/",
+            data={
+                "content": {
+                    "email": {
+                        "subject": "Test Subject",
+                        "text": "Plain body",
+                        "html": "",
+                    }
+                }
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## Problem

This PR solves the issue when trying to save a workflow template on Plaintext mode instead of HTML.

Closes #61619 

## Changes

Set the `html` property to `allow_bank=True` in the serialization of the payload.

## How did you test this code?

I've added an additional unit test and did a manual test to verify that the message template is being saved.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context
