### PR TITLE
fix(slack-app): clarify data scope in external-channel approval prompt

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1723,9 +1723,10 @@ def _post_channel_approval_prompt(
 
     org_label = _org_label(integration)
     text = (
-        ":wave: This is an externally-shared Slack channel. Anything I answer here can be "
-        f"seen by every member, including people outside {org_label}'s workspace. "
-        f"A member of {org_label} can enable me below."
+        f":wave: This is an externally-shared Slack channel. My answers can pull from {org_label}'s "
+        "PostHog project — including data about users, customers, and other internal metrics that aren't "
+        "otherwise visible in this channel — and anything I post will be seen by every member here, "
+        f"including people outside {org_label}'s workspace. A member of {org_label} can enable me below."
     )
 
     blocks: list[dict[str, Any]] = [


### PR DESCRIPTION
## Problem

In the external-channel approval prompt, the line "Anything I answer here can be seen by every member" doesn't make it obvious that answers may include PostHog data beyond what's visible in the channel itself. Follow-up tweak requested in Slack on the rollout thread.

## Changes

Reword the ephemeral approval prompt to spell out that answers can pull from the org's PostHog project — users, customers, and other internal metrics — in addition to being visible to everyone in the channel.

## How did you test this code?

I'm an agent (Claude). No new automated tests added — this is a pure copy change to an ephemeral message; existing tests in `test_channel_approval_interactivity.py` don't assert the prompt text, so they still pass logically. Not manually tested in Slack.

## 🤖 Agent context

Authored by Claude Code at Vojta's request to address a nit on the previously-merged external-channel approval prompt (#61571). Single string edit in `_post_channel_approval_prompt`; no logic changes.