### PR TITLE
fix(funnels): restore drop-off vs converted click on hog-charts steps bar

### DIFF
--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.test.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.test.tsx
@@ -486,8 +486,37 @@ describe('BarChart', () => {
                 expect(click.dataIndex).toBe(1)
                 expect(click.series.key).toBe(key)
                 expect(click.value).toBe(value)
+                // Cursor is in the track above the bar's fill — funnel drop-off relies on this.
+                expect(click.inTrackArea).toBe(true)
             }
         )
+
+        // Complement of the track test above: a click inside the bar's filled extent must report
+        // `inTrackArea: false` so funnel "converted" clicks route correctly.
+        it('grouped onPointClick reports inTrackArea false when the cursor is within the bar fill', async () => {
+            const onPointClick = jest.fn()
+            const { chart } = renderHogChart(
+                <BarChart
+                    series={SERIES}
+                    labels={LABELS}
+                    theme={THEME}
+                    config={{ barLayout: 'grouped' }}
+                    onPointClick={onPointClick}
+                />
+            )
+            const step = dimensions.plotWidth / LABELS.length
+            // Same column as the 'a' sub-bar at index 1, but just above the baseline so the
+            // cursor sits inside the fill rather than in the track above it.
+            fireEvent.mouseMove(chart.element, {
+                clientX: dimensions.plotLeft + step * 1.3,
+                clientY: dimensions.plotTop + dimensions.plotHeight - 2,
+            })
+            fireEvent.click(chart.element)
+            const click: PointClickData = onPointClick.mock.calls[0][0]
+            expect(click.dataIndex).toBe(1)
+            expect(click.series.key).toBe('a')
+            expect(click.inTrackArea).toBe(false)
+        })
 
         it('pins the tooltip on click when tooltip.pinnable is true', async () => {
             const { chart } = renderHogChart(

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.test.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.test.tsx
@@ -493,30 +493,36 @@ describe('BarChart', () => {
 
         // Complement of the track test above: a click inside the bar's filled extent must report
         // `inTrackArea: false` so funnel "converted" clicks route correctly.
-        it('grouped onPointClick reports inTrackArea false when the cursor is within the bar fill', async () => {
-            const onPointClick = jest.fn()
-            const { chart } = renderHogChart(
-                <BarChart
-                    series={SERIES}
-                    labels={LABELS}
-                    theme={THEME}
-                    config={{ barLayout: 'grouped' }}
-                    onPointClick={onPointClick}
-                />
-            )
-            const step = dimensions.plotWidth / LABELS.length
-            // Same column as the 'a' sub-bar at index 1, but just above the baseline so the
-            // cursor sits inside the fill rather than in the track above it.
-            fireEvent.mouseMove(chart.element, {
-                clientX: dimensions.plotLeft + step * 1.3,
-                clientY: dimensions.plotTop + dimensions.plotHeight - 2,
-            })
-            fireEvent.click(chart.element)
-            const click: PointClickData = onPointClick.mock.calls[0][0]
-            expect(click.dataIndex).toBe(1)
-            expect(click.series.key).toBe('a')
-            expect(click.inTrackArea).toBe(false)
-        })
+        it.each<[string, number, string]>([
+            ['left sub-bar (a)', 1.3, 'a'],
+            ['right sub-bar (b)', 1.65, 'b'],
+        ])(
+            'grouped onPointClick reports inTrackArea false when the cursor is within the bar fill — %s',
+            async (_name, stepMultiplier, key) => {
+                const onPointClick = jest.fn()
+                const { chart } = renderHogChart(
+                    <BarChart
+                        series={SERIES}
+                        labels={LABELS}
+                        theme={THEME}
+                        config={{ barLayout: 'grouped' }}
+                        onPointClick={onPointClick}
+                    />
+                )
+                const step = dimensions.plotWidth / LABELS.length
+                // Same column as the sub-bar at index 1, but just above the baseline so the
+                // cursor sits inside the fill rather than in the track above it.
+                fireEvent.mouseMove(chart.element, {
+                    clientX: dimensions.plotLeft + step * stepMultiplier,
+                    clientY: dimensions.plotTop + dimensions.plotHeight - 2,
+                })
+                fireEvent.click(chart.element)
+                const click: PointClickData = onPointClick.mock.calls[0][0]
+                expect(click.dataIndex).toBe(1)
+                expect(click.series.key).toBe(key)
+                expect(click.inTrackArea).toBe(false)
+            }
+        )
 
         it('pins the tooltip on click when tooltip.pinnable is true', async () => {
             const { chart } = renderHogChart(

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -714,7 +714,11 @@ export function resolveClickedBarSeries<Meta>({
                 continue
             }
             const hit = crossSeriesData.find((d) => d.series.key === s.key)
-            return hit ? rewrite(hit.series, hit.value, dataIndex) : null
+            if (!hit) {
+                return null
+            }
+            const inTrackArea = cursorOutsideBarFillExtent(bar, cursor, isHorizontal)
+            return { ...rewrite(hit.series, hit.value, dataIndex), inTrackArea }
         }
         return null
     }

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -108,6 +108,11 @@ export interface PointClickData<Meta = unknown> {
     /** Cursor position in pixels relative to the chart wrapper at click time, or `null`
      *  when unavailable. Same origin as `TooltipContext.hoverPosition`. */
     cursor: { x: number; y: number } | null
+    /** Grouped layouts only: `true` when the cursor was in the bar's band slot but beyond its
+     *  filled value extent — i.e. the track region above (vertical) or past (horizontal) a short
+     *  bar. Lets consumers route "clicked the empty remainder" differently from "clicked the bar"
+     *  (e.g. funnel drop-off vs converted). `undefined` outside grouped click resolution. */
+    inTrackArea?: boolean
 }
 
 /** Context object passed to the `renderTooltip` render prop and tooltip event callbacks. */

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -14,10 +14,14 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
-import { ChartParams, type FunnelStepWithConversionMetrics } from '~/types'
+import { ChartParams } from '~/types'
 
 import { FunnelStepsBarTooltip } from './FunnelStepsBarTooltip'
-import { buildFunnelStepsBarData, type FunnelStepsBarSeriesMeta } from './funnelStepsBarTransforms'
+import {
+    buildFunnelStepsBarData,
+    type FunnelStepsBarSeriesMeta,
+    resolveFunnelStepClick,
+} from './funnelStepsBarTransforms'
 
 const BASE_STEP_WIDTH_PX = 240
 const PER_BAR_WIDTH_PX = 20
@@ -86,15 +90,11 @@ export function FunnelStepsBarChart({
 
     const onPointClick = useCallback(
         (clickData: PointClickData<FunnelStepsBarSeriesMeta>): void => {
-            const step = steps[clickData.dataIndex]
-            if (!step) {
+            const target = resolveFunnelStepClick(steps, clickData)
+            if (!target) {
                 return
             }
-            const breakdownIndex = clickData.series.meta?.breakdownIndex ?? 0
-            const variant: FunnelStepWithConversionMetrics = step.nested_breakdown?.[breakdownIndex] ?? step
-            // The bar's filled extent is the converted portion; the track above it is the drop-off.
-            // `inTrackArea` tells us which the user clicked, restoring the legacy StepBar behavior.
-            openPersonsModalForSeries({ step, series: variant, converted: !clickData.inTrackArea })
+            openPersonsModalForSeries(target)
         },
         [steps, openPersonsModalForSeries]
     )

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -92,7 +92,9 @@ export function FunnelStepsBarChart({
             }
             const breakdownIndex = clickData.series.meta?.breakdownIndex ?? 0
             const variant: FunnelStepWithConversionMetrics = step.nested_breakdown?.[breakdownIndex] ?? step
-            openPersonsModalForSeries({ step, series: variant, converted: true })
+            // The bar's filled extent is the converted portion; the track above it is the drop-off.
+            // `inTrackArea` tells us which the user clicked, restoring the legacy StepBar behavior.
+            openPersonsModalForSeries({ step, series: variant, converted: !clickData.inTrackArea })
         },
         [steps, openPersonsModalForSeries]
     )

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.test.ts
@@ -1,6 +1,13 @@
+import type { PointClickData, Series } from '@posthog/quill-charts'
+
 import { EntityTypes, type FunnelStepWithConversionMetrics } from '~/types'
 
-import { buildFunnelStepsBarData, FUNNEL_STEPS_SERIES_KEY_PREFIX } from './funnelStepsBarTransforms'
+import {
+    buildFunnelStepsBarData,
+    FUNNEL_STEPS_SERIES_KEY_PREFIX,
+    type FunnelStepsBarSeriesMeta,
+    resolveFunnelStepClick,
+} from './funnelStepsBarTransforms'
 
 type StepOverrides = Partial<FunnelStepWithConversionMetrics> & { fromBasisStep: number }
 
@@ -110,5 +117,50 @@ describe('buildFunnelStepsBarData', () => {
 
         expect(series).toEqual([])
         expect(labels).toEqual([])
+    })
+})
+
+function makeSeries(breakdownIndex: number): Series<FunnelStepsBarSeriesMeta> {
+    return {
+        key: `${FUNNEL_STEPS_SERIES_KEY_PREFIX}${breakdownIndex}`,
+        label: 'series',
+        data: [],
+        meta: { breakdownIndex },
+    }
+}
+
+function makeClick(
+    overrides: Partial<Pick<PointClickData<FunnelStepsBarSeriesMeta>, 'dataIndex' | 'series' | 'inTrackArea'>>
+): Pick<PointClickData<FunnelStepsBarSeriesMeta>, 'dataIndex' | 'series' | 'inTrackArea'> {
+    return { dataIndex: 0, series: makeSeries(0), ...overrides }
+}
+
+describe('resolveFunnelStepClick', () => {
+    it.each<[string, boolean | undefined, boolean]>([
+        ['filled bar (inTrackArea false) opens converted', false, true],
+        ['track above the bar (inTrackArea true) opens drop-off', true, false],
+        ['non-grouped click (inTrackArea undefined) falls back to converted', undefined, true],
+    ])('%s', (_name, inTrackArea, expectedConverted) => {
+        const target = resolveFunnelStepClick(noBreakdownSteps, makeClick({ dataIndex: 1, inTrackArea }))
+
+        expect(target).not.toBeNull()
+        expect(target?.step).toBe(noBreakdownSteps[1])
+        expect(target?.series).toBe(noBreakdownSteps[1])
+        expect(target?.converted).toBe(expectedConverted)
+    })
+
+    it('resolves the breakdown variant via the series meta breakdownIndex', () => {
+        const target = resolveFunnelStepClick(
+            breakdownSteps,
+            makeClick({ dataIndex: 1, series: makeSeries(1), inTrackArea: false })
+        )
+
+        expect(target?.step).toBe(breakdownSteps[1])
+        expect(target?.series).toBe(breakdownSteps[1].nested_breakdown?.[1])
+        expect(target?.converted).toBe(true)
+    })
+
+    it('returns null when the clicked column has no step', () => {
+        expect(resolveFunnelStepClick(noBreakdownSteps, makeClick({ dataIndex: 99 }))).toBeNull()
     })
 })

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.ts
@@ -1,4 +1,4 @@
-import type { Series } from '@posthog/quill-charts'
+import type { PointClickData, Series } from '@posthog/quill-charts'
 
 import type { FunnelStepWithConversionMetrics } from '~/types'
 
@@ -68,4 +68,27 @@ export function buildFunnelStepsBarData(
     }
 
     return { series, labels: steps.map((_, stepIndex) => `${stepIndex + 1}`) }
+}
+
+export interface FunnelStepClickTarget {
+    step: FunnelStepWithConversionMetrics
+    series: FunnelStepWithConversionMetrics
+    converted: boolean
+}
+
+/** Resolves a grouped-bar click back to the funnel step, breakdown variant, and whether the
+ *  converted or drop-off actors should open. The bar's filled extent is the converted portion;
+ *  the track above it (`inTrackArea`) is the drop-off — restoring the legacy StepBar behavior.
+ *  Returns `null` when the click does not map to a step. */
+export function resolveFunnelStepClick(
+    steps: FunnelStepWithConversionMetrics[],
+    clickData: Pick<PointClickData<FunnelStepsBarSeriesMeta>, 'dataIndex' | 'series' | 'inTrackArea'>
+): FunnelStepClickTarget | null {
+    const step = steps[clickData.dataIndex]
+    if (!step) {
+        return null
+    }
+    const breakdownIndex = clickData.series.meta?.breakdownIndex ?? 0
+    const variant = step.nested_breakdown?.[breakdownIndex] ?? step
+    return { step, series: variant, converted: !clickData.inTrackArea }
 }


### PR DESCRIPTION
## Problem

Clicking a funnel step bar opens the persons modal for everyone who **completed** the step, regardless of whether the user clicked the drop-off segment or the completed segment. It used to show drop-off or completion depending on where you clicked.

This is a regression from the funnel **Steps** visualization migration to hog-charts (gated behind the `PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL` flag). The new vertical chart `FunnelStepsBarChart` (introduced in #59743) renders each step as a grouped bar with a visual `track` for the drop-off region, but its `onPointClick` hardcoded `converted: true` — so every click resolved to the completed actors. The later horizontal hog-charts chart handles this correctly via stacked `isDropOff` segments; the vertical chart never got equivalent treatment.

The grouped bar chart already distinguishes the track region from the bar fill at hover time (`cursorOutsideBarFillExtent` → `isTrackHighlight`), but that information was not surfaced to `onPointClick`.

## Changes

- **quill-charts:** add an optional `inTrackArea` flag to `PointClickData`, set during grouped-layout click resolution (`resolveClickedBarSeries`) using the existing `cursorOutsideBarFillExtent` helper. It is `true` when the cursor was in a bar's band slot but beyond its filled value extent (the track above a short bar). The field is additive and backwards-compatible; only consumers that read it change behavior.
- **FunnelStepsBarChart:** map `converted = !clickData.inTrackArea`, so clicking the filled (converted) portion opens completed actors and clicking the track (drop-off) portion opens dropped-off actors — restoring the legacy `StepBar` behavior, including the per-breakdown case.

No change to the legacy renderer, the horizontal hog-charts chart, or the flag-off code path.

## How did you test this code?

I'm an agent (PostHog Slack app); I have not performed manual testing. Dependencies were not installed in my environment, so I could not run jest locally — CI will exercise the suite.

Automated tests added/updated in `BarChart.test.tsx`:
- extended the existing grouped-click-above-the-bar test to assert `inTrackArea === true`
- added a companion test asserting `inTrackArea === false` when the cursor is inside the bar fill

Reviewers should verify the fix in the funnel UI with `PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL` enabled: clicking the lower (filled) part of a step bar opens "completed", and clicking the upper (drop-off) part opens "dropped off".

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by the PostHog Slack app agent in response to a regression report. The investigation traced the funnel persons-modal chain (legacy `StepBar`/`FunnelBarHorizontal`, `funnelPersonsModalLogic`, and the backend `_get_funnel_person_step_condition`) and found all of them correct, then identified the hog-charts migration as the source: `FunnelStepsBarChart.onPointClick` hardcoded `converted: true`.

Two fix approaches were considered: (1) rebuild the vertical chart as a stacked converted/drop-off filler like the horizontal chart, or (2) surface the track-vs-fill distinction from the chart. Approach (1) was rejected because the vertical chart uses a grouped layout for breakdowns (side-by-side bars), and the chart has no grouped-of-stacks mode — switching to stacked would change the breakdown visualization. Approach (2) reuses geometry the chart already computes for hover, is backwards-compatible, and restores per-breakdown drop-off clicks.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
