### PR TITLE
feat(data-warehouse): implement wrike import source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -117,6 +117,7 @@ the row lists both.
 | webflow          | HTTP                        | requests                                                        | ✅                          |
 | woocommerce      | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | workos           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| wrike            | HTTP                        | requests                                                        | ✅                          |
 | zendesk          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 
 ### Notes on partially-tracked sources
@@ -219,7 +220,6 @@ doesn't conflict with concurrent PRs.
 - twilio
 - twitter_ads
 - workday
-- wrike
 - xero
 - youtube_analytics
 - zoho_crm

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -905,7 +905,8 @@ class WorkOSSourceConfig(config.Config):
 
 @config.config
 class WrikeSourceConfig(config.Config):
-    pass
+    access_token: str
+    host: str
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/wrike/settings.py
+++ b/posthog/temporal/data_imports/sources/wrike/settings.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class WrikeEndpointConfig:
+    name: str
+    path: str
+    primary_key: str = "id"
+    # Stable creation-time field used for datetime partitioning. Only set where the resource
+    # exposes an immutable creation timestamp — never an `updatedDate`-style field, which would
+    # rewrite partitions on every sync.
+    partition_key: Optional[str] = None
+    # Wrike paginates a small number of large list endpoints (`/tasks`, `/comments`,
+    # `/audit_log`) via `pageSize` + `nextPageToken`. Most endpoints (folders, contacts,
+    # workflows, custom fields, spaces) return the full result set in a single response with no
+    # pagination token, so we fetch them in one request.
+    paginated: bool = False
+
+
+# Wrike's REST API (v4) does not expose a server-side cursor/timestamp filter we can reliably
+# map onto an incremental watermark without live verification: only a handful of endpoints accept
+# an `updatedDate` range and combining it with `nextPageToken` paging and the 1000-row page cap
+# has ordering edge cases we can't confirm without credentials. We therefore ship every endpoint
+# as full refresh (matching Airbyte's Wrike connector); incremental sync can be layered on later
+# once the `updatedDate` filter is curl-verified against the live API.
+WRIKE_ENDPOINTS: dict[str, WrikeEndpointConfig] = {
+    "tasks": WrikeEndpointConfig(
+        name="tasks",
+        path="/tasks",
+        partition_key="createdDate",
+        paginated=True,
+    ),
+    "folders": WrikeEndpointConfig(
+        name="folders",
+        path="/folders",
+    ),
+    "contacts": WrikeEndpointConfig(
+        name="contacts",
+        path="/contacts",
+    ),
+    "workflows": WrikeEndpointConfig(
+        name="workflows",
+        path="/workflows",
+    ),
+    "custom_fields": WrikeEndpointConfig(
+        name="custom_fields",
+        path="/customfields",
+    ),
+    "spaces": WrikeEndpointConfig(
+        name="spaces",
+        path="/spaces",
+    ),
+}
+
+ENDPOINTS = tuple(WRIKE_ENDPOINTS.keys())

--- a/posthog/temporal/data_imports/sources/wrike/source.py
+++ b/posthog/temporal/data_imports/sources/wrike/source.py
@@ -1,19 +1,31 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import WrikeSourceConfig
+from posthog.temporal.data_imports.sources.wrike.settings import ENDPOINTS
+from posthog.temporal.data_imports.sources.wrike.wrike import (
+    WrikeResumeConfig,
+    validate_credentials as validate_wrike_credentials,
+    wrike_source,
+)
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class WrikeSource(SimpleSource[WrikeSourceConfig]):
+class WrikeSource(ResumableSource[WrikeSourceConfig, WrikeResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.WRIKE
@@ -23,7 +35,86 @@ class WrikeSource(SimpleSource[WrikeSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.WRIKE,
             label="Wrike",
-            iconPath="/static/services/wrike.png",
-            fields=cast(list[FieldType], []),
+            releaseStatus=ReleaseStatus.ALPHA,
             unreleasedSource=True,
+            caption="""Enter a Wrike permanent access token to pull your Wrike data into the PostHog Data warehouse.
+
+Create a permanent access token under **Apps & Integrations → API** in Wrike. The token needs read access (the default `Default` scope is sufficient) to the resources you want to sync.
+
+Set **Host** to the domain shown in your browser when you're logged into Wrike (e.g. `www.wrike.com`, `app-us2.wrike.com`, or `app-eu.wrike.com`).""",
+            iconPath="/static/services/wrike.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/wrike",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="access_token",
+                        label="Permanent access token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                    SourceFieldInputConfig(
+                        name="host",
+                        label="Host",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="www.wrike.com",
+                        secret=False,
+                    ),
+                ],
+            ),
+        )
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error": "Invalid or expired Wrike access token. Please generate a new token and reconnect.",
+            "403 Client Error": "Your Wrike access token does not have the required permissions for this resource.",
+        }
+
+    def get_schemas(
+        self,
+        config: WrikeSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # Wrike's API has no reliably-verifiable server-side timestamp filter, so every endpoint
+        # ships as full refresh (see settings.py for the rationale).
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=[],
+            )
+            for endpoint in list(ENDPOINTS)
+        ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: WrikeSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        return validate_wrike_credentials(config.access_token, config.host)
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[WrikeResumeConfig]:
+        return ResumableSourceManager[WrikeResumeConfig](inputs, WrikeResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: WrikeSourceConfig,
+        resumable_source_manager: ResumableSourceManager[WrikeResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return wrike_source(
+            access_token=config.access_token,
+            host=config.host,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/posthog/temporal/data_imports/sources/wrike/source.py
+++ b/posthog/temporal/data_imports/sources/wrike/source.py
@@ -90,7 +90,7 @@ Set **Host** to the domain shown in your browser when you're logged into Wrike (
                 supports_append=False,
                 incremental_fields=[],
             )
-            for endpoint in list(ENDPOINTS)
+            for endpoint in ENDPOINTS
         ]
         if names is not None:
             names_set = set(names)

--- a/posthog/temporal/data_imports/sources/wrike/tests/test_wrike.py
+++ b/posthog/temporal/data_imports/sources/wrike/tests/test_wrike.py
@@ -1,0 +1,176 @@
+from typing import Any
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.wrike.settings import WRIKE_ENDPOINTS
+from posthog.temporal.data_imports.sources.wrike.wrike import (
+    WrikeResumeConfig,
+    _build_url,
+    get_rows,
+    is_host_valid,
+    validate_credentials,
+    wrike_source,
+)
+
+
+def _mock_response(status_code: int = 200, json_body: dict[str, Any] | None = None) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.status_code = status_code
+    response.ok = 200 <= status_code < 300
+    response.json.return_value = json_body or {}
+    response.text = ""
+    return response
+
+
+def _mock_session_returning(responses: list[mock.MagicMock]) -> mock.MagicMock:
+    session = mock.MagicMock()
+    session.get.side_effect = responses
+    return session
+
+
+class TestIsHostValid:
+    @pytest.mark.parametrize(
+        "host, expected",
+        [
+            ("www.wrike.com", True),
+            ("app-us2.wrike.com", True),
+            ("app-eu.wrike.com", True),
+            ("https://www.wrike.com/", True),
+            ("WWW.WRIKE.COM", True),
+            ("evil.com", False),
+            ("wrike.com.evil.com", False),
+            ("notwrike.com", False),
+            ("localhost", False),
+            ("169.254.169.254", False),
+            ("", False),
+        ],
+    )
+    def test_is_host_valid(self, host: str, expected: bool) -> None:
+        assert is_host_valid(host) is expected
+
+
+class TestBuildUrl:
+    def test_no_params(self) -> None:
+        assert _build_url("www.wrike.com", "/tasks", {}) == "https://www.wrike.com/api/v4/tasks"
+
+    def test_with_params(self) -> None:
+        url = _build_url("www.wrike.com", "/tasks", {"pageSize": 1000})
+        assert url == "https://www.wrike.com/api/v4/tasks?pageSize=1000"
+
+    def test_drops_none_values(self) -> None:
+        url = _build_url("app-us2.wrike.com", "/tasks", {"pageSize": 1000, "nextPageToken": None})
+        assert url == "https://app-us2.wrike.com/api/v4/tasks?pageSize=1000"
+
+    def test_normalizes_scheme_and_trailing_slash(self) -> None:
+        assert _build_url("https://www.wrike.com/", "/contacts", {}) == "https://www.wrike.com/api/v4/contacts"
+
+
+class TestValidateCredentials:
+    def test_rejects_non_wrike_host_without_request(self) -> None:
+        with mock.patch("posthog.temporal.data_imports.sources.wrike.wrike.make_tracked_session") as make_session:
+            is_valid, error = validate_credentials("token", "evil.com")
+        assert is_valid is False
+        assert error is not None and "Wrike domain" in error
+        make_session.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "status_code, expected_valid, expected_error",
+        [
+            (200, True, None),
+            (401, False, "Invalid Wrike access token"),
+            (403, False, "Wrike access token is missing the required permissions"),
+            (500, False, "Wrike API error: status=500"),
+        ],
+    )
+    def test_status_mapping(self, status_code: int, expected_valid: bool, expected_error: str | None) -> None:
+        session = _mock_session_returning([_mock_response(status_code)])
+        with mock.patch("posthog.temporal.data_imports.sources.wrike.wrike.make_tracked_session", return_value=session):
+            is_valid, error = validate_credentials("token", "www.wrike.com")
+        assert is_valid is expected_valid
+        assert error == expected_error
+
+    def test_probes_current_user_endpoint(self) -> None:
+        session = _mock_session_returning([_mock_response(200)])
+        with mock.patch("posthog.temporal.data_imports.sources.wrike.wrike.make_tracked_session", return_value=session):
+            validate_credentials("token", "www.wrike.com")
+        called_url = session.get.call_args.args[0]
+        assert called_url == "https://www.wrike.com/api/v4/contacts?me=true"
+
+
+class TestGetRows:
+    def _manager(self, can_resume: bool = False, resume_state: WrikeResumeConfig | None = None) -> mock.MagicMock:
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = can_resume
+        manager.load_state.return_value = resume_state
+        return manager
+
+    def test_non_paginated_endpoint_single_page(self) -> None:
+        session = _mock_session_returning(
+            [_mock_response(200, {"kind": "contacts", "data": [{"id": "a"}, {"id": "b"}]})]
+        )
+        manager = self._manager()
+        with mock.patch("posthog.temporal.data_imports.sources.wrike.wrike.make_tracked_session", return_value=session):
+            batches = list(get_rows("token", "www.wrike.com", "contacts", mock.MagicMock(), manager))
+
+        assert batches == [[{"id": "a"}, {"id": "b"}]]
+        assert session.get.call_count == 1
+        manager.save_state.assert_not_called()
+
+    def test_paginated_endpoint_follows_next_page_token(self) -> None:
+        session = _mock_session_returning(
+            [
+                _mock_response(200, {"data": [{"id": 1}], "nextPageToken": "tok2"}),
+                _mock_response(200, {"data": [{"id": 2}]}),
+            ]
+        )
+        manager = self._manager()
+        with mock.patch("posthog.temporal.data_imports.sources.wrike.wrike.make_tracked_session", return_value=session):
+            batches = list(get_rows("token", "www.wrike.com", "tasks", mock.MagicMock(), manager))
+
+        assert batches == [[{"id": 1}], [{"id": 2}]]
+        # First request carries pageSize; second carries only the token.
+        first_url, second_url = session.get.call_args_list[0].args[0], session.get.call_args_list[1].args[0]
+        assert "pageSize=1000" in first_url
+        assert "nextPageToken=tok2" in second_url
+        # State saved once, after yielding the first page, before fetching the next.
+        manager.save_state.assert_called_once_with(WrikeResumeConfig(next_page_token="tok2"))
+
+    def test_resumes_from_saved_state(self) -> None:
+        session = _mock_session_returning([_mock_response(200, {"data": [{"id": 3}]})])
+        manager = self._manager(can_resume=True, resume_state=WrikeResumeConfig(next_page_token="resume_tok"))
+        with mock.patch("posthog.temporal.data_imports.sources.wrike.wrike.make_tracked_session", return_value=session):
+            batches = list(get_rows("token", "www.wrike.com", "tasks", mock.MagicMock(), manager))
+
+        assert batches == [[{"id": 3}]]
+        assert "nextPageToken=resume_tok" in session.get.call_args.args[0]
+
+    def test_rejects_non_wrike_host_before_any_request(self) -> None:
+        with mock.patch("posthog.temporal.data_imports.sources.wrike.wrike.make_tracked_session") as make_session:
+            with pytest.raises(ValueError, match="non-Wrike host"):
+                list(get_rows("token", "evil.com", "tasks", mock.MagicMock(), self._manager()))
+        make_session.assert_not_called()
+
+    def test_empty_data_yields_nothing(self) -> None:
+        session = _mock_session_returning([_mock_response(200, {"data": []})])
+        manager = self._manager()
+        with mock.patch("posthog.temporal.data_imports.sources.wrike.wrike.make_tracked_session", return_value=session):
+            batches = list(get_rows("token", "www.wrike.com", "tasks", mock.MagicMock(), manager))
+        assert batches == []
+
+
+class TestWrikeSource:
+    def test_tasks_partition_on_created_date(self) -> None:
+        response = wrike_source("token", "www.wrike.com", "tasks", mock.MagicMock(), mock.MagicMock())
+        assert response.name == "tasks"
+        assert response.primary_keys == ["id"]
+        assert response.sort_mode == "asc"
+        assert response.partition_mode == "datetime"
+        assert response.partition_keys == ["createdDate"]
+
+    @pytest.mark.parametrize("endpoint", [name for name, cfg in WRIKE_ENDPOINTS.items() if cfg.partition_key is None])
+    def test_unpartitioned_endpoints(self, endpoint: str) -> None:
+        response = wrike_source("token", "www.wrike.com", endpoint, mock.MagicMock(), mock.MagicMock())
+        assert response.primary_keys == ["id"]
+        assert response.partition_mode is None
+        assert response.partition_keys is None

--- a/posthog/temporal/data_imports/sources/wrike/tests/test_wrike.py
+++ b/posthog/temporal/data_imports/sources/wrike/tests/test_wrike.py
@@ -38,16 +38,35 @@ class TestIsHostValid:
             ("app-eu.wrike.com", True),
             ("https://www.wrike.com/", True),
             ("WWW.WRIKE.COM", True),
+            ("www.wrike.com:443", True),
             ("evil.com", False),
             ("wrike.com.evil.com", False),
             ("notwrike.com", False),
             ("localhost", False),
             ("169.254.169.254", False),
             ("", False),
+            # SSRF bypass attempts: a path/query/credentials must not smuggle a non-Wrike
+            # netloc past the suffix check.
+            ("evil.com?.wrike.com", False),
+            ("evil.com/.wrike.com", False),
+            ("internal.service/path.wrike.com", False),
+            ("evil.com#.wrike.com", False),
+            ("user:pass@evil.com", False),
+            ("user@evil.com:443", False),
         ],
     )
     def test_is_host_valid(self, host: str, expected: bool) -> None:
         assert is_host_valid(host) is expected
+
+    @pytest.mark.parametrize(
+        "host",
+        ["evil.com?.wrike.com", "internal.service/path.wrike.com", "user:pass@evil.com.attacker.net"],
+    )
+    def test_build_url_target_never_diverges_from_validation(self, host: str) -> None:
+        # The connection target is built from the same normalized hostname is_host_valid checks,
+        # so a host that fails validation can never resolve to a Wrike URL.
+        assert is_host_valid(host) is False
+        assert "wrike.com/api/v4" not in _build_url(host, "/tasks", {})
 
 
 class TestBuildUrl:

--- a/posthog/temporal/data_imports/sources/wrike/tests/test_wrike_source.py
+++ b/posthog/temporal/data_imports/sources/wrike/tests/test_wrike_source.py
@@ -1,0 +1,129 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.generated_configs import WrikeSourceConfig
+from posthog.temporal.data_imports.sources.wrike.settings import ENDPOINTS
+from posthog.temporal.data_imports.sources.wrike.source import WrikeSource
+from posthog.temporal.data_imports.sources.wrike.wrike import WrikeResumeConfig
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestWrikeSource:
+    def setup_method(self):
+        self.source = WrikeSource()
+        self.team_id = 123
+        self.config = WrikeSourceConfig(access_token="token", host="www.wrike.com")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.WRIKE
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "Wrike"
+        assert config.label == "Wrike"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is True
+        assert config.iconPath == "/static/services/wrike.png"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["access_token", "host"]
+
+    def test_access_token_field_is_secret_password(self):
+        config = self.source.get_source_config
+        token_field = next(
+            f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "access_token"
+        )
+        assert token_field.type == SourceFieldInputConfigType.PASSWORD
+        assert token_field.secret is True
+        assert token_field.required is True
+
+    def test_host_field_is_plain_required_text(self):
+        config = self.source.get_source_config
+        host_field = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "host")
+        assert host_field.type == SourceFieldInputConfigType.TEXT
+        assert host_field.secret is False
+        assert host_field.required is True
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://www.wrike.com/api/v4/tasks",
+            "403 Client Error: Forbidden for url: https://www.wrike.com/api/v4/contacts",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            "429 Client Error: Too Many Requests for url: https://www.wrike.com/api/v4/tasks",
+            "500 Server Error for url: https://www.wrike.com/api/v4/tasks",
+        ],
+    )
+    def test_non_retryable_errors_does_not_match_transient(self, other_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)
+
+    def test_get_schemas_covers_all_endpoints(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert {schema.name for schema in schemas} == set(ENDPOINTS)
+
+    def test_get_schemas_are_full_refresh_only(self):
+        # Wrike ships full refresh only until the server-side updatedDate filter is verified.
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert all(not schema.supports_incremental for schema in schemas)
+        assert all(not schema.supports_append for schema in schemas)
+        assert all(schema.incremental_fields == [] for schema in schemas)
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["tasks"])
+        assert len(schemas) == 1
+        assert schemas[0].name == "tasks"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self):
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    @pytest.mark.parametrize(
+        "mock_return",
+        [
+            (True, None),
+            (False, "Invalid Wrike access token"),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.wrike.source.validate_wrike_credentials")
+    def test_validate_credentials(self, mock_validate, mock_return):
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert (is_valid, error_message) == mock_return
+        mock_validate.assert_called_once_with(self.config.access_token, self.config.host)
+
+    def test_get_resumable_source_manager_binds_resume_config(self):
+        inputs = mock.MagicMock()
+        manager = self.source.get_resumable_source_manager(inputs)
+
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is WrikeResumeConfig
+
+    @mock.patch("posthog.temporal.data_imports.sources.wrike.source.wrike_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_wrike_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "tasks"
+        manager = mock.MagicMock()
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_wrike_source.assert_called_once()
+        kwargs = mock_wrike_source.call_args.kwargs
+        assert kwargs["access_token"] == "token"
+        assert kwargs["host"] == "www.wrike.com"
+        assert kwargs["endpoint"] == "tasks"
+        assert kwargs["resumable_source_manager"] is manager

--- a/posthog/temporal/data_imports/sources/wrike/wrike.py
+++ b/posthog/temporal/data_imports/sources/wrike/wrike.py
@@ -1,0 +1,174 @@
+import dataclasses
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import urlencode
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.wrike.settings import WRIKE_ENDPOINTS, WrikeEndpointConfig
+
+# Wrike serves each account from a region-specific host (www.wrike.com, app-us2.wrike.com,
+# app-eu.wrike.com, ...). The user supplies their host; we only ever send the token to a
+# *.wrike.com host to avoid being retargeted at an attacker-controlled or internal address.
+WRIKE_HOST_SUFFIX = "wrike.com"
+API_PATH = "/api/v4"
+# Wrike caps paginated list pages at 1000 items.
+PAGE_SIZE = 1000
+REQUEST_TIMEOUT_SECONDS = 60
+MAX_RETRIES = 5
+
+
+class WrikeRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class WrikeResumeConfig:
+    next_page_token: str
+
+
+def _normalize_host(host: str) -> str:
+    return host.strip().lower().removeprefix("https://").removeprefix("http://").rstrip("/")
+
+
+def is_host_valid(host: str) -> bool:
+    """Only allow Wrike-owned hosts as the credential target (anti-SSRF)."""
+    if not host:
+        return False
+    normalized = _normalize_host(host)
+    return normalized == WRIKE_HOST_SUFFIX or normalized.endswith(f".{WRIKE_HOST_SUFFIX}")
+
+
+def _base_url(host: str) -> str:
+    return f"https://{_normalize_host(host)}{API_PATH}"
+
+
+def _build_url(host: str, path: str, params: dict[str, Any]) -> str:
+    clean_params = {key: value for key, value in params.items() if value is not None}
+    base = f"{_base_url(host)}{path}"
+    if not clean_params:
+        return base
+    return f"{base}?{urlencode(clean_params)}"
+
+
+def _get_headers(access_token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json",
+    }
+
+
+def validate_credentials(access_token: str, host: str) -> tuple[bool, str | None]:
+    """Confirm the access token is genuine. `/contacts?me=true` is a cheap authenticated probe
+    that returns the current user."""
+    if not is_host_valid(host):
+        return False, "Host must be a Wrike domain (e.g. www.wrike.com or app-us2.wrike.com)"
+
+    url = _build_url(host, "/contacts", {"me": "true"})
+    try:
+        response = make_tracked_session().get(url, headers=_get_headers(access_token), timeout=10)
+    except requests.exceptions.RequestException as e:
+        return False, str(e)
+
+    if response.status_code == 200:
+        return True, None
+    if response.status_code == 401:
+        return False, "Invalid Wrike access token"
+    if response.status_code == 403:
+        return False, "Wrike access token is missing the required permissions"
+
+    return False, f"Wrike API error: status={response.status_code}"
+
+
+def _initial_params(config: WrikeEndpointConfig) -> dict[str, Any]:
+    return {"pageSize": PAGE_SIZE} if config.paginated else {}
+
+
+def get_rows(
+    access_token: str,
+    host: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[WrikeResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    config = WRIKE_ENDPOINTS[endpoint]
+    headers = _get_headers(access_token)
+
+    if not is_host_valid(host):
+        raise ValueError(f"Refusing to send Wrike credentials to non-Wrike host: {host}")
+
+    resume_config = (
+        resumable_source_manager.load_state() if config.paginated and resumable_source_manager.can_resume() else None
+    )
+    if resume_config is not None:
+        url = _build_url(host, config.path, {"nextPageToken": resume_config.next_page_token})
+        logger.debug(f"Wrike: resuming {endpoint} from saved nextPageToken")
+    else:
+        url = _build_url(host, config.path, _initial_params(config))
+
+    @retry(
+        retry=retry_if_exception_type((WrikeRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(MAX_RETRIES),
+        wait=wait_exponential_jitter(initial=1, max=60),
+        reraise=True,
+    )
+    def fetch_page(page_url: str) -> dict[str, Any]:
+        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        # Wrike rate-limits around 400 req/min; 429s and transient 5xx are retried with backoff.
+        if response.status_code == 429 or response.status_code >= 500:
+            raise WrikeRetryableError(f"Wrike API error (retryable): status={response.status_code}, url={page_url}")
+
+        if not response.ok:
+            logger.error(f"Wrike API error: status={response.status_code}, body={response.text}, url={page_url}")
+            response.raise_for_status()
+
+        return response.json()
+
+    while True:
+        data = fetch_page(url)
+        items = data.get("data", []) or []
+
+        if items:
+            yield items
+
+        # Only the paginated endpoints return a nextPageToken; everything else is a single page.
+        next_page_token = data.get("nextPageToken") if config.paginated else None
+        if not next_page_token:
+            break
+
+        resumable_source_manager.save_state(WrikeResumeConfig(next_page_token=next_page_token))
+        url = _build_url(host, config.path, {"nextPageToken": next_page_token})
+
+
+def wrike_source(
+    access_token: str,
+    host: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[WrikeResumeConfig],
+) -> SourceResponse:
+    config = WRIKE_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            access_token=access_token,
+            host=host,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+        ),
+        primary_keys=[config.primary_key],
+        sort_mode="asc",
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+    )

--- a/posthog/temporal/data_imports/sources/wrike/wrike.py
+++ b/posthog/temporal/data_imports/sources/wrike/wrike.py
@@ -1,7 +1,7 @@
 import dataclasses
 from collections.abc import Iterator
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 
 import requests
 from structlog.types import FilteringBoundLogger
@@ -33,15 +33,26 @@ class WrikeResumeConfig:
 
 
 def _normalize_host(host: str) -> str:
-    return host.strip().lower().removeprefix("https://").removeprefix("http://").rstrip("/")
+    """Extract the bare hostname the credential would actually be sent to.
+
+    The user-supplied value is parsed as a URL and reduced to its hostname, so a value
+    carrying a path, query, port, or credentials (e.g. `evil.com?.wrike.com` or
+    `internal.service/x.wrike.com`) can't smuggle a non-Wrike netloc past `is_host_valid`'s
+    suffix check — `requests` would otherwise connect to `evil.com`/`internal.service`.
+    Both validation and URL construction go through this, so the validated host and the
+    connection target are always the same value."""
+    candidate = host.strip().lower()
+    if "://" not in candidate:
+        candidate = f"//{candidate}"
+    return urlsplit(candidate).hostname or ""
 
 
 def is_host_valid(host: str) -> bool:
     """Only allow Wrike-owned hosts as the credential target (anti-SSRF)."""
     if not host:
         return False
-    normalized = _normalize_host(host)
-    return normalized == WRIKE_HOST_SUFFIX or normalized.endswith(f".{WRIKE_HOST_SUFFIX}")
+    hostname = _normalize_host(host)
+    return hostname == WRIKE_HOST_SUFFIX or hostname.endswith(f".{WRIKE_HOST_SUFFIX}")
 
 
 def _base_url(host: str) -> str:


### PR DESCRIPTION
## Problem

Wrike (project management SaaS) was registered as a scaffolded Data warehouse source but had no sync logic, so it was invisible and unusable. This fills it in so teams can pull their Wrike tasks, folders, projects, contacts, workflows, custom fields, and spaces into the PostHog Data warehouse.

## Changes

Implements the `wrike` source end-to-end following the `implementing-warehouse-sources` skill, using the standard `source.py` / `settings.py` / `wrike.py` split.

- **Base class:** `ResumableSource` — Wrike's `/tasks` endpoint paginates via `pageSize` + `nextPageToken`, so a sync can resume mid-pagination after a heartbeat timeout. State is saved *after* each page is yielded so a crash re-yields (merge dedupes on primary key) rather than skipping.
- **Endpoints:** `tasks`, `folders` (folders + projects), `contacts`, `workflows`, `custom_fields`, `spaces` — the canonical user-relevant set, cross-referenced with the Airbyte/Fivetran Wrike connectors. `tasks` partitions on the stable `createdDate`; the rest are unpartitioned single-page reads.
- **Auth:** permanent access token. The connection host is user-supplied (Wrike serves accounts from region-specific hosts such as `www.wrike.com`, `app-us2.wrike.com`, `app-eu.wrike.com`), and is constrained to `*.wrike.com` in both credential validation and the transport to prevent the stored token from being retargeted at an attacker-controlled or internal address.
- **Tracked transport:** every request goes through `make_tracked_session()`; `requests` is imported for exception types only.
- **Errors:** `validate_credentials` maps 401/403/transport failures; `get_non_retryable_errors` covers 401/403 so bad credentials fail fast instead of retrying.

### Sync mode decision (full refresh only)

Wrike documents an `updatedDate` range filter on a few endpoints, but I could not curl-verify against the live API (no credentials available) that it filters server-side when combined with `nextPageToken` paging and the 1000-row page cap. Per the skill's guidance to enable incremental only on a *verified* server-side timestamp filter, every endpoint ships as **full refresh** — matching Airbyte's Wrike connector. This is documented in `settings.py`. Incremental can be layered on later once the filter is verified.

Kept behind `unreleasedSource=True` with `releaseStatus=alpha`.

The existing `frontend/public/services/wrike.png` logo is reused; no new icon was fetched.

## How did you test this code?

I'm an agent. I added and ran automated tests only — no manual end-to-end sync against a live Wrike account.

- `posthog/temporal/data_imports/sources/wrike/tests/test_wrike_source.py` — source-class behavior: `source_type`, config fields/labels, schema list, full-refresh assertions, credential plumbing, resumable-manager binding, `source_for_pipeline` argument plumbing, non-retryable error matching.
- `posthog/temporal/data_imports/sources/wrike/tests/test_wrike.py` — transport behavior: host allow-listing (anti-SSRF), URL construction, credential-validation status mapping, single-page vs paginated reads, resume-from-saved-state, save-after-yield, partition shape.

48 tests pass. `ruff check` and `ruff format` are clean on the changed Python. `pnpm run generate:source-configs` produced the `WrikeSourceConfig` (`access_token`, `host`); only that hunk was applied to avoid unrelated drift in the generated file. No `schema-general.ts` change was needed (the Wrike enum entries were already present), so `schema:build` and a Django migration were not required.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored with Claude Code (Opus 4.8) via the `implementing-warehouse-sources` skill. Modeled on the `aircall` source (Resumable HTTP source with a mixed incremental/full-refresh shape) after surveying `klaviyo` and `github`.

Key decisions:
- **Full refresh over incremental:** Wrike's `updatedDate` filter is documented but unverifiable here without live credentials; chose the conservative, Airbyte-aligned full-refresh path rather than shipping an unverified server-side filter.
- **Host allow-listing:** since the user supplies the host the token is sent to, constrained it to `*.wrike.com` to close the SSRF/credential-exfiltration vector rather than relying on a free-form host.
- **Dropped `comments`:** the account-level `/comments` endpoint defaults to the last 7 days, which would silently ship incomplete data, so it was left out of the initial endpoint set.

Reviewer notes: requires human review; no live sync was performed.
