### PR TITLE
fix(rust): improves selective build accuracy and CI performance

### DIFF
--- a/.github/actions/rust-compute-affected/action.yml
+++ b/.github/actions/rust-compute-affected/action.yml
@@ -8,11 +8,7 @@ inputs:
         description: github.event_name — controls how the base ref is resolved
         required: true
     pr-base-sha:
-        description: 'Base SHA for PR / merge-group events (fallback if pr-base-ref unavailable)'
-        required: false
-        default: ''
-    pr-base-ref:
-        description: 'Base branch name for PR events (e.g. master) — used to compute a fresh merge-base'
+        description: 'Base SHA for PR / merge-group events'
         required: false
         default: ''
     push-before-sha:
@@ -64,7 +60,6 @@ runs:
           env:
               EVENT_NAME: ${{ inputs.event-name }}
               PR_BASE_SHA: ${{ inputs.pr-base-sha }}
-              PR_BASE_REF: ${{ inputs.pr-base-ref }}
               PUSH_BEFORE_SHA: ${{ inputs.push-before-sha }}
               FORCE_REBUILD: ${{ inputs.rebuild-all }}
           working-directory: rust
@@ -79,8 +74,8 @@ runs:
                       # Try to resolve the base branch name from the input or
                       # the GitHub event payload so we diff against the current
                       # tip rather than the potentially stale PR base SHA.
-                      base_branch="${PR_BASE_REF}"
-                      if [ -z "$base_branch" ] && [ -f "$GITHUB_EVENT_PATH" ]; then
+                      base_branch=""
+                      if [ -f "$GITHUB_EVENT_PATH" ]; then
                           base_branch=$(jq -r '.pull_request.base.ref // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
                       fi
 

--- a/.github/actions/rust-compute-affected/action.yml
+++ b/.github/actions/rust-compute-affected/action.yml
@@ -8,7 +8,11 @@ inputs:
         description: github.event_name — controls how the base ref is resolved
         required: true
     pr-base-sha:
-        description: 'Base SHA for PR / merge-group events'
+        description: 'Base SHA for PR / merge-group events (fallback if pr-base-ref unavailable)'
+        required: false
+        default: ''
+    pr-base-ref:
+        description: 'Base branch name for PR events (e.g. master) — used to compute a fresh merge-base'
         required: false
         default: ''
     push-before-sha:
@@ -60,6 +64,7 @@ runs:
           env:
               EVENT_NAME: ${{ inputs.event-name }}
               PR_BASE_SHA: ${{ inputs.pr-base-sha }}
+              PR_BASE_REF: ${{ inputs.pr-base-ref }}
               PUSH_BEFORE_SHA: ${{ inputs.push-before-sha }}
               FORCE_REBUILD: ${{ inputs.rebuild-all }}
           working-directory: rust
@@ -70,6 +75,12 @@ runs:
               else
                   if [ "$EVENT_NAME" = "push" ]; then
                       base_ref="$PUSH_BEFORE_SHA"
+                  elif [ -n "$PR_BASE_REF" ]; then
+                      # Fetch the current tip of the base branch so we diff
+                      # against it rather than the potentially stale PR base SHA.
+                      git fetch --no-tags --depth=1 origin "$PR_BASE_REF"
+                      base_ref=$(git merge-base FETCH_HEAD HEAD)
+                      echo "Using merge-base of origin/$PR_BASE_REF and HEAD: $base_ref"
                   else
                       base_ref="$PR_BASE_SHA"
                   fi

--- a/.github/actions/rust-compute-affected/action.yml
+++ b/.github/actions/rust-compute-affected/action.yml
@@ -75,14 +75,22 @@ runs:
               else
                   if [ "$EVENT_NAME" = "push" ]; then
                       base_ref="$PUSH_BEFORE_SHA"
-                  elif [ -n "$PR_BASE_REF" ]; then
-                      # Fetch the current tip of the base branch so we diff
-                      # against it rather than the potentially stale PR base SHA.
-                      git fetch --no-tags --depth=1 origin "$PR_BASE_REF"
-                      base_ref=$(git merge-base FETCH_HEAD HEAD)
-                      echo "Using merge-base of origin/$PR_BASE_REF and HEAD: $base_ref"
                   else
-                      base_ref="$PR_BASE_SHA"
+                      # Try to resolve the base branch name from the input or
+                      # the GitHub event payload so we diff against the current
+                      # tip rather than the potentially stale PR base SHA.
+                      base_branch="${PR_BASE_REF}"
+                      if [ -z "$base_branch" ] && [ -f "$GITHUB_EVENT_PATH" ]; then
+                          base_branch=$(jq -r '.pull_request.base.ref // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
+                      fi
+
+                      if [ -n "$base_branch" ]; then
+                          git fetch --no-tags --depth=1 origin "$base_branch"
+                          base_ref=$(git merge-base FETCH_HEAD HEAD)
+                          echo "Using merge-base of origin/$base_branch and HEAD: $base_ref"
+                      else
+                          base_ref="$PR_BASE_SHA"
+                      fi
                   fi
 
                   if [ -z "$base_ref" ] || echo "$base_ref" | grep -qE '^0+$'; then

--- a/.github/actions/rust-compute-affected/action.yml
+++ b/.github/actions/rust-compute-affected/action.yml
@@ -80,9 +80,14 @@ runs:
                       fi
 
                       if [ -n "$base_branch" ]; then
-                          git fetch --no-tags --depth=1 origin "$base_branch"
-                          base_ref=$(git merge-base FETCH_HEAD HEAD)
-                          echo "Using merge-base of origin/$base_branch and HEAD: $base_ref"
+                          git fetch --no-tags origin "$base_branch"
+                          base_ref=$(git merge-base FETCH_HEAD HEAD || true)
+                          if [ -n "$base_ref" ]; then
+                              echo "Using merge-base of origin/$base_branch and HEAD: $base_ref"
+                          else
+                              echo "merge-base empty; falling back to PR base SHA"
+                              base_ref="$PR_BASE_SHA"
+                          fi
                       else
                           base_ref="$PR_BASE_SHA"
                       fi

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -104,7 +104,6 @@ jobs:
               with:
                   event-name: ${{ github.event_name }}
                   pr-base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-                  pr-base-ref: ${{ github.event.pull_request.base.ref }}
                   push-before-sha: ${{ github.event.before }}
                   rebuild-all: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -104,6 +104,7 @@ jobs:
               with:
                   event-name: ${{ github.event_name }}
                   pr-base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+                  pr-base-ref: ${{ github.event.pull_request.base.ref }}
                   push-before-sha: ${{ github.event.before }}
                   rebuild-all: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -85,6 +85,12 @@ jobs:
               with:
                   fetch-depth: 0
                   filter: blob:none
+                  sparse-checkout: |
+                      rust/
+                      proto/
+                      .github/rust-images.yml
+                      .github/actions/rust-compute-affected/
+                  sparse-checkout-cone-mode: false
                   clean: false
 
             - name: Install rust

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -42,6 +42,7 @@ dependencies = [
  "clap",
  "determinator",
  "guppy",
+ "rstest",
  "serde",
  "serde_json",
  "tempfile",

--- a/rust/affected-services/Cargo.toml
+++ b/rust/affected-services/Cargo.toml
@@ -11,3 +11,6 @@ guppy = "0.17"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3"
+
+[dev-dependencies]
+rstest = "0.26"

--- a/rust/affected-services/determinator-rules.toml
+++ b/rust/affected-services/determinator-rules.toml
@@ -33,6 +33,13 @@ mark-changed = "all"
 globs = ["../proto/**"]
 mark-changed = ["personhog-proto", "kafka-assigner-proto", "cymbal-proto"]
 
+# Catch-all for files outside the rust workspace (Python, frontend, CI, docs,
+# etc.) — these are not crate source and should not trigger rust rebuilds.
+# Must come AFTER the specific ../proto and ../.github/rust-images.yml rules.
+[[path-rule]]
+globs = ["../**"]
+mark-changed = []
+
 # Migration directories are not cargo crates. Tell the determinator to
 # ignore them (don't try ancestor-walk package matching). The sqlx-migrate
 # image trigger is handled in custom code outside the determinator.

--- a/rust/affected-services/determinator-rules.toml
+++ b/rust/affected-services/determinator-rules.toml
@@ -53,6 +53,21 @@ globs = [
 ]
 mark-changed = "all"
 
+# CI harness inputs that the rust test/build jobs depend on — a change here
+# should run all rust CI to catch regressions.
+[[path-rule]]
+globs = [
+    "../manage.py",
+    "../posthog/settings/**",
+    "../bin/download-mmdb",
+    "../.github/workflows/ci-rust.yml",
+    "../.github/actions/setup-protoc/**",
+    "../.github/actions/setup-sccache/**",
+    "../.github/actions/setup-sqlx-cli/**",
+    "../.github/actions/rust-compute-affected/**",
+]
+mark-changed = "all"
+
 # Catch-all for files outside the rust workspace (Python, frontend, CI, docs,
 # etc.) — these are not crate source and should not trigger rust rebuilds.
 # Must come AFTER all specific rules for files outside the workspace.

--- a/rust/affected-services/determinator-rules.toml
+++ b/rust/affected-services/determinator-rules.toml
@@ -33,9 +33,29 @@ mark-changed = "all"
 globs = ["../proto/**"]
 mark-changed = ["personhog-proto", "kafka-assigner-proto", "cymbal-proto"]
 
+# Hypercache contract: Python serializer changes may break Rust deserialization.
+# Must come BEFORE the catch-all rule below.
+[[path-rule]]
+globs = [
+    "../posthog/api/feature_flag.py",
+    "../posthog/models/feature_flag/flags_cache.py",
+    "../posthog/models/feature_flag/feature_flag.py",
+]
+mark-changed = ["feature-flags", "hypercache-server", "common-hypercache"]
+
+# Django migrations and test environment setup — needed for Rust integration tests.
+[[path-rule]]
+globs = [
+    "../posthog/migrations/**",
+    "../ee/migrations/**",
+    "../posthog/management/commands/setup_test_environment.py",
+    "../docker-compose.dev.yml",
+]
+mark-changed = "all"
+
 # Catch-all for files outside the rust workspace (Python, frontend, CI, docs,
 # etc.) — these are not crate source and should not trigger rust rebuilds.
-# Must come AFTER the specific ../proto and ../.github/rust-images.yml rules.
+# Must come AFTER all specific rules for files outside the workspace.
 [[path-rule]]
 globs = ["../**"]
 mark-changed = []

--- a/rust/affected-services/src/affected.rs
+++ b/rust/affected-services/src/affected.rs
@@ -46,16 +46,6 @@ pub fn compute_affected(
         .map(|f| to_workspace_relative(f))
         .collect();
 
-    eprintln!("DEBUG changed_files ({}):", changed_files.len());
-    for f in changed_files {
-        eprintln!("  {f}");
-    }
-    eprintln!("DEBUG workspace_paths ({}):", workspace_paths.len());
-    for p in &workspace_paths {
-        eprintln!("  {p}");
-    }
-    eprintln!("DEBUG old_graph available: {}", old_graph.is_some());
-
     // When no old graph is available (single-graph fallback) and Cargo.lock
     // changed, the determinator can't diff resolved dependencies — it sees
     // old == new. Force a full rebuild to be safe.
@@ -90,20 +80,6 @@ pub fn compute_affected(
     let workspace_size = new_graph.workspace().iter().count();
     let affected_count = result.affected_set.len();
     let rebuild_all = affected_count == workspace_size;
-
-    eprintln!("DEBUG affected_count: {affected_count}, workspace_size: {workspace_size}, rebuild_all: {rebuild_all}");
-    let affected_debug: Vec<String> = result
-        .affected_set
-        .packages(DependencyDirection::Forward)
-        .map(|p| p.name().to_string())
-        .collect();
-    eprintln!("DEBUG affected crates: {affected_debug:?}");
-    let path_changed_debug: Vec<String> = result
-        .path_changed_set
-        .packages(DependencyDirection::Forward)
-        .map(|p| p.name().to_string())
-        .collect();
-    eprintln!("DEBUG path_changed crates: {path_changed_debug:?}");
 
     let bin_to_crate = build_binary_to_crate_map(new_graph);
 

--- a/rust/affected-services/src/affected.rs
+++ b/rust/affected-services/src/affected.rs
@@ -46,6 +46,16 @@ pub fn compute_affected(
         .map(|f| to_workspace_relative(f))
         .collect();
 
+    eprintln!("DEBUG changed_files ({}):", changed_files.len());
+    for f in changed_files {
+        eprintln!("  {f}");
+    }
+    eprintln!("DEBUG workspace_paths ({}):", workspace_paths.len());
+    for p in &workspace_paths {
+        eprintln!("  {p}");
+    }
+    eprintln!("DEBUG old_graph available: {}", old_graph.is_some());
+
     // When no old graph is available (single-graph fallback) and Cargo.lock
     // changed, the determinator can't diff resolved dependencies — it sees
     // old == new. Force a full rebuild to be safe.
@@ -80,6 +90,20 @@ pub fn compute_affected(
     let workspace_size = new_graph.workspace().iter().count();
     let affected_count = result.affected_set.len();
     let rebuild_all = affected_count == workspace_size;
+
+    eprintln!("DEBUG affected_count: {affected_count}, workspace_size: {workspace_size}, rebuild_all: {rebuild_all}");
+    let affected_debug: Vec<String> = result
+        .affected_set
+        .packages(DependencyDirection::Forward)
+        .map(|p| p.name().to_string())
+        .collect();
+    eprintln!("DEBUG affected crates: {affected_debug:?}");
+    let path_changed_debug: Vec<String> = result
+        .path_changed_set
+        .packages(DependencyDirection::Forward)
+        .map(|p| p.name().to_string())
+        .collect();
+    eprintln!("DEBUG path_changed crates: {path_changed_debug:?}");
 
     let bin_to_crate = build_binary_to_crate_map(new_graph);
 

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -45,7 +45,7 @@ struct TempWorktree {
 }
 
 impl TempWorktree {
-    fn create(base_ref: &str) -> Result<Self> {
+    fn create(base_ref: &str, sparse_paths: &[&str]) -> Result<Self> {
         let path = tempfile::Builder::new()
             .prefix("affected-services-")
             .tempdir()
@@ -53,48 +53,46 @@ impl TempWorktree {
             .keep();
         let path_s = path.to_string_lossy();
 
-        // Read the current sparse checkout setting so we can restore it after
-        // creating the worktree. Without this, CI's sparse checkout config
-        // would be inherited by the worktree and produce an incomplete checkout.
-        let prev_sparse = Command::new("git")
-            .args(["config", "--local", "core.sparseCheckout"])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
-
-        if prev_sparse.as_deref() == Some("true") {
-            let _ = Command::new("git")
-                .args(["config", "--local", "core.sparseCheckout", "false"])
-                .output();
-        }
-
         let out = Command::new("git")
-            .args(["worktree", "add", "--detach", path_s.as_ref(), base_ref])
+            .args([
+                "worktree",
+                "add",
+                "--detach",
+                "--no-checkout",
+                path_s.as_ref(),
+                base_ref,
+            ])
             .output()
             .context("failed to create git worktree")?;
-
-        // Restore the original sparse checkout setting
-        let restore_ok = match prev_sparse.as_deref() {
-            Some(val) => Command::new("git")
-                .args(["config", "--local", "core.sparseCheckout", val])
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false),
-            None => Command::new("git")
-                .args(["config", "--local", "--unset", "core.sparseCheckout"])
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false),
-        };
-        if !restore_ok {
-            anyhow::bail!("failed to restore core.sparseCheckout after worktree creation");
-        }
-
         anyhow::ensure!(
             out.status.success(),
             "git worktree add failed: {}",
             String::from_utf8_lossy(&out.stderr).trim()
+        );
+
+        // Configure sparse checkout on the worktree so we only materialize
+        // the paths needed for cargo metadata, not the entire repo.
+        let mut sparse_args = vec!["sparse-checkout", "set", "--no-cone"];
+        sparse_args.extend_from_slice(sparse_paths);
+        let sparse_out = Command::new("git")
+            .args(["-C", path_s.as_ref()])
+            .args(&sparse_args)
+            .output()
+            .context("failed to configure sparse checkout on worktree")?;
+        anyhow::ensure!(
+            sparse_out.status.success(),
+            "git sparse-checkout set failed: {}",
+            String::from_utf8_lossy(&sparse_out.stderr).trim()
+        );
+
+        let checkout_out = Command::new("git")
+            .args(["-C", path_s.as_ref(), "checkout"])
+            .output()
+            .context("failed to checkout worktree")?;
+        anyhow::ensure!(
+            checkout_out.status.success(),
+            "git checkout in worktree failed: {}",
+            String::from_utf8_lossy(&checkout_out.stderr).trim()
         );
 
         Ok(Self { path })
@@ -119,7 +117,7 @@ impl Drop for TempWorktree {
 }
 
 pub fn build_old_package_graph(base_ref: &str, workspace_subdir: &str) -> Option<PackageGraph> {
-    let worktree = match TempWorktree::create(base_ref) {
+    let worktree = match TempWorktree::create(base_ref, &[workspace_subdir]) {
         Ok(w) => w,
         Err(e) => {
             eprintln!("warning: could not create worktree at {base_ref}: {e}");

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -117,14 +117,8 @@ impl Drop for TempWorktree {
 }
 
 pub fn build_old_package_graph(base_ref: &str, workspace_subdir: &str) -> Option<PackageGraph> {
-    eprintln!(
-        "DEBUG building old graph for base_ref={base_ref}, workspace_subdir={workspace_subdir}"
-    );
     let worktree = match TempWorktree::create(base_ref, &[workspace_subdir]) {
-        Ok(w) => {
-            eprintln!("DEBUG worktree created at {:?}", w.path());
-            w
-        }
+        Ok(w) => w,
         Err(e) => {
             eprintln!("warning: could not create worktree at {base_ref}: {e}");
             return None;
@@ -136,19 +130,12 @@ pub fn build_old_package_graph(base_ref: &str, workspace_subdir: &str) -> Option
         eprintln!("warning: {base_ref} has no {workspace_subdir}/Cargo.toml");
         return None;
     }
-    eprintln!("DEBUG old workspace Cargo.toml found at {old_workspace:?}");
 
     let mut cmd = MetadataCommand::new();
     cmd.current_dir(&old_workspace);
     cmd.other_options(["--locked"]);
     match cmd.build_graph() {
-        Ok(graph) => {
-            eprintln!(
-                "DEBUG old graph built successfully ({} crates)",
-                graph.workspace().iter().count()
-            );
-            Some(graph)
-        }
+        Ok(graph) => Some(graph),
         Err(e) => {
             eprintln!("warning: could not build old package graph: {e}");
             None

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -16,20 +16,8 @@ pub fn find_repo_root() -> Result<PathBuf> {
 }
 
 pub fn get_changed_files(base_ref: &str) -> Result<Vec<String>> {
-    // Compute the actual merge base so we don't pick up unrelated master
-    // commits when the PR base SHA is behind the branch's rebase point.
-    let merge_base_out = Command::new("git")
-        .args(["merge-base", base_ref, "HEAD"])
-        .output()
-        .context("failed to run git merge-base")?;
-    let diff_base = if merge_base_out.status.success() {
-        String::from_utf8(merge_base_out.stdout)?.trim().to_string()
-    } else {
-        base_ref.to_string()
-    };
-
     let out = Command::new("git")
-        .args(["diff", "--name-only", &format!("{diff_base}...HEAD")])
+        .args(["diff", "--name-only", &format!("{base_ref}...HEAD")])
         .output()
         .context("failed to run git diff")?;
     anyhow::ensure!(
@@ -87,17 +75,20 @@ impl TempWorktree {
             .context("failed to create git worktree")?;
 
         // Restore the original sparse checkout setting
-        match prev_sparse.as_deref() {
-            Some(val) => {
-                let _ = Command::new("git")
-                    .args(["config", "--local", "core.sparseCheckout", val])
-                    .output();
-            }
-            None => {
-                let _ = Command::new("git")
-                    .args(["config", "--local", "--unset", "core.sparseCheckout"])
-                    .output();
-            }
+        let restore_ok = match prev_sparse.as_deref() {
+            Some(val) => Command::new("git")
+                .args(["config", "--local", "core.sparseCheckout", val])
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false),
+            None => Command::new("git")
+                .args(["config", "--local", "--unset", "core.sparseCheckout"])
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false),
+        };
+        if !restore_ok {
+            eprintln!("warning: failed to restore core.sparseCheckout — CI checkout config may be corrupted");
         }
 
         anyhow::ensure!(

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -117,8 +117,14 @@ impl Drop for TempWorktree {
 }
 
 pub fn build_old_package_graph(base_ref: &str, workspace_subdir: &str) -> Option<PackageGraph> {
+    eprintln!(
+        "DEBUG building old graph for base_ref={base_ref}, workspace_subdir={workspace_subdir}"
+    );
     let worktree = match TempWorktree::create(base_ref, &[workspace_subdir]) {
-        Ok(w) => w,
+        Ok(w) => {
+            eprintln!("DEBUG worktree created at {:?}", w.path());
+            w
+        }
         Err(e) => {
             eprintln!("warning: could not create worktree at {base_ref}: {e}");
             return None;
@@ -130,12 +136,19 @@ pub fn build_old_package_graph(base_ref: &str, workspace_subdir: &str) -> Option
         eprintln!("warning: {base_ref} has no {workspace_subdir}/Cargo.toml");
         return None;
     }
+    eprintln!("DEBUG old workspace Cargo.toml found at {old_workspace:?}");
 
     let mut cmd = MetadataCommand::new();
     cmd.current_dir(&old_workspace);
     cmd.other_options(["--locked"]);
     match cmd.build_graph() {
-        Ok(graph) => Some(graph),
+        Ok(graph) => {
+            eprintln!(
+                "DEBUG old graph built successfully ({} crates)",
+                graph.workspace().iter().count()
+            );
+            Some(graph)
+        }
         Err(e) => {
             eprintln!("warning: could not build old package graph: {e}");
             None

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -88,7 +88,7 @@ impl TempWorktree {
                 .unwrap_or(false),
         };
         if !restore_ok {
-            eprintln!("warning: failed to restore core.sparseCheckout — CI checkout config may be corrupted");
+            anyhow::bail!("failed to restore core.sparseCheckout after worktree creation");
         }
 
         anyhow::ensure!(

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -65,22 +65,40 @@ impl TempWorktree {
             .keep();
         let path_s = path.to_string_lossy();
 
-        // Disable sparse checkout before creating the worktree so it doesn't
-        // inherit the parent's sparse-checkout filter (CI uses sparse checkout
-        // for the main working tree).
-        let _ = Command::new("git")
-            .args(["config", "--local", "core.sparseCheckout", "false"])
-            .output();
+        // Read the current sparse checkout setting so we can restore it after
+        // creating the worktree. Without this, CI's sparse checkout config
+        // would be inherited by the worktree and produce an incomplete checkout.
+        let prev_sparse = Command::new("git")
+            .args(["config", "--local", "core.sparseCheckout"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+
+        if prev_sparse.as_deref() == Some("true") {
+            let _ = Command::new("git")
+                .args(["config", "--local", "core.sparseCheckout", "false"])
+                .output();
+        }
 
         let out = Command::new("git")
             .args(["worktree", "add", "--detach", path_s.as_ref(), base_ref])
             .output()
             .context("failed to create git worktree")?;
 
-        // Re-enable sparse checkout for the parent worktree
-        let _ = Command::new("git")
-            .args(["config", "--local", "core.sparseCheckout", "true"])
-            .output();
+        // Restore the original sparse checkout setting
+        match prev_sparse.as_deref() {
+            Some(val) => {
+                let _ = Command::new("git")
+                    .args(["config", "--local", "core.sparseCheckout", val])
+                    .output();
+            }
+            None => {
+                let _ = Command::new("git")
+                    .args(["config", "--local", "--unset", "core.sparseCheckout"])
+                    .output();
+            }
+        }
 
         anyhow::ensure!(
             out.status.success(),

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -16,8 +16,20 @@ pub fn find_repo_root() -> Result<PathBuf> {
 }
 
 pub fn get_changed_files(base_ref: &str) -> Result<Vec<String>> {
+    // Compute the actual merge base so we don't pick up unrelated master
+    // commits when the PR base SHA is behind the branch's rebase point.
+    let merge_base_out = Command::new("git")
+        .args(["merge-base", base_ref, "HEAD"])
+        .output()
+        .context("failed to run git merge-base")?;
+    let diff_base = if merge_base_out.status.success() {
+        String::from_utf8(merge_base_out.stdout)?.trim().to_string()
+    } else {
+        base_ref.to_string()
+    };
+
     let out = Command::new("git")
-        .args(["diff", "--name-only", &format!("{base_ref}...HEAD")])
+        .args(["diff", "--name-only", &format!("{diff_base}...HEAD")])
         .output()
         .context("failed to run git diff")?;
     anyhow::ensure!(
@@ -51,21 +63,31 @@ impl TempWorktree {
             .tempdir()
             .context("failed to create temp directory")?
             .keep();
+        let path_s = path.to_string_lossy();
+
+        // Disable sparse checkout before creating the worktree so it doesn't
+        // inherit the parent's sparse-checkout filter (CI uses sparse checkout
+        // for the main working tree).
+        let _ = Command::new("git")
+            .args(["config", "--local", "core.sparseCheckout", "false"])
+            .output();
+
         let out = Command::new("git")
-            .args([
-                "worktree",
-                "add",
-                "--detach",
-                &path.to_string_lossy(),
-                base_ref,
-            ])
+            .args(["worktree", "add", "--detach", path_s.as_ref(), base_ref])
             .output()
             .context("failed to create git worktree")?;
+
+        // Re-enable sparse checkout for the parent worktree
+        let _ = Command::new("git")
+            .args(["config", "--local", "core.sparseCheckout", "true"])
+            .output();
+
         anyhow::ensure!(
             out.status.success(),
             "git worktree add failed: {}",
             String::from_utf8_lossy(&out.stderr).trim()
         );
+
         Ok(Self { path })
     }
 

--- a/rust/affected-services/tests/integration.rs
+++ b/rust/affected-services/tests/integration.rs
@@ -6,6 +6,7 @@ use affected_services::images::{
     build_binary_to_crate_map, parse_images_yaml, ImageConfig, NON_CRATE_IMAGE_TRIGGERS,
 };
 use guppy::graph::PackageGraph;
+use rstest::rstest;
 
 fn load_test_fixtures() -> (PackageGraph, Vec<ImageConfig>) {
     let repo_root = find_repo_root().expect("must be in a git repo");
@@ -287,6 +288,50 @@ fn multi_binary_crate_produces_all_images() {
     assert!(!result.rebuild_all);
     assert!(result.images.contains(&"feature-flags".into()));
     assert!(result.images.contains(&"flags-cache-warmer".into()));
+}
+
+// ── Path-rule ordering tests ─────────────────────────────────────
+
+#[rstest]
+#[case::hypercache_rule_fires_before_catch_all(
+    "posthog/api/feature_flag.py",
+    false,
+    &["feature-flags", "hypercache-server", "common-hypercache"],
+)]
+#[case::catch_all_ignores_unrelated_non_rust_files(
+    "frontend/src/foo.tsx",
+    false,
+    &[],
+)]
+#[case::ci_harness_change_triggers_rebuild_all(
+    ".github/workflows/ci-rust.yml",
+    true,
+    &[],
+)]
+fn path_rule_ordering(
+    #[case] file: &str,
+    #[case] expect_rebuild_all: bool,
+    #[case] expect_crates: &[&str],
+) {
+    let (graph, images) = load_test_fixtures();
+    let result = compute_affected(&[file.into()], None, &graph, &images).unwrap();
+    assert_eq!(
+        result.rebuild_all, expect_rebuild_all,
+        "rebuild_all mismatch for {file}"
+    );
+    if !expect_rebuild_all {
+        let crates: HashSet<&str> = result.crates.iter().map(|s| s.as_str()).collect();
+        if expect_crates.is_empty() {
+            assert!(
+                crates.is_empty(),
+                "expected no crates for {file}, got {crates:?}"
+            );
+        } else {
+            for name in expect_crates {
+                assert!(crates.contains(name), "{file} should mark {name} affected");
+            }
+        }
+    }
 }
 
 // ── Determinator two-graph tests ─────────────────────────────────


### PR DESCRIPTION
## Problem

The rust selective builds CI flow had some issues causing `rebuild_all=true` more often than necessary:

non-rust file changes were triggering full rebuilds. If a change included any non-rust files outside of the ones defined in the determinator-rules.toml dir and it contained one rust change, we would trigger a rebuild_all.

adding a sparse checkout to the `affected` job was breaking the two graph comparison: we need to ensure the sparse checkout gets args around which directories to checkout when running its job, otherwise it checks out nothing, and our two graph comparison job fails and we fall back to building all

The PR base SHA (github.event.pull_request.base.sha) points to the tip of master at the time the PR was opened or last synchronized, not the current tip. For long-lived PRs, master moves forward and the diff between the stale SHA and HEAD includes unrelated master commit...

And we had a slow checkout being done in one of the workflows/actions because we weren't using checkout sparse


## Changes

- `rust/affected-services/determinator-rules.toml`: Added a `../**` catch-all path rule (`mark-changed = []`) that ignores all files outside the rust workspace. Placed after the specific `../proto/**` and `../.github/rust-images.yml` rules so those still trigger their intended behavior.

- `rust/affected-services/src/graph.rs`: specifies the `/rust/` directory as a path to checkout during the sparse checkout in the graph.rs computation

- `.github/workflows/ci-rust.yml`: Added sparse checkout config to the `affected` job's checkout step, matching `rust-docker-build.yml`. Cuts checkout time from 3ish mins to 20 secs


- the action now fetches the current tip of the base branch and computes git merge-base against it, so the diff only contains the PR's own changes. This matches the pattern used by other workflows in the repo)


## How did you test this code?

Tested iteratively on a PR branch with various change combinations