### PR TITLE
chore(auth): lock in legacy default for missing auth-flow-variant flag

### DIFF
--- a/frontend/src/scenes/authentication/authFlowVariants.test.ts
+++ b/frontend/src/scenes/authentication/authFlowVariants.test.ts
@@ -1,0 +1,27 @@
+import { FEATURE_FLAGS } from 'lib/constants'
+import type { FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
+
+import { type AuthFlowVariant, resolveAuthFlowVariant } from './authFlowVariants'
+
+describe('resolveAuthFlowVariant', () => {
+    // A missing flag must fall back to the legacy pages — otherwise a freshly spun-up
+    // local stack (no flag defined) would render the unfinished redesign screens.
+    it('defaults to legacy when the flag does not exist', () => {
+        expect(resolveAuthFlowVariant({})).toEqual('legacy')
+    })
+
+    it.each<[string, FeatureFlagsSet, AuthFlowVariant]>([
+        ['flag absent', {}, 'legacy'],
+        ['flag is boolean true', { [FEATURE_FLAGS.AUTH_FLOW_VARIANT]: true }, 'legacy'],
+        ['flag is boolean false', { [FEATURE_FLAGS.AUTH_FLOW_VARIANT]: false }, 'legacy'],
+        ['flag is an unknown variant string', { [FEATURE_FLAGS.AUTH_FLOW_VARIANT]: 'something-else' }, 'legacy'],
+        ['flag is the legacy variant', { [FEATURE_FLAGS.AUTH_FLOW_VARIANT]: 'legacy' }, 'legacy'],
+        [
+            'flag is the redesign variant',
+            { [FEATURE_FLAGS.AUTH_FLOW_VARIANT]: 'redesign-2026-06-02' },
+            'redesign-2026-06-02',
+        ],
+    ])('resolves %s to %s', (_description, featureFlags, expected) => {
+        expect(resolveAuthFlowVariant(featureFlags)).toEqual(expected)
+    })
+})


### PR DESCRIPTION
## Problem

When spinning up the stack locally, the new (unfinished) signin/signup redesign was reported showing up instead of the existing legacy pages.
The `auth-flow-variant` multivariate flag gates which auth flow renders, and the safe behavior is: if the flag does not exist, fall back to the legacy pages.

## Changes

`resolveAuthFlowVariant` already returns `legacy` whenever the flag is absent or holds any value that isn't the literal `redesign-2026-06-02` variant string (missing key, boolean `true`/`false`, or an unknown string all resolve to legacy). This change does not alter that production logic — it adds a regression test that locks the guarantee in, covering:

- flag absent → `legacy`
- flag is boolean `true`/`false` → `legacy`
- flag is an unknown variant string → `legacy`
- flag is the explicit `legacy` / `redesign-2026-06-02` variant → respective variant

This prevents a future edit (flipping `DEFAULT_VARIANT`, loosening the variant check, etc.) from silently re-introducing the redesign-by-default symptom for anyone running a local stack.

## How did you test this code?

I'm an agent. I added an automated Jest unit test (`authFlowVariants.test.ts`) for `resolveAuthFlowVariant` covering the cases above. I was unable to execute the Jest suite in this environment (no installed `node_modules`); the test targets a pure function and the assertions map directly to each branch of the resolver. A reviewer/CI should run `pnpm --filter=@posthog/frontend jest src/scenes/authentication/authFlowVariants.test.ts` to confirm.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by the PostHog Slack app (PostHog Code) in response to a report that the auth redesign showed up on fresh local stacks. I traced the flag resolution (`resolveAuthFlowVariant` in `frontend/src/scenes/authentication/authFlowVariants.ts`), the three entry points (`Login.tsx`, `SignupContainer.tsx`, `InviteSignup.tsx`), the registry, and the feature-flag plumbing (`featureFlagLogic`, `PERSISTED_FEATURE_FLAGS`). I confirmed the committed resolver already defaults to legacy for any missing/non-variant value and that nothing in the backend seeds the flag, so the requested "default to legacy when the flag does not exist" guarantee is already met in production code. The remaining gap was the absence of a test, so I added one rather than changing behavior that was already correct.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
