### PR TITLE
fix(mcp): enable cli mode for librechat

### DIFF
--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -59,6 +59,9 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
     'aider',
     'copilot',
     'gemini-cli',
+    // LibreChat is a general MCP client, but benefits from the same CLI-shaped
+    // single-exec mode as coding agents.
+    'librechat',
     // Notion AI ships its own `notion-mcp-client` (not a coding agent per se,
     // but an LLM-driven consumer that benefits from the same single-exec mode
     // and formatted-text rendering as coding agents).

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -25,6 +25,7 @@ describe('isCodingAgentClient', () => {
             ['zed'],
             ['aider'],
             ['copilot'],
+            ['librechat'],
             ['notion'],
         ])('returns true for %s', (clientName) => {
             expect(isCodingAgentClient(clientName)).toBe(true)
@@ -43,6 +44,9 @@ describe('isCodingAgentClient', () => {
             ['GitHub Copilot Chat'],
             ['zed-editor'],
             ['Codex CLI'],
+            ['LibreChat'],
+            ['libre-chat'],
+            ['LibreChat/1.2.3'],
             ['notion-mcp-client'],
             ['Notion'],
         ])('returns true for variant %s (case-insensitive substring match)', (clientName) => {
@@ -170,6 +174,8 @@ describe('MCPClientProfile', () => {
             ['aider'],
             ['github.copilot'],
             ['GitHub Copilot Chat'],
+            ['LibreChat'],
+            ['libre-chat'],
             ['notion-mcp-client'],
         ])('returns true for %s', (clientName) => {
             expect(new MCPClientProfile({ clientName }).isCodingAgent()).toBe(true)

--- a/services/mcp/tests/unit/protocol-types.test.ts
+++ b/services/mcp/tests/unit/protocol-types.test.ts
@@ -38,6 +38,14 @@ describe('resolveMode', () => {
         expect(result).toEqual({ mode: 'cli', useSingleExec: true })
     })
 
+    it('LibreChat activates single exec', () => {
+        const result = resolveMode({
+            ...base,
+            clientProfile: profile({ clientName: 'LibreChat' }),
+        })
+        expect(result).toEqual({ mode: 'cli', useSingleExec: true })
+    })
+
     it('non-coding agent does NOT activate single exec', () => {
         const result = resolveMode({
             ...base,


### PR DESCRIPTION
## Problem

LibreChat MCP sessions should receive the CLI-shaped single-exec mode rollout, but the MCP client detection allowlist did not include LibreChat yet.

## Changes

Added LibreChat to the MCP client-name fragments that opt into CLI mode and covered normalized client-name variants such as `LibreChat`, `libre-chat`, and versioned names.

Added a resolver test to confirm LibreChat resolves to `cli` mode with single-exec enabled.

## How did you test this code?

As Codex, I ran:

```sh
pnpm --filter=@posthog/mcp exec vitest run tests/unit/client-detection.test.ts tests/unit/protocol-types.test.ts
```

## Docs update

No docs update needed; this is a code-only MCP client rollout change.

## 🤖 Agent context

Authored by Codex in the local PostHog worktree. I used the MCP tools implementation skill, followed the existing client-profile detection path, and kept the change scoped to adding LibreChat to the existing single-exec client detection logic plus focused unit coverage.

The first package-script test invocation ran broader MCP tests and hit an unrelated local `@shared/guidelines.md` module-resolution issue in worker/exec suites. I reran the focused changed tests directly with `pnpm --filter=@posthog/mcp exec vitest run ...`, and they passed.
