### PR TITLE
CLOSED

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -44,6 +44,7 @@ import {
     findNewlyAddedWidgetTiles,
     WIDGET_CLIENT_TTL_MS,
 } from 'scenes/dashboard/widgetFetchUtils'
+import { createDashboardWidgetTileRefreshScheduler } from 'scenes/dashboard/widgetTileRefreshScheduler'
 import { dataThemeLogic } from 'scenes/dataThemeLogic'
 import { MaxContextInput, createMaxContextHelpers } from 'scenes/max/maxTypes'
 import { Scene } from 'scenes/sceneTypes'
@@ -265,6 +266,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
             forceRefresh?: boolean
         }) => payload,
         refreshDashboardWidgets: (payload: { tileIds: number[]; forceRefresh?: boolean }) => payload,
+        /** Debounced run_widgets refresh for a single tile (tile filters, in-tile issue metadata). */
+        scheduleRefreshDashboardWidgets: (tileId: number) => ({ tileId }),
         setWidgetRunResults: (results: Record<number, DashboardWidgetRunResultApi>) => ({ results }),
         setWidgetRefreshStatuses: (tileIds: number[], loading: boolean, error?: string | null) => ({
             tileIds,
@@ -735,7 +738,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             dashboardsModel.actions.updateDashboardSuccess(dashboard)
                         }
                         if (config !== undefined) {
-                            actions.refreshDashboardWidgets({ tileIds: [tile.id], forceRefresh: true })
+                            actions.scheduleRefreshDashboardWidgets(tile.id)
                         }
                         return null
                     } catch (e) {
@@ -1883,7 +1886,16 @@ export const dashboardLogic = kea<dashboardLogicType>([
             }
         },
         beforeUnmount: () => {
+            cache.widgetTileRefreshScheduler?.cancelAll()
             actions.abortAnyRunningQuery()
+        },
+        scheduleRefreshDashboardWidgets: ({ tileId }) => {
+            if (!cache.widgetTileRefreshScheduler) {
+                cache.widgetTileRefreshScheduler = createDashboardWidgetTileRefreshScheduler((id) =>
+                    actions.refreshDashboardWidgets({ tileIds: [id], forceRefresh: true })
+                )
+            }
+            cache.widgetTileRefreshScheduler.schedule(tileId)
         },
     })),
     sharedListeners(({ values, props, actions }) => ({

--- a/frontend/src/scenes/dashboard/widgetTileRefreshScheduler.ts
+++ b/frontend/src/scenes/dashboard/widgetTileRefreshScheduler.ts
@@ -1,0 +1,35 @@
+import { WIDGET_TILE_REFRESH_DEBOUNCE_MS } from '@posthog/products-dashboards/frontend/widgets/constants'
+
+export type DashboardWidgetTileRefreshScheduler = {
+    schedule: (tileId: number) => void
+    cancelAll: () => void
+}
+
+export function createDashboardWidgetTileRefreshScheduler(
+    refreshTile: (tileId: number) => void,
+    debounceMs: number = WIDGET_TILE_REFRESH_DEBOUNCE_MS
+): DashboardWidgetTileRefreshScheduler {
+    const timeouts = new Map<number, ReturnType<typeof setTimeout>>()
+
+    return {
+        schedule(tileId: number): void {
+            const existing = timeouts.get(tileId)
+            if (existing) {
+                clearTimeout(existing)
+            }
+            timeouts.set(
+                tileId,
+                setTimeout(() => {
+                    timeouts.delete(tileId)
+                    refreshTile(tileId)
+                }, debounceMs)
+            )
+        },
+        cancelAll(): void {
+            for (const timeout of timeouts.values()) {
+                clearTimeout(timeout)
+            }
+            timeouts.clear()
+        },
+    }
+}

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -101,6 +101,7 @@ from products.dashboards.backend.widget_layouts import (
     collect_dashboard_sm_layouts_for_dashboard,
     stack_widget_layout_at_bottom,
 )
+from products.dashboards.backend.widget_query_throttle import get_dashboard_widget_query_throttle_error
 from products.dashboards.backend.widget_registry import (
     EXPECTED_WIDGET_TYPES,
     SESSION_REPLAY_LIST_WIDGET_TYPE,
@@ -204,6 +205,7 @@ def _run_widget_query(
                 team,
                 work_item["config"],
                 user=work_item["user"],
+                include_total_count=False,
             )
             return {
                 "tile_id": tile_id,
@@ -2710,6 +2712,16 @@ class DashboardsViewSet(
                     "widget_type": widget.widget_type,
                     "result": None,
                     "error": scope_error,
+                }
+                continue
+
+            widget_throttle_error = get_dashboard_widget_query_throttle_error(request, self)
+            if widget_throttle_error:
+                results_by_id[tile_id] = {
+                    "tile_id": tile_id,
+                    "widget_type": widget.widget_type,
+                    "result": None,
+                    "error": widget_throttle_error,
                 }
                 continue
 

--- a/products/dashboards/backend/test/test_widget_query_throttle.py
+++ b/products/dashboards/backend/test/test_widget_query_throttle.py
@@ -1,0 +1,53 @@
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from products.dashboards.backend.widget_query_throttle import (
+    DashboardWidgetQueryBurstRateThrottle,
+    get_dashboard_widget_query_throttle_error,
+)
+
+
+class TestDashboardWidgetQueryThrottle(BaseTest):
+    def test_get_dashboard_widget_query_throttle_error_when_burst_blocks(self) -> None:
+        request = MagicMock()
+        view = MagicMock()
+        view.team_id = self.team.id
+
+        with patch(
+            "products.dashboards.backend.widget_query_throttle.is_rate_limit_enabled",
+            return_value=True,
+        ):
+            with patch(
+                "products.dashboards.backend.widget_query_throttle.DashboardWidgetQueryBurstRateThrottle.allow_request",
+                return_value=False,
+            ):
+                with patch(
+                    "products.dashboards.backend.widget_query_throttle.DashboardWidgetQueryBurstRateThrottle.wait",
+                    return_value=12,
+                ):
+                    with patch(
+                        "products.dashboards.backend.widget_query_throttle.DashboardWidgetQuerySustainedRateThrottle.allow_request",
+                        return_value=True,
+                    ):
+                        error = get_dashboard_widget_query_throttle_error(request, view)
+
+        self.assertEqual(error, "Rate limit exceeded. Expected available in 12 seconds.")
+
+    def test_dashboard_widget_burst_throttle_applies_to_session_users(self) -> None:
+        request = MagicMock()
+        request.user.is_authenticated = True
+        view = MagicMock()
+        view.team_id = self.team.id
+
+        with patch(
+            "products.dashboards.backend.widget_query_throttle.is_rate_limit_enabled",
+            return_value=True,
+        ):
+            with patch(
+                "products.dashboards.backend.widget_query_throttle.team_is_allowed_to_bypass_throttle",
+                return_value=False,
+            ):
+                throttle = DashboardWidgetQueryBurstRateThrottle()
+                allow = throttle.allow_request(request, view)
+
+        self.assertIsInstance(allow, bool)

--- a/products/dashboards/backend/widget_query_throttle.py
+++ b/products/dashboards/backend/widget_query_throttle.py
@@ -1,0 +1,47 @@
+"""Rate limits for dashboard run_widgets (ClickHouse-backed widget queries)."""
+
+from __future__ import annotations
+
+import time
+
+from posthog.rate_limit import PersonalApiKeyRateThrottle, is_rate_limit_enabled, team_is_allowed_to_bypass_throttle
+
+
+class DashboardWidgetQueryBurstRateThrottle(PersonalApiKeyRateThrottle):
+    """Per-team burst cap on dashboard widget data fetches (web session and API keys)."""
+
+    scope = "dashboard_widget_query_burst"
+    rate = "120/minute"
+
+    def allow_request(self, request, view) -> bool:
+        return self._allow_request_internal(request, view, personal_api_key_only=False)
+
+
+class DashboardWidgetQuerySustainedRateThrottle(PersonalApiKeyRateThrottle):
+    """Per-team sustained cap on dashboard widget data fetches."""
+
+    scope = "dashboard_widget_query_sustained"
+    rate = "600/hour"
+
+    def allow_request(self, request, view) -> bool:
+        return self._allow_request_internal(request, view, personal_api_key_only=False)
+
+
+def get_dashboard_widget_query_throttle_error(request, view) -> str | None:
+    """Return a client-facing error when dashboard widget query throttles would block this request."""
+    if not is_rate_limit_enabled(round(time.time() / 60)):
+        return None
+
+    team_id = PersonalApiKeyRateThrottle.safely_get_team_id_from_view(view)
+    if team_id is not None and team_is_allowed_to_bypass_throttle(team_id):
+        return None
+
+    for throttle_cls in (DashboardWidgetQueryBurstRateThrottle, DashboardWidgetQuerySustainedRateThrottle):
+        throttle = throttle_cls()
+        if throttle.allow_request(request, view):
+            continue
+        wait = throttle.wait()
+        if wait:
+            return f"Rate limit exceeded. Expected available in {wait} seconds."
+        return "Rate limit exceeded. Try again later."
+    return None

--- a/products/dashboards/frontend/widgets/constants.test.ts
+++ b/products/dashboards/frontend/widgets/constants.test.ts
@@ -1,0 +1,34 @@
+import { formatWidgetListCountFooter, WIDGET_LIST_COUNT_RECORDINGS } from './constants'
+
+describe('formatWidgetListCountFooter', () => {
+    it('formats exact totals for issues', () => {
+        expect(formatWidgetListCountFooter(1, 1, false)).toBe('1 of 1 issue')
+        expect(formatWidgetListCountFooter(3, 12, false)).toBe('3 of 12 issues')
+    })
+
+    it('formats capped totals for issues', () => {
+        expect(formatWidgetListCountFooter(1, 25, true)).toBe('1 of 25+ issues')
+    })
+
+    it('falls back when total is missing', () => {
+        expect(formatWidgetListCountFooter(2, undefined)).toBe('2 issues')
+    })
+
+    it('shows lower-bound style footer when hasMore and total is omitted', () => {
+        expect(formatWidgetListCountFooter(10, undefined, undefined, undefined, true)).toBe('10+ issues')
+        expect(formatWidgetListCountFooter(1, undefined, undefined, undefined, true)).toBe('1+ issue')
+    })
+
+    it('formats exact totals for recordings', () => {
+        expect(formatWidgetListCountFooter(1, 1, false, WIDGET_LIST_COUNT_RECORDINGS)).toBe('1 of 1 recording')
+        expect(formatWidgetListCountFooter(3, 12, false, WIDGET_LIST_COUNT_RECORDINGS)).toBe('3 of 12 recordings')
+    })
+
+    it('formats capped totals for recordings', () => {
+        expect(formatWidgetListCountFooter(2, 25, true, WIDGET_LIST_COUNT_RECORDINGS)).toBe('2 of 25+ recordings')
+    })
+
+    it('falls back for recordings when total is missing', () => {
+        expect(formatWidgetListCountFooter(2, undefined, undefined, WIDGET_LIST_COUNT_RECORDINGS)).toBe('2 recordings')
+    })
+})

--- a/products/dashboards/frontend/widgets/constants.ts
+++ b/products/dashboards/frontend/widgets/constants.ts
@@ -6,6 +6,9 @@ export const WIDGET_LIST_ORDER_DIRECTION_OPTIONS = [
     { value: 'ASC', label: 'Ascending' },
 ] as const
 
+/** Debounce tile config PATCH → run_widgets refresh to avoid query storms while scrubbing filters. */
+export const WIDGET_TILE_REFRESH_DEBOUNCE_MS = 500
+
 /** Shown on widget tile filter controls when the viewer cannot edit the dashboard. */
 export const DASHBOARD_WIDGET_TILE_FILTERS_READONLY_REASON =
     "You don't have edit permissions for this dashboard. Ask a dashboard collaborator with edit access to add you."


### PR DESCRIPTION
## Problem

Scrubbing tile filters and refreshing many list widgets can spam ClickHouse and `run_widgets`; capped total-count queries are wasted when the page already has `hasMore`.

## Changes

- `widget_query_throttle.py` (per-team burst/sustained on `run_widgets`; replay listing throttle unchanged)
- Dashboard `run_widgets`: `include_total_count=False`; debounced tile refresh via `widgetTileRefreshScheduler` + `WIDGET_TILE_REFRESH_DEBOUNCE_MS`
- `formatWidgetListCountFooter` + `hasMore` → `N+` copy in `constants.ts`
- List `run_*` accept `include_total_count`; tests for throttle + skip count

## How did you test this code?

Agent — did not manually test in the app.

- `hogli test products/dashboards/backend/test/test_widget_query_throttle.py`
- `hogli test products/dashboards/backend/api/test/test_run_widgets.py`
- `hogli test products/dashboards/frontend/widgets/constants.test.ts`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

Stack 5/6. Perf/security follow-up after filter UX ships.
