### PR TITLE
fix(replay-vision): poll fallback so observation detail page lands the result

### DIFF
--- a/products/replay_vision/frontend/observations/replayObservationLogic.ts
+++ b/products/replay_vision/frontend/observations/replayObservationLogic.ts
@@ -5,6 +5,7 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { visionObservationsRetrieve } from '../generated/api'
 import type { ReplayObservationApi } from '../generated/api.schemas'
+import { scheduleObservationPoll } from '../logics/observationPolling'
 import { observationProgressLogic } from './observationProgressLogic'
 import type { replayObservationLogicType } from './replayObservationLogicType'
 import { replayObservationSceneLogic } from './replayObservationSceneLogic'
@@ -47,7 +48,7 @@ export const replayObservationLogic = kea<replayObservationLogicType>([
         ],
     }),
 
-    listeners(({ actions, props }) => ({
+    listeners(({ actions, props, cache }) => ({
         loadObservation: async () => {
             const teamId = teamLogic.values.currentTeamId
             if (!teamId) {
@@ -65,6 +66,14 @@ export const replayObservationLogic = kea<replayObservationLogicType>([
                 lemonToast.error(`Failed to load observation: ${String(error)}`)
                 actions.loadObservationFailure()
             }
+        },
+
+        loadObservationSuccess: ({ observation }) => {
+            // SSE flips us to the result instantly when our listener catches `streamCompleted`, but the
+            // stream is a shared keyed logic — if the dock started and finished it before this page opened,
+            // the past event isn't replayed here. Poll while in flight as a fallback so we still land the result.
+            const inFlight = observation.status === 'pending' || observation.status === 'running'
+            scheduleObservationPoll(cache.disposables, inFlight, actions.loadObservation)
         },
 
         // When the stream reports the observation has settled, reload once to render the final result.


### PR DESCRIPTION
## Problem

TLDR: had to test in prod, found an edge case

The Replay Vision **observation detail page** could get stuck showing an in-flight progress bar ("Queued…") forever, never flipping to the result — even though the same observation showed as completed in the Session Replay dock.

Root cause: the detail page reloaded only on the SSE `streamCompleted` event from `observationProgressLogic`, which is a **shared logic keyed only by observation id**. When an observation is triggered from the dock, the dock starts and finishes that single stream; if it completes before the detail page is opened, the `streamCompleted` action has already fired and kea doesn't replay it to the detail page's late-attaching listener (and `afterMount` won't start a fresh stream for the already-mounted instance). With no other completion path, the detail page sat on its initial in-flight load. The dock avoids this only because it independently polls the observations list every 3s.

## Changes

`replayObservationLogic` now polls the observation while it's in flight (reusing `scheduleObservationPoll`, the same helper the dock uses), as a fallback. SSE still flips the page instantly when its listener catches `streamCompleted`; the poll guarantees the page lands on the terminal result otherwise. Polling stops once the observation reaches a terminal status.

## How did you test this code?

I'm an agent (PostHog Code). Manual prod testing of the symptom was done by the PR author. Automated checks I ran: oxlint, oxfmt, and `tsc` typecheck on the changed file — all clean. No backend changes.

## 🤖 Agent context

Authored with PostHog Code (Claude). Diagnosed from a prod repro where the dock updated promptly but the detail page hung on "Queued". Initially suspected a non-ASGI/streaming issue, but the author confirmed it was prod — so the real cause is the shared-keyed-logic late-subscribe race described above, not the environment.

Chosen fix is the minimal, robust one: restore a poll fallback on the detail page (matching the dock's resilience) rather than re-architecting the shared stream. A deeper follow-up — keying `observationProgressLogic` per surface so the detail page always gets its own live stream (so the bar animates live there too, not just lands the result) — was considered and left out to keep this fix small.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)