### PR TITLE
fix(hobby): enable zookeeper autopurge for transaction logs

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -60,6 +60,9 @@ services:
             file: docker-compose.base.yml
             service: zookeeper
         logging: *default-logging
+        environment:
+            ZOO_AUTOPURGE_PURGEINTERVAL: 1
+            ZOO_AUTOPURGE_SNAPRETAINCOUNT: 3
         volumes:
             - zookeeper-datalog:/datalog
             - zookeeper-data:/data


### PR DESCRIPTION
this cleared 20GB from my hobby instance that i can now use to store sweet sweet pageview events

----

## Problem

ZooKeeper's `autopurge` is off by default and the hobby compose stack never enables it, so ZooKeeper keeps every transaction log and snapshot indefinitely. ClickHouse uses ZooKeeper for table coordination, so on a long-running self-hosted hobby install the `zookeeper-datalog` volume grows without bound. Left unchecked it can fill the host disk — at which point ClickHouse, Postgres, Kafka and the rest of the stack can no longer write and the deployment goes down. Nothing caps these logs or surfaces the growth today.

## Changes

Enable ZooKeeper's built-in auto-purge on the hobby `zookeeper` service:

- `ZOO_AUTOPURGE_PURGEINTERVAL: 1` — run the purge hourly
- `ZOO_AUTOPURGE_SNAPRETAINCOUNT: 3` — keep the 3 most recent snapshots plus the transaction logs needed to restore them, delete the rest

Scoped to `docker-compose.hobby.yml` (not the shared base service) since that's the deployment where data persists long enough to matter. Mirrors the bounded-retention already configured for the neighbouring `kafka` service.

## How did you test this code?

I'm an agent (PostHog Code) and did not run the hobby stack in CI. I validated `docker-compose.hobby.yml` parses and the `zookeeper` service renders the new `environment` block, and confirmed these are the official `zookeeper` image's documented variables (they map to `autopurge.purgeInterval` / `autopurge.snapRetainCount` in the generated `zoo.cfg`). For context, the underlying cleanup — ZooKeeper's `PurgeTxnLog` keeping the 3 most recent snapshots — was run manually against a live self-hosted hobby instance and safely reclaimed the accumulated logs; these env vars make ZooKeeper run that same purge automatically. No automated test is added (no test harness exists for the hobby compose stack; one-line config change).

## 🤖 Agent context

Authored with PostHog Code (Claude Opus), out of debugging a self-hosted hobby install that had run out of disk — the dominant consumer was an unbounded `zookeeper-datalog` volume, traced to autopurge being disabled.

- Scoped to `docker-compose.hobby.yml` rather than the shared base (also extended by dev/sandbox/multinode) to keep the blast radius on long-lived single-node installs.
- Matched the existing `kafka` conventions in the same file (unquoted numeric env values, `environment` before `volumes`).
- `SNAPRETAINCOUNT=3` is ZooKeeper's documented minimum; `PURGEINTERVAL=1` (hourly) keeps the volume bounded with negligible overhead.

Agent-authored; requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
