### PR TITLE
fix(replay-vision): scanner-overview stats and observation-page polish

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5835,9 +5835,9 @@ snapshots:
     scenes-app-promoted-product--intent-with-product--light:
         hash: v1.k794b7964.a520d81ca3c66ae61e8fa10602ed5f40da3d97bee4efd9daf03009c238a8b0dc.Ruf-wJ_f_UjycVlKd7vE_z2t-r_SY8cC5bO-NSR0Ao4
     scenes-app-replay-vision--scanners-list--dark:
-        hash: v1.k794b7964.8baa79fe6754700e3ffe6e0255bad618354a151b8526390dbff69e5034ad084e.FxzD_jSM8T4J2AdyvY-9g-ZlWhfcilBLO7YrVhG3LLY
+        hash: v1.k794b7964.a071938f5b745d1b6096c3d45126316a93a656d009b1e9d60bd589c6fbbf2eea.JNJof48nrSqm-xKWn19bCnlnCNMTiQfSQKYxPqUPx1I
     scenes-app-replay-vision--scanners-list--light:
-        hash: v1.k794b7964.26853e2ab68d17ea6e87fd9dbf9a258b2c060707b13061a4b7e569b6a91e222f.1Co_SpKKDI3nFlxi2xzqGDUTgwhn7Fg5V8njstAuFy0
+        hash: v1.k794b7964.0f1eb55f1322005e852dd4ce6396f45fff1d4f1c92b07bec5f26b07be6c58792.b5H9qgJdi4NyB4dsSNg9SDGSm9AVJDzkoqhoZht41Hc
     scenes-app-revenue-analytics--revenue-analytics-dashboard--dark:
         hash: v1.k794b7964.7c2a90fe3c3a969c054186bb666664efa891d65d411a546539a968518938ea71.OoOKh-Mc_IiPWTgIV4QNPtACZXPPktfU7bjGk-q-uLE
     scenes-app-revenue-analytics--revenue-analytics-dashboard--light:
@@ -5951,9 +5951,9 @@ snapshots:
     scenes-app-settings-environment--settings-environment-product-analytics--light:
         hash: v1.k794b7964.954d1b340965051ef2d55fd12cba6bf03d86d83a94d5a954d8228cc6981808a5.PSFBSIUBoJybY7J_UCp_hexWD4QskVAgZynfUDBY2WA
     scenes-app-settings-environment--settings-environment-replay--dark:
-        hash: v1.k794b7964.0a84909f961757ada10fda250675bdc143a4594d752951e62fa20ee249411231.0CB3YoPKVT3KY7Lo_7KU-k8BDfZUGdoooQ5vuoqaqhE
+        hash: v1.k794b7964.ba60bfbf98de5592216589808ad521f77a07d52ec4a2eed451ddfb83be74e3ce.B4aBNuY2j1-Ffgm71pDC9XnPX0Y9eC5Z818RCyTo8lU
     scenes-app-settings-environment--settings-environment-replay--light:
-        hash: v1.k794b7964.360f1955af5bf88bae866d8ae35ae70c298fa8b89635d5bf85c28cbf6bfbaa07.BGSJicTbhS9CAQNy5mMiQ7sIGimJP1ntjS1pAAFtEvE
+        hash: v1.k794b7964.c9478fa31ea024f0f01038d33f41d359ad02c809d0a2eb3868e382c39f7dc91f.9nge5I5MoN-Ugpapm6_HlEOkVI5re05Le1HpeXnyW3A
     scenes-app-settings-environment--settings-environment-revenue-analytics--dark:
         hash: v1.k794b7964.5677bd47da6b9b34eb1c107e4b9e05f24c02efc4385a5c64dff77277675fea70.N6vQFbQwCJMLEEcOKh42nhD2rGYCDa2RwsVa3wGuVG4
     scenes-app-settings-environment--settings-environment-revenue-analytics--light:
@@ -6023,9 +6023,9 @@ snapshots:
     scenes-app-settings-project--settings-project-product-analytics--light:
         hash: v1.k794b7964.51bdb57a8e711b8699eb0598841bb5fb507597a98af916057906d9c150796939.KKXTU4m1sN1oVQN26bXLSgNu7v14jeHKvMFCOO8uAw4
     scenes-app-settings-project--settings-project-replay--dark:
-        hash: v1.k794b7964.0a84909f961757ada10fda250675bdc143a4594d752951e62fa20ee249411231.MBglrolOtzeH9TyXQbSqoC4zJ0o2NSj-x12jNcYFcEY
+        hash: v1.k794b7964.ba60bfbf98de5592216589808ad521f77a07d52ec4a2eed451ddfb83be74e3ce.dar84_LEwqHpOsgERR81YBLmbO611_mtZkkY0Pe23qY
     scenes-app-settings-project--settings-project-replay--light:
-        hash: v1.k794b7964.360f1955af5bf88bae866d8ae35ae70c298fa8b89635d5bf85c28cbf6bfbaa07.XxmjNKP4UOZlOTdAsW00EBfT7dnQ1BO786AESgV-wyU
+        hash: v1.k794b7964.c9478fa31ea024f0f01038d33f41d359ad02c809d0a2eb3868e382c39f7dc91f.ZtIw0iZbRRa0-Q7jRSLBfSr8h220b0TcGA8bqRIAT-g
     scenes-app-settings-project--settings-project-surveys--dark:
         hash: v1.k794b7964.fcd7c3f51e479c01cd914eb2ae65deb88561074aac19f2135ec15b7435487207.M2If7pEUuhyfgfGTbxgjef9HYzpGwAI97z9Hfdyxrlo
     scenes-app-settings-project--settings-project-surveys--light:

--- a/products/replay_vision/backend/api/observation_stats.py
+++ b/products/replay_vision/backend/api/observation_stats.py
@@ -46,7 +46,8 @@ def compute_observation_stats(scanner: ReplayScanner, queryset: QuerySet[ReplayO
 
 def _status_counts(queryset: QuerySet[ReplayObservation]) -> dict[str, Any]:
     counts: dict[str, int] = {}
-    for row in queryset.values("status").annotate(c=Count("*")):
+    # `.order_by()` so the parent ordering doesn't leak into GROUP BY.
+    for row in queryset.order_by().values("status").annotate(c=Count("*")):
         counts[row["status"]] = row["c"]
     succeeded = counts.get(ObservationStatus.SUCCEEDED, 0)
     failed = counts.get(ObservationStatus.FAILED, 0)
@@ -84,6 +85,7 @@ def _monitor_stats(queryset: QuerySet[ReplayObservation]) -> dict[str, Any]:
         queryset.filter(status=ObservationStatus.SUCCEEDED)
         .annotate(verdict=KeyTextTransform("verdict", KeyTextTransform("model_output", "scanner_result")))
         .filter(verdict__in=counts.keys())
+        .order_by()  # Don't let parent ordering leak into GROUP BY.
         .values("verdict")
         .annotate(c=Count("*"))
     )
@@ -97,7 +99,8 @@ def _monitor_stats(queryset: QuerySet[ReplayObservation]) -> dict[str, Any]:
 
 
 def _classifier_stats(queryset: QuerySet[ReplayObservation]) -> tuple[dict[str, Any], list[str]]:
-    succeeded = queryset.filter(status=ObservationStatus.SUCCEEDED)
+    # `.order_by()` skips a wasted sort inside the CTE; the outer aggregate doesn't need ordering.
+    succeeded = queryset.filter(status=ObservationStatus.SUCCEEDED).order_by()
     inner_sql, inner_params = succeeded.values("scanner_result").query.sql_with_params()
     # One query: per-bucket tag counts plus a sentinel `total` row counting observations that emitted any tag.
     with connection.cursor() as cursor:
@@ -151,7 +154,8 @@ def _rank_counts(counts: dict[str, int]) -> list[dict[str, Any]]:
 
 
 def _scorer_stats(scanner: ReplayScanner, queryset: QuerySet[ReplayObservation]) -> dict[str, Any]:
-    succeeded = queryset.filter(status=ObservationStatus.SUCCEEDED)
+    # `.order_by()` skips a wasted sort inside the subquery; the outer aggregate doesn't need ordering.
+    succeeded = queryset.filter(status=ObservationStatus.SUCCEEDED).order_by()
     inner_sql, inner_params = succeeded.values("scanner_result").query.sql_with_params()
     with connection.cursor() as cursor:
         cursor.execute(

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -3,7 +3,7 @@ from typing import Any, NoReturn, cast
 
 from django.conf import settings
 from django.db import IntegrityError
-from django.db.models import CharField, F, Q, QuerySet, Value
+from django.db.models import CharField, Count, F, Q, QuerySet, Value
 from django.db.models.functions import Coalesce, NullIf
 
 import structlog
@@ -369,6 +369,32 @@ class EstimateRequestSerializer(serializers.Serializer):
         return {k: v for k, v in value.items() if k not in _QUERY_FIELDS_TO_STRIP}
 
 
+class ScannerTypeStatsSerializer(serializers.Serializer):
+    """Per-scanner-type count of enabled vs total scanners."""
+
+    enabled = serializers.IntegerField(help_text="Number of enabled scanners of this type.")
+    total = serializers.IntegerField(help_text="Number of scanners of this type (enabled + disabled).")
+
+
+class ScannerStatsByTypeSerializer(serializers.Serializer):
+    """One `ScannerTypeStats` per scanner type — explicit fields give callers a typed shape, not `Record<string, …>`."""
+
+    monitor = ScannerTypeStatsSerializer()
+    classifier = ScannerTypeStatsSerializer()
+    scorer = ScannerTypeStatsSerializer()
+    summarizer = ScannerTypeStatsSerializer()
+
+
+class ScannerStatsResponseSerializer(serializers.Serializer):
+    """Team-wide scanner counts independent of any list-filter state."""
+
+    total = serializers.IntegerField(help_text="Total scanners on the team.")
+    enabled = serializers.IntegerField(help_text="Number of enabled scanners on the team.")
+    by_type = ScannerStatsByTypeSerializer(
+        help_text="Per-scanner-type breakdown (monitor / classifier / scorer / summarizer)."
+    )
+
+
 class ScannerCreatorsResponseSerializer(serializers.Serializer):
     """Distinct creators across all scanners on the team — feeds the `Created by` filter dropdown."""
 
@@ -424,7 +450,7 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     scope_object = "replay_scanner"
     # Custom actions must be listed explicitly or personal-API-key callers 403 silently.
-    scope_object_read_actions = ["list", "retrieve", "creators"]
+    scope_object_read_actions = ["list", "retrieve", "creators", "stats"]
     scope_object_write_actions = ["create", "update", "partial_update", "destroy", "observe"]
     permission_classes = [ReplayVisionEnabledPermission]
     serializer_class = ReplayScannerSerializer
@@ -464,6 +490,27 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             id__in=accessible.values_list("created_by_id", flat=True),
         ).order_by("first_name", "last_name", "email", "id")
         return Response({"creators": UserBasicSerializer(users, many=True).data})
+
+    @extend_schema(responses={200: ScannerStatsResponseSerializer})
+    @action(detail=False, methods=["get"], pagination_class=None)
+    def stats(self, request: Request, **kwargs: Any) -> Response:
+        """Team-wide scanner counts — independent of list filters, so the overview stays stable."""
+        accessible = self.user_access_control.filter_queryset_by_access_level(
+            ReplayScanner.objects.filter(team_id=self.team_id)
+        )
+        # `.order_by()` so the default ordering doesn't leak into GROUP BY.
+        rows = accessible.order_by().values("scanner_type", "enabled").annotate(c=Count("*"))
+        by_type: dict[str, dict[str, int]] = {value: {"enabled": 0, "total": 0} for value, _ in ScannerType.choices}
+        total = 0
+        enabled = 0
+        for row in rows:
+            bucket = by_type.setdefault(row["scanner_type"], {"enabled": 0, "total": 0})
+            bucket["total"] += row["c"]
+            total += row["c"]
+            if row["enabled"]:
+                bucket["enabled"] += row["c"]
+                enabled += row["c"]
+        return Response({"total": total, "enabled": enabled, "by_type": by_type})
 
     @extend_schema(
         request=ObserveRequestSerializer,

--- a/products/replay_vision/backend/temporal/activities/fetch_session_events.py
+++ b/products/replay_vision/backend/temporal/activities/fetch_session_events.py
@@ -84,19 +84,19 @@ def _fetch_payload(team_id: int, session_id: str) -> ScannerLlmInputs | None:
     duration_seconds = float(metadata["duration"])
     if duration_seconds < MIN_SESSION_DURATION_FOR_VIDEO_SCANNER_S:
         raise IneligibleSessionError(
-            f"Only {round(duration_seconds)}s long; min is {MIN_SESSION_DURATION_FOR_VIDEO_SCANNER_S}s",
+            f"Only {round(duration_seconds, 1)}s long; min is {MIN_SESSION_DURATION_FOR_VIDEO_SCANNER_S}s",
             kind=IneligibleSessionKind.TOO_SHORT,
         )
     # `RecordingMetadata` types this as `int` but it can be missing on sparse fixtures; default to 0.
     active_seconds = metadata.get("active_seconds") or 0
     if active_seconds < MIN_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S:
         raise IneligibleSessionError(
-            f"Only {round(active_seconds)}s of active interaction; min is {MIN_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
+            f"Only {round(active_seconds, 1)}s of active interaction; min is {MIN_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
             kind=IneligibleSessionKind.TOO_INACTIVE,
         )
     if active_seconds > MAX_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S:
         raise IneligibleSessionError(
-            f"{round(active_seconds)}s of active interaction; max is {MAX_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
+            f"{round(active_seconds, 1)}s of active interaction; max is {MAX_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
             kind=IneligibleSessionKind.TOO_LONG,
         )
 

--- a/products/replay_vision/backend/temporal/activities/fetch_session_events.py
+++ b/products/replay_vision/backend/temporal/activities/fetch_session_events.py
@@ -84,19 +84,19 @@ def _fetch_payload(team_id: int, session_id: str) -> ScannerLlmInputs | None:
     duration_seconds = float(metadata["duration"])
     if duration_seconds < MIN_SESSION_DURATION_FOR_VIDEO_SCANNER_S:
         raise IneligibleSessionError(
-            f"Only {duration_seconds}s long; min is {MIN_SESSION_DURATION_FOR_VIDEO_SCANNER_S}s",
+            f"Only {round(duration_seconds)}s long; min is {MIN_SESSION_DURATION_FOR_VIDEO_SCANNER_S}s",
             kind=IneligibleSessionKind.TOO_SHORT,
         )
     # `RecordingMetadata` types this as `int` but it can be missing on sparse fixtures; default to 0.
     active_seconds = metadata.get("active_seconds") or 0
     if active_seconds < MIN_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S:
         raise IneligibleSessionError(
-            f"Only {active_seconds}s of active interaction; min is {MIN_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
+            f"Only {round(active_seconds)}s of active interaction; min is {MIN_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
             kind=IneligibleSessionKind.TOO_INACTIVE,
         )
     if active_seconds > MAX_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S:
         raise IneligibleSessionError(
-            f"{active_seconds}s of active interaction; max is {MAX_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
+            f"{round(active_seconds)}s of active interaction; max is {MAX_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S}s",
             kind=IneligibleSessionKind.TOO_LONG,
         )
 

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -408,7 +408,7 @@ class TestReplayScannerViewSet(_VisionAPITestCase):
         self.assertEqual(body["by_type"]["summarizer"], {"enabled": 0, "total": 0})
 
     def test_stats_endpoint_respects_per_scanner_access_control(self) -> None:
-        visible = self._create_scanner(name="visible")
+        self._create_scanner(name="visible")
         hidden = self._create_scanner(name="hidden")
         with patch(
             "posthog.rbac.user_access_control.UserAccessControl.filter_queryset_by_access_level",
@@ -417,7 +417,6 @@ class TestReplayScannerViewSet(_VisionAPITestCase):
             resp = self.client.get(f"{self.scanners_url}stats/")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["total"], 1)
-        self.assertEqual(visible.id, ReplayScanner.objects.filter(name="visible").first().id)
 
     def test_creators_endpoint_respects_per_scanner_access_control(self) -> None:
         other = User.objects.create_and_join(self.team.organization, "hidden@example.com", "pw")

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -392,6 +392,33 @@ class TestReplayScannerViewSet(_VisionAPITestCase):
         resp = self.client.get(f"{self.scanners_url}?order_by=sampling_rate")
         self.assertEqual([r["name"] for r in resp.json()["results"]], ["low", "mid", "high"])
 
+    def test_stats_endpoint_returns_team_wide_counts(self) -> None:
+        self._create_scanner(name="m1", scanner_type=ScannerType.MONITOR, enabled=True)
+        self._create_scanner(name="m2", scanner_type=ScannerType.MONITOR, enabled=False)
+        self._create_scanner(name="c1", scanner_type=ScannerType.CLASSIFIER, enabled=True)
+        self._create_scanner(name="s1", scanner_type=ScannerType.SCORER, enabled=False)
+        resp = self.client.get(f"{self.scanners_url}stats/?enabled=enabled&scanner_type=monitor")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["total"], 4)
+        self.assertEqual(body["enabled"], 2)
+        self.assertEqual(body["by_type"]["monitor"], {"enabled": 1, "total": 2})
+        self.assertEqual(body["by_type"]["classifier"], {"enabled": 1, "total": 1})
+        self.assertEqual(body["by_type"]["scorer"], {"enabled": 0, "total": 1})
+        self.assertEqual(body["by_type"]["summarizer"], {"enabled": 0, "total": 0})
+
+    def test_stats_endpoint_respects_per_scanner_access_control(self) -> None:
+        visible = self._create_scanner(name="visible")
+        hidden = self._create_scanner(name="hidden")
+        with patch(
+            "posthog.rbac.user_access_control.UserAccessControl.filter_queryset_by_access_level",
+            side_effect=lambda qs, **_: qs.exclude(pk=hidden.pk),
+        ):
+            resp = self.client.get(f"{self.scanners_url}stats/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["total"], 1)
+        self.assertEqual(visible.id, ReplayScanner.objects.filter(name="visible").first().id)
+
     def test_creators_endpoint_respects_per_scanner_access_control(self) -> None:
         other = User.objects.create_and_join(self.team.organization, "hidden@example.com", "pw")
         visible = self._create_scanner(name="visible")
@@ -667,6 +694,46 @@ class TestReplayObservationViewSet(_VisionAPITestCase):
         self.assertEqual(body["monitor"], {"yes_total": 1, "no_total": 0, "inconclusive_total": 0})
         self.assertIsNone(body["classifier"])
         self.assertIsNone(body["scorer"])
+
+    def test_stats_status_counts_with_multiple_rows_per_status(self) -> None:
+        for i in range(5):
+            self._create_observation(session_id=f"p-{i}", status=ObservationStatus.PENDING)
+        for i in range(3):
+            self._create_observation(
+                session_id=f"yes-{i}",
+                status=ObservationStatus.SUCCEEDED,
+                completed_at=timezone.now(),
+                scanner_result={
+                    "model_output": {
+                        "scanner_type": "monitor",
+                        "verdict": "yes",
+                        "reasoning": "r",
+                        "confidence": 0.9,
+                    },
+                    "signals_count": 0,
+                },
+            )
+        for i in range(2):
+            self._create_observation(
+                session_id=f"no-{i}",
+                status=ObservationStatus.SUCCEEDED,
+                completed_at=timezone.now(),
+                scanner_result={
+                    "model_output": {
+                        "scanner_type": "monitor",
+                        "verdict": "no",
+                        "reasoning": "r",
+                        "confidence": 0.9,
+                    },
+                    "signals_count": 0,
+                },
+            )
+        resp = self.client.get(f"{self.observations_url(str(self.scanner.id))}stats/")
+        body = resp.json()
+        self.assertEqual(body["status_counts"]["total"], 10)
+        self.assertEqual(body["status_counts"]["succeeded"], 5)
+        self.assertEqual(body["status_counts"]["in_flight"], 5)
+        self.assertEqual(body["monitor"], {"yes_total": 3, "no_total": 2, "inconclusive_total": 0})
 
     def test_stats_classifier_tag_rankings(self) -> None:
         classifier = self._create_scanner(

--- a/products/replay_vision/frontend/components/ObservationCard.tsx
+++ b/products/replay_vision/frontend/components/ObservationCard.tsx
@@ -7,6 +7,7 @@ import { urls } from 'scenes/urls'
 import type { ReplayObservationApi, ScannerSnapshotApi } from '../generated/api.schemas'
 import {
     failureKindDescription,
+    ineligibleKindDescription,
     parseFailureReason,
     parseIneligibleReason,
     scannerTypeLabel,
@@ -24,11 +25,9 @@ export function ObservationStatusTag({
         return <LemonTag type="success">Succeeded</LemonTag>
     }
     if (status === 'failed') {
+        // Raw exception text lives in `FailureDetail`; tooltip is the description only.
         const parsed = errorReason ? parseFailureReason(errorReason) : null
-        const tooltip =
-            [parsed?.label, parsed ? failureKindDescription(parsed.kind) : null, parsed?.message ?? errorReason]
-                .filter(Boolean)
-                .join('\n\n') || null
+        const tooltip = parsed ? failureKindDescription(parsed.kind) : errorReason || null
         return (
             <Tooltip title={tooltip}>
                 <LemonTag type="danger">Failed</LemonTag>
@@ -38,7 +37,14 @@ export function ObservationStatusTag({
     if (status === 'ineligible') {
         // Muted, not danger — the session was skipped at the gate, not a scanner failure.
         const parsed = errorReason ? parseIneligibleReason(errorReason) : null
-        const tooltip = [parsed?.label, parsed?.message ?? errorReason].filter(Boolean).join('\n\n') || null
+        const tooltip = parsed ? (
+            <div className="flex flex-col gap-1">
+                <div>{ineligibleKindDescription(parsed.kind)}</div>
+                {parsed.message && <div className="text-xs opacity-80">{parsed.message}</div>}
+            </div>
+        ) : errorReason ? (
+            <div>{errorReason}</div>
+        ) : null
         return (
             <Tooltip title={tooltip}>
                 <LemonTag type="muted">Ineligible</LemonTag>

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -488,6 +488,38 @@ export interface EstimateResponseApi {
     sampling_rate: number
 }
 
+/**
+ * Per-scanner-type count of enabled vs total scanners.
+ */
+export interface ScannerTypeStatsApi {
+    /** Number of enabled scanners of this type. */
+    enabled: number
+    /** Number of scanners of this type (enabled + disabled). */
+    total: number
+}
+
+/**
+ * One `ScannerTypeStats` per scanner type — explicit fields give callers a typed shape, not `Record<string, …>`.
+ */
+export interface ScannerStatsByTypeApi {
+    monitor: ScannerTypeStatsApi
+    classifier: ScannerTypeStatsApi
+    scorer: ScannerTypeStatsApi
+    summarizer: ScannerTypeStatsApi
+}
+
+/**
+ * Team-wide scanner counts independent of any list-filter state.
+ */
+export interface ScannerStatsResponseApi {
+    /** Total scanners on the team. */
+    total: number
+    /** Number of enabled scanners on the team. */
+    enabled: number
+    /** Per-scanner-type breakdown (monitor / classifier / scorer / summarizer). */
+    by_type: ScannerStatsByTypeApi
+}
+
 export type VisionObservationsListParams = {
     /**
      * Number of results to return per page.

--- a/products/replay_vision/frontend/generated/api.ts
+++ b/products/replay_vision/frontend/generated/api.ts
@@ -20,6 +20,7 @@ import type {
     ReplayObservationApi,
     ReplayScannerApi,
     ScannerCreatorsResponseApi,
+    ScannerStatsResponseApi,
     VisionObservationsListParams,
     VisionQuotaApi,
     VisionScannersListParams,
@@ -359,5 +360,22 @@ export const visionScannersEstimateCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(estimateRequestApi),
+    })
+}
+
+export const getVisionScannersStatsRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/vision/scanners/stats/`
+}
+
+/**
+ * Team-wide scanner counts — independent of list filters, so the overview stays stable.
+ */
+export const visionScannersStatsRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<ScannerStatsResponseApi> => {
+    return apiMutator<ScannerStatsResponseApi>(getVisionScannersStatsRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
     })
 }

--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -31,6 +31,7 @@ import {
 import { ObservationProgressBar } from '../components/ObservationProgressBar'
 import {
     failureKindDescription,
+    ineligibleKindDescription,
     modelLabel,
     parseFailureReason,
     parseIneligibleReason,
@@ -181,123 +182,6 @@ export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): J
                 description={`Observation of session ${observation.session_id}`}
                 resourceType={{ type: 'replay_vision' }}
             />
-
-            <div className={scannerType === 'summarizer' ? '' : 'grid grid-cols-1 lg:grid-cols-2 gap-4'}>
-                <section className="border rounded p-4 bg-surface-primary space-y-3">
-                    <div className="text-sm font-medium">Result</div>
-
-                    {observation.status === 'failed' && observation.error_reason && (
-                        <div className="flex flex-col gap-3">
-                            {scannerType && (
-                                <LabeledRow label="Type">
-                                    <LemonTag type="option" className="self-start">
-                                        {scannerTypeLabel(scannerType)}
-                                    </LemonTag>
-                                </LabeledRow>
-                            )}
-                            {prompt && (
-                                <LabeledRow label="Prompt">
-                                    <p className="text-sm text-default m-0 leading-snug">{prompt}</p>
-                                </LabeledRow>
-                            )}
-                            <LabeledRow label="Reason">
-                                <LemonTag type="danger" className="self-start">
-                                    {failedParsed?.label ?? 'Failed'}
-                                </LemonTag>
-                            </LabeledRow>
-                            {failedParsed && (
-                                <LabeledRow label="What this means">
-                                    <p className="text-sm text-default m-0 leading-snug">
-                                        {failureKindDescription(failedParsed.kind)}
-                                    </p>
-                                </LabeledRow>
-                            )}
-                            {failedMessage && (
-                                <LabeledRow label="Details">
-                                    <p className="text-sm text-default m-0 leading-snug font-mono">{failedMessage}</p>
-                                </LabeledRow>
-                            )}
-                        </div>
-                    )}
-
-                    {observation.status === 'ineligible' && observation.error_reason && (
-                        <div className="flex flex-col gap-3">
-                            {scannerType && (
-                                <LabeledRow label="Type">
-                                    <LemonTag type="option" className="self-start">
-                                        {scannerTypeLabel(scannerType)}
-                                    </LemonTag>
-                                </LabeledRow>
-                            )}
-                            {prompt && (
-                                <LabeledRow label="Prompt">
-                                    <p className="text-sm text-default m-0 leading-snug">{prompt}</p>
-                                </LabeledRow>
-                            )}
-                            <LabeledRow label="Reason">
-                                <LemonTag type="muted" className="self-start">
-                                    {ineligibleParsed?.label ?? 'Ineligible'}
-                                </LemonTag>
-                            </LabeledRow>
-                            {ineligibleMessage && (
-                                <LabeledRow label="Details">
-                                    <p className="text-sm text-default m-0 leading-snug">{ineligibleMessage}</p>
-                                </LabeledRow>
-                            )}
-                        </div>
-                    )}
-
-                    {observation.status === 'succeeded' && snapshot && result && (
-                        <div className="flex flex-col gap-3">
-                            {scannerType && (
-                                <LabeledRow label="Type">
-                                    <LemonTag type="option" className="self-start">
-                                        {scannerTypeLabel(scannerType)}
-                                    </LemonTag>
-                                </LabeledRow>
-                            )}
-                            {prompt && scannerType !== 'summarizer' && (
-                                <LabeledRow label="Prompt">
-                                    <p className="text-sm text-default m-0 leading-snug">{prompt}</p>
-                                </LabeledRow>
-                            )}
-                            <LabeledRow label={scannerType ? SUCCEEDED_OUTPUT_LABEL[scannerType] : ''}>
-                                <ObservationPrimaryOutput
-                                    observation={observation}
-                                    showPrompt={false}
-                                    onSeek={seekEmbeddedPlayer}
-                                />
-                            </LabeledRow>
-                            {observation.completed_at && (
-                                <LabeledRow label="Event">
-                                    <Link to={urls.event(observation.id, observation.completed_at)}>
-                                        $recording_observed
-                                    </Link>
-                                </LabeledRow>
-                            )}
-                        </div>
-                    )}
-
-                    {(observation.status === 'pending' || observation.status === 'running') && (
-                        <ObservationProgressBar observationId={observation.id} sessionId={observation.session_id} />
-                    )}
-                </section>
-
-                {scannerType !== 'summarizer' && (
-                    <section className="border rounded p-4 bg-surface-primary space-y-2">
-                        <div className="text-sm font-medium">Reasoning</div>
-                        {reasoning ? (
-                            <p className="text-sm whitespace-pre-wrap m-0">
-                                <CitedText text={reasoning} segments={reasoningSegments} onSeek={seekEmbeddedPlayer} />
-                            </p>
-                        ) : (
-                            <p className="text-muted text-sm m-0">
-                                {observation.status === 'succeeded' ? 'No reasoning provided.' : 'N/A'}
-                            </p>
-                        )}
-                    </section>
-                )}
-            </div>
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
                 <LemonCard className="p-4" hoverEffect={false}>
@@ -453,6 +337,120 @@ export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): J
                         )}
                     </div>
                 </LemonCard>
+            </div>
+
+            <div className={scannerType === 'summarizer' ? '' : 'grid grid-cols-1 lg:grid-cols-2 gap-4'}>
+                <section className="border rounded p-4 bg-surface-primary space-y-3">
+                    <div className="text-sm font-medium">Result</div>
+
+                    {observation.status === 'failed' && observation.error_reason && (
+                        <div className="flex flex-col gap-3">
+                            {scannerType && (
+                                <LabeledRow label="Type">
+                                    <LemonTag type="option" className="self-start">
+                                        {scannerTypeLabel(scannerType)}
+                                    </LemonTag>
+                                </LabeledRow>
+                            )}
+                            <LabeledRow label="Reason">
+                                <p className="text-sm text-default m-0 leading-snug">
+                                    {failedParsed
+                                        ? failureKindDescription(failedParsed.kind)
+                                        : observation.error_reason}
+                                </p>
+                            </LabeledRow>
+                            {failedParsed && failedMessage && (
+                                <LabeledRow label="Details">
+                                    <p className="text-sm text-default m-0 leading-snug font-mono">{failedMessage}</p>
+                                </LabeledRow>
+                            )}
+                        </div>
+                    )}
+
+                    {observation.status === 'ineligible' && observation.error_reason && (
+                        <div className="flex flex-col gap-3">
+                            {scannerType && (
+                                <LabeledRow label="Type">
+                                    <LemonTag type="option" className="self-start">
+                                        {scannerTypeLabel(scannerType)}
+                                    </LemonTag>
+                                </LabeledRow>
+                            )}
+                            <LabeledRow label="Reason">
+                                <p className="text-sm text-default m-0 leading-snug">
+                                    {ineligibleParsed
+                                        ? ineligibleKindDescription(ineligibleParsed.kind)
+                                        : observation.error_reason}
+                                </p>
+                            </LabeledRow>
+                            {ineligibleParsed && ineligibleMessage && (
+                                <LabeledRow label="Details">
+                                    <p className="text-sm text-default m-0 leading-snug">{ineligibleMessage}</p>
+                                </LabeledRow>
+                            )}
+                        </div>
+                    )}
+
+                    {observation.status === 'succeeded' && snapshot && result && (
+                        <div className="flex flex-col gap-3">
+                            {scannerType && (
+                                <LabeledRow label="Type">
+                                    <LemonTag type="option" className="self-start">
+                                        {scannerTypeLabel(scannerType)}
+                                    </LemonTag>
+                                </LabeledRow>
+                            )}
+                            {prompt && scannerType !== 'summarizer' && (
+                                <LabeledRow label="Prompt">
+                                    <p className="text-sm text-default m-0 leading-snug">{prompt}</p>
+                                </LabeledRow>
+                            )}
+                            <LabeledRow label={scannerType ? SUCCEEDED_OUTPUT_LABEL[scannerType] : ''}>
+                                <ObservationPrimaryOutput
+                                    observation={observation}
+                                    showPrompt={false}
+                                    onSeek={seekEmbeddedPlayer}
+                                />
+                            </LabeledRow>
+                            {observation.completed_at && (
+                                <LabeledRow label="Event">
+                                    <Link to={urls.event(observation.id, observation.completed_at)}>
+                                        $recording_observed
+                                    </Link>
+                                </LabeledRow>
+                            )}
+                        </div>
+                    )}
+
+                    {(observation.status === 'pending' || observation.status === 'running') && (
+                        <ObservationProgressBar observationId={observation.id} sessionId={observation.session_id} />
+                    )}
+                </section>
+
+                {scannerType !== 'summarizer' && (
+                    <section
+                        className={`border rounded p-4 space-y-2 ${
+                            reasoning ? 'bg-surface-primary' : 'bg-surface-secondary opacity-60'
+                        }`}
+                    >
+                        <div className="text-sm font-medium">Model reasoning</div>
+                        {reasoning ? (
+                            <p className="text-sm whitespace-pre-wrap m-0">
+                                <CitedText text={reasoning} segments={reasoningSegments} onSeek={seekEmbeddedPlayer} />
+                            </p>
+                        ) : (
+                            <p className="text-muted text-sm m-0 italic">
+                                {observation.status === 'ineligible'
+                                    ? 'The model was not invoked.'
+                                    : observation.status === 'failed'
+                                      ? 'No reasoning available — the observation failed before completion.'
+                                      : observation.status === 'succeeded'
+                                        ? 'No reasoning provided.'
+                                        : 'Awaiting model output…'}
+                            </p>
+                        )}
+                    </section>
+                )}
             </div>
 
             <LemonCard className="overflow-hidden p-0" hoverEffect={false}>

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
@@ -57,6 +57,7 @@ export function ReplayScannersScene(): JSX.Element {
         createdByFilter,
         createdByOptions,
         hasActiveFilters,
+        scannerStats,
     } = useValues(replayScannersLogic)
     const { loadScanners, deleteScanner, duplicateScanner, toggleScannerEnabled, setScannersFilters, clearFilters } =
         useActions(replayScannersLogic)
@@ -215,7 +216,7 @@ export function ReplayScannersScene(): JSX.Element {
                 action={() => push(urls.replayVisionTemplates())}
             />
 
-            {scanners.length > 0 && <VisionMetrics />}
+            {(scannerStats?.total ?? 0) > 0 && <VisionMetrics />}
 
             <SceneSection
                 title="Scanners"

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
@@ -175,7 +175,7 @@ export function ScannerObservationsTable({ scannerId, tabId }: { scannerId: stri
             <ScannerOverview scannerId={scannerId} tabId={tabId} />
             <div className="flex items-start justify-between gap-4">
                 <p className="text-muted text-sm m-0">
-                    Past applications of this scanner to session recordings. Each row is one observation.
+                    Past observations made by this scanner. Each row is one observation.
                 </p>
                 <div className="flex items-center gap-4">
                     {observationStats.total > 0 && (
@@ -231,7 +231,7 @@ export function ScannerObservationsTable({ scannerId, tabId }: { scannerId: stri
                     </Tooltip>
                 </div>
             </div>
-            {observationStats.total > 0 && (
+            {(observationStats.total > 0 || hasActiveObservationFilters) && (
                 <div className="flex flex-wrap items-center gap-2">
                     <FilterPill<ObservationStatusValue>
                         label="Status"

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -37,12 +37,18 @@ function OverviewPanel({
     )
 }
 
-function MonitorOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element | null {
-    const { monitorStats } = useValues(replayScannerLogic({ id: scannerId, tabId }))
+function MonitorOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element {
+    const { monitorStats, hasActiveObservationFilters } = useValues(replayScannerLogic({ id: scannerId, tabId }))
     const { yesTotal, noTotal, inconclusiveTotal } = monitorStats
     const total = yesTotal + noTotal + inconclusiveTotal
     if (total === 0) {
-        return null
+        return (
+            <OverviewPanel title="Verdict mix">
+                <div className="text-muted text-sm">
+                    {hasActiveObservationFilters ? 'No verdicts match the current filter.' : 'No verdicts yet.'}
+                </div>
+            </OverviewPanel>
+        )
     }
     const yesPct = Math.round((yesTotal / total) * 100)
     const noPct = Math.round((noTotal / total) * 100)
@@ -78,14 +84,22 @@ function MonitorOverview({ scannerId, tabId }: { scannerId: string; tabId: strin
 }
 
 function ClassifierOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element | null {
-    const { scanner, classifierTagStats } = useValues(replayScannerLogic({ id: scannerId, tabId }))
-    const { fixedRanked, freeformRanked, totalWithTags } = classifierTagStats
+    const { scanner, classifierTagStats, hasActiveObservationFilters } = useValues(
+        replayScannerLogic({ id: scannerId, tabId })
+    )
+    const { fixedRanked, freeformRanked } = classifierTagStats
     // Wait for the scanner config — without it `freeformAllowed` defaults to `false` and the panel flashes the
     // "disabled" copy while the config is still loading.
-    if (totalWithTags === 0 || !scanner || scanner.scanner_type !== 'classifier') {
+    if (!scanner || scanner.scanner_type !== 'classifier') {
         return null
     }
     const freeformAllowed = !!scanner.scanner_config.allow_freeform_tags
+    const fixedEmpty = hasActiveObservationFilters
+        ? 'No fixed-vocabulary tags match the current filter.'
+        : 'No fixed-vocabulary tags emitted yet.'
+    const freeformEmpty = hasActiveObservationFilters
+        ? 'No freeform tags match the current filter.'
+        : 'No freeform tags emitted yet.'
 
     const renderRanked = (ranked: [string, number][], emptyMessage: string): JSX.Element => {
         if (ranked.length === 0) {
@@ -110,7 +124,7 @@ function ClassifierOverview({ scannerId, tabId }: { scannerId: string; tabId: st
     return (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             <OverviewPanel title="Top fixed tags" subtitle="from configured vocabulary">
-                {renderRanked(fixedRanked, 'No fixed-vocabulary tags emitted yet.')}
+                {renderRanked(fixedRanked, fixedEmpty)}
             </OverviewPanel>
 
             <OverviewPanel
@@ -119,7 +133,7 @@ function ClassifierOverview({ scannerId, tabId }: { scannerId: string; tabId: st
                 disabled={!freeformAllowed}
             >
                 {freeformAllowed ? (
-                    renderRanked(freeformRanked, 'No freeform tags emitted yet.')
+                    renderRanked(freeformRanked, freeformEmpty)
                 ) : (
                     <div className="text-muted text-sm">
                         Freeform tags are disabled for this scanner — the model can only pick from your configured
@@ -131,11 +145,21 @@ function ClassifierOverview({ scannerId, tabId }: { scannerId: string; tabId: st
     )
 }
 
-function ScorerOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element | null {
-    const { scorerSummary, scorerHistogram } = useValues(replayScannerLogic({ id: scannerId, tabId }))
+function ScorerOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element {
+    const { scorerSummary, scorerHistogram, hasActiveObservationFilters } = useValues(
+        replayScannerLogic({ id: scannerId, tabId })
+    )
     const theme = useMemo(() => buildTheme(), [])
     if (!scorerSummary || !scorerHistogram) {
-        return null
+        return (
+            <OverviewPanel title="Score distribution">
+                <div className="text-muted text-sm">
+                    {hasActiveObservationFilters
+                        ? 'No scored observations match the current filter.'
+                        : 'No scored observations yet.'}
+                </div>
+            </OverviewPanel>
+        )
     }
     return (
         <OverviewPanel title="Score distribution" subtitle={`${scorerSummary.count} scored`}>

--- a/products/replay_vision/frontend/replay_scanners/components/VisionMetrics.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionMetrics.tsx
@@ -11,32 +11,15 @@ import { BaseMathType, ChartDisplayType } from '~/types'
 
 import { visionQuotaLogic } from '../../logics/visionQuotaLogic'
 import { replayScannersLogic } from '../replayScannersLogic'
-import { SCANNER_TYPE_OPTIONS, SCANNER_TYPE_TAG_TYPE, ScannerType, scannerTypeLabel } from '../types'
+import { SCANNER_TYPE_OPTIONS, SCANNER_TYPE_TAG_TYPE, scannerTypeLabel } from '../types'
 
 const RECORDING_OBSERVED_EVENT = '$recording_observed'
 const COLLECTION_ID = 'replay-vision-list-observations'
 
 export function VisionMetrics(): JSX.Element {
-    const { scanners, chartDateFrom, chartDateTo } = useValues(replayScannersLogic)
+    const { scannerStats, chartDateFrom, chartDateTo } = useValues(replayScannersLogic)
     const { setChartDateRange } = useActions(replayScannersLogic)
     const { quota } = useValues(visionQuotaLogic)
-
-    const enabledCount = scanners.filter((s) => s.enabled).length
-    const typeCounts = scanners.reduce<Record<ScannerType, { enabled: number; total: number }>>(
-        (acc, s) => {
-            acc[s.scanner_type].total += 1
-            if (s.enabled) {
-                acc[s.scanner_type].enabled += 1
-            }
-            return acc
-        },
-        {
-            monitor: { enabled: 0, total: 0 },
-            classifier: { enabled: 0, total: 0 },
-            scorer: { enabled: 0, total: 0 },
-            summarizer: { enabled: 0, total: 0 },
-        }
-    )
 
     const ratio = quota && quota.monthly_quota > 0 ? Math.min(quota.usage_this_month / quota.monthly_quota, 1) : 0
     const quotaStroke = quota?.exhausted ? 'var(--danger)' : ratio >= 0.8 ? 'var(--warning)' : 'var(--success)'
@@ -59,83 +42,81 @@ export function VisionMetrics(): JSX.Element {
     }
 
     return (
-        <div className="space-y-2">
-            <div className="flex justify-end">
-                <DateFilter
-                    dateFrom={chartDateFrom}
-                    dateTo={chartDateTo}
-                    onChange={(from, to) => setChartDateRange(from ?? null, to ?? null)}
-                />
+        <div className="flex gap-4 h-96">
+            <div className="flex-1 bg-bg-light rounded p-4 flex flex-col InsightCard h-full">
+                <div className="flex items-start justify-between gap-2 mb-1">
+                    <h3 className="text-lg font-semibold m-0">Observations over time</h3>
+                    <DateFilter
+                        dateFrom={chartDateFrom}
+                        dateTo={chartDateTo}
+                        onChange={(from, to) => setChartDateRange(from ?? null, to ?? null)}
+                    />
+                </div>
+                <p className="text-muted text-sm mb-4">Total scanner observations across all scanners</p>
+                <div className="flex-1 flex flex-col min-h-0">
+                    <Query
+                        query={{ kind: NodeKind.InsightVizNode, source: chartSource } as InsightVizNode}
+                        readOnly
+                        embedded
+                        inSharedMode
+                        context={{
+                            insightProps: {
+                                dashboardItemId: 'new-replay-vision-list-observations-chart',
+                                dataNodeCollectionId: COLLECTION_ID,
+                            },
+                        }}
+                    />
+                </div>
             </div>
-            <div className="flex gap-4 h-96">
-                <div className="flex-1 bg-bg-light rounded p-4 flex flex-col InsightCard h-full">
-                    <h3 className="text-lg font-semibold mb-1">Observations over time</h3>
-                    <p className="text-muted text-sm mb-4">Total scanner observations across all scanners</p>
-                    <div className="flex-1 flex flex-col min-h-0">
-                        <Query
-                            query={{ kind: NodeKind.InsightVizNode, source: chartSource } as InsightVizNode}
-                            readOnly
-                            embedded
-                            inSharedMode
-                            context={{
-                                insightProps: {
-                                    dashboardItemId: 'new-replay-vision-list-observations-chart',
-                                    dataNodeCollectionId: COLLECTION_ID,
-                                },
-                            }}
-                        />
+
+            <div className="flex flex-1 flex-col gap-4">
+                <div className="flex-1 bg-bg-light border rounded p-4 flex flex-col">
+                    <div className="text-muted text-xs font-medium uppercase mb-2">Enabled scanners</div>
+                    <div className="text-3xl font-semibold">
+                        {scannerStats?.enabled ?? 0}
+                        <span className="text-muted text-lg font-normal">
+                            {' / '}
+                            {scannerStats?.total ?? 0}
+                        </span>
+                    </div>
+                    <div className="flex flex-wrap gap-1.5 mt-3">
+                        {SCANNER_TYPE_OPTIONS.map(({ value }) => {
+                            const { enabled = 0, total = 0 } = scannerStats?.by_type?.[value] ?? {}
+                            return (
+                                <LemonTag key={value} type={total > 0 ? SCANNER_TYPE_TAG_TYPE[value] : 'muted'}>
+                                    {scannerTypeLabel(value)} {enabled}/{total}
+                                </LemonTag>
+                            )
+                        })}
                     </div>
                 </div>
-
-                <div className="flex flex-1 flex-col gap-4">
-                    <div className="flex-1 bg-bg-light border rounded p-4 flex flex-col">
-                        <div className="text-muted text-xs font-medium uppercase mb-2">Enabled scanners</div>
-                        <div className="text-3xl font-semibold">
-                            {enabledCount}
-                            <span className="text-muted text-lg font-normal">
-                                {' / '}
-                                {scanners.length}
-                            </span>
-                        </div>
-                        <div className="flex flex-wrap gap-1.5 mt-3">
-                            {SCANNER_TYPE_OPTIONS.map(({ value }) => {
-                                const { enabled, total } = typeCounts[value]
-                                return (
-                                    <LemonTag key={value} type={total > 0 ? SCANNER_TYPE_TAG_TYPE[value] : 'muted'}>
-                                        {scannerTypeLabel(value)} {enabled}/{total}
-                                    </LemonTag>
-                                )
-                            })}
-                        </div>
-                    </div>
-                    <div className="flex-1 bg-bg-light border rounded p-4 flex flex-col">
-                        <div className="text-muted text-xs font-medium uppercase mb-2">Observations this month</div>
-                        {quota ? (
-                            <>
-                                <div className="text-3xl font-semibold tabular-nums">
-                                    {quota.usage_this_month.toLocaleString()}
-                                    <span className="text-muted text-lg font-normal">
-                                        {' / '}
-                                        {quota.monthly_quota.toLocaleString()}
-                                    </span>
-                                </div>
-                                <LemonProgress
-                                    className="mt-2"
-                                    percent={Math.round(ratio * 100)}
-                                    strokeColor={quotaStroke}
-                                />
-                                <div className="text-muted text-sm mt-1">
-                                    {quota.exhausted ? (
-                                        <span className="text-danger">Quota reached</span>
-                                    ) : (
-                                        `${quota.remaining.toLocaleString()} remaining`
-                                    )}
-                                </div>
-                            </>
-                        ) : (
-                            <div className="text-3xl font-semibold">—</div>
-                        )}
-                    </div>
+                <div className="flex-1 bg-bg-light border rounded p-4 flex flex-col">
+                    <div className="text-muted text-xs font-medium uppercase mb-2">Observations this month</div>
+                    {quota ? (
+                        <>
+                            <div className="text-3xl font-semibold tabular-nums">
+                                {quota.usage_this_month.toLocaleString()}
+                                <span className="text-muted text-lg font-normal">
+                                    {' / '}
+                                    {quota.monthly_quota.toLocaleString()}
+                                </span>
+                            </div>
+                            <LemonProgress
+                                className="mt-2"
+                                percent={Math.round(ratio * 100)}
+                                strokeColor={quotaStroke}
+                            />
+                            <div className="text-muted text-sm mt-1">
+                                {quota.exhausted ? (
+                                    <span className="text-danger">Quota reached</span>
+                                ) : (
+                                    `${quota.remaining.toLocaleString()} remaining`
+                                )}
+                            </div>
+                        </>
+                    ) : (
+                        <div className="text-3xl font-semibold">—</div>
+                    )}
                 </div>
             </div>
         </div>

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
@@ -240,6 +240,14 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
                 loadScannersFailure: () => false,
             },
         ],
+        scannerStatsLoading: [
+            false,
+            {
+                loadScannerStats: () => true,
+                loadScannerStatsSuccess: () => false,
+                loadScannerStatsFailure: () => false,
+            },
+        ],
         chartDateFrom: [
             '-30d' as string | null,
             {
@@ -344,7 +352,9 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
             }
         },
 
-        loadScannerStats: async () => {
+        loadScannerStats: async (_, breakpoint) => {
+            // Debounce so a burst of mutations (rapid toggles, bulk delete) coalesces into one refetch.
+            await breakpoint(50)
             const teamId = teamLogic.values.currentTeamId
             if (!teamId) {
                 return

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
@@ -15,8 +15,9 @@ import {
     visionScannersDestroy,
     visionScannersList,
     visionScannersPartialUpdate,
+    visionScannersStatsRetrieve,
 } from '../generated/api'
-import type { UserBasicApi, VisionScannersListParams } from '../generated/api.schemas'
+import type { ScannerStatsResponseApi, UserBasicApi, VisionScannersListParams } from '../generated/api.schemas'
 import type { replayScannersLogicType } from './replayScannersLogicType'
 import {
     ENABLED_OPTIONS,
@@ -157,6 +158,9 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
         loadCreators: true,
         loadCreatorsSuccess: (creators: UserBasicApi[]) => ({ creators }),
         loadCreatorsFailure: true,
+        loadScannerStats: true,
+        loadScannerStatsSuccess: (stats: ScannerStatsResponseApi) => ({ stats }),
+        loadScannerStatsFailure: true,
         deleteScanner: (id: string) => ({ id }),
         deleteScannerSuccess: (id: string) => ({ id }),
         duplicateScanner: (id: string) => ({ id }),
@@ -220,6 +224,12 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
             [] as UserBasicApi[],
             {
                 loadCreatorsSuccess: (_, { creators }) => creators,
+            },
+        ],
+        scannerStats: [
+            null as ScannerStatsResponseApi | null,
+            {
+                loadScannerStatsSuccess: (_, { stats }) => stats,
             },
         ],
         scannersLoading: [
@@ -334,14 +344,32 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
             }
         },
 
-        // Refetch after a delete or duplicate so the paginated page + count + creator dropdown stay accurate.
+        loadScannerStats: async () => {
+            const teamId = teamLogic.values.currentTeamId
+            if (!teamId) {
+                return
+            }
+            try {
+                const response = await visionScannersStatsRetrieve(String(teamId))
+                actions.loadScannerStatsSuccess(response)
+            } catch {
+                actions.loadScannerStatsFailure()
+            }
+        },
+
+        // Refetch after any mutation so the page + creator dropdown + team-wide stats stay accurate.
         deleteScannerSuccess: () => {
             actions.loadScanners()
             actions.loadCreators()
+            actions.loadScannerStats()
         },
         duplicateScannerSuccess: () => {
             actions.loadScanners()
             actions.loadCreators()
+            actions.loadScannerStats()
+        },
+        toggleScannerEnabledDone: () => {
+            actions.loadScannerStats()
         },
 
         toggleScannerEnabled: async ({ id }) => {
@@ -450,5 +478,6 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
 
     afterMount(({ actions }) => {
         actions.loadCreators()
+        actions.loadScannerStats()
     }),
 ])

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -18,12 +18,12 @@ export type EnabledFilter = 'enabled' | 'disabled'
 
 export type IneligibleKind = 'no_recording' | 'too_short' | 'too_inactive' | 'too_long' | 'no_events'
 
-const INELIGIBLE_KIND_LABELS: Record<IneligibleKind, string> = {
-    no_recording: 'No recording',
-    too_short: 'Too short',
-    too_inactive: 'Too inactive',
-    too_long: 'Too long',
-    no_events: 'No events',
+const INELIGIBLE_KINDS: Record<IneligibleKind, { label: string; description: string }> = {
+    no_recording: { label: 'No recording', description: 'No recording was found for this session.' },
+    too_short: { label: 'Too short', description: 'The session was too short to analyze.' },
+    too_inactive: { label: 'Too inactive', description: 'The session had too little active interaction to analyze.' },
+    too_long: { label: 'Too long', description: 'The session was too long to analyze.' },
+    no_events: { label: 'No events', description: 'The session had no events to analyze.' },
 }
 
 export type FailureKind =
@@ -59,39 +59,42 @@ const FAILURE_KINDS: Record<FailureKind, { label: string; description: string }>
     },
 }
 
-const FAILURE_KIND_LABELS = Object.fromEntries(
-    Object.entries(FAILURE_KINDS).map(([kind, meta]) => [kind, meta.label])
-) as Record<FailureKind, string>
-
 export type ParsedReason<K extends string> = { kind: K; label: string; message: string }
 
-function parseKindReason<K extends string>(error_reason: string, labels: Record<K, string>): ParsedReason<K> | null {
+function parseKindReason<K extends string>(
+    error_reason: string,
+    kinds: Record<K, { label: string }>
+): ParsedReason<K> | null {
     // The backend formats `error_reason` as `kind:human message`; fall back to a generic label on drift.
     const idx = error_reason.indexOf(':')
     if (idx <= 0) {
         return null
     }
     const kind = error_reason.slice(0, idx)
-    if (!(kind in labels)) {
+    if (!(kind in kinds)) {
         return null
     }
     return {
         kind: kind as K,
-        label: labels[kind as K],
+        label: kinds[kind as K].label,
         message: error_reason.slice(idx + 1).trim(),
     }
 }
 
 export function parseIneligibleReason(error_reason: string): ParsedReason<IneligibleKind> | null {
-    return parseKindReason(error_reason, INELIGIBLE_KIND_LABELS)
+    return parseKindReason(error_reason, INELIGIBLE_KINDS)
 }
 
 export function parseFailureReason(error_reason: string): ParsedReason<FailureKind> | null {
-    return parseKindReason(error_reason, FAILURE_KIND_LABELS)
+    return parseKindReason(error_reason, FAILURE_KINDS)
 }
 
 export function failureKindDescription(kind: FailureKind): string {
     return FAILURE_KINDS[kind].description
+}
+
+export function ineligibleKindDescription(kind: IneligibleKind): string {
+    return INELIGIBLE_KINDS[kind].description
 }
 
 export const DEFAULT_PROVIDER = 'google'

--- a/products/replay_vision/mcp/tools.yaml
+++ b/products/replay_vision/mcp/tools.yaml
@@ -235,6 +235,9 @@ tools:
             already has an observation (even a failed or ineligible one) is a no-op and will not produce a fresh scan.
         requires_ai_consent: true
         feature_flag: replay-vision
+    vision-scanners-stats-retrieve:
+        operation: vision_scanners_stats_retrieve
+        enabled: false
     vision-scanners-update:
         operation: vision_scanners_partial_update
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -36990,6 +36990,38 @@ export namespace Schemas {
       creators: UserBasic[];
     }
 
+    /**
+     * Per-scanner-type count of enabled vs total scanners.
+     */
+    export interface ScannerTypeStats {
+      /** Number of enabled scanners of this type. */
+      enabled: number;
+      /** Number of scanners of this type (enabled + disabled). */
+      total: number;
+    }
+
+    /**
+     * One `ScannerTypeStats` per scanner type — explicit fields give callers a typed shape, not `Record<string, …>`.
+     */
+    export interface ScannerStatsByType {
+      monitor: ScannerTypeStats;
+      classifier: ScannerTypeStats;
+      scorer: ScannerTypeStats;
+      summarizer: ScannerTypeStats;
+    }
+
+    /**
+     * Team-wide scanner counts independent of any list-filter state.
+     */
+    export interface ScannerStatsResponse {
+      /** Total scanners on the team. */
+      total: number;
+      /** Number of enabled scanners on the team. */
+      enabled: number;
+      /** Per-scanner-type breakdown (monitor / classifier / scorer / summarizer). */
+      by_type: ScannerStatsByType;
+    }
+
     export interface ScoreDefinitionCreate {
       /**
          * Human-readable scorer name.


### PR DESCRIPTION
## Problem

Replay Vision polish + a few observation bugs found post-pagination rollout.

## Changes

- Fix `Total` mini-card showing `3` for a scanner with 263 observations (`_status_counts` accidentally grouped by `(status, created_at, id)` because the parent ordering leaked into GROUP BY). Same fix in `_monitor_stats`. Defensive `.order_by()` in `_classifier_stats` / `_scorer_stats` to skip a wasted CTE sort.
- Round float seconds in ineligible reason strings.
- New `GET /vision/scanners/stats/` returns team-wide `{total, enabled, by_type}`; `VisionMetrics` reads it so the overview stays stable when list filters change.
- Scanner-overview panels (Verdict mix / Top tags / Score distribution) no longer disappear on filter-empty — empty-state copy distinguishes "yet" vs "match the current filter".
- Status-badge tooltips: failed → description only; ineligible → description + numbers.
- Observation page layout: small cards above Result + Model reasoning. Failed/ineligible Result panel is Type / Reason / Details. "Reasoning" → "Model reasoning". Empty Model reasoning panel dimmed.
- `DateFilter` moved inside the chart card on the scanner list.

## How did you test this code?

Agent-authored, no manual UI testing. 104 backend + 62 frontend tests.

## 🤖 Agent context

Authored with Claude Code (Opus 4.7).