### PR TITLE
fix(devex): clear stale vite optimize cache when deps change

### DIFF
--- a/bin/start-frontend
+++ b/bin/start-frontend
@@ -12,4 +12,20 @@ export DEBUG=0
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 pnpm --filter=@posthog/frontend... install
+
+# Vite pre-bundles dependencies into frontend/node_modules/.vite, keyed on the lockfile.
+# When you switch to a branch whose deps differ, the leftover cache makes Vite re-optimize
+# lazily on the first browser request, which can blank the page with a 504 "Outdated
+# Optimize Dep" until a hard reload. Drop the cache only when the lockfile (or vite config)
+# actually changed, so Vite re-optimizes once, cleanly, at startup instead of mid-load.
+# No-op on the common restart where deps are unchanged.
+vite_cache="frontend/node_modules/.vite"
+deps_hash_file="frontend/.cache/vite-deps.hash"
+deps_hash="$(git hash-object pnpm-lock.yaml frontend/vite.config.mts 2>/dev/null | tr -d '\n')"
+if [ -n "$deps_hash" ] && [ -d "$vite_cache" ] && [ "$(cat "$deps_hash_file" 2>/dev/null)" != "$deps_hash" ]; then
+    echo "[start-frontend] deps changed since last start — clearing stale Vite optimize cache"
+    rm -rf "$vite_cache"
+fi
+[ -n "$deps_hash" ] && mkdir -p "$(dirname "$deps_hash_file")" && printf '%s' "$deps_hash" >"$deps_hash_file"
+
 bin/turbo --filter=@posthog/frontend start-vite


### PR DESCRIPTION
## Problem

Switching to a branch whose dependencies differ and restarting the dev stack can blank the page, with the console showing `504 (Outdated Optimize Dep)` for a pre-bundled chunk. Restarting the `frontend` process doesn't help; only a hard reload (after retries) recovers. It happens most going from a branch up to date with master to one behind it.

Root cause: `bin/start-frontend` leaves Vite's `node_modules/.vite` dep cache in place across restarts. When the lockfile changed, Vite defers re-optimization to the **first browser request** and then fires a full reload — the browser is mid-load when the optimized-dep `?v=` hashes flip, so in-flight chunk requests `504`. A leftover *stale* cache is worse than none: with no cache Vite re-optimizes eagerly at startup, before the browser connects.

## Changes

In `bin/start-frontend`, after `pnpm install`: hash `pnpm-lock.yaml` + `frontend/vite.config.mts`, compare to the value recorded at the last start (`frontend/.cache/vite-deps.hash`), and `rm -rf node_modules/.vite` only when it changed. Vite then re-optimizes **once, cleanly, at startup** instead of lazily mid-load.

- No-op on the common restart where deps are unchanged.
- Keyed on the lockfile, **not** the branch tip — branch tips move without changing deps, so HEAD-keying would clear the cache (and eat a full re-optimize) on every switch for nothing.

## How did you test this code?

I'm an agent (Claude Code). Verified empirically, not through the full UI:

- **Mechanism, measured:** with a stale cache the first page load after a branch-switch restart blocks ~2 s on a lazy `[vite] (client) Re-optimizing` event; with the cache cleared, Vite optimizes eagerly at startup and the first load is ~25 ms with **0** churn events.
- **Logic, unit-tested 5/5:** unchanged→keep, changed→clear, fresh checkout→keep, first-adoption→one-time clear, git-unavailable→safe no-op.
- **Integrated:** simulated prior start → branch switch + `pnpm install` → ran the block → it detected the change, cleared the cache, and Vite did a clean eager optimize (0 `(client) Re-optimizing`).

Caveat: in an isolated harness the branch-switch flow self-heals on its own, so this is a robustness + startup-timing improvement (it should matter under a real, loaded `hogli start`); I did not reproduce the persistent blank itself. An already-open tab still needs one reload — inherent to content-hashed deps.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs; dev-environment change only.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Raúl's direction. Reproduced the 504 mechanism in an isolated worktree, then evaluated two fixes:

- First tried `server.warmup` (move the re-optimize to startup via a synthetic request). Rejected after testing — it keeps the stale cache and relies on Vite's flaky lazy invalidation path.
- **Chosen:** conditional `rm -rf node_modules/.vite` keyed on the lockfile hash. Gives Vite a clean slate (the widely-used `rm -rf node_modules/.vite` remedy), runs only when deps changed, and lives exactly where the original report suggested (`hogli start` / `bin/start-frontend`).

Also rejected: a flox activation hook (flox activation is cached and won't fire on `git checkout`), and unconditional clearing / `optimizeDeps.force` on every start (slow every start, and forcing re-optimization is itself a documented cause of the same 504 race).

(Branch name `rauln/vite-warmup-optimize-dep` predates the pivot and is now cosmetically stale.)
