### PR TITLE
chore(cli): describe skip SSL flag

### DIFF
--- a/cli/.sampo/changesets/cli-skip-ssl-help.md
+++ b/cli/.sampo/changesets/cli-skip-ssl-help.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Add help text for the SSL verification flag.

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -25,6 +25,8 @@ pub struct Cli {
     #[arg(long, default_value = "false")]
     no_fail: bool,
 
+    /// Skip SSL certificate verification when talking to the PostHog API. Use only with
+    /// self-signed certificates.
     #[arg(long, default_value = "false")]
     skip_ssl_verification: bool,
 


### PR DESCRIPTION
## Summary

- Adds help text for the top-level SSL verification flag.
- Adds a Sampo patch changeset for posthog-cli release testing.

## Testing

- cargo run --quiet -- --help
- cargo fmt --all -- --check
- cargo test --quiet
- cargo clippy --all-targets --all-features -- -D warnings
