### PR TITLE
fix(cli): rename --env-file to --dotenv-file (node collision)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.7.18
+
+- fix: rename `--env-file` to `--dotenv-file`. The npm package runs the CLI binary through a `node` wrapper script, and Node has its own built-in `--env-file` flag — so Node intercepted the flag before it reached the binary, failing with `node: .env: not found` for a missing file. `--env-file` still works as an alias for native installs.
+
 # 0.7.17
 
 - fix: treat a missing `--env-file` as a warning instead of a fatal error — the CLI logs that the file wasn't found and falls back to the other credential sources (process env, then stored credentials). A file that exists but can't be read still errors.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-cli"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.7.17"
+version = "0.7.18"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/README.md
+++ b/cli/README.md
@@ -28,9 +28,9 @@ You can authenticate with PostHog interactively for using the CLI locally, but i
 - `POSTHOG_CLI_API_KEY`: [A posthog personal API key.](https://posthog.com/docs/api#private-endpoint-authentication) (also accepts `POSTHOG_CLI_TOKEN` for backward compatibility)
 - `POSTHOG_CLI_PROJECT_ID`: The ID number of the project/environment to connect to. E.g. the "2" in `https://us.posthog.com/project/2` (also accepts `POSTHOG_CLI_ENV_ID` for backward compatibility)
 
-These variables can also be loaded from a dotenv-style file via `--env-file <PATH>` (e.g. `posthog-cli --env-file .env query ...`). The process environment always wins; the file is only consulted if the required variables aren't set. `POSTHOG_CLI_HOST` is only read from the same source that supplied the rest, so a stray host in the file cannot redirect a key supplied by the process env.
+These variables can also be loaded from a dotenv-style file via `--dotenv-file <PATH>` (e.g. `posthog-cli --dotenv-file .env query ...`). The process environment always wins; the file is only consulted if the required variables aren't set. `POSTHOG_CLI_HOST` is only read from the same source that supplied the rest, so a stray host in the file cannot redirect a key supplied by the process env.
 
-Full precedence: CLI args → process env → `--env-file` → `~/.posthog/credentials.json` (from `posthog-cli login`).
+Full precedence: CLI args → process env → `--dotenv-file` → `~/.posthog/credentials.json` (from `posthog-cli login`).
 
 ## Skipping uploads (dry run)
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -32,8 +32,10 @@ pub struct Cli {
     #[arg(long, env = "POSTHOG_CLIENT_RATE_LIMIT")]
     rate_limit: Option<usize>,
 
-    /// Load PostHog credentials from this dotenv-style file when not present in the process environment.
-    #[arg(long, value_name = "PATH")]
+    /// Load PostHog credentials from this dotenv-style file when not present in the process
+    /// environment. Prefer this over the `--env-file` alias: the npm package runs the binary
+    /// through a `node` wrapper, and Node's own built-in `--env-file` flag intercepts that spelling.
+    #[arg(long = "dotenv-file", alias = "env-file", value_name = "PATH")]
     env_file: Option<PathBuf>,
 
     /// Skip artifact processing and upload (sourcemap, dSYM, hermes, proguard) without contacting

--- a/cli/src/utils/auth.rs
+++ b/cli/src/utils/auth.rs
@@ -62,8 +62,8 @@ impl CredentialProvider for HomeDirProvider {
 }
 
 /// Reads credentials atomically from a single source. Tries the process env first; if the
-/// required variables aren't there and an explicit `--env-file` path was supplied, tries that
-/// file next. A missing `--env-file` is a warning, not a fatal error — we skip it and let the
+/// required variables aren't there and an explicit `--dotenv-file` path was supplied, tries that
+/// file next. A missing `--dotenv-file` is a warning, not a fatal error — we skip it and let the
 /// caller fall back to other credential sources. `host` is optional and is only read from the
 /// same source that supplied the rest.
 pub struct EnvVarProvider {
@@ -166,7 +166,7 @@ pub fn get_token(env_file: Option<PathBuf>) -> Result<Token, Error> {
     let env_err = match env.get_credentials() {
         Ok(token) => {
             info!(
-                "Using token from environment or --env-file, for environment {}",
+                "Using token from environment or --dotenv-file, for environment {}",
                 token.env_id
             );
             return Ok(token);


### PR DESCRIPTION
Pretty insane thing is going on. So recently I've added `--env-file` flag to the CLI right? YEAH. It works. But then I changed it so that if you pass this flag and file doesn't exist, it just logs a warning. SUPRISE - it doesn't work. There is an error!

After digging I found out that because our cli binary is packaged as an npm package, somewhere along the execution some script is launched using `node xxx {args}`. Funny thing is that `--env-file` is a native node flag and it gets intercepted by node and its node which throws an error. This never gets to rust.

Another funny thing is that positive case works properly even though the flag is intercepted by node because it attaches .env contents to the process and our CLI also reads stuff from the process.

There is no workaround for that so I am renaming that flag :)