### PR TITLE
CLOSED

### DIFF
--- a/frontend/src/lib/components/QuickFilters/QuickFiltersSection.tsx
+++ b/frontend/src/lib/components/QuickFilters/QuickFiltersSection.tsx
@@ -1,12 +1,12 @@
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { QuickFilterSelector, quickFiltersLogic } from 'lib/components/QuickFilters'
-
 import { QuickFilterContext } from '~/queries/schema/schema-general'
 import { QuickFilter } from '~/types'
 
 import { QuickFiltersConfigureButton } from './QuickFiltersConfigureButton'
+import { QuickFilterSelector } from './QuickFilterSelector'
+import { quickFiltersLogic } from './quickFiltersLogic'
 import { quickFiltersSectionLogic } from './quickFiltersSectionLogic'
 
 export interface QuickFiltersSectionProps {
@@ -21,6 +21,7 @@ export interface QuickFiltersSectionProps {
      * - `['id1', 'id2']`: show only filters with matching IDs
      */
     filterIds?: string[] | null
+    hideConfigureButton?: boolean
 }
 
 export function QuickFiltersSection({
@@ -28,6 +29,7 @@ export function QuickFiltersSection({
     logicKey,
     onNewFilterCreated,
     filterIds,
+    hideConfigureButton = false,
 }: QuickFiltersSectionProps): JSX.Element {
     const { quickFilters } = useValues(quickFiltersLogic({ context }))
     const { selectedQuickFilters } = useValues(quickFiltersSectionLogic({ context, logicKey }))
@@ -61,11 +63,13 @@ export function QuickFiltersSection({
                     />
                 )
             })}
-            <QuickFiltersConfigureButton
-                context={context}
-                onNewFilterCreated={onNewFilterCreated}
-                showLabel={quickFilters.length === 0}
-            />
+            {!hideConfigureButton ? (
+                <QuickFiltersConfigureButton
+                    context={context}
+                    onNewFilterCreated={onNewFilterCreated}
+                    showLabel={quickFilters.length === 0}
+                />
+            ) : null}
         </>
     )
 }

--- a/frontend/src/lib/components/QuickFilters/quickFiltersSectionLogic.ts
+++ b/frontend/src/lib/components/QuickFilters/quickFiltersSectionLogic.ts
@@ -2,12 +2,11 @@ import { actions, connect, kea, key, listeners, path, props, reducers } from 'ke
 import { actionToUrl, router, urlToAction } from 'kea-router'
 import posthog from 'posthog-js'
 
-import { quickFiltersLogic } from 'lib/components/QuickFilters'
-
 import { QuickFilterContext } from '~/queries/schema/schema-general'
 import { PropertyOperator, QuickFilterOption } from '~/types'
 
 import { QuickFiltersEvents } from './consts'
+import { quickFiltersLogic } from './quickFiltersLogic'
 import type { quickFiltersSectionLogicType } from './quickFiltersSectionLogicType'
 
 const QUICK_FILTERS_URL_PARAM = 'quick_filters'


### PR DESCRIPTION
## Problem

Tile filter bars need isolated QuickFilters logic instances per tile (restore + persist without clobbering dashboard-level filter state).

## Changes

- `quickFiltersSectionLogic`: stable `logicKey` for per-tile instances
- `QuickFiltersSection`: props needed for embedded tile bars

## How did you test this code?

Agent — did not manually test in the app.

- Relies on tile filter tests in PR 4; no dedicated test file in this PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

Stack 2/8. Depends on PR 1. UI-only plumbing for QuickFilters; no widget tile components yet.
