### PR TITLE
fix(duckling): raise duckgres connect_timeout for server-side warm wait

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -110,7 +110,11 @@ def iceberg_enabled_for_team(team_id: int) -> bool:
 # A backfill connection may have to wait for duckgres to spin up a fresh worker
 # (a cold worker can require provisioning a new node, which takes minutes), so
 # the handshake budget is generous and `_connect_duckgres` retries with backoff.
-DUCKGRES_CONNECT_TIMEOUT = 60  # seconds
+# Must exceed the duckgres control-plane warmAcquireTimeout (5m): on a warm-pool
+# miss the CP now blocks the connect server-side up to ~5m waiting for a colocated
+# worker (which may need a cold node) instead of bouncing us with "no warm worker
+# available". 330s gives margin over the 300s server block + TLS/handshake.
+DUCKGRES_CONNECT_TIMEOUT = 330  # seconds
 DUCKGRES_STATEMENT_TIMEOUT_MS = 300_000  # 5 minutes
 
 # Worker-profile opt-in. When enabled, a backfill connection asks duckgres for a

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -181,11 +181,15 @@ def _get_cluster() -> ClickhouseCluster:
 
 
 @retry(
-    # Deep enough to outlast a cold colocated-node provision (minutes) or a brief
-    # warm-pool exhaustion under a burst: up to ~5 minutes or 12 attempts. A
-    # shallow 3-attempt/~10s budget would surface the very ConnectionTimeout this
-    # feature exists to remove. statement_timeout (set per connection) is separate.
-    stop=stop_after_delay(300) | stop_after_attempt(12),
+    # The duckgres CP now absorbs a warm-pool miss by blocking the connect itself
+    # up to ~5m (DUCKGRES_K8S_WARM_ACQUIRE_TIMEOUT) for a colocated worker — so a
+    # single attempt can run the full connect_timeout (330s). The retry budget here
+    # is the BACKSTOP for fast failures (network blip, CP pod rolled mid-handshake,
+    # or the CP giving up after its block): the delay cap must exceed one full
+    # attempt so a second one can actually run, hence 700s (~2 attempts) rather
+    # than 300s (which a single 330s attempt would exhaust, making retries a no-op).
+    # statement_timeout (set per connection) is separate.
+    stop=stop_after_delay(700) | stop_after_attempt(12),
     wait=wait_exponential(multiplier=1, min=5, max=60),
     retry=retry_if_exception_type((psycopg.OperationalError, OSError)),
     reraise=True,


### PR DESCRIPTION
## What

Raise `DUCKGRES_CONNECT_TIMEOUT` 60s → 330s for the duckling events backfill connection.

## Why

duckgres is gaining a server-side wait (PostHog/duckgres#677 + PostHog/charts#11737): on a warm-pool miss the control plane now **blocks the acquire up to ~5 min** for a colocated worker to become available (it may need a cold node) instead of bouncing the client with `no warm Duckgres worker is currently available; retry in about 45 seconds`.

At the old `connect_timeout=60`, the client would give up before the CP finishes waiting. 330s gives margin over the 300s server block + TLS/handshake. The existing connect retry decorator still backstops genuine network errors.

Harmless before the duckgres side ships (it just permits a longer connect; the CP keeps fast-failing until then and the retry handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)