### PR TITLE
feat(data-warehouse): implement zoom import source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -118,6 +118,7 @@ the row lists both.
 | woocommerce      | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | workos           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | zendesk          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| zoom             | HTTP                        | requests                                                        | ✅                          |
 
 ### Notes on partially-tracked sources
 
@@ -223,7 +224,6 @@ doesn't conflict with concurrent PRs.
 - xero
 - youtube_analytics
 - zoho_crm
-- zoom
 - zuora
 
 ---

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -932,7 +932,9 @@ class ZohoCRMSourceConfig(config.Config):
 
 @config.config
 class ZoomSourceConfig(config.Config):
-    pass
+    account_id: str
+    client_id: str
+    client_secret: str
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/zoom/settings.py
+++ b/posthog/temporal/data_imports/sources/zoom/settings.py
@@ -1,0 +1,67 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from products.data_warehouse.backend.types import IncrementalField
+
+
+@dataclass
+class ZoomEndpointConfig:
+    name: str
+    # Path template relative to the Zoom API base. Fan-out endpoints contain a
+    # ``{user_id}`` placeholder that is filled in per user (see ``fan_out``).
+    path: str
+    # Key in the JSON response body that holds the list of records
+    # (e.g. ``{"users": [...], "next_page_token": "..."}``).
+    data_key: str
+    primary_key: str = "id"
+    # A STABLE datetime field used for partitioning. Never use a field that
+    # mutates over time (e.g. ``updated_at``) — partitions would be rewritten
+    # on every sync.
+    partition_key: Optional[str] = "created_at"
+    # When True the endpoint is queried once per user returned by ``/users``.
+    fan_out: bool = False
+    # Static query params sent on every request to this endpoint.
+    params: dict[str, str] = field(default_factory=dict)
+    # Zoom caps ``page_size`` at 300 for these list endpoints.
+    page_size: int = 300
+
+
+# Zoom's list endpoints expose no server-side timestamp filter (no ``since`` /
+# ``from`` on the meeting/webinar/user list endpoints), so every endpoint is a
+# full refresh. ``created_at`` is declared as a partition key for stable
+# partitioning but not as an incremental cursor — see ``get_schemas``.
+ZOOM_ENDPOINTS: dict[str, ZoomEndpointConfig] = {
+    "users": ZoomEndpointConfig(
+        name="users",
+        path="/users",
+        data_key="users",
+        primary_key="id",
+        partition_key="created_at",
+    ),
+    "meetings": ZoomEndpointConfig(
+        name="meetings",
+        path="/users/{user_id}/meetings",
+        data_key="meetings",
+        primary_key="id",
+        partition_key="created_at",
+        fan_out=True,
+        # ``scheduled`` returns all of a user's stored scheduled meetings,
+        # including recurring ones — the most complete list for ingestion.
+        params={"type": "scheduled"},
+    ),
+    "webinars": ZoomEndpointConfig(
+        name="webinars",
+        path="/users/{user_id}/webinars",
+        data_key="webinars",
+        primary_key="id",
+        partition_key="created_at",
+        fan_out=True,
+    ),
+}
+
+ENDPOINTS = tuple(ZOOM_ENDPOINTS.keys())
+
+# No endpoint supports server-side incremental filtering, so this stays empty.
+# Kept for parity with other sources and to make enabling incremental later a
+# one-line change once Zoom exposes a usable filter.
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {}

--- a/posthog/temporal/data_imports/sources/zoom/source.py
+++ b/posthog/temporal/data_imports/sources/zoom/source.py
@@ -1,29 +1,141 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import ZoomSourceConfig
+from posthog.temporal.data_imports.sources.zoom.settings import ENDPOINTS, INCREMENTAL_FIELDS
+from posthog.temporal.data_imports.sources.zoom.zoom import (
+    ZoomResumeConfig,
+    validate_credentials as validate_zoom_credentials,
+    zoom_source,
+)
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class ZoomSource(SimpleSource[ZoomSourceConfig]):
+class ZoomSource(ResumableSource[ZoomSourceConfig, ZoomResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.ZOOM
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error": "Zoom authentication failed. Please check your account ID, client ID, and client secret.",
+            "Invalid access token": "Zoom authentication failed. Please reconnect the source.",
+            "403 Client Error": "Your Zoom app is missing the required scopes. Grant user/meeting/webinar read scopes and reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: ZoomSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # Zoom's list endpoints expose no server-side timestamp filter, so every
+        # endpoint is a full refresh (no incremental sync).
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+            )
+            for endpoint in list(ENDPOINTS)
+        ]
+
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+
+        return schemas
+
+    def validate_credentials(
+        self, config: ZoomSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        return validate_zoom_credentials(
+            account_id=config.account_id,
+            client_id=config.client_id,
+            client_secret=config.client_secret,
+            schema_name=schema_name,
+        )
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[ZoomResumeConfig]:
+        return ResumableSourceManager[ZoomResumeConfig](inputs, ZoomResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: ZoomSourceConfig,
+        resumable_source_manager: ResumableSourceManager[ZoomResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return zoom_source(
+            account_id=config.account_id,
+            client_id=config.client_id,
+            client_secret=config.client_secret,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
+        )
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.ZOOM,
             label="Zoom",
-            iconPath="/static/services/zoom.png",
-            fields=cast(list[FieldType], []),
+            releaseStatus=ReleaseStatus.ALPHA,
             unreleasedSource=True,
+            caption="""Sync your Zoom users, meetings, and webinars into the PostHog Data warehouse.
+
+Create a **Server-to-Server OAuth** app in the [Zoom App Marketplace](https://marketplace.zoom.us/develop/create) and copy its Account ID, Client ID, and Client Secret below.
+
+Grant the following read scopes:
+- `user:read:list_users:admin`
+- `meeting:read:list_meetings:admin`
+- `webinar:read:list_webinars:admin`
+""",
+            iconPath="/static/services/zoom.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/zoom",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="account_id",
+                        label="Account ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
+                        secret=False,
+                    ),
+                    SourceFieldInputConfig(
+                        name="client_id",
+                        label="Client ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
+                        secret=False,
+                    ),
+                    SourceFieldInputConfig(
+                        name="client_secret",
+                        label="Client secret",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
         )

--- a/posthog/temporal/data_imports/sources/zoom/source.py
+++ b/posthog/temporal/data_imports/sources/zoom/source.py
@@ -54,7 +54,7 @@ class ZoomSource(ResumableSource[ZoomSourceConfig, ZoomResumeConfig]):
                 supports_append=False,
                 incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
             )
-            for endpoint in list(ENDPOINTS)
+            for endpoint in ENDPOINTS
         ]
 
         if names is not None:

--- a/posthog/temporal/data_imports/sources/zoom/tests/test_zoom.py
+++ b/posthog/temporal/data_imports/sources/zoom/tests/test_zoom.py
@@ -1,0 +1,284 @@
+import json
+from typing import Any
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from requests import HTTPError, Response
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.zoom.zoom import (
+    ZoomClient,
+    ZoomResumeConfig,
+    get_rows,
+    validate_credentials,
+    zoom_source,
+)
+
+MODULE = "posthog.temporal.data_imports.sources.zoom.zoom"
+
+
+def _resp(body: dict[str, Any], status: int = 200) -> Response:
+    response = Response()
+    response.status_code = status
+    response._content = json.dumps(body).encode()
+    response.headers["Content-Type"] = "application/json"
+    return response
+
+
+def _manager(can_resume: bool = False, state: ZoomResumeConfig | None = None) -> MagicMock:
+    manager = MagicMock(spec=ResumableSourceManager)
+    manager.can_resume.return_value = can_resume
+    manager.load_state.return_value = state
+    return manager
+
+
+class TestZoomResumeConfig:
+    def test_defaults(self) -> None:
+        assert ZoomResumeConfig() == ZoomResumeConfig(next_page_token="", user_index=0)
+
+    def test_round_trips_through_manager_load(self) -> None:
+        # Older state without user_index must still deserialize (default applies).
+        assert ZoomResumeConfig(next_page_token="tok") == ZoomResumeConfig(next_page_token="tok", user_index=0)
+
+
+class TestZoomClient:
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_fetch_token_returns_access_token(self, mock_session: MagicMock) -> None:
+        mock_session.return_value.post.return_value = _resp({"access_token": "tok-1", "expires_in": 3599})
+        client = ZoomClient("acc", "cid", "secret")
+        assert client.fetch_token() == "tok-1"
+
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_fetch_token_raises_on_bad_credentials(self, mock_session: MagicMock) -> None:
+        mock_session.return_value.post.return_value = _resp({"error": "invalid_client"}, status=400)
+        client = ZoomClient("acc", "cid", "secret")
+        with pytest.raises(HTTPError):
+            client.fetch_token()
+
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_fetch_token_raises_when_token_missing(self, mock_session: MagicMock) -> None:
+        mock_session.return_value.post.return_value = _resp({"token_type": "bearer"})
+        client = ZoomClient("acc", "cid", "secret")
+        with pytest.raises(ValueError):
+            client.fetch_token()
+
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_request_refreshes_token_once_on_401(self, mock_session: MagicMock) -> None:
+        session = mock_session.return_value
+        session.post.return_value = _resp({"access_token": "tok"})
+        session.get.side_effect = [
+            _resp({"code": 124, "message": "Invalid access token."}, status=401),
+            _resp({"users": []}, status=200),
+        ]
+
+        client = ZoomClient("acc", "cid", "secret")
+        response = client.request("/users", {"page_size": 1})
+
+        assert response.status_code == 200
+        # Token fetched twice: initial + refresh after the 401.
+        assert session.post.call_count == 2
+        assert session.get.call_count == 2
+
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_request_caches_token_across_calls(self, mock_session: MagicMock) -> None:
+        session = mock_session.return_value
+        session.post.return_value = _resp({"access_token": "tok"})
+        session.get.return_value = _resp({"users": []})
+
+        client = ZoomClient("acc", "cid", "secret")
+        client.request("/users")
+        client.request("/users")
+
+        # Token is fetched lazily once and reused.
+        assert session.post.call_count == 1
+
+
+class TestTopLevelRows:
+    def test_paginates_and_yields_each_page(self) -> None:
+        client = MagicMock()
+        client.request.side_effect = [
+            _resp({"users": [{"id": "u1"}], "next_page_token": "t1"}),
+            _resp({"users": [{"id": "u2"}], "next_page_token": ""}),
+        ]
+        manager = _manager()
+
+        rows = list(get_rows(client, "users", MagicMock(), manager))
+
+        assert rows == [[{"id": "u1"}], [{"id": "u2"}]]
+
+    def test_saves_state_after_each_non_terminal_page(self) -> None:
+        client = MagicMock()
+        client.request.side_effect = [
+            _resp({"users": [{"id": "u1"}], "next_page_token": "t1"}),
+            _resp({"users": [{"id": "u2"}], "next_page_token": ""}),
+        ]
+        manager = _manager()
+
+        list(get_rows(client, "users", MagicMock(), manager))
+
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [ZoomResumeConfig(next_page_token="t1")]
+
+    def test_first_request_omits_token_then_carries_cursor(self) -> None:
+        client = MagicMock()
+        client.request.side_effect = [
+            _resp({"users": [{"id": "u1"}], "next_page_token": "t1"}),
+            _resp({"users": [{"id": "u2"}], "next_page_token": ""}),
+        ]
+
+        list(get_rows(client, "users", MagicMock(), _manager()))
+
+        calls = client.request.call_args_list
+        assert calls[0].args[0] == "/users"
+        assert "next_page_token" not in calls[0].args[1]
+        assert calls[1].args[1]["next_page_token"] == "t1"
+
+    def test_resume_seeds_first_request_with_saved_token(self) -> None:
+        client = MagicMock()
+        client.request.side_effect = [
+            _resp({"users": [{"id": "u9"}], "next_page_token": ""}),
+        ]
+        manager = _manager(can_resume=True, state=ZoomResumeConfig(next_page_token="resumed"))
+
+        list(get_rows(client, "users", MagicMock(), manager))
+
+        assert client.request.call_args_list[0].args[1]["next_page_token"] == "resumed"
+        manager.load_state.assert_called_once()
+
+    def test_terminal_single_page_saves_no_state(self) -> None:
+        client = MagicMock()
+        client.request.side_effect = [_resp({"users": [{"id": "u1"}], "next_page_token": ""})]
+        manager = _manager()
+
+        list(get_rows(client, "users", MagicMock(), manager))
+
+        manager.save_state.assert_not_called()
+
+
+class TestFanOutRows:
+    def _client_with(self, responses: dict[str, Response]) -> MagicMock:
+        client = MagicMock()
+
+        def side_effect(path: str, params: dict[str, Any] | None = None) -> Response:
+            assert path in responses, f"unexpected path {path}"
+            return responses[path]
+
+        client.request.side_effect = side_effect
+        return client
+
+    def test_fans_out_meetings_per_user(self) -> None:
+        client = self._client_with(
+            {
+                "/users": _resp({"users": [{"id": "u1"}, {"id": "u2"}], "next_page_token": ""}),
+                "/users/u1/meetings": _resp({"meetings": [{"id": 1}], "next_page_token": ""}),
+                "/users/u2/meetings": _resp({"meetings": [{"id": 2}], "next_page_token": ""}),
+            }
+        )
+
+        rows = list(get_rows(client, "meetings", MagicMock(), _manager()))
+
+        assert rows == [[{"id": 1}], [{"id": 2}]]
+
+    @pytest.mark.parametrize("status", [400, 404])
+    def test_skips_user_lacking_feature(self, status: int) -> None:
+        client = self._client_with(
+            {
+                "/users": _resp({"users": [{"id": "u1"}, {"id": "u2"}], "next_page_token": ""}),
+                "/users/u1/webinars": _resp({"code": 200, "message": "no webinar plan"}, status=status),
+                "/users/u2/webinars": _resp({"webinars": [{"id": 9}], "next_page_token": ""}),
+            }
+        )
+
+        rows = list(get_rows(client, "webinars", MagicMock(), _manager()))
+
+        # The unlicensed user is skipped without aborting the sync.
+        assert rows == [[{"id": 9}]]
+
+    def test_checkpoints_user_index_after_each_user(self) -> None:
+        client = self._client_with(
+            {
+                "/users": _resp({"users": [{"id": "u1"}, {"id": "u2"}], "next_page_token": ""}),
+                "/users/u1/meetings": _resp({"meetings": [{"id": 1}], "next_page_token": ""}),
+                "/users/u2/meetings": _resp({"meetings": [{"id": 2}], "next_page_token": ""}),
+            }
+        )
+        manager = _manager()
+
+        list(get_rows(client, "meetings", MagicMock(), manager))
+
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert ZoomResumeConfig(next_page_token="", user_index=1) in saved
+        assert ZoomResumeConfig(next_page_token="", user_index=2) in saved
+
+    def test_resume_starts_at_saved_user_index(self) -> None:
+        client = self._client_with(
+            {
+                "/users": _resp({"users": [{"id": "u1"}, {"id": "u2"}], "next_page_token": ""}),
+                "/users/u2/meetings": _resp({"meetings": [{"id": 2}], "next_page_token": ""}),
+            }
+        )
+        manager = _manager(can_resume=True, state=ZoomResumeConfig(next_page_token="", user_index=1))
+
+        rows = list(get_rows(client, "meetings", MagicMock(), manager))
+
+        # u1 is skipped entirely (its meetings path is never requested).
+        assert rows == [[{"id": 2}]]
+        requested = [call.args[0] for call in client.request.call_args_list]
+        assert "/users/u1/meetings" not in requested
+
+
+class TestZoomSource:
+    def test_source_response_shape(self) -> None:
+        response = zoom_source("acc", "cid", "secret", "users", MagicMock(), _manager())
+        assert response.name == "users"
+        assert response.primary_keys == ["id"]
+        assert response.partition_mode == "datetime"
+        assert response.partition_keys == ["created_at"]
+        assert response.partition_format == "week"
+
+    @pytest.mark.parametrize(
+        ("endpoint", "primary_key"),
+        [("users", "id"), ("meetings", "id"), ("webinars", "id")],
+    )
+    def test_primary_keys_per_endpoint(self, endpoint: str, primary_key: str) -> None:
+        response = zoom_source("acc", "cid", "secret", endpoint, MagicMock(), _manager())
+        assert response.primary_keys == [primary_key]
+
+
+class TestValidateCredentials:
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_bad_credentials_return_false(self, mock_session: MagicMock) -> None:
+        mock_session.return_value.post.return_value = _resp({"error": "invalid_client"}, status=400)
+        ok, error = validate_credentials("acc", "cid", "secret")
+        assert ok is False
+        assert error is not None
+
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_source_create_only_validates_token(self, mock_session: MagicMock) -> None:
+        session = mock_session.return_value
+        session.post.return_value = _resp({"access_token": "tok"})
+        ok, error = validate_credentials("acc", "cid", "secret", schema_name=None)
+        assert ok is True
+        assert error is None
+        # No endpoint probe at source-create.
+        session.get.assert_not_called()
+
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_schema_probe_success(self, mock_session: MagicMock) -> None:
+        session = mock_session.return_value
+        session.post.return_value = _resp({"access_token": "tok"})
+        session.get.return_value = _resp({"users": []})
+        ok, error = validate_credentials("acc", "cid", "secret", schema_name="users")
+        assert ok is True
+        assert error is None
+
+    @pytest.mark.parametrize("status", [401, 403])
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_schema_probe_missing_scope(self, mock_session: MagicMock, status: int) -> None:
+        session = mock_session.return_value
+        session.post.return_value = _resp({"access_token": "tok"})
+        session.get.return_value = _resp({"code": 104}, status=status)
+        ok, error = validate_credentials("acc", "cid", "secret", schema_name="users")
+        assert ok is False
+        assert error is not None and "scope" in error

--- a/posthog/temporal/data_imports/sources/zoom/tests/test_zoom_source.py
+++ b/posthog/temporal/data_imports/sources/zoom/tests/test_zoom_source.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.generated_configs import ZoomSourceConfig
+from posthog.temporal.data_imports.sources.zoom.source import ZoomSource
+from posthog.temporal.data_imports.sources.zoom.zoom import ZoomResumeConfig
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+MODULE = "posthog.temporal.data_imports.sources.zoom.source"
+
+
+def _config() -> ZoomSourceConfig:
+    return ZoomSourceConfig(account_id="acc", client_id="cid", client_secret="secret")
+
+
+def _inputs(schema_name: str = "users") -> SourceInputs:
+    return SourceInputs(
+        schema_name=schema_name,
+        schema_id="schema-1",
+        source_id="source-1",
+        team_id=1,
+        should_use_incremental_field=False,
+        db_incremental_field_last_value=None,
+        db_incremental_field_earliest_value=None,
+        incremental_field=None,
+        incremental_field_type=None,
+        job_id="job-1",
+        logger=MagicMock(),
+        reset_pipeline=False,
+    )
+
+
+class TestZoomSource:
+    def test_source_type(self) -> None:
+        assert ZoomSource().source_type == ExternalDataSourceType.ZOOM
+
+    def test_source_config_fields(self) -> None:
+        config = ZoomSource().get_source_config
+        fields = {f.name: f for f in config.fields if isinstance(f, SourceFieldInputConfig)}
+        assert set(fields) == {"account_id", "client_id", "client_secret"}
+        assert fields["client_secret"].type == SourceFieldInputConfigType.PASSWORD
+        assert fields["client_secret"].secret is True
+        assert fields["account_id"].secret is False
+        assert fields["client_id"].secret is False
+
+    def test_source_config_is_alpha_and_unreleased(self) -> None:
+        config = ZoomSource().get_source_config
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is True
+
+    def test_get_schemas_lists_all_endpoints_as_full_refresh(self) -> None:
+        schemas = ZoomSource().get_schemas(_config(), team_id=1)
+        names = {s.name for s in schemas}
+        assert names == {"users", "meetings", "webinars"}
+        assert all(s.supports_incremental is False for s in schemas)
+        assert all(s.supports_append is False for s in schemas)
+
+    @pytest.mark.parametrize("names", [["users"], ["meetings", "webinars"]])
+    def test_get_schemas_filters_by_names(self, names: list[str]) -> None:
+        schemas = ZoomSource().get_schemas(_config(), team_id=1, names=names)
+        assert {s.name for s in schemas} == set(names)
+
+    def test_validate_credentials_delegates(self) -> None:
+        with patch(f"{MODULE}.validate_zoom_credentials", return_value=(True, None)) as mock_validate:
+            result = ZoomSource().validate_credentials(_config(), team_id=1, schema_name="users")
+        assert result == (True, None)
+        mock_validate.assert_called_once_with(
+            account_id="acc", client_id="cid", client_secret="secret", schema_name="users"
+        )
+
+    def test_get_resumable_source_manager_binds_resume_config(self) -> None:
+        manager = ZoomSource().get_resumable_source_manager(_inputs())
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is ZoomResumeConfig
+
+    def test_source_for_pipeline_plumbs_arguments(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        inputs = _inputs(schema_name="meetings")
+        with patch(f"{MODULE}.zoom_source") as mock_source:
+            ZoomSource().source_for_pipeline(_config(), manager, inputs)
+        mock_source.assert_called_once_with(
+            account_id="acc",
+            client_id="cid",
+            client_secret="secret",
+            endpoint="meetings",
+            logger=inputs.logger,
+            resumable_source_manager=manager,
+        )
+
+    def test_non_retryable_errors_cover_auth_failures(self) -> None:
+        errors = ZoomSource().get_non_retryable_errors()
+        assert "401 Client Error" in errors
+        assert "403 Client Error" in errors
+        assert "Invalid access token" in errors

--- a/posthog/temporal/data_imports/sources/zoom/zoom.py
+++ b/posthog/temporal/data_imports/sources/zoom/zoom.py
@@ -162,10 +162,10 @@ def _list_all_user_ids(client: ZoomClient, logger: FilteringBoundLogger) -> list
             response.raise_for_status()
 
         body = response.json()
+        # Direct access: a user without an id is a malformed response that should
+        # fail loudly rather than silently drop the user (and its meetings/webinars).
         for user in body.get("users") or []:
-            user_id = user.get("id")
-            if user_id:
-                user_ids.append(user_id)
+            user_ids.append(user["id"])
 
         token = body.get("next_page_token") or ""
         if not token:

--- a/posthog/temporal/data_imports/sources/zoom/zoom.py
+++ b/posthog/temporal/data_imports/sources/zoom/zoom.py
@@ -1,0 +1,317 @@
+import base64
+import dataclasses
+from collections.abc import Callable, Iterator
+from typing import Any, Optional
+from urllib.parse import urlencode
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from urllib3.util.retry import Retry
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.zoom.settings import ZOOM_ENDPOINTS, ZoomEndpointConfig
+
+ZOOM_API_BASE = "https://api.zoom.us/v2"
+ZOOM_OAUTH_URL = "https://zoom.us/oauth/token"
+
+# Bound the number of pages we fetch for a single user during fan-out so a
+# pathological account can't trigger an unbounded scan.
+MAX_PAGES_PER_USER = 1000
+
+
+class ZoomRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class ZoomResumeConfig:
+    # Cursor for the list endpoint currently being paginated.
+    next_page_token: str = ""
+    # Fan-out only: number of users fully processed so far. Top-level endpoints
+    # leave this at 0.
+    user_index: int = 0
+
+
+class ZoomClient:
+    """Server-to-server OAuth client for the Zoom REST API.
+
+    Zoom access tokens expire after ~1 hour, so the token is fetched lazily and
+    refreshed once on a mid-sync 401 before giving up.
+    """
+
+    def __init__(
+        self,
+        account_id: str,
+        client_id: str,
+        client_secret: str,
+        logger: Optional[FilteringBoundLogger] = None,
+    ) -> None:
+        self.account_id = account_id
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self._logger = logger
+        # Disable session-level retries — retry/backoff is handled explicitly by
+        # tenacity below so we can honour Zoom's 429 semantics deterministically.
+        self._session = make_tracked_session(retry=Retry(total=0), redact_values=(client_secret,))
+        self._token: Optional[str] = None
+
+    def _basic_auth_header(self) -> str:
+        raw = f"{self.client_id}:{self.client_secret}".encode()
+        return "Basic " + base64.b64encode(raw).decode()
+
+    def fetch_token(self) -> str:
+        params = {"grant_type": "account_credentials", "account_id": self.account_id}
+        url = f"{ZOOM_OAUTH_URL}?{urlencode(params)}"
+        response = self._session.post(url, headers={"Authorization": self._basic_auth_header()}, timeout=30)
+        response.raise_for_status()
+        token = response.json().get("access_token")
+        if not token:
+            raise ValueError("Zoom OAuth response did not include an access token")
+        return token
+
+    def _ensure_token(self) -> str:
+        if self._token is None:
+            self._token = self.fetch_token()
+        return self._token
+
+    @retry(
+        retry=retry_if_exception_type((ZoomRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(5),
+        wait=wait_exponential_jitter(initial=1, max=60),
+        reraise=True,
+    )
+    def _get(self, url: str, token: str) -> requests.Response:
+        response = self._session.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=60)
+        if response.status_code == 429 or response.status_code >= 500:
+            raise ZoomRetryableError(f"Zoom API error (retryable): status={response.status_code}, url={url}")
+        return response
+
+    def request(self, path: str, params: Optional[dict[str, Any]] = None) -> requests.Response:
+        url = f"{ZOOM_API_BASE}{path}"
+        if params:
+            url = f"{url}?{urlencode(params)}"
+
+        token = self._ensure_token()
+        response = self._get(url, token)
+
+        # The token may have expired mid-sync — refresh once and retry.
+        if response.status_code == 401:
+            self._token = None
+            token = self._ensure_token()
+            response = self._get(url, token)
+
+        return response
+
+
+def _paginate(
+    client: ZoomClient,
+    path: str,
+    config: ZoomEndpointConfig,
+    logger: FilteringBoundLogger,
+    start_token: str,
+    on_page: Callable[[str], None],
+) -> Iterator[list[dict[str, Any]]]:
+    """Yield each page of records for a single list endpoint.
+
+    ``on_page(next_token)`` is invoked after each page is yielded so the caller
+    can persist resume state *after* the batch is handed to the pipeline.
+    """
+    token = start_token
+    pages = 0
+    while True:
+        params: dict[str, Any] = {"page_size": config.page_size, **config.params}
+        if token:
+            params["next_page_token"] = token
+
+        response = client.request(path, params)
+        if not response.ok:
+            logger.error(f"Zoom API error: status={response.status_code}, body={response.text}, path={path}")
+            response.raise_for_status()
+
+        body = response.json()
+        records = body.get(config.data_key) or []
+        next_token = body.get("next_page_token") or ""
+
+        if records:
+            yield records
+
+        pages += 1
+        if not next_token or pages >= MAX_PAGES_PER_USER:
+            if next_token:
+                logger.warning(f"Zoom: hit page cap ({MAX_PAGES_PER_USER}) for {config.name} at path={path}")
+            break
+
+        token = next_token
+        on_page(next_token)
+
+
+def _list_all_user_ids(client: ZoomClient, logger: FilteringBoundLogger) -> list[str]:
+    user_ids: list[str] = []
+    token = ""
+    while True:
+        params: dict[str, Any] = {"page_size": ZOOM_ENDPOINTS["users"].page_size}
+        if token:
+            params["next_page_token"] = token
+
+        response = client.request("/users", params)
+        if not response.ok:
+            logger.error(f"Zoom API error listing users: status={response.status_code}, body={response.text}")
+            response.raise_for_status()
+
+        body = response.json()
+        for user in body.get("users") or []:
+            user_id = user.get("id")
+            if user_id:
+                user_ids.append(user_id)
+
+        token = body.get("next_page_token") or ""
+        if not token:
+            break
+
+    return user_ids
+
+
+def _top_level_rows(
+    client: ZoomClient,
+    config: ZoomEndpointConfig,
+    logger: FilteringBoundLogger,
+    manager: ResumableSourceManager[ZoomResumeConfig],
+    resume: Optional[ZoomResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    start_token = resume.next_page_token if resume else ""
+
+    def checkpoint(next_token: str) -> None:
+        manager.save_state(ZoomResumeConfig(next_page_token=next_token))
+
+    yield from _paginate(client, config.path, config, logger, start_token, checkpoint)
+
+
+def _fan_out_rows(
+    client: ZoomClient,
+    config: ZoomEndpointConfig,
+    logger: FilteringBoundLogger,
+    manager: ResumableSourceManager[ZoomResumeConfig],
+    resume: Optional[ZoomResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    # Fan-out resumes at user granularity. The user list isn't guaranteed to be
+    # stable across a 24h resume window, but primary-key merge dedupes any rows
+    # re-yielded after the list shifts, so resuming by index is safe.
+    user_ids = _list_all_user_ids(client, logger)
+    start_index = resume.user_index if resume else 0
+    start_token = resume.next_page_token if resume else ""
+
+    for index in range(start_index, len(user_ids)):
+        user_id = user_ids[index]
+        path = config.path.format(user_id=user_id)
+        token = start_token if index == start_index else ""
+
+        # Probe the first page so we can skip users that lack the feature
+        # (e.g. no webinar license → 400) without aborting the whole sync.
+        params: dict[str, Any] = {"page_size": config.page_size, **config.params}
+        if token:
+            params["next_page_token"] = token
+        first = client.request(path, params)
+        if first.status_code in (400, 404):
+            logger.info(f"Zoom: skipping user {user_id} for {config.name} (status={first.status_code})")
+            manager.save_state(ZoomResumeConfig(next_page_token="", user_index=index + 1))
+            continue
+        if not first.ok:
+            logger.error(f"Zoom API error: status={first.status_code}, body={first.text}, path={path}")
+            first.raise_for_status()
+
+        body = first.json()
+        records = body.get(config.data_key) or []
+        next_token = body.get("next_page_token") or ""
+        if records:
+            yield records
+
+        if next_token:
+
+            def checkpoint(tok: str, _index: int = index) -> None:
+                manager.save_state(ZoomResumeConfig(next_page_token=tok, user_index=_index))
+
+            checkpoint(next_token)
+            yield from _paginate(client, path, config, logger, next_token, checkpoint)
+
+        manager.save_state(ZoomResumeConfig(next_page_token="", user_index=index + 1))
+
+
+def get_rows(
+    client: ZoomClient,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[ZoomResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    config = ZOOM_ENDPOINTS[endpoint]
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume is not None:
+        logger.debug(f"Zoom: resuming {endpoint} from state {resume}")
+
+    if config.fan_out:
+        yield from _fan_out_rows(client, config, logger, resumable_source_manager, resume)
+    else:
+        yield from _top_level_rows(client, config, logger, resumable_source_manager, resume)
+
+
+def zoom_source(
+    account_id: str,
+    client_id: str,
+    client_secret: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[ZoomResumeConfig],
+) -> SourceResponse:
+    config = ZOOM_ENDPOINTS[endpoint]
+    client = ZoomClient(account_id, client_id, client_secret, logger)
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            client=client,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+        ),
+        primary_keys=[config.primary_key],
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+    )
+
+
+def validate_credentials(
+    account_id: str,
+    client_id: str,
+    client_secret: str,
+    schema_name: Optional[str] = None,
+) -> tuple[bool, str | None]:
+    client = ZoomClient(account_id, client_id, client_secret)
+
+    try:
+        client.fetch_token()
+    except requests.HTTPError:
+        return False, "Invalid Zoom account ID, client ID, or client secret"
+    except requests.RequestException as e:
+        return False, str(e)
+    except ValueError as e:
+        return False, str(e)
+
+    # At source-create (no specific schema) a genuine token is enough — users
+    # may only grant scopes for the endpoints they intend to sync.
+    if schema_name is None:
+        return True, None
+
+    response = client.request("/users", {"page_size": 1})
+    if response.status_code == 200:
+        return True, None
+    if response.status_code in (401, 403):
+        return (
+            False,
+            "Zoom credentials are valid but lack the required scopes. Grant user/meeting/webinar read scopes and retry.",
+        )
+    return False, f"Zoom API returned an unexpected status ({response.status_code})"


### PR DESCRIPTION
## Problem

PostHog's data warehouse had Zoom only as a scaffolded stub (registered with `unreleasedSource=True`, no sync logic). Customers using Zoom for video conferencing want to pull their users, meetings, and webinars into the warehouse to join against product analytics. This implements the Zoom source end-to-end.

## Changes

Implements the `zoom` source following the `implementing-warehouse-sources` skill's `source.py` / `settings.py` / `zoom.py` split:

- **Auth**: Server-to-server OAuth (account credentials) — the recommended flow for service integrations since JWT was deprecated. The user supplies an Account ID, Client ID, and Client Secret from a Server-to-Server OAuth app. Tokens are fetched lazily and refreshed once on a mid-sync 401 (Zoom tokens expire after ~1 hour).
- **Endpoints**: `users` (account-level), plus `meetings` and `webinars` fanned out per user (Zoom has no account-wide meeting/webinar list endpoint — this mirrors the Airbyte/Fivetran connectors). Users that lack a feature (e.g. no webinar license → `400`) are skipped per-user rather than failing the whole sync.
- **Base class**: `ResumableSource`. Cursor pagination via `next_page_token`; resume state is saved **after** each yielded batch, and at user granularity for fan-out so a heartbeat timeout doesn't restart from scratch.
- **Incremental**: full refresh only. Zoom's list endpoints expose no server-side timestamp filter, so per the skill no endpoint advertises `supports_incremental`. `created_at` (a stable field) is used as a datetime partition key; primary-key merge dedupes re-yielded rows on resume.
- **Transport**: all outbound HTTP goes through `make_tracked_session()`; the client secret is passed to `redact_values`. `tenacity` handles `429`/`5xx`/transient retries with exponential backoff.
- Wired `ZoomSourceConfig` (account_id / client_id / client_secret) into `generated_configs.py`, added the source to the Implemented table in `SOURCES.md`, and reused the existing `zoom.png` icon.

Kept behind `unreleasedSource=True` with `releaseStatus=alpha`.

### Notes / conservative choices

- I do not have Zoom credentials, so endpoint behavior was verified against the live API only for reachability and error shapes (the OAuth and `/users` endpoints return the documented `400 invalid_client` / `401 Invalid access token` responses). Response field names (`users`/`meetings`/`webinars` arrays, `next_page_token`, `created_at`) follow the current public docs; this is noted in a code comment where ordering/stability is assumed.
- The `users` endpoint uses Zoom's default `status=active`, so inactive/pending users (and their meetings/webinars) are not synced in this alpha. This is a deliberate scope limit, easy to extend later.

## How did you test this code?

I'm an agent. I added and ran automated tests only — no manual end-to-end sync (no Zoom account available):

- `tests/test_zoom.py` (transport): token fetch + 401 refresh + caching, top-level pagination and resume, fan-out per user, skip-on-`400`/`404`, user-index checkpointing, `SourceResponse` shape, and `validate_credentials` status mapping.
- `tests/test_zoom_source.py` (source class): `source_type`, form fields/secrets, schema list, `validate_credentials` delegation, resumable-manager binding, `source_for_pipeline` plumbing, non-retryable errors.

All 36 tests pass. Also ran the existing source-registry and config-generator tests, plus `ruff check`/`ruff format` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8). Followed the `implementing-warehouse-sources` skill and used klaviyo/github (hand-rolled transport) and chargebee (resumable cursor) as references.

Key decisions:
- Chose a hand-rolled `requests`-based client over the declarative `rest_source.RESTClient` because Zoom needs a custom token-fetch step and per-user fan-out, which are awkward to express declaratively.
- Regenerating `generated_configs.py` wholesale produced unrelated diffs (pre-existing ruff-format/ordering drift in the committed baseline), so only the `ZoomSourceConfig` block was applied to keep the diff minimal and avoid touching other sources.
- Shipped full-refresh only after confirming Zoom's list endpoints have no server-side time filter — an "incremental" sync there would cost the same as a full refresh, which the skill explicitly warns against.

Requires human review; not self-merged.
