### PR TITLE
feat(slack-app): register SlackChannel in Django admin

### DIFF
--- a/products/slack_app/backend/admin.py
+++ b/products/slack_app/backend/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import SlackSettings, SlackThreadTaskMapping, SlackUserProfileCache
+from .models import SlackChannel, SlackSettings, SlackThreadTaskMapping, SlackUserProfileCache
 
 
 @admin.register(SlackSettings)
@@ -68,6 +68,39 @@ class SlackThreadTaskMappingAdmin(admin.ModelAdmin):
             {"fields": ("slack_workspace_id", "channel", "thread_ts", "mentioning_slack_user_id")},
         ),
         ("Task", {"fields": ("task", "task_run")}),
+        ("Dates", {"fields": ("created_at", "updated_at")}),
+    )
+
+
+@admin.register(SlackChannel)
+class SlackChannelAdmin(admin.ModelAdmin):
+    list_select_related = ("approved_by",)
+    list_display = (
+        "id",
+        "slack_workspace_id",
+        "slack_channel_id",
+        "approved_at",
+        "approved_by",
+        "created_at",
+        "updated_at",
+    )
+    list_filter = (
+        "slack_workspace_id",
+        ("approved_at", admin.DateFieldListFilter),
+        ("created_at", admin.DateFieldListFilter),
+    )
+    search_fields = (
+        "slack_workspace_id",
+        "slack_channel_id",
+        "approved_by__email",
+    )
+    autocomplete_fields = ("approved_by",)
+    readonly_fields = ("id", "created_at", "updated_at")
+    ordering = ("-updated_at",)
+
+    fieldsets = (
+        (None, {"fields": ("id", "slack_workspace_id", "slack_channel_id")}),
+        ("Approval", {"fields": ("approved_at", "approved_by")}),
         ("Dates", {"fields": ("created_at", "updated_at")}),
     )
 


### PR DESCRIPTION
## Problem

The `SlackChannel` model tracks per-(workspace, channel) approval state for the Slack bot answering in externally-shared channels, but it had no Django admin entry — so support/eng had no UI to inspect or audit approvals.

## Changes

Register `SlackChannel` with `admin.ModelAdmin`. Follows the same shape as the other Slack admins in `products/slack_app/backend/admin.py`:

- `list_display` covers workspace, channel, approval timestamp + approver, and timestamps
- `list_filter` on workspace + date filters for `approved_at` / `created_at`
- `search_fields` on workspace ID, channel ID, and approver email
- `autocomplete_fields` for `approved_by` to avoid loading the full user table
- `list_select_related` on `approved_by`
- Read-only `id`, `created_at`, `updated_at`

## How did you test this code?

Agent-authored. No automated tests added — this is a Django admin registration with no behavior beyond what `ModelAdmin` already provides. Ran `ruff format` and `ruff check` on the modified file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Mirrored the existing pattern in `products/slack_app/backend/admin.py` (`SlackSettingsAdmin`, `SlackUserProfileCacheAdmin`) for field selection and `autocomplete_fields` to avoid the unbounded `<select>` widget warned about in the repo's admin conventions.