### PR TITLE
feat(usage-reports): send usage reports v2 sqs pointer

### DIFF
--- a/posthog/temporal/tests/usage_report/test_workflow.py
+++ b/posthog/temporal/tests/usage_report/test_workflow.py
@@ -1,10 +1,8 @@
 """End-to-end workflow tests using a Temporal `WorkflowEnvironment`.
 
 The activities are mocked at the `@activity.defn` boundary so the workflow's
-orchestration logic — query fan-out, aggregation — can be verified without
-standing up real ClickHouse / Postgres / S3. The SQS pointer activity call
-is currently disabled in the workflow (see `workflow.py`), so it's not
-exercised here.
+orchestration logic — query fan-out, aggregation, and SQS pointer dispatch —
+can be verified without standing up real ClickHouse / Postgres / S3.
 """
 
 import uuid
@@ -33,7 +31,14 @@ from posthog.temporal.usage_report.workflow import RunUsageReportsWorkflow
 async def test_workflow_runs_query_then_aggregate() -> None:
     seen_query_names: list[str] = []
     aggregated_with: list[list[str]] = []
+    aggregate_payloads: list[AggregateInputs] = []
     pointer_payloads: list[EnqueuePointerInputs] = []
+    expected_aggregate = AggregateResult(
+        chunk_keys=["chunks/chunk_0000.jsonl.gz"],
+        manifest_key="manifest.json",
+        total_orgs=2,
+        total_orgs_with_usage=1,
+    )
 
     @activity.defn(name="run-usage-report-query")
     async def query_mock(inputs: RunQueryToS3Inputs) -> RunQueryToS3Result:
@@ -46,16 +51,10 @@ async def test_workflow_runs_query_then_aggregate() -> None:
 
     @activity.defn(name="aggregate-and-chunk-org-reports")
     async def aggregate_mock(inputs: AggregateInputs) -> AggregateResult:
+        aggregate_payloads.append(inputs)
         aggregated_with.append([r.query_name for r in inputs.query_results])
-        return AggregateResult(
-            chunk_keys=["chunks/chunk_0000.jsonl.gz"],
-            manifest_key="manifest.json",
-            total_orgs=2,
-            total_orgs_with_usage=1,
-        )
+        return expected_aggregate
 
-    # Pointer activity is registered so the worker accepts it if dispatched,
-    # but the workflow currently does not call it (see workflow.py for why).
     @activity.defn(name="usage-reports-enqueue-pointer-message")
     async def pointer_mock(inputs: EnqueuePointerInputs) -> None:
         pointer_payloads.append(inputs)
@@ -101,20 +100,13 @@ async def test_workflow_runs_query_then_aggregate() -> None:
     assert len(aggregated_with) == 1
     assert aggregated_with[0] == expected_names
 
-    # Pointer dispatch is currently disabled in the workflow.
-    assert pointer_payloads == []
+    assert len(pointer_payloads) == 1
+    assert pointer_payloads[0].ctx == aggregate_payloads[0].ctx
+    assert pointer_payloads[0].aggregate == expected_aggregate
 
     # Each scheduled query activity carries its query name as the Temporal
     # `summary`, so the UI surfaces which query is running.
     assert set(scheduled_summaries.values()) == set(expected_names)
     assert len(scheduled_summaries) == len(expected_names)
 
-    assert (
-        result
-        == AggregateResult(
-            chunk_keys=["chunks/chunk_0000.jsonl.gz"],
-            manifest_key="manifest.json",
-            total_orgs=2,
-            total_orgs_with_usage=1,
-        ).model_dump()
-    )
+    assert result == expected_aggregate.model_dump()

--- a/posthog/temporal/usage_report/workflow.py
+++ b/posthog/temporal/usage_report/workflow.py
@@ -6,11 +6,8 @@ then a single aggregation activity reads them all back from S3, builds one
 `FullUsageReport` dict per organization, and writes those reports as gzipped
 JSONL chunks (≤10k orgs each) plus a manifest.
 
-The final step — an `enqueue_pointer_message` activity that sends a single
-SQS pointer to billing — is currently disabled until the `usage_reports_v2`
-queue is provisioned in deployment. For now the workflow stops after the
-chunks and manifest are in S3; billing isn't notified yet. See the
-commented-out call below for re-enabling.
+The final step is an `enqueue_pointer_message` activity that sends a single
+SQS pointer to billing so it can read the chunks and manifest from S3.
 
 This replaces the per-org SQS fan-out in
 `posthog/tasks/usage_report.py:send_all_org_usage_reports`. The Celery task
@@ -27,11 +24,16 @@ from temporalio import common, workflow
 
 from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.usage_report.activities import aggregate_and_chunk_org_reports, run_query_to_s3
+from posthog.temporal.usage_report.activities import (
+    aggregate_and_chunk_org_reports,
+    enqueue_pointer_message,
+    run_query_to_s3,
+)
 from posthog.temporal.usage_report.queries import QUERIES, QuerySpec
 from posthog.temporal.usage_report.storage import run_prefix
 from posthog.temporal.usage_report.types import (
     AggregateInputs,
+    EnqueuePointerInputs,
     RunQueryToS3Inputs,
     RunQueryToS3Result,
     RunUsageReportsInputs,
@@ -108,22 +110,16 @@ class RunUsageReportsWorkflow(PostHogWorkflow):
                 heartbeat_timeout=timedelta(minutes=5),
             )
 
-            # SQS pointer dispatch is disabled until the `usage_reports_v2`
-            # queue is provisioned in deployment and
-            # `SQS_USAGE_REPORT_V2_QUEUE_URL` is set on the temporal-worker
-            # pods. Re-enable by uncommenting the call below once billing has
-            # the queue ready to consume.
-            #
-            # await workflow.execute_activity(
-            #     enqueue_pointer_message,
-            #     EnqueuePointerInputs(ctx=ctx, aggregate=agg),
-            #     start_to_close_timeout=timedelta(minutes=2),
-            #     retry_policy=common.RetryPolicy(
-            #         maximum_attempts=5,
-            #         initial_interval=timedelta(seconds=10),
-            #     ),
-            #     heartbeat_timeout=timedelta(minutes=1),
-            # )
+            await workflow.execute_activity(
+                enqueue_pointer_message,
+                EnqueuePointerInputs(ctx=ctx, aggregate=agg),
+                start_to_close_timeout=timedelta(minutes=2),
+                retry_policy=common.RetryPolicy(
+                    maximum_attempts=5,
+                    initial_interval=timedelta(seconds=10),
+                ),
+                heartbeat_timeout=timedelta(minutes=1),
+            )
 
             # Intentionally NOT cleaning up the per-query intermediates yet —
             # we want them around in S3 for debugging while we validate the


### PR DESCRIPTION
## Problem

The Temporal usage reports workflow writes the aggregated reports to object storage, but it did not notify billing after the chunks and manifest were created. That left the S3-backed v2 flow incomplete even though the pointer activity and queue configuration path already existed.

## Changes

Enable the existing `enqueue_pointer_message` activity after aggregation in the `run-usage-reports` workflow.

Update the workflow orchestration test to assert that the pointer activity is scheduled with the same workflow context and aggregate result that aggregation produced.

## How did you test this code?

As an agent, I ran:

- `ruff check posthog/temporal/usage_report/workflow.py posthog/temporal/tests/usage_report/test_workflow.py`
- `ruff format --check posthog/temporal/usage_report/workflow.py posthog/temporal/tests/usage_report/test_workflow.py`
- `git diff --check`
- `./bin/hogli test posthog/temporal/tests/usage_report/test_workflow.py::test_workflow_runs_query_then_aggregate posthog/temporal/tests/usage_report/test_pointer_activity.py`

I also attempted the full `posthog/temporal/tests/usage_report` suite locally, but the service-dependent tests failed because local object storage/Postgres dependencies were not running.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this wires an existing backend workflow step.

## 🤖 Agent context

Authored with Codex in the local PostHog worktree. The implementation enables the existing v2 SQS pointer activity rather than adding a new messaging path, keeping the change limited to workflow orchestration.

Before opening the PR, I verified that the workflow runs on the billing Temporal task queue and that the deployment configuration has the matching v2 SQS environment variables for that worker. The focused workflow and pointer activity tests cover the behavior changed here.