### PR TITLE
fix(demo): mark Demo OAuth Application as first-party

### DIFF
--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -1788,6 +1788,7 @@ class HedgeboxMatrix(Matrix):
                     client_type=OAuthApplication.CLIENT_PUBLIC,
                     authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
                     algorithm="RS256",
+                    is_first_party=True,
                 )
             except (IntegrityError, ValidationError):
                 pass


### PR DESCRIPTION
## Summary
PostHog Code (`apps/code`) and the PostHog mobile app (`apps/mobile`) both authenticate against the seeded "Demo OAuth Application" via its hardcoded client_id (`DC5uRL...`). Both clients expect **org-scoped** tokens so they can hit org endpoints (org switching, AI consent, listing all projects, etc.). Org-scoped tokens are only issued when the OAuth application has `is_first_party=True`.

Without this flag, the seeded app issues project-scoped tokens. The token comes back with `scoped_organizations: []` and `scoped_teams: [...]`, the client builds an empty `orgProjectsMap`, no project is auto-selected, and the user sees "No projects available" with `Missing auth credentials` errors when trying to start an agent session.

The change is one line: add `is_first_party=True` to the `OAuthApplication.objects.create(...)` call in `posthog/demo/products/hedgebox/matrix.py`.

## Caveats
- This affects **new** local installs only. Existing demo data hits the `try / except IntegrityError` branch and won't be reseeded — those devs still need to either tick `is_first_party` once in `/admin/oauth2_provider/application/` or delete the row before reseeding.
- Only consumers of this specific seeded client_id are PostHog Code + PostHog mobile, both of which want org-scoped tokens. No other clients depend on the project-scoped behavior.

## Test plan
- [x] Fresh local install: run demo data seed, log into PostHog Code against `dev` region, confirm project switcher populates and an agent session starts.
- [x] Same flow on PostHog mobile.
- [ ] Existing install: confirm seed call still hits `IntegrityError` path and doesn't blow up (no behavior change for already-seeded rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)