### PR TITLE
chore(propdefs): accept gzip for personhog calls

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10689,6 +10689,7 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
+ "flate2",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -188,7 +188,7 @@ fancy-regex = "0.17"
 lz-str = "0.2.1"
 lz4 = "1.28"
 opentelemetry-proto = { version = "0.29.0", features = ["with-serde"] }
-tonic = { version = "0.12.3", features = ["zstd"] }
+tonic = { version = "0.12.3", features = ["gzip", "zstd"] }
 tonic-build = "0.12"
 clickhouse = { version = "0.13.2", features = [
   "uuid",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -188,7 +188,7 @@ fancy-regex = "0.17"
 lz-str = "0.2.1"
 lz4 = "1.28"
 opentelemetry-proto = { version = "0.29.0", features = ["with-serde"] }
-tonic = { version = "0.12.3", features = ["gzip", "zstd"] }
+tonic = { version = "0.12.3", features = ["zstd"] }
 tonic-build = "0.12"
 clickhouse = { version = "0.13.2", features = [
   "uuid",

--- a/rust/property-defs-rs/Cargo.toml
+++ b/rust/property-defs-rs/Cargo.toml
@@ -28,7 +28,7 @@ uuid = { workspace = true }
 rand = { workspace = true }
 anyhow = { workspace = true }
 personhog-proto = { path = "../personhog-proto" }
-tonic = { workspace = true }
+tonic = { workspace = true, features = ["gzip"] }
 thiserror.workspace = true
 regex.workspace = true
 

--- a/rust/property-defs-rs/src/group_type_resolver.rs
+++ b/rust/property-defs-rs/src/group_type_resolver.rs
@@ -4,6 +4,7 @@ use personhog_proto::personhog::{
 };
 use quick_cache::sync::Cache;
 use std::collections::HashMap;
+use tonic::codec::CompressionEncoding;
 use tonic::transport::Channel;
 use tracing::{info, warn};
 
@@ -38,7 +39,10 @@ impl GroupTypeResolver {
                         connect_timeout_ms = config.personhog_connect_timeout_ms,
                         "Created personhog gRPC client"
                     );
-                    Some(PersonHogServiceClient::new(channel))
+                    Some(
+                        PersonHogServiceClient::new(channel)
+                            .accept_compressed(CompressionEncoding::Gzip),
+                    )
                 }
                 Err(e) => {
                     warn!(


### PR DESCRIPTION

## Problem

the django and node grpc clients set accept encoding gzip by default - rust doesn't, so propdefs is currently not getting response compression from personhog.

## Changes

- accept_compressed(CompressionEncoding::Gzip) on the personhog client