### PR TITLE
docs(cli): clarify release tag format

### DIFF
--- a/cli/.sampo/changesets/cli-release-tag-docs.md
+++ b/cli/.sampo/changesets/cli-release-tag-docs.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Clarify the CLI release tag format in the release docs.

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -20,7 +20,7 @@ After the pull request merges to `master`, the `Release CLI` workflow:
 4. Updates `cli/Cargo.toml`, `cli/Cargo.lock`, and `cli/CHANGELOG.md`
 5. Commits the release bump to `master`
 6. Runs cargo-dist against the release bump commit
-7. Creates the GitHub release and publishes the npm package
+7. Creates the `posthog-cli/vX.Y.Z` GitHub release and publishes the npm package
 
 Do not run `sampo publish`; cargo-dist owns publishing for `posthog-cli`.
 


### PR DESCRIPTION
## Summary

- Clarifies that the CLI release workflow creates `posthog-cli/vX.Y.Z` GitHub releases.
- Adds a Sampo patch changeset for the docs update.

## Testing

- bin/hogli format:markdown cli/CONTRIBUTING.md
- bin/hogli format:markdown cli/.sampo/changesets/cli-release-tag-docs.md
