### PR TITLE
feat(audit): describe instance setting changes in the activity log

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityDescriptions/instanceSettingActivityDescriber.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityDescriptions/instanceSettingActivityDescriber.test.tsx
@@ -1,0 +1,87 @@
+import { render } from '@testing-library/react'
+
+import { ActivityChange, ActivityLogItem } from 'lib/components/ActivityLog/humanizeActivity'
+
+import { ActivityScope } from '~/types'
+
+import { instanceSettingActivityDescriber } from './instanceSettingActivityDescriber'
+
+const makeLogItem = (field: string, before: unknown, after: unknown, activity = 'updated'): ActivityLogItem => ({
+    user: { first_name: 'Ada', last_name: 'Lovelace', email: 'ada@posthog.com' },
+    activity,
+    created_at: '2026-06-04T00:00:00Z',
+    scope: ActivityScope.INSTANCE_SETTING,
+    item_id: field,
+    detail: {
+        merge: null,
+        trigger: null,
+        name: field,
+        changes: [
+            {
+                type: ActivityScope.INSTANCE_SETTING,
+                action: 'changed',
+                field,
+                before: before as ActivityChange['before'],
+                after: after as ActivityChange['after'],
+            },
+        ],
+    },
+})
+
+const describedText = (item: ActivityLogItem): string => {
+    const { description } = instanceSettingActivityDescriber(item)
+    if (!description) {
+        return ''
+    }
+    const { container } = render(description as JSX.Element)
+    return container.textContent || ''
+}
+
+describe('instanceSettingActivityDescriber', () => {
+    it('renders a non-secret boolean change with both values', () => {
+        const text = describedText(makeLogItem('AUTO_START_ASYNC_MIGRATIONS', false, true))
+        expect(text).toContain('changed instance setting AUTO_START_ASYNC_MIGRATIONS from false to true')
+    })
+
+    it('renders a non-secret string change with both values verbatim', () => {
+        const text = describedText(makeLogItem('GITHUB_APP_SLUG', '', 'posthog-app'))
+        expect(text).toContain('changed instance setting GITHUB_APP_SLUG from "" to "posthog-app"')
+    })
+
+    it('renders a secret install as "set" without leaking sentinels', () => {
+        const text = describedText(makeLogItem('EMAIL_HOST_PASSWORD', '<unset>', '<redacted>'))
+        expect(text).toContain('set instance setting EMAIL_HOST_PASSWORD')
+        expect(text).not.toContain('<redacted>')
+        expect(text).not.toContain('<unset>')
+    })
+
+    it('renders a secret rotation as "rotated" without leaking sentinels', () => {
+        const text = describedText(makeLogItem('EMAIL_HOST_PASSWORD', '<redacted>', '<redacted>'))
+        expect(text).toContain('rotated instance setting EMAIL_HOST_PASSWORD')
+        expect(text).not.toContain('<redacted>')
+    })
+
+    it('renders a secret clear as "cleared" without leaking sentinels', () => {
+        const text = describedText(makeLogItem('EMAIL_HOST_PASSWORD', '<redacted>', '<unset>'))
+        expect(text).toContain('cleared instance setting EMAIL_HOST_PASSWORD')
+        expect(text).not.toContain('<redacted>')
+        expect(text).not.toContain('<unset>')
+    })
+
+    it('renders an unrecognized secret transition generically without leaking sentinels', () => {
+        // A sentinel pair with no mapped verb (e.g. <unset> → <unset>) must not fall
+        // through to the cleartext branch and echo the raw marker into the audit line.
+        const text = describedText(makeLogItem('EMAIL_HOST_PASSWORD', '<unset>', '<unset>'))
+        expect(text).toContain('updated instance setting EMAIL_HOST_PASSWORD')
+        expect(text).not.toContain('<unset>')
+        expect(text).not.toContain('changed instance setting')
+    })
+
+    it('falls through to the default describer for non-updated activity', () => {
+        // A "created" activity has no before/after transition; the describer must
+        // hand off to the default describer rather than render a "changed" line.
+        const text = describedText(makeLogItem('SOME_KEY', null, true, 'created'))
+        expect(text).toContain('created')
+        expect(text).not.toContain('changed instance setting')
+    })
+})

--- a/frontend/src/lib/components/ActivityLog/activityDescriptions/instanceSettingActivityDescriber.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityDescriptions/instanceSettingActivityDescriber.test.tsx
@@ -48,31 +48,18 @@ describe('instanceSettingActivityDescriber', () => {
         expect(text).toContain('changed instance setting GITHUB_APP_SLUG from "" to "posthog-app"')
     })
 
-    it('renders a secret install as "set" without leaking sentinels', () => {
-        const text = describedText(makeLogItem('EMAIL_HOST_PASSWORD', '<unset>', '<redacted>'))
-        expect(text).toContain('set instance setting EMAIL_HOST_PASSWORD')
+    // Each secret transition must render its verb and never echo the raw sentinels. The
+    // `<unset>` → `<unset>` pair has no mapped verb and must render "updated" rather than
+    // falling through to the cleartext "changed … from … to …" branch.
+    it.each([
+        ['set', '<unset>', '<redacted>'],
+        ['rotated', '<redacted>', '<redacted>'],
+        ['cleared', '<redacted>', '<unset>'],
+        ['updated', '<unset>', '<unset>'],
+    ])('renders a secret %s transition without leaking sentinels', (verb, before, after) => {
+        const text = describedText(makeLogItem('EMAIL_HOST_PASSWORD', before, after))
+        expect(text).toContain(`${verb} instance setting EMAIL_HOST_PASSWORD`)
         expect(text).not.toContain('<redacted>')
-        expect(text).not.toContain('<unset>')
-    })
-
-    it('renders a secret rotation as "rotated" without leaking sentinels', () => {
-        const text = describedText(makeLogItem('EMAIL_HOST_PASSWORD', '<redacted>', '<redacted>'))
-        expect(text).toContain('rotated instance setting EMAIL_HOST_PASSWORD')
-        expect(text).not.toContain('<redacted>')
-    })
-
-    it('renders a secret clear as "cleared" without leaking sentinels', () => {
-        const text = describedText(makeLogItem('EMAIL_HOST_PASSWORD', '<redacted>', '<unset>'))
-        expect(text).toContain('cleared instance setting EMAIL_HOST_PASSWORD')
-        expect(text).not.toContain('<redacted>')
-        expect(text).not.toContain('<unset>')
-    })
-
-    it('renders an unrecognized secret transition generically without leaking sentinels', () => {
-        // A sentinel pair with no mapped verb (e.g. <unset> → <unset>) must not fall
-        // through to the cleartext branch and echo the raw marker into the audit line.
-        const text = describedText(makeLogItem('EMAIL_HOST_PASSWORD', '<unset>', '<unset>'))
-        expect(text).toContain('updated instance setting EMAIL_HOST_PASSWORD')
         expect(text).not.toContain('<unset>')
         expect(text).not.toContain('changed instance setting')
     })

--- a/frontend/src/lib/components/ActivityLog/activityDescriptions/instanceSettingActivityDescriber.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityDescriptions/instanceSettingActivityDescriber.tsx
@@ -6,6 +6,8 @@ import {
     userNameForLogItem,
 } from 'lib/components/ActivityLog/humanizeActivity'
 
+import { ActivityScope } from '~/types'
+
 // Kept in sync with the sentinels the backend records in posthog/api/instance_settings.py.
 const REDACTED = '<redacted>'
 const UNSET = '<unset>'
@@ -33,7 +35,7 @@ export const instanceSettingActivityDescriber: Describer = (
     logItem: ActivityLogItem,
     asNotification?: boolean
 ): HumanizedChange => {
-    if (logItem.scope !== 'InstanceSetting' || logItem.activity !== 'updated') {
+    if (logItem.scope !== ActivityScope.INSTANCE_SETTING || logItem.activity !== 'updated') {
         return defaultDescriber(logItem, asNotification)
     }
 

--- a/frontend/src/lib/components/ActivityLog/activityDescriptions/instanceSettingActivityDescriber.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityDescriptions/instanceSettingActivityDescriber.tsx
@@ -1,0 +1,79 @@
+import {
+    ActivityLogItem,
+    Describer,
+    HumanizedChange,
+    defaultDescriber,
+    userNameForLogItem,
+} from 'lib/components/ActivityLog/humanizeActivity'
+
+// Kept in sync with the sentinels the backend records in posthog/api/instance_settings.py.
+const REDACTED = '<redacted>'
+const UNSET = '<unset>'
+
+// Secret settings are never logged in cleartext — the backend records these
+// sentinels instead of the value. Translate the before/after sentinel pair into
+// the operation that happened so the audit line is legible without exposing the
+// raw markers. Returns null for any non-secret transition.
+const describeSecretTransition = (before: unknown, after: unknown): string | null => {
+    if (before === UNSET && after === REDACTED) {
+        return 'set'
+    }
+    if (before === REDACTED && after === REDACTED) {
+        return 'rotated'
+    }
+    if (before === REDACTED && after === UNSET) {
+        return 'cleared'
+    }
+    return null
+}
+
+const isSentinel = (value: unknown): boolean => value === REDACTED || value === UNSET
+
+export const instanceSettingActivityDescriber: Describer = (
+    logItem: ActivityLogItem,
+    asNotification?: boolean
+): HumanizedChange => {
+    if (logItem.scope !== 'InstanceSetting' || logItem.activity !== 'updated') {
+        return defaultDescriber(logItem, asNotification)
+    }
+
+    const change = logItem.detail.changes?.[0]
+    if (!change) {
+        return defaultDescriber(logItem, asNotification)
+    }
+
+    const key = change.field || logItem.detail.name || 'unknown setting'
+    const transition = describeSecretTransition(change.before, change.after)
+    const actor = <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong>
+
+    if (transition) {
+        return {
+            description: (
+                <>
+                    {actor} {transition} instance setting <code>{key}</code>
+                </>
+            ),
+        }
+    }
+
+    // A secret transition we don't have a verb for: render a generic line rather than
+    // echo the raw sentinel into the audit log.
+    if (isSentinel(change.before) || isSentinel(change.after)) {
+        return {
+            description: (
+                <>
+                    {actor} updated instance setting <code>{key}</code>
+                </>
+            ),
+        }
+    }
+
+    return {
+        description: (
+            <>
+                {actor} changed instance setting <code>{key}</code> from <code>{JSON.stringify(change.before)}</code> to{' '}
+                <code>{JSON.stringify(change.after)}</code>
+            </>
+        ),
+    }
+}

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -5,6 +5,7 @@ import { router, urlToAction } from 'kea-router'
 import { ActivityDescriber as errorTrackingActivityDescriber } from '@posthog/products-error-tracking/frontend/components/ActivityDescriber'
 
 import api, { ActivityLogPaginatedResponse } from 'lib/api'
+import { instanceSettingActivityDescriber } from 'lib/components/ActivityLog/activityDescriptions/instanceSettingActivityDescriber'
 import { tagActivityDescriber } from 'lib/components/ActivityLog/activityDescriptions/tagActivityDescriber'
 import {
     ActivityLogItem,
@@ -135,8 +136,8 @@ export const describerFor = (logItem?: ActivityLogItem): Describer | undefined =
             return cohortActivityDescriber
         case ActivityScope.INSIGHT:
             return insightActivityDescriber
-        case ActivityScope.DASHBOARD:
-            return dashboardActivityDescriber
+        case ActivityScope.INSTANCE_SETTING:
+            return instanceSettingActivityDescriber
         case ActivityScope.PERSON:
             return personActivityDescriber
         case ActivityScope.PERSONAL_API_KEY:


### PR DESCRIPTION
## Problem

This is a polish follow-up to https://github.com/PostHog/posthog/pull/59555.

Instance setting changes are written to the activity log, but there was no describer for them, so they fell back to the generic default rendering. An admin reviewing the audit log couldn't easily see which setting changed or how. Secret settings need extra care: the line must never expose the redaction sentinels the backend stores in place of the real value.

## Changes

Adds `instanceSettingActivityDescriber` and registers it for `ActivityScope.INSTANCE_SETTING` in `activityLogLogic`.

- Non-secret changes render the actor, the setting key, and the before/after values.
- Secret changes are translated from the backend's `<redacted>`/`<unset>` sentinels into plain verbs (set, rotated, cleared) so the line stays legible without echoing the markers.
- A sentinel pair with no mapped verb renders a generic "updated" line rather than printing the raw sentinel into the audit log.
- Non-`updated` activities fall back to `defaultDescriber`.

The sentinel constants are kept in sync with `posthog/api/instance_settings.py`, where the backend redacts secret values before they reach the activity log.

## How did you test this code?

Added jest tests in `instanceSettingActivityDescriber.test.tsx` covering non-secret boolean and string changes, the three secret transitions (asserting no sentinel leaks), the unrecognized-sentinel fallback, and the non-`updated` fallthrough. All 7 pass via `hogli test`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.