### PR TITLE
fix(legal_documents): use autocomplete widget for organization FK to prevent timeout

### DIFF
--- a/products/legal_documents/backend/admin.py
+++ b/products/legal_documents/backend/admin.py
@@ -67,6 +67,10 @@ class LegalDocumentAdminForm(forms.ModelForm):
 
 @admin.register(LegalDocument)
 class LegalDocumentAdmin(admin.ModelAdmin):
+    # FK to posthog.Organization — without this the add view renders a <select>
+    # of every org on Cloud, which times out. Autocomplete searches lazily via
+    # OrganizationAdmin.search_fields.
+    autocomplete_fields = ("organization",)
     list_display = (
         "id",
         "document_type",

--- a/products/legal_documents/backend/tests/test_admin.py
+++ b/products/legal_documents/backend/tests/test_admin.py
@@ -4,6 +4,7 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from django.contrib.admin import AdminSite
+from django.contrib.admin.widgets import AutocompleteSelect
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
 from django.test import RequestFactory
@@ -183,6 +184,16 @@ class TestLegalDocumentAdminSave(APIBaseTest):
 
         mock_storage.delete.assert_called_once_with(expected_key)
         self.assertFalse(LegalDocument.objects.filter(id=document_id).exists())
+
+    def test_add_form_uses_autocomplete_for_organization(self) -> None:
+        # The organization FK must render an autocomplete widget, not the default
+        # <select> — the latter loads every org row into the page and times out
+        # the add view on Cloud.
+        add_form_class = self.admin.get_form(self._request(), obj=None, change=False)
+        widget = add_form_class.base_fields["organization"].widget
+        # Admin wraps FK widgets in RelatedFieldWidgetWrapper (the +add/edit links).
+        inner = getattr(widget, "widget", widget)
+        self.assertIsInstance(inner, AutocompleteSelect)
 
     def test_change_view_form_saves_without_signed_pdf(self) -> None:
         # The add form (LegalDocumentAdminForm) declares signed_pdf


### PR DESCRIPTION
## Fix `LegalDocument` admin add view timing out on Cloud

The `organization` foreign key field on `LegalDocumentAdmin` was rendering as a `<select>` dropdown, which caused the admin add view to time out on Cloud by attempting to load every organization into the page.

`autocomplete_fields = ("organization",)` has been added to `LegalDocumentAdmin` so the field uses a lazy autocomplete search instead, delegating to `OrganizationAdmin.search_fields`.

A test has been added to assert that the `organization` field renders an `AutocompleteSelect` widget on the add form, preventing a regression back to the full `<select>` behavior.