### PR TITLE
fix(ws): skip S3 data deletion on v3 pipeline resets

### DIFF
--- a/posthog/temporal/data_imports/pipelines/common/extract.py
+++ b/posthog/temporal/data_imports/pipelines/common/extract.py
@@ -231,17 +231,17 @@ async def handle_reset_or_full_refresh(
     schema: "ExternalDataSchema",
     delta_table_helper: DeltaTableHelper,
     logger: FilteringBoundLogger,
+    delete_s3_data: bool = True,
 ) -> None:
     from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 
     if reset_pipeline and not should_resume:
-        await logger.adebug("Deleting existing table due to reset_pipeline being set")
-        await delta_table_helper.reset_table()
+        await logger.adebug("Resetting existing table due to reset_pipeline being set")
+        await delta_table_helper.reset_table(delete_s3_data=delete_s3_data)
         await database_sync_to_async_pool(schema.update_sync_type_config_for_reset_pipeline)()
     elif schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH and not should_resume:
-        # Avoid schema mismatches from existing data about to be overwritten
-        await logger.adebug("Deleting existing table due to sync being full refresh")
-        await delta_table_helper.reset_table()
+        await logger.adebug("Resetting existing table due to sync being full refresh")
+        await delta_table_helper.reset_table(delete_s3_data=delete_s3_data)
         await database_sync_to_async_pool(schema.update_sync_type_config_for_reset_pipeline)()
 
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -211,14 +211,15 @@ class DeltaTableHelper:
 
         return None
 
-    async def reset_table(self):
-        delta_uri = await self._get_delta_table_uri()
+    async def reset_table(self, delete_s3_data: bool = True):
+        if delete_s3_data:
+            delta_uri = await self._get_delta_table_uri()
 
-        async with aget_s3_client() as s3:
-            try:
-                await s3._rm(delta_uri, recursive=True)
-            except FileNotFoundError:
-                pass
+            async with aget_s3_client() as s3:
+                try:
+                    await s3._rm(delta_uri, recursive=True)
+                except FileNotFoundError:
+                    pass
 
         self.get_delta_table.cache_clear()
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -520,3 +520,34 @@ class TestWriteMisalignedDecimalEndToEnd:
         assert set(final.column("amount").to_pylist()) == {5, 7}
         closed = final.filter(pc.equal(final.column("amount"), Decimal("5.00")))
         assert closed.column("valid_to").to_pylist() == [ts2]
+
+
+class TestResetTableDeleteGating:
+    @pytest.mark.parametrize(
+        "delete_s3_data,expect_delete",
+        [(True, True), (False, False)],
+        ids=["delete", "skip"],
+    )
+    @pytest.mark.asyncio
+    async def test_reset_table_only_deletes_s3_when_requested(
+        self, helper: DeltaTableHelper, delete_s3_data: bool, expect_delete: bool
+    ) -> None:
+        helper._is_first_sync = False
+        s3 = AsyncMock()
+        s3_cm = MagicMock()
+        s3_cm.__aenter__ = AsyncMock(return_value=s3)
+        s3_cm.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.object(helper, "_get_delta_table_uri", new=AsyncMock(return_value="s3://bucket/path")),
+            patch(
+                "posthog.temporal.data_imports.pipelines.pipeline.delta_table_helper.aget_s3_client",
+                return_value=s3_cm,
+            ) as mock_client,
+        ):
+            await helper.reset_table(delete_s3_data=delete_s3_data)
+
+        assert mock_client.called is expect_delete
+        assert s3._rm.called is expect_delete
+        # always flags a fresh sync so the next write overwrites
+        assert helper._is_first_sync is True

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -216,7 +216,12 @@ class PipelineV3(Generic[ResumableData]):
             chunk_index = 0
 
             await handle_reset_or_full_refresh(
-                self._reset_pipeline, should_resume, self._schema, self._delta_table_helper, self._logger
+                self._reset_pipeline,
+                should_resume,
+                self._schema,
+                self._delta_table_helper,
+                self._logger,
+                delete_s3_data=False,
             )
 
             is_fresh_sync = self._delta_table_helper.is_first_sync or self._schema.table is None

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/test_pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/test_pipeline.py
@@ -71,3 +71,34 @@ class TestExtractionFailureDoesNotCleanupS3:
                 await pipeline.run()
 
         s3_writer.cleanup.assert_not_called()
+
+
+class TestFullRefreshDefersTableClearToLoad:
+    @pytest.mark.asyncio
+    async def test_v3_full_refresh_does_not_delete_s3_on_extract(self) -> None:
+        # drives the real handle_reset_or_full_refresh: v3 must ask reset_table to skip the racy
+        # S3 delete (delete_s3_data=False) and let the load's overwrite clear instead
+        from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+
+        pipeline = _make_pipeline()
+        pipeline._schema.sync_type = ExternalDataSchema.SyncType.FULL_REFRESH
+        reset_table = AsyncMock()
+        cast(MagicMock, pipeline._delta_table_helper).reset_table = reset_table
+        # stop run() right after reset/full-refresh handling so we don't drive extraction
+        cast(MagicMock, pipeline._resource).items.side_effect = RuntimeError("stop after reset handling")
+
+        module = "posthog.temporal.data_imports.pipelines.pipeline_v3.pipeline"
+        extract = "posthog.temporal.data_imports.pipelines.common.extract"
+        with (
+            patch(f"{module}.cdp_producer_clear_chunks", new=AsyncMock()),
+            patch(f"{module}.reset_rows_synced_if_needed", new=AsyncMock()),
+            patch(f"{module}.setup_row_tracking_with_billing_check", new=AsyncMock()),
+            patch(f"{extract}.database_sync_to_async_pool", new=lambda fn: AsyncMock()),
+            patch(f"{module}.activity") as mock_activity,
+        ):
+            mock_activity.in_activity.return_value = False
+
+            with pytest.raises(RuntimeError, match="stop after reset handling"):
+                await pipeline.run()
+
+        reset_table.assert_awaited_once_with(delete_s3_data=False)


### PR DESCRIPTION
## Problem

When the v3-kafka-s3 pipeline resets a table (due to `reset_pipeline` or a full refresh sync), the existing code deletes the S3 data before rewriting it.
In the v3 pipeline this deletion can cause transient failures or race conditions with concurrent reads.

## Changes

  - Added a `delete_s3_data` parameter (default `True`) to `DeltaTableHelper.reset_table()` and `handle_reset_or_full_refresh()`, allowing callers to opt out of the S3 file deletion step
  - The v3 pipeline (`PipelineV3`) now passes `delete_s3_data=False` when calling `handle_reset_or_full_refresh`, skipping the `s3._rm` call while still clearing the delta table cache and resetting sync type config
  - v1/v2 pipelines are unaffected (they use the default `delete_s3_data=True`)


## How did you test this code?

Test pass + New tests

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Co-authored with Claude Code: Creation of tests + pr-create-description
