### PR TITLE
chore(rust): debug a thing

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -84,6 +84,12 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
+                  sparse-checkout: |
+                      rust/
+                      proto/
+                      .github/rust-images.yml
+                      .github/actions/rust-compute-affected/
+                  sparse-checkout-cone-mode: false
                   clean: false
 
             - name: Install rust

--- a/rust/affected-services/determinator-rules.toml
+++ b/rust/affected-services/determinator-rules.toml
@@ -33,6 +33,13 @@ mark-changed = "all"
 globs = ["../proto/**"]
 mark-changed = ["personhog-proto", "kafka-assigner-proto", "cymbal-proto"]
 
+# Catch-all for files outside the rust workspace (Python, frontend, CI, docs,
+# etc.) — these are not crate source and should not trigger rust rebuilds.
+# Must come AFTER the specific ../proto and ../.github/rust-images.yml rules.
+[[path-rule]]
+globs = ["../**"]
+mark-changed = []
+
 # Migration directories are not cargo crates. Tell the determinator to
 # ignore them (don't try ancestor-walk package matching). The sqlx-migrate
 # image trigger is handled in custom code outside the determinator.

--- a/rust/affected-services/determinator-rules.toml
+++ b/rust/affected-services/determinator-rules.toml
@@ -33,9 +33,29 @@ mark-changed = "all"
 globs = ["../proto/**"]
 mark-changed = ["personhog-proto", "kafka-assigner-proto", "cymbal-proto"]
 
+# Hypercache contract: Python serializer changes may break Rust deserialization.
+# Must come BEFORE the catch-all rule below.
+[[path-rule]]
+globs = [
+    "../posthog/api/feature_flag.py",
+    "../posthog/models/feature_flag/flags_cache.py",
+    "../posthog/models/feature_flag/feature_flag.py",
+]
+mark-changed = ["feature-flags", "hypercache-server", "common-hypercache"]
+
+# Django migrations and test environment setup — needed for Rust integration tests.
+[[path-rule]]
+globs = [
+    "../posthog/migrations/**",
+    "../ee/migrations/**",
+    "../posthog/management/commands/setup_test_environment.py",
+    "../docker-compose.dev.yml",
+]
+mark-changed = "all"
+
 # Catch-all for files outside the rust workspace (Python, frontend, CI, docs,
 # etc.) — these are not crate source and should not trigger rust rebuilds.
-# Must come AFTER the specific ../proto and ../.github/rust-images.yml rules.
+# Must come AFTER all specific rules for files outside the workspace.
 [[path-rule]]
 globs = ["../**"]
 mark-changed = []

--- a/rust/affected-services/src/affected.rs
+++ b/rust/affected-services/src/affected.rs
@@ -46,6 +46,16 @@ pub fn compute_affected(
         .map(|f| to_workspace_relative(f))
         .collect();
 
+    eprintln!("DEBUG changed_files ({}):", changed_files.len());
+    for f in changed_files {
+        eprintln!("  {f}");
+    }
+    eprintln!("DEBUG workspace_paths ({}):", workspace_paths.len());
+    for p in &workspace_paths {
+        eprintln!("  {p}");
+    }
+    eprintln!("DEBUG old_graph available: {}", old_graph.is_some());
+
     // When no old graph is available (single-graph fallback) and Cargo.lock
     // changed, the determinator can't diff resolved dependencies — it sees
     // old == new. Force a full rebuild to be safe.
@@ -80,6 +90,20 @@ pub fn compute_affected(
     let workspace_size = new_graph.workspace().iter().count();
     let affected_count = result.affected_set.len();
     let rebuild_all = affected_count == workspace_size;
+
+    eprintln!("DEBUG affected_count: {affected_count}, workspace_size: {workspace_size}, rebuild_all: {rebuild_all}");
+    let affected_names_debug: Vec<String> = result
+        .affected_set
+        .packages(DependencyDirection::Forward)
+        .map(|p| p.name().to_string())
+        .collect();
+    eprintln!("DEBUG affected crates: {affected_names_debug:?}");
+    let path_changed_debug: Vec<String> = result
+        .path_changed_set
+        .packages(DependencyDirection::Forward)
+        .map(|p| p.name().to_string())
+        .collect();
+    eprintln!("DEBUG path_changed crates: {path_changed_debug:?}");
 
     let bin_to_crate = build_binary_to_crate_map(new_graph);
 

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -45,7 +45,7 @@ struct TempWorktree {
 }
 
 impl TempWorktree {
-    fn create(base_ref: &str) -> Result<Self> {
+    fn create(base_ref: &str, sparse_paths: &[&str]) -> Result<Self> {
         let path = tempfile::Builder::new()
             .prefix("affected-services-")
             .tempdir()
@@ -53,48 +53,46 @@ impl TempWorktree {
             .keep();
         let path_s = path.to_string_lossy();
 
-        // Read the current sparse checkout setting so we can restore it after
-        // creating the worktree. Without this, CI's sparse checkout config
-        // would be inherited by the worktree and produce an incomplete checkout.
-        let prev_sparse = Command::new("git")
-            .args(["config", "--local", "core.sparseCheckout"])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
-
-        if prev_sparse.as_deref() == Some("true") {
-            let _ = Command::new("git")
-                .args(["config", "--local", "core.sparseCheckout", "false"])
-                .output();
-        }
-
         let out = Command::new("git")
-            .args(["worktree", "add", "--detach", path_s.as_ref(), base_ref])
+            .args([
+                "worktree",
+                "add",
+                "--detach",
+                "--no-checkout",
+                path_s.as_ref(),
+                base_ref,
+            ])
             .output()
             .context("failed to create git worktree")?;
-
-        // Restore the original sparse checkout setting
-        let restore_ok = match prev_sparse.as_deref() {
-            Some(val) => Command::new("git")
-                .args(["config", "--local", "core.sparseCheckout", val])
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false),
-            None => Command::new("git")
-                .args(["config", "--local", "--unset", "core.sparseCheckout"])
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false),
-        };
-        if !restore_ok {
-            anyhow::bail!("failed to restore core.sparseCheckout after worktree creation");
-        }
-
         anyhow::ensure!(
             out.status.success(),
             "git worktree add failed: {}",
             String::from_utf8_lossy(&out.stderr).trim()
+        );
+
+        // Configure sparse checkout on the worktree so we only materialize
+        // the paths needed for cargo metadata, not the entire repo.
+        let mut sparse_args = vec!["sparse-checkout", "set", "--no-cone"];
+        sparse_args.extend_from_slice(sparse_paths);
+        let sparse_out = Command::new("git")
+            .args(["-C", path_s.as_ref()])
+            .args(&sparse_args)
+            .output()
+            .context("failed to configure sparse checkout on worktree")?;
+        anyhow::ensure!(
+            sparse_out.status.success(),
+            "git sparse-checkout set failed: {}",
+            String::from_utf8_lossy(&sparse_out.stderr).trim()
+        );
+
+        let checkout_out = Command::new("git")
+            .args(["-C", path_s.as_ref(), "checkout"])
+            .output()
+            .context("failed to checkout worktree")?;
+        anyhow::ensure!(
+            checkout_out.status.success(),
+            "git checkout in worktree failed: {}",
+            String::from_utf8_lossy(&checkout_out.stderr).trim()
         );
 
         Ok(Self { path })
@@ -119,7 +117,7 @@ impl Drop for TempWorktree {
 }
 
 pub fn build_old_package_graph(base_ref: &str, workspace_subdir: &str) -> Option<PackageGraph> {
-    let worktree = match TempWorktree::create(base_ref) {
+    let worktree = match TempWorktree::create(base_ref, &[workspace_subdir]) {
         Ok(w) => w,
         Err(e) => {
             eprintln!("warning: could not create worktree at {base_ref}: {e}");

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -16,20 +16,8 @@ pub fn find_repo_root() -> Result<PathBuf> {
 }
 
 pub fn get_changed_files(base_ref: &str) -> Result<Vec<String>> {
-    // Compute the actual merge base so we don't pick up unrelated master
-    // commits when the PR base SHA is behind the branch's rebase point.
-    let merge_base_out = Command::new("git")
-        .args(["merge-base", base_ref, "HEAD"])
-        .output()
-        .context("failed to run git merge-base")?;
-    let diff_base = if merge_base_out.status.success() {
-        String::from_utf8(merge_base_out.stdout)?.trim().to_string()
-    } else {
-        base_ref.to_string()
-    };
-
     let out = Command::new("git")
-        .args(["diff", "--name-only", &format!("{diff_base}...HEAD")])
+        .args(["diff", "--name-only", &format!("{base_ref}...HEAD")])
         .output()
         .context("failed to run git diff")?;
     anyhow::ensure!(
@@ -87,17 +75,20 @@ impl TempWorktree {
             .context("failed to create git worktree")?;
 
         // Restore the original sparse checkout setting
-        match prev_sparse.as_deref() {
-            Some(val) => {
-                let _ = Command::new("git")
-                    .args(["config", "--local", "core.sparseCheckout", val])
-                    .output();
-            }
-            None => {
-                let _ = Command::new("git")
-                    .args(["config", "--local", "--unset", "core.sparseCheckout"])
-                    .output();
-            }
+        let restore_ok = match prev_sparse.as_deref() {
+            Some(val) => Command::new("git")
+                .args(["config", "--local", "core.sparseCheckout", val])
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false),
+            None => Command::new("git")
+                .args(["config", "--local", "--unset", "core.sparseCheckout"])
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false),
+        };
+        if !restore_ok {
+            eprintln!("warning: failed to restore core.sparseCheckout — CI checkout config may be corrupted");
         }
 
         anyhow::ensure!(

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -117,8 +117,14 @@ impl Drop for TempWorktree {
 }
 
 pub fn build_old_package_graph(base_ref: &str, workspace_subdir: &str) -> Option<PackageGraph> {
+    eprintln!(
+        "DEBUG building old graph for base_ref={base_ref}, workspace_subdir={workspace_subdir}"
+    );
     let worktree = match TempWorktree::create(base_ref, &[workspace_subdir]) {
-        Ok(w) => w,
+        Ok(w) => {
+            eprintln!("DEBUG worktree created at {:?}", w.path());
+            w
+        }
         Err(e) => {
             eprintln!("warning: could not create worktree at {base_ref}: {e}");
             return None;
@@ -130,12 +136,19 @@ pub fn build_old_package_graph(base_ref: &str, workspace_subdir: &str) -> Option
         eprintln!("warning: {base_ref} has no {workspace_subdir}/Cargo.toml");
         return None;
     }
+    eprintln!("DEBUG old workspace Cargo.toml found at {old_workspace:?}");
 
     let mut cmd = MetadataCommand::new();
     cmd.current_dir(&old_workspace);
     cmd.other_options(["--locked"]);
     match cmd.build_graph() {
-        Ok(graph) => Some(graph),
+        Ok(graph) => {
+            eprintln!(
+                "DEBUG old graph built successfully ({} crates)",
+                graph.workspace().iter().count()
+            );
+            Some(graph)
+        }
         Err(e) => {
             eprintln!("warning: could not build old package graph: {e}");
             None

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -88,7 +88,7 @@ impl TempWorktree {
                 .unwrap_or(false),
         };
         if !restore_ok {
-            eprintln!("warning: failed to restore core.sparseCheckout — CI checkout config may be corrupted");
+            anyhow::bail!("failed to restore core.sparseCheckout after worktree creation");
         }
 
         anyhow::ensure!(

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -65,22 +65,40 @@ impl TempWorktree {
             .keep();
         let path_s = path.to_string_lossy();
 
-        // Disable sparse checkout before creating the worktree so it doesn't
-        // inherit the parent's sparse-checkout filter (CI uses sparse checkout
-        // for the main working tree).
-        let _ = Command::new("git")
-            .args(["config", "--local", "core.sparseCheckout", "false"])
-            .output();
+        // Read the current sparse checkout setting so we can restore it after
+        // creating the worktree. Without this, CI's sparse checkout config
+        // would be inherited by the worktree and produce an incomplete checkout.
+        let prev_sparse = Command::new("git")
+            .args(["config", "--local", "core.sparseCheckout"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+
+        if prev_sparse.as_deref() == Some("true") {
+            let _ = Command::new("git")
+                .args(["config", "--local", "core.sparseCheckout", "false"])
+                .output();
+        }
 
         let out = Command::new("git")
             .args(["worktree", "add", "--detach", path_s.as_ref(), base_ref])
             .output()
             .context("failed to create git worktree")?;
 
-        // Re-enable sparse checkout for the parent worktree
-        let _ = Command::new("git")
-            .args(["config", "--local", "core.sparseCheckout", "true"])
-            .output();
+        // Restore the original sparse checkout setting
+        match prev_sparse.as_deref() {
+            Some(val) => {
+                let _ = Command::new("git")
+                    .args(["config", "--local", "core.sparseCheckout", val])
+                    .output();
+            }
+            None => {
+                let _ = Command::new("git")
+                    .args(["config", "--local", "--unset", "core.sparseCheckout"])
+                    .output();
+            }
+        }
 
         anyhow::ensure!(
             out.status.success(),

--- a/rust/affected-services/src/graph.rs
+++ b/rust/affected-services/src/graph.rs
@@ -16,8 +16,20 @@ pub fn find_repo_root() -> Result<PathBuf> {
 }
 
 pub fn get_changed_files(base_ref: &str) -> Result<Vec<String>> {
+    // Compute the actual merge base so we don't pick up unrelated master
+    // commits when the PR base SHA is behind the branch's rebase point.
+    let merge_base_out = Command::new("git")
+        .args(["merge-base", base_ref, "HEAD"])
+        .output()
+        .context("failed to run git merge-base")?;
+    let diff_base = if merge_base_out.status.success() {
+        String::from_utf8(merge_base_out.stdout)?.trim().to_string()
+    } else {
+        base_ref.to_string()
+    };
+
     let out = Command::new("git")
-        .args(["diff", "--name-only", &format!("{base_ref}...HEAD")])
+        .args(["diff", "--name-only", &format!("{diff_base}...HEAD")])
         .output()
         .context("failed to run git diff")?;
     anyhow::ensure!(
@@ -51,21 +63,31 @@ impl TempWorktree {
             .tempdir()
             .context("failed to create temp directory")?
             .keep();
+        let path_s = path.to_string_lossy();
+
+        // Disable sparse checkout before creating the worktree so it doesn't
+        // inherit the parent's sparse-checkout filter (CI uses sparse checkout
+        // for the main working tree).
+        let _ = Command::new("git")
+            .args(["config", "--local", "core.sparseCheckout", "false"])
+            .output();
+
         let out = Command::new("git")
-            .args([
-                "worktree",
-                "add",
-                "--detach",
-                &path.to_string_lossy(),
-                base_ref,
-            ])
+            .args(["worktree", "add", "--detach", path_s.as_ref(), base_ref])
             .output()
             .context("failed to create git worktree")?;
+
+        // Re-enable sparse checkout for the parent worktree
+        let _ = Command::new("git")
+            .args(["config", "--local", "core.sparseCheckout", "true"])
+            .output();
+
         anyhow::ensure!(
             out.status.success(),
             "git worktree add failed: {}",
             String::from_utf8_lossy(&out.stderr).trim()
         );
+
         Ok(Self { path })
     }
 


### PR DESCRIPTION
- Add catch-all determinator rule to ignore files outside the rust
  workspace (Python, frontend, CI workflows, etc.) that were falsely
  triggering rebuild-all
- Use git merge-base for changed file detection so stale PR base SHAs
  don't include unrelated master commits in the diff
- Disable sparse checkout before worktree creation so CI environments
  with sparse checkout enabled get a full worktree for the old graph
- Add sparse checkout to ci-rust.yml affected job to match
  rust-docker-build.yml (~2min faster checkout)<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
