### PR TITLE
ci: optimize full-depth checkouts

### DIFF
--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -162,8 +162,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  fetch-depth: 0
 
             - name: Log in to Docker Hub
               if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
@@ -255,8 +253,8 @@ jobs:
             - name: Determine next version
               id: version
               run: |
-                  git fetch --tags --force
-                  LATEST_TAG=$(git tag -l 'agent-skills-v*' | grep -E '^agent-skills-v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
+                  REMOTE_TAGS=$(git ls-remote --tags --refs origin 'refs/tags/agent-skills-v*')
+                  LATEST_TAG=$(printf '%s\n' "$REMOTE_TAGS" | awk '{print $2}' | sed 's#refs/tags/##' | grep -E '^agent-skills-v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
                   if [ -z "$LATEST_TAG" ]; then LATEST_TAG="agent-skills-v0.0.0"; fi
                   MINOR=$(echo "${LATEST_TAG#agent-skills-v}" | cut -d. -f2)
                   echo "tag=agent-skills-v0.$((MINOR + 1)).0" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -84,6 +84,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
+                  filter: blob:none
                   clean: false
 
             - name: Install rust

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -30,7 +30,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: master
-                  fetch-depth: 0
+                  sparse-checkout: cli/.sampo/changesets
 
             - name: Check for changesets
               id: check
@@ -92,6 +92,7 @@ jobs:
               with:
                   ref: master
                   fetch-depth: 0
+                  filter: blob:none
                   token: ${{ steps.app-token.outputs.token }}
 
             - name: Install Rust

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -48,6 +48,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
+                  filter: blob:none
                   sparse-checkout: |
                       rust/
                       proto/

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -48,7 +48,6 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
-                  filter: blob:none
                   sparse-checkout: |
                       rust/
                       proto/

--- a/.github/workflows/terragrunt-posthog.yaml
+++ b/.github/workflows/terragrunt-posthog.yaml
@@ -31,7 +31,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
-                  fetch-depth: 0
+                  sparse-checkout: terraform
 
             - name: Find all terraform modules
               id: changes


### PR DESCRIPTION
## Problem

Some workflow jobs use full-history checkouts when they do not need full blob history, which makes checkout expensive in this monorepo.

## Changes

- Remove full-history checkout from simple current-tree scans in agent skills and Terragrunt setup.
- Use `git ls-remote` for agent-skills tag discovery instead of fetching all tags into the checkout.
- Make remaining full-history checkouts blobless where history is still being used.
- Narrow the Release CLI changeset precheck checkout to `cli/.sampo/changesets`.

## Validation

- `git diff --check`
- Ruby YAML load for all changed workflows
- `SHELLCHECK_OPTS=--severity=error pnpm exec actionlint` on the four changed workflows without existing actionlint findings
- Pre-commit `bin/hogli format:yaml` via `flox activate`

Note: full actionlint over all five touched workflows still reports the existing `matrix.is_shadow` issue in `ci-rust.yml`, outside this diff.
