### PR TITLE
fix(data-warehouse): skip sync run while prior load is in flight

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -33,7 +33,9 @@ from posthog.temporal.data_imports.workflow_activities.check_billing_limits impo
     check_billing_limits_activity,
 )
 from posthog.temporal.data_imports.workflow_activities.create_job_model import (
+    CheckForInFlightRunActivityInputs,
     CreateExternalDataJobModelActivityInputs,
+    check_for_in_flight_run_activity,
     create_external_data_job_model_activity,
 )
 from posthog.temporal.data_imports.workflow_activities.emit_signals import (
@@ -245,6 +247,30 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
     @workflow.run
     async def run(self, inputs: ExternalDataWorkflowInputs):
         assert inputs.external_data_schema_id is not None
+
+        # Skip this scheduled run if a prior run's load (the decoupled V3 merge) is
+        # still in flight. The schedule's SKIP overlap policy only covers the producer
+        # workflow, not the consumer, so without this guard the reset_table() below
+        # would delete the working Delta table while that consumer is still writing it
+        # and corrupt the table. Returning here — before any ExternalDataJob is created
+        # — leaves no job/status to reconcile; the schedule just fires again next tick.
+        # An explicit resync (reset_pipeline) is a deliberate override and is exempt.
+        if not inputs.reset_pipeline:
+            prior_run_in_flight = await workflow.execute_activity(
+                check_for_in_flight_run_activity,
+                CheckForInFlightRunActivityInputs(team_id=inputs.team_id, schema_id=inputs.external_data_schema_id),
+                start_to_close_timeout=dt.timedelta(minutes=1),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+            if prior_run_in_flight:
+                workflow.logger.info(
+                    "Skipping scheduled run: a prior load is still in flight for this schema",
+                    extra={
+                        "schema_id": str(inputs.external_data_schema_id),
+                        "source_id": str(inputs.external_data_source_id),
+                    },
+                )
+                return
 
         update_inputs = UpdateExternalDataJobStatusInputs(
             job_id=None,

--- a/posthog/temporal/data_imports/settings.py
+++ b/posthog/temporal/data_imports/settings.py
@@ -10,6 +10,7 @@ from posthog.temporal.data_imports.external_data_job import (
     ExternalDataJobWorkflow,
     calculate_table_size_activity,
     check_billing_limits_activity,
+    check_for_in_flight_run_activity,
     create_external_data_job_model_activity,
     create_source_templates,
     import_data_activity_sync,
@@ -38,6 +39,7 @@ WORKFLOWS = [
 
 ACTIVITIES = [
     create_external_data_job_model_activity,
+    check_for_in_flight_run_activity,
     update_external_data_job_model,
     import_data_activity_sync,
     create_source_templates,

--- a/posthog/temporal/data_imports/workflow_activities/create_job_model.py
+++ b/posthog/temporal/data_imports/workflow_activities/create_job_model.py
@@ -1,9 +1,11 @@
 import uuid
 import typing
 import dataclasses
+from datetime import timedelta
 from typing import Any
 
 from django.db import close_old_connections
+from django.utils import timezone
 
 import posthoganalytics
 from structlog.contextvars import bind_contextvars
@@ -176,3 +178,39 @@ def create_external_data_job_model_activity(
             f"External data job failed on create_external_data_job_model_activity for {str(inputs.source_id)} with error: {e}"
         )
         raise
+
+
+# A V3 load (the merge step) runs in a decoupled consumer that keeps writing the
+# working Delta table after the producer workflow has finished. The schedule's
+# SKIP overlap policy only sees the producer workflow, so it won't stop the next
+# scheduled run from starting while a prior run's load is still in flight — and
+# that new run's reset_table() would delete the working Delta table out from under
+# the lagging consumer, orphaning a commit with no protocol/metadata and wedging
+# the table. Bounded by a staleness window so an orphaned RUNNING job (e.g. from a
+# dead consumer) can't suppress runs forever.
+IN_FLIGHT_RUN_MAX_AGE = timedelta(hours=24)
+
+
+@dataclasses.dataclass
+class CheckForInFlightRunActivityInputs:
+    team_id: int
+    schema_id: uuid.UUID
+
+    @property
+    def properties_to_log(self) -> dict[str, typing.Any]:
+        return {"team_id": self.team_id, "schema_id": self.schema_id}
+
+
+@activity.defn
+def check_for_in_flight_run_activity(inputs: CheckForInFlightRunActivityInputs) -> bool:
+    bind_contextvars(team_id=inputs.team_id)
+    close_old_connections()
+
+    cutoff = timezone.now() - IN_FLIGHT_RUN_MAX_AGE
+    return ExternalDataJob.objects.filter(
+        team_id=inputs.team_id,
+        schema_id=inputs.schema_id,
+        status=ExternalDataJob.Status.RUNNING,
+        pipeline_version=ExternalDataJob.PipelineVersion.V3,
+        created_at__gte=cutoff,
+    ).exists()

--- a/posthog/temporal/tests/external_data/test_external_data_job.py
+++ b/posthog/temporal/tests/external_data/test_external_data_job.py
@@ -1,6 +1,7 @@
 import uuid
 import functools
 from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
 from typing import Optional
 
 import pytest
@@ -8,6 +9,7 @@ from unittest import mock
 
 from django.conf import settings
 from django.test import override_settings
+from django.utils import timezone
 
 import boto3
 import psycopg
@@ -37,7 +39,9 @@ from posthog.temporal.data_imports.sources.stripe.settings import ENDPOINTS as S
 from posthog.temporal.data_imports.workflow_activities.calculate_table_size import calculate_table_size_activity
 from posthog.temporal.data_imports.workflow_activities.check_billing_limits import check_billing_limits_activity
 from posthog.temporal.data_imports.workflow_activities.create_job_model import (
+    CheckForInFlightRunActivityInputs,
     CreateExternalDataJobModelActivityInputs,
+    check_for_in_flight_run_activity,
     create_external_data_job_model_activity,
 )
 from posthog.temporal.data_imports.workflow_activities.import_data_sync import ImportDataActivityInputs
@@ -252,6 +256,54 @@ def test_create_external_job_activity_emit_signals_respects_ai_consent(
     )
     result = activity_environment.run(create_external_data_job_model_activity, inputs)
     assert result.emit_signals_enabled is expected
+
+
+def _create_source_for_in_flight(team):
+    return ExternalDataSource.objects.create(
+        source_id=str(uuid.uuid4()),
+        connection_id=str(uuid.uuid4()),
+        destination_id=str(uuid.uuid4()),
+        team=team,
+        status="running",
+        source_type="Postgres",
+    )
+
+
+@pytest.mark.parametrize(
+    "status,pipeline_version,age_hours,expected",
+    [
+        (ExternalDataJob.Status.RUNNING, ExternalDataJob.PipelineVersion.V3, 1, True),
+        (ExternalDataJob.Status.COMPLETED, ExternalDataJob.PipelineVersion.V3, 1, False),
+        (ExternalDataJob.Status.FAILED, ExternalDataJob.PipelineVersion.V3, 1, False),
+        (ExternalDataJob.Status.RUNNING, ExternalDataJob.PipelineVersion.V2, 1, False),
+        (ExternalDataJob.Status.RUNNING, ExternalDataJob.PipelineVersion.V3, 48, False),
+    ],
+)
+@pytest.mark.django_db(transaction=True)
+def test_check_for_in_flight_run_activity(activity_environment, team, status, pipeline_version, age_hours, expected):
+    source = _create_source_for_in_flight(team)
+    schema = _create_schema("in_flight_test", source, team)
+    job = ExternalDataJob.objects.create(
+        team_id=team.id,
+        pipeline_id=source.pk,
+        schema_id=schema.id,
+        status=status,
+        rows_synced=0,
+        pipeline_version=pipeline_version,
+    )
+    ExternalDataJob.objects.filter(id=job.id).update(created_at=timezone.now() - timedelta(hours=age_hours))
+
+    inputs = CheckForInFlightRunActivityInputs(team_id=team.id, schema_id=schema.id)
+    assert activity_environment.run(check_for_in_flight_run_activity, inputs) is expected
+
+
+@pytest.mark.django_db(transaction=True)
+def test_check_for_in_flight_run_activity_no_prior_job(activity_environment, team):
+    source = _create_source_for_in_flight(team)
+    schema = _create_schema("no_prior_run", source, team)
+
+    inputs = CheckForInFlightRunActivityInputs(team_id=team.id, schema_id=schema.id)
+    assert activity_environment.run(check_for_in_flight_run_activity, inputs) is False
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Problem

A data warehouse `full_refresh` sync can corrupt its own working Delta table, after which it fails forever with `Kernel error: No table metadata or protocol found in delta log.` and `max retries exceeded`.

**Root cause (confirmed from the on-disk `_delta_log`):** a sync runs in two stages, in two different runtimes.

- **Producer** — the `external-data-job` Temporal workflow. For `full_refresh` it calls `reset_table()` (`s3._rm(working_delta_folder, recursive=True)`) at the start, extracts, and stages batches to S3. It completes in minutes.
- **Consumer** — the `run_warehouse_sources_load` async worker. It reads the staged batches and writes them into the working Delta table as one commit per batch. On a large table this runs for *hours* after the producer finished.

The schedule already carries `ScheduleOverlapPolicy.SKIP` (`products/data_warehouse/backend/data_load/service.py`), which is meant to stop a new run from starting while the previous one is unfinished. That worked when a run was a single workflow doing extract + load end-to-end. The producer/consumer split silently defeated it: `SKIP` only sees the **producer** workflow, which finishes in minutes, so Temporal treats the run as "done" and starts the next one — whose `reset_table()` then deletes the working Delta table **out from under the still-running consumer**. A consumer commit that lands a moment after that delete survives as an orphaned `append` with no `protocol`/`metaData`, and the table is wedged.

This was verified on a stuck table: its `_delta_log/` held exactly one object — an `append` commit, timestamped to the same second as the next hourly run's `reset_table`, written by a consumer still processing a run from hours earlier.

## Changes

Restore the original "don't start a run while the previous one is unfinished" behaviour, at the data layer:

- New activity `check_for_in_flight_run_activity` (`create_job_model.py`): returns true if a prior **V3** run for this schema is still `RUNNING` (i.e. its decoupled load hasn't finished). Bounded by a staleness window (`IN_FLIGHT_RUN_MAX_AGE = 24h`) so an orphaned/zombie `RUNNING` job — e.g. from a dead consumer — can't suppress runs forever.
- `ExternalDataJobWorkflow.run()` calls it **before** creating the job / running the import, and returns early (skips the run) if a prior load is in flight. Returning before any `ExternalDataJob` is created leaves no job or status to reconcile — the schedule simply fires again on the next tick. An explicit `resync` (`reset_pipeline`) is a deliberate override and is exempt.

This is preferred over removing the producer-side `reset_table` (which would change write semantics) or adding cross-runtime locking: it changes nothing about how data is written, it just stops two runs from overlapping — which is what `SKIP` was always supposed to guarantee.

### Reviewer notes / open questions
- **Effective cadence:** when the load is genuinely slower than the schedule interval, runs will be skipped until it catches up, so the table syncs at the load's pace. That's correct (no overlap, no race), but pairs naturally with lengthening the cadence for such tables.
- **Staleness window:** 24h is a safety valve, not a tuned value. A truly massive initial load could exceed it; teams may prefer tying it to the sync interval, or replacing the `RUNNING`-job check with a queue-based check (any pending `SourceBatchStatus` batches for the schema) for precision.
- **Scope:** gated to V3 (`pipeline_version=V3`) since the decoupled-consumer race is V3-only; V2 is untouched.

## How did you test this code?

I'm an agent; I have not done manual testing. Automated checks only:

- Added parameterized DB-backed tests in `test_external_data_job.py` for `check_for_in_flight_run_activity`: recent V3 `RUNNING` → skip; `COMPLETED` / `FAILED` / V2 `RUNNING` / stale V3 `RUNNING` → don't skip; and no prior job → don't skip.
- `ruff check` / `ruff format`: clean.
- Pytest **collection** passes, which exercises the full import chain (new activity → re-export in `external_data_job` → registration in `settings.py`). The DB-backed assertions were **not run locally** — the dev stack was down (no Postgres) — and will run in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Authored by an agent (Claude Code) while diagnosing a stuck data warehouse sync. The diagnosis traced the failure through the two-stage producer/consumer architecture and was confirmed from the on-disk `_delta_log` (a single orphaned `append` commit timestamped to the next run's `reset_table`, written by a consumer hours behind).

The fix evolved during review with the human: an initial self-heal in `get_delta_table()` was rejected because `full_refresh` already deletes the working table each run, so self-heal was redundant and didn't address the race. We also weighed removing the producer-side `reset_table` (changes write semantics) and cross-runtime advisory locking. We chose to restore the `SKIP`-overlap intent at the data layer — skip a run while a prior load is in flight — as the lowest-risk change that fixes the actual cause. Kept as a **draft**: it touches the core sync workflow and the staleness-window / queue-based-check questions above want the data-warehouse team's call. Agent-authored; requires human review.
