### PR TITLE
feat(data-warehouse): implement omnisend import source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -85,6 +85,7 @@ the row lists both.
 | mysql            | DB protocol                 | pymysql                                                         | ➖                          |
 | okta             | HTTP                        | requests                                                        | ✅                          |
 | notion           | HTTP                        | requests                                                        | ✅                          |
+| omnisend         | HTTP                        | requests                                                        | ✅                          |
 | paddle           | HTTP                        | requests                                                        | ✅                          |
 | pagerduty        | HTTP                        | requests                                                        | ✅                          |
 | pinterest_ads    | HTTP                        | requests                                                        | ✅                          |
@@ -196,7 +197,6 @@ doesn't conflict with concurrent PRs.
 - mixpanel
 - monday
 - netsuite
-- omnisend
 - onedrive
 - oracle
 - outreach

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -577,7 +577,7 @@ class OktaSourceConfig(config.Config):
 
 @config.config
 class OmnisendSourceConfig(config.Config):
-    pass
+    api_key: str
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/omnisend/api_inventory.md
+++ b/posthog/temporal/data_imports/sources/omnisend/api_inventory.md
@@ -1,0 +1,48 @@
+# Omnisend API inventory
+
+Reference for the `omnisend` warehouse source. Verify against the live API before
+changing endpoint behavior — see the `implementing-warehouse-sources` skill.
+
+- **API version:** v3 (`https://api.omnisend.com/v3`). v3 is the stable resource-based
+  REST surface for contacts/orders/products/carts/categories/campaigns. (v5 / v2026-03-15
+  reshape several of these into event-centric endpoints; v3 is the right fit for a
+  list-and-sync warehouse source.)
+- **Auth:** API key in the `X-API-KEY` header.
+- **Pagination:** offset/limit with a fully-formed next-page URL at `paging.next`
+  (`null` when exhausted). We follow `paging.next` directly, which makes pagination
+  resumable. `limit` default 100, max 250.
+- **Rate limits:** 400 req/min general; 100 req/min segment reads; 15 req/min segment
+  writes. We only read general list endpoints. 429s carry `Retry-After`.
+
+## List endpoints
+
+| Schema     | Path          | Response array key | Primary key  | Partition (stable) |
+| ---------- | ------------- | ------------------ | ------------ | ------------------ |
+| contacts   | `/contacts`   | `contacts`         | `contactID`  | `createdAt`        |
+| campaigns  | `/campaigns`  | `campaigns`        | `campaignID` | `createdAt`        |
+| carts      | `/carts`      | `carts`            | `cartID`     | `createdAt`        |
+| orders     | `/orders`     | `orders`           | `orderID`    | `createdAt`        |
+| products   | `/products`   | `products`         | `productID`  | `createdAt`        |
+| categories | `/categories` | `categories`       | `categoryID` | —                  |
+
+Endpoint existence confirmed against the live API (all return non-404 without a key).
+Primary-key / response-key names follow Omnisend's consistent `<resource>` /
+`<resource>ID` v3 convention (the create-contact response returns `contactID`); exact
+shapes of the list responses were not re-verified with a live key.
+
+## Sync mode
+
+All endpoints ship **full refresh (replace)**.
+
+Omnisend documents `updatedAtFrom` as a server-side filter on `/contacts`, but with hard
+restrictions (it cannot be combined with `email`, `phone`, `status`, `segmentID`, or
+`tag`). The skill requires confirming a server-side timestamp filter actually filters via
+a live curl smoke test (future-date cutoff) before advertising incremental sync. Without
+API credentials to run that check, we conservatively ship full refresh everywhere. Once a
+key is available, `/contacts` is the candidate to flip to incremental on `updatedAt`.
+
+## Caveats
+
+- `/orders`: orders that Omnisend auto-syncs from e-commerce platforms (Shopify,
+  BigCommerce, WooCommerce) are **not** exposed through v3 — only orders pushed via the
+  API are returned.

--- a/posthog/temporal/data_imports/sources/omnisend/omnisend.py
+++ b/posthog/temporal/data_imports/sources/omnisend/omnisend.py
@@ -1,0 +1,137 @@
+import dataclasses
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import urlencode
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from urllib3.util.retry import Retry
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.omnisend.settings import OMNISEND_ENDPOINTS
+
+OMNISEND_BASE_URL = "https://api.omnisend.com/v3"
+
+# Omnisend allows up to 250 items per page; larger pages mean fewer requests against the
+# 400 req/min general rate limit.
+PAGE_SIZE = 250
+
+REQUEST_TIMEOUT_SECONDS = 60
+MAX_RETRIES = 5
+
+
+class OmnisendRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class OmnisendResumeConfig:
+    # Fully-formed next-page URL from the API's `paging.next`; we follow it verbatim.
+    next_url: str
+
+
+def _get_headers(api_key: str) -> dict[str, str]:
+    return {
+        "X-API-KEY": api_key,
+        "Accept": "application/json",
+    }
+
+
+def validate_credentials(api_key: str) -> tuple[bool, int | None]:
+    """Cheap probe to confirm the API key is genuine. Returns (is_valid, status_code)."""
+    try:
+        session = make_tracked_session(headers=_get_headers(api_key), redact_values=(api_key,))
+        response = session.get(f"{OMNISEND_BASE_URL}/contacts?{urlencode({'limit': 1})}", timeout=10)
+        return response.status_code == 200, response.status_code
+    except Exception:
+        return False, None
+
+
+def get_rows(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[OmnisendResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    config = OMNISEND_ENDPOINTS[endpoint]
+
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume_config is not None:
+        url: str | None = resume_config.next_url
+        logger.debug(f"Omnisend: resuming {endpoint} from URL: {url}")
+    else:
+        url = f"{OMNISEND_BASE_URL}{config.path}?{urlencode({'limit': PAGE_SIZE})}"
+
+    # One session reused across all pages (TCP/connection reuse). `tenacity` below is the sole
+    # retry mechanism, so disable the transport's built-in urllib3 retries to avoid nested backoff.
+    # `redact_values` masks the API key in logs and sample capture.
+    session = make_tracked_session(headers=_get_headers(api_key), retry=Retry(total=0), redact_values=(api_key,))
+
+    @retry(
+        retry=retry_if_exception_type((OmnisendRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(MAX_RETRIES),
+        wait=wait_exponential_jitter(initial=1, max=60),
+        reraise=True,
+    )
+    def fetch_page(page_url: str) -> dict[str, Any]:
+        response = session.get(page_url, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        if response.status_code == 429 or response.status_code >= 500:
+            raise OmnisendRetryableError(
+                f"Omnisend API error (retryable): status={response.status_code}, url={page_url}"
+            )
+
+        if not response.ok:
+            logger.error(f"Omnisend API error: status={response.status_code}, body={response.text}, url={page_url}")
+            response.raise_for_status()
+
+        return response.json()
+
+    try:
+        while url:
+            data = fetch_page(url)
+            # Fail loudly if the expected envelope key is missing (e.g. an API-shape change),
+            # rather than silently reporting a successful sync of zero rows.
+            items = data[config.data_key]
+            next_url = data.get("paging", {}).get("next")
+
+            if items:
+                yield items
+
+            # Save AFTER yielding so a crash re-yields the last page (merge dedupes on the
+            # primary key) rather than skipping it.
+            if next_url:
+                resumable_source_manager.save_state(OmnisendResumeConfig(next_url=next_url))
+
+            url = next_url
+    finally:
+        session.close()
+
+
+def omnisend_source(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[OmnisendResumeConfig],
+) -> SourceResponse:
+    config = OMNISEND_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_key=api_key,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+        ),
+        primary_keys=[config.primary_key],
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="month" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+        sort_mode="asc",
+    )

--- a/posthog/temporal/data_imports/sources/omnisend/settings.py
+++ b/posthog/temporal/data_imports/sources/omnisend/settings.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from products.data_warehouse.backend.types import IncrementalField
+
+
+@dataclass
+class OmnisendEndpointConfig:
+    name: str
+    path: str
+    data_key: str  # Response array key, e.g. {"contacts": [...], "paging": {...}}
+    primary_key: str
+    # Stable creation-time field used for delta partitioning. Never a mutable field
+    # like updatedAt — partitions would rewrite on every sync.
+    partition_key: Optional[str] = None
+    # Advertised incremental options. Empty = full refresh only (see api_inventory.md:
+    # Omnisend's only server-side timestamp filter is unverified, so we ship full refresh).
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+
+
+OMNISEND_ENDPOINTS: dict[str, OmnisendEndpointConfig] = {
+    "contacts": OmnisendEndpointConfig(
+        name="contacts",
+        path="/contacts",
+        data_key="contacts",
+        primary_key="contactID",
+        partition_key="createdAt",
+    ),
+    "campaigns": OmnisendEndpointConfig(
+        name="campaigns",
+        path="/campaigns",
+        data_key="campaigns",
+        primary_key="campaignID",
+        partition_key="createdAt",
+    ),
+    "carts": OmnisendEndpointConfig(
+        name="carts",
+        path="/carts",
+        data_key="carts",
+        primary_key="cartID",
+        partition_key="createdAt",
+    ),
+    "orders": OmnisendEndpointConfig(
+        name="orders",
+        path="/orders",
+        data_key="orders",
+        primary_key="orderID",
+        partition_key="createdAt",
+    ),
+    "products": OmnisendEndpointConfig(
+        name="products",
+        path="/products",
+        data_key="products",
+        primary_key="productID",
+        partition_key="createdAt",
+    ),
+    "categories": OmnisendEndpointConfig(
+        name="categories",
+        path="/categories",
+        data_key="categories",
+        primary_key="categoryID",
+    ),
+}
+
+ENDPOINTS = tuple(OMNISEND_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in OMNISEND_ENDPOINTS.items()
+}

--- a/posthog/temporal/data_imports/sources/omnisend/source.py
+++ b/posthog/temporal/data_imports/sources/omnisend/source.py
@@ -69,12 +69,11 @@ You can create an API key in your [Omnisend account settings](https://app.omnise
         schemas = [
             SourceSchema(
                 name=endpoint,
-                supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None
-                and len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
-                supports_append=len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+                supports_incremental=bool(fields := INCREMENTAL_FIELDS.get(endpoint)),
+                supports_append=bool(fields),
+                incremental_fields=fields or [],
             )
-            for endpoint in list(ENDPOINTS)
+            for endpoint in ENDPOINTS
         ]
         if names is not None:
             names_set = set(names)

--- a/posthog/temporal/data_imports/sources/omnisend/source.py
+++ b/posthog/temporal/data_imports/sources/omnisend/source.py
@@ -1,19 +1,31 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import OmnisendSourceConfig
+from posthog.temporal.data_imports.sources.omnisend.omnisend import (
+    OmnisendResumeConfig,
+    omnisend_source,
+    validate_credentials as validate_omnisend_credentials,
+)
+from posthog.temporal.data_imports.sources.omnisend.settings import ENDPOINTS, INCREMENTAL_FIELDS
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class OmnisendSource(SimpleSource[OmnisendSourceConfig]):
+class OmnisendSource(ResumableSource[OmnisendSourceConfig, OmnisendResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.OMNISEND
@@ -23,7 +35,82 @@ class OmnisendSource(SimpleSource[OmnisendSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.OMNISEND,
             label="Omnisend",
-            iconPath="/static/services/omnisend.png",
-            fields=cast(list[FieldType], []),
+            releaseStatus=ReleaseStatus.ALPHA,
             unreleasedSource=True,
+            caption="""Enter your Omnisend API key to automatically pull your Omnisend data into the PostHog Data warehouse.
+
+You can create an API key in your [Omnisend account settings](https://app.omnisend.com/settings/integrations/api-keys).
+""",
+            iconPath="/static/services/omnisend.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/omnisend",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_schemas(
+        self,
+        config: OmnisendSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None
+                and len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
+                supports_append=len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+            )
+            for endpoint in list(ENDPOINTS)
+        ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: OmnisendSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        is_valid, status_code = validate_omnisend_credentials(config.api_key)
+        if is_valid:
+            return True, None
+
+        if status_code in (401, 403):
+            return False, "Invalid Omnisend API key"
+
+        return False, "Could not connect to Omnisend with the provided API key"
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error": "Your Omnisend API key is invalid or expired. Please generate a new key and reconnect.",
+            "403 Client Error": "Your Omnisend API key does not have the required permissions. Please check the key and try again.",
+        }
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[OmnisendResumeConfig]:
+        return ResumableSourceManager[OmnisendResumeConfig](inputs, OmnisendResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: OmnisendSourceConfig,
+        resumable_source_manager: ResumableSourceManager[OmnisendResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return omnisend_source(
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/posthog/temporal/data_imports/sources/omnisend/tests/test_omnisend.py
+++ b/posthog/temporal/data_imports/sources/omnisend/tests/test_omnisend.py
@@ -1,0 +1,251 @@
+import json
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from requests import Response
+from requests.exceptions import HTTPError
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.omnisend.omnisend import (
+    OMNISEND_BASE_URL,
+    OmnisendResumeConfig,
+    get_rows,
+    omnisend_source,
+    validate_credentials,
+)
+from posthog.temporal.data_imports.sources.omnisend.settings import OMNISEND_ENDPOINTS
+
+
+def _make_response(body: dict[str, Any], status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    resp.url = f"{OMNISEND_BASE_URL}/contacts"
+    resp.reason = "OK" if status_code == 200 else "Client Error"
+    resp.headers["Content-Type"] = "application/json"
+    return resp
+
+
+def _query(url: str) -> dict[str, list[str]]:
+    return parse_qs(urlsplit(url).query)
+
+
+def _drive_get_rows(
+    endpoint: str,
+    manager: MagicMock,
+    responses: list[Response],
+) -> tuple[list[str], list[list[dict[str, Any]]]]:
+    sent_urls: list[str] = []
+    response_iter = iter(responses)
+
+    def fake_get(url: str, timeout: Any = None) -> Response:
+        sent_urls.append(url)
+        return next(response_iter)
+
+    with patch("posthog.temporal.data_imports.sources.omnisend.omnisend.make_tracked_session") as MockSession:
+        MockSession.return_value.get.side_effect = fake_get
+        rows = list(
+            get_rows(
+                api_key="test-key",
+                endpoint=endpoint,
+                logger=MagicMock(),
+                resumable_source_manager=manager,
+            )
+        )
+
+    return sent_urls, rows
+
+
+def _next_url(offset: int) -> str:
+    return f"{OMNISEND_BASE_URL}/contacts?limit=250&offset={offset}"
+
+
+class TestGetRowsPagination:
+    def test_follows_paging_next_until_exhausted(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [
+            _make_response({"contacts": [{"contactID": "1"}], "paging": {"next": _next_url(250)}}),
+            _make_response({"contacts": [{"contactID": "2"}], "paging": {"next": None}}),
+        ]
+        sent_urls, rows = _drive_get_rows("contacts", manager, responses)
+
+        # First request hits the limit-seeded base URL; second follows paging.next verbatim.
+        assert _query(sent_urls[0])["limit"] == ["250"]
+        assert "offset" not in _query(sent_urls[0])
+        assert sent_urls[1] == _next_url(250)
+        assert rows == [[{"contactID": "1"}], [{"contactID": "2"}]]
+
+    def test_saves_state_after_each_non_terminal_page(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [
+            _make_response({"contacts": [{"contactID": "1"}], "paging": {"next": _next_url(250)}}),
+            _make_response({"contacts": [{"contactID": "2"}], "paging": {"next": None}}),
+        ]
+        _drive_get_rows("contacts", manager, responses)
+
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [OmnisendResumeConfig(next_url=_next_url(250))]
+
+    def test_single_terminal_page_does_not_save_state(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [_make_response({"contacts": [{"contactID": "1"}], "paging": {"next": None}})]
+        _drive_get_rows("contacts", manager, responses)
+
+        manager.save_state.assert_not_called()
+
+    def test_missing_paging_block_terminates(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [_make_response({"contacts": [{"contactID": "1"}]})]
+        sent_urls, rows = _drive_get_rows("contacts", manager, responses)
+
+        assert len(sent_urls) == 1
+        assert rows == [[{"contactID": "1"}]]
+        manager.save_state.assert_not_called()
+
+    def test_empty_page_yields_nothing(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [_make_response({"contacts": [], "paging": {"next": None}})]
+        _, rows = _drive_get_rows("contacts", manager, responses)
+
+        assert rows == []
+
+
+class TestGetRowsResume:
+    def test_resume_seeds_starting_url(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = True
+        manager.load_state.return_value = OmnisendResumeConfig(next_url=_next_url(500))
+
+        responses = [_make_response({"contacts": [{"contactID": "6"}], "paging": {"next": None}})]
+        sent_urls, _ = _drive_get_rows("contacts", manager, responses)
+
+        assert sent_urls[0] == _next_url(500)
+        manager.load_state.assert_called_once()
+
+    def test_does_not_load_state_when_cannot_resume(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [_make_response({"contacts": [{"contactID": "1"}], "paging": {"next": None}})]
+        _drive_get_rows("contacts", manager, responses)
+
+        manager.load_state.assert_not_called()
+
+
+class TestGetRowsErrors:
+    @pytest.mark.parametrize("status_code", [401, 403, 422])
+    def test_non_retryable_status_raises(self, status_code: int) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [_make_response({"error": "Forbidden"}, status_code=status_code)]
+        with pytest.raises(HTTPError):
+            _drive_get_rows("contacts", manager, responses)
+
+    def test_missing_envelope_key_raises(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        # 200 OK with an unexpected body shape must fail loudly, not sync zero rows.
+        responses = [_make_response({"unexpected": [], "paging": {"next": None}})]
+        with pytest.raises(KeyError):
+            _drive_get_rows("contacts", manager, responses)
+
+
+class TestGetRowsSession:
+    def test_session_disables_transport_retry_redacts_key_and_closes(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        with patch("posthog.temporal.data_imports.sources.omnisend.omnisend.make_tracked_session") as MockSession:
+            MockSession.return_value.get.return_value = _make_response(
+                {"contacts": [{"contactID": "1"}], "paging": {"next": None}}
+            )
+            list(
+                get_rows(
+                    api_key="test-key",
+                    endpoint="contacts",
+                    logger=MagicMock(),
+                    resumable_source_manager=manager,
+                )
+            )
+
+        kwargs = MockSession.call_args.kwargs
+        assert kwargs["retry"].total == 0
+        assert kwargs["redact_values"] == ("test-key",)
+        assert kwargs["headers"]["X-API-KEY"] == "test-key"
+        MockSession.assert_called_once()
+        MockSession.return_value.close.assert_called_once()
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        ("status_code", "expected_ok"),
+        [(200, True), (401, False), (403, False), (500, False)],
+    )
+    def test_validate_credentials_status_mapping(self, status_code: int, expected_ok: bool) -> None:
+        with patch("posthog.temporal.data_imports.sources.omnisend.omnisend.make_tracked_session") as MockSession:
+            MockSession.return_value.get.return_value = _make_response({}, status_code=status_code)
+            ok, code = validate_credentials("test-key")
+        assert ok is expected_ok
+        assert code == status_code
+
+    def test_validate_credentials_network_error(self) -> None:
+        with patch("posthog.temporal.data_imports.sources.omnisend.omnisend.make_tracked_session") as MockSession:
+            MockSession.return_value.get.side_effect = Exception("network down")
+            ok, code = validate_credentials("test-key")
+        assert ok is False
+        assert code is None
+
+
+class TestOmnisendSourceResponse:
+    @pytest.mark.parametrize(
+        ("endpoint", "primary_key", "expects_partition"),
+        [
+            ("contacts", "contactID", True),
+            ("campaigns", "campaignID", True),
+            ("carts", "cartID", True),
+            ("orders", "orderID", True),
+            ("products", "productID", True),
+            ("categories", "categoryID", False),
+        ],
+    )
+    def test_source_response_shape(self, endpoint: str, primary_key: str, expects_partition: bool) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        response = omnisend_source(
+            api_key="test-key",
+            endpoint=endpoint,
+            logger=MagicMock(),
+            resumable_source_manager=manager,
+        )
+
+        assert response.name == endpoint
+        assert response.primary_keys == [primary_key]
+        assert response.sort_mode == "asc"
+
+        if expects_partition:
+            assert response.partition_mode == "datetime"
+            assert response.partition_keys == ["createdAt"]
+            assert response.partition_format == "month"
+        else:
+            assert response.partition_mode is None
+            assert response.partition_keys is None
+
+    def test_every_endpoint_partition_key_is_stable(self) -> None:
+        # Partition keys must be creation-time fields, never mutable ones.
+        for config in OMNISEND_ENDPOINTS.values():
+            if config.partition_key is not None:
+                assert config.partition_key == "createdAt"

--- a/posthog/temporal/data_imports/sources/omnisend/tests/test_omnisend_source.py
+++ b/posthog/temporal/data_imports/sources/omnisend/tests/test_omnisend_source.py
@@ -1,0 +1,119 @@
+from typing import Any
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.generated_configs import OmnisendSourceConfig
+from posthog.temporal.data_imports.sources.omnisend.omnisend import OmnisendResumeConfig
+from posthog.temporal.data_imports.sources.omnisend.source import OmnisendSource
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+def _config() -> OmnisendSourceConfig:
+    return OmnisendSourceConfig(api_key="test-key")
+
+
+def _source_inputs(schema_name: str = "contacts", **overrides: Any) -> SourceInputs:
+    defaults: dict[str, Any] = {
+        "schema_name": schema_name,
+        "schema_id": "schema-1",
+        "source_id": "source-1",
+        "team_id": 1,
+        "should_use_incremental_field": False,
+        "db_incremental_field_last_value": None,
+        "db_incremental_field_earliest_value": None,
+        "incremental_field": None,
+        "incremental_field_type": None,
+        "job_id": "job-1",
+        "logger": MagicMock(),
+        "reset_pipeline": False,
+    }
+    defaults.update(overrides)
+    return SourceInputs(**defaults)
+
+
+class TestOmnisendSource:
+    def test_source_type(self) -> None:
+        assert OmnisendSource().source_type == ExternalDataSourceType.OMNISEND
+
+    def test_source_config_basics(self) -> None:
+        config = OmnisendSource().get_source_config
+        assert config.label == "Omnisend"
+        assert config.unreleasedSource is True
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.iconPath == "/static/services/omnisend.png"
+
+    def test_source_config_has_api_key_password_field(self) -> None:
+        fields = OmnisendSource().get_source_config.fields
+        assert len(fields) == 1
+        field = fields[0]
+        assert isinstance(field, SourceFieldInputConfig)
+        assert field.name == "api_key"
+        assert field.type == SourceFieldInputConfigType.PASSWORD
+        assert field.required is True
+        assert field.secret is True
+
+    def test_get_schemas_returns_all_endpoints(self) -> None:
+        schemas = OmnisendSource().get_schemas(_config(), team_id=1)
+        names = {s.name for s in schemas}
+        assert names == {"contacts", "campaigns", "carts", "orders", "products", "categories"}
+
+    def test_all_endpoints_are_full_refresh(self) -> None:
+        # We can't curl-verify Omnisend's server-side timestamp filter, so every endpoint
+        # ships full refresh (no incremental advertised). See api_inventory.md.
+        for schema in OmnisendSource().get_schemas(_config(), team_id=1):
+            assert schema.supports_incremental is False
+            assert schema.supports_append is False
+            assert schema.incremental_fields == []
+
+    def test_get_schemas_filters_by_names(self) -> None:
+        schemas = OmnisendSource().get_schemas(_config(), team_id=1, names=["contacts", "orders"])
+        assert {s.name for s in schemas} == {"contacts", "orders"}
+
+    @pytest.mark.parametrize(
+        ("validate_return", "expected_ok", "expected_msg"),
+        [
+            ((True, 200), True, None),
+            ((False, 401), False, "Invalid Omnisend API key"),
+            ((False, 403), False, "Invalid Omnisend API key"),
+            ((False, None), False, "Could not connect to Omnisend with the provided API key"),
+            ((False, 500), False, "Could not connect to Omnisend with the provided API key"),
+        ],
+    )
+    def test_validate_credentials(
+        self, validate_return: tuple[bool, int | None], expected_ok: bool, expected_msg: str | None
+    ) -> None:
+        with patch(
+            "posthog.temporal.data_imports.sources.omnisend.source.validate_omnisend_credentials",
+            return_value=validate_return,
+        ):
+            ok, msg = OmnisendSource().validate_credentials(_config(), team_id=1)
+        assert ok is expected_ok
+        assert msg == expected_msg
+
+    def test_get_resumable_source_manager_is_bound_to_resume_config(self) -> None:
+        manager = OmnisendSource().get_resumable_source_manager(_source_inputs())
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is OmnisendResumeConfig
+
+    def test_get_non_retryable_errors_covers_auth(self) -> None:
+        errors = OmnisendSource().get_non_retryable_errors()
+        assert any("401" in key for key in errors)
+        assert any("403" in key for key in errors)
+
+    def test_source_for_pipeline_plumbs_arguments(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        inputs = _source_inputs(schema_name="orders")
+        with patch("posthog.temporal.data_imports.sources.omnisend.source.omnisend_source") as mock_source:
+            mock_source.return_value = MagicMock(spec=SourceResponse)
+            OmnisendSource().source_for_pipeline(_config(), manager, inputs)
+
+        _, kwargs = mock_source.call_args
+        assert kwargs["api_key"] == "test-key"
+        assert kwargs["endpoint"] == "orders"
+        assert kwargs["resumable_source_manager"] is manager


### PR DESCRIPTION
## Problem

Omnisend (eCommerce email/SMS marketing automation) was registered as a scaffolded data warehouse source with an empty stub. Users connecting Omnisend had no way to pull their marketing data into the PostHog data warehouse.

## Changes

Implements the `omnisend` source end-to-end against the Omnisend **v3** REST API.

- **Endpoints:** `contacts`, `campaigns`, `carts`, `orders`, `products`, `categories` — declared in `settings.py` with per-endpoint primary keys (`<resource>ID`) and a stable `createdAt` partition key (omitted for `categories`).
- **Auth:** API key via the `X-API-KEY` header. `validate_credentials` probes `/contacts?limit=1` and distinguishes auth failures (401/403) from connectivity errors.
- **Base class:** `ResumableSource`. Pagination follows the API's fully-formed `paging.next` URL, which is saved to Redis *after* each batch so Temporal can resume mid-sync after a heartbeat timeout (a crash re-yields the last page; merge dedupes on the primary key).
- **Transport:** all outbound HTTP goes through `make_tracked_session()` (single reused session, API key redacted, `tenacity` as the sole retry mechanism on 429/5xx). The envelope key is read fail-loud so an unexpected 200 body errors instead of silently syncing zero rows.
- **Sync mode:** full refresh for every endpoint (see below).
- **Release:** kept behind `unreleasedSource=True` with `releaseStatus=ReleaseStatus.ALPHA`.

The architecture follows the `implementing-warehouse-sources` skill split: `source.py` (registration/fields/schemas/validation/manager wiring), `settings.py` (endpoint catalog), `omnisend.py` (client, paginator, `SourceResponse`). An endpoint inventory lives in `api_inventory.md`. `SOURCES.md` moves `omnisend` from Scaffolded into the Implemented table (HTTP / requests / ✅ tracked).

### Why full refresh (no incremental)

Omnisend documents `updatedAtFrom` as a server-side filter on `/contacts`, but with hard restrictions (it cannot be combined with `email`, `phone`, `status`, `segmentID`, or `tag`). The skill requires confirming a timestamp filter *actually* filters via a live curl smoke test (future-date cutoff) before advertising incremental — and that check needs API credentials, which weren't available here. The conservative choice is full refresh everywhere; `/contacts` on `updatedAt` is the natural follow-up once a key is available. This is documented in `api_inventory.md`.

Endpoint existence and auth behavior were verified against the live API without a key (all v3 paths return non-404). Exact list-response shapes (array key names, `<resource>ID` primary keys) follow Omnisend's consistent v3 convention but were not re-verified with a live key — noted in `api_inventory.md`.

The `omnisend.png` icon already existed in `frontend/public/services/`, so no logo fetch was needed.

## How did you test this code?

I'm an agent. I did not perform manual testing against a live Omnisend account (no API credentials). Automated tests I wrote and ran (all 38 passing):

- `tests/test_omnisend.py` — transport: `paging.next` pagination, save-state-after-each-page and resume-from-saved-state, fail-loud on missing envelope key, non-retryable status codes, session config (retry disabled / key redacted / closed), `validate_credentials` status mapping, and `SourceResponse` shape per endpoint.
- `tests/test_omnisend_source.py` — source class: `source_type`, config fields/labels, `get_schemas`, full-refresh assertions, `validate_credentials` message mapping, resumable-manager binding, non-retryable errors, and `source_for_pipeline` plumbing.

I also confirmed the source loads through `SourceRegistry`, regenerated the source config (`OmnisendSourceConfig.api_key`), and ran the existing source-config-generator snapshot tests plus `ruff check`/`ruff format`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (PostHog Code) following the `implementing-warehouse-sources` skill. Used klaviyo, chargebee, and especially brevo as reference implementations (brevo's single-reused-session + fail-loud-envelope patterns were adopted).

Key decisions:
- **v3 over v5/v2026-03-15:** v3 keeps the resource-based list endpoints (orders/carts/products/categories) that a list-and-sync warehouse source needs; newer versions reshape several of these into event-centric endpoints.
- **`ResumableSource` over the declarative RESTClient path:** the `paging.next` full-URL cursor maps cleanly onto the resumable `next_url` dataclass pattern and is straightforward to unit-test.
- **Full refresh:** see rationale above — couldn't curl-verify the server-side filter without credentials, so didn't advertise incremental.

Genuine blocker documented in `api_inventory.md` and above: no Omnisend API key to verify live response shapes or the `updatedAtFrom` filter.
