### PR TITLE
feat: Add multi-topic support to livestream

### DIFF
--- a/livestream/events/kafka.go
+++ b/livestream/events/kafka.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -187,8 +188,9 @@ func (c *PostHogKafkaConsumer) Consume(ctx context.Context) {
 		return nil
 	}
 
-	if err := c.consumer.SubscribeTopics([]string{c.topic}, rebalanceCallback); err != nil {
-		log.Fatalf("Failed to subscribe to topic: %v", err)
+	topics := splitTopics(c.topic)
+	if err := c.consumer.SubscribeTopics(topics, rebalanceCallback); err != nil {
+		log.Fatalf("Failed to subscribe to topics: %v", err)
 	}
 
 	for i := 0; i < c.parallel; i++ {
@@ -398,4 +400,14 @@ func applyKafkaConfigOverrides(config *kafka.ConfigMap, consumerConfig configs.C
 	if consumerConfig.MaxPollIntervalMs > 0 {
 		_ = config.SetKey("max.poll.interval.ms", consumerConfig.MaxPollIntervalMs)
 	}
+}
+
+func splitTopics(topic string) []string {
+	out := make([]string, 0, 2)
+	for p := range strings.SplitSeq(topic, ",") {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }

--- a/livestream/events/kafka_test.go
+++ b/livestream/events/kafka_test.go
@@ -261,8 +261,8 @@ func TestSplitTopics(t *testing.T) {
 		},
 		{
 			name:     "two topics",
-			input:    "ingestion-analytics-main-1024,ingestion-analytics-team2-256",
-			expected: []string{"ingestion-analytics-main-1024", "ingestion-analytics-team2-256"},
+			input:    "topic-1,topic-2",
+			expected: []string{"topic-1", "topic-2"},
 		},
 		{
 			name:     "surrounding whitespace",

--- a/livestream/events/kafka_test.go
+++ b/livestream/events/kafka_test.go
@@ -247,3 +247,43 @@ func TestParse_InnerTimestampOverridesWrapper(t *testing.T) {
 	assert.Equal(t, "2026-01-09T02:00:00.000Z", got.Timestamp)
 	assert.Equal(t, "$pageview", got.Event)
 }
+
+func TestSplitTopics(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "single topic",
+			input:    "events_topic",
+			expected: []string{"events_topic"},
+		},
+		{
+			name:     "two topics",
+			input:    "ingestion-analytics-main-1024,ingestion-analytics-team2-256",
+			expected: []string{"ingestion-analytics-main-1024", "ingestion-analytics-team2-256"},
+		},
+		{
+			name:     "surrounding whitespace",
+			input:    " a , b ",
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "empty and trailing segments",
+			input:    "a,,b,",
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, splitTopics(tt.input))
+		})
+	}
+}

--- a/livestream/events/notification_consumer.go
+++ b/livestream/events/notification_consumer.go
@@ -46,7 +46,7 @@ func NewNotificationKafkaConsumer(
 }
 
 func (c *NotificationKafkaConsumer) Consume(ctx context.Context) {
-	if err := c.consumer.SubscribeTopics([]string{c.topic}, nil); err != nil {
+	if err := c.consumer.SubscribeTopics(splitTopics(c.topic), nil); err != nil {
 		log.Printf("Failed to subscribe to notification topic: %v", err)
 		return
 	}

--- a/livestream/events/session_recording_consumer.go
+++ b/livestream/events/session_recording_consumer.go
@@ -53,7 +53,7 @@ func NewSessionRecordingKafkaConsumer(
 }
 
 func (c *SessionRecordingKafkaConsumer) Consume(ctx context.Context) {
-	if err := c.consumer.SubscribeTopics([]string{c.topic}, nil); err != nil {
+	if err := c.consumer.SubscribeTopics(splitTopics(c.topic), nil); err != nil {
 		log.Fatalf("Failed to subscribe to session recording topic: %v", err)
 	}
 	log.Printf("Session recording consumer subscribed to topic: %s", c.topic)


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
Events come from multiple different kafka topics which results in the Livestream service missing some of them
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add multi-topic support to livestream
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
