### PR TITLE
feat: split tags in workflows for support

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/posthog_conversations/posthog-update-ticket.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_conversations/posthog-update-ticket.template.ts
@@ -6,7 +6,8 @@ export const template: HogFunctionTemplate = {
     type: 'destination',
     id: 'template-posthog-update-ticket',
     name: 'Update conversation ticket',
-    description: 'Update the status, priority, SLA, assignee, or tags of a conversation ticket',
+    description:
+        'Update the status, priority, SLA, assignee, or tags of a conversation ticket. Tags are additive by default.',
     icon_url: '/static/posthog-icon.svg',
     category: ['Custom'],
     code_language: 'hog',
@@ -51,6 +52,7 @@ if (not empty(inputs.assignee)) {
 
 if (not empty(inputs.tags)) {
   updates.tags := inputs.tags
+  updates.tags_mode := (not empty(inputs.tags_mode)) ? inputs.tags_mode : 'add'
 }
 
 let response := postHogUpdateTicket({
@@ -147,7 +149,22 @@ return response.body
             label: 'Tags',
             secret: false,
             required: false,
-            description: 'Set tags on the ticket. Leave empty to keep current tags.',
+            description: 'Tags to apply to the ticket. Leave empty to keep current tags.',
+        },
+        {
+            key: 'tags_mode',
+            type: 'choice',
+            label: 'Tag mode',
+            secret: false,
+            required: false,
+            default: 'add',
+            choices: [
+                { label: 'Add to existing tags', value: 'add' },
+                { label: 'Replace all tags', value: 'set' },
+                { label: 'Remove these tags', value: 'remove' },
+            ],
+            description:
+                'How the tags above are applied. Add (default) is safe when multiple workflows tag the same ticket.',
         },
     ],
 }

--- a/products/conversations/backend/api/external.py
+++ b/products/conversations/backend/api/external.py
@@ -91,6 +91,7 @@ class ExternalTicketUpdateSerializer(serializers.Serializer):
     snoozed_until = serializers.DateTimeField(required=False, allow_null=True)
     assignee = serializers.JSONField(required=False, allow_null=True)
     tags = serializers.ListField(child=serializers.CharField(max_length=200), required=False, max_length=100)
+    tags_mode = serializers.ChoiceField(choices=["add", "set", "remove"], required=False, default="add")
 
     def validate_sla_business_hours(self, value):
         if value is None:
@@ -398,13 +399,22 @@ class ExternalTicketView(APIView):
 
         if "tags" in serializer.validated_data:
             try:
-                new_tags = list({tagify(t) for t in serializer.validated_data["tags"]})
-                for tag_name in new_tags:
-                    tag_instance, _ = Tag.objects.get_or_create(name=tag_name, team_id=team.id)
-                    ticket.tagged_items.get_or_create(tag_id=tag_instance.id)
-                for tagged_item in ticket.tagged_items.exclude(tag__name__in=new_tags):
-                    tagged_item.delete()
-                Tag.objects.filter(team_id=team.id, tagged_items__isnull=True).delete()
+                tags_mode = serializer.validated_data.get("tags_mode", "add")
+                normalized_tags = list({tagify(t) for t in serializer.validated_data["tags"]})
+
+                if tags_mode == "remove":
+                    ticket.tagged_items.filter(tag__name__in=normalized_tags).delete()
+                    Tag.objects.filter(team_id=team.id, tagged_items__isnull=True).delete()
+                elif tags_mode == "set":
+                    for tag_name in normalized_tags:
+                        tag_instance, _ = Tag.objects.get_or_create(name=tag_name, team_id=team.id)
+                        ticket.tagged_items.get_or_create(tag_id=tag_instance.id)
+                    ticket.tagged_items.exclude(tag__name__in=normalized_tags).delete()
+                    Tag.objects.filter(team_id=team.id, tagged_items__isnull=True).delete()
+                else:
+                    for tag_name in normalized_tags:
+                        tag_instance, _ = Tag.objects.get_or_create(name=tag_name, team_id=team.id)
+                        ticket.tagged_items.get_or_create(tag_id=tag_instance.id)
             except Exception as e:
                 capture_exception(e, {"ticket_id": str(ticket.id)})
                 return Response({"error": "Failed to update tags"}, status=status.HTTP_400_BAD_REQUEST)

--- a/products/conversations/backend/api/tests/test_external.py
+++ b/products/conversations/backend/api/tests/test_external.py
@@ -405,6 +405,104 @@ class TestExternalTicketAPI(BaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["tags"], ["bug"])
 
+    # -- PATCH tags --------------------------------------------------------
+
+    def test_patch_tags_add_mode_preserves_existing(self):
+        from posthog.models import Tag
+
+        existing_tag = Tag.objects.create(name="bug", team_id=self.team.id)
+        self.ticket.tagged_items.create(tag=existing_tag)
+
+        response = self.client.patch(
+            self.url,
+            {"tags": ["urgent"], "tags_mode": "add"},
+            content_type="application/json",
+            **self._auth_headers(),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tags = sorted(self.ticket.tagged_items.values_list("tag__name", flat=True))
+        self.assertEqual(tags, ["bug", "urgent"])
+
+    def test_patch_tags_add_is_idempotent(self):
+        from posthog.models import Tag
+
+        existing_tag = Tag.objects.create(name="bug", team_id=self.team.id)
+        self.ticket.tagged_items.create(tag=existing_tag)
+
+        response = self.client.patch(
+            self.url,
+            {"tags": ["bug"], "tags_mode": "add"},
+            content_type="application/json",
+            **self._auth_headers(),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self.ticket.tagged_items.count(), 1)
+
+    def test_patch_tags_concurrent_add_produces_union(self):
+        self.client.patch(
+            self.url,
+            {"tags": ["urgent"], "tags_mode": "add"},
+            content_type="application/json",
+            **self._auth_headers(),
+        )
+        self.client.patch(
+            self.url,
+            {"tags": ["billing"], "tags_mode": "add"},
+            content_type="application/json",
+            **self._auth_headers(),
+        )
+        tags = sorted(self.ticket.tagged_items.values_list("tag__name", flat=True))
+        self.assertEqual(tags, ["billing", "urgent"])
+
+    def test_patch_tags_default_mode_is_add(self):
+        from posthog.models import Tag
+
+        existing_tag = Tag.objects.create(name="bug", team_id=self.team.id)
+        self.ticket.tagged_items.create(tag=existing_tag)
+
+        response = self.client.patch(
+            self.url,
+            {"tags": ["feature"]},
+            content_type="application/json",
+            **self._auth_headers(),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tags = sorted(self.ticket.tagged_items.values_list("tag__name", flat=True))
+        self.assertEqual(tags, ["bug", "feature"])
+
+    def test_patch_tags_set_mode_replaces_all(self):
+        from posthog.models import Tag
+
+        existing_tag = Tag.objects.create(name="bug", team_id=self.team.id)
+        self.ticket.tagged_items.create(tag=existing_tag)
+
+        response = self.client.patch(
+            self.url,
+            {"tags": ["urgent"], "tags_mode": "set"},
+            content_type="application/json",
+            **self._auth_headers(),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tags = list(self.ticket.tagged_items.values_list("tag__name", flat=True))
+        self.assertEqual(tags, ["urgent"])
+
+    def test_patch_tags_remove_mode_strips_named(self):
+        from posthog.models import Tag
+
+        for name in ["bug", "urgent", "billing"]:
+            tag = Tag.objects.create(name=name, team_id=self.team.id)
+            self.ticket.tagged_items.create(tag=tag)
+
+        response = self.client.patch(
+            self.url,
+            {"tags": ["bug", "billing"], "tags_mode": "remove"},
+            content_type="application/json",
+            **self._auth_headers(),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tags = list(self.ticket.tagged_items.values_list("tag__name", flat=True))
+        self.assertEqual(tags, ["urgent"])
+
     # -- URL validation ---------------------------------------------------
 
     def test_invalid_uuid_in_url_returns_404(self):


### PR DESCRIPTION
Problem

in workflows we "set" tags in workflows. if you set tag1 and then another workflow tag2, the tag1 is rewritten.

Solution

split into add/set/delete tags instead

<img width="800" height="516" alt="ezgif-28b329c4393adf8b" src="https://github.com/user-attachments/assets/00bf3c69-d1e6-4ea8-9248-ae4cb5736692" />

