### PR TITLE
feat(funnels): hide incomplete conversion-window periods in trends

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -21132,6 +21132,11 @@
                     },
                     "type": "array"
                 },
+                "hideIncompleteConversionWindowPeriods": {
+                    "default": false,
+                    "description": "Trends only: hide periods whose conversion window has not fully elapsed yet, so the recent tail of the trend isn't dragged down by entrants who still have time to convert.",
+                    "type": "boolean"
+                },
                 "layout": {
                     "$ref": "#/definitions/FunnelLayout",
                     "default": "vertical"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1685,6 +1685,12 @@ export type FunnelsFilter = {
      * @default true
      */
     showAnnotations?: boolean
+    /**
+     * Trends only: hide periods whose conversion window has not fully elapsed yet, so the recent
+     * tail of the trend isn't dragged down by entrants who still have time to convert.
+     * @default false
+     */
+    hideIncompleteConversionWindowPeriods?: boolean
 }
 
 export interface FunnelsQuery extends InsightsQueryBase<FunnelsQueryResponse> {

--- a/posthog/hogql_queries/insights/funnels/funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_trends.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from itertools import groupby
 from typing import Any, Optional, cast
 
@@ -504,6 +504,32 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelBase):
             select=fill_select,
             select_from=fill_select_from,
         )
+
+        if self.context.funnelsFilter.hideIncompleteConversionWindowPeriods:
+            # Drop periods whose conversion window hasn't fully elapsed yet (relative to now), so the
+            # recent tail of the trend isn't dragged down by entrants who still have time to convert.
+            # A period is kept only once its whole interval has cleared the window, i.e. even its last
+            # possible entrant has had the full window: entrance_period_start + interval <= now - window.
+            cutoff = date_range.now_with_timezone - timedelta(seconds=self.conversion_window_limit())
+            cutoff_as_hogql = ast.Call(
+                name="assumeNotNull",
+                args=[ast.Call(name="toDateTime", args=[ast.Constant(value=cutoff.strftime("%Y-%m-%d %H:%M:%S"))])],
+            )
+            period_end = ast.ArithmeticOperation(
+                left=ast.ArithmeticOperation(
+                    left=get_start_of_interval_hogql(interval.value, team=team, source=date_from_as_hogql),
+                    right=ast.Call(name=interval_func, args=[ast.Field(chain=["number"])]),
+                    op=ast.ArithmeticOperationOp.Add,
+                ),
+                right=ast.Call(name=interval_func, args=[ast.Constant(value=1)]),
+                op=ast.ArithmeticOperationOp.Add,
+            )
+            fill_query.where = ast.CompareOperation(
+                op=ast.CompareOperationOp.LtEq,
+                left=period_end,
+                right=cutoff_as_hogql,
+            )
+
         return fill_query
 
     def get_step_counts_without_aggregation_query(

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -131,8 +131,37 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(results), 7)
         self.assertEqual(formatted_results[0]["days"][0], "2021-06-07")
 
+    @parameterized.expand(
+        [
+            # Flag off: every daily period in range is present, including the recent incomplete ones.
+            # user_a's two entrances both converted; recent_entrant shows as a non-converter, which is
+            # exactly what drags the recent trend down.
+            (
+                "keeps_incomplete_periods_when_off",
+                False,
+                [date(2021, 6, day) for day in range(7, 19)],  # 2021-06-07 .. 2021-06-18 inclusive
+                {date(2021, 6, 7): (1, 1), date(2021, 6, 12): (1, 1), date(2021, 6, 15): (1, 0)},
+            ),
+            # Flag on: now=2021-06-18 12:00, window=7d -> cutoff=2021-06-11 12:00. A period is kept only
+            # once its whole day has cleared the window (entrance_period_start + 1 day <= cutoff), i.e.
+            # entrances on or before 2021-06-10. The old entrance that converted is retained even though
+            # its conversion event is recent; the recent entrance (06-12) and non-converter (06-15) are gone.
+            (
+                "drops_incomplete_periods_when_on",
+                True,
+                [date(2021, 6, day) for day in range(7, 11)],  # 2021-06-07 .. 2021-06-10
+                {date(2021, 6, 7): (1, 1)},
+            ),
+        ]
+    )
     @freeze_time("2021-06-18 12:00:00")
-    def test_hide_incomplete_conversion_window_periods(self):
+    def test_hide_incomplete_conversion_window_periods(
+        self,
+        _name: str,
+        hide_incomplete_periods: bool,
+        expected_days: list[date],
+        expected_counts: dict[date, tuple[int, int]],
+    ):
         # user_a enters twice: once well in the past (06-07, window long elapsed) and once recently
         # (06-12, window still open). A single later step-two event (06-13) converts BOTH entrances,
         # since each is within the 7-day window. recent_entrant only just entered and hasn't converted.
@@ -150,45 +179,24 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        def run_trends(hide_incomplete_periods: bool) -> list[dict]:
-            query = FunnelsQuery(
-                dateRange=DateRange(date_from="2021-06-07 00:00:00", date_to="2021-06-18 23:59:59"),
-                interval="day",
-                series=[EventsNode(event="step one"), EventsNode(event="step two")],
-                funnelsFilter=FunnelsFilter(
-                    funnelVizType="trends",
-                    funnelWindowInterval=7,
-                    funnelWindowIntervalUnit="day",
-                    hideIncompleteConversionWindowPeriods=hide_incomplete_periods,
-                ),
-            )
-            return FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
-
-        # Flag off: every daily period in range is present, including the recent incomplete ones.
-        periods_with_incomplete = run_trends(hide_incomplete_periods=False)
-        with_incomplete_by_day = {row["timestamp"].date(): row for row in periods_with_incomplete}
-        self.assertEqual(len(periods_with_incomplete), 12)  # 2021-06-07 .. 2021-06-18 inclusive
-        # both of user_a's entrances converted
-        self.assertEqual(with_incomplete_by_day[date(2021, 6, 7)]["reached_to_step_count"], 1)
-        self.assertEqual(with_incomplete_by_day[date(2021, 6, 12)]["reached_to_step_count"], 1)
-        # recent entrant shows as a non-converter, dragging the recent trend down
-        self.assertEqual(with_incomplete_by_day[date(2021, 6, 15)]["reached_from_step_count"], 1)
-        self.assertEqual(with_incomplete_by_day[date(2021, 6, 15)]["reached_to_step_count"], 0)
-
-        # Flag on: now=2021-06-18 12:00, window=7d -> cutoff=2021-06-11 12:00. A period is kept only
-        # once its whole day has cleared the window (entrance_period_start + 1 day <= cutoff), i.e.
-        # entrances on or before 2021-06-10.
-        periods_without_incomplete = run_trends(hide_incomplete_periods=True)
-        without_incomplete_by_day = {row["timestamp"].date(): row for row in periods_without_incomplete}
-        self.assertEqual(
-            [row["timestamp"].date() for row in periods_without_incomplete],
-            [date(2021, 6, day) for day in range(7, 11)],
+        query = FunnelsQuery(
+            dateRange=DateRange(date_from="2021-06-07 00:00:00", date_to="2021-06-18 23:59:59"),
+            interval="day",
+            series=[EventsNode(event="step one"), EventsNode(event="step two")],
+            funnelsFilter=FunnelsFilter(
+                funnelVizType="trends",
+                funnelWindowInterval=7,
+                funnelWindowIntervalUnit="day",
+                hideIncompleteConversionWindowPeriods=hide_incomplete_periods,
+            ),
         )
-        # the old entrance that converted is retained, even though its conversion event is recent
-        self.assertEqual(without_incomplete_by_day[date(2021, 6, 7)]["reached_to_step_count"], 1)
-        # the recent entrance (06-12) and the recent non-converter (06-15) are hidden
-        self.assertNotIn(date(2021, 6, 12), without_incomplete_by_day)
-        self.assertNotIn(date(2021, 6, 15), without_incomplete_by_day)
+        results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
+
+        by_day = {row["timestamp"].date(): row for row in results}
+        self.assertEqual([row["timestamp"].date() for row in results], expected_days)
+        for day, (reached_from, reached_to) in expected_counts.items():
+            self.assertEqual(by_day[day]["reached_from_step_count"], reached_from)
+            self.assertEqual(by_day[day]["reached_to_step_count"], reached_to)
 
     @parameterized.expand(["US/Pacific", "UTC"])
     def test_only_one_user_reached_one_step(self, timezone):

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -131,6 +131,65 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(results), 7)
         self.assertEqual(formatted_results[0]["days"][0], "2021-06-07")
 
+    @freeze_time("2021-06-18 12:00:00")
+    def test_hide_incomplete_conversion_window_periods(self):
+        # user_a enters twice: once well in the past (06-07, window long elapsed) and once recently
+        # (06-12, window still open). A single later step-two event (06-13) converts BOTH entrances,
+        # since each is within the 7-day window. recent_entrant only just entered and hasn't converted.
+        journeys_for(
+            {
+                "user_a": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 7)},
+                    {"event": "step one", "timestamp": datetime(2021, 6, 12)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 13)},
+                ],
+                "recent_entrant": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 15)},
+                ],
+            },
+            self.team,
+        )
+
+        def run_trends(hide_incomplete_periods: bool) -> list[dict]:
+            query = FunnelsQuery(
+                dateRange=DateRange(date_from="2021-06-07 00:00:00", date_to="2021-06-18 23:59:59"),
+                interval="day",
+                series=[EventsNode(event="step one"), EventsNode(event="step two")],
+                funnelsFilter=FunnelsFilter(
+                    funnelVizType="trends",
+                    funnelWindowInterval=7,
+                    funnelWindowIntervalUnit="day",
+                    hideIncompleteConversionWindowPeriods=hide_incomplete_periods,
+                ),
+            )
+            return FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
+
+        # Flag off: every daily period in range is present, including the recent incomplete ones.
+        periods_with_incomplete = run_trends(hide_incomplete_periods=False)
+        with_incomplete_by_day = {row["timestamp"].date(): row for row in periods_with_incomplete}
+        self.assertEqual(len(periods_with_incomplete), 12)  # 2021-06-07 .. 2021-06-18 inclusive
+        # both of user_a's entrances converted
+        self.assertEqual(with_incomplete_by_day[date(2021, 6, 7)]["reached_to_step_count"], 1)
+        self.assertEqual(with_incomplete_by_day[date(2021, 6, 12)]["reached_to_step_count"], 1)
+        # recent entrant shows as a non-converter, dragging the recent trend down
+        self.assertEqual(with_incomplete_by_day[date(2021, 6, 15)]["reached_from_step_count"], 1)
+        self.assertEqual(with_incomplete_by_day[date(2021, 6, 15)]["reached_to_step_count"], 0)
+
+        # Flag on: now=2021-06-18 12:00, window=7d -> cutoff=2021-06-11 12:00. A period is kept only
+        # once its whole day has cleared the window (entrance_period_start + 1 day <= cutoff), i.e.
+        # entrances on or before 2021-06-10.
+        periods_without_incomplete = run_trends(hide_incomplete_periods=True)
+        without_incomplete_by_day = {row["timestamp"].date(): row for row in periods_without_incomplete}
+        self.assertEqual(
+            [row["timestamp"].date() for row in periods_without_incomplete],
+            [date(2021, 6, day) for day in range(7, 11)],
+        )
+        # the old entrance that converted is retained, even though its conversion event is recent
+        self.assertEqual(without_incomplete_by_day[date(2021, 6, 7)]["reached_to_step_count"], 1)
+        # the recent entrance (06-12) and the recent non-converter (06-15) are hidden
+        self.assertNotIn(date(2021, 6, 12), without_incomplete_by_day)
+        self.assertNotIn(date(2021, 6, 15), without_incomplete_by_day)
+
     @parameterized.expand(["US/Pacific", "UTC"])
     def test_only_one_user_reached_one_step(self, timezone):
         self.team.timezone = timezone

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -131,37 +131,7 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(results), 7)
         self.assertEqual(formatted_results[0]["days"][0], "2021-06-07")
 
-    @parameterized.expand(
-        [
-            # Flag off: every daily period in range is present, including the recent incomplete ones.
-            # user_a's two entrances both converted; recent_entrant shows as a non-converter, which is
-            # exactly what drags the recent trend down.
-            (
-                "keeps_incomplete_periods_when_off",
-                False,
-                [date(2021, 6, day) for day in range(7, 19)],  # 2021-06-07 .. 2021-06-18 inclusive
-                {date(2021, 6, 7): (1, 1), date(2021, 6, 12): (1, 1), date(2021, 6, 15): (1, 0)},
-            ),
-            # Flag on: now=2021-06-18 12:00, window=7d -> cutoff=2021-06-11 12:00. A period is kept only
-            # once its whole day has cleared the window (entrance_period_start + 1 day <= cutoff), i.e.
-            # entrances on or before 2021-06-10. The old entrance that converted is retained even though
-            # its conversion event is recent; the recent entrance (06-12) and non-converter (06-15) are gone.
-            (
-                "drops_incomplete_periods_when_on",
-                True,
-                [date(2021, 6, day) for day in range(7, 11)],  # 2021-06-07 .. 2021-06-10
-                {date(2021, 6, 7): (1, 1)},
-            ),
-        ]
-    )
-    @freeze_time("2021-06-18 12:00:00")
-    def test_hide_incomplete_conversion_window_periods(
-        self,
-        _name: str,
-        hide_incomplete_periods: bool,
-        expected_days: list[date],
-        expected_counts: dict[date, tuple[int, int]],
-    ):
+    def _run_conversion_window_trends(self, *, hide_incomplete_periods: bool) -> list[dict]:
         # user_a enters twice: once well in the past (06-07, window long elapsed) and once recently
         # (06-12, window still open). A single later step-two event (06-13) converts BOTH entrances,
         # since each is within the 7-day window. recent_entrant only just entered and hasn't converted.
@@ -190,13 +160,36 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
                 hideIncompleteConversionWindowPeriods=hide_incomplete_periods,
             ),
         )
-        results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
+        return FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
 
+    @freeze_time("2021-06-18 12:00:00")
+    def test_keeps_incomplete_conversion_window_periods_by_default(self):
+        results = self._run_conversion_window_trends(hide_incomplete_periods=False)
         by_day = {row["timestamp"].date(): row for row in results}
-        self.assertEqual([row["timestamp"].date() for row in results], expected_days)
-        for day, (reached_from, reached_to) in expected_counts.items():
-            self.assertEqual(by_day[day]["reached_from_step_count"], reached_from)
-            self.assertEqual(by_day[day]["reached_to_step_count"], reached_to)
+
+        # every daily period in range is present, including the recent incomplete ones
+        self.assertEqual([row["timestamp"].date() for row in results], [date(2021, 6, day) for day in range(7, 19)])
+        # both of user_a's entrances converted
+        self.assertEqual(by_day[date(2021, 6, 7)]["reached_to_step_count"], 1)
+        self.assertEqual(by_day[date(2021, 6, 12)]["reached_to_step_count"], 1)
+        # recent entrant shows as a non-converter, which is what drags the recent trend down
+        self.assertEqual(by_day[date(2021, 6, 15)]["reached_from_step_count"], 1)
+        self.assertEqual(by_day[date(2021, 6, 15)]["reached_to_step_count"], 0)
+
+    @freeze_time("2021-06-18 12:00:00")
+    def test_hides_incomplete_conversion_window_periods_when_enabled(self):
+        results = self._run_conversion_window_trends(hide_incomplete_periods=True)
+        by_day = {row["timestamp"].date(): row for row in results}
+
+        # now=2021-06-18 12:00, window=7d -> cutoff=2021-06-11 12:00. A period is kept only once its
+        # whole day has cleared the window (entrance_period_start + 1 day <= cutoff), i.e. entrances
+        # on or before 2021-06-10.
+        self.assertEqual([row["timestamp"].date() for row in results], [date(2021, 6, day) for day in range(7, 11)])
+        # the old entrance that converted is retained, even though its conversion event is recent
+        self.assertEqual(by_day[date(2021, 6, 7)]["reached_to_step_count"], 1)
+        # the recent entrance (06-12) and the recent non-converter (06-15) are hidden
+        self.assertNotIn(date(2021, 6, 12), by_day)
+        self.assertNotIn(date(2021, 6, 15), by_day)
 
     @parameterized.expand(["US/Pacific", "UTC"])
     def test_only_one_user_reached_one_step(self, timezone):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -22784,6 +22784,14 @@ class FunnelsFilter(BaseModel):
     funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit | None = FunnelConversionWindowTimeUnit.DAY
     goalLines: list[GoalLine] | None = Field(default=None, description="Goal Lines")
     hiddenLegendBreakdowns: list[str] | None = None
+    hideIncompleteConversionWindowPeriods: bool | None = Field(
+        default=False,
+        description=(
+            "Trends only: hide periods whose conversion window has not fully elapsed"
+            " yet, so the recent tail of the trend isn't dragged down by entrants who"
+            " still have time to convert."
+        ),
+    )
     layout: FunnelLayout | None = FunnelLayout.VERTICAL
     resultCustomizations: dict[str, ResultCustomizationByValue] | None = Field(
         default=None,

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -2188,6 +2188,8 @@ export interface FunnelsFilterApi {
     /** Goal Lines */
     goalLines?: GoalLineApi[] | null
     hiddenLegendBreakdowns?: string[] | null
+    /** Trends only: hide periods whose conversion window has not fully elapsed yet, so the recent tail of the trend isn't dragged down by entrants who still have time to convert. */
+    hideIncompleteConversionWindowPeriods?: boolean | null
     layout?: FunnelLayoutApi | null
     /** Customizations for the appearance of result datasets. */
     resultCustomizations?: FunnelsFilterApiResultCustomizations

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -1881,6 +1881,8 @@ export interface FunnelsFilterApi {
     /** Goal Lines */
     goalLines?: GoalLineApi[] | null
     hiddenLegendBreakdowns?: string[] | null
+    /** Trends only: hide periods whose conversion window has not fully elapsed yet, so the recent tail of the trend isn't dragged down by entrants who still have time to convert. */
+    hideIncompleteConversionWindowPeriods?: boolean | null
     layout?: FunnelLayoutApi | null
     /** Customizations for the appearance of result datasets. */
     resultCustomizations?: FunnelsFilterApiResultCustomizations

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2372,6 +2372,8 @@ export namespace Schemas {
       /** Goal Lines */
       goalLines?: GoalLine[] | null;
       hiddenLegendBreakdowns?: string[] | null;
+      /** Trends only: hide periods whose conversion window has not fully elapsed yet, so the recent tail of the trend isn't dragged down by entrants who still have time to convert. */
+      hideIncompleteConversionWindowPeriods?: boolean | null;
       layout?: FunnelLayout | null;
       /** Customizations for the appearance of result datasets. */
       resultCustomizations?: FunnelsFilterResultCustomizations;


### PR DESCRIPTION
## Problem

In funnel **trends**, the most recent periods are dragged down because entrants whose conversion window (e.g. 90 days) hasn't fully elapsed yet are counted as non-converters — they still have time to convert. There's no signal showing where reliable data ends and "window-not-elapsed-yet" data begins.

## Changes

Opt-in `FunnelsFilter.hideIncompleteConversionWindowPeriods` toggle (default off, trends only). When on, the fill query keeps a period only once its whole interval has cleared the window (`entrance_period_start + interval <= now - conversion_window`), so every plotted point is computed over entrants that had the full window.

- Filtering happens in the generated HogQL fill query — the Rust funnel UDF is unchanged, no redeploy needed.
- Filters by step-1 (entrance) time, independent of outcome: an old entrance that converts recently is kept; a recent entrance is dropped.

## How did you test this code?

Agent-authored. Added `test_hide_incomplete_conversion_window_periods` covering a multi-entrance user (old entrance retained, recent entrance dropped) and a recent non-converter being hidden; passes locally. Ran adjacent trends tests — the only failures are a pre-existing local personhog/`distinct_ids` env issue that also reproduces on master.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Scoped to trends only: the same censoring bias exists in steps funnels but there's no time axis to confuse there, so it was left out. Chose a conservative cutoff (drop the boundary period unless its whole interval cleared the window) per author preference to over-trim rather than show a half-elapsed point. Implemented as a fill-query `WHERE` rather than touching the shared funnel UDF. Frontend toggle will follow in a separate PR.
