### PR TITLE
feat(data-warehouse): implement smartsheet import source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -104,6 +104,7 @@ the row lists both.
 | shopify          | HTTP                        | requests                                                        | ✅                          |
 | shortcut         | HTTP                        | requests                                                        | ✅                          |
 | slack            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| smartsheet       | HTTP                        | requests                                                        | ✅                          |
 | snapchat_ads     | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | snowflake        | DB protocol                 | snowflake-connector-python                                      | ➖                          |
 | square           | HTTP                        | requests                                                        | ✅                          |
@@ -213,7 +214,6 @@ doesn't conflict with concurrent PRs.
 - sendgrid
 - sftp
 - sharepoint
-- smartsheet
 - surveymonkey
 - trello
 - twilio

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -784,7 +784,7 @@ class SlackSourceConfig(config.Config):
 
 @config.config
 class SmartsheetSourceConfig(config.Config):
-    pass
+    access_token: str
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/smartsheet/settings.py
+++ b/posthog/temporal/data_imports/sources/smartsheet/settings.py
@@ -1,0 +1,67 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from products.data_warehouse.backend.types import IncrementalField
+
+# Smartsheet's list endpoints all share the same offset-based pagination envelope
+# ({pageNumber, pageSize, totalPages, totalCount, data: [...]}). We model each as a
+# top-level resource and full-refresh it on every sync.
+#
+# Incremental sync is intentionally not enabled. Although `List Sheets` / `List Reports`
+# document a `modifiedSince` server-side filter, these list endpoints expose no stable
+# `sort` parameter, so we cannot guarantee the ascending ordering the pipeline relies on
+# to advance an incremental watermark safely across resumed syncs. The payloads here are
+# small (account-level metadata listings), so a full refresh is cheap and correct.
+
+
+@dataclass
+class SmartsheetEndpointConfig:
+    name: str
+    path: str
+    incremental_fields: list[IncrementalField]
+    primary_key: str = "id"
+    # A stable creation-date field used for datetime partitioning. Only set it where the
+    # list response is documented to return it on every row.
+    partition_key: Optional[str] = None
+
+
+SMARTSHEET_ENDPOINTS: dict[str, SmartsheetEndpointConfig] = {
+    "sheets": SmartsheetEndpointConfig(
+        name="sheets",
+        path="/sheets",
+        partition_key="createdAt",
+        incremental_fields=[],
+    ),
+    "reports": SmartsheetEndpointConfig(
+        name="reports",
+        path="/reports",
+        partition_key="createdAt",
+        incremental_fields=[],
+    ),
+    "workspaces": SmartsheetEndpointConfig(
+        name="workspaces",
+        path="/workspaces",
+        incremental_fields=[],
+    ),
+    "users": SmartsheetEndpointConfig(
+        name="users",
+        path="/users",
+        incremental_fields=[],
+    ),
+    "contacts": SmartsheetEndpointConfig(
+        name="contacts",
+        path="/contacts",
+        incremental_fields=[],
+    ),
+    "templates": SmartsheetEndpointConfig(
+        name="templates",
+        path="/templates",
+        incremental_fields=[],
+    ),
+}
+
+ENDPOINTS = tuple(SMARTSHEET_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in SMARTSHEET_ENDPOINTS.items()
+}

--- a/posthog/temporal/data_imports/sources/smartsheet/smartsheet.py
+++ b/posthog/temporal/data_imports/sources/smartsheet/smartsheet.py
@@ -1,0 +1,129 @@
+import dataclasses
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import urlencode
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.smartsheet.settings import SMARTSHEET_ENDPOINTS
+
+SMARTSHEET_BASE_URL = "https://api.smartsheet.com/2.0"
+# Smartsheet list endpoints page with `page` (1-based) and `pageSize` (max 100).
+PAGE_SIZE = 100
+REQUEST_TIMEOUT_SECONDS = 60
+MAX_RETRIES = 5
+
+
+class SmartsheetRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class SmartsheetResumeConfig:
+    next_page: int
+
+
+def _get_headers(access_token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json",
+    }
+
+
+def _build_url(path: str, page: int) -> str:
+    params = {"page": page, "pageSize": PAGE_SIZE}
+    return f"{SMARTSHEET_BASE_URL}{path}?{urlencode(params)}"
+
+
+def validate_credentials(access_token: str) -> bool:
+    """Confirm the access token is valid. ``/users/me`` is a cheap authenticated probe
+    that works for any valid token regardless of granted scopes."""
+    try:
+        response = make_tracked_session().get(
+            f"{SMARTSHEET_BASE_URL}/users/me",
+            headers=_get_headers(access_token),
+            timeout=10,
+        )
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def get_rows(
+    access_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[SmartsheetResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    config = SMARTSHEET_ENDPOINTS[endpoint]
+    headers = _get_headers(access_token)
+
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    page = resume_config.next_page if resume_config is not None else 1
+    if resume_config is not None:
+        logger.debug(f"Smartsheet: resuming {endpoint} from page {page}")
+
+    @retry(
+        retry=retry_if_exception_type((SmartsheetRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(MAX_RETRIES),
+        wait=wait_exponential_jitter(initial=1, max=60),
+        reraise=True,
+    )
+    def fetch_page(page_url: str) -> dict[str, Any]:
+        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        # Smartsheet rate-limits at 300 req/min; 429s are retryable, as are transient 5xx.
+        if response.status_code == 429 or response.status_code >= 500:
+            raise SmartsheetRetryableError(
+                f"Smartsheet API error (retryable): status={response.status_code}, url={page_url}"
+            )
+
+        if not response.ok:
+            logger.error(f"Smartsheet API error: status={response.status_code}, body={response.text}, url={page_url}")
+            response.raise_for_status()
+
+        return response.json()
+
+    while True:
+        data = fetch_page(_build_url(config.path, page))
+
+        items = data.get("data", []) or []
+        if items:
+            yield items
+
+        total_pages = data.get("totalPages", 0) or 0
+        if not items or page >= total_pages:
+            break
+
+        page += 1
+        resumable_source_manager.save_state(SmartsheetResumeConfig(next_page=page))
+
+
+def smartsheet_source(
+    access_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[SmartsheetResumeConfig],
+) -> SourceResponse:
+    config = SMARTSHEET_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            access_token=access_token,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+        ),
+        primary_keys=[config.primary_key],
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+    )

--- a/posthog/temporal/data_imports/sources/smartsheet/source.py
+++ b/posthog/temporal/data_imports/sources/smartsheet/source.py
@@ -78,7 +78,7 @@ You can generate a personal access token under **Personal Settings → API Acces
                 supports_append=bool(INCREMENTAL_FIELDS.get(endpoint)),
                 incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
             )
-            for endpoint in list(ENDPOINTS)
+            for endpoint in ENDPOINTS
         ]
 
         if names is not None:

--- a/posthog/temporal/data_imports/sources/smartsheet/source.py
+++ b/posthog/temporal/data_imports/sources/smartsheet/source.py
@@ -1,29 +1,112 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import SmartsheetSourceConfig
+from posthog.temporal.data_imports.sources.smartsheet.settings import ENDPOINTS, INCREMENTAL_FIELDS
+from posthog.temporal.data_imports.sources.smartsheet.smartsheet import (
+    SmartsheetResumeConfig,
+    smartsheet_source,
+    validate_credentials as validate_smartsheet_credentials,
+)
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class SmartsheetSource(SimpleSource[SmartsheetSourceConfig]):
+class SmartsheetSource(ResumableSource[SmartsheetSourceConfig, SmartsheetResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.SMARTSHEET
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://api.smartsheet.com": "Smartsheet authentication failed. Your access token is invalid or expired. Please generate a new token and reconnect.",
+            "403 Client Error: Forbidden for url: https://api.smartsheet.com": "Smartsheet denied access. Please check that your access token has the required permissions.",
+        }
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SMARTSHEET,
             label="Smartsheet",
+            caption="""Enter your Smartsheet API access token to pull your Smartsheet data into the PostHog Data warehouse.
+
+You can generate a personal access token under **Personal Settings → API Access** in your [Smartsheet account](https://app.smartsheet.com). The token inherits your account's read access; the `users` table additionally requires a system administrator account.""",
             iconPath="/static/services/smartsheet.png",
-            fields=cast(list[FieldType], []),
+            docsUrl="https://posthog.com/docs/cdp/sources/smartsheet",
+            releaseStatus=ReleaseStatus.ALPHA,
             unreleasedSource=True,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="access_token",
+                        label="Access token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_schemas(
+        self,
+        config: SmartsheetSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=bool(INCREMENTAL_FIELDS.get(endpoint)),
+                supports_append=bool(INCREMENTAL_FIELDS.get(endpoint)),
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+            )
+            for endpoint in list(ENDPOINTS)
+        ]
+
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+
+        return schemas
+
+    def validate_credentials(
+        self, config: SmartsheetSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_smartsheet_credentials(config.access_token):
+            return True, None
+
+        return False, "Invalid Smartsheet access token"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[SmartsheetResumeConfig]:
+        return ResumableSourceManager[SmartsheetResumeConfig](inputs, SmartsheetResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: SmartsheetSourceConfig,
+        resumable_source_manager: ResumableSourceManager[SmartsheetResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return smartsheet_source(
+            access_token=config.access_token,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/posthog/temporal/data_imports/sources/smartsheet/tests/test_smartsheet.py
+++ b/posthog/temporal/data_imports/sources/smartsheet/tests/test_smartsheet.py
@@ -1,0 +1,146 @@
+from typing import Any
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.smartsheet.settings import ENDPOINTS, SMARTSHEET_ENDPOINTS
+from posthog.temporal.data_imports.sources.smartsheet.smartsheet import (
+    PAGE_SIZE,
+    SmartsheetResumeConfig,
+    _build_url,
+    get_rows,
+    smartsheet_source,
+    validate_credentials,
+)
+
+
+def _make_manager(resume_state: SmartsheetResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _page(items: list[dict[str, Any]], total_pages: int) -> dict[str, Any]:
+    return {"pageNumber": 1, "pageSize": PAGE_SIZE, "totalPages": total_pages, "data": items}
+
+
+def _ok_response(payload: dict[str, Any]) -> mock.MagicMock:
+    resp = mock.MagicMock(status_code=200, ok=True)
+    resp.json.return_value = payload
+    return resp
+
+
+class TestBuildUrl:
+    def test_includes_pagination_params(self):
+        url = _build_url("/sheets", page=1)
+        assert url == f"https://api.smartsheet.com/2.0/sheets?page=1&pageSize={PAGE_SIZE}"
+
+    def test_uses_requested_page(self):
+        assert "page=4" in _build_url("/reports", page=4)
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        "status_code, expected",
+        [
+            (200, True),
+            (401, False),
+            (403, False),
+            (500, False),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.smartsheet.smartsheet.make_tracked_session")
+    def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
+        response = mock.MagicMock()
+        response.status_code = status_code
+        mock_session.return_value.get.return_value = response
+
+        assert validate_credentials("token") is expected
+
+    @mock.patch("posthog.temporal.data_imports.sources.smartsheet.smartsheet.make_tracked_session")
+    def test_validate_credentials_probes_users_me(self, mock_session):
+        response = mock.MagicMock(status_code=200)
+        mock_session.return_value.get.return_value = response
+
+        validate_credentials("token")
+
+        assert mock_session.return_value.get.call_args.args[0] == "https://api.smartsheet.com/2.0/users/me"
+
+    @mock.patch("posthog.temporal.data_imports.sources.smartsheet.smartsheet.make_tracked_session")
+    def test_validate_credentials_swallows_exceptions(self, mock_session):
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("token") is False
+
+
+class TestGetRows:
+    @mock.patch("posthog.temporal.data_imports.sources.smartsheet.smartsheet.make_tracked_session")
+    def test_paginates_through_total_pages(self, mock_session):
+        mock_session.return_value.get.side_effect = [
+            _ok_response(_page([{"id": 1}, {"id": 2}], total_pages=2)),
+            _ok_response(_page([{"id": 3}], total_pages=2)),
+        ]
+
+        manager = _make_manager()
+        batches = list(get_rows("token", "sheets", mock.MagicMock(), manager))
+
+        assert [item["id"] for batch in batches for item in batch] == [1, 2, 3]
+        # Each request asks for an explicit ascending page number.
+        assert "page=1" in mock_session.return_value.get.call_args_list[0].args[0]
+        assert "page=2" in mock_session.return_value.get.call_args_list[1].args[0]
+        # State is saved once — only while a further page remains.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0].next_page == 2
+
+    @mock.patch("posthog.temporal.data_imports.sources.smartsheet.smartsheet.make_tracked_session")
+    def test_single_page_does_not_save_state(self, mock_session):
+        mock_session.return_value.get.return_value = _ok_response(_page([{"id": 1}], total_pages=1))
+
+        manager = _make_manager()
+        batches = list(get_rows("token", "sheets", mock.MagicMock(), manager))
+
+        assert [item["id"] for batch in batches for item in batch] == [1]
+        assert mock_session.return_value.get.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch("posthog.temporal.data_imports.sources.smartsheet.smartsheet.make_tracked_session")
+    def test_empty_response_stops_without_saving(self, mock_session):
+        mock_session.return_value.get.return_value = _ok_response(_page([], total_pages=0))
+
+        manager = _make_manager()
+        batches = list(get_rows("token", "sheets", mock.MagicMock(), manager))
+
+        assert batches == []
+        manager.save_state.assert_not_called()
+
+    @mock.patch("posthog.temporal.data_imports.sources.smartsheet.smartsheet.make_tracked_session")
+    def test_resumes_from_saved_page(self, mock_session):
+        mock_session.return_value.get.return_value = _ok_response(_page([{"id": 9}], total_pages=3))
+
+        manager = _make_manager(SmartsheetResumeConfig(next_page=3))
+        list(get_rows("token", "sheets", mock.MagicMock(), manager))
+
+        assert "page=3" in mock_session.return_value.get.call_args_list[0].args[0]
+
+
+class TestSmartsheetSourceResponse:
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_response_metadata_per_endpoint(self, endpoint):
+        config = SMARTSHEET_ENDPOINTS[endpoint]
+        response = smartsheet_source("token", endpoint, mock.MagicMock(), _make_manager())
+
+        assert response.name == endpoint
+        assert response.primary_keys == [config.primary_key]
+        assert response.sort_mode == "asc"
+        if config.partition_key:
+            assert response.partition_mode == "datetime"
+            assert response.partition_keys == [config.partition_key]
+        else:
+            assert response.partition_mode is None
+            assert response.partition_keys is None
+
+    @pytest.mark.parametrize("config", list(SMARTSHEET_ENDPOINTS.values()))
+    def test_partition_keys_are_stable_creation_fields(self, config):
+        # Never partition on a mutable field like modifiedAt.
+        if config.partition_key:
+            assert config.partition_key == "createdAt"

--- a/posthog/temporal/data_imports/sources/smartsheet/tests/test_smartsheet_source.py
+++ b/posthog/temporal/data_imports/sources/smartsheet/tests/test_smartsheet_source.py
@@ -1,0 +1,123 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.generated_configs import SmartsheetSourceConfig
+from posthog.temporal.data_imports.sources.smartsheet.settings import ENDPOINTS, INCREMENTAL_FIELDS
+from posthog.temporal.data_imports.sources.smartsheet.smartsheet import SmartsheetResumeConfig
+from posthog.temporal.data_imports.sources.smartsheet.source import SmartsheetSource
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestSmartsheetSource:
+    def setup_method(self):
+        self.source = SmartsheetSource()
+        self.team_id = 123
+        self.config = SmartsheetSourceConfig(access_token="token")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.SMARTSHEET
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "Smartsheet"
+        assert config.label == "Smartsheet"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is True
+        assert config.iconPath == "/static/services/smartsheet.png"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["access_token"]
+
+    def test_access_token_field_is_secret_password(self):
+        config = self.source.get_source_config
+        token_field = next(
+            f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "access_token"
+        )
+        assert token_field.type == SourceFieldInputConfigType.PASSWORD
+        assert token_field.secret is True
+        assert token_field.required is True
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.smartsheet.com/2.0/sheets?page=1&pageSize=100",
+            "403 Client Error: Forbidden for url: https://api.smartsheet.com/2.0/users",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.stripe.com/v1/customers",
+            "500 Server Error for url: https://api.smartsheet.com/2.0/sheets",
+        ],
+    )
+    def test_non_retryable_errors_does_not_match_unrelated(self, other_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)
+
+    def test_get_schemas_lists_all_endpoints(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert {schema.name for schema in schemas} == set(ENDPOINTS)
+
+    def test_get_schemas_are_full_refresh(self):
+        # No Smartsheet list endpoint exposes an order-stable server-side timestamp filter,
+        # so every schema ships as full refresh.
+        for schema in self.source.get_schemas(self.config, self.team_id):
+            assert schema.supports_incremental is False
+            assert schema.supports_append is False
+            assert schema.incremental_fields == INCREMENTAL_FIELDS[schema.name]
+            assert schema.incremental_fields == []
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["sheets"])
+        assert len(schemas) == 1
+        assert schemas[0].name == "sheets"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self):
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    @pytest.mark.parametrize(
+        "mock_return, expected_valid, expected_message",
+        [
+            (True, True, None),
+            (False, False, "Invalid Smartsheet access token"),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.smartsheet.source.validate_smartsheet_credentials")
+    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is expected_valid
+        assert error_message == expected_message
+        mock_validate.assert_called_once_with(self.config.access_token)
+
+    def test_get_resumable_source_manager_binds_resume_config(self):
+        manager = self.source.get_resumable_source_manager(mock.MagicMock())
+
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is SmartsheetResumeConfig
+
+    @mock.patch("posthog.temporal.data_imports.sources.smartsheet.source.smartsheet_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_smartsheet_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "sheets"
+        manager = mock.MagicMock()
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_smartsheet_source.assert_called_once()
+        kwargs = mock_smartsheet_source.call_args.kwargs
+        assert kwargs["access_token"] == "token"
+        assert kwargs["endpoint"] == "sheets"
+        assert kwargs["resumable_source_manager"] is manager


### PR DESCRIPTION
## Problem

Smartsheet was registered as a scaffolded data warehouse source (empty stub, `unreleasedSource=True`) with no sync logic. Users who keep project/work-management data in Smartsheet had no way to pull it into the PostHog Data warehouse.

## Changes

Implements the Smartsheet source end-to-end following the `implementing-warehouse-sources` skill.

- **Base class:** `ResumableSource` — Smartsheet's list endpoints use offset pagination (`page`/`pageSize`), so the page cursor is persisted to Redis and Temporal can resume after a heartbeat timeout instead of restarting.
- **Endpoints** (account-level list endpoints, declared in `settings.py`): `sheets`, `reports`, `workspaces`, `users`, `contacts`, `templates`. Each maps to the shared `{pageNumber, totalPages, data: [...]}` envelope. Primary key `id`; `sheets`/`reports` partition on the stable `createdAt` (datetime, weekly), never on `modifiedAt`.
- **Auth:** Bearer access token (Smartsheet personal access token). Validated cheaply against `GET /users/me`.
- **Transport** (`smartsheet.py`): all HTTP goes through `make_tracked_session()`, with `tenacity` retries on 429/5xx and resume-state saved after each yielded batch.
- **Errors:** `get_non_retryable_errors()` maps 401 (invalid/expired token) and 403 (missing permissions) to friendly messages.
- Released behind `unreleasedSource=True` with `releaseStatus=alpha`.
- `SOURCES.md` updated: `smartsheet` moved into the Implemented table (HTTP / requests / ✅ tracked).

### Full refresh only (no incremental)

Although `List Sheets`/`List Reports` document a `modifiedSince` server-side filter, these list endpoints expose no order-stable `sort` parameter, so the ascending ordering the pipeline relies on to advance an incremental watermark safely across resumed syncs can't be guaranteed. The payloads are small account-level metadata listings, so full refresh is cheap and correct. This decision is documented inline in `settings.py`.

## How did you test this code?

I'm an agent. I added and ran automated tests only — no manual end-to-end sync was performed (see blocker below).

- `tests/test_smartsheet_source.py` — source type, config fields, schema list, full-refresh assertions, credential mapping, resumable-manager binding, pipeline argument plumbing.
- `tests/test_smartsheet.py` — URL/pagination behavior, `totalPages` termination, empty-response stop, resume-from-saved-page, credential status mapping, per-endpoint `SourceResponse` metadata and partition-key stability.

39 tests pass locally. `ruff check`/`ruff format` clean on the changed files.

**Blocker / verification note:** This sandbox has no Smartsheet API credentials and no running dev database. Endpoint behavior (pagination envelope, auth error codes) was confirmed with anonymous/bad-token `curl` against the live API, which validated the `401`/`403` error shapes and base URL. Live-data verification of pagination and the `modifiedSince` filter could not be performed without a token, which is part of why incremental sync ships disabled. The config generator was run to produce `SmartsheetSourceConfig`; `schema:build` was a no-op since the `Smartsheet` enum already exists in `schema-general.ts`/`schema.py`. The existing `frontend/public/services/smartsheet.png` icon is reused.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8). Implementation followed the `implementing-warehouse-sources` skill, using the existing `aircall` and `klaviyo` sources as references for the `ResumableSource` + tracked-`requests` pattern.

Key decisions:
- Chose `ResumableSource` over `SimpleSource` because the offset page number is a persistable cursor.
- Shipped **full refresh only** rather than enabling incremental on `modifiedSince`: the list endpoints have no stable sort guarantee, and live filtering could not be curl-verified without a token — the conservative, correct choice for an alpha given small payload sizes.
- Reverted the unrelated formatting/sort churn the config generator emitted and hand-applied only the one-line `SmartsheetSourceConfig` field to keep the generated-file diff minimal.
