### PR TITLE
CLOSED

### DIFF
--- a/products/dashboards/frontend/widgetProductAccess.ts
+++ b/products/dashboards/frontend/widgetProductAccess.ts
@@ -16,3 +16,8 @@ export function userHasDashboardWidgetProductAccess(productAccess: DashboardWidg
     }
     return WIDGET_PRODUCT_ACCESS_CHECKS[productAccess]()
 }
+
+/** In-tile issue status/assignee edits: dashboard editor or Error tracking editor at project level. */
+export function userCanMutateErrorTrackingIssuesOnDashboard(canEditDashboard: boolean): boolean {
+    return canEditDashboard || userHasAccess(AccessControlResourceType.ErrorTracking, AccessControlLevel.Editor)
+}

--- a/products/dashboards/frontend/widgets/error_tracking/ErrorTrackingWidget.stories.tsx
+++ b/products/dashboards/frontend/widgets/error_tracking/ErrorTrackingWidget.stories.tsx
@@ -12,8 +12,11 @@ import {
     withErrorTrackingProjectState,
 } from '../../components/WidgetCard/widgetCardStoryFixtures'
 import { getDashboardWidgetCatalogEntry, getDashboardWidgetGroupLabel } from '../../widget_types/catalog'
+import { useWidgetAvailability } from '../../widget_types/widgetAvailability'
+import { DASHBOARD_WIDGET_TILE_FILTERS_READONLY_REASON } from '../constants'
 import type { DashboardWidgetComponentProps } from '../registry'
 import { ErrorTrackingWidget } from './ErrorTrackingWidget'
+import { ErrorTrackingWidgetTileFilters } from './ErrorTrackingWidgetTileFilters'
 
 const ERROR_TRACKING_CATALOG = getDashboardWidgetCatalogEntry('error_tracking_list')!
 const DEFAULT_CONFIG = ERROR_TRACKING_CATALOG.defaultConfig as Record<string, unknown>
@@ -23,6 +26,8 @@ type ErrorTrackingWidgetTileStoryProps = DashboardWidgetComponentProps & {
     description?: string
     showDescription?: boolean
     body?: ReactNode
+    /** When true, tile filter bar matches view-only dashboard access (no edit permissions). */
+    tileFiltersReadOnly?: boolean
 }
 
 function ErrorTrackingWidgetTileStory({
@@ -30,10 +35,12 @@ function ErrorTrackingWidgetTileStory({
     description = 'Track the most common errors affecting your users.',
     showDescription = true,
     body,
+    tileFiltersReadOnly = false,
     ...widgetProps
 }: ErrorTrackingWidgetTileStoryProps): JSX.Element {
     const widgetTypeLabel = getDashboardWidgetGroupLabel(ERROR_TRACKING_CATALOG.groupId)
     const defaultTitle = ERROR_TRACKING_CATALOG.headerTitle ?? ERROR_TRACKING_CATALOG.label
+    const { isAvailable: showTileFilters } = useWidgetAvailability(ERROR_TRACKING_CATALOG.availability)
 
     return (
         <WidgetCard className="h-full">
@@ -51,6 +58,14 @@ function ErrorTrackingWidgetTileStory({
                 shouldHideMoreButton={widgetCardShouldHideMoreButton(DashboardPlacement.Dashboard, false)}
                 moreButtonOverlay={mockMoreOverlay}
             />
+            {showTileFilters ? (
+                <ErrorTrackingWidgetTileFilters
+                    tileId={widgetProps.tileId}
+                    config={widgetProps.config}
+                    onUpdateConfig={tileFiltersReadOnly ? undefined : widgetProps.onUpdateConfig}
+                    disabledReason={tileFiltersReadOnly ? DASHBOARD_WIDGET_TILE_FILTERS_READONLY_REASON : undefined}
+                />
+            ) : null}
             <WidgetCardBody>{body ?? <ErrorTrackingWidget {...widgetProps} />}</WidgetCardBody>
         </WidgetCard>
     )
@@ -133,7 +148,33 @@ export default meta
 
 type Story = StoryObj<typeof ErrorTrackingWidgetTileStory>
 
-export const Populated: Story = {
+export const TileFiltersReadOnly: Story = {
+    decorators: [withErrorTrackingProjectState(true)],
+    args: {
+        title: 'Top issues',
+        config: {
+            ...DEFAULT_CONFIG,
+            status: 'resolved',
+            dateRange: { date_from: '-30d' },
+        },
+        tileFiltersReadOnly: true,
+        loading: false,
+        result: {
+            results: sampleIssues,
+            hasMore: true,
+            limit: 10,
+        },
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Tile filter bar when the viewer lacks dashboard edit access — filters shown as read-only values.',
+            },
+        },
+    },
+}
+
+export const Default: Story = {
     decorators: [withErrorTrackingProjectState(true)],
     args: {
         title: 'Top issues',

--- a/products/dashboards/frontend/widgets/error_tracking/ErrorTrackingWidget.test.tsx
+++ b/products/dashboards/frontend/widgets/error_tracking/ErrorTrackingWidget.test.tsx
@@ -52,11 +52,51 @@ describe('ErrorTrackingWidget', () => {
                 tileId={1}
                 config={{ limit: 10 }}
                 loading={false}
-                result={{ results: [issue], hasMore: true, limit: 10 }}
+                result={{ results: [issue], hasMore: false, limit: 10, totalCount: 1, totalCountCapped: false }}
             />
         )
 
         expect(screen.getByText('Issue list')).toBeInTheDocument()
+        expect(screen.getByText('1 of 1 issue')).toBeInTheDocument()
+    })
+
+    it('shows capped total in footer when more issues exist than the count cap', () => {
+        render(
+            <ErrorTrackingWidget
+                tileId={1}
+                config={{ limit: 1, status: 'active', dateRange: { date_from: '-7d' } }}
+                loading={false}
+                result={{ results: [issue], hasMore: true, limit: 1, totalCount: 25, totalCountCapped: true }}
+            />
+        )
+
+        expect(screen.getByText('1 of 25+ issues')).toBeInTheDocument()
+    })
+
+    it('shows lower-bound footer when hasMore and total count was not fetched', () => {
+        render(
+            <ErrorTrackingWidget
+                tileId={1}
+                config={{ limit: 1 }}
+                loading={false}
+                result={{ results: [issue], hasMore: true, limit: 1 }}
+            />
+        )
+
+        expect(screen.getByText('1+ issue')).toBeInTheDocument()
+    })
+
+    it('shows exact total in footer when hasMore and total is known', () => {
+        render(
+            <ErrorTrackingWidget
+                tileId={1}
+                config={{ limit: 1 }}
+                loading={false}
+                result={{ results: [issue], hasMore: true, limit: 1, totalCount: 4, totalCountCapped: false }}
+            />
+        )
+
+        expect(screen.getByText('1 of 4 issues')).toBeInTheDocument()
     })
 
     it('renders a celebratory empty state when there are no issues', () => {

--- a/products/dashboards/frontend/widgets/error_tracking/ErrorTrackingWidget.tsx
+++ b/products/dashboards/frontend/widgets/error_tracking/ErrorTrackingWidget.tsx
@@ -1,4 +1,4 @@
-import { useValues } from 'kea'
+import { BindLogic, useValues } from 'kea'
 import type { ReactNode } from 'react'
 
 import { Spinner } from '@posthog/lemon-ui'
@@ -15,16 +15,27 @@ import { ErrorTrackingIngestionPrompt } from 'products/error_tracking/frontend/c
 
 import { WidgetCardBodyMessage, WidgetCardContent } from '../../components/WidgetCard'
 import { WidgetCardProductIntroduction } from '../../components/WidgetCardProductIntroduction/WidgetCardProductIntroduction'
+import { formatWidgetListCountFooter } from '../constants'
 import type { DashboardWidgetComponentProps } from '../registry'
+import { parseErrorTrackingWidgetConfig } from './errorTrackingWidgetConfigValidation'
+import { errorTrackingWidgetLogic } from './errorTrackingWidgetLogic'
 import { canConfigureErrorTrackingWidgetIssues } from './utils'
 
 type ErrorTrackingWidgetResult = {
     results?: ErrorTrackingIssue[]
     hasMore?: boolean
     limit?: number
+    totalCount?: number
+    totalCountCapped?: boolean
 }
 
-export function ErrorTrackingWidget({ result, loading }: DashboardWidgetComponentProps): JSX.Element {
+export function ErrorTrackingWidget({
+    result,
+    loading,
+    config,
+    onRefreshData,
+    canMutateErrorTrackingIssues = false,
+}: DashboardWidgetComponentProps): JSX.Element {
     if (loading) {
         return (
             <WidgetCardContent>
@@ -35,7 +46,13 @@ export function ErrorTrackingWidget({ result, loading }: DashboardWidgetComponen
 
     return (
         <ErrorTrackingWidgetSetupGate>
-            <ErrorTrackingWidgetBody result={result} />
+            <BindLogic logic={errorTrackingWidgetLogic} props={{ onRefreshData }}>
+                <ErrorTrackingWidgetBody
+                    result={result}
+                    config={config}
+                    canMutateIssues={canMutateErrorTrackingIssues}
+                />
+            </BindLogic>
         </ErrorTrackingWidgetSetupGate>
     )
 }
@@ -70,9 +87,18 @@ function ErrorTrackingWidgetSetupGate({ children }: { children: ReactNode }): JS
     return <>{children}</>
 }
 
-function ErrorTrackingWidgetBody({ result }: { result: DashboardWidgetComponentProps['result'] }): JSX.Element {
+function ErrorTrackingWidgetBody({
+    result,
+    config,
+    canMutateIssues,
+}: {
+    result: DashboardWidgetComponentProps['result']
+    config: DashboardWidgetComponentProps['config']
+    canMutateIssues: boolean
+}): JSX.Element {
     const payload = result as ErrorTrackingWidgetResult | null | undefined
     const rows = payload?.results ?? []
+    const orderBy = parseErrorTrackingWidgetConfig(config).orderBy
 
     if (rows.length === 0) {
         return (
@@ -93,9 +119,22 @@ function ErrorTrackingWidgetBody({ result }: { result: DashboardWidgetComponentP
         )
     }
 
+    const footer =
+        rows.length > 0 ? (
+            <p className="text-xs text-muted m-0 text-center" data-attr="error-tracking-widget-count">
+                {formatWidgetListCountFooter(
+                    rows.length,
+                    payload?.totalCount,
+                    payload?.totalCountCapped,
+                    undefined,
+                    payload?.hasMore
+                )}
+            </p>
+        ) : undefined
+
     return (
-        <WidgetCardContent>
-            <ErrorTrackingIssueList issues={rows} />
+        <WidgetCardContent footer={footer}>
+            <ErrorTrackingIssueList issues={rows} orderBy={orderBy} canMutateIssues={canMutateIssues} />
         </WidgetCardContent>
     )
 }

--- a/products/dashboards/frontend/widgets/error_tracking/errorTrackingWidgetLogic.ts
+++ b/products/dashboards/frontend/widgets/error_tracking/errorTrackingWidgetLogic.ts
@@ -1,0 +1,30 @@
+import { connect, kea, listeners, path, props } from 'kea'
+
+import { issueActionsLogic } from 'products/error_tracking/frontend/components/IssueActions/issueActionsLogic'
+
+export type ErrorTrackingWidgetLogicProps = {
+    onRefreshData?: () => void
+}
+
+const ISSUE_METADATA_MUTATIONS_REFRESHING_TILE = new Set(['updateIssueStatus', 'updateIssueAssignee'])
+
+export const errorTrackingWidgetLogic = kea([
+    path(['products', 'dashboards', 'widgets', 'error_tracking', 'errorTrackingWidgetLogic']),
+
+    props({
+        onRefreshData: undefined,
+    } as ErrorTrackingWidgetLogicProps),
+
+    connect({
+        actions: [issueActionsLogic, ['mutationSuccess']],
+    }),
+
+    listeners(({ props }) => ({
+        [issueActionsLogic.actionTypes.mutationSuccess]: ({ mutationName }: { mutationName: string }) => {
+            if (!props.onRefreshData || !ISSUE_METADATA_MUTATIONS_REFRESHING_TILE.has(mutationName)) {
+                return
+            }
+            props.onRefreshData()
+        },
+    })),
+])


### PR DESCRIPTION
## Problem

Error tracking list tiles should support in-tile status/assignee changes when the viewer can edit the dashboard or has error tracking editor access.

## Changes

- `ErrorTrackingWidget` + `errorTrackingWidgetLogic` (debounced refresh wired in perf PR)
- `userCanMutateErrorTrackingIssuesOnDashboard` in `widgetProductAccess.ts`
- Stories/tests for tile filter + list behavior

## How did you test this code?

Agent — did not manually test in the app.

- `hogli test products/dashboards/frontend/widgets/error_tracking/ErrorTrackingWidget.test.tsx`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

Stack 4/7. Assumes tile filter bar (PR 3). List footer copy/throttle land in perf PR.
