### PR TITLE
fix(ci): set personhog env for error-tracking in dev compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -272,6 +272,9 @@ services:
         environment:
             DATABASE_URL: postgres://posthog:posthog@db:5432/${POSTHOG_DB_NAME:-posthog}
             PERSONS_DATABASE_URL: postgres://posthog:posthog@db:5432/${POSTHOG_PERSONS_DB_NAME:-posthog}
+            # Error tracking requires PersonHog — point at the local gRPC router
+            PERSONHOG_ADDR: 'personhog-router:50052'
+            PERSONHOG_ENABLED: 'true'
         depends_on:
             kafka:
                 condition: service_started
@@ -279,6 +282,8 @@ services:
                 condition: service_healthy
             db:
                 condition: service_healthy
+            personhog-router:
+                condition: service_started
         healthcheck:
             test: ['CMD', 'curl', '-f', 'http://localhost:6738/_ready']
             interval: 5s


### PR DESCRIPTION
## Problem

`chore(error-tracking): use personhog only repos (#61411)` made the error-tracking ingestion server hard-require PersonHog (`nodejs/src/servers/error-tracking-server.ts` throws `PersonHog client is required for error tracking — set PERSONHOG_ENABLED=true and PERSONHOG_ADDR` at startup). But the `ingestion-error-tracking` service in `docker-compose.dev.yml` was never given those vars, so it crash-loops on boot.

This breaks the Playwright E2E for everyone: the test setup waits for `ingestion-error-tracking` to become healthy, the container never comes up, and `/_health` returns 502 until the 300s timeout. It's red on master and on every PR that actually runs the E2E.

It slipped in because #61411's own Playwright E2E was **skipped** by the path filter (its changes were nodejs-only), so the break was never exercised pre-merge.

## Changes

- Add `PERSONHOG_ENABLED: 'true'` + `PERSONHOG_ADDR: 'personhog-router:50052'` to the `ingestion-error-tracking` service, and a `personhog-router` startup dependency — mirroring the existing `plugins` service.

Scoped to error-tracking only: it's the sole ingestion server that hard-requires PersonHog (`ingestion-logs` / `ingestion-traces` do not).

## How did you test this code?

Agent-authored (Claude Code). I validated `docker compose -f docker-compose.dev.yml config` resolves cleanly with the change. I did **not** run the full Playwright E2E locally — the authoritative check is the Playwright E2E job on this PR, which previously timed out waiting on `ingestion-error-tracking`.

## 🤖 Agent context

Authored with Claude Code at the request of @rnegron. Surfaced while rebasing the Python 3.13 cutover onto latest master: the rebased branch's Playwright E2E failed, and the failure was traced to #61411 rather than the cutover (master's own E2E on the same commit fails identically). Confirmed via `nodejs/src/servers/*` that only `error-tracking-server.ts` carries the hard PersonHog requirement, then mirrored the `plugins` service's personhog wiring onto the error-tracking service. Human review required; not self-merged.
