### PR TITLE
feat(replay): keep trigger groups on v2 when last group deleted

### DIFF
--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
@@ -10,7 +10,6 @@ import {
     LemonModal,
     LemonSelect,
     LemonSnack,
-    LemonTag,
 } from '@posthog/lemon-ui'
 
 import { FlagSelector } from 'lib/components/FlagSelector'
@@ -83,6 +82,7 @@ export function TriggerGroupsEditor(): JSX.Element {
         previewLegacyGroups,
         _savingStateLoading,
         shouldShowMigrationBanner,
+        hasLegacyTriggers,
     } = useValues(replayTriggersV2Logic)
     const {
         addTriggerGroup,
@@ -135,7 +135,7 @@ export function TriggerGroupsEditor(): JSX.Element {
                 </div>
                 {!isAddingGroup && !editingGroupId && (
                     <div className="flex gap-2">
-                        {triggerGroups.length === 0 && (
+                        {hasLegacyTriggers && (
                             <LemonButton
                                 type="secondary"
                                 size="small"
@@ -537,79 +537,18 @@ interface DeleteLastGroupModalProps {
 }
 
 function DeleteLastGroupModal({ isOpen, onClose, onConfirm, groupName }: DeleteLastGroupModalProps): JSX.Element {
-    const { legacyTriggersPreview } = useValues(replayTriggersV2Logic)
-
-    const { sampleRate, minDurationMs, matchType, urls, events, flag, hasConditions } = legacyTriggersPreview
-
     return (
         <LemonModal isOpen={isOpen} onClose={onClose} title="Delete last trigger group?">
             <div className="space-y-4">
                 <p>
-                    Deleting "{groupName}" will remove all trigger groups and your project will revert to using{' '}
-                    <strong>legacy recording triggers</strong>.
+                    "{groupName}" is your only trigger group. Deleting it will replace it with a default group that{' '}
+                    <strong>records all sessions</strong>, so your project keeps using trigger groups.
                 </p>
 
                 <p className="text-sm text-muted">
-                    Your project will immediately use the following legacy trigger configuration:
+                    To record a subset of sessions instead, edit the group's conditions or sample rate rather than
+                    deleting it. To stop recording entirely, disable session recording in General settings.
                 </p>
-
-                <div className="border rounded p-3 bg-surface-primary">
-                    {hasConditions ? (
-                        <>
-                            <div className="mb-2">
-                                <span className="text-sm">
-                                    Match <b>sessions</b> against{' '}
-                                    <LemonTag type="success" className="uppercase">
-                                        {matchType}
-                                    </LemonTag>{' '}
-                                    criteria
-                                </span>
-                            </div>
-
-                            {/* Conditions */}
-                            <div className="space-y-2 text-sm mb-3">
-                                {urls.length > 0 && (
-                                    <div className="flex items-center gap-2 flex-wrap">
-                                        <span className="text-muted">User has visited URL matching pattern</span>
-                                        {urls.map((u) => (
-                                            <LemonSnack key={u.url}>{u.url}</LemonSnack>
-                                        ))}
-                                    </div>
-                                )}
-                                {events.length > 0 && (
-                                    <div className="flex items-center gap-2 flex-wrap">
-                                        <span className="text-muted">Event</span>
-                                        {events.map((event) => (
-                                            <LemonSnack key={event}>{event}</LemonSnack>
-                                        ))}
-                                        <span className="text-muted">occurred</span>
-                                    </div>
-                                )}
-                                {flag && (
-                                    <div className="flex items-center gap-2 flex-wrap">
-                                        <span className="text-muted">Feature flag</span>
-                                        <LemonSnack>{typeof flag === 'string' ? flag : flag.key}</LemonSnack>
-                                        <span className="text-muted">is enabled</span>
-                                    </div>
-                                )}
-                            </div>
-                        </>
-                    ) : null}
-
-                    {/* Sample rate - always shown */}
-                    <div className="flex items-center gap-2 text-sm">
-                        <span className="text-muted">Sample</span>
-                        <span className="font-semibold">{Math.round(sampleRate * 100)}%</span>
-                        <span className="text-muted">of all sessions</span>
-                    </div>
-
-                    {/* Minimum duration */}
-                    {minDurationMs !== undefined && minDurationMs !== null && minDurationMs > 0 && (
-                        <div className="text-sm text-muted mt-3">
-                            Minimum duration: <b>{minDurationMs / 1000}</b> seconds
-                        </div>
-                    )}
-                </div>
 
                 <div className="flex justify-end gap-2 pt-2 border-t">
                     <LemonButton type="secondary" onClick={onClose}>
@@ -621,7 +560,7 @@ function DeleteLastGroupModal({ isOpen, onClose, onConfirm, groupName }: DeleteL
                         onClick={onConfirm}
                         data-attr="trigger-group-delete-last-confirm"
                     >
-                        Delete and use legacy trigger settings
+                        Delete and record all sessions
                     </LemonButton>
                 </div>
             </div>

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.test.ts
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.test.ts
@@ -2,6 +2,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { teamLogic } from 'scenes/teamLogic'
 
+import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import { replayTriggersV2Logic } from './replayTriggersV2Logic'
@@ -10,6 +11,11 @@ describe('replayTriggersV2Logic', () => {
     let logic: ReturnType<typeof replayTriggersV2Logic.build>
 
     beforeEach(() => {
+        useMocks({
+            patch: {
+                'api/environments/:id': (req) => [200, { id: 1, ...(req.body as Record<string, any>) }],
+            },
+        })
         initKeaTests()
         logic = replayTriggersV2Logic()
         logic.mount()
@@ -132,6 +138,68 @@ describe('replayTriggersV2Logic', () => {
                 } as any)
             }).toMatchValues({
                 previewLegacyGroups: expected,
+            })
+        })
+    })
+
+    describe('deleteTriggerGroup stays on V2', () => {
+        it('deleting the only group replaces it with a record-everything group', async () => {
+            logic.actions.setTriggerGroupsConfig({
+                version: 2,
+                groups: [
+                    {
+                        id: 'group-1',
+                        name: 'Checkout',
+                        sampleRate: 0.5,
+                        conditions: { matchType: 'all', urls: [{ url: '^/checkout$', matching: 'regex' }] },
+                    },
+                ],
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.deleteTriggerGroup('group-1')
+            }).toMatchValues({
+                triggerGroupsConfig: {
+                    version: 2,
+                    groups: [
+                        {
+                            id: expect.any(String),
+                            name: 'Record all sessions',
+                            sampleRate: 1,
+                            conditions: { matchType: 'all' },
+                        },
+                    ],
+                },
+            })
+        })
+
+        it('deleting one of several groups keeps the rest', async () => {
+            const group2 = {
+                id: 'group-2',
+                name: 'Signup',
+                sampleRate: 1,
+                conditions: { matchType: 'all' as const, events: [{ name: 'signed_up' }] },
+            }
+            logic.actions.setTriggerGroupsConfig({
+                version: 2,
+                groups: [
+                    {
+                        id: 'group-1',
+                        name: 'Checkout',
+                        sampleRate: 0.5,
+                        conditions: { matchType: 'all', urls: [{ url: '^/checkout$', matching: 'regex' }] },
+                    },
+                    group2,
+                ],
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.deleteTriggerGroup('group-1')
+            }).toMatchValues({
+                triggerGroupsConfig: {
+                    version: 2,
+                    groups: [group2],
+                },
             })
         })
     })

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.ts
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.ts
@@ -6,13 +6,25 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import {
     EventTriggerConfig,
-    LinkedFeatureFlag,
     SessionRecordingTriggerGroup,
     SessionRecordingTriggerGroupsConfig,
-    UrlTriggerConfig,
 } from '~/lib/components/IngestionControls/types'
 
 import type { replayTriggersV2LogicType } from './replayTriggersV2LogicType'
+
+/**
+ * A conditionless group at 100% sample rate matches every session, so it's the explicit "record
+ * everything" state in V2. We keep teams on this rather than dropping to zero groups (which would
+ * fall back to legacy V1 config) so V2 stays the source of truth.
+ */
+export function buildRecordEverythingGroup(): SessionRecordingTriggerGroup {
+    return {
+        id: uuid(),
+        name: 'Record all sessions',
+        sampleRate: 1,
+        conditions: { matchType: 'all' },
+    }
+}
 
 export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
     path(['lib', 'components', 'IngestionControls', 'triggers', 'triggerGroups', 'replayTriggersV2Logic']),
@@ -91,9 +103,12 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
                     if (!state) {
                         return state
                     }
+                    const groups = state.groups.filter((g) => g.id !== id)
+                    // Stay on V2 when the last group is removed: a record-everything group keeps the
+                    // team on trigger groups (record all) instead of falling back to legacy V1 config.
                     return {
                         ...state,
-                        groups: state.groups.filter((g) => g.id !== id),
+                        groups: groups.length === 0 ? [buildRecordEverythingGroup()] : groups,
                     }
                 },
                 updateTriggerGroup: (state, { id, updates }) => {
@@ -253,34 +268,6 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
                         },
                     },
                 ]
-            },
-        ],
-        legacyTriggersPreview: [
-            (s) => [s.currentTeam],
-            (
-                team
-            ): {
-                sampleRate: number
-                minDurationMs: number | undefined
-                matchType: 'any' | 'all'
-                urls: UrlTriggerConfig[]
-                events: string[]
-                flag: string | LinkedFeatureFlag | null
-                hasConditions: boolean
-            } => {
-                const sampleRate = team?.session_recording_sample_rate
-                    ? parseFloat(team.session_recording_sample_rate)
-                    : 1
-                const minDurationMs = team?.session_recording_minimum_duration_milliseconds ?? undefined
-                const matchType = team?.session_recording_trigger_match_type_config || 'all'
-                const urls = team?.session_recording_url_trigger_config || []
-                const events: string[] = (team?.session_recording_event_trigger_config || []).filter(
-                    (e): e is string => typeof e === 'string' && e.length > 0
-                )
-                const flag = team?.session_recording_linked_flag || null
-                const hasConditions = urls.length > 0 || events.length > 0 || !!flag
-
-                return { sampleRate, minDurationMs, matchType, urls, events, flag, hasConditions }
             },
         ],
     }),

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -399,12 +399,8 @@ export function ReplayTriggers(): JSX.Element {
                                 <strong>JavaScript SDK version compatibility</strong>
                                 <ul className="list-disc ml-4 mt-2 space-y-1">
                                     <li>
-                                        Older SDK versions (&lt; v{TRIGGER_GROUPS_MIN_SDK_VERSION}) will use the legacy
-                                        recording conditions below
-                                    </li>
-                                    <li>
-                                        Newer SDK versions (&gt;= v{TRIGGER_GROUPS_MIN_SDK_VERSION}) will use trigger
-                                        groups if configured, otherwise will fallback to the legacy recording conditions
+                                        SDK versions &gt;= v{TRIGGER_GROUPS_MIN_SDK_VERSION} use trigger groups if
+                                        configured, otherwise fall back to the legacy recording conditions
                                     </li>
                                     <li>
                                         Both configurations are sent to ensure backward compatibility with all


### PR DESCRIPTION
## Problem

Session replay's V2 trigger groups carry an overloaded "empty" state. A team is treated as "on V2" only while `session_recording_trigger_groups` is non-null, but the meaning of an empty/zero-group config was ambiguous:

- `null` → backend sends `version: 1` and the legacy fields (records everything via V1's permissive default).
- `{version: 2, groups: [...]}` → V2, conditional recording.
- `{version: 2, groups: []}` → a truthy dict, so the backend sent `version: 2` with **no** groups → the SDK recorded **nothing**. But the delete-last-group modal told the user it would "revert to legacy recording triggers." So deleting the last group was silently inconsistent with its own copy.

Because "no groups" was overloaded to mean "fall back to V1," a team that removed its last group was pushed back onto the V1 code path — which is exactly what keeps V1 impossible to retire. The settings UI also carried a verbose three-bullet V1/V2 compatibility banner that duplicated the dedicated "Legacy recording conditions" note below it.

## Changes

- **V2 stays sticky.** Deleting the last trigger group now replaces it with a conditionless 100% "record all sessions" group instead of leaving `{groups: []}` or dropping to `null`. Recording behavior is unchanged (record all), but the config stays in V2 (`version: 2`) so the legacy V1 fields become dead weight rather than something the team relies on. `{groups: []}` is never produced; `null` keeps meaning only "never adopted V2."
- **Delete-last-group modal reworked** to explain the project will record all sessions (via a default group) rather than "revert to legacy"; dropped the now-irrelevant legacy-config preview and the unused `legacyTriggersPreview` selector.
- **Trimmed the V1/V2 compatibility banner** — removed the redundant "Older SDK versions (< v{min}) will use the legacy recording conditions below" bullet, which duplicated the legacy-conditions banner directly beneath it.
- **Migrate-from-legacy button** now shows whenever legacy config exists (`hasLegacyTriggers`) rather than only when there are zero groups — otherwise, with sticky-delete keeping at least one group, the button would become permanently unreachable after adoption.

Backend changes to stop emitting the V1 fields once a team's posthog-js floor is ≥ the trigger-groups minimum are intentionally **out of scope** here (that needs SDK-version detection) and are a follow-up.

This is a frontend-only change; no backend, API, or schema changes.

## How did you test this code?

Clicked around -- deleting final group now gives a warning/placeholder group  
![Screenshot 2026-06-04 at 1.17.43 PM.png](https://app.graphite.com/user-attachments/assets/7205c2cd-bb90-409a-bd21-54157aa576cb.png)![Screenshot 2026-06-04 at 1.25.42 PM.png](https://app.graphite.com/user-attachments/assets/4d539193-a2db-4f70-931a-5b5aa444f19e.png)





- `replayTriggersV2Logic.test.ts` — extended with cases for the sticky delete: deleting the only group yields a single record-everything group (never `null`/`{groups: []}`); deleting one of several keeps the rest. **6/6 pass.**
- `tsc --noEmit` — clean for the changed files (kea logic types regenerated).
- `oxlint` + `oxfmt` — clean on the changed files.

Manual verification in the running app (banner copy, the "Record all sessions" modal flow, and confirming `session_recording_trigger_groups` stays `{version: 2, groups: [<record-all>]}` after deleting the last group) is still recommended before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). The work started as "only show V2 to teams that never used older SDKs," but during exploration we found the more impactful issue was the empty-state ambiguity in the V2 trigger-groups data model and its delete-last-group footgun.

Key decisions made along the way:

- Chose a no-new-state model: rather than adding an explicit "adopted V2" marker (DB migration + extra handling), the conditionless 100% group serves as the explicit "on V2, record all" state. Simpler and migration-free.
- Initially reverted delete-last-group to `null` (matching the old modal copy), but reversed course — that re-introduces the V1 dependency and works against retiring V1. Sticky-delete (convert to record-all stub) keeps the team on V2.
- Dropped a short-lived "Record everything" button in favor of relying on sticky-delete plus the always-reachable migrate button.

Agent-authored; requires human review.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)