### PR TITLE
feat(replay): collapse legacy recording conditions when only new SDKs seen

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -10,13 +10,17 @@ import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { pluralize } from 'lib/utils'
-import { ReplayPlatform, replayTriggersLogic } from 'scenes/settings/environment/replayTriggersLogic'
+import {
+    ReplayPlatform,
+    replayTriggersLogic,
+    TRIGGER_GROUPS_MIN_SDK_VERSION,
+} from 'scenes/settings/environment/replayTriggersLogic'
 import { Since } from 'scenes/settings/environment/SessionRecordingSettings'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { AccessControlResourceType, AvailableFeature, TeamPublicType, TeamType } from '~/types'
 
-export const TRIGGER_GROUPS_MIN_SDK_VERSION = '1.369.0'
+export { TRIGGER_GROUPS_MIN_SDK_VERSION }
 
 /** Convert the stored sample-rate string (decimal 0–1) to a display percentage (0–100). */
 function toDisplaySampleRate(rate: string | null | undefined): number {
@@ -377,13 +381,96 @@ function useHeaderStatuses(currentTeam: TeamType | TeamPublicType | null): {
     }
 }
 
-export function ReplayTriggers(): JSX.Element {
+function LegacyRecordingConditions(): JSX.Element {
     const { selectedPlatform } = useValues(replayTriggersLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const statuses = useHeaderStatuses(currentTeam)
+
+    const isV2TriggersEnabled = featureFlags[FEATURE_FLAGS.REPLAY_TRIGGERS_V2]
+
+    return (
+        <>
+            {currentTeam && <RecordingTriggersSummary currentTeam={currentTeam} selectedPlatform={selectedPlatform} />}
+
+            <IngestionControls.MatchTypeSelect />
+
+            <AnyWith100SamplingWarning currentTeam={currentTeam} isV2TriggersEnabled={!!isV2TriggersEnabled} />
+
+            <div>
+                <h3 className="text-sm font-semibold mb-2">Recording conditions</h3>
+                <LemonCollapse
+                    multiple
+                    panels={[
+                        {
+                            key: 'url',
+                            header: <TriggerPanelHeader title="URL matches" status={statuses.urlStatus} showMatchTag />,
+                            content: <UrlTriggerOptions />,
+                        },
+                        {
+                            key: 'event',
+                            header: (
+                                <TriggerPanelHeader title="Event emitted" status={statuses.eventStatus} showMatchTag />
+                            ),
+                            content: <EventTriggerOptions />,
+                        },
+                        {
+                            key: 'flag',
+                            header: (
+                                <TriggerPanelHeader title="Feature flag" status={statuses.flagStatus} showMatchTag />
+                            ),
+                            content: <LinkedFlagSelector />,
+                        },
+                    ]}
+                />
+            </div>
+
+            <div>
+                <h3 className="text-sm font-semibold mb-2">Recording limits</h3>
+                <LemonCollapse
+                    multiple
+                    panels={[
+                        {
+                            key: 'sampling',
+                            header: (
+                                <TriggerPanelHeader title="Sampling" status={statuses.samplingStatus} showMatchTag />
+                            ),
+                            content: <Sampling />,
+                        },
+                        {
+                            key: 'min-duration',
+                            header: <TriggerPanelHeader title="Minimum duration" status={statuses.minDurationStatus} />,
+                            content: <MinimumDurationSetting />,
+                        },
+                    ]}
+                />
+            </div>
+
+            <div>
+                <h3 className="text-base font-semibold mb-2">
+                    Recording exclusions <Since web={{ version: '1.171.0' }} />
+                </h3>
+                <LemonCollapse
+                    multiple
+                    panels={[
+                        {
+                            key: 'blocklist',
+                            header: <TriggerPanelHeader title="URL blocklist" status={statuses.blocklistStatus} />,
+                            content: <UrlBlocklistOptions />,
+                        },
+                    ]}
+                />
+            </div>
+        </>
+    )
+}
+
+export function ReplayTriggers(): JSX.Element {
+    const { selectedPlatform, shouldMinimizeLegacyConditions } = useValues(replayTriggersLogic)
     const { selectPlatform } = useActions(replayTriggersLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const statuses = useHeaderStatuses(currentTeam)
 
     const isV2TriggersEnabled = featureFlags[FEATURE_FLAGS.REPLAY_TRIGGERS_V2]
 
@@ -410,112 +497,45 @@ export function ReplayTriggers(): JSX.Element {
                             </LemonBanner>
 
                             <TriggerGroupsEditor />
-
-                            <h3 className="text-base font-semibold">Legacy recording conditions</h3>
-                            <LemonBanner type="warning">
-                                Used by SDK versions &lt; v{TRIGGER_GROUPS_MIN_SDK_VERSION} and as fallback for newer
-                                versions if trigger groups are not configured.
-                            </LemonBanner>
                         </>
                     )}
 
-                    {currentTeam && (
-                        <RecordingTriggersSummary currentTeam={currentTeam} selectedPlatform={selectedPlatform} />
+                    {isV2TriggersEnabled && shouldMinimizeLegacyConditions ? (
+                        <LemonCollapse
+                            panels={[
+                                {
+                                    key: 'legacy-recording-conditions',
+                                    header: (
+                                        <div className="flex flex-col">
+                                            <span className="font-semibold">Legacy recording conditions</span>
+                                            <span className="text-muted text-xs font-normal">
+                                                Hidden because your web SDKs (v{TRIGGER_GROUPS_MIN_SDK_VERSION}+) use
+                                                trigger groups. Expand to configure fallbacks for older SDK versions.
+                                            </span>
+                                        </div>
+                                    ),
+                                    content: (
+                                        <div className="flex flex-col gap-y-4 pt-2">
+                                            <LegacyRecordingConditions />
+                                        </div>
+                                    ),
+                                },
+                            ]}
+                        />
+                    ) : (
+                        <>
+                            {isV2TriggersEnabled && (
+                                <>
+                                    <h3 className="text-base font-semibold">Legacy recording conditions</h3>
+                                    <LemonBanner type="warning">
+                                        Used by SDK versions &lt; v{TRIGGER_GROUPS_MIN_SDK_VERSION} and as fallback for
+                                        newer versions if trigger groups are not configured.
+                                    </LemonBanner>
+                                </>
+                            )}
+                            <LegacyRecordingConditions />
+                        </>
                     )}
-
-                    <IngestionControls.MatchTypeSelect />
-
-                    <AnyWith100SamplingWarning currentTeam={currentTeam} isV2TriggersEnabled={!!isV2TriggersEnabled} />
-
-                    <div>
-                        <h3 className="text-sm font-semibold mb-2">Recording conditions</h3>
-                        <LemonCollapse
-                            multiple
-                            panels={[
-                                {
-                                    key: 'url',
-                                    header: (
-                                        <TriggerPanelHeader
-                                            title="URL matches"
-                                            status={statuses.urlStatus}
-                                            showMatchTag
-                                        />
-                                    ),
-                                    content: <UrlTriggerOptions />,
-                                },
-                                {
-                                    key: 'event',
-                                    header: (
-                                        <TriggerPanelHeader
-                                            title="Event emitted"
-                                            status={statuses.eventStatus}
-                                            showMatchTag
-                                        />
-                                    ),
-                                    content: <EventTriggerOptions />,
-                                },
-                                {
-                                    key: 'flag',
-                                    header: (
-                                        <TriggerPanelHeader
-                                            title="Feature flag"
-                                            status={statuses.flagStatus}
-                                            showMatchTag
-                                        />
-                                    ),
-                                    content: <LinkedFlagSelector />,
-                                },
-                            ]}
-                        />
-                    </div>
-
-                    <div>
-                        <h3 className="text-sm font-semibold mb-2">Recording limits</h3>
-                        <LemonCollapse
-                            multiple
-                            panels={[
-                                {
-                                    key: 'sampling',
-                                    header: (
-                                        <TriggerPanelHeader
-                                            title="Sampling"
-                                            status={statuses.samplingStatus}
-                                            showMatchTag
-                                        />
-                                    ),
-                                    content: <Sampling />,
-                                },
-                                {
-                                    key: 'min-duration',
-                                    header: (
-                                        <TriggerPanelHeader
-                                            title="Minimum duration"
-                                            status={statuses.minDurationStatus}
-                                        />
-                                    ),
-                                    content: <MinimumDurationSetting />,
-                                },
-                            ]}
-                        />
-                    </div>
-
-                    <div>
-                        <h3 className="text-base font-semibold mb-2">
-                            Recording exclusions <Since web={{ version: '1.171.0' }} />
-                        </h3>
-                        <LemonCollapse
-                            multiple
-                            panels={[
-                                {
-                                    key: 'blocklist',
-                                    header: (
-                                        <TriggerPanelHeader title="URL blocklist" status={statuses.blocklistStatus} />
-                                    ),
-                                    content: <UrlBlocklistOptions />,
-                                },
-                            ]}
-                        />
-                    </div>
                 </div>
             ),
         },

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonBanner, LemonCollapse, LemonLabel, LemonTab, LemonTabs, Tooltip } from '@posthog/lemon-ui'
+import { LemonBanner, LemonCollapse, LemonDivider, LemonLabel, LemonTab, LemonTabs, Tooltip } from '@posthog/lemon-ui'
 
 import IngestionControls from 'lib/components/IngestionControls'
 import { IngestionControlsSummary } from 'lib/components/IngestionControls/Summary'
@@ -465,6 +465,43 @@ function LegacyRecordingConditions(): JSX.Element {
     )
 }
 
+function SdkCompatibilityBanner(): JSX.Element {
+    const { shouldMinimizeLegacyConditions, hasOutdatedWebSdk } = useValues(replayTriggersLogic)
+
+    if (shouldMinimizeLegacyConditions) {
+        return (
+            <LemonBanner type="success">
+                All your recent web SDK traffic is on v{TRIGGER_GROUPS_MIN_SDK_VERSION}+, so trigger groups apply to
+                every session. The legacy recording conditions below are kept only as a fallback for older SDKs.
+            </LemonBanner>
+        )
+    }
+
+    if (hasOutdatedWebSdk) {
+        return (
+            <LemonBanner type="warning">
+                <strong>Some of your web traffic is on an older posthog-js</strong> (before v
+                {TRIGGER_GROUPS_MIN_SDK_VERSION}), which uses the legacy recording conditions below. Upgrade posthog-js
+                to v{TRIGGER_GROUPS_MIN_SDK_VERSION}+ so trigger groups apply to every session. Until then, both
+                configurations are sent for backward compatibility.
+            </LemonBanner>
+        )
+    }
+
+    return (
+        <LemonBanner type="warning">
+            <strong>JavaScript SDK version compatibility</strong>
+            <ul className="list-disc ml-4 mt-2 space-y-1">
+                <li>
+                    SDK versions &gt;= v{TRIGGER_GROUPS_MIN_SDK_VERSION} use trigger groups if configured, otherwise
+                    fall back to the legacy recording conditions
+                </li>
+                <li>Both configurations are sent to ensure backward compatibility with all JavaScript SDK versions</li>
+            </ul>
+        </LemonBanner>
+    )
+}
+
 export function ReplayTriggers(): JSX.Element {
     const { selectedPlatform, shouldMinimizeLegacyConditions } = useValues(replayTriggersLogic)
     const { selectPlatform } = useActions(replayTriggersLogic)
@@ -482,22 +519,17 @@ export function ReplayTriggers(): JSX.Element {
                 <div className="flex flex-col gap-y-4">
                     {isV2TriggersEnabled && (
                         <>
-                            <LemonBanner type="warning">
-                                <strong>JavaScript SDK version compatibility</strong>
-                                <ul className="list-disc ml-4 mt-2 space-y-1">
-                                    <li>
-                                        SDK versions &gt;= v{TRIGGER_GROUPS_MIN_SDK_VERSION} use trigger groups if
-                                        configured, otherwise fall back to the legacy recording conditions
-                                    </li>
-                                    <li>
-                                        Both configurations are sent to ensure backward compatibility with all
-                                        JavaScript SDK versions
-                                    </li>
-                                </ul>
-                            </LemonBanner>
+                            <SdkCompatibilityBanner />
 
                             <TriggerGroupsEditor />
                         </>
+                    )}
+
+                    {isV2TriggersEnabled && (
+                        <div className="mt-2">
+                            <LemonDivider className="mb-4" />
+                            <h3 className="text-base font-semibold mb-1">Legacy recording conditions</h3>
+                        </div>
                     )}
 
                     {isV2TriggersEnabled && shouldMinimizeLegacyConditions ? (
@@ -506,13 +538,10 @@ export function ReplayTriggers(): JSX.Element {
                                 {
                                     key: 'legacy-recording-conditions',
                                     header: (
-                                        <div className="flex flex-col">
-                                            <span className="font-semibold">Legacy recording conditions</span>
-                                            <span className="text-muted text-xs font-normal">
-                                                Hidden because your web SDKs (v{TRIGGER_GROUPS_MIN_SDK_VERSION}+) use
-                                                trigger groups. Expand to configure fallbacks for older SDK versions.
-                                            </span>
-                                        </div>
+                                        <span className="text-muted text-sm font-normal">
+                                            Hidden because your web SDKs (v{TRIGGER_GROUPS_MIN_SDK_VERSION}+) use
+                                            trigger groups. Expand to configure fallbacks for older SDK versions.
+                                        </span>
                                     ),
                                     content: (
                                         <div className="flex flex-col gap-y-4 pt-2">
@@ -525,13 +554,10 @@ export function ReplayTriggers(): JSX.Element {
                     ) : (
                         <>
                             {isV2TriggersEnabled && (
-                                <>
-                                    <h3 className="text-base font-semibold">Legacy recording conditions</h3>
-                                    <LemonBanner type="warning">
-                                        Used by SDK versions &lt; v{TRIGGER_GROUPS_MIN_SDK_VERSION} and as fallback for
-                                        newer versions if trigger groups are not configured.
-                                    </LemonBanner>
-                                </>
+                                <LemonBanner type="warning">
+                                    Used by SDK versions &lt; v{TRIGGER_GROUPS_MIN_SDK_VERSION} and as fallback for
+                                    newer versions if trigger groups are not configured.
+                                </LemonBanner>
                             )}
                             <LegacyRecordingConditions />
                         </>

--- a/frontend/src/scenes/settings/environment/replayTriggersLogic.test.ts
+++ b/frontend/src/scenes/settings/environment/replayTriggersLogic.test.ts
@@ -1,4 +1,4 @@
-import { legacyConditionsAreInactive, TRIGGER_GROUPS_MIN_SDK_VERSION } from './replayTriggersLogic'
+import { hasOutdatedWebSdk, legacyConditionsAreInactive, TRIGGER_GROUPS_MIN_SDK_VERSION } from './replayTriggersLogic'
 
 describe('replayTriggersLogic', () => {
     describe('legacyConditionsAreInactive', () => {
@@ -11,6 +11,19 @@ describe('replayTriggersLogic', () => {
             ['unparseable version stays conservative', ['not-a-version', '1.400.0'], false],
         ])('%s -> %s', (_description, versions, expected) => {
             expect(legacyConditionsAreInactive(versions as string[])).toBe(expected)
+        })
+    })
+
+    describe('hasOutdatedWebSdk', () => {
+        it.each([
+            ['no web data', [], false],
+            ['only new versions', ['1.369.0', '1.400.1'], false],
+            ['only old versions', ['1.300.0', '1.368.9'], true],
+            ['mix of old and new', ['1.368.0', '1.400.0'], true],
+            ['exactly the minimum version', [TRIGGER_GROUPS_MIN_SDK_VERSION], false],
+            ['unparseable version stays conservative', ['not-a-version', '1.400.0'], true],
+        ])('%s -> %s', (_description, versions, expected) => {
+            expect(hasOutdatedWebSdk(versions as string[])).toBe(expected)
         })
     })
 })

--- a/frontend/src/scenes/settings/environment/replayTriggersLogic.test.ts
+++ b/frontend/src/scenes/settings/environment/replayTriggersLogic.test.ts
@@ -1,0 +1,16 @@
+import { legacyConditionsAreInactive, TRIGGER_GROUPS_MIN_SDK_VERSION } from './replayTriggersLogic'
+
+describe('replayTriggersLogic', () => {
+    describe('legacyConditionsAreInactive', () => {
+        it.each([
+            ['no web data', [], false],
+            ['only new versions', ['1.369.0', '1.400.1'], true],
+            ['only old versions', ['1.300.0', '1.368.9'], false],
+            ['mix of old and new', ['1.368.0', '1.400.0'], false],
+            ['exactly the minimum version', [TRIGGER_GROUPS_MIN_SDK_VERSION], true],
+            ['unparseable version stays conservative', ['not-a-version', '1.400.0'], false],
+        ])('%s -> %s', (_description, versions, expected) => {
+            expect(legacyConditionsAreInactive(versions as string[])).toBe(expected)
+        })
+    })
+})

--- a/frontend/src/scenes/settings/environment/replayTriggersLogic.ts
+++ b/frontend/src/scenes/settings/environment/replayTriggersLogic.ts
@@ -41,14 +41,7 @@ export function legacyConditionsAreInactive(webVersions: string[]): boolean {
             return true
         }
     }
-    const isNew = (v: string): boolean => {
-        try {
-            return compareVersion(v, TRIGGER_GROUPS_MIN_SDK_VERSION) >= 0
-        } catch {
-            return false
-        }
-    }
-    return webVersions.some(isNew) && !webVersions.some(isOld)
+    return !webVersions.some(isOld)
 }
 
 function ensureAnchored(url: string): string {

--- a/frontend/src/scenes/settings/environment/replayTriggersLogic.ts
+++ b/frontend/src/scenes/settings/environment/replayTriggersLogic.ts
@@ -29,19 +29,25 @@ export function isStringWithLength(x: unknown): x is string {
  * window, so this answers "have only new SDKs been seen recently". Returns false when there's no web data
  * (e.g. a brand-new or self-hosted team) — we never minimize the legacy UI without positive evidence.
  */
+// Unparseable versions count as "predates" so we stay conservative (prompt upgrade / keep legacy visible).
+function webSdkPredatesTriggerGroups(version: string): boolean {
+    try {
+        return compareVersion(version, TRIGGER_GROUPS_MIN_SDK_VERSION) < 0
+    } catch {
+        return true
+    }
+}
+
 export function legacyConditionsAreInactive(webVersions: string[]): boolean {
     if (webVersions.length === 0) {
         return false
     }
-    // Unparseable versions count as "old" so we stay conservative and keep the legacy UI visible.
-    const isOld = (v: string): boolean => {
-        try {
-            return compareVersion(v, TRIGGER_GROUPS_MIN_SDK_VERSION) < 0
-        } catch {
-            return true
-        }
-    }
-    return !webVersions.some(isOld)
+    return !webVersions.some(webSdkPredatesTriggerGroups)
+}
+
+/** True when there's web SDK data and at least one version predates trigger-group support. */
+export function hasOutdatedWebSdk(webVersions: string[]): boolean {
+    return webVersions.some(webSdkPredatesTriggerGroups)
 }
 
 function ensureAnchored(url: string): string {
@@ -211,6 +217,11 @@ export const replayTriggersLogic = kea<replayTriggersLogicType>([
             (s) => [s.augmentedData],
             (augmentedData): boolean =>
                 legacyConditionsAreInactive((augmentedData?.web?.allReleases ?? []).map((r) => r.version)),
+        ],
+        hasOutdatedWebSdk: [
+            (s) => [s.augmentedData],
+            (augmentedData): boolean =>
+                hasOutdatedWebSdk((augmentedData?.web?.allReleases ?? []).map((r) => r.version)),
         ],
         isAddUrlTriggerConfigFormVisible: [
             (s) => [s.editUrlTriggerIndex],

--- a/frontend/src/scenes/settings/environment/replayTriggersLogic.ts
+++ b/frontend/src/scenes/settings/environment/replayTriggersLogic.ts
@@ -4,6 +4,8 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 
 import { UrlTriggerConfig } from 'lib/components/IngestionControls/types'
+import { compareVersion } from 'lib/utils/semver'
+import { sdkDoctorLogic } from 'scenes/onboarding/sdks/sdkDoctorLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { TeamPublicType, TeamType } from '~/types'
@@ -12,10 +14,41 @@ import type { replayTriggersLogicType } from './replayTriggersLogicType'
 
 export type ReplayPlatform = 'web' | 'mobile'
 
+/** Minimum posthog-js version that understands V2 trigger groups. Older web SDKs fall back to legacy conditions. */
+export const TRIGGER_GROUPS_MIN_SDK_VERSION = '1.369.0'
+
 const NEW_URL_TRIGGER = { url: '', matching: 'regex' }
 
 export function isStringWithLength(x: unknown): x is string {
     return typeof x === 'string' && x.trim() !== ''
+}
+
+/**
+ * True when the team's recent web SDK traffic is entirely on versions that understand trigger groups, so the
+ * legacy recording conditions only serve SDKs the team no longer runs. The SDK Doctor data is a rolling ~7-day
+ * window, so this answers "have only new SDKs been seen recently". Returns false when there's no web data
+ * (e.g. a brand-new or self-hosted team) — we never minimize the legacy UI without positive evidence.
+ */
+export function legacyConditionsAreInactive(webVersions: string[]): boolean {
+    if (webVersions.length === 0) {
+        return false
+    }
+    // Unparseable versions count as "old" so we stay conservative and keep the legacy UI visible.
+    const isOld = (v: string): boolean => {
+        try {
+            return compareVersion(v, TRIGGER_GROUPS_MIN_SDK_VERSION) < 0
+        } catch {
+            return true
+        }
+    }
+    const isNew = (v: string): boolean => {
+        try {
+            return compareVersion(v, TRIGGER_GROUPS_MIN_SDK_VERSION) >= 0
+        } catch {
+            return false
+        }
+    }
+    return webVersions.some(isNew) && !webVersions.some(isOld)
 }
 
 function ensureAnchored(url: string): string {
@@ -55,7 +88,10 @@ export const replayTriggersLogic = kea<replayTriggersLogicType>([
         setCheckUrlBlocklist: (url: string) => ({ url }),
         validateUrlInput: (url: string, type: 'trigger' | 'blocklist') => ({ url, type }),
     }),
-    connect(() => ({ values: [teamLogic, ['currentTeam']], actions: [teamLogic, ['updateCurrentTeam']] })),
+    connect(() => ({
+        values: [teamLogic, ['currentTeam'], sdkDoctorLogic, ['augmentedData']],
+        actions: [teamLogic, ['updateCurrentTeam']],
+    })),
     reducers({
         urlTriggerConfig: [
             null as UrlTriggerConfig[] | null,
@@ -178,6 +214,11 @@ export const replayTriggersLogic = kea<replayTriggersLogicType>([
         ],
     }),
     selectors({
+        shouldMinimizeLegacyConditions: [
+            (s) => [s.augmentedData],
+            (augmentedData): boolean =>
+                legacyConditionsAreInactive((augmentedData?.web?.allReleases ?? []).map((r) => r.version)),
+        ],
         isAddUrlTriggerConfigFormVisible: [
             (s) => [s.editUrlTriggerIndex],
             (editUrlTriggerIndex) => editUrlTriggerIndex === -1,


### PR DESCRIPTION
## Problem

With V2 trigger groups enabled, the session replay settings page shows the full "Legacy recording conditions" block (match type, URL/event/flag conditions, sampling, minimum duration, URL blocklist) inline beneath the trigger groups editor. For teams whose users are all on recent posthog-js versions, these legacy conditions only ever apply to SDKs the team no longer runs — so the block is visual noise that competes with the V2 UI newcomers should focus on.

Follow-up to the V2-sticky trigger-groups change (squash-merged to master).

## Changes

- Added `legacyConditionsAreInactive(webVersions)` and a `shouldMinimizeLegacyConditions` selector to `replayTriggersLogic`. It returns true only when the team's recent web SDK traffic is **entirely** on versions `>= TRIGGER_GROUPS_MIN_SDK_VERSION` (1.369.0) **and** there is web SDK data. Detection reuses `sdkDoctorLogic`'s rolling ~7-day version window; unparseable versions are treated as "old" so we stay conservative.
- When V2 trigger groups are enabled **and** the team is detected as new-SDK-only, the entire legacy block collapses into a single `LemonCollapse` accordion (collapsed by default) with a subtitle explaining it's hidden because the team's web SDKs use trigger groups — so it's still one click away. Otherwise (old SDKs present, no data yet, or V2 disabled) it renders expanded exactly as before.
- Extracted the legacy controls into a `LegacyRecordingConditions` component so they render identically whether expanded or inside the accordion (no duplicated JSX).
- Moved the `TRIGGER_GROUPS_MIN_SDK_VERSION` constant into `replayTriggersLogic` (re-exported from `ReplayTriggers` for existing importers) to avoid a circular import between the logic and the component.

Conservative by design: a brand-new team with no events, or a self-hosted instance with no SDK Doctor data, keeps the legacy block expanded — we never hide it without positive evidence that only new SDKs are in use. The ~7-day window means this answers "have only new SDKs been seen recently," not a true all-time "ever"; a longer lookback would need a backend query and is a possible follow-up.

This is a frontend-only change.

## How did you test this code?

![Screenshot 2026-06-05 at 12.18.56 PM.png](https://app.graphite.com/user-attachments/assets/1e7938ae-1a9b-4142-bd74-293d7d35560e.png)



I'm an agent (PostHog Code). I did not perform manual UI testing. Automated checks run locally:

- New `replayTriggersLogic.test.ts` covering `legacyConditionsAreInactive`: no data → false, only-new → true, only-old → false, mixed → false, exactly-min → true, unparseable → false. **6/6 pass.**
- `tsc --noEmit` clean for the changed files (kea types regenerated).
- `oxlint` + `oxfmt` clean on the changed files.

Manual verification in the running app (accordion collapse/expand behavior and the detection against a real team's SDK mix) is recommended before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). Decisions:

- Reused the existing SDK Doctor 7-day version data rather than adding a new backend ClickHouse query — ships now; a longer "truly gone" lookback is noted as a follow-up.
- Collapse scope is the _entire_ legacy block (including team-level sampling and minimum duration), since V2 trigger groups carry their own per-group sample rate and minimum duration — the team-level ones are V1-specific fallbacks.
- Detection is fail-safe: no web data → keep legacy expanded.

Agent-authored; requires human review.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)