### PR TITLE
fix: Reload insight when returning from SQL editor

### DIFF
--- a/frontend/src/scenes/insights/InsightAsScene.tsx
+++ b/frontend/src/scenes/insights/InsightAsScene.tsx
@@ -3,7 +3,7 @@ import { BindLogic, BuiltLogic, Logic, LogicWrapper, useActions, useValues } fro
 
 import { AccessDenied } from 'lib/components/AccessDenied'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
-import { Spinner } from 'lib/lemon-ui/Spinner'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { InsightModals } from 'scenes/insights/InsightModals'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
@@ -90,9 +90,7 @@ export function InsightAsScene({ insightId, attachTo, tabId }: InsightAsScenePro
 
                 {isDataVisualizationNode(query) && insightLoading ? (
                     // Avoid painting the stale chart type during a reload (the query re-syncs in insightDataLogic).
-                    <div className="flex items-center justify-center border rounded p-6 min-h-100">
-                        <Spinner className="text-3xl" />
-                    </div>
+                    <LemonSkeleton className="h-100 w-full" />
                 ) : (
                     <Query
                         attachTo={attachTo}

--- a/frontend/src/scenes/insights/InsightAsScene.tsx
+++ b/frontend/src/scenes/insights/InsightAsScene.tsx
@@ -3,6 +3,7 @@ import { BindLogic, BuiltLogic, Logic, LogicWrapper, useActions, useValues } fro
 
 import { AccessDenied } from 'lib/components/AccessDenied'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { InsightModals } from 'scenes/insights/InsightModals'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
@@ -10,7 +11,7 @@ import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { Query } from '~/queries/Query/Query'
 import { Node } from '~/queries/schema/schema-general'
-import { containsHogQLQuery, isInsightVizNode } from '~/queries/utils'
+import { containsHogQLQuery, isDataVisualizationNode, isInsightVizNode } from '~/queries/utils'
 import { InsightShortId, ItemMode } from '~/types'
 
 import { teamLogic } from '../teamLogic'
@@ -40,7 +41,7 @@ export function InsightAsScene({ insightId, attachTo, tabId }: InsightAsScenePro
         filtersOverride,
         variablesOverride,
     })
-    const { insightProps, accessDeniedToInsight } = useValues(logic)
+    const { insightProps, accessDeniedToInsight, insightLoading } = useValues(logic)
 
     // insightDataLogic
     const { query, showQueryEditor } = useValues(insightDataLogic(insightProps))
@@ -87,21 +88,28 @@ export function InsightAsScene({ insightId, attachTo, tabId }: InsightAsScenePro
                     <InsightSceneHeader insightLogicProps={insightProps} />
                 )}
 
-                <Query
-                    attachTo={attachTo}
-                    query={isInsightVizNode(query) ? { ...query, full: true } : query}
-                    setQuery={setQuery}
-                    readOnly={insightMode !== ItemMode.Edit}
-                    editMode={insightMode === ItemMode.Edit}
-                    context={{
-                        showOpenEditorButton: false,
-                        showQueryEditor: actuallyShowQueryEditor,
-                        showQueryHelp: insightMode === ItemMode.Edit && !containsHogQLQuery(query),
-                        insightProps,
-                    }}
-                    filtersOverride={filtersOverride}
-                    variablesOverride={variablesOverride}
-                />
+                {isDataVisualizationNode(query) && insightLoading ? (
+                    // Avoid painting the stale chart type during a reload (the query re-syncs in insightDataLogic).
+                    <div className="flex items-center justify-center border rounded p-6 min-h-100">
+                        <Spinner className="text-3xl" />
+                    </div>
+                ) : (
+                    <Query
+                        attachTo={attachTo}
+                        query={isInsightVizNode(query) ? { ...query, full: true } : query}
+                        setQuery={setQuery}
+                        readOnly={insightMode !== ItemMode.Edit}
+                        editMode={insightMode === ItemMode.Edit}
+                        context={{
+                            showOpenEditorButton: false,
+                            showQueryEditor: actuallyShowQueryEditor,
+                            showQueryHelp: insightMode === ItemMode.Edit && !containsHogQLQuery(query),
+                            insightProps,
+                        }}
+                        filtersOverride={filtersOverride}
+                        variablesOverride={variablesOverride}
+                    />
+                )}
             </SceneContent>
         </BindLogic>
     )

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -73,7 +73,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
         ],
         actions: [
             insightLogic,
-            ['setInsight', 'setInsightMetadata'],
+            ['setInsight', 'setInsightMetadata', 'loadInsightSuccess'],
             dataNodeLogic({ key: insightVizDataNodeKey(props) } as DataNodeLogicProps),
             ['loadData', 'loadDataSuccess', 'loadDataFailure', 'setResponse as setInsightData'],
         ],
@@ -288,6 +288,14 @@ export const insightDataLogic = kea<insightDataLogicType>([
 
             if (result) {
                 actions.setInsightData({ ...values.insightData, result })
+            }
+        },
+        loadInsightSuccess: ({ insight }) => {
+            // `internalQuery` wins over `insight.query` in the `query` selector, and the SQL editor
+            // updates a different logic instance — so a reload alone leaves this scene on the stale
+            // query until a hard refresh. Re-sync the override to the freshly loaded query.
+            if (insight.query && !objectsEqual(insight.query, values.query)) {
+                actions.syncQueryFromProps(insight.query)
             }
         },
         cancelChanges: () => {


### PR DESCRIPTION
## Problem

After making changes to a visualization and clicking the 'update insight' button in the SQL editor, we were showing a stale chart.

## Changes

Reload the insight after navigating back to the insight following the update, and show a loading state rather than flashing a stale visualization.

## How did you test this code?

Verified the fix locally