### PR TITLE
chore(property-vals): remove unused event name stamping and emitting

### DIFF
--- a/rust/property-vals-rs/src/aggregator.rs
+++ b/rust/property-vals-rs/src/aggregator.rs
@@ -48,7 +48,6 @@ mod tests {
             property_type: PropertyType::Event,
             property_key: key.to_string(),
             property_value: value.to_string(),
-            event_name: String::new(),
         }
     }
 
@@ -66,9 +65,8 @@ mod tests {
             property_type in arb_property_type(),
             property_key in "[a-c]{1,3}",
             property_value in "[x-z]{1,3}",
-            event_name in "[a-b]{0,2}",
         ) -> TupleKey {
-            TupleKey { team_id, property_type, property_key, property_value, event_name }
+            TupleKey { team_id, property_type, property_key, property_value }
         }
     }
 

--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -48,12 +48,6 @@ pub struct Config {
     #[envconfig(nested = true)]
     pub length_caps: LengthCaps,
 
-    #[envconfig(default = "false")]
-    pub aggregate_by_event_name: bool,
-
-    #[envconfig(default = "false")]
-    pub emit_event_name: bool,
-
     #[envconfig(default = "0")]
     pub merger_seen_cache_capacity: usize,
 
@@ -94,9 +88,6 @@ pub struct LengthCaps {
 
     #[envconfig(default = "255")]
     pub max_property_value_len: usize,
-
-    #[envconfig(default = "200")]
-    pub max_event_name_len: usize,
 }
 
 #[derive(Clone)]
@@ -214,7 +205,6 @@ mod tests {
         let caps = LengthCaps::init_from_hashmap(&std::collections::HashMap::new()).unwrap();
         assert_eq!(caps.max_property_key_len, 400);
         assert_eq!(caps.max_property_value_len, 255);
-        assert_eq!(caps.max_event_name_len, 200);
     }
 
     #[test]
@@ -222,12 +212,10 @@ mod tests {
         let env = std::collections::HashMap::from([
             ("MAX_PROPERTY_KEY_LEN".to_string(), "500".to_string()),
             ("MAX_PROPERTY_VALUE_LEN".to_string(), "1000".to_string()),
-            ("MAX_EVENT_NAME_LEN".to_string(), "300".to_string()),
         ]);
         let caps = LengthCaps::init_from_hashmap(&env).unwrap();
         assert_eq!(caps.max_property_key_len, 500);
         assert_eq!(caps.max_property_value_len, 1000);
-        assert_eq!(caps.max_event_name_len, 300);
     }
 
     fn arb_team_list() -> impl Strategy<Value = Vec<i64>> {

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -8,24 +8,13 @@ pub fn fan_out(
     event: &Event,
     excluded: &ExcludedPropertyKeys,
     caps: LengthCaps,
-    aggregate_by_event_name: bool,
 ) -> Vec<(TupleKey, u64)> {
     let mut out = Vec::new();
 
     if let Some(raw) = &event.properties {
-        let event_name = if aggregate_by_event_name {
-            event
-                .event
-                .as_deref()
-                .filter(|e| e.chars().count() <= caps.max_event_name_len)
-                .unwrap_or("")
-        } else {
-            ""
-        };
         emit_from_blob(
             event.team_id,
             PropertyType::Event,
-            event_name,
             raw,
             excluded,
             caps,
@@ -33,11 +22,9 @@ pub fn fan_out(
         );
     }
     if let Some(raw) = &event.person_properties {
-        // Person values are not scoped by event, so they carry no event name.
         emit_from_blob(
             event.team_id,
             PropertyType::Person,
-            "",
             raw,
             excluded,
             caps,
@@ -58,7 +45,6 @@ pub fn fan_out_group(
         emit_from_blob(
             event.team_id,
             PropertyType::Group(event.group_type_index),
-            "",
             raw,
             excluded,
             caps,
@@ -78,7 +64,6 @@ pub fn extract_tuple(msg: &PropertyValueMessage) -> Vec<(TupleKey, u64)> {
             property_type: msg.property_type,
             property_key: msg.property_key.clone(),
             property_value: msg.property_value.clone(),
-            event_name: msg.event_name.clone(),
         },
         msg.property_count,
     )]
@@ -87,7 +72,6 @@ pub fn extract_tuple(msg: &PropertyValueMessage) -> Vec<(TupleKey, u64)> {
 fn emit_from_blob(
     team_id: i64,
     property_type: PropertyType,
-    event_name: &str,
     raw: &str,
     excluded: &ExcludedPropertyKeys,
     caps: LengthCaps,
@@ -139,7 +123,6 @@ fn emit_from_blob(
                 property_type,
                 property_key: key.clone(),
                 property_value,
-                event_name: event_name.to_string(),
             },
             1,
         ));
@@ -164,13 +147,11 @@ mod tests {
     const TEST_CAPS: LengthCaps = LengthCaps {
         max_property_key_len: 400,
         max_property_value_len: 255,
-        max_event_name_len: 200,
     };
 
     fn event(properties: &str) -> Event {
         Event {
             team_id: 2,
-            event: None,
             properties: Some(properties.to_string()),
             person_properties: None,
         }
@@ -209,11 +190,10 @@ mod tests {
     prop_compose! {
         fn arb_event()(
             team_id: i64,
-            event in prop::option::of(arb_property_string()),
             properties in prop::option::of(arb_blob()),
             person_properties in prop::option::of(arb_blob()),
         ) -> Event {
-            Event { team_id, event, properties, person_properties }
+            Event { team_id, properties, person_properties }
         }
     }
 
@@ -247,7 +227,7 @@ mod tests {
     proptest! {
         #[test]
         fn fan_out_outputs_obey_caps_and_team(e in arb_event()) {
-            for (t, n) in fan_out(&e, &none(), TEST_CAPS, false) {
+            for (t, n) in fan_out(&e, &none(), TEST_CAPS) {
                 check_tuple_invariants(&t, n, e.team_id);
             }
         }
@@ -262,8 +242,8 @@ mod tests {
         #[test]
         fn fan_out_is_pure(e in arb_event()) {
             prop_assert_eq!(
-                fan_out(&e, &none(), TEST_CAPS, true),
-                fan_out(&e, &none(), TEST_CAPS, true)
+                fan_out(&e, &none(), TEST_CAPS),
+                fan_out(&e, &none(), TEST_CAPS)
             );
         }
 
@@ -279,35 +259,11 @@ mod tests {
             }
         }
 
-        #[test]
-        fn stamped_event_tuples_carry_source_event_name(name in "[a-z]{1,20}", blob in arb_blob()) {
-            let e = Event {
-                team_id: 2,
-                event: Some(name.clone()),
-                properties: Some(blob),
-                person_properties: None,
-            };
-            for (t, _) in fan_out(&e, &none(), TEST_CAPS, true) {
-                prop_assert_eq!(&t.event_name, &name);
-            }
-        }
-
-        #[test]
-        fn unstamped_tuples_have_empty_event_name(e in arb_event()) {
-            for (t, _) in fan_out(&e, &none(), TEST_CAPS, false) {
-                prop_assert!(t.event_name.is_empty());
-            }
-        }
     }
 
     #[test]
     fn event_property_produces_event_type_tuple() {
-        let tuples = fan_out(
-            &event(r#"{"$browser":"Chrome"}"#),
-            &none(),
-            TEST_CAPS,
-            false,
-        );
+        let tuples = fan_out(&event(r#"{"$browser":"Chrome"}"#), &none(), TEST_CAPS);
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].0.property_type, PropertyType::Event);
         assert_eq!(tuples[0].0.property_key, "$browser");
@@ -316,61 +272,14 @@ mod tests {
     }
 
     #[test]
-    fn stamping_uses_source_event_name_for_event_type_only() {
-        let ev = Event {
-            team_id: 2,
-            event: Some("$pageview".to_string()),
-            properties: Some(r#"{"$browser":"Chrome"}"#.to_string()),
-            person_properties: Some(r#"{"email":"a@b.com"}"#.to_string()),
-        };
-        let tuples = fan_out(&ev, &none(), TEST_CAPS, true);
-        let event_tuple = tuples
-            .iter()
-            .find(|(t, _)| t.property_type == PropertyType::Event)
-            .unwrap();
-        assert_eq!(event_tuple.0.event_name, "$pageview");
-        let person_tuple = tuples
-            .iter()
-            .find(|(t, _)| t.property_type == PropertyType::Person)
-            .unwrap();
-        assert_eq!(
-            person_tuple.0.event_name, "",
-            "person values are not event-scoped"
-        );
-    }
-
-    #[test]
-    fn oversized_event_name_is_not_stamped() {
-        let long_name = "a".repeat(TEST_CAPS.max_event_name_len + 1);
-        let ev = Event {
-            team_id: 2,
-            event: Some(long_name),
-            properties: Some(r#"{"$browser":"Chrome"}"#.to_string()),
-            person_properties: None,
-        };
-        let tuples = fan_out(&ev, &none(), TEST_CAPS, true);
-        assert_eq!(tuples.len(), 1);
-        assert_eq!(
-            tuples[0].0.event_name, "",
-            "oversized event name is dropped"
-        );
-        assert_eq!(tuples[0].0.property_value, "Chrome");
-    }
-
-    #[test]
     fn json_null_value_is_dropped() {
-        let tuples = fan_out(
-            &event(r#"{"nullable_field":null}"#),
-            &none(),
-            TEST_CAPS,
-            false,
-        );
+        let tuples = fan_out(&event(r#"{"nullable_field":null}"#), &none(), TEST_CAPS);
         assert!(tuples.is_empty());
     }
 
     #[test]
     fn empty_string_value_is_dropped() {
-        let tuples = fan_out(&event(r#"{"blank":""}"#), &none(), TEST_CAPS, false);
+        let tuples = fan_out(&event(r#"{"blank":""}"#), &none(), TEST_CAPS);
         assert!(tuples.is_empty());
     }
 
@@ -387,7 +296,7 @@ mod tests {
                 ..TEST_CAPS
             };
             let blob = format!(r#"{{"k":"{}"}}"#, "a".repeat(value_len));
-            let kept = !fan_out(&event(&blob), &none(), caps, false).is_empty();
+            let kept = !fan_out(&event(&blob), &none(), caps).is_empty();
             assert_eq!(
                 kept, expected_kept,
                 "{value_len}-char value at cap {cap}: expected kept={expected_kept}"
@@ -408,7 +317,7 @@ mod tests {
                 ..TEST_CAPS
             };
             let blob = format!(r#"{{"{}":"v"}}"#, "k".repeat(key_len));
-            let kept = !fan_out(&event(&blob), &none(), caps, false).is_empty();
+            let kept = !fan_out(&event(&blob), &none(), caps).is_empty();
             assert_eq!(
                 kept, expected_kept,
                 "{key_len}-char key at cap {cap}: expected kept={expected_kept}"
@@ -417,46 +326,13 @@ mod tests {
     }
 
     #[test]
-    fn event_name_length_cap_is_configurable() {
-        for (name_len, cap, expected_stamped) in [
-            (200usize, 200usize, true),
-            (201, 200, false),
-            (201, 250, true),
-            (251, 250, false),
-        ] {
-            let caps = LengthCaps {
-                max_event_name_len: cap,
-                ..TEST_CAPS
-            };
-            let ev = Event {
-                team_id: 2,
-                event: Some("e".repeat(name_len)),
-                properties: Some(r#"{"$browser":"Chrome"}"#.to_string()),
-                person_properties: None,
-            };
-            let tuples = fan_out(&ev, &none(), caps, true);
-            assert_eq!(
-                tuples.len(),
-                1,
-                "{name_len}-char event name at cap {cap}: expected 1 tuple"
-            );
-            let stamped = !tuples[0].0.event_name.is_empty();
-            assert_eq!(
-                stamped, expected_stamped,
-                "{name_len}-char event name at cap {cap}: expected stamped={expected_stamped}"
-            );
-        }
-    }
-
-    #[test]
     fn person_properties_emit_person_type() {
         let ev = Event {
             team_id: 2,
-            event: None,
             properties: None,
             person_properties: Some(r#"{"email":"foo@bar.com"}"#.to_string()),
         };
-        let tuples = fan_out(&ev, &none(), TEST_CAPS, false);
+        let tuples = fan_out(&ev, &none(), TEST_CAPS);
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].0.property_type, PropertyType::Person);
         assert_eq!(tuples[0].0.property_key, "email");
@@ -465,27 +341,27 @@ mod tests {
 
     #[test]
     fn bool_value_coerces_to_string() {
-        let tuples = fan_out(&event(r#"{"a_bool":true}"#), &none(), TEST_CAPS, false);
+        let tuples = fan_out(&event(r#"{"a_bool":true}"#), &none(), TEST_CAPS);
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].0.property_value, "true");
     }
 
     #[test]
     fn number_value_coerces_to_string() {
-        let tuples = fan_out(&event(r#"{"a_number":42}"#), &none(), TEST_CAPS, false);
+        let tuples = fan_out(&event(r#"{"a_number":42}"#), &none(), TEST_CAPS);
         assert_eq!(tuples.len(), 1);
         assert_eq!(tuples[0].0.property_value, "42");
     }
 
     #[test]
     fn unparseable_blob_emits_nothing() {
-        let tuples = fan_out(&event(r#"not valid json"#), &none(), TEST_CAPS, false);
+        let tuples = fan_out(&event(r#"not valid json"#), &none(), TEST_CAPS);
         assert!(tuples.is_empty());
     }
 
     #[test]
     fn empty_object_emits_nothing() {
-        let tuples = fan_out(&event("{}"), &none(), TEST_CAPS, false);
+        let tuples = fan_out(&event("{}"), &none(), TEST_CAPS);
         assert!(tuples.is_empty());
     }
 
@@ -534,7 +410,7 @@ mod tests {
         let blob =
             r#"{"$insert_id":"abc-123","$browser":"Chrome","distinct_id":"u1","$session_id":"s1"}"#;
         let exclusions = excluded(&["$insert_id", "distinct_id", "$session_id"]);
-        let tuples = fan_out(&event(blob), &exclusions, TEST_CAPS, false);
+        let tuples = fan_out(&event(blob), &exclusions, TEST_CAPS);
         assert_eq!(tuples.len(), 1, "only $browser should survive exclusion");
         assert_eq!(tuples[0].0.property_key, "$browser");
         assert_eq!(tuples[0].0.property_value, "Chrome");
@@ -544,13 +420,12 @@ mod tests {
     fn excluded_person_property_keys_are_skipped() {
         let ev = Event {
             team_id: 2,
-            event: None,
             properties: None,
             person_properties: Some(
                 r#"{"email":"a@b.com","$session_id":"s1","plan":"enterprise"}"#.to_string(),
             ),
         };
-        let tuples = fan_out(&ev, &excluded(&["$session_id"]), TEST_CAPS, false);
+        let tuples = fan_out(&ev, &excluded(&["$session_id"]), TEST_CAPS);
         assert_eq!(tuples.len(), 2);
         let keys: Vec<&str> = tuples
             .iter()
@@ -572,9 +447,9 @@ mod tests {
     #[test]
     fn empty_exclusion_list_is_a_noop() {
         let blob = r#"{"$browser":"Chrome","email":"a@b.com"}"#;
-        let with_default = fan_out(&event(blob), &none(), TEST_CAPS, false);
+        let with_default = fan_out(&event(blob), &none(), TEST_CAPS);
         let parsed_empty: ExcludedPropertyKeys = "".parse().unwrap();
-        let with_parsed_empty = fan_out(&event(blob), &parsed_empty, TEST_CAPS, false);
+        let with_parsed_empty = fan_out(&event(blob), &parsed_empty, TEST_CAPS);
         assert_eq!(with_default.len(), 2);
         assert_eq!(with_default, with_parsed_empty);
     }
@@ -592,16 +467,7 @@ mod tests {
             property_key: key.to_string(),
             property_value: value.to_string(),
             property_count: count,
-            event_name: String::new(),
         }
-    }
-
-    #[test]
-    fn extract_tuple_carries_event_name_from_message() {
-        let mut msg = pv_message(2, PropertyType::Event, "$browser", "Chrome", 1);
-        msg.event_name = "$pageview".to_string();
-        let out = extract_tuple(&msg);
-        assert_eq!(out[0].0.event_name, "$pageview");
     }
 
     #[test]
@@ -655,7 +521,6 @@ mod tests {
                 property_key: "$browser",
                 property_value: "Chrome",
                 property_count: 99,
-                event_name: "$pageview",
             };
             let serialized = serde_json::to_string(&outgoing).unwrap();
             assert!(
@@ -668,27 +533,6 @@ mod tests {
             assert_eq!(parsed.property_key, "$browser");
             assert_eq!(parsed.property_value, "Chrome");
             assert_eq!(parsed.property_count, 99);
-            assert_eq!(parsed.event_name, "$pageview");
         }
-    }
-
-    #[test]
-    fn empty_event_name_is_omitted_from_wire_format() {
-        use crate::producer::Outgoing;
-        let outgoing = Outgoing {
-            team_id: 2,
-            property_type: PropertyType::Event,
-            property_key: "$browser",
-            property_value: "Chrome",
-            property_count: 1,
-            event_name: "",
-        };
-        let serialized = serde_json::to_string(&outgoing).unwrap();
-        assert!(
-            !serialized.contains("event_name"),
-            "empty event_name must be omitted so flag-off messages match the old format: {serialized}"
-        );
-        let parsed: PropertyValueMessage = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(parsed.event_name, "");
     }
 }

--- a/rust/property-vals-rs/src/main.rs
+++ b/rust/property-vals-rs/src/main.rs
@@ -102,7 +102,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         events_handle.clone(),
         config.intermediate_topic.clone(),
         produce_timeout,
-        true,
         config.intermediate_topic_encoding,
     )
     .await?;
@@ -116,7 +115,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         groups_handle.clone(),
         config.intermediate_topic.clone(),
         produce_timeout,
-        true,
         config.intermediate_topic_encoding,
     )
     .await?;
@@ -131,7 +129,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         merger_handle.clone(),
         config.output_topic.clone(),
         produce_timeout,
-        config.emit_event_name,
         EnvelopeEncoding::None,
     )
     .await?;
@@ -153,14 +150,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let excluded_events = shared_config.excluded_property_keys.clone();
     let excluded_groups = shared_config.excluded_property_keys.clone();
     let length_caps = shared_config.length_caps;
-    let aggregate_by_event_name = shared_config.aggregate_by_event_name;
 
     tokio::spawn(worker_loop::<Event, _, _>(
         shared_config.clone(),
         events_consumer,
         events_producer,
         events_handle.clone(),
-        move |e: &Event| fan_out(e, &excluded_events, length_caps, aggregate_by_event_name),
+        move |e: &Event| fan_out(e, &excluded_events, length_caps),
         "events",
         ReductionConfig::default(),
     ));

--- a/rust/property-vals-rs/src/producer.rs
+++ b/rust/property-vals-rs/src/producer.rs
@@ -13,10 +13,6 @@ use tracing::warn;
 
 use crate::types::{PropertyType, TupleKey};
 
-fn str_is_empty(s: &&str) -> bool {
-    s.is_empty()
-}
-
 #[derive(serde::Serialize)]
 pub(crate) struct Outgoing<'a> {
     pub team_id: i64,
@@ -24,11 +20,6 @@ pub(crate) struct Outgoing<'a> {
     pub property_key: &'a str,
     pub property_value: &'a str,
     pub property_count: u64,
-    // Omitted when empty so flag-off (and person/group) messages are identical
-    // to before this field existed, letting the service ship ahead of the
-    // ClickHouse column that reads it.
-    #[serde(skip_serializing_if = "str_is_empty")]
-    pub event_name: &'a str,
 }
 
 #[derive(Debug, Error)]
@@ -54,7 +45,6 @@ pub struct AggregatedProducer {
     inner: FutureProducer<KafkaContext>,
     output_topic: String,
     produce_timeout: Duration,
-    serialize_event_name: bool,
     // Envelope encoding for the produced payloads. Only `Lz4`-safe for the
     // intermediate topic, which the merger consumes; the output topic is read
     // by ClickHouse and must stay `None`.
@@ -67,7 +57,6 @@ impl AggregatedProducer {
         liveness: L,
         output_topic: String,
         produce_timeout: Duration,
-        serialize_event_name: bool,
         encoding: EnvelopeEncoding,
     ) -> Result<Self, KafkaError>
     where
@@ -78,7 +67,6 @@ impl AggregatedProducer {
             inner,
             output_topic,
             produce_timeout,
-            serialize_event_name,
             encoding,
         })
     }
@@ -100,11 +88,6 @@ impl Producer for AggregatedProducer {
                 property_key: &tuple.property_key,
                 property_value: &tuple.property_value,
                 property_count: *count,
-                event_name: if self.serialize_event_name {
-                    &tuple.event_name
-                } else {
-                    ""
-                },
             })
             .collect();
 

--- a/rust/property-vals-rs/src/types.rs
+++ b/rust/property-vals-rs/src/types.rs
@@ -10,8 +10,6 @@ pub struct Event {
     pub team_id: i64,
 
     #[serde(default)]
-    pub event: Option<String>,
-    #[serde(default)]
     pub properties: Option<String>,
     #[serde(default)]
     pub person_properties: Option<String>,
@@ -43,10 +41,6 @@ pub struct TupleKey {
     pub property_type: PropertyType,
     pub property_key: String,
     pub property_value: String,
-    // Source event name for event-type values, used to scope value lookups to a
-    // specific event. Empty for person/group (not event-scoped) and for event
-    // values until STAMP_EVENT_NAME is enabled.
-    pub event_name: String,
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
@@ -101,8 +95,6 @@ pub struct PropertyValueMessage {
     pub property_key: String,
     pub property_value: String,
     pub property_count: u64,
-    #[serde(default)]
-    pub event_name: String,
 }
 
 impl IngestableEvent for PropertyValueMessage {

--- a/rust/property-vals-rs/src/worker.rs
+++ b/rust/property-vals-rs/src/worker.rs
@@ -173,10 +173,10 @@ pub(crate) async fn flush<P: Producer>(
     }
 }
 
-/// Cap each (team, type, key, event) to its `k` highest-count values, dropping
+/// Cap each (team, type, key) to its `k` highest-count values, dropping
 /// the rest. Keys with `<= k` distinct values are untouched, so low-cardinality
 /// keys keep everything; only high-cardinality keys lose their long tail.
-type CapGroup = (i64, PropertyType, String, String);
+type CapGroup = (i64, PropertyType, String);
 
 fn cap_top_k(
     snapshot: Vec<(TupleKey, u64)>,
@@ -189,7 +189,6 @@ fn cap_top_k(
             entry.0.team_id,
             entry.0.property_type,
             entry.0.property_key.clone(),
-            entry.0.event_name.clone(),
         );
         by_key.entry(group).or_default().push(entry);
     }
@@ -282,7 +281,6 @@ mod tests {
             property_type: PropertyType::Event,
             property_key: key.to_string(),
             property_value: value.to_string(),
-            event_name: String::new(),
         }
     }
 
@@ -646,9 +644,8 @@ mod tests {
             property_type in arb_property_type(),
             property_key in "[a-c]{1,2}",
             property_value in "[x-z]{1,2}",
-            event_name in "[a-b]{0,2}",
         ) -> TupleKey {
-            TupleKey { team_id, property_type, property_key, property_value, event_name }
+            TupleKey { team_id, property_type, property_key, property_value }
         }
     }
 


### PR DESCRIPTION
## Problem

The property-vals-rs service carries an `event_name` dimension that was scaffolded for an event-scoped property values table we are not building. The feature was never turned on: `AGGREGATE_BY_EVENT_NAME` and `EMIT_EVENT_NAME` default to `false` and are not set in any environment, and the ClickHouse column that would read the field was never added. The field is therefore always empty and already omitted from the wire format, so it is dead plumbing that widens the aggregation key type and every tuple allocation for nothing.

## Changes

- Drop `event_name` from `TupleKey` and `PropertyValueMessage`, and the now-unused `Event.event` field (it existed only to read the name at fan-out).
- Drop the `AGGREGATE_BY_EVENT_NAME` and `EMIT_EVENT_NAME` config flags and the `MAX_EVENT_NAME_LEN` length cap.
- Remove the stamping branch in `fan_out` and the `serialize_event_name` plumbing in the producer (`Outgoing.event_name` and its skip-when-empty serializer).
- Narrow the merger's top-K cap group from (team, type, key, event) to (team, type, key).
- Delete the event-name tests; remaining tests updated for the narrower signatures.

No behavior change: with the flags off everywhere the field was always empty, empty values were already omitted from produced messages, and aggregation keys are unchanged. `PropertyValueMessage` deserialization ignores unknown fields, so any in-flight intermediate message is still parseable during rollout.

## How did you test this code?

Agent-authored. Automated tests only: `cargo test -p property-vals-rs` (52 tests pass) and `cargo clippy -p property-vals-rs --all-targets -- -D warnings` (clean). No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed; internal service plumbing only.

## 🤖 Agent context

Authored with Claude Code at the request of the service owner. Before removing, verified the feature is dormant end to end: no charts environment sets the env vars, `posthog/clickhouse/property_values.py` has no `event_name` column, and the only references in the repo are inside this crate. Chose full removal (including `Event.event` and the length cap) over just disabling the emit path, since the whole dimension exists only for the abandoned event-scoped table.
