### PR TITLE
fix(duckling): align backfill connect_timeout to workerQueueTimeout (5m)

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -110,11 +110,13 @@ def iceberg_enabled_for_team(team_id: int) -> bool:
 # A backfill connection may have to wait for duckgres to spin up a fresh worker
 # (a cold worker can require provisioning a new node, which takes minutes), so
 # the handshake budget is generous and `_connect_duckgres` retries with backoff.
-# Must exceed the duckgres control-plane warmAcquireTimeout (5m): on a warm-pool
-# miss the CP now blocks the connect server-side up to ~5m waiting for a colocated
-# worker (which may need a cold node) instead of bouncing us with "no warm worker
-# available". 330s gives margin over the 300s server block + TLS/handshake.
-DUCKGRES_CONNECT_TIMEOUT = 330  # seconds
+# Must exceed the binding duckgres server-side wait, which is the OUTER
+# workerQueueTimeout (5m) — not warmAcquireTimeout (4m). On a warm-pool miss the
+# CP blocks the connect server-side waiting for a colocated worker (which may need
+# a cold node) instead of bouncing us with "no warm worker available"; that whole
+# block is bounded by workerQueueTimeout. 360s gives margin over the 300s server
+# block + TLS/handshake. Ladder: warmAcquire 4m < workerQueueTimeout 5m < 360s.
+DUCKGRES_CONNECT_TIMEOUT = 360  # seconds
 DUCKGRES_STATEMENT_TIMEOUT_MS = 300_000  # 5 minutes
 
 # Worker-profile opt-in. When enabled, a backfill connection asks duckgres for a
@@ -181,15 +183,15 @@ def _get_cluster() -> ClickhouseCluster:
 
 
 @retry(
-    # The duckgres CP now absorbs a warm-pool miss by blocking the connect itself
-    # up to ~5m (DUCKGRES_K8S_WARM_ACQUIRE_TIMEOUT) for a colocated worker — so a
-    # single attempt can run the full connect_timeout (330s). The retry budget here
+    # The duckgres CP absorbs a warm-pool miss by blocking the connect itself for
+    # up to the outer workerQueueTimeout (5m) waiting for a colocated worker — so a
+    # single attempt can run the full connect_timeout (360s). The retry budget here
     # is the BACKSTOP for fast failures (network blip, CP pod rolled mid-handshake,
     # or the CP giving up after its block): the delay cap must exceed one full
-    # attempt so a second one can actually run, hence 700s (~2 attempts) rather
-    # than 300s (which a single 330s attempt would exhaust, making retries a no-op).
+    # attempt so a second one can actually run, hence 780s (~2 attempts) rather
+    # than 360s (which a single 360s attempt would exhaust, making retries a no-op).
     # statement_timeout (set per connection) is separate.
-    stop=stop_after_delay(700) | stop_after_attempt(12),
+    stop=stop_after_delay(780) | stop_after_attempt(12),
     wait=wait_exponential(multiplier=1, min=5, max=60),
     retry=retry_if_exception_type((psycopg.OperationalError, OSError)),
     reraise=True,


### PR DESCRIPTION
## Why

The duckgres CP's binding server-side wait on a warm-pool miss is the **outer `workerQueueTimeout`** (being set to 5m in [charts #11772](https://github.com/PostHog/charts/pull/11772)), not `warmAcquireTimeout` (4m). The current client `connect_timeout=330` is below that, so on a cold-node acquire the client can bail before the server returns.

## Change

- `DUCKGRES_CONNECT_TIMEOUT` `330 → 360` — must exceed the 5m server block + TLS/handshake.
- tenacity `stop_after_delay` `700 → 780` — so a fast early failure still gets a genuine second full-length (360s) attempt.

Ladder: `warmAcquireTimeout 4m < workerQueueTimeout 5m < connect_timeout 360s`.

Part of unblocking the duckling events backfill (companion to charts #11772 timeout-ladder and #11771 backfill concurrency throttle). Needs a normal code-location redeploy to take effect (constants read at process start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)