### PR TITLE
feat(llma): move skills to standalone /skills product URL

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -189,8 +189,8 @@ export const productRoutes: Record<string, [string, string]> = {
     '/ai-evals/evaluations/:id': ['AIObservabilityEvaluation', 'aiObservabilityEvaluation'],
     '/prompt-management/prompts': ['AIObservabilityPrompts', 'aiObservabilityPrompts'],
     '/prompt-management/prompts/:name': ['AIObservabilityPrompt', 'aiObservabilityPrompt'],
-    '/prompt-management/skills': ['AIObservabilitySkills', 'aiObservabilitySkills'],
-    '/prompt-management/skills/:name': ['AIObservabilitySkill', 'aiObservabilitySkill'],
+    '/skills': ['AIObservabilitySkills', 'aiObservabilitySkills'],
+    '/skills/:name': ['AIObservabilitySkill', 'aiObservabilitySkill'],
     '/business-knowledge': ['BusinessKnowledge', 'businessKnowledge'],
     '/transformations': ['Transformations', 'transformations'],
     '/event-filtering': ['EventFiltering', 'eventFiltering'],
@@ -315,6 +315,10 @@ export const productRedirects: Record<
         combineUrl(urls.aiObservabilityTag(params.id), searchParams, hashParams).url,
     '/prompt-management': (_params, searchParams, hashParams) =>
         combineUrl(urls.aiObservabilityPrompts(), searchParams, hashParams).url,
+    '/prompt-management/skills': (_params, searchParams, hashParams) =>
+        combineUrl(urls.aiObservabilitySkills(), searchParams, hashParams).url,
+    '/prompt-management/skills/:name': (params, searchParams, hashParams) =>
+        combineUrl(urls.aiObservabilitySkill(params.name), searchParams, hashParams).url,
     '/llm-analytics': (_params, searchParams, hashParams) =>
         combineUrl(urls.aiObservabilityDashboard(), searchParams, hashParams).url,
     '/llm-analytics/settings': (_params, searchParams, hashParams) => {
@@ -845,14 +849,14 @@ export const productUrls = {
     aiObservabilityEvaluation: (id: string): string => `/ai-evals/evaluations/${id}`,
     aiObservabilityPrompts: (): string => '/prompt-management/prompts',
     aiObservabilityPrompt: (name: string): string => `/prompt-management/prompts/${name}`,
-    aiObservabilitySkills: (): string => '/prompt-management/skills',
+    aiObservabilitySkills: (): string => '/skills',
     aiObservabilitySkill: (
         name: string,
         params?: {
             file?: string
             version?: number
         }
-    ): string => combineUrl(`/prompt-management/skills/${name}`, params).url,
+    ): string => combineUrl(`/skills/${name}`, params).url,
     aiObservabilityClusters: (runId?: string): string =>
         runId ? `/ai-observability/clusters/${encodeURIComponent(runId)}` : '/ai-observability/clusters',
     aiObservabilityCluster: (runId: string, clusterId: number | string): string =>

--- a/products/ai_observability/frontend/aiObservabilityLogic.test.ts
+++ b/products/ai_observability/frontend/aiObservabilityLogic.test.ts
@@ -38,7 +38,7 @@ describe('LLM analytics URL split', () => {
         expect(urls.aiObservabilityTags()).toBe('/ai-evals/taggers')
         expect(urls.aiObservabilityEvaluations()).toBe('/ai-evals/evaluations')
         expect(urls.aiObservabilityPrompts()).toBe('/prompt-management/prompts')
-        expect(urls.aiObservabilitySkills()).toBe('/prompt-management/skills')
+        expect(urls.aiObservabilitySkills()).toBe('/skills')
     })
 
     it('redirects legacy LLM analytics URLs to their new product areas', () => {
@@ -63,9 +63,12 @@ describe('LLM analytics URL split', () => {
         expect(redirectUrl('/llm-analytics/prompts/:name', { name: 'prompt-1' })).toBe(
             '/prompt-management/prompts/prompt-1'
         )
-        expect(redirectUrl('/llm-analytics/skills/:name', { name: 'skill-1' })).toBe(
-            '/prompt-management/skills/skill-1'
-        )
+        expect(redirectUrl('/llm-analytics/skills/:name', { name: 'skill-1' })).toBe('/skills/skill-1')
+    })
+
+    it('redirects the legacy prompt-management skills URLs to the standalone skills product', () => {
+        expect(redirectUrl('/prompt-management/skills')).toBe('/skills')
+        expect(redirectUrl('/prompt-management/skills/:name', { name: 'skill-1' })).toBe('/skills/skill-1')
     })
 
     it('redirects AI observability settings to the project-level BYOK setting', () => {

--- a/products/ai_observability/frontend/skills/llmSkillLogic.ts
+++ b/products/ai_observability/frontend/skills/llmSkillLogic.ts
@@ -558,7 +558,7 @@ export const llmSkillLogic = kea<llmSkillLogicType>([
     }),
 
     tabAwareUrlToAction(({ actions, values }) => ({
-        '/prompt-management/skills/:name': (_, __, ___, { method }) => {
+        '/skills/:name': (_, __, ___, { method }) => {
             if (method === 'PUSH' && values.isNewSkill) {
                 actions.setSkill(DEFAULT_SKILL_FORM_VALUES)
                 actions.resetSkillForm(DEFAULT_SKILL_FORM_VALUES)

--- a/products/ai_observability/manifest.tsx
+++ b/products/ai_observability/manifest.tsx
@@ -181,8 +181,8 @@ export const manifest: ProductManifest = {
         '/ai-evals/evaluations/:id': ['AIObservabilityEvaluation', 'aiObservabilityEvaluation'],
         '/prompt-management/prompts': ['AIObservabilityPrompts', 'aiObservabilityPrompts'],
         '/prompt-management/prompts/:name': ['AIObservabilityPrompt', 'aiObservabilityPrompt'],
-        '/prompt-management/skills': ['AIObservabilitySkills', 'aiObservabilitySkills'],
-        '/prompt-management/skills/:name': ['AIObservabilitySkill', 'aiObservabilitySkill'],
+        '/skills': ['AIObservabilitySkills', 'aiObservabilitySkills'],
+        '/skills/:name': ['AIObservabilitySkill', 'aiObservabilitySkill'],
     },
     redirects: {
         '/ai-observability': (_params, searchParams, hashParams) =>
@@ -213,6 +213,10 @@ export const manifest: ProductManifest = {
             combineUrl(urls.aiObservabilityTag(params.id), searchParams, hashParams).url,
         '/prompt-management': (_params, searchParams, hashParams) =>
             combineUrl(urls.aiObservabilityPrompts(), searchParams, hashParams).url,
+        '/prompt-management/skills': (_params, searchParams, hashParams) =>
+            combineUrl(urls.aiObservabilitySkills(), searchParams, hashParams).url,
+        '/prompt-management/skills/:name': (params, searchParams, hashParams) =>
+            combineUrl(urls.aiObservabilitySkill(params.name), searchParams, hashParams).url,
         '/llm-analytics': (_params, searchParams, hashParams) =>
             combineUrl(urls.aiObservabilityDashboard(), searchParams, hashParams).url,
         '/llm-analytics/settings': (_params, searchParams, hashParams) => {
@@ -356,9 +360,9 @@ export const manifest: ProductManifest = {
         aiObservabilityEvaluation: (id: string): string => `/ai-evals/evaluations/${id}`,
         aiObservabilityPrompts: (): string => '/prompt-management/prompts',
         aiObservabilityPrompt: (name: string): string => `/prompt-management/prompts/${name}`,
-        aiObservabilitySkills: (): string => '/prompt-management/skills',
+        aiObservabilitySkills: (): string => '/skills',
         aiObservabilitySkill: (name: string, params?: { file?: string; version?: number }): string =>
-            combineUrl(`/prompt-management/skills/${name}`, params).url,
+            combineUrl(`/skills/${name}`, params).url,
         aiObservabilityClusters: (runId?: string): string =>
             runId ? `/ai-observability/clusters/${encodeURIComponent(runId)}` : '/ai-observability/clusters',
         aiObservabilityCluster: (runId: string, clusterId: number | string): string =>


### PR DESCRIPTION
## Problem

The Skills feature was nested under AI observability's prompt management, so it lived at `/prompt-management/skills/...` even though it already has its own product navigation entry, feature flag, and backend. The nested URL made it read as a sub-feature of prompt management rather than a standalone product.

## Changes

- Skills now lives at the top-level `/skills` and `/skills/:name` (previously `/prompt-management/skills` and `/prompt-management/skills/:name`).
- Added redirects from the old `/prompt-management/skills` and `/prompt-management/skills/:name` paths to the new URLs, so existing links and bookmarks keep working. The pre-existing `/llm-analytics/skills*` legacy redirects now resolve to `/skills` as well.
- Updated the URL helpers (`aiObservabilitySkills` / `aiObservabilitySkill`), routes, the `tabAwareUrlToAction` matcher in `llmSkillLogic`, and the regenerated `frontend/src/products.tsx`.

The implementation files remain under `products/ai_observability/` for now: the feature's generated frontend API client (`products/ai_observability/frontend/generated/`) is keyed to the backend viewset's location, so a full physical move into a new `products/skills/` directory would require relocating the Django app (with a model state-migration to preserve table names) and regenerating the OpenAPI + MCP clients. That can be done as a follow-up; this PR delivers the standalone top-level URL and product surface without that migration risk.

The Skills navigation tile, feature flag (`llm-analytics-skills`), and backend API (`/api/projects/:id/llm_skills/`) are unchanged.

## How did you test this code?

I'm an agent. I did not run the app or perform manual testing. I updated `products/ai_observability/frontend/aiObservabilityLogic.test.ts` to assert the new canonical URL and the new redirects, but I was unable to execute the Jest suite or regenerate `products.tsx` via `build-products.mjs` in this environment (no frontend `node_modules` / `oxfmt`). The generated `products.tsx` was edited by hand to mirror the manifest changes exactly; CI regenerates it deterministically from `products/ai_observability/manifest.tsx`. Please rely on CI for the frontend test + codegen verification.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference the old skills URL.

## 🤖 Agent context

Authored by the PostHog Code agent at the request of the maintainer, who asked to move Skills out of AI observability prompt management into its own standalone product at `/skills`.

Key decision: a clean physical `products/skills/` extraction is coupled to the backend because the per-product generated API client is produced from the viewset's Python module path. Moving the Django app would also require an OpenAPI/MCP regeneration that couldn't be verified in this sandbox (no `flox`/Django toolchain). I chose the lower-risk URL + navigation split — top-level `/skills` with redirects from the old paths — and documented the full backend extraction as a follow-up. The generated `frontend/src/products.tsx` was mirrored by hand from the manifest since the codegen couldn't run locally.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
