### PR TITLE
chore(llma): replace recipe priority with explicit dispatch order

### DIFF
--- a/products/ai_observability/frontend/normalizer/recipe/compile/compiler.test.ts
+++ b/products/ai_observability/frontend/normalizer/recipe/compile/compiler.test.ts
@@ -18,7 +18,7 @@ function emitContent(content: unknown, input: unknown = INPUT): CompatMessage['c
 
 describe('compileRecipe', () => {
     it('compiles a full recipe into runnable rules', () => {
-        const recipe = compileRecipe({ id: 'greet', priority: 5, rules: [{ on: {}, emit: { content: 'hi' } }] })
+        const recipe = compileRecipe({ id: 'greet', rules: [{ on: {}, emit: { content: 'hi' } }] })
         expect(recipe.id).toBe('greet')
         const produced = recipe.rules[0].produce(Scope.forNode({}, 'user'), ENGINE, false, 0)
         expect(produced).toEqual([{ role: 'user', content: 'hi' }])
@@ -40,10 +40,6 @@ describe('compileRecipe', () => {
         const recipe = compileRecipe({ id: 't', rules: [{ on: { type: 'reasoning' }, emit: {} }] })
         expect(recipe.rules[0].on.matches({ type: 'reasoning' })).toBe(true)
         expect(recipe.rules[0].on.matches({ type: 'text' })).toBe(false)
-    })
-
-    it('priority defaults to 100 when omitted', () => {
-        expect(compileRecipe({ id: 't', rules: [{ on: {}, emit: {} }] }).priority).toBe(100)
     })
 
     it('literal: preserves a one-key object that collides with an operator name', () => {

--- a/products/ai_observability/frontend/normalizer/recipe/compile/compiler.ts
+++ b/products/ai_observability/frontend/normalizer/recipe/compile/compiler.ts
@@ -60,7 +60,6 @@ export function compileRecipe(raw: unknown): Recipe {
     }
     return {
         id,
-        priority: numField(raw, 'priority') ?? 100,
         capture: stringField(raw, 'capture'),
         rules: rulesRaw.map((r, i) => {
             try {
@@ -385,9 +384,4 @@ function isObject(v: unknown): v is Record<string, unknown> {
 function stringField(o: Record<string, unknown>, key: string): string | undefined {
     const value = o[key]
     return typeof value === 'string' ? value : undefined
-}
-
-function numField(o: Record<string, unknown>, key: string): number | undefined {
-    const value = o[key]
-    return typeof value === 'number' ? value : undefined
 }

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/anthropic.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/anthropic.yaml
@@ -4,7 +4,6 @@
 # block plus a synthetic tool_calls message) via delegateEach + followups.
 
 id: anthropic
-priority: 50
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/cajole.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/cajole.yaml
@@ -2,7 +2,6 @@
 # so brand-new shapes still surface in telemetry. Highest priority so it runs last.
 
 id: cajole
-priority: 1000
 capture: llma message normalization failed
 
 rules:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/compat_array.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/compat_array.yaml
@@ -2,7 +2,6 @@
 # Lowest priority (5) so it claims these before the envelope rules can shadow it.
 
 id: compat_array
-priority: 5
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/dispatcher_entry.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/dispatcher_entry.yaml
@@ -2,7 +2,6 @@
 # the lowest priority so envelopes are peeled before any provider rule matches.
 
 id: dispatcher_entry
-priority: 1
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/langchain.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/langchain.yaml
@@ -2,7 +2,6 @@
 # object, so it goes through `stringify` (strings/arrays pass through unchanged).
 
 id: langchain
-priority: 20
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/langchain_envelope.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/langchain_envelope.yaml
@@ -2,7 +2,6 @@
 # message is in `kwargs`; delegate it so the bare langchain rule picks it up.
 
 id: langchain_envelope
-priority: 15
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/litellm.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/litellm.yaml
@@ -2,7 +2,6 @@
 # delegate `.message` so its own provider recipe handles it.
 
 id: litellm
-priority: 10
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/openai_chat.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/openai_chat.yaml
@@ -1,7 +1,6 @@
 # Example: { role: assistant, content: "hi", tool_calls: [{ id, type: function, function: { name, arguments } }] }
 
 id: openai_chat
-priority: 35
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/openai_responses.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/openai_responses.yaml
@@ -1,7 +1,6 @@
 # Example: { type: function_call, call_id: c1, name: search, arguments: '{"q":"x"}' }
 
 id: openai_responses
-priority: 40
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/otel.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/otel.yaml
@@ -6,7 +6,6 @@
 # parts produce nothing at all still emits one empty-content message (legacy parity).
 
 id: otel
-priority: 60
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/typed_agent_items.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/typed_agent_items.yaml
@@ -5,7 +5,6 @@
 # tool_call / tool_result items match nothing and fall to cajole's stringify.
 
 id: typed_agent_items
-priority: 42
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/vercel_sdk.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/vercel_sdk.yaml
@@ -1,7 +1,6 @@
 # Example: { type: tool-call, toolCallId: t1, toolName: search, input: { q: "x" } }
 
 id: vercel_sdk
-priority: 30
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/wrappers.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/wrappers.yaml
@@ -4,7 +4,6 @@
 # so an output-side wrapper stays `assistant`.
 
 id: wrappers
-priority: 90
 
 rules:
     - on:

--- a/products/ai_observability/frontend/normalizer/recipe/registry.test.ts
+++ b/products/ai_observability/frontend/normalizer/recipe/registry.test.ts
@@ -7,8 +7,8 @@ describe('loadRecipes', () => {
         expect(recipes.every((r) => typeof r.id === 'string' && r.id.length > 0)).toBe(true)
     })
 
-    it('every loaded recipe has a unique priority', () => {
-        const priorities = loadRecipes().map((r) => r.priority)
-        expect(new Set(priorities).size).toBe(priorities.length)
+    it('has unique recipe ids', () => {
+        const ids = loadRecipes().map((recipe) => recipe.id)
+        expect(new Set(ids).size).toBe(ids.length)
     })
 })

--- a/products/ai_observability/frontend/normalizer/recipe/registry.ts
+++ b/products/ai_observability/frontend/normalizer/recipe/registry.ts
@@ -16,39 +16,37 @@ import vercelSdk from './default_recipes/vercel_sdk.yaml?raw'
 import wrappers from './default_recipes/wrappers.yaml?raw'
 import { Recipe } from './spec/recipe'
 
-const RECIPE_SOURCES = {
-    anthropic,
-    cajole,
-    compatArray,
+// Order here determines deafult recipe order
+const RECIPE_SOURCES: readonly string[] = [
     dispatcherEntry,
-    langchain,
-    langchainEnvelope,
+    compatArray,
     litellm,
+    langchainEnvelope,
+    langchain,
+    vercelSdk,
     openaiChat,
     openaiResponses,
-    otel,
     typedAgentItems,
-    vercelSdk,
+    anthropic,
+    otel,
     wrappers,
-}
+    cajole,
+]
 
-const RECIPES: Recipe[] = Object.entries(RECIPE_SOURCES).map(([name, source]) => {
+const RECIPES: Recipe[] = []
+const seenIds = new Set<string>()
+for (const [index, source] of RECIPE_SOURCES.entries()) {
+    let recipe: Recipe
     try {
-        return compileRecipe(parseYaml(source))
+        recipe = compileRecipe(parseYaml(source))
     } catch (err) {
-        throw new Error(`Loading recipe ${name}: ${err instanceof Error ? err.message : String(err)}`)
+        throw new Error(`Loading recipe #${index}: ${err instanceof Error ? err.message : String(err)}`)
     }
-})
-
-// Dispatch is first-match-wins over priority order, so two recipes sharing a
-// priority would have an undefined relative order. Fail loudly instead.
-const seenPriorities = new Map<number, string>()
-for (const recipe of RECIPES) {
-    const clash = seenPriorities.get(recipe.priority)
-    if (clash !== undefined) {
-        throw new Error(`Recipe priority ${recipe.priority} is used by both '${clash}' and '${recipe.id}'`)
+    if (seenIds.has(recipe.id)) {
+        throw new Error(`Duplicate recipe id '${recipe.id}'`)
     }
-    seenPriorities.set(recipe.priority, recipe.id)
+    seenIds.add(recipe.id)
+    RECIPES.push(recipe)
 }
 
 export function loadRecipes(): Recipe[] {

--- a/products/ai_observability/frontend/normalizer/recipe/runtime/pipeline.test.ts
+++ b/products/ai_observability/frontend/normalizer/recipe/runtime/pipeline.test.ts
@@ -21,29 +21,29 @@ class StubRule extends Rule {
     }
 }
 
-const recipe = (id: string, priority: number, rule: Rule): Recipe => ({ id, priority, rules: [rule] })
+const recipe = (id: string, rule: Rule): Recipe => ({ id, rules: [rule] })
 
 describe('RecipePipeline', () => {
     it('dispatches to the matching rule and returns its messages', () => {
         const messages: CompatMessage[] = [{ role: 'user', content: 'hi' }]
-        const pipeline = new RecipePipeline([recipe('only', 100, new StubRule(MATCH_ALL, messages))])
+        const pipeline = new RecipePipeline([recipe('only', new StubRule(MATCH_ALL, messages))])
         expect(pipeline.run({ role: 'user' }, 'user')).toEqual(messages)
     })
 
-    it('when several recipes match, the lowest priority number wins', () => {
-        const high = recipe('high', 200, new StubRule(MATCH_ALL, [{ role: 'user', content: 'low-priority' }]))
-        const low = recipe('low', 1, new StubRule(MATCH_ALL, [{ role: 'user', content: 'high-priority' }]))
-        const pipeline = new RecipePipeline([high, low])
-        expect(pipeline.run({ role: 'user' }, 'user')).toEqual([{ role: 'user', content: 'high-priority' }])
+    it('when several recipes match, the first in order wins', () => {
+        const first = recipe('first', new StubRule(MATCH_ALL, [{ role: 'user', content: 'first-wins' }]))
+        const second = recipe('second', new StubRule(MATCH_ALL, [{ role: 'user', content: 'second' }]))
+        const pipeline = new RecipePipeline([first, second])
+        expect(pipeline.run({ role: 'user' }, 'user')).toEqual([{ role: 'user', content: 'first-wins' }])
     })
 
     it('returns NO_MATCH when no rule matches', () => {
-        const pipeline = new RecipePipeline([recipe('none', 100, new StubRule(MATCH_NONE, []))])
+        const pipeline = new RecipePipeline([recipe('none', new StubRule(MATCH_NONE, []))])
         expect(pipeline.run({ role: 'user' }, 'user')).toBe(NO_MATCH)
     })
 
     it('throws when recursion exceeds the max delegation depth', () => {
-        const pipeline = new RecipePipeline([recipe('only', 100, new StubRule(MATCH_ALL, []))])
+        const pipeline = new RecipePipeline([recipe('only', new StubRule(MATCH_ALL, []))])
         expect(() => pipeline.dispatch({ role: 'user' }, 'user', 11)).toThrow(/max depth/)
     })
 })

--- a/products/ai_observability/frontend/normalizer/recipe/runtime/pipeline.ts
+++ b/products/ai_observability/frontend/normalizer/recipe/runtime/pipeline.ts
@@ -15,9 +15,8 @@ export class RecipePipeline implements DispatchEngine {
     readonly coercer = new SlotCoercer()
     private readonly recipes: Recipe[]
 
-    constructor(recipes: Recipe[]) {
-        // Sort a copy: the input is the shared module-level registry array.
-        this.recipes = [...recipes].sort((a, b) => a.priority - b.priority)
+    constructor(recipes: Iterable<Recipe>) {
+        this.recipes = [...recipes]
     }
 
     run(input: unknown, defaultRole: string): DispatchResult {

--- a/products/ai_observability/frontend/normalizer/recipe/spec/recipe.ts
+++ b/products/ai_observability/frontend/normalizer/recipe/spec/recipe.ts
@@ -2,7 +2,6 @@ import type { Rule } from '../ast/rule'
 
 export interface Recipe {
     id: string
-    priority: number
     rules: Rule[]
     // Fires a PostHog capture on every dispatch match — including recursive
     // delegation, so only set it on a recipe that is never delegated into (a


### PR DESCRIPTION
## Problem

Priorities as scalar are hard to maintain and don't pair well with custom recipes.

## Changes

Instead of having priorities on each recipe, have an authoritative order definition.

## How did you test this code?

I'm an agent (Claude Code) and did no manual testing. Automated tests run: the recipe registry / compiler / pipeline / merge Jest suites and the normalizer parity suites (`messageNormalization`, `utils`) — all green. I also verified the new array order matched the old priority-sorted order before removing the numbers.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Add the `skip-inkeep-docs` label — internal refactor, no docs impact.

## 🤖 Agent context

Authored with Claude Code. This is the base of a two-PR stack: a mechanical ordering refactor, split out so it reviews on its own, separate from the stacked feature PR (`feat(llma): custom parsing recipes for trace normalization`) that builds on it. Main decision: make array position the single source of dispatch order and read recipe identity from each YAML's `id:`, dropping the redundant `priority` field — after verifying equivalence to the old sort. Agent-authored; requires human review.
