### PR TITLE
feat(taxonomic-filter): emit telemetry parity from rebuild

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/headless/Panel.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/Panel.tsx
@@ -1,3 +1,4 @@
+import posthog from 'posthog-js'
 import { ReactNode, useEffect, useRef } from 'react'
 
 import { Empty, EmptyHeader, EmptyTitle, ItemMenuItem, Spinner } from '@posthog/quill'
@@ -66,7 +67,7 @@ function TaxonomicFilterActivePanel({
     loadingState,
     className,
 }: ActivePanelProps): JSX.Element {
-    const { groups, getGroupListInput, registerActiveList, selectItem } = useTaxonomicFilterContext()
+    const { groups, searchQuery, getGroupListInput, registerActiveList, selectItem } = useTaxonomicFilterContext()
     const list: UseGroupListResult = useGroupList(getGroupListInput(group))
 
     // Register this list as the keyboard target for as long as the panel
@@ -82,6 +83,27 @@ function TaxonomicFilterActivePanel({
         registerActiveList(() => listRef.current)
         return () => registerActiveList(null)
     }, [registerActiveList])
+
+    // `taxonomic filter empty result` — fired from the single active panel (not
+    // per useGroupList instance, which would multi-fire), once per group+query.
+    // The panel remounts on group change (key=group.type), resetting the dedupe
+    // set. "Type more" is not an empty result.
+    const emptyResultFiredRef = useRef<Set<string>>(new Set())
+    const trimmedQuery = searchQuery.trim()
+    useEffect(() => {
+        if (!list.showEmptyState || list.needsMoreSearchCharacters || !trimmedQuery) {
+            return
+        }
+        const key = `${group.type}::${trimmedQuery}`
+        if (emptyResultFiredRef.current.has(key)) {
+            return
+        }
+        emptyResultFiredRef.current.add(key)
+        posthog.capture('taxonomic filter empty result', {
+            groupType: group.type,
+            searchQuery: trimmedQuery,
+        })
+    }, [list.showEmptyState, list.needsMoreSearchCharacters, trimmedQuery, group.type])
 
     if (list.showLoadingState) {
         return (
@@ -125,7 +147,7 @@ function TaxonomicFilterActivePanel({
                 const onSelect = (): void => {
                     const sourceGroup = resolveItemGroup(item, groups, group)
                     const itemValue = sourceGroup.getValue?.(item) ?? null
-                    selectItem(sourceGroup, itemValue, item)
+                    selectItem(sourceGroup, itemValue, item, { position: index })
                 }
                 const onMouseEnter = (): void => list.setIndex(index)
                 if (renderRow) {

--- a/frontend/src/lib/components/TaxonomicFilter/headless/headless.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/headless.test.tsx
@@ -26,7 +26,13 @@ jest.mock('lib/api', () => ({
     },
 }))
 
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: jest.fn() },
+}))
+
 const apiGet = jest.requireMock('lib/api').default.get as jest.MockedFunction<any>
+const captureMock = jest.requireMock('posthog-js').default.capture as jest.Mock
 
 describe('TaxonomicFilterHeadless integration', () => {
     let onChangeMock: jest.Mock
@@ -35,6 +41,7 @@ describe('TaxonomicFilterHeadless integration', () => {
     beforeEach(() => {
         __clearTaxonomicResourceCache()
         apiGet.mockReset()
+        captureMock.mockClear()
         ;(performQuery as jest.Mock).mockResolvedValue({ tables: {}, joins: [] })
         useMocks({
             get: { '/api/projects/:team/event_definitions': { results: [], count: 0 } },
@@ -243,5 +250,42 @@ describe('TaxonomicFilterHeadless integration', () => {
         await user.click(screen.getByTestId('taxonomic-tab-wildcard'))
         await user.type(screen.getByTestId('taxonomic-filter-searchfield'), 'no-match-zzz')
         await waitFor(() => expect(screen.getByTestId('empty')).toBeInTheDocument())
+    })
+
+    it('captures `taxonomic filter item selected` on click, resolved to the source group', async () => {
+        const item = { id: 7, name: 'pageview' }
+        apiGet.mockResolvedValue({ results: [item], count: 1 })
+        renderHeadless()
+        await waitFor(() => screen.getByText('pageview'))
+        await user.click(screen.getByText('pageview'))
+        expect(captureMock).toHaveBeenCalledWith(
+            'taxonomic filter item selected',
+            expect.objectContaining({
+                sourceGroupType: TaxonomicFilterGroupType.Events,
+                wasFromRecents: false,
+                wasFromPinnedList: false,
+                wasQuickFilter: false,
+                position: expect.any(Number),
+            })
+        )
+    })
+
+    it('captures `taxonomic filter empty result` once for a no-match search', async () => {
+        apiGet.mockResolvedValue({ results: [], count: 0 })
+        renderHeadless()
+        await user.click(screen.getByTestId('taxonomic-tab-wildcard'))
+        await user.type(screen.getByTestId('taxonomic-filter-searchfield'), 'no-match-zzz')
+        await waitFor(() =>
+            expect(captureMock).toHaveBeenCalledWith('taxonomic filter empty result', {
+                groupType: TaxonomicFilterGroupType.Wildcards,
+                searchQuery: 'no-match-zzz',
+            })
+        )
+        // Deduped per group+query: the final query fires exactly once even
+        // across re-renders (intermediate keystroke queries fire separately).
+        const finalQueryCalls = captureMock.mock.calls.filter(
+            (c) => c[0] === 'taxonomic filter empty result' && c[1].searchQuery === 'no-match-zzz'
+        )
+        expect(finalQueryCalls).toHaveLength(1)
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
@@ -63,6 +63,7 @@ import { AnyDataNode } from '~/queries/schema/schema-general'
 import { UseGroupListInput, UseGroupListResult } from './useGroupList'
 import { useTaxonomicGroupsContext } from './useTaxonomicGroupsContext'
 import { useRecentPinnedItems, useTaxonomicLocalOverrides } from './useTaxonomicLocalOverrides'
+import { useTaxonomicTelemetry } from './useTaxonomicTelemetry'
 
 export interface UseTaxonomicFilterOptions {
     taxonomicGroupTypes: TaxonomicFilterGroupType[]
@@ -132,7 +133,12 @@ export interface TaxonomicFilterApi {
     searchPlaceholder: string
 
     // selection
-    selectItem: (group: TaxonomicFilterGroup, value: TaxonomicFilterValue | null, item: any) => void
+    selectItem: (
+        group: TaxonomicFilterGroup,
+        value: TaxonomicFilterValue | null,
+        item: any,
+        meta?: { position?: number }
+    ) => void
     /** Forwards Enter to the registered active list, falling back to onEnter(query). */
     selectSelected: () => void
 
@@ -164,6 +170,7 @@ export interface TaxonomicFilterApi {
         value: string
         onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
         onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void
+        onPaste: (e: React.ClipboardEvent<HTMLInputElement>) => void
         placeholder: string
     }
 }
@@ -467,13 +474,16 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         }
     }, [groupTypes, activeGroupType, defaultActiveGroup])
 
+    const telemetry = useTaxonomicTelemetry({ activeGroupType, searchQuery })
+
     const setActiveGroupType = useCallback(
         (t: TaxonomicFilterGroupType) => {
             if (groupTypes.includes(t)) {
+                telemetry.markInteraction()
                 setActiveGroupTypeInternal(t)
             }
         },
-        [groupTypes]
+        [groupTypes, telemetry]
     )
 
     const tabLeft = useCallback(() => {
@@ -482,18 +492,20 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
             return
         }
         for (let i = idx - 1; i >= 0; i--) {
+            telemetry.markInteraction()
             setActiveGroupTypeInternal(groupTypes[i])
             return
         }
-    }, [groupTypes, activeGroupType])
+    }, [groupTypes, activeGroupType, telemetry])
 
     const tabRight = useCallback(() => {
         const idx = groupTypes.indexOf(activeGroupType)
         if (idx === -1 || idx >= groupTypes.length - 1) {
             return
         }
+        telemetry.markInteraction()
         setActiveGroupTypeInternal(groupTypes[idx + 1])
-    }, [groupTypes, activeGroupType])
+    }, [groupTypes, activeGroupType, telemetry])
 
     const activeGroup = useMemo(() => groups.find((g) => g.type === activeGroupType), [groups, activeGroupType])
 
@@ -531,47 +543,77 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
     }, [])
 
     const selectItem = useCallback(
-        (group: TaxonomicFilterGroup, valueIn: TaxonomicFilterValue | null, item: any) => {
-            // Mirror the legacy `taxonomicFilterLogic.selectItem` recent
-            // recording so menu commits show up in the dropdown's
-            // "Recent" entry. Quick-filter items are skipped (they're
-            // shortcuts, not filterable definitions); pinned/recent
-            // context wrappers get stripped before persisting.
-            if (valueIn != null && item && !isQuickFilterItem(item)) {
+        (
+            group: TaxonomicFilterGroup,
+            valueIn: TaxonomicFilterValue | null,
+            item: any,
+            meta?: { position?: number }
+        ) => {
+            if (item) {
                 const recentContext = hasRecentContext(item) ? item._recentContext : undefined
                 const pinnedContext = hasPinnedContext(item) ? item._pinnedContext : undefined
+                const wasQuickFilter = isQuickFilterItem(item)
                 const sourceGroupType = recentContext?.sourceGroupType ?? pinnedContext?.sourceGroupType ?? group.type
-                const sourceGroupName = recentContext?.sourceGroupName ?? pinnedContext?.sourceGroupName ?? group.name
-                const stripped = recentContext
-                    ? stripRecentContext(item)
-                    : pinnedContext
-                      ? stripPinnedContext(item)
-                      : item
-                const cleanItem = {
-                    name: stripped.name,
-                    ...(stripped.id ? { id: stripped.id } : {}),
-                }
-                const propertyFilterFromRecent = recentContext?.propertyFilter
-                // Defer one tick — keeps the recents write off the
-                // commit's render cycle so React doesn't re-render the
-                // closing popover with a stale list.
-                setTimeout(() => {
-                    if (recentTaxonomicFiltersLogic.isMounted()) {
-                        recentTaxonomicFiltersLogic.actions.recordRecentFilter({
-                            groupType: sourceGroupType,
-                            groupName: sourceGroupName,
-                            value: valueIn,
-                            item: cleanItem,
-                            teamId: teamLogic.values.currentTeamId ?? undefined,
-                            propertyFilter: propertyFilterFromRecent,
-                        })
+
+                telemetry.captureItemSelected({
+                    groupType: activeGroupType,
+                    sourceGroupType,
+                    wasFromRecents: !!recentContext,
+                    wasFromPinnedList: !!pinnedContext,
+                    wasQuickFilter,
+                    hadSearchInput: !!searchQuery,
+                    position: meta?.position,
+                    query: searchQuery,
+                    quickFilterProps: wasQuickFilter
+                        ? {
+                              filterName: item.name,
+                              propertyKey: item.propertyKey,
+                              operator: item.operator,
+                              filterValue: item.filterValue,
+                              propertyFilterType: item.propertyFilterType,
+                              eventName: item.eventName,
+                          }
+                        : undefined,
+                })
+
+                // Mirror the legacy recents recording so menu commits show up in
+                // the "Recent" entry. Quick-filter items are skipped (shortcuts,
+                // not filterable definitions); recent/pinned context wrappers are
+                // stripped before persisting.
+                if (valueIn != null && !wasQuickFilter) {
+                    const sourceGroupName =
+                        recentContext?.sourceGroupName ?? pinnedContext?.sourceGroupName ?? group.name
+                    const stripped = recentContext
+                        ? stripRecentContext(item)
+                        : pinnedContext
+                          ? stripPinnedContext(item)
+                          : item
+                    const cleanItem = {
+                        name: stripped.name,
+                        ...(stripped.id ? { id: stripped.id } : {}),
                     }
-                }, 0)
+                    const propertyFilterFromRecent = recentContext?.propertyFilter
+                    // Defer one tick — keeps the recents write off the commit's
+                    // render cycle so React doesn't re-render the closing popover
+                    // with a stale list.
+                    setTimeout(() => {
+                        if (recentTaxonomicFiltersLogic.isMounted()) {
+                            recentTaxonomicFiltersLogic.actions.recordRecentFilter({
+                                groupType: sourceGroupType,
+                                groupName: sourceGroupName,
+                                value: valueIn,
+                                item: cleanItem,
+                                teamId: teamLogic.values.currentTeamId ?? undefined,
+                                propertyFilter: propertyFilterFromRecent,
+                            })
+                        }
+                    }, 0)
+                }
             }
             onChange?.(group, valueIn, item)
             setSearchQuery('')
         },
-        [onChange, setSearchQuery]
+        [onChange, setSearchQuery, telemetry, activeGroupType, searchQuery]
     )
 
     const selectSelected = useCallback(() => {
@@ -583,7 +625,7 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
             // the row's origin, not the meta tab it's shown under.
             const sourceGroup = resolveItemGroup(selected, groups, activeGroup)
             const itemValue = sourceGroup.getValue?.(selected) ?? null
-            selectItem(sourceGroup, itemValue, selected)
+            selectItem(sourceGroup, itemValue, selected, { position: list?.index })
         } else {
             onEnter?.(searchQuery)
         }
@@ -644,10 +686,12 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
             const list = readActiveList()
             switch (e.key) {
                 case 'ArrowUp':
+                    telemetry.markInteraction()
                     list?.moveUp()
                     e.preventDefault()
                     break
                 case 'ArrowDown':
+                    telemetry.markInteraction()
                     list?.moveDown()
                     e.preventDefault()
                     break
@@ -665,7 +709,7 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
                     break
             }
         },
-        [selectSelected, setSearchQuery, tabLeft, tabRight, readActiveList]
+        [selectSelected, setSearchQuery, tabLeft, tabRight, readActiveList, telemetry]
     )
 
     return {
@@ -690,8 +734,17 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         rootProps: { onKeyDown },
         inputProps: {
             value: searchQuery,
-            onChange: (e) => setSearchQuery(e.target.value),
+            onChange: (e) => {
+                telemetry.markInteraction()
+                setSearchQuery(e.target.value)
+            },
             onKeyDown,
+            onPaste: (e) => {
+                const pasted = e.clipboardData?.getData('text') ?? ''
+                if (pasted.length > 0) {
+                    telemetry.recordPaste(pasted.length)
+                }
+            },
             placeholder: searchPlaceholder ? `Search ${searchPlaceholder}` : 'Search',
         },
     }

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicTelemetry.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicTelemetry.test.tsx
@@ -1,0 +1,176 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import posthog from 'posthog-js'
+
+import { TaxonomicFilterGroupType } from '../types'
+import { useTaxonomicTelemetry } from './useTaxonomicTelemetry'
+
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: jest.fn() },
+}))
+
+const capture = posthog.capture as jest.Mock
+
+const render = (
+    initialQuery = ''
+): ReturnType<typeof renderHook<ReturnType<typeof useTaxonomicTelemetry>, { q: string }>> =>
+    renderHook(({ q }) => useTaxonomicTelemetry({ activeGroupType: TaxonomicFilterGroupType.Events, searchQuery: q }), {
+        initialProps: { q: initialQuery },
+    })
+
+describe('useTaxonomicTelemetry', () => {
+    beforeEach(() => {
+        capture.mockClear()
+        jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers()
+        jest.useRealTimers()
+        cleanup()
+    })
+
+    describe('taxonomic filter closed', () => {
+        it('does not fire on unmount when the user never interacted', () => {
+            const { unmount } = render()
+            act(() => unmount())
+            expect(capture).not.toHaveBeenCalledWith('taxonomic filter closed', expect.anything())
+        })
+
+        it('fires on unmount once the user interacted, with dwell + no selection', () => {
+            const { result, unmount } = render()
+            act(() => result.current.markInteraction())
+            act(() => unmount())
+            expect(capture).toHaveBeenCalledWith(
+                'taxonomic filter closed',
+                expect.objectContaining({
+                    groupType: TaxonomicFilterGroupType.Events,
+                    hadSelection: false,
+                    dwellMs: expect.any(Number),
+                })
+            )
+        })
+
+        it('reports hadSelection=true when an item was selected', () => {
+            const { result, unmount } = render()
+            act(() =>
+                result.current.captureItemSelected({
+                    groupType: TaxonomicFilterGroupType.Events,
+                    sourceGroupType: TaxonomicFilterGroupType.Events,
+                    wasFromRecents: false,
+                    wasFromPinnedList: false,
+                    wasQuickFilter: false,
+                    hadSearchInput: false,
+                })
+            )
+            act(() => unmount())
+            expect(capture).toHaveBeenCalledWith(
+                'taxonomic filter closed',
+                expect.objectContaining({ hadSelection: true })
+            )
+        })
+    })
+
+    describe('taxonomic_filter_search_query', () => {
+        it('fires debounced for a non-empty query, marked as typed', () => {
+            const { rerender } = render('')
+            act(() => rerender({ q: 'pageview' }))
+            expect(capture).not.toHaveBeenCalledWith('taxonomic_filter_search_query', expect.anything())
+            act(() => jest.advanceTimersByTime(500))
+            expect(capture).toHaveBeenCalledWith('taxonomic_filter_search_query', {
+                searchQuery: 'pageview',
+                groupType: TaxonomicFilterGroupType.Events,
+                inputMode: 'typed',
+                pastedFraction: 0,
+            })
+        })
+
+        it('does not fire for an empty / whitespace query', () => {
+            const { rerender } = render('')
+            act(() => rerender({ q: '   ' }))
+            act(() => jest.advanceTimersByTime(500))
+            expect(capture).not.toHaveBeenCalledWith('taxonomic_filter_search_query', expect.anything())
+        })
+
+        it.each([
+            { pasted: 8, query: 'pageview', mode: 'pasted', fraction: 1 },
+            { pasted: 4, query: 'pageview', mode: 'mixed', fraction: 0.5 },
+        ])('classifies pasted input as $mode', ({ pasted, query, mode, fraction }) => {
+            const { result, rerender } = render('')
+            act(() => result.current.recordPaste(pasted))
+            act(() => rerender({ q: query }))
+            act(() => jest.advanceTimersByTime(500))
+            expect(capture).toHaveBeenCalledWith(
+                'taxonomic_filter_search_query',
+                expect.objectContaining({ inputMode: mode, pastedFraction: fraction })
+            )
+        })
+
+        it('resets the pasted-char accumulator after each capture', () => {
+            const { result, rerender } = render('')
+            act(() => result.current.recordPaste(8))
+            act(() => rerender({ q: 'pageview' }))
+            act(() => jest.advanceTimersByTime(500))
+            capture.mockClear()
+            act(() => rerender({ q: 'pageviews' }))
+            act(() => jest.advanceTimersByTime(500))
+            expect(capture).toHaveBeenCalledWith(
+                'taxonomic_filter_search_query',
+                expect.objectContaining({ inputMode: 'typed' })
+            )
+        })
+    })
+
+    describe('taxonomic filter item selected', () => {
+        it('fires with the full payload', () => {
+            const { result } = render('pa')
+            act(() =>
+                result.current.captureItemSelected({
+                    groupType: TaxonomicFilterGroupType.SuggestedFilters,
+                    sourceGroupType: TaxonomicFilterGroupType.EventProperties,
+                    wasFromRecents: true,
+                    wasFromPinnedList: false,
+                    wasQuickFilter: false,
+                    hadSearchInput: true,
+                    position: 2,
+                    query: 'pa',
+                })
+            )
+            expect(capture).toHaveBeenCalledWith('taxonomic filter item selected', {
+                groupType: TaxonomicFilterGroupType.SuggestedFilters,
+                sourceGroupType: TaxonomicFilterGroupType.EventProperties,
+                wasFromRecents: true,
+                wasFromPinnedList: false,
+                wasQuickFilter: false,
+                hadSearchInput: true,
+                position: 2,
+                query: 'pa',
+            })
+        })
+
+        it('spreads quick-filter props and normalises an empty query to undefined', () => {
+            const { result } = render('')
+            act(() =>
+                result.current.captureItemSelected({
+                    groupType: TaxonomicFilterGroupType.Events,
+                    sourceGroupType: TaxonomicFilterGroupType.Events,
+                    wasFromRecents: false,
+                    wasFromPinnedList: false,
+                    wasQuickFilter: true,
+                    hadSearchInput: false,
+                    query: '',
+                    quickFilterProps: { filterName: 'click', operator: 'exact' },
+                })
+            )
+            expect(capture).toHaveBeenCalledWith(
+                'taxonomic filter item selected',
+                expect.objectContaining({
+                    wasQuickFilter: true,
+                    filterName: 'click',
+                    operator: 'exact',
+                    query: undefined,
+                })
+            )
+        })
+    })
+})

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicTelemetry.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicTelemetry.ts
@@ -1,0 +1,125 @@
+/**
+ * Emits the TaxonomicFilter telemetry contract from the headless rebuild so it
+ * matches what the legacy kea picker emits. PostHog auto-attaches the active
+ * `$feature/taxonomic-filter-headless` flag to every event, so the legacy
+ * (control) and rebuild (test) arms are comparable by flag value once both
+ * fire the same events with the same property shapes.
+ *
+ * Four of the five legacy events apply here; the fifth — `taxonomic filter
+ * category dropdown opened` — is specific to the dead CategoryDropdown A/B and
+ * has no analogue in the pills rebuild.
+ *
+ * Event ownership:
+ *   - `taxonomic filter closed`        — here (mount/unmount lifecycle)
+ *   - `taxonomic_filter_search_query`  — here (500ms debounce + paste tracking)
+ *   - `taxonomic filter item selected` — here, via `captureItemSelected`
+ *   - `taxonomic filter empty result`  — in Panel (the single active-group view)
+ */
+import posthog from 'posthog-js'
+import { useCallback, useEffect, useRef } from 'react'
+
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+const SEARCH_QUERY_DEBOUNCE_MS = 500
+
+export interface ItemSelectedEvent {
+    groupType: TaxonomicFilterGroupType
+    sourceGroupType: TaxonomicFilterGroupType
+    wasFromRecents: boolean
+    wasFromPinnedList: boolean
+    wasQuickFilter: boolean
+    hadSearchInput: boolean
+    position?: number
+    query?: string
+    /** Extra fields for quick-filter (keyword shortcut) selections. */
+    quickFilterProps?: Record<string, unknown>
+}
+
+export interface TaxonomicTelemetry {
+    /** Flip the interaction flag so a `closed` event fires on unmount. Call on
+     *  any genuine user action (type, tab, arrow, select). */
+    markInteraction: () => void
+    /** Accumulate pasted characters for the next search-query capture. */
+    recordPaste: (pastedLength: number) => void
+    /** Fire `taxonomic filter item selected` and record that a selection happened. */
+    captureItemSelected: (event: ItemSelectedEvent) => void
+}
+
+export function useTaxonomicTelemetry({
+    activeGroupType,
+    searchQuery,
+}: {
+    activeGroupType: TaxonomicFilterGroupType
+    searchQuery: string
+}): TaxonomicTelemetry {
+    const openedAtRef = useRef<number>(Date.now())
+    const hadInteractionRef = useRef(false)
+    const hadSelectionRef = useRef(false)
+    const pastedCharsRef = useRef(0)
+    // Read the live active tab inside the unmount cleanup / debounce timer
+    // without re-running those effects when the tab changes.
+    const activeGroupTypeRef = useRef(activeGroupType)
+    activeGroupTypeRef.current = activeGroupType
+
+    // `taxonomic filter closed` — fire once on unmount, but only if the user
+    // actually interacted (mirrors the legacy `hadInteraction` guard that
+    // suppresses phantom closes from popovers mounted before they're shown).
+    useEffect(() => {
+        openedAtRef.current = Date.now()
+        return () => {
+            if (!hadInteractionRef.current) {
+                return
+            }
+            posthog.capture('taxonomic filter closed', {
+                dwellMs: Date.now() - openedAtRef.current,
+                hadSelection: hadSelectionRef.current,
+                groupType: activeGroupTypeRef.current,
+            })
+        }
+    }, [])
+
+    // `taxonomic_filter_search_query` — debounced; only fires for a non-empty
+    // query. `inputMode`/`pastedFraction` distinguish typed vs pasted input.
+    useEffect(() => {
+        const trimmed = searchQuery.trim()
+        if (!trimmed) {
+            return
+        }
+        const timer = setTimeout(() => {
+            const pastedChars = pastedCharsRef.current
+            pastedCharsRef.current = 0
+            const totalLength = searchQuery.length
+            const inputMode =
+                pastedChars >= totalLength && pastedChars > 0 ? 'pasted' : pastedChars > 0 ? 'mixed' : 'typed'
+            posthog.capture('taxonomic_filter_search_query', {
+                searchQuery,
+                groupType: activeGroupTypeRef.current,
+                inputMode,
+                pastedFraction: totalLength > 0 ? Math.min(1, pastedChars / totalLength) : 0,
+            })
+        }, SEARCH_QUERY_DEBOUNCE_MS)
+        return () => clearTimeout(timer)
+    }, [searchQuery])
+
+    const markInteraction = useCallback(() => {
+        hadInteractionRef.current = true
+    }, [])
+
+    const recordPaste = useCallback((pastedLength: number) => {
+        pastedCharsRef.current += Math.max(0, pastedLength)
+        hadInteractionRef.current = true
+    }, [])
+
+    const captureItemSelected = useCallback((event: ItemSelectedEvent) => {
+        hadInteractionRef.current = true
+        hadSelectionRef.current = true
+        const { quickFilterProps, ...rest } = event
+        posthog.capture('taxonomic filter item selected', {
+            ...rest,
+            query: rest.query || undefined,
+            ...quickFilterProps,
+        })
+    }, [])
+
+    return { markInteraction, recordPaste, captureItemSelected }
+}


### PR DESCRIPTION
## Problem

The headless TaxonomicFilter rebuild emits **none** of the picker's analytics events, so the `TAXONOMIC_FILTER_HEADLESS` A/B (legacy vs rebuild) can't be compared at all — there's no data on whether the rebuild changes selection rate, dwell, search behaviour, or empty-result rate. To judge the rebuild (and the Suggested-as-default bet in the rest of this stack) against real behaviour rather than taste, both arms must emit the same events with the same shapes.

Stacked on #61638. Addresses the observability concern raised in the QA Swarm review of #61636.

## Changes

Emit the legacy telemetry contract from the rebuild. PostHog auto-attaches the active `$feature/taxonomic-filter-headless` flag to every event, so once both arms fire identically the comparison is just a flag-value split.

- `taxonomic filter closed` — `dwellMs`, `hadSelection`, `groupType`, on unmount, gated on a `hadInteraction` flag so popovers pre-rendered before they're shown don't emit phantom closes (ports the legacy guard).
- `taxonomic filter item selected` — `sourceGroupType`, `wasFromRecents`, `wasFromPinnedList`, `wasQuickFilter`, `hadSearchInput`, `position`, `query` (+ quick-filter extras). `position` is threaded from the Panel row / active-list index.
- `taxonomic_filter_search_query` — `searchQuery`, `groupType`, `inputMode`, `pastedFraction`, debounced 500ms, with typed-vs-pasted tracking via an `onPaste` handler on the input.
- `taxonomic filter empty result` — `groupType`, `searchQuery`, fired once per group+query from the **single active Panel** (not from `useGroupList`, which would multi-fire across the Categories/probe instances).

A new `useTaxonomicTelemetry` hook owns the orchestrator-level events (closed / search / item-selected) and the dwell + paste + interaction state; the Panel owns empty-result.

The fifth legacy event, `taxonomic filter category dropdown opened`, is specific to the dead CategoryDropdown A/B and has no analogue in the pills rebuild — intentionally not ported.

## How did you test this code?

I'm an agent (PostHog Code); no manual testing. Automated tests added and run (`hogli test`, all green; `tsc --noEmit` clean for these files):
- `useTaxonomicTelemetry.test.tsx` (unit, mocks `posthog-js`, fake timers): closed fires only after interaction and carries dwell/hadSelection; search-query debounce + typed/pasted/mixed classification + accumulator reset; item-selected payload + quick-filter spread + empty-query normalisation.
- `headless.test.tsx` (integration): item-selected fires on click resolved to the source group with a `position`; empty-result fires once per group+query on a no-match search.

## 🤖 Agent context

Authored with PostHog Code (Claude), prompted by the reviewer/author note that the two implementations need matching telemetry to be comparable. Recon mapped each legacy event's exact firing site and payload, then the rebuild seams. Key decision: fire `empty result` from the Panel rather than `useGroupList`, because the rebuild mounts multiple `useGroupList` instances per group (tab counts + active panel + the Suggested top-match probes) and firing there would multi-fire; the Panel is the single active-group view, so once-per-group+query dedup lives there. Property shapes mirror the documented telemetry contract; two legacy-only extras (`wasStale`, `excludeStale`) were left off as they're outside the contract the dashboards key on.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
