### PR TITLE
chore(flags): parameterize geoip person-property override tests

### DIFF
--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -45,6 +45,7 @@ use common_cache::NegativeCache;
 use common_database::Client;
 use common_geoip::GeoIpClient;
 use reqwest::header::CONTENT_TYPE;
+use rstest::rstest;
 use serde_json::{json, Value};
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -88,90 +89,90 @@ fn create_test_geoip_service() -> GeoIpClient {
         .expect("Failed to create GeoIpService for testing")
 }
 
-#[test]
-fn test_geoip_enabled_with_person_properties() {
-    let geoip_service = create_test_geoip_service();
-
-    let mut person_props = HashMap::new();
-    person_props.insert("name".to_string(), Value::String("John".to_string()));
-
-    let result = properties::get_person_property_overrides(
-        false,
-        Some(person_props),
-        &IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), // Google's public DNS, should be in the US
-        &geoip_service,
-    );
-
-    assert!(result.is_some());
-    let result = result.unwrap();
-    assert!(result.len() > 1);
-    assert_eq!(result.get("name"), Some(&Value::String("John".to_string())));
-    assert!(result.contains_key("$geoip_country_name"));
+enum GeoipExpected {
+    /// GeoIP resolves and merges with the supplied person props (name + country keys).
+    NameAndCountry,
+    /// GeoIP is off, so only the supplied person prop survives.
+    NameOnly,
+    /// GeoIP resolves with no person props (country keys only).
+    CountryOnly,
+    /// Nothing to override.
+    None,
 }
 
-#[test]
-fn test_geoip_enabled_without_person_properties() {
+#[rstest]
+// GeoIP on, public IP, with person props → name preserved + geoip merged
+#[case(
+    false,
+    true,
+    IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+    GeoipExpected::NameAndCountry
+)]
+// GeoIP on, public IP, no person props → geoip only
+#[case(
+    false,
+    false,
+    IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+    GeoipExpected::CountryOnly
+)]
+// GeoIP off, public IP, with person props → only the person prop survives
+#[case(
+    true,
+    true,
+    IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+    GeoipExpected::NameOnly
+)]
+// GeoIP off, public IP, no person props → nothing
+#[case(
+    true,
+    false,
+    IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+    GeoipExpected::None
+)]
+// GeoIP on, loopback IP → GeoIP is on but resolves nothing
+#[case(
+    false,
+    false,
+    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+    GeoipExpected::None
+)]
+fn test_geoip_person_property_overrides(
+    #[case] geoip_disabled: bool,
+    #[case] with_name: bool,
+    #[case] ip: IpAddr,
+    #[case] expected: GeoipExpected,
+) {
     let geoip_service = create_test_geoip_service();
+    let name = Value::String("John".to_string());
+
+    let person_properties = with_name.then(|| HashMap::from([("name".to_string(), name.clone())]));
 
     let result = properties::get_person_property_overrides(
-        false,
-        None,
-        &IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), // Google's public DNS, should be in the US
+        geoip_disabled,
+        person_properties,
+        &ip,
         &geoip_service,
     );
 
-    assert!(result.is_some());
-    let result = result.unwrap();
-    assert!(!result.is_empty());
-    assert!(result.contains_key("$geoip_country_name"));
-}
-
-#[test]
-fn test_geoip_disabled_with_person_properties() {
-    let geoip_service = create_test_geoip_service();
-
-    let mut person_props = HashMap::new();
-    person_props.insert("name".to_string(), Value::String("John".to_string()));
-
-    let result = properties::get_person_property_overrides(
-        true,
-        Some(person_props),
-        &IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
-        &geoip_service,
-    );
-
-    assert!(result.is_some());
-    let result = result.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result.get("name"), Some(&Value::String("John".to_string())));
-}
-
-#[test]
-fn test_geoip_disabled_without_person_properties() {
-    let geoip_service = create_test_geoip_service();
-
-    let result = properties::get_person_property_overrides(
-        true,
-        None,
-        &IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
-        &geoip_service,
-    );
-
-    assert!(result.is_none());
-}
-
-#[test]
-fn test_geoip_enabled_local_ip() {
-    let geoip_service = create_test_geoip_service();
-
-    let result = properties::get_person_property_overrides(
-        true,
-        None,
-        &IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-        &geoip_service,
-    );
-
-    assert!(result.is_none());
+    match expected {
+        GeoipExpected::NameAndCountry => {
+            let result = result.expect("expected property overrides");
+            assert!(result.len() > 1);
+            assert_eq!(result.get("name"), Some(&name));
+            assert!(result.contains_key("$geoip_country_name"));
+        }
+        GeoipExpected::NameOnly => {
+            let result = result.expect("expected property overrides");
+            assert_eq!(result.len(), 1);
+            assert_eq!(result.get("name"), Some(&name));
+        }
+        GeoipExpected::CountryOnly => {
+            let result = result.expect("expected property overrides");
+            assert!(!result.is_empty());
+            assert!(result.contains_key("$geoip_country_name"));
+        }
+        GeoipExpected::None => assert!(result.is_none()),
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

This is some test cleanup I noticed while working on something else, but deferred to later.

The five `test_geoip_*` cases in the flags handler tests were near-identical. Each built a `GeoIpClient`, called `get_person_property_overrides`, unwrapped, and asserted, so adding a scenario meant copying a whole function. The loopback case also had a latent mismatch: it passed `true` for `geoip_disabled`, so GeoIP was actually off, which contradicts the "enabled" in its name.

## Changes

Collapse the five cases into one `#[rstest]`-driven `test_geoip_person_property_overrides`. The shared setup lives once and each scenario is a single `#[case]` row over `(geoip_disabled, with_name, ip, expected)`, where `expected` is a small enum that selects the assertion shape. This uses the `rstest` dev-dependency already present across the crate.

Fix the loopback case to pass `false` for `geoip_disabled` so it exercises what it claims: GeoIP enabled, but a loopback IP resolves to no enrichment, so there's no override.

## How did you test this code?

- `cargo test -p feature-flags --lib handler::tests::test_geoip_person_property_overrides` passes all 5 cases.
- `cargo clippy -p feature-flags --tests` shows no new warnings on the file.

The behavior the original five tests covered is preserved one-to-one.