### PR TITLE
ci: lint full-depth checkouts

### DIFF
--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -676,7 +676,7 @@ class TestCheckoutFullDepthCheck:
         assert issue.step == "step[0]"
         assert "fetch-depth: 0" in issue.message
 
-    def test_fails_filter_combined_with_sparse_checkout(self, tmp_path: Path) -> None:
+    def test_passes_filter_combined_with_sparse_checkout(self, tmp_path: Path) -> None:
         _write(
             tmp_path,
             "wf.yml",
@@ -696,9 +696,7 @@ class TestCheckoutFullDepthCheck:
                         rust/
             """,
         )
-        [issue] = CheckoutFullDepthCheck().run(_read_all(tmp_path)).issues
-        assert "filter" in issue.message
-        assert "sparse-checkout" in issue.message
+        assert CheckoutFullDepthCheck().run(_read_all(tmp_path)).issues == []
 
 
 # ---------------------------------------------------------------------------

--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -600,7 +600,7 @@ class TestCheckoutFullDepthCheck:
                 steps:
                   # hogli-lint: allow-full-depth-checkout -- mirror needs full blobs
                   - name: Checkout mirror
-                    uses: actions/checkout@v6
+                    uses: "actions/checkout@v6"
                     with:
                       fetch-depth: 0
             """,
@@ -662,7 +662,7 @@ class TestCheckoutFullDepthCheck:
                 runs-on: ubuntu-latest
                 timeout-minutes: 5
                 steps:
-                  - uses: actions/checkout@v6
+                  - uses: "actions/checkout@v6"
                     with:
                       fetch-depth: 0
 

--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -599,7 +599,8 @@ class TestCheckoutFullDepthCheck:
                 timeout-minutes: 5
                 steps:
                   # hogli-lint: allow-full-depth-checkout -- mirror needs full blobs
-                  - uses: actions/checkout@v6
+                  - name: Checkout mirror
+                    uses: actions/checkout@v6
                     with:
                       fetch-depth: 0
             """,
@@ -648,6 +649,32 @@ class TestCheckoutFullDepthCheck:
         )
         [issue] = CheckoutFullDepthCheck().run(_read_all(tmp_path)).issues
         assert "allow-full-depth-checkout" in issue.message
+
+    def test_allow_marker_does_not_apply_to_previous_checkout(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            """
+            name: x
+            on: [push]
+            jobs:
+              mirror:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - uses: actions/checkout@v6
+                    with:
+                      fetch-depth: 0
+
+                  # hogli-lint: allow-full-depth-checkout -- mirror needs full blobs
+                  - uses: actions/checkout@v6
+                    with:
+                      fetch-depth: 0
+            """,
+        )
+        [issue] = CheckoutFullDepthCheck().run(_read_all(tmp_path)).issues
+        assert issue.step == "step[0]"
+        assert "fetch-depth: 0" in issue.message
 
     def test_fails_filter_combined_with_sparse_checkout(self, tmp_path: Path) -> None:
         _write(

--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -15,6 +15,7 @@ import pytest
 
 from hogli_commands.workflow_lint.check import CheckResult, WorkflowCheck
 from hogli_commands.workflow_lint.checks import CHECKS, _build_lookup, get_check
+from hogli_commands.workflow_lint.checks.checkout_full_depth import CheckoutFullDepthCheck
 from hogli_commands.workflow_lint.checks.dorny_negation import DornyNegationCheck
 from hogli_commands.workflow_lint.checks.job_timeouts import JobTimeoutsCheck
 from hogli_commands.workflow_lint.checks.pr_concurrency import PrConcurrencyCheck
@@ -518,6 +519,159 @@ class TestSemgrepServicesCoverageCheck:
         [issue] = SemgrepServicesCoverageCheck(repo_root=repo_root).run(_read_all(workflows_dir)).issues
         assert issue.workflow == "ci-security.yaml"
         assert "services/worker/" in issue.message
+
+
+# ---------------------------------------------------------------------------
+# CheckoutFullDepthCheck
+# ---------------------------------------------------------------------------
+
+
+class TestCheckoutFullDepthCheck:
+    def test_passes_default_checkout(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            """
+            name: x
+            on: [pull_request]
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - uses: actions/checkout@v6
+            """,
+        )
+        assert CheckoutFullDepthCheck().run(_read_all(tmp_path)).issues == []
+
+    def test_passes_blobless_full_depth_checkout(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            """
+            name: x
+            on: [pull_request]
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - uses: actions/checkout@v6
+                    with:
+                      fetch-depth: 0
+                      filter: blob:none
+            """,
+        )
+        assert CheckoutFullDepthCheck().run(_read_all(tmp_path)).issues == []
+
+    def test_passes_sparse_full_depth_checkout(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            """
+            name: x
+            on: [pull_request]
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - uses: actions/checkout@v6
+                    with:
+                      fetch-depth: 0
+                      sparse-checkout: |
+                        rust/
+                        proto/
+            """,
+        )
+        assert CheckoutFullDepthCheck().run(_read_all(tmp_path)).issues == []
+
+    def test_passes_explicit_allow_marker_with_reason(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            """
+            name: x
+            on: [push]
+            jobs:
+              mirror:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  # hogli-lint: allow-full-depth-checkout -- mirror needs full blobs
+                  - uses: actions/checkout@v6
+                    with:
+                      fetch-depth: 0
+            """,
+        )
+        assert CheckoutFullDepthCheck().run(_read_all(tmp_path)).issues == []
+
+    def test_fails_full_depth_without_optimization(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            """
+            name: x
+            on: [pull_request]
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - uses: actions/checkout@v6
+                    with:
+                      fetch-depth: "0"
+            """,
+        )
+        [issue] = CheckoutFullDepthCheck().run(_read_all(tmp_path)).issues
+        assert issue.workflow == "wf.yml"
+        assert issue.job == "build"
+        assert "fetch-depth: 0" in issue.message
+
+    def test_allow_marker_requires_reason(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            """
+            name: x
+            on: [push]
+            jobs:
+              mirror:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  # hogli-lint: allow-full-depth-checkout
+                  - uses: actions/checkout@v6
+                    with:
+                      fetch-depth: 0
+            """,
+        )
+        [issue] = CheckoutFullDepthCheck().run(_read_all(tmp_path)).issues
+        assert "allow-full-depth-checkout" in issue.message
+
+    def test_fails_filter_combined_with_sparse_checkout(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            """
+            name: x
+            on: [pull_request]
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - uses: actions/checkout@v6
+                    with:
+                      fetch-depth: 0
+                      filter: blob:none
+                      sparse-checkout: |
+                        rust/
+            """,
+        )
+        [issue] = CheckoutFullDepthCheck().run(_read_all(tmp_path)).issues
+        assert "filter" in issue.message
+        assert "sparse-checkout" in issue.message
 
 
 # ---------------------------------------------------------------------------

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/__init__.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/__init__.py
@@ -12,6 +12,7 @@ up first.
 from __future__ import annotations
 
 from ..check import WorkflowCheck
+from .checkout_full_depth import CheckoutFullDepthCheck
 from .dorny_negation import DornyNegationCheck
 from .job_timeouts import JobTimeoutsCheck
 from .pr_concurrency import PrConcurrencyCheck
@@ -22,6 +23,7 @@ CHECKS: list[WorkflowCheck] = [
     PrConcurrencyCheck(),
     DornyNegationCheck(),
     SemgrepServicesCoverageCheck(),
+    CheckoutFullDepthCheck(),
 ]
 
 

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/checkout_full_depth.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/checkout_full_depth.py
@@ -10,6 +10,7 @@ from ..model import Step, Workflow
 
 ALLOW_MARKER = "hogli-lint: allow-full-depth-checkout"
 CHECKOUT_USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*actions/checkout@", re.IGNORECASE)
+STEP_START_RE = re.compile(r"^\s*-\s")
 
 
 def _is_checkout(step: Step) -> bool:
@@ -46,6 +47,28 @@ def _allow_marker_has_reason(line: str) -> bool:
     return reason.strip().startswith("--") and bool(reason.strip()[2:].strip())
 
 
+def _step_start_line(lines: list[str], uses_idx: int) -> int:
+    for idx in range(uses_idx, max(-1, uses_idx - 8), -1):
+        if STEP_START_RE.search(lines[idx]):
+            return idx
+    return uses_idx
+
+
+def _checkout_has_allow_marker(lines: list[str], uses_idx: int) -> bool:
+    step_start = _step_start_line(lines, uses_idx)
+    for candidate in lines[step_start : uses_idx + 1]:
+        if ALLOW_MARKER in candidate and _allow_marker_has_reason(candidate):
+            return True
+
+    idx = step_start - 1
+    while idx >= 0 and lines[idx].strip().startswith("#"):
+        if ALLOW_MARKER in lines[idx] and _allow_marker_has_reason(lines[idx]):
+            return True
+        idx -= 1
+
+    return False
+
+
 @cache
 def _allowed_checkout_ordinals(path: str) -> frozenset[int]:
     """Return checkout step ordinals with a nearby allow marker.
@@ -62,8 +85,7 @@ def _allowed_checkout_ordinals(path: str) -> frozenset[int]:
     for idx, line in enumerate(lines):
         if not CHECKOUT_USES_RE.search(line):
             continue
-        window = lines[max(0, idx - 4) : min(len(lines), idx + 12)]
-        if any(ALLOW_MARKER in candidate and _allow_marker_has_reason(candidate) for candidate in window):
+        if _checkout_has_allow_marker(lines, idx):
             allowed.add(checkout_ordinal)
         checkout_ordinal += 1
 

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/checkout_full_depth.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/checkout_full_depth.py
@@ -9,7 +9,7 @@ from ..check import CheckResult, Issue, WorkflowCheck
 from ..model import Step, Workflow
 
 ALLOW_MARKER = "hogli-lint: allow-full-depth-checkout"
-CHECKOUT_USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*actions/checkout@", re.IGNORECASE)
+CHECKOUT_USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*[\"']?actions/checkout@", re.IGNORECASE)
 STEP_START_RE = re.compile(r"^\s*-\s")
 
 

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/checkout_full_depth.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/checkout_full_depth.py
@@ -1,0 +1,128 @@
+"""Full-depth checkouts should avoid fetching full history plus full blobs."""
+
+from __future__ import annotations
+
+import re
+from functools import cache
+
+from ..check import CheckResult, Issue, WorkflowCheck
+from ..model import Step, Workflow
+
+ALLOW_MARKER = "hogli-lint: allow-full-depth-checkout"
+CHECKOUT_USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*actions/checkout@", re.IGNORECASE)
+
+
+def _is_checkout(step: Step) -> bool:
+    return step.uses is not None and step.uses.lower().startswith("actions/checkout@")
+
+
+def _fetch_depth_is_zero(step: Step) -> bool:
+    if step.with_ is None:
+        return False
+    value = step.with_.get("fetch-depth")
+    return value == 0 or value == "0"
+
+
+def _has_blobless_filter(step: Step) -> bool:
+    return step.with_ is not None and step.with_.get("filter") == "blob:none"
+
+
+def _has_filter(step: Step) -> bool:
+    if step.with_ is None:
+        return False
+    value = step.with_.get("filter")
+    return isinstance(value, str) and value.strip() != ""
+
+
+def _has_sparse_checkout(step: Step) -> bool:
+    if step.with_ is None:
+        return False
+    value = step.with_.get("sparse-checkout")
+    return isinstance(value, str) and value.strip() != ""
+
+
+def _allow_marker_has_reason(line: str) -> bool:
+    _, _, reason = line.partition(ALLOW_MARKER)
+    return reason.strip().startswith("--") and bool(reason.strip()[2:].strip())
+
+
+@cache
+def _allowed_checkout_ordinals(path: str) -> frozenset[int]:
+    """Return checkout step ordinals with a nearby allow marker.
+
+    PyYAML drops comments, so the parsed model handles workflow semantics while
+    this raw scan only maps explicit reviewable bypass comments to checkout
+    steps.
+    """
+
+    lines = open(path, encoding="utf-8").read().splitlines()
+    allowed: set[int] = set()
+    checkout_ordinal = 0
+
+    for idx, line in enumerate(lines):
+        if not CHECKOUT_USES_RE.search(line):
+            continue
+        window = lines[max(0, idx - 4) : min(len(lines), idx + 12)]
+        if any(ALLOW_MARKER in candidate and _allow_marker_has_reason(candidate) for candidate in window):
+            allowed.add(checkout_ordinal)
+        checkout_ordinal += 1
+
+    return frozenset(allowed)
+
+
+class CheckoutFullDepthCheck(WorkflowCheck):
+    id = "WF005-checkout-full-depth"
+    label = "checkout full depth"
+    description = "full-depth actions/checkout steps use blobless, sparse, or explicit allow comments"
+
+    @property
+    def fix_hint(self) -> str | None:
+        return (
+            "For `actions/checkout` with `fetch-depth: 0`, add `filter: blob:none`, "
+            "use `sparse-checkout`, or add `# hogli-lint: allow-full-depth-checkout -- <reason>`. "
+            "Do not combine `filter` with `sparse-checkout`; checkout ignores sparse patterns when filter is set."
+        )
+
+    def run(self, workflows: list[Workflow]) -> CheckResult:
+        result = CheckResult()
+        for wf in workflows:
+            checkout_ordinal = 0
+            allowed_ordinals = _allowed_checkout_ordinals(str(wf.path))
+            for job in wf.jobs:
+                for step in job.steps:
+                    if not _is_checkout(step):
+                        continue
+
+                    if _fetch_depth_is_zero(step) and _has_filter(step) and _has_sparse_checkout(step):
+                        result.issues.append(
+                            Issue(
+                                workflow=wf.path.name,
+                                job=job.name,
+                                step=step.ref,
+                                message="actions/checkout `filter` overrides `sparse-checkout`; use one optimization mode",
+                                file=str(wf.path),
+                            )
+                        )
+
+                    if (
+                        _fetch_depth_is_zero(step)
+                        and not _has_blobless_filter(step)
+                        and not _has_sparse_checkout(step)
+                        and checkout_ordinal not in allowed_ordinals
+                    ):
+                        result.issues.append(
+                            Issue(
+                                workflow=wf.path.name,
+                                job=job.name,
+                                step=step.ref,
+                                message=(
+                                    "fetch-depth: 0 without filter: blob:none, sparse-checkout, "
+                                    f"or `{ALLOW_MARKER} -- <reason>`"
+                                ),
+                                file=str(wf.path),
+                            )
+                        )
+
+                    checkout_ordinal += 1
+
+        return result

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/checkout_full_depth.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/checkout_full_depth.py
@@ -28,13 +28,6 @@ def _has_blobless_filter(step: Step) -> bool:
     return step.with_ is not None and step.with_.get("filter") == "blob:none"
 
 
-def _has_filter(step: Step) -> bool:
-    if step.with_ is None:
-        return False
-    value = step.with_.get("filter")
-    return isinstance(value, str) and value.strip() != ""
-
-
 def _has_sparse_checkout(step: Step) -> bool:
     if step.with_ is None:
         return False
@@ -101,8 +94,7 @@ class CheckoutFullDepthCheck(WorkflowCheck):
     def fix_hint(self) -> str | None:
         return (
             "For `actions/checkout` with `fetch-depth: 0`, add `filter: blob:none`, "
-            "use `sparse-checkout`, or add `# hogli-lint: allow-full-depth-checkout -- <reason>`. "
-            "Do not combine `filter` with `sparse-checkout`; checkout ignores sparse patterns when filter is set."
+            "use `sparse-checkout`, or add `# hogli-lint: allow-full-depth-checkout -- <reason>`."
         )
 
     def run(self, workflows: list[Workflow]) -> CheckResult:
@@ -114,17 +106,6 @@ class CheckoutFullDepthCheck(WorkflowCheck):
                 for step in job.steps:
                     if not _is_checkout(step):
                         continue
-
-                    if _fetch_depth_is_zero(step) and _has_filter(step) and _has_sparse_checkout(step):
-                        result.issues.append(
-                            Issue(
-                                workflow=wf.path.name,
-                                job=job.name,
-                                step=step.ref,
-                                message="actions/checkout `filter` overrides `sparse-checkout`; use one optimization mode",
-                                file=str(wf.path),
-                            )
-                        )
 
                     if (
                         _fetch_depth_is_zero(step)

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/checkout_full_depth.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/checkout_full_depth.py
@@ -71,7 +71,8 @@ def _allowed_checkout_ordinals(path: str) -> frozenset[int]:
     steps.
     """
 
-    lines = open(path, encoding="utf-8").read().splitlines()
+    with open(path, encoding="utf-8") as f:
+        lines = f.read().splitlines()
     allowed: set[int] = set()
     checkout_ordinal = 0
 

--- a/tools/hogli-commands/hogli_commands/workflow_lint/cli.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/cli.py
@@ -44,7 +44,7 @@ def _default_workflows_dir() -> Path:
 
 @click.command(
     name="lint:workflows",
-    help="Lint .github/workflows/** for repo conventions (timeouts, concurrency, dorny negation, semgrep coverage)",
+    help="Lint .github/workflows/** for repo conventions",
 )
 @click.option(
     "--check",


### PR DESCRIPTION
## Problem

Full-depth GitHub Actions checkouts can quietly regress into slow full-history plus full-blob clones.

## Changes

- Add WF005 to Hogli workflow lint.
- Require actions/checkout steps with fetch-depth: 0 to use filter: blob:none, sparse-checkout, or an explicit allow comment with a reason.
- Allow filter: blob:none and sparse-checkout together; WF005 only blocks full-depth checkouts that have neither blobless filtering nor sparse checkout nor an explicit allow reason.
- Add isolated workflow-lint tests for passing, failing, and bypass cases.

## Tests

- uv run pytest tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
- ./bin/hogli lint:workflows
- UV_CACHE_DIR=.uv-cache uv run ruff check tools/hogli-commands/hogli_commands/workflow_lint/checks/checkout_full_depth.py tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
- git diff --check origin/codex/ci-checkout-optimization...HEAD
