### PR TITLE
feat(replay): warn on 100% sampling with "ANY" condition type

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -23,6 +23,41 @@ function toDisplaySampleRate(rate: string | null | undefined): number {
     return typeof rate === 'string' ? Math.floor(parseFloat(rate) * 100) : 100
 }
 
+function AnyWith100SamplingWarning({
+    currentTeam,
+    isV2TriggersEnabled,
+}: {
+    currentTeam: TeamType | TeamPublicType | null | undefined
+    isV2TriggersEnabled: boolean
+}): JSX.Element | null {
+    const { urlTriggerConfig, eventTriggerConfig } = useValues(replayTriggersLogic)
+
+    const matchType = currentTeam?.session_recording_trigger_match_type_config || 'all'
+    const sampleRate = toDisplaySampleRate(currentTeam?.session_recording_sample_rate)
+    const hasOtherCondition =
+        (urlTriggerConfig?.length ?? 0) > 0 ||
+        (eventTriggerConfig?.length ?? 0) > 0 ||
+        !!currentTeam?.session_recording_linked_flag
+
+    if (matchType !== 'any' || sampleRate !== 100 || !hasOtherCondition) {
+        return null
+    }
+
+    return (
+        <LemonBanner type="error">
+            <strong>100% sampling rate with "any" matching records every session.</strong> To fix this, either lower the
+            sample rate or switch to "all" matching.
+            {isV2TriggersEnabled && (
+                <>
+                    {' '}
+                    Consider using <strong>trigger groups</strong> above for more precise control over when sessions are
+                    recorded.
+                </>
+            )}
+        </LemonBanner>
+    )
+}
+
 function TriggerPanelHeader({
     title,
     status,
@@ -394,6 +429,8 @@ export function ReplayTriggers(): JSX.Element {
 
                     <IngestionControls.MatchTypeSelect />
 
+                    <AnyWith100SamplingWarning currentTeam={currentTeam} isV2TriggersEnabled={!!isV2TriggersEnabled} />
+
                     <div>
                         <h3 className="text-sm font-semibold mb-2">Recording conditions</h3>
                         <LemonCollapse
@@ -443,7 +480,13 @@ export function ReplayTriggers(): JSX.Element {
                             panels={[
                                 {
                                     key: 'sampling',
-                                    header: <TriggerPanelHeader title="Sampling" status={statuses.samplingStatus} />,
+                                    header: (
+                                        <TriggerPanelHeader
+                                            title="Sampling"
+                                            status={statuses.samplingStatus}
+                                            showMatchTag
+                                        />
+                                    ),
                                     content: <Sampling />,
                                 },
                                 {


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

this came up twice in one week within our literal internal team lol  
its super unclear how "ANY/ALL" trigger rules interact with sample rate

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

if a team has ANY sample rate, 100% sampling AND another condition, this implies they think something else is going to happen than a simple "record 100% of everything". Warn in those cases, since they probably want their other trigger to be respected too.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

100% + ANY + no other condition (thats fine, no big deal)

 ![Screenshot 2026-06-04 at 12.17.15 PM.png](https://app.graphite.com/user-attachments/assets/d08cb791-d9be-4416-b3ed-fde453b34788.png)  
  
100% + ANY + another condition = WARN  
![Screenshot 2026-06-04 at 12.17.06 PM.png](https://app.graphite.com/user-attachments/assets/7bd52d75-6743-4ee5-98fc-a04a8e442488.png)



<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->