### PR TITLE
feat(signals): add a Send to PostHog Code button to the inbox

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -429,6 +429,7 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_RETENTION_AGGREGATION: 'retention-aggregation', // owner: @anirudhpillai #team-product-analytics
     PRODUCT_ANALYTICS_RETENTION_DWH: 'retention-dwh', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_AUTONOMY: 'product-autonomy', // owner: #team-signals
+    SIGNALS_REPORT_DISPATCH: 'signals-report-dispatch', // owner: #team-signals
     PRODUCT_BUSINESS_KNOWLEDGE: 'product-business-knowledge', // owner: @veryayskiy #team-conversations
     PRODUCT_SELECTION_SCREEN_VARIANT: 'product-selection-screen-variant', // owner: @fercgomes #team-growth multivariate=control,spotlight,multiproduct
     PRODUCT_SUPPORT_AI_SUGGESTION: 'product-support-ai-suggestion', // owner: @veryayskiy #team-conversations

--- a/frontend/src/scenes/inbox/InboxScene.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.tsx
@@ -529,8 +529,10 @@ function ReportDetailPane(): JSX.Element {
         selectedReportSignals,
         reportSignalsLoading,
         selectedReportReviewers,
+        canDispatch,
+        isDispatchingSelectedReport,
     } = useValues(inboxSceneLogic)
-    const { deleteReport, reingestReport, setActiveDetailTab } = useActions(inboxSceneLogic)
+    const { deleteReport, reingestReport, dispatchReport, setActiveDetailTab } = useActions(inboxSceneLogic)
     const { hasNoSources } = useValues(signalSourcesLogic)
     const { openSourcesModal } = useActions(signalSourcesLogic)
 
@@ -625,6 +627,21 @@ function ReportDetailPane(): JSX.Element {
                             <span className="inline-flex items-center gap-1">
                                 Updated: <TZLabel time={selectedReport.updated_at} />
                             </span>
+                            {canDispatch && (
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    icon={<IconSparkles />}
+                                    tooltip="Runs in PostHog's hosted coding agent and opens a PR"
+                                    loading={isDispatchingSelectedReport}
+                                    disabledReason={isDispatchingSelectedReport ? 'Dispatching…' : undefined}
+                                    onClick={() => dispatchReport(selectedReport.id)}
+                                    data-attr="dispatch-report-button"
+                                    className="ml-auto"
+                                >
+                                    Send to PostHog Code
+                                </LemonButton>
+                            )}
                             <More
                                 overlay={
                                     <LemonMenuOverlay

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -5,12 +5,17 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api, { CountedPaginatedResponse } from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { SignalNode } from 'scenes/debug/signals/types'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { Breadcrumb } from '~/types'
+
+import { signalsReportsDispatchCreate } from 'products/signals/frontend/generated/api'
 
 import type { inboxSceneLogicType } from './inboxSceneLogicType'
 import { signalSourcesLogic } from './signalSourcesLogic'
@@ -32,7 +37,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
     path(['scenes', 'inbox', 'inboxSceneLogic']),
 
     connect({
-        values: [signalSourcesLogic, ['hasNoSources', 'isSessionAnalysisRunning']],
+        values: [signalSourcesLogic, ['hasNoSources', 'isSessionAnalysisRunning'], featureFlagLogic, ['featureFlags']],
         actions: [signalSourcesLogic, ['loadSourceConfigs']],
     }),
 
@@ -43,6 +48,9 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         setActiveDetailTab: (tab: DetailTab) => ({ tab }),
         deleteReport: (reportId: string) => ({ reportId }),
         reingestReport: (reportId: string) => ({ reportId }),
+        dispatchReport: (reportId: string) => ({ reportId }),
+        dispatchReportSuccess: (reportId: string) => ({ reportId }),
+        dispatchReportFailure: (reportId: string) => ({ reportId }),
         runSessionAnalysis: true,
         runSessionAnalysisSuccess: true,
         runSessionAnalysisFailure: (error: string) => ({ error }),
@@ -137,6 +145,17 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                 runSessionAnalysisFailure: () => false,
             },
         ],
+        dispatchingReportIds: [
+            [] as string[],
+            {
+                dispatchReport: (state: string[], { reportId }: { reportId: string }) =>
+                    state.includes(reportId) ? state : [...state, reportId],
+                dispatchReportSuccess: (state: string[], { reportId }: { reportId: string }) =>
+                    state.filter((id) => id !== reportId),
+                dispatchReportFailure: (state: string[], { reportId }: { reportId: string }) =>
+                    state.filter((id) => id !== reportId),
+            },
+        ],
     }),
 
     selectors({
@@ -205,6 +224,16 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                 return reviewersArtefact.content as EnrichedReviewer[]
             },
         ],
+        canDispatch: [
+            (s) => [s.featureFlags],
+            (featureFlags: Record<string, boolean | string>): boolean =>
+                !!featureFlags[FEATURE_FLAGS.SIGNALS_REPORT_DISPATCH],
+        ],
+        isDispatchingSelectedReport: [
+            (s) => [s.dispatchingReportIds, s.selectedReportId],
+            (dispatchingReportIds: string[], selectedReportId: string | null): boolean =>
+                selectedReportId !== null && dispatchingReportIds.includes(selectedReportId),
+        ],
     }),
 
     listeners(({ actions, values, cache }) => ({
@@ -242,6 +271,20 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                 const errorMessage = error?.detail || error?.message || 'Failed to delete report'
                 lemonToast.error(errorMessage)
                 actions.loadReports()
+            }
+        },
+        dispatchReport: async ({ reportId }) => {
+            try {
+                await signalsReportsDispatchCreate(String(getCurrentTeamId()), reportId)
+                lemonToast.success(
+                    'PostHog Code is on it — the implementation PR will appear on this report when it’s ready'
+                )
+                actions.dispatchReportSuccess(reportId)
+                actions.loadReports()
+            } catch (error: any) {
+                const errorMessage = error?.detail || error?.message || 'Failed to dispatch report'
+                lemonToast.error(errorMessage)
+                actions.dispatchReportFailure(reportId)
             }
         },
         reingestReport: async ({ reportId }) => {

--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -118,6 +118,47 @@ def _resolve_autostart_assignee(
     return None
 
 
+def start_internal_implementation_task(
+    *,
+    team: Team,
+    report_id: str,
+    title: str,
+    summary: str,
+    repository: str,
+    assignee: User,
+    priority: PriorityAssessment | None = None,
+) -> Task:
+    """Create and run an internal implementation Task (the PostHog Code runner) for a report.
+
+    Shared by the autonomy auto-start path and the manual dispatch endpoint so both produce
+    an identical Task + SignalReportTask(IMPLEMENTATION) link, surfaced via implementation-PR tracking.
+    """
+    task = Task.create_and_run(
+        team=team,
+        title=title,
+        description=_build_autostart_task_description(
+            report_id=report_id, summary=summary, repository=repository, priority=priority
+        ),
+        origin_product=Task.OriginProduct.SIGNAL_REPORT,
+        user_id=assignee.id,
+        repository=repository,
+        signal_report_id=report_id,
+        posthog_mcp_scopes="read_only",
+        interaction_origin="signal_report",  # Makes the agent auto-push and open a draft PR
+    )
+    task_run = task.runs.order_by("-created_at").first()
+    if task_run is None:
+        raise RuntimeError(f"Task {task.id} started without producing a TaskRun")
+
+    SignalReportTask.objects.create(
+        team_id=team.id,
+        report_id=report_id,
+        task=task,
+        relationship=SignalReportTask.Relationship.IMPLEMENTATION,
+    )
+    return task
+
+
 async def maybe_autostart_implementation_task(
     *,
     team_id: int,
@@ -163,26 +204,12 @@ async def maybe_autostart_implementation_task(
     if task_user is None:
         return
 
-    task = await database_sync_to_async(Task.create_and_run, thread_sensitive=False)(
+    await database_sync_to_async(start_internal_implementation_task, thread_sensitive=False)(
         team=team,
-        title=title,
-        description=_build_autostart_task_description(
-            report_id=report_id, summary=summary, repository=repository, priority=priority
-        ),
-        origin_product=Task.OriginProduct.SIGNAL_REPORT,
-        user_id=task_user.id,
-        repository=repository,
-        signal_report_id=report_id,
-        posthog_mcp_scopes="read_only",
-        interaction_origin="signal_report",  # Makes the agent auto-push and open a draft PR
-    )
-    task_run = await task.runs.order_by("-created_at").afirst()
-    if task_run is None:
-        raise RuntimeError(f"Task {task.id} auto-started without producing a TaskRun")
-
-    await SignalReportTask.objects.acreate(
-        team_id=team_id,
         report_id=report_id,
-        task=task,
-        relationship=SignalReportTask.Relationship.IMPLEMENTATION,
+        title=title,
+        summary=summary,
+        repository=repository,
+        assignee=task_user,
+        priority=priority,
     )

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -165,6 +165,16 @@ class SignalTeamConfigSerializer(serializers.ModelSerializer):
         }
 
 
+class SignalReportDispatchResponseSerializer(serializers.Serializer):
+    task_id = serializers.CharField(
+        allow_null=True,
+        help_text="Id of the internal implementation Task started (or already running) for this report.",
+    )
+    status = serializers.CharField(
+        help_text="Dispatch outcome: 'started' for a new Task, or 'already_dispatched' if one already existed.",
+    )
+
+
 class _UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User

--- a/products/signals/backend/test/test_report_dispatch.py
+++ b/products/signals/backend/test/test_report_dispatch.py
@@ -1,0 +1,98 @@
+import json
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+from rest_framework import status
+
+from posthog.models import Organization, Team
+
+from products.signals.backend.models import SignalReport, SignalReportArtefact, SignalReportTask
+from products.tasks.backend.models import Task
+
+FLAG_PATH = "products.signals.backend.views.posthoganalytics.feature_enabled"
+START_INTERNAL_PATH = "products.signals.backend.views.start_internal_implementation_task"
+
+
+class TestReportDispatchEndpoint(APIBaseTest):
+    def _url(self, report_id: str) -> str:
+        return f"/api/projects/{self.team.id}/signals/reports/{report_id}/dispatch/"
+
+    def _create_report(self, *, with_repo: bool = True) -> SignalReport:
+        report = SignalReport.objects.create(
+            team=self.team,
+            status=SignalReport.Status.READY,
+            title="Checkout 500s",
+            summary="Users hit a 500 on the checkout page",
+            signal_count=3,
+            total_weight=1.5,
+        )
+        if with_repo:
+            SignalReportArtefact.objects.create(
+                team=self.team,
+                report=report,
+                type=SignalReportArtefact.ArtefactType.REPO_SELECTION,
+                content=json.dumps({"repository": "PostHog/posthog", "reason": "matches the stack trace"}),
+            )
+        return report
+
+    def test_flag_off_returns_404(self):
+        report = self._create_report()
+        with patch(FLAG_PATH, return_value=False):
+            response = self.client.post(self._url(str(report.id)))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_cannot_dispatch_another_teams_report(self):
+        other_team = Team.objects.create(organization=Organization.objects.create(name="other-org"), name="other-team")
+        other_report = SignalReport.objects.create(
+            team=other_team, status=SignalReport.Status.READY, title="x", summary="y", signal_count=1, total_weight=1.0
+        )
+        with patch(FLAG_PATH, return_value=True):
+            response = self.client.post(self._url(str(other_report.id)))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_dispatch_creates_internal_task(self):
+        report = self._create_report()
+        task = MagicMock(id="task-123")
+        with patch(FLAG_PATH, return_value=True), patch(START_INTERNAL_PATH, return_value=task) as mock_start:
+            response = self.client.post(self._url(str(report.id)))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"task_id": "task-123", "status": "started"}
+        mock_start.assert_called_once()
+        assert mock_start.call_args.kwargs["repository"] == "PostHog/posthog"
+
+    def test_without_repository_returns_409(self):
+        report = self._create_report(with_repo=False)
+        with patch(FLAG_PATH, return_value=True), patch(START_INTERNAL_PATH) as mock_start:
+            response = self.client.post(self._url(str(report.id)))
+        assert response.status_code == status.HTTP_409_CONFLICT
+        mock_start.assert_not_called()
+
+    def test_missing_github_integration_returns_409(self):
+        # Task.create_and_run raises ValueError when the team has no GitHub integration; the
+        # endpoint must surface it as an actionable 409, not an unhandled 500.
+        report = self._create_report()
+        with (
+            patch(FLAG_PATH, return_value=True),
+            patch(START_INTERNAL_PATH, side_effect=ValueError("Team 1 does not have a GitHub integration")),
+        ):
+            response = self.client.post(self._url(str(report.id)))
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert "GitHub integration" in response.json()["error"]
+
+    def test_duplicate_dispatch_is_idempotent(self):
+        report = self._create_report()
+        task = Task.objects.create(team=self.team, title="t", origin_product=Task.OriginProduct.SIGNAL_REPORT)
+        SignalReportTask.objects.create(
+            team=self.team,
+            report=report,
+            task=task,
+            relationship=SignalReportTask.Relationship.IMPLEMENTATION,
+        )
+        with patch(FLAG_PATH, return_value=True), patch(START_INTERNAL_PATH) as mock_start:
+            response = self.client.post(self._url(str(report.id)))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["status"] == "already_dispatched"
+        assert response.json()["task_id"] == str(task.id)
+        mock_start.assert_not_called()

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -26,6 +26,7 @@ from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Cast, Coalesce
 
 import structlog
+import posthoganalytics
 from asgiref.sync import async_to_sync
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
@@ -50,6 +51,7 @@ from posthog.temporal.common.client import sync_connect
 from posthog.user_permissions import UserPermissions
 
 from products.data_warehouse.backend.data_load.service import trigger_external_data_workflow
+from products.signals.backend.auto_start import start_internal_implementation_task
 from products.signals.backend.facade.api import emit_signal
 from products.signals.backend.implementation_pr import fetch_implementation_pr_urls_for_reports
 from products.signals.backend.models import (
@@ -71,6 +73,7 @@ from products.signals.backend.report_generation.resolve_reviewers import (
 from products.signals.backend.serializers import (
     SignalReportArtefactSerializer,
     SignalReportArtefactWriteSerializer,
+    SignalReportDispatchResponseSerializer,
     SignalReportSerializer,
     SignalReportTaskSerializer,
     SignalSourceConfigSerializer,
@@ -98,6 +101,10 @@ from products.tasks.backend.models import TaskRun
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 
 logger = structlog.get_logger(__name__)
+
+# Manual report→coding-agent dispatch (the "Send to PostHog Code" button). Agent-agnostic;
+# Cursor as an alternate agent is layered on top behind its own flag.
+SIGNALS_REPORT_DISPATCH_FLAG = "signals-report-dispatch"
 
 
 class EmitSignalSerializer(serializers.Serializer):
@@ -948,6 +955,79 @@ class SignalReportViewSet(
             )
 
         return Response({"status": "reingestion_started", "report_id": report_id}, status=status.HTTP_202_ACCEPTED)
+
+    def _report_repository(self, report: SignalReport) -> str | None:
+        artefact = (
+            report.artefacts.filter(type=SignalReportArtefact.ArtefactType.REPO_SELECTION)
+            .order_by("-created_at")
+            .first()
+        )
+        if artefact is None:
+            return None
+        try:
+            content = json.loads(artefact.content)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        repository = content.get("repository") if isinstance(content, dict) else None
+        return repository if isinstance(repository, str) and repository else None
+
+    @extend_schema(request=None, responses={200: SignalReportDispatchResponseSerializer})
+    @action(detail=True, methods=["post"], url_path="dispatch", required_scopes=["task:write"])
+    def dispatch_report(self, request, pk=None, **kwargs):
+        """Dispatch this report to PostHog Code (the internal Tasks runner). Behind the signals-report-dispatch flag.
+
+        Creates an implementation Task that investigates the report and opens a PR, the same work the
+        autonomy auto-start path performs automatically. Idempotent: a report has at most one such Task.
+        """
+        if not posthoganalytics.feature_enabled(
+            SIGNALS_REPORT_DISPATCH_FLAG,
+            str(request.user.distinct_id),
+            groups={"organization": str(self.team.organization_id)},
+            send_feature_flag_events=False,
+        ):
+            raise NotFound()
+
+        report = cast(SignalReport, self.get_object())
+
+        existing = (
+            SignalReportTask.objects.filter(
+                team=self.team,
+                report_id=report.id,
+                relationship=SignalReportTask.Relationship.IMPLEMENTATION,
+            )
+            .select_related("task")
+            .first()
+        )
+        if existing is not None:
+            return Response(
+                SignalReportDispatchResponseSerializer(
+                    {"task_id": str(existing.task_id), "status": "already_dispatched"}
+                ).data
+            )
+
+        repository = self._report_repository(report)
+        if not repository:
+            return Response(
+                {"error": "Report has no selected repository to act on."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        try:
+            task = start_internal_implementation_task(
+                team=self.team,
+                report_id=str(report.id),
+                title=report.title or "Signal report",
+                summary=report.summary or "",
+                repository=repository,
+                assignee=request.user,
+            )
+        except ValueError as e:
+            # PostHog Code needs a GitHub integration on the team to open a PR. Surface it as an
+            # actionable conflict rather than an unhandled 500.
+            logger.warning("signals.report_dispatch.precondition_failed", report_id=str(report.id), error=str(e))
+            return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
+
+        return Response(SignalReportDispatchResponseSerializer({"task_id": str(task.id), "status": "started"}).data)
 
 
 @extend_schema_view(

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -108,6 +108,16 @@ export interface PaginatedSignalReportListApi {
     results: SignalReportApi[]
 }
 
+export interface SignalReportDispatchResponseApi {
+    /**
+     * Id of the internal implementation Task started (or already running) for this report.
+     * @nullable
+     */
+    task_id: string | null
+    /** Dispatch outcome: 'started' for a new Task, or 'already_dispatched' if one already existed. */
+    status: string
+}
+
 /**
  * * `suppressed` - suppressed
  * `potential` - potential

--- a/products/signals/frontend/generated/api.ts
+++ b/products/signals/frontend/generated/api.ts
@@ -24,6 +24,7 @@ import type {
     RememberRequestApi,
     ScratchpadEntryApi,
     SignalReportApi,
+    SignalReportDispatchResponseApi,
     SignalReportStateRequestApi,
     SignalScoutConfigApi,
     SignalScoutRunDetailApi,
@@ -161,6 +162,27 @@ export const signalsReportsRetrieve = async (
     return apiMutator<SignalReportApi>(getSignalsReportsRetrieveUrl(projectId, id), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getSignalsReportsDispatchCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/signals/reports/${id}/dispatch/`
+}
+
+/**
+ * Dispatch this report to PostHog Code (the internal Tasks runner). Behind the signals-report-dispatch flag.
+
+Creates an implementation Task that investigates the report and opens a PR, the same work the
+autonomy auto-start path performs automatically. Idempotent: a report has at most one such Task.
+ */
+export const signalsReportsDispatchCreate = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<SignalReportDispatchResponseApi> => {
+    return apiMutator<SignalReportDispatchResponseApi>(getSignalsReportsDispatchCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
     })
 }
 

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -137,6 +137,9 @@ tools:
     inbox-source-configs-update:
         operation: signals_source_configs_update
         enabled: false
+    signals-reports-dispatch-create:
+        operation: signals_reports_dispatch_create
+        enabled: false
     signals-scout-config-list:
         operation: signals_scout_config_list
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37248,6 +37248,16 @@ export namespace Schemas {
       release_to_everyone?: boolean;
     }
 
+    export interface SignalReportDispatchResponse {
+      /**
+         * Id of the internal implementation Task started (or already running) for this report.
+         * @nullable
+         */
+      task_id: string | null;
+      /** Dispatch outcome: 'started' for a new Task, or 'already_dispatched' if one already existed. */
+      status: string;
+    }
+
     /**
      * * `suppressed` - suppressed
     * `potential` - potential


### PR DESCRIPTION
## Problem

PostHog Signals surfaces actionable reports in the Inbox. Today a report is only acted on automatically (the autonomy auto-start path) or by copying its prompt into your own agent — there's no one-click way to hand a report to PostHog's own hosted coding agent.

## Changes

Adds a **"Send to PostHog Code"** button to a report. It dispatches the report to the internal Tasks runner (PostHog Code), which investigates the root cause and opens a PR — the same work autonomy auto-starts, now available on demand.

- Extracts a shared `start_internal_implementation_task` helper used by both the autonomy path and the new manual endpoint, so they behave identically.
- New `dispatch` action, flag-gated (`signals-report-dispatch`), idempotent (a report has at most one implementation Task), with actionable 409s when the report has no selected repository or the team has no GitHub integration.

This is the **base of a stack**; the Cursor agent is layered on top in the next PR.

## How did you test this code?

Backend tests (6) cover the dispatch endpoint: creates an internal Task, idempotency (already-dispatched), no-repository 409, missing-GitHub-integration 409, flag gating, and cross-team (IDOR) access. `ruff` + oxlint/oxfmt clean. `typescript:check` runs on CI.

## Changelog

No — behind the `signals-report-dispatch` feature flag, not yet GA.

## 🤖 Agent context

Authored with Claude Code. Base of a two-PR stack (the Cursor agent stacks on top). Requires human review; not self-merged.
