### PR TITLE
fix(trends): fix hideWeekends zeroing out current in-progress week

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -1111,6 +1111,44 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert len(response.results[1]["data"]) == 12
         assert len(response.results[1]["days"]) == 12
 
+
+    def test_hide_weekends_action_days_mid_week_range(self):
+        """
+        Regression test: hideWeekends zeroes out the current in-progress week.
+        action["days"] was filtered using d.weekday() on raw strings instead of
+        parsed datetimes, corrupting results for all days after the last weekend.
+        """
+        self._create_test_events()
+
+        response = self._run_trends_query(
+            "2020-01-13",  # Mon
+            "2020-01-16",  # Thu — ends mid-week, no trailing weekend
+            IntervalType.DAY,
+            [EventsNode(event="$pageview")],
+            trends_filters=TrendsFilter(hideWeekends=True),
+        )
+
+        result = response.results[0]
+
+        # All four days are weekdays — none should be filtered
+        assert result["days"] == [
+            "2020-01-13",  # Mon
+            "2020-01-14",  # Tue
+            "2020-01-15",  # Wed
+            "2020-01-16",  # Thu
+        ], f"Expected all weekdays present, got: {result['days']}"
+
+        # Data must not be zeroed out
+        assert any(v > 0 for v in result["data"]), (
+            f"All values zero — mid-week days incorrectly zeroed: {result['data']}"
+        )
+
+        # action["days"] must not be corrupted
+        if result.get("action") is not None and "days" in result["action"]:
+            for day_str in result["action"]["days"]:
+                parsed = datetime.strptime(day_str[:10], "%Y-%m-%d")
+                assert parsed.weekday() < 5, f"Weekend day {day_str} found in action['days']"
+
     @parameterized.expand(
         [
             ("2_cohorts_limit_1", 2, 1),

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -744,7 +744,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
             if new_result.get("action") is not None and "days" in new_result["action"]:
                 action_days = new_result["action"]["days"]
                 new_result["action"] = {**new_result["action"]}
-                new_result["action"]["days"] = [d for d in action_days if d.weekday() < 5]
+                new_result["action"]["days"] = [d for d in action_days if datetime.strptime(d[:10], "%Y-%m-%d").weekday() < 5]
 
             filtered.append(new_result)
         return filtered


### PR DESCRIPTION
## Problem

When "Hide weekend data" is enabled on a daily Trends insight with a date range ending mid-week (e.g. last 30 days ending on a Thursday), all weekday data points after the most recent Saturday/Sunday are zeroed out instead of only Saturday and Sunday being removed.

Closes #61782

## Changes

In `_filter_weekend_buckets` (trends_query_runner.py), `action["days"]` was filtered using `d.weekday()` directly on raw date strings. Since strings don't have a `.weekday()` method, this raised an `AttributeError` that corrupted the result for the entire current in-progress week.

Fixed by parsing each date string with `datetime.strptime(d[:10], "%Y-%m-%d")` before calling `.weekday()`, consistent with how the main `days`/`data`/`labels` filtering already works in the same function.

## How did you test this code?

Added regression test `test_hide_weekends_action_days_mid_week_range` covering a date range ending mid-week (Mon–Thu) with no trailing weekend, verifying:
- All weekday buckets are preserved in `days`
- Data values are not zeroed out
- `action["days"]` contains only valid weekday strings

## Agent context

Investigated with Claude (claude.ai). Root cause was identified by reading `_filter_weekend_buckets` and spotting the `.weekday()` call on raw strings. Fix and test were written with AI assistance — I have read and understood all changed code and can explain every line.