### PR TITLE
feat(navbar): hide campaign advert on hobby instances

### DIFF
--- a/frontend/src/lib/components/NavPanelAdvertisement/NavPanelAdvertisement.tsx
+++ b/frontend/src/lib/components/NavPanelAdvertisement/NavPanelAdvertisement.tsx
@@ -8,6 +8,7 @@ import { Link } from '@posthog/lemon-ui'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { getFeatureFlagPayload } from 'lib/logic/featureFlagLogic'
 import { addProductIntent } from 'lib/utils/product-intents'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { getTreeItemsProducts } from '~/products'
@@ -46,6 +47,7 @@ export function NavPanelAdvertisement(): JSX.Element | null {
     const logic = navPanelAdvertisementRecommendedLogic()
     const { oldestRecommendedProduct } = useValues(logic)
     const { isLayoutNavCollapsed } = useValues(panelLayoutLogic)
+    const { isCloudOrDev } = useValues(preflightLogic)
 
     const campaignFlagPayload = getFeatureFlagPayload('nav-panel-campaign') as CampaignPayload | undefined
 
@@ -53,8 +55,8 @@ export function NavPanelAdvertisement(): JSX.Element | null {
         return null
     }
 
-    // Campaign flag payload takes priority over product recommendations
-    if (isCampaignPayload(campaignFlagPayload)) {
+    // Campaign flag payload takes priority over product recommendations, but campaigns promote cloud features so are not shown on hobby
+    if (isCloudOrDev && isCampaignPayload(campaignFlagPayload)) {
         return <NavPanelCampaignContent campaign={campaignFlagPayload} />
     }
 


### PR DESCRIPTION
## Problem

The nav panel campaign advertisement (driven by the `nav-panel-campaign` feature flag payload) promotes PostHog Cloud features — for example the current "PostHog now in Slack" campaign, which points at cloud-only functionality. Hobby (self-hosted) instances were showing this advert, which is irrelevant to those users.

## Changes

Gate the campaign-payload branch of `NavPanelAdvertisement` behind `isCloudOrDev` from `preflightLogic`. Campaigns now render on PostHog Cloud and local dev, but not on hobby instances.

Product recommendations (the `✨` "we recommend this product" path) are unaffected — only the marketing campaign content is suppressed on hobby.

## How did you test this code?

I'm an agent. I made the change and verified it against the existing `preflightLogic` selectors (`isCloudOrDev = preflight.cloud || preflight.is_debug`, the inverse of `isHobby`). I did not run the app or add automated tests for this component.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). The initial implementation gated on `isCloud`, but that excluded local dev (`is_debug`); switched to `isCloudOrDev` so the advert still shows in local development while remaining hidden on hobby. `isCloudOrDev` is the exact inverse of the existing `isHobby` selector, so the gate aligns with how the rest of the codebase defines hobby.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
