### PR TITLE
feat(experiments): add metric breakdown injector for funnels

### DIFF
--- a/products/experiments/backend/hogql_queries/breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/breakdown_injector.py
@@ -40,6 +40,10 @@ class BreakdownInjector:
         self.breakdowns = breakdowns
         self.metric = metric
 
+    def attributes_from_exposure(self) -> bool:
+        """This injector attributes the breakdown value from the exposure event."""
+        return True
+
     def _has_breakdown(self) -> bool:
         """Returns True if any breakdowns are configured"""
         return len(self.breakdowns) > 0

--- a/products/experiments/backend/hogql_queries/experiment_exposure_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposure_query_builder.py
@@ -10,6 +10,7 @@ from products.experiments.backend.hogql_queries import MULTIPLE_VARIANT_KEY
 from products.experiments.backend.hogql_queries.base_query_utils import event_or_action_to_filter
 from products.experiments.backend.hogql_queries.breakdown_injector import BreakdownInjector
 from products.experiments.backend.hogql_queries.experiment_query_context import ExperimentQueryContext
+from products.experiments.backend.hogql_queries.metric_breakdown_injector import MetricBreakdownInjector
 
 
 def _optimize_and_chain(expr: ast.Expr) -> ast.Expr:
@@ -59,7 +60,7 @@ class ExposureQueryBuilder:
     def __init__(
         self,
         context: ExperimentQueryContext,
-        breakdown_injector: BreakdownInjector | None = None,
+        breakdown_injector: BreakdownInjector | MetricBreakdownInjector | None = None,
         maturity_having_builder: Callable[[str], ast.Expr | None] | None = None,
         preaggregation_job_ids: list[str] | None = None,
     ):
@@ -284,8 +285,9 @@ class ExposureQueryBuilder:
         )
         assert isinstance(exposure_query, ast.SelectQuery)
 
-        # Inject breakdown columns into the exposure query if needed
-        if self.breakdown_injector:
+        # Inject breakdown columns into the exposure query if needed. The metric-event
+        # injector attributes from the metric event instead, so it keeps exposures breakdown-free.
+        if self.breakdown_injector and self.breakdown_injector.attributes_from_exposure():
             breakdown_exprs = self.breakdown_injector.build_breakdown_exprs(table_alias="")
 
             # Add breakdown columns to SELECT using argMin attribution

--- a/products/experiments/backend/hogql_queries/experiment_exposure_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposure_query_builder.py
@@ -256,7 +256,13 @@ class ExposureQueryBuilder:
         )
 
     def select_query(self) -> ast.SelectQuery:
-        if self.preaggregation_job_ids and not self.context.breakdowns:
+        # Precomputed exposures carry no event properties, so they can't serve breakdowns
+        # attributed from the exposure event. Metric-event breakdowns never read exposure
+        # properties, so they can still use the precomputed table.
+        needs_exposure_breakdowns = bool(
+            self.context.breakdowns and self.breakdown_injector and self.breakdown_injector.attributes_from_exposure()
+        )
+        if self.preaggregation_job_ids and not needs_exposure_breakdowns:
             return self.precomputed_select_query(self.preaggregation_job_ids)
 
         return self._build_exposure_select_query()

--- a/products/experiments/backend/hogql_queries/experiment_exposure_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposure_query_builder.py
@@ -319,7 +319,13 @@ class ExposureQueryBuilder:
         if self.context.activation_config is not None:
             return self._build_activation_exposure_select_query()
 
-        if self.preaggregation_job_ids and not self.context.breakdowns:
+        # Precomputed exposures carry no event properties, so they can't serve breakdowns
+        # attributed from the exposure event. Metric-event breakdowns never read exposure
+        # properties, so they can still use the precomputed table.
+        needs_exposure_breakdowns = bool(
+            self.context.breakdowns and self.breakdown_injector and self.breakdown_injector.attributes_from_exposure()
+        )
+        if self.preaggregation_job_ids and not needs_exposure_breakdowns:
             return self.precomputed_select_query(self.preaggregation_job_ids)
 
         return self._build_exposure_select_query()

--- a/products/experiments/backend/hogql_queries/experiment_exposure_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposure_query_builder.py
@@ -14,6 +14,7 @@ from products.experiments.backend.hogql_queries.exposure_query_logic import (
     DEFAULT_EXPOSURE_EVENT,
     EXPERIMENT_EXPOSURE_EVENT,
 )
+from products.experiments.backend.hogql_queries.metric_breakdown_injector import MetricBreakdownInjector
 
 
 def _optimize_and_chain(expr: ast.Expr) -> ast.Expr:
@@ -63,7 +64,7 @@ class ExposureQueryBuilder:
     def __init__(
         self,
         context: ExperimentQueryContext,
-        breakdown_injector: BreakdownInjector | None = None,
+        breakdown_injector: BreakdownInjector | MetricBreakdownInjector | None = None,
         maturity_having_builder: Callable[[str], ast.Expr | None] | None = None,
         preaggregation_job_ids: list[str] | None = None,
     ):
@@ -431,8 +432,9 @@ class ExposureQueryBuilder:
         return self._finalize_exposure_select(exposure_query)
 
     def _finalize_exposure_select(self, exposure_query: ast.SelectQuery) -> ast.SelectQuery:
-        # Inject breakdown columns into the exposure query if needed
-        if self.breakdown_injector:
+        # Inject breakdown columns into the exposure query if needed. The metric-event
+        # injector attributes from the metric event instead, so it keeps exposures breakdown-free.
+        if self.breakdown_injector and self.breakdown_injector.attributes_from_exposure():
             breakdown_exprs = self.breakdown_injector.build_breakdown_exprs(table_alias="")
 
             # Add breakdown columns to SELECT using argMin attribution

--- a/products/experiments/backend/hogql_queries/experiment_mean_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_mean_query_builder.py
@@ -9,6 +9,7 @@ from products.experiments.backend.hogql_queries.base_query_utils import (
     is_session_property_metric,
     validate_session_property,
 )
+from products.experiments.backend.hogql_queries.breakdown_injector import BreakdownInjector
 from products.experiments.backend.hogql_queries.metric_source import MetricSourceInfo
 
 if TYPE_CHECKING:
@@ -303,8 +304,9 @@ class MeanQueryBuilder:
 
         assert isinstance(query, ast.SelectQuery)
 
-        # Inject breakdown columns into the query AST
-        if self._b.breakdown_injector:
+        # Inject breakdown columns into the query AST. The metric-event injector is funnel-only,
+        # so mean metrics always use the property-from-exposure BreakdownInjector.
+        if isinstance(self._b.breakdown_injector, BreakdownInjector):
             self._b.breakdown_injector.inject_mean_breakdown_columns(query, final_cte_name="entity_metrics")
 
         return query
@@ -401,8 +403,9 @@ class MeanQueryBuilder:
 
         assert isinstance(query, ast.SelectQuery)
 
-        # Inject breakdown columns into the query AST
-        if self._b.breakdown_injector:
+        # Inject breakdown columns into the query AST. The metric-event injector is funnel-only,
+        # so mean metrics always use the property-from-exposure BreakdownInjector.
+        if isinstance(self._b.breakdown_injector, BreakdownInjector):
             self._b.breakdown_injector.inject_mean_breakdown_columns(query, final_cte_name="winsorized_entity_metrics")
 
         return query

--- a/products/experiments/backend/hogql_queries/experiment_mean_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_mean_query_builder.py
@@ -10,6 +10,7 @@ from products.experiments.backend.hogql_queries.base_query_utils import (
     is_session_property_metric,
     validate_session_property,
 )
+from products.experiments.backend.hogql_queries.breakdown_injector import BreakdownInjector
 from products.experiments.backend.hogql_queries.metric_source import MetricSourceInfo
 
 if TYPE_CHECKING:
@@ -392,8 +393,9 @@ class MeanQueryBuilder:
 
         assert isinstance(query, ast.SelectQuery)
 
-        # Inject breakdown columns into the query AST
-        if self._b.breakdown_injector:
+        # Inject breakdown columns into the query AST. The metric-event injector is funnel-only,
+        # so mean metrics always use the property-from-exposure BreakdownInjector.
+        if isinstance(self._b.breakdown_injector, BreakdownInjector):
             self._b.breakdown_injector.inject_mean_breakdown_columns(query, final_cte_name="entity_metrics")
 
         return query
@@ -490,8 +492,9 @@ class MeanQueryBuilder:
 
         assert isinstance(query, ast.SelectQuery)
 
-        # Inject breakdown columns into the query AST
-        if self._b.breakdown_injector:
+        # Inject breakdown columns into the query AST. The metric-event injector is funnel-only,
+        # so mean metrics always use the property-from-exposure BreakdownInjector.
+        if isinstance(self._b.breakdown_injector, BreakdownInjector):
             self._b.breakdown_injector.inject_mean_breakdown_columns(query, final_cte_name="winsorized_entity_metrics")
 
         return query

--- a/products/experiments/backend/hogql_queries/experiment_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_builder.py
@@ -46,6 +46,7 @@ from products.experiments.backend.hogql_queries.experiment_ratio_query_builder i
 from products.experiments.backend.hogql_queries.experiment_retention_query_builder import RetentionQueryBuilder
 from products.experiments.backend.hogql_queries.exposure_query_logic import normalize_to_exposure_criteria
 from products.experiments.backend.hogql_queries.funnel_step_builder import FunnelStepBuilder
+from products.experiments.backend.hogql_queries.metric_breakdown_injector import MetricBreakdownInjector
 from products.experiments.backend.hogql_queries.metric_source import MetricSourceInfo
 
 
@@ -85,6 +86,7 @@ class ExperimentQueryBuilder:
             ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric
         ] = None,
         breakdowns: list[Breakdown] | None = None,
+        breakdown_injector: BreakdownInjector | MetricBreakdownInjector | None = None,
         only_count_matured_users: bool = False,
         cuped_config: CupedQueryConfig | None = None,
     ):
@@ -99,7 +101,14 @@ class ExperimentQueryBuilder:
         self.filter_test_accounts = filter_test_accounts
         self.multiple_variant_handling = multiple_variant_handling
         self.breakdowns = breakdowns or []
-        self.breakdown_injector = BreakdownInjector(self.breakdowns, metric) if metric else None
+        # Caller may supply a pre-built injector (e.g. the metric-event injector gated behind
+        # a feature flag); otherwise default to the property-from-exposure injector.
+        if breakdown_injector is not None:
+            self.breakdown_injector: BreakdownInjector | MetricBreakdownInjector | None = breakdown_injector
+        elif metric:
+            self.breakdown_injector = BreakdownInjector(self.breakdowns, metric)
+        else:
+            self.breakdown_injector = None
         self.preaggregation_job_ids: list[str] | None = None
         self.metric_events_preaggregation_job_ids: list[str] | None = None
         self.cuped_config = cuped_config or CupedQueryConfig()

--- a/products/experiments/backend/hogql_queries/experiment_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_builder.py
@@ -56,6 +56,7 @@ from products.experiments.backend.hogql_queries.exposure_query_logic import (
     resolve_default_exposure_event,
 )
 from products.experiments.backend.hogql_queries.funnel_step_builder import FunnelStepBuilder
+from products.experiments.backend.hogql_queries.metric_breakdown_injector import MetricBreakdownInjector
 from products.experiments.backend.hogql_queries.metric_source import MetricSourceInfo
 
 
@@ -140,6 +141,7 @@ class ExperimentQueryBuilder:
             ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric
         ] = None,
         breakdowns: list[Breakdown] | None = None,
+        breakdown_injector: BreakdownInjector | MetricBreakdownInjector | None = None,
         only_count_matured_users: bool = False,
         cuped_config: CupedQueryConfig | None = None,
         activation_config: ExperimentEventExposureConfig | ActionsNode | None = None,
@@ -156,7 +158,14 @@ class ExperimentQueryBuilder:
         self.filter_test_accounts = filter_test_accounts
         self.multiple_variant_handling = multiple_variant_handling
         self.breakdowns = breakdowns or []
-        self.breakdown_injector = BreakdownInjector(self.breakdowns, metric) if metric else None
+        # Caller may supply a pre-built injector (e.g. the metric-event injector gated behind
+        # a feature flag); otherwise default to the property-from-exposure injector.
+        if breakdown_injector is not None:
+            self.breakdown_injector: BreakdownInjector | MetricBreakdownInjector | None = breakdown_injector
+        elif metric:
+            self.breakdown_injector = BreakdownInjector(self.breakdowns, metric)
+        else:
+            self.breakdown_injector = None
         self.preaggregation_job_ids: list[str] | None = None
         self.metric_events_preaggregation_job_ids: list[str] | None = None
         self.cuped_config = cuped_config or CupedQueryConfig()

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -33,6 +33,7 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tag_queries, tags_context
+from posthog.constants import EXPERIMENT_METRIC_EVENT_BREAKDOWNS_FEATURE_FLAG_KEY
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -60,6 +61,7 @@ from products.experiments.backend.hogql_queries.exposure_query_logic import (
     get_entity_key,
     get_multiple_variant_handling_from_experiment,
 )
+from products.experiments.backend.hogql_queries.metric_breakdown_injector import MetricBreakdownInjector
 from products.experiments.backend.hogql_queries.utils import (
     aggregate_variants_across_breakdowns,
     get_bayesian_experiment_result,
@@ -315,6 +317,23 @@ class ExperimentQueryRunner(QueryRunner):
 
         return breakdowns
 
+    def _metric_event_breakdowns_enabled(self) -> bool:
+        """Team-scoped, local-only flag gating the metric-event breakdown injector.
+
+        Local-only evaluation keeps this off the network in the query hot path and
+        fails closed (old behavior) when flag definitions aren't cached.
+        """
+        return bool(
+            posthoganalytics.feature_enabled(
+                EXPERIMENT_METRIC_EVENT_BREAKDOWNS_FEATURE_FLAG_KEY,
+                str(self.team.id),
+                groups={"project": str(self.team.id)},
+                group_properties={"project": {"id": str(self.team.id)}},
+                only_evaluate_locally=True,
+                send_feature_flag_events=False,
+            )
+        )
+
     def _ensure_exposures_precomputed(self, builder: ExperimentQueryBuilder) -> LazyComputationResult:
         """
         Ensures lazy-computed exposure data exists for this experiment.
@@ -448,6 +467,11 @@ class ExperimentQueryRunner(QueryRunner):
             filter_test_accounts,
         ) = get_exposure_config_params_for_builder(self.experiment.exposure_criteria)
 
+        breakdowns = self._get_breakdowns_for_builder()
+        breakdown_injector: MetricBreakdownInjector | None = None
+        if breakdowns and isinstance(self.metric, ExperimentFunnelMetric) and self._metric_event_breakdowns_enabled():
+            breakdown_injector = MetricBreakdownInjector(breakdowns, self.metric)
+
         builder = ExperimentQueryBuilder(
             team=self.team,
             feature_flag_key=self.feature_flag_key,
@@ -458,7 +482,8 @@ class ExperimentQueryRunner(QueryRunner):
             date_range_query=self.date_range_query,
             entity_key=self.entity_key,
             metric=self.metric,
-            breakdowns=self._get_breakdowns_for_builder(),
+            breakdowns=breakdowns,
+            breakdown_injector=breakdown_injector,
             only_count_matured_users=self.experiment.only_count_matured_users,
             cuped_config=self.cuped_config,
         )

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -35,6 +35,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.clickhouse.query_tagging import Product, tag_queries, tags_context
 from posthog.constants import EXPERIMENT_METRIC_EVENT_BREAKDOWNS_FEATURE_FLAG_KEY
 from posthog.exceptions_capture import capture_exception
+from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_NULL_STRING_LABEL, BREAKDOWN_OTHER_STRING_LABEL
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models.team.extensions import get_or_create_team_extension
@@ -704,7 +705,14 @@ class ExperimentQueryRunner(QueryRunner):
         self, variant_results: list[tuple[tuple[str, ...] | None, ExperimentStatsBase]]
     ) -> tuple[list[ExperimentBreakdownResult], list[ExperimentStatsBase]]:
         """Compute per-breakdown statistics and aggregate across breakdowns."""
-        breakdown_tuples = sorted({bv for bv, _ in variant_results if bv is not None})
+
+        def _sort_key(breakdown_tuple: tuple[str, ...]) -> tuple[int, int, tuple[str, ...]]:
+            # Keep the "Other" bucket (and null) at the bottom of the breakdown list, matching insights.
+            has_other = any(value == BREAKDOWN_OTHER_STRING_LABEL for value in breakdown_tuple)
+            has_null = any(value == BREAKDOWN_NULL_STRING_LABEL for value in breakdown_tuple)
+            return (int(has_other), int(has_null), breakdown_tuple)
+
+        breakdown_tuples = sorted({bv for bv, _ in variant_results if bv is not None}, key=_sort_key)
 
         breakdown_results = [
             self._compute_breakdown_statistics(breakdown_tuple, variant_results) for breakdown_tuple in breakdown_tuples

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -36,7 +36,10 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tag_queries, tags_context
-from posthog.constants import EXPERIMENTS_RETENTION_METRIC_EVENTS_PREAGGREGATION_FEATURE_FLAG_KEY
+from posthog.constants import (
+    EXPERIMENT_METRIC_EVENT_BREAKDOWNS_FEATURE_FLAG_KEY,
+    EXPERIMENTS_RETENTION_METRIC_EVENTS_PREAGGREGATION_FEATURE_FLAG_KEY,
+)
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -72,6 +75,7 @@ from products.experiments.backend.hogql_queries.exposure_query_logic import (
     get_multiple_variant_handling_from_experiment,
     has_activation_config,
 )
+from products.experiments.backend.hogql_queries.metric_breakdown_injector import MetricBreakdownInjector
 from products.experiments.backend.hogql_queries.utils import (
     aggregate_variants_across_breakdowns,
     get_bayesian_experiment_result,
@@ -333,6 +337,23 @@ class ExperimentQueryRunner(QueryRunner):
 
         return breakdowns
 
+    def _metric_event_breakdowns_enabled(self) -> bool:
+        """Team-scoped, local-only flag gating the metric-event breakdown injector.
+
+        Local-only evaluation keeps this off the network in the query hot path and
+        fails closed (old behavior) when flag definitions aren't cached.
+        """
+        return bool(
+            posthoganalytics.feature_enabled(
+                EXPERIMENT_METRIC_EVENT_BREAKDOWNS_FEATURE_FLAG_KEY,
+                str(self.team.id),
+                groups={"project": str(self.team.id)},
+                group_properties={"project": {"id": str(self.team.id)}},
+                only_evaluate_locally=True,
+                send_feature_flag_events=False,
+            )
+        )
+
     def _ensure_exposures_precomputed(self, builder: ExperimentQueryBuilder) -> LazyComputationResult:
         """
         Ensures lazy-computed exposure data exists for this experiment.
@@ -520,6 +541,11 @@ class ExperimentQueryRunner(QueryRunner):
             self.experiment.exposure_criteria, self.team, self.experiment.start_date
         )
 
+        breakdowns = self._get_breakdowns_for_builder()
+        breakdown_injector: MetricBreakdownInjector | None = None
+        if breakdowns and isinstance(self.metric, ExperimentFunnelMetric) and self._metric_event_breakdowns_enabled():
+            breakdown_injector = MetricBreakdownInjector(breakdowns, self.metric)
+
         builder = ExperimentQueryBuilder(
             team=self.team,
             feature_flag_key=self.feature_flag_key,
@@ -530,7 +556,8 @@ class ExperimentQueryRunner(QueryRunner):
             date_range_query=self.date_range_query,
             entity_key=self.entity_key,
             metric=self.metric,
-            breakdowns=self._get_breakdowns_for_builder(),
+            breakdowns=breakdowns,
+            breakdown_injector=breakdown_injector,
             only_count_matured_users=self.experiment.only_count_matured_users,
             cuped_config=self.cuped_config,
             activation_config=exposure_params.activation_config,

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -544,7 +544,15 @@ class ExperimentQueryRunner(QueryRunner):
 
         breakdowns = self._get_breakdowns_for_builder()
         breakdown_injector: MetricBreakdownInjector | None = None
-        if breakdowns and isinstance(self.metric, ExperimentFunnelMetric) and self._metric_event_breakdowns_enabled():
+        # Data warehouse funnels route through the legacy UNION ALL builder, which replaces the
+        # metric_events CTE and drops the injected breakdown columns, so gate them out until the
+        # injector supports that path.
+        if (
+            breakdowns
+            and isinstance(self.metric, ExperimentFunnelMetric)
+            and not self.is_data_warehouse_query
+            and self._metric_event_breakdowns_enabled()
+        ):
             breakdown_injector = MetricBreakdownInjector(breakdowns, self.metric)
 
         builder = ExperimentQueryBuilder(

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -41,6 +41,7 @@ from posthog.constants import (
     EXPERIMENTS_RETENTION_METRIC_EVENTS_PREAGGREGATION_FEATURE_FLAG_KEY,
 )
 from posthog.exceptions_capture import capture_exception
+from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_NULL_STRING_LABEL, BREAKDOWN_OTHER_STRING_LABEL
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models.team.extensions import get_or_create_team_extension
@@ -780,7 +781,14 @@ class ExperimentQueryRunner(QueryRunner):
         self, variant_results: list[tuple[tuple[str, ...] | None, ExperimentStatsBase]]
     ) -> tuple[list[ExperimentBreakdownResult], list[ExperimentStatsBase]]:
         """Compute per-breakdown statistics and aggregate across breakdowns."""
-        breakdown_tuples = sorted({bv for bv, _ in variant_results if bv is not None})
+
+        def _sort_key(breakdown_tuple: tuple[str, ...]) -> tuple[int, int, tuple[str, ...]]:
+            # Keep the "Other" bucket (and null) at the bottom of the breakdown list, matching insights.
+            has_other = any(value == BREAKDOWN_OTHER_STRING_LABEL for value in breakdown_tuple)
+            has_null = any(value == BREAKDOWN_NULL_STRING_LABEL for value in breakdown_tuple)
+            return (int(has_other), int(has_null), breakdown_tuple)
+
+        breakdown_tuples = sorted({bv for bv, _ in variant_results if bv is not None}, key=_sort_key)
 
         breakdown_results = [
             self._compute_breakdown_statistics(breakdown_tuple, variant_results) for breakdown_tuple in breakdown_tuples

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -790,11 +790,13 @@ class ExperimentQueryRunner(QueryRunner):
     ) -> tuple[list[ExperimentBreakdownResult], list[ExperimentStatsBase]]:
         """Compute per-breakdown statistics and aggregate across breakdowns."""
 
-        def _sort_key(breakdown_tuple: tuple[str, ...]) -> tuple[int, int, tuple[str, ...]]:
-            # Keep the "Other" bucket (and null) at the bottom of the breakdown list, matching insights.
+        def _sort_key(breakdown_tuple: tuple[str, ...]) -> tuple[int, tuple[str, ...]]:
+            # Keep the "Other" bucket last and null just above it, matching insights. A single rank
+            # (0 normal, 1 null, 2 other) then the tuple itself breaks ties alphabetically.
             has_other = any(value == BREAKDOWN_OTHER_STRING_LABEL for value in breakdown_tuple)
             has_null = any(value == BREAKDOWN_NULL_STRING_LABEL for value in breakdown_tuple)
-            return (int(has_other), int(has_null), breakdown_tuple)
+            rank = 2 if has_other else 1 if has_null else 0
+            return (rank, breakdown_tuple)
 
         breakdown_tuples = sorted({bv for bv, _ in variant_results if bv is not None}, key=_sort_key)
 

--- a/products/experiments/backend/hogql_queries/experiment_ratio_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_ratio_query_builder.py
@@ -5,6 +5,7 @@ from posthog.schema import ExperimentDataWarehouseNode, ExperimentMetricOutlierH
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr, parse_select
 
+from products.experiments.backend.hogql_queries.breakdown_injector import BreakdownInjector
 from products.experiments.backend.hogql_queries.metric_source import MetricSourceInfo
 
 if TYPE_CHECKING:
@@ -61,8 +62,9 @@ class RatioQueryBuilder:
 
         assert isinstance(query, ast.SelectQuery)
 
-        # Inject breakdown columns into the query AST
-        if self._b.breakdown_injector:
+        # Inject breakdown columns into the query AST. The metric-event injector is funnel-only,
+        # so ratio metrics always use the property-from-exposure BreakdownInjector.
+        if isinstance(self._b.breakdown_injector, BreakdownInjector):
             self._b.breakdown_injector.inject_ratio_breakdown_columns(query)
 
         return query
@@ -197,8 +199,9 @@ class RatioQueryBuilder:
 
         assert isinstance(query, ast.SelectQuery)
 
-        # Inject breakdown columns into the query AST
-        if self._b.breakdown_injector:
+        # Inject breakdown columns into the query AST. The metric-event injector is funnel-only,
+        # so ratio metrics always use the property-from-exposure BreakdownInjector.
+        if isinstance(self._b.breakdown_injector, BreakdownInjector):
             self._b.breakdown_injector.inject_ratio_breakdown_columns(query, winsorized=True)
 
         return query

--- a/products/experiments/backend/hogql_queries/experiment_retention_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_retention_query_builder.py
@@ -19,6 +19,7 @@ from products.experiments.backend.hogql_queries.base_query_utils import (
     data_warehouse_node_to_filter,
     event_or_action_to_filter,
 )
+from products.experiments.backend.hogql_queries.breakdown_injector import BreakdownInjector
 
 if TYPE_CHECKING:
     from products.experiments.backend.hogql_queries.experiment_query_builder import ExperimentQueryBuilder
@@ -229,8 +230,9 @@ class RetentionQueryBuilder:
                 else:
                     start_events_cte.expr.having = ast.And(exprs=[start_events_cte.expr.having, retention_maturity])
 
-        # Inject breakdown columns if breakdown filter is present
-        if self._b.breakdown_injector:
+        # Inject breakdown columns if breakdown filter is present. The metric-event injector is
+        # funnel-only, so retention metrics always use the property-from-exposure BreakdownInjector.
+        if isinstance(self._b.breakdown_injector, BreakdownInjector):
             self._b.breakdown_injector.inject_retention_breakdown_columns(query)
 
         return query

--- a/products/experiments/backend/hogql_queries/experiment_retention_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_retention_query_builder.py
@@ -21,6 +21,7 @@ from products.experiments.backend.hogql_queries.base_query_utils import (
     data_warehouse_node_to_filter,
     event_or_action_to_filter,
 )
+from products.experiments.backend.hogql_queries.breakdown_injector import BreakdownInjector
 
 if TYPE_CHECKING:
     from products.experiments.backend.hogql_queries.experiment_query_builder import ExperimentQueryBuilder
@@ -358,8 +359,9 @@ class RetentionQueryBuilder:
                 else:
                     start_events_cte.expr.having = ast.And(exprs=[start_events_cte.expr.having, retention_maturity])
 
-        # Inject breakdown columns if breakdown filter is present
-        if self._b.breakdown_injector:
+        # Inject breakdown columns if breakdown filter is present. The metric-event injector is
+        # funnel-only, so retention metrics always use the property-from-exposure BreakdownInjector.
+        if isinstance(self._b.breakdown_injector, BreakdownInjector):
             self._b.breakdown_injector.inject_retention_breakdown_columns(query)
 
         return query

--- a/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
@@ -17,10 +17,11 @@ from typing import cast
 from posthog.schema import Breakdown, BreakdownAttributionType, ExperimentFunnelMetric, MultipleBreakdownType
 
 from posthog.hogql import ast
+from posthog.hogql.constants import BREAKDOWN_VALUES_LIMIT
 from posthog.hogql.parser import parse_expr
 
 from posthog.hogql_queries.insights.trends.utils import get_properties_chain
-from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_NULL_STRING_LABEL
+from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_NULL_STRING_LABEL, BREAKDOWN_OTHER_STRING_LABEL
 
 
 class MetricBreakdownInjector:
@@ -116,14 +117,69 @@ class MetricBreakdownInjector:
             ],
         )
 
+    def _breakdown_limit(self) -> int:
+        """Top-N cap on breakdown values; mirrors insights' default of BREAKDOWN_VALUES_LIMIT."""
+        breakdown_filter = self.metric.breakdownFilter
+        limit = breakdown_filter.breakdown_limit if breakdown_filter else None
+        return limit or BREAKDOWN_VALUES_LIMIT
+
+    def _top_breakdowns_subquery(self, aliases: list[str]) -> ast.SelectQuery:
+        """Top-N breakdown tuples by entity (user) count, pooled across variants.
+
+        Selects from entity_metrics (one row per user) so the ranking measure is the
+        number of experiment units in each breakdown bucket — the funnel analog of
+        insights ranking by frequency.
+        """
+        # Project a scalar for a single breakdown, or a tuple for multiple, so the
+        # membership test on the outer query matches shapes.
+        if len(aliases) == 1:
+            projection: ast.Expr = ast.Field(chain=["entity_metrics", aliases[0]])
+        else:
+            projection = ast.Tuple(exprs=[ast.Field(chain=["entity_metrics", alias]) for alias in aliases])
+        subquery = ast.SelectQuery(
+            select=[projection],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["entity_metrics"])),
+            group_by=[ast.Field(chain=["entity_metrics", alias]) for alias in aliases],
+            order_by=[ast.OrderExpr(expr=ast.Call(name="count", args=[]), order="DESC")],
+            limit=ast.Constant(value=self._breakdown_limit()),
+        )
+        return subquery
+
     def _inject_final_breakdown_columns(self, query: ast.SelectQuery, aliases: list[str]) -> None:
-        """Surface breakdown columns in the outer SELECT (after variant) and GROUP BY."""
+        """Surface breakdown columns in the outer SELECT (after variant) and GROUP BY.
+
+        Applies the top-N + "Other" limit: breakdown tuples beyond the limit (ranked by
+        user count) are relabeled to BREAKDOWN_OTHER_STRING_LABEL before the final GROUP BY,
+        capping output cardinality. The relabel collapses the whole tuple together so all
+        breakdown columns of an "Other" row carry the Other label.
+        """
+        # Membership test against the top-N set. Single breakdown compares the scalar value
+        # directly; multiple breakdowns compare the value tuple element-wise.
+        if len(aliases) == 1:
+            left: ast.Expr = ast.Field(chain=["entity_metrics", aliases[0]])
+        else:
+            left = ast.Tuple(exprs=[ast.Field(chain=["entity_metrics", alias]) for alias in aliases])
+        in_top = ast.CompareOperation(
+            op=ast.CompareOperationOp.In,
+            left=left,
+            right=self._top_breakdowns_subquery(aliases),
+        )
+
         for i, alias in enumerate(aliases):
-            query.select.insert(1 + i, ast.Alias(alias=alias, expr=ast.Field(chain=["entity_metrics", alias])))
+            limited_expr = parse_expr(
+                "if({in_top}, {value}, {other})",
+                placeholders={
+                    "in_top": in_top,
+                    "value": ast.Field(chain=["entity_metrics", alias]),
+                    "other": ast.Constant(value=BREAKDOWN_OTHER_STRING_LABEL),
+                },
+            )
+            query.select.insert(1 + i, ast.Alias(alias=alias, expr=limited_expr))
+
         if query.group_by is None:
             query.group_by = []
         for alias in aliases:
-            query.group_by.append(ast.Field(chain=["entity_metrics", alias]))
+            query.group_by.append(ast.Field(chain=[alias]))
 
     def inject_funnel_breakdown_columns(self, query: ast.SelectQuery) -> None:
         """Legacy 3-CTE path: exposures + metric_events + entity_metrics.

--- a/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
@@ -1,0 +1,178 @@
+"""
+Metric-event breakdown injection for experiment funnel queries.
+
+Unlike ``BreakdownInjector`` (which attributes the breakdown value from the
+exposure event), this injector reads the breakdown property off the *metric*
+event and attributes it across funnel steps using the metric's configured
+``breakdownAttributionType`` — aligning experiment funnel breakdowns with how
+insights funnels behave.
+
+Scope: funnel metrics only. This is a standalone class (it does not subclass
+``BreakdownInjector``); the old injector is removed once all metric types
+migrate to metric-event breakdowns.
+"""
+
+from typing import cast
+
+from posthog.schema import Breakdown, BreakdownAttributionType, ExperimentFunnelMetric, MultipleBreakdownType
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_expr
+
+from posthog.hogql_queries.insights.trends.utils import get_properties_chain
+from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_NULL_STRING_LABEL
+
+
+class MetricBreakdownInjector:
+    def __init__(self, breakdowns: list[Breakdown], metric: ExperimentFunnelMetric):
+        self.breakdowns = breakdowns
+        self.metric = metric
+
+    def attributes_from_exposure(self) -> bool:
+        """This injector attributes from the metric event, so the exposure query stays breakdown-free."""
+        return False
+
+    def _has_breakdown(self) -> bool:
+        return len(self.breakdowns) > 0
+
+    def _get_breakdown_aliases(self) -> list[str]:
+        return [f"breakdown_value_{i + 1}" for i in range(len(self.breakdowns))]
+
+    def build_breakdown_exprs(self, table_alias: str = "events") -> list[tuple[str, ast.Expr]]:
+        """Returns (alias, expression) tuples reading each breakdown property off the metric event.
+
+        Coalesces NULL to BREAKDOWN_NULL_STRING_LABEL. Empty list if no breakdowns.
+        """
+        if not self._has_breakdown():
+            return []
+
+        result = []
+        for i, breakdown in enumerate(self.breakdowns):
+            breakdown_type = breakdown.type or cast(MultipleBreakdownType, "event")
+            breakdown_field = str(breakdown.property)
+
+            properties_chain = get_properties_chain(
+                breakdown_type=breakdown_type,
+                breakdown_field=breakdown_field,
+                group_type_index=breakdown.group_type_index,
+            )
+
+            if table_alias and properties_chain[0] == "properties":
+                property_expr: ast.Expr = ast.Field(chain=[table_alias, *properties_chain])
+            else:
+                property_expr = ast.Field(chain=properties_chain)
+
+            expr = parse_expr(
+                "coalesce(toString({property_expr}), {null_label})",
+                placeholders={
+                    "property_expr": property_expr,
+                    "null_label": ast.Constant(value=BREAKDOWN_NULL_STRING_LABEL),
+                },
+            )
+            result.append((f"breakdown_value_{i + 1}", expr))
+
+        return result
+
+    def _attribution_step(self) -> tuple[str, int]:
+        """Resolve (aggregation_fn, step_column_index) for the configured attribution mode.
+
+        In experiment funnels ``step_0`` is the exposure event and the metric series
+        events are ``step_1 .. step_N`` (N = len(series)). The breakdown is read off
+        the metric events, so attribution targets those steps, never the exposure step.
+
+        - first_touch / all_events: argMinIf from the first metric step (step_1).
+        - last_touch: argMaxIf from the last metric step (step_N).
+        - step: argMinIf from ``breakdownAttributionValue`` (0-indexed into the series,
+          mapped to the corresponding step column step_{value + 1}).
+        """
+        attribution = self.metric.breakdownAttributionType or BreakdownAttributionType.FIRST_TOUCH
+        num_metric_steps = len(self.metric.series)
+
+        if attribution == BreakdownAttributionType.LAST_TOUCH:
+            return "argMaxIf", num_metric_steps
+        if attribution == BreakdownAttributionType.STEP:
+            series_index = self.metric.breakdownAttributionValue
+            if series_index is None or series_index < 0 or series_index >= num_metric_steps:
+                raise ValueError(
+                    f"breakdownAttributionValue must be in [0, {num_metric_steps - 1}] for step attribution, "
+                    f"got {series_index}"
+                )
+            return "argMinIf", series_index + 1
+        return "argMinIf", 1
+
+    def _attribution_expr(self, breakdown_field: ast.Expr) -> ast.Call:
+        """argMin/argMax that picks the attributed breakdown value at the configured step."""
+        agg, step_index = self._attribution_step()
+        return ast.Call(
+            name=agg,
+            args=[
+                breakdown_field,
+                ast.Field(chain=["timestamp"]),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=[f"step_{step_index}"]),
+                    right=ast.Constant(value=1),
+                ),
+            ],
+        )
+
+    def _inject_final_breakdown_columns(self, query: ast.SelectQuery, aliases: list[str]) -> None:
+        """Surface breakdown columns in the outer SELECT (after variant) and GROUP BY."""
+        for i, alias in enumerate(aliases):
+            query.select.insert(1 + i, ast.Alias(alias=alias, expr=ast.Field(chain=["entity_metrics", alias])))
+        if query.group_by is None:
+            query.group_by = []
+        for alias in aliases:
+            query.group_by.append(ast.Field(chain=["entity_metrics", alias]))
+
+    def inject_funnel_breakdown_columns(self, query: ast.SelectQuery) -> None:
+        """Legacy 3-CTE path: exposures + metric_events + entity_metrics.
+
+        The breakdown is always attributed from the metric event (never carried
+        from exposures), so attribution is uniform regardless of funnel order.
+        """
+        if not self._has_breakdown():
+            return
+
+        aliases = self._get_breakdown_aliases()
+        breakdown_exprs = self.build_breakdown_exprs(table_alias="")
+
+        if query.ctes and "metric_events" in query.ctes:
+            metric_events_cte = query.ctes["metric_events"]
+            if isinstance(metric_events_cte, ast.CTE) and isinstance(metric_events_cte.expr, ast.SelectQuery):
+                for alias, expr in breakdown_exprs:
+                    metric_events_cte.expr.select.append(ast.Alias(alias=alias, expr=expr))
+
+        if query.ctes and "entity_metrics" in query.ctes:
+            entity_metrics_cte = query.ctes["entity_metrics"]
+            if isinstance(entity_metrics_cte, ast.CTE) and isinstance(entity_metrics_cte.expr, ast.SelectQuery):
+                for alias in aliases:
+                    entity_metrics_cte.expr.select.append(
+                        ast.Alias(alias=alias, expr=self._attribution_expr(ast.Field(chain=["metric_events", alias])))
+                    )
+
+        self._inject_final_breakdown_columns(query, aliases)
+
+    def inject_funnel_breakdown_columns_optimized(self, query: ast.SelectQuery) -> None:
+        """Optimized 2-CTE path: base_events + entity_metrics (no exposures CTE)."""
+        if not self._has_breakdown():
+            return
+
+        aliases = self._get_breakdown_aliases()
+        breakdown_exprs = self.build_breakdown_exprs(table_alias="")
+
+        if query.ctes and "base_events" in query.ctes:
+            base_events_cte = query.ctes["base_events"]
+            if isinstance(base_events_cte, ast.CTE) and isinstance(base_events_cte.expr, ast.SelectQuery):
+                for alias, expr in breakdown_exprs:
+                    base_events_cte.expr.select.append(ast.Alias(alias=alias, expr=expr))
+
+        if query.ctes and "entity_metrics" in query.ctes:
+            entity_metrics_cte = query.ctes["entity_metrics"]
+            if isinstance(entity_metrics_cte, ast.CTE) and isinstance(entity_metrics_cte.expr, ast.SelectQuery):
+                for alias in aliases:
+                    entity_metrics_cte.expr.select.append(
+                        ast.Alias(alias=alias, expr=self._attribution_expr(ast.Field(chain=[alias])))
+                    )
+
+        self._inject_final_breakdown_columns(query, aliases)

--- a/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
@@ -140,7 +140,12 @@ class MetricBreakdownInjector:
             select=[projection],
             select_from=ast.JoinExpr(table=ast.Field(chain=["entity_metrics"])),
             group_by=[ast.Field(chain=["entity_metrics", alias]) for alias in aliases],
-            order_by=[ast.OrderExpr(expr=ast.Call(name="count", args=[]), order="DESC")],
+            # Tie-break by breakdown value so the cutoff at the limit is deterministic
+            # across executions; count() alone lets ClickHouse pick tied tuples arbitrarily.
+            order_by=[
+                ast.OrderExpr(expr=ast.Call(name="count", args=[]), order="DESC"),
+                *[ast.OrderExpr(expr=ast.Field(chain=["entity_metrics", alias]), order="ASC") for alias in aliases],
+            ],
             limit=ast.Constant(value=self._breakdown_limit()),
         )
         return subquery

--- a/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
@@ -14,7 +14,13 @@ migrate to metric-event breakdowns.
 
 from typing import cast
 
-from posthog.schema import Breakdown, BreakdownAttributionType, ExperimentFunnelMetric, MultipleBreakdownType
+from posthog.schema import (
+    Breakdown,
+    BreakdownAttributionType,
+    ExperimentFunnelMetric,
+    MultipleBreakdownType,
+    StepOrderValue,
+)
 
 from posthog.hogql import ast
 from posthog.hogql.constants import BREAKDOWN_VALUES_LIMIT
@@ -74,8 +80,8 @@ class MetricBreakdownInjector:
 
         return result
 
-    def _attribution_step(self) -> tuple[str, int]:
-        """Resolve (aggregation_fn, step_column_index) for the configured attribution mode.
+    def _attribution_agg_and_steps(self) -> tuple[str, list[int]]:
+        """Resolve (aggregation_fn, step_column_indexes) for the configured attribution mode.
 
         In experiment funnels ``step_0`` is the exposure event and the metric series
         events are ``step_1 .. step_N`` (N = len(series)). The breakdown is read off
@@ -83,38 +89,62 @@ class MetricBreakdownInjector:
 
         - first_touch / all_events: argMinIf from the first metric step (step_1).
         - last_touch: argMaxIf from the last metric step (step_N).
-        - step: argMinIf from ``breakdownAttributionValue`` (0-indexed into the series,
-          mapped to the corresponding step column step_{value + 1}).
+        - step (ordered): argMinIf from ``breakdownAttributionValue`` (0-indexed into the
+          series, mapped to the corresponding step column step_{value + 1}).
+        - step (unordered, "Any step"): argMinIf across all metric step columns, since an
+          unordered funnel has no fixed step position and any matching step attributes.
         """
         attribution = self.metric.breakdownAttributionType or BreakdownAttributionType.FIRST_TOUCH
         num_metric_steps = len(self.metric.series)
+        is_unordered = self.metric.funnel_order_type == StepOrderValue.UNORDERED
 
         if attribution == BreakdownAttributionType.LAST_TOUCH:
-            return "argMaxIf", num_metric_steps
+            return "argMaxIf", [num_metric_steps]
         if attribution == BreakdownAttributionType.STEP:
+            if is_unordered:
+                # "Any step": the stored index is ignored, attribute from the earliest matching step.
+                return "argMinIf", list(range(1, num_metric_steps + 1))
             series_index = self.metric.breakdownAttributionValue
             if series_index is None or series_index < 0 or series_index >= num_metric_steps:
                 raise ValueError(
                     f"breakdownAttributionValue must be in [0, {num_metric_steps - 1}] for step attribution, "
                     f"got {series_index}"
                 )
-            return "argMinIf", series_index + 1
-        return "argMinIf", 1
+            return "argMinIf", [series_index + 1]
+        return "argMinIf", [1]
 
-    def _attribution_expr(self, breakdown_field: ast.Expr) -> ast.Call:
-        """argMin/argMax that picks the attributed breakdown value at the configured step."""
-        agg, step_index = self._attribution_step()
-        return ast.Call(
+    def _attribution_condition(self, step_indexes: list[int]) -> ast.Expr:
+        """Match a metric event at any of the attribution step columns (``step_i = 1``)."""
+        comparisons: list[ast.Expr] = [
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ast.Field(chain=[f"step_{index}"]),
+                right=ast.Constant(value=1),
+            )
+            for index in step_indexes
+        ]
+        return comparisons[0] if len(comparisons) == 1 else ast.Or(exprs=comparisons)
+
+    def _attribution_expr(self, breakdown_field: ast.Expr) -> ast.Expr:
+        """Attributed breakdown value at the configured step(s).
+
+        argMinIf/argMaxIf over zero matching rows returns ClickHouse's empty string, which would
+        create an invisible ``""`` bucket that collides with real empty-string values and steals a
+        top-N slot. Users with no attributable metric event get the null label instead.
+        """
+        agg, step_indexes = self._attribution_agg_and_steps()
+        condition = self._attribution_condition(step_indexes)
+        attributed = ast.Call(
             name=agg,
-            args=[
-                breakdown_field,
-                ast.Field(chain=["timestamp"]),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Eq,
-                    left=ast.Field(chain=[f"step_{step_index}"]),
-                    right=ast.Constant(value=1),
-                ),
-            ],
+            args=[breakdown_field, ast.Field(chain=["timestamp"]), condition],
+        )
+        return parse_expr(
+            "if({has_match} = 0, {null_label}, {attributed})",
+            placeholders={
+                "has_match": ast.Call(name="countIf", args=[condition]),
+                "null_label": ast.Constant(value=BREAKDOWN_NULL_STRING_LABEL),
+                "attributed": attributed,
+            },
         )
 
     def _breakdown_limit(self) -> int:

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_breakdown.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_breakdown.py
@@ -523,6 +523,81 @@ class TestExperimentBreakdown(ExperimentQueryRunnerBaseTest):
         self.assertEqual(buckets, expected_buckets)
 
     @freeze_time("2020-01-01T12:00:00Z")
+    def test_funnel_breakdown_limit_collapses_to_other(self):
+        from unittest.mock import patch
+
+        from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_OTHER_STRING_LABEL
+
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = ExperimentFunnelMetric(
+            series=[EventsNode(event="purchase")],
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")], breakdown_limit=2),
+        )
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Four browser values with descending user counts: Chrome(4) > Safari(3) > Firefox(2) > Edge(1).
+        # With breakdown_limit=2, only Chrome + Safari survive; Firefox + Edge collapse to "Other".
+        browser_counts = {"Chrome": 4, "Safari": 3, "Firefox": 2, "Edge": 1}
+        user_index = 0
+        for browser, count in browser_counts.items():
+            for _ in range(count):
+                variant = "control" if user_index % 2 == 0 else "test"
+                distinct_id = f"user_{user_index}"
+                user_index += 1
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: variant, "$browser": browser},
+                )
+
+        flush_persons_and_events()
+
+        with patch(
+            "products.experiments.backend.hogql_queries.experiment_query_runner.posthoganalytics.feature_enabled",
+            return_value=True,
+        ):
+            query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+            result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        buckets = {value for br in result.breakdown_results for value in br.breakdown_value}
+        # Top 2 by frequency survive; the rest collapse into a single "Other" bucket.
+        self.assertEqual(buckets, {"Chrome", "Safari", BREAKDOWN_OTHER_STRING_LABEL})
+
+        # The "Other" bucket is ordered last in the breakdown list.
+        ordered_values = [value for br in result.breakdown_results for value in br.breakdown_value]
+        self.assertEqual(ordered_values[-1], BREAKDOWN_OTHER_STRING_LABEL)
+
+        # The "Other" bucket preserves totals: per-breakdown baseline samples sum to the overall.
+        assert result.baseline is not None
+        per_breakdown_baseline = sum(
+            br.baseline.number_of_samples for br in result.breakdown_results if br.baseline is not None
+        )
+        self.assertEqual(per_breakdown_baseline, result.baseline.number_of_samples)
+
+    @freeze_time("2020-01-01T12:00:00Z")
     @snapshot_clickhouse_queries
     def test_ratio_metric_with_breakdown(self):
         feature_flag = self.create_feature_flag()

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_breakdown.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_breakdown.py
@@ -9,6 +9,7 @@ from parameterized import parameterized
 
 from posthog.schema import (
     Breakdown,
+    BreakdownAttributionType,
     BreakdownFilter,
     EventsNode,
     ExperimentFunnelMetric,
@@ -387,6 +388,139 @@ class TestExperimentBreakdown(ExperimentQueryRunnerBaseTest):
             self.assertIsNotNone(breakdown_result.baseline)
             self.assertIsNotNone(breakdown_result.variants)
             self.assertGreater(len(breakdown_result.variants), 0)
+
+    @parameterized.expand(
+        [
+            ("flag_off", False, {"ExposureBrowser"}),
+            ("flag_on", True, {"MetricBrowser"}),
+        ]
+    )
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_funnel_breakdown_source_respects_flag(self, _name, flag_on, expected_buckets):
+        from unittest.mock import patch
+
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = ExperimentFunnelMetric(
+            series=[EventsNode(event="purchase")],
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")]),
+        )
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Exposure event carries "ExposureBrowser"; the metric event carries "MetricBrowser".
+        for variant in ["control", "test"]:
+            distinct_id = f"user_{variant}"
+            _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: variant,
+                    "$feature_flag_response": variant,
+                    "$feature_flag": feature_flag.key,
+                    "$browser": "ExposureBrowser",
+                },
+            )
+            _create_event(
+                team=self.team,
+                event="purchase",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:01:00Z",
+                properties={feature_flag_property: variant, "$browser": "MetricBrowser"},
+            )
+
+        flush_persons_and_events()
+
+        with patch(
+            "products.experiments.backend.hogql_queries.experiment_query_runner.posthoganalytics.feature_enabled",
+            return_value=flag_on,
+        ):
+            query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+            result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        buckets = {value for br in result.breakdown_results for value in br.breakdown_value}
+        self.assertEqual(buckets, expected_buckets)
+
+    @parameterized.expand(
+        [
+            ("first_touch", BreakdownAttributionType.FIRST_TOUCH, None, {"StepZeroBrowser"}),
+            ("last_touch", BreakdownAttributionType.LAST_TOUCH, None, {"StepOneBrowser"}),
+            ("step_1", BreakdownAttributionType.STEP, 1, {"StepOneBrowser"}),
+        ]
+    )
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_funnel_attribution_modes_bucket_correctly(self, _name, attribution, attribution_value, expected_buckets):
+        from unittest.mock import patch
+
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = ExperimentFunnelMetric(
+            series=[EventsNode(event="step_zero"), EventsNode(event="step_one")],
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")]),
+            breakdownAttributionType=attribution,
+            breakdownAttributionValue=attribution_value,
+        )
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Step 0 and step 1 carry different breakdown values, so each attribution mode resolves differently.
+        for variant in ["control", "test"]:
+            distinct_id = f"user_{variant}"
+            _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: variant,
+                    "$feature_flag_response": variant,
+                    "$feature_flag": feature_flag.key,
+                },
+            )
+            _create_event(
+                team=self.team,
+                event="step_zero",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:01:00Z",
+                properties={feature_flag_property: variant, "$browser": "StepZeroBrowser"},
+            )
+            _create_event(
+                team=self.team,
+                event="step_one",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:02:00Z",
+                properties={feature_flag_property: variant, "$browser": "StepOneBrowser"},
+            )
+
+        flush_persons_and_events()
+
+        with patch(
+            "products.experiments.backend.hogql_queries.experiment_query_runner.posthoganalytics.feature_enabled",
+            return_value=True,
+        ):
+            query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+            result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        buckets = {value for br in result.breakdown_results for value in br.breakdown_value}
+        self.assertEqual(buckets, expected_buckets)
 
     @freeze_time("2020-01-01T12:00:00Z")
     @snapshot_clickhouse_queries

--- a/products/experiments/backend/hogql_queries/test/test_experiment_exposure_preaggregation.py
+++ b/products/experiments/backend/hogql_queries/test/test_experiment_exposure_preaggregation.py
@@ -11,6 +11,9 @@ from django.test import override_settings
 from parameterized import parameterized
 
 from posthog.schema import (
+    Breakdown,
+    BreakdownFilter,
+    DateRange,
     EventsNode,
     ExperimentExposureQuery,
     ExperimentFunnelMetric,
@@ -21,6 +24,7 @@ from posthog.schema import (
     IntervalType,
 )
 
+from posthog.hogql import ast
 from posthog.hogql.constants import MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY, get_default_hogql_global_settings
 
 from posthog.clickhouse.client import sync_execute
@@ -33,6 +37,8 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
 )
 from products.analytics_platform.backend.models import PreaggregationJob
 from products.experiments.backend.hogql_queries.base_query_utils import experiment_window
+from products.experiments.backend.hogql_queries.breakdown_injector import BreakdownInjector
+from products.experiments.backend.hogql_queries.experiment_exposure_query_builder import ExposureQueryBuilder
 from products.experiments.backend.hogql_queries.experiment_exposures_query_runner import ExperimentExposuresQueryRunner
 from products.experiments.backend.hogql_queries.experiment_query_builder import (
     ExperimentQueryBuilder,
@@ -43,6 +49,7 @@ from products.experiments.backend.hogql_queries.experiment_query_runner import (
     ExperimentQueryRunner,
 )
 from products.experiments.backend.hogql_queries.exposure_query_logic import get_entity_key
+from products.experiments.backend.hogql_queries.metric_breakdown_injector import MetricBreakdownInjector
 from products.experiments.backend.hogql_queries.test.experiment_query_runner.base import ExperimentQueryRunnerBaseTest
 
 
@@ -934,3 +941,49 @@ class TestExperimentExposurePreaggregation(ExperimentQueryRunnerBaseTest):
         # be surfaced to error tracking rather than silently masked.
         mock_capture.assert_called_once()
         assert mock_capture.call_args.kwargs["additional_properties"]["precomputation_path"] == expected_path
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestExposurePreaggregationBreakdownGating(ExperimentQueryRunnerBaseTest):
+    @parameterized.expand(
+        [
+            ("metric_event_injector", MetricBreakdownInjector, "experiment_exposures_preaggregated"),
+            ("exposure_injector", BreakdownInjector, "events"),
+        ]
+    )
+    def test_precomputed_exposures_gated_on_exposure_attributed_breakdowns(self, _name, injector_cls, expected_table):
+        breakdowns = [Breakdown(property="$browser")]
+        metric = ExperimentFunnelMetric(
+            series=[EventsNode(event="purchase")],
+            breakdownFilter=BreakdownFilter(breakdowns=breakdowns),
+        )
+        exposure_config, multiple_variant_handling, filter_test_accounts = get_exposure_config_params_for_builder(None)
+        builder = ExperimentQueryBuilder(
+            team=self.team,
+            feature_flag_key="test-flag",
+            exposure_config=exposure_config,
+            filter_test_accounts=filter_test_accounts,
+            multiple_variant_handling=multiple_variant_handling,
+            variants=["control", "test"],
+            date_range_query=QueryDateRange(
+                date_range=DateRange(date_from="2024-01-01", date_to="2024-01-14"),
+                team=self.team,
+                interval=IntervalType.DAY,
+                now=datetime(2024, 1, 14, tzinfo=UTC),
+            ),
+            entity_key="person_id",
+            metric=metric,
+            breakdowns=breakdowns,
+            breakdown_injector=injector_cls(breakdowns, metric),
+        )
+
+        exposure_builder = ExposureQueryBuilder(
+            context=builder.context,
+            breakdown_injector=builder.breakdown_injector,
+            preaggregation_job_ids=["job-1"],
+        )
+        query = exposure_builder.select_query()
+
+        assert query.select_from is not None
+        assert isinstance(query.select_from.table, ast.Field)
+        assert query.select_from.table.chain == [expected_table]

--- a/products/experiments/backend/hogql_queries/test/test_experiment_exposure_preaggregation.py
+++ b/products/experiments/backend/hogql_queries/test/test_experiment_exposure_preaggregation.py
@@ -957,13 +957,13 @@ class TestExposurePreaggregationBreakdownGating(ExperimentQueryRunnerBaseTest):
             series=[EventsNode(event="purchase")],
             breakdownFilter=BreakdownFilter(breakdowns=breakdowns),
         )
-        exposure_config, multiple_variant_handling, filter_test_accounts = get_exposure_config_params_for_builder(None)
+        exposure_params = get_exposure_config_params_for_builder(None, self.team, None)
         builder = ExperimentQueryBuilder(
             team=self.team,
             feature_flag_key="test-flag",
-            exposure_config=exposure_config,
-            filter_test_accounts=filter_test_accounts,
-            multiple_variant_handling=multiple_variant_handling,
+            exposure_config=exposure_params.exposure_config,
+            filter_test_accounts=exposure_params.filter_test_accounts,
+            multiple_variant_handling=exposure_params.multiple_variant_handling,
             variants=["control", "test"],
             date_range_query=QueryDateRange(
                 date_range=DateRange(date_from="2024-01-01", date_to="2024-01-14"),
@@ -975,6 +975,7 @@ class TestExposurePreaggregationBreakdownGating(ExperimentQueryRunnerBaseTest):
             metric=metric,
             breakdowns=breakdowns,
             breakdown_injector=injector_cls(breakdowns, metric),
+            activation_config=exposure_params.activation_config,
         )
 
         exposure_builder = ExposureQueryBuilder(

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -83,8 +83,32 @@ class TestMetricBreakdownInjector:
 
         select_aliases = [c.alias for c in query.select if isinstance(c, ast.Alias)]
         assert "breakdown_value_1" in select_aliases
+        # The limit relabel groups by the output alias (the relabeled column), not the raw
+        # entity_metrics column, so "Other" rows merge.
         assert query.group_by is not None
-        assert ast.Field(chain=["entity_metrics", "breakdown_value_1"]) in query.group_by
+        assert ast.Field(chain=["breakdown_value_1"]) in query.group_by
+
+    def test_final_breakdown_column_applies_top_n_other_relabel(self):
+        metric = _funnel_metric()
+        metric.breakdownFilter.breakdown_limit = 3
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _optimized_query()
+
+        injector.inject_funnel_breakdown_columns_optimized(query)
+
+        final_alias = next(c for c in query.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        # if(<in top-N>, value, 'Other')
+        assert isinstance(final_alias.expr, ast.Call)
+        assert final_alias.expr.name == "if"
+        in_top = final_alias.expr.args[0]
+        assert isinstance(in_top, ast.CompareOperation)
+        assert in_top.op == ast.CompareOperationOp.In
+        assert isinstance(in_top.right, ast.SelectQuery)
+        assert isinstance(in_top.right.limit, ast.Constant)
+        assert in_top.right.limit.value == 3
+        other = final_alias.expr.args[2]
+        assert isinstance(other, ast.Constant)
+        assert other.value == "$$_posthog_breakdown_other_$$"
 
     def test_step_attribution_out_of_range_raises(self):
         metric = _funnel_metric(attribution=BreakdownAttributionType.STEP, attribution_value=5, num_steps=2)

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -1,0 +1,98 @@
+from parameterized import parameterized
+
+from posthog.schema import Breakdown, BreakdownAttributionType, BreakdownFilter, EventsNode, ExperimentFunnelMetric
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+
+from products.experiments.backend.hogql_queries.metric_breakdown_injector import MetricBreakdownInjector
+
+
+def _funnel_metric(attribution=None, attribution_value=None, num_steps=2):
+    return ExperimentFunnelMetric(
+        series=[EventsNode(event=f"step_{i}") for i in range(num_steps)],
+        breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")]),
+        breakdownAttributionType=attribution,
+        breakdownAttributionValue=attribution_value,
+    )
+
+
+def _optimized_query() -> ast.SelectQuery:
+    query = parse_select("SELECT variant FROM base_events AS entity_metrics")
+    assert isinstance(query, ast.SelectQuery)
+    base = parse_select("SELECT variant, entity_id, timestamp, step_0, step_1, step_2 FROM events")
+    em = parse_select("SELECT variant FROM base_events GROUP BY variant")
+    assert isinstance(base, ast.SelectQuery) and isinstance(em, ast.SelectQuery)
+    query.ctes = {
+        "base_events": ast.CTE(name="base_events", expr=base, cte_type="subquery"),
+        "entity_metrics": ast.CTE(name="entity_metrics", expr=em, cte_type="subquery"),
+    }
+    return query
+
+
+def _entity_metrics_aliases(query: ast.SelectQuery) -> dict[str, ast.Expr]:
+    cte = query.ctes["entity_metrics"]
+    assert isinstance(cte, ast.CTE) and isinstance(cte.expr, ast.SelectQuery)
+    return {c.alias: c.expr for c in cte.expr.select if isinstance(c, ast.Alias)}
+
+
+class TestMetricBreakdownInjector:
+    # step_0 is the exposure step; metric series events are step_1..step_N.
+    @parameterized.expand(
+        [
+            ("first_touch", BreakdownAttributionType.FIRST_TOUCH, None, "argMinIf", "step_1"),
+            ("last_touch", BreakdownAttributionType.LAST_TOUCH, None, "argMaxIf", "step_2"),
+            ("step_series_0", BreakdownAttributionType.STEP, 0, "argMinIf", "step_1"),
+            ("step_series_1", BreakdownAttributionType.STEP, 1, "argMinIf", "step_2"),
+            ("all_events", BreakdownAttributionType.ALL_EVENTS, None, "argMinIf", "step_1"),
+            ("default_none", None, None, "argMinIf", "step_1"),
+        ]
+    )
+    def test_optimized_attribution_modes(self, _name, attribution, value, expected_agg, expected_step):
+        metric = _funnel_metric(attribution=attribution, attribution_value=value, num_steps=2)
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _optimized_query()
+
+        injector.inject_funnel_breakdown_columns_optimized(query)
+
+        expr = _entity_metrics_aliases(query)["breakdown_value_1"]
+        assert isinstance(expr, ast.Call)
+        assert expr.name == expected_agg
+        cond = expr.args[2]
+        assert isinstance(cond, ast.CompareOperation)
+        assert cond.left == ast.Field(chain=[expected_step])
+
+    def test_breakdown_read_from_metric_event_in_base_events(self):
+        metric = _funnel_metric(attribution=BreakdownAttributionType.FIRST_TOUCH)
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _optimized_query()
+
+        injector.inject_funnel_breakdown_columns_optimized(query)
+
+        base_cte = query.ctes["base_events"]
+        assert isinstance(base_cte, ast.CTE) and isinstance(base_cte.expr, ast.SelectQuery)
+        base_aliases = [c.alias for c in base_cte.expr.select if isinstance(c, ast.Alias)]
+        assert "breakdown_value_1" in base_aliases
+
+    def test_breakdown_added_to_final_select_and_group_by(self):
+        metric = _funnel_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _optimized_query()
+
+        injector.inject_funnel_breakdown_columns_optimized(query)
+
+        select_aliases = [c.alias for c in query.select if isinstance(c, ast.Alias)]
+        assert "breakdown_value_1" in select_aliases
+        assert query.group_by is not None
+        assert ast.Field(chain=["entity_metrics", "breakdown_value_1"]) in query.group_by
+
+    def test_step_attribution_out_of_range_raises(self):
+        metric = _funnel_metric(attribution=BreakdownAttributionType.STEP, attribution_value=5, num_steps=2)
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _optimized_query()
+
+        try:
+            injector.inject_funnel_breakdown_columns_optimized(query)
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            pass

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -31,6 +31,7 @@ def _optimized_query() -> ast.SelectQuery:
 
 
 def _entity_metrics_aliases(query: ast.SelectQuery) -> dict[str, ast.Expr]:
+    assert query.ctes is not None
     cte = query.ctes["entity_metrics"]
     assert isinstance(cte, ast.CTE) and isinstance(cte.expr, ast.SelectQuery)
     return {c.alias: c.expr for c in cte.expr.select if isinstance(c, ast.Alias)}
@@ -69,6 +70,7 @@ class TestMetricBreakdownInjector:
 
         injector.inject_funnel_breakdown_columns_optimized(query)
 
+        assert query.ctes is not None
         base_cte = query.ctes["base_events"]
         assert isinstance(base_cte, ast.CTE) and isinstance(base_cte.expr, ast.SelectQuery)
         base_aliases = [c.alias for c in base_cte.expr.select if isinstance(c, ast.Alias)]

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -108,6 +108,9 @@ class TestMetricBreakdownInjector:
         assert isinstance(in_top.right, ast.SelectQuery)
         assert isinstance(in_top.right.limit, ast.Constant)
         assert in_top.right.limit.value == 3
+        # count() DESC plus a breakdown-value tiebreak keeps the cutoff deterministic on ties
+        assert in_top.right.order_by is not None
+        assert [o.order for o in in_top.right.order_by] == ["DESC", "ASC"]
         other = final_alias.expr.args[2]
         assert isinstance(other, ast.Constant)
         assert other.value == "$$_posthog_breakdown_other_$$"

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -111,7 +111,9 @@ class TestMetricBreakdownInjector:
 
         cond = _unwrap_attribution(_entity_metrics_aliases(query)["breakdown_value_1"]).args[2]
         assert isinstance(cond, ast.Or)
-        matched_steps = {c.left.chain[0] for c in cond.exprs if isinstance(c, ast.CompareOperation)}
+        matched_steps = {
+            c.left.chain[0] for c in cond.exprs if isinstance(c, ast.CompareOperation) and isinstance(c.left, ast.Field)
+        }
         assert matched_steps == {"step_1", "step_2"}
 
     def test_breakdown_read_from_metric_event_in_base_events(self):

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -1,20 +1,39 @@
 from parameterized import parameterized
 
-from posthog.schema import Breakdown, BreakdownAttributionType, BreakdownFilter, EventsNode, ExperimentFunnelMetric
+from posthog.schema import (
+    Breakdown,
+    BreakdownAttributionType,
+    BreakdownFilter,
+    EventsNode,
+    ExperimentFunnelMetric,
+    StepOrderValue,
+)
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 
+from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_NULL_STRING_LABEL
+
 from products.experiments.backend.hogql_queries.metric_breakdown_injector import MetricBreakdownInjector
 
 
-def _funnel_metric(attribution=None, attribution_value=None, num_steps=2):
+def _funnel_metric(attribution=None, attribution_value=None, num_steps=2, funnel_order_type=None):
     return ExperimentFunnelMetric(
         series=[EventsNode(event=f"step_{i}") for i in range(num_steps)],
         breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")]),
         breakdownAttributionType=attribution,
         breakdownAttributionValue=attribution_value,
+        funnel_order_type=funnel_order_type,
     )
+
+
+def _unwrap_attribution(expr: ast.Expr) -> ast.Call:
+    """Users with no attribution event get the null label, so the attribution agg is nested in an
+    ``if(countIf(cond) = 0, null_label, agg(...))``. Return the inner argMin/argMax call."""
+    assert isinstance(expr, ast.Call) and expr.name == "if"
+    attributed = expr.args[2]
+    assert isinstance(attributed, ast.Call)
+    return attributed
 
 
 def _optimized_query() -> ast.SelectQuery:
@@ -56,12 +75,44 @@ class TestMetricBreakdownInjector:
 
         injector.inject_funnel_breakdown_columns_optimized(query)
 
-        expr = _entity_metrics_aliases(query)["breakdown_value_1"]
-        assert isinstance(expr, ast.Call)
+        expr = _unwrap_attribution(_entity_metrics_aliases(query)["breakdown_value_1"])
         assert expr.name == expected_agg
         cond = expr.args[2]
         assert isinstance(cond, ast.CompareOperation)
         assert cond.left == ast.Field(chain=[expected_step])
+
+    def test_unattributed_users_get_null_label_not_empty_string(self):
+        # argMinIf over zero matching rows returns "", which would form an invisible bucket that
+        # collides with real empty values and steals a top-N slot. It must map to the null label.
+        metric = _funnel_metric(attribution=BreakdownAttributionType.FIRST_TOUCH, num_steps=2)
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _optimized_query()
+
+        injector.inject_funnel_breakdown_columns_optimized(query)
+
+        expr = _entity_metrics_aliases(query)["breakdown_value_1"]
+        assert isinstance(expr, ast.Call) and expr.name == "if"
+        null_label = expr.args[1]
+        assert isinstance(null_label, ast.Constant) and null_label.value == BREAKDOWN_NULL_STRING_LABEL
+
+    def test_unordered_any_step_attributes_across_all_steps(self):
+        # For unordered funnels "Any step" (step attribution) must match a metric event at any step,
+        # not just step_1, or a user who completed through a later series event lands unattributed.
+        metric = _funnel_metric(
+            attribution=BreakdownAttributionType.STEP,
+            attribution_value=0,
+            num_steps=2,
+            funnel_order_type=StepOrderValue.UNORDERED,
+        )
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _optimized_query()
+
+        injector.inject_funnel_breakdown_columns_optimized(query)
+
+        cond = _unwrap_attribution(_entity_metrics_aliases(query)["breakdown_value_1"]).args[2]
+        assert isinstance(cond, ast.Or)
+        matched_steps = {c.left.chain[0] for c in cond.exprs if isinstance(c, ast.CompareOperation)}
+        assert matched_steps == {"step_1", "step_2"}
 
     def test_breakdown_read_from_metric_event_in_base_events(self):
         metric = _funnel_metric(attribution=BreakdownAttributionType.FIRST_TOUCH)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Experiment breakdowns attribute the breakdown value from the exposure event (`BreakdownInjector`). Insights funnels instead read the value off the funnel events, with a user-selectable attribution mode. The mismatch means an experiment funnel and the equivalent funnel insight bucket users differently, and exposure events often lack the property entirely, inflating the null bucket.

This PR starts the migration to metric-event attribution with funnel metrics, the only type where the user picks an attribution mode. The frontend controls are in #61788; mean, retention, and ratio follow in #62291, #62292, #62293.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR adds a new breakdown injector that reads the breakdown off the metric events for funnel metrics, gated behind the `experiment-metric-event-breakdowns` flag.

### Metric-event breakdown injector

`MetricBreakdownInjector` is a standalone class, deliberately not a subclass of `BreakdownInjector`; the old injector gets deleted once every metric type migrates. It reads each breakdown property off the metric event and attributes per user with `argMinIf`/`argMaxIf` over the funnel step columns. In experiment funnels `step_0` is the exposure event and the metric series maps to `step_1..step_N`, so attribution targets the metric steps and never the exposure. First touch and all events resolve to the first step, last touch to the last, and step attribution validates `breakdownAttributionValue` against the series length. Both the legacy 3-CTE and the optimized 2-CTE funnel shapes are supported.

- `products/experiments/backend/hogql_queries/metric_breakdown_injector.py`

### Top-N limit and the Other bucket

Breakdown tuples are ranked by number of experiment units per bucket, pooled across variants, and capped at `breakdownFilter.breakdown_limit` (default `BREAKDOWN_VALUES_LIMIT`). Tuples beyond the cap are relabeled to the standard Other label before the final GROUP BY, collapsing the whole tuple together so output cardinality stays bounded.

### Wiring and gating

The runner builds the injector only when the flag is on, the metric is a funnel, and breakdowns exist; everything else falls back to the old `BreakdownInjector`. The flag is evaluated locally only (no network on the query hot path) and fails closed. The injector exposes `attributes_from_exposure()` so `ExposureQueryBuilder` keeps the exposure query breakdown-free on the new path, and the mean, ratio, and retention builders guard with `isinstance` so they stay on the old injector for now.

- `products/experiments/backend/hogql_queries/experiment_query_runner.py`
- `products/experiments/backend/hogql_queries/experiment_query_builder.py`
- `products/experiments/backend/hogql_queries/experiment_exposure_query_builder.py`
- `products/experiments/backend/hogql_queries/breakdown_injector.py`
- `products/experiments/backend/hogql_queries/experiment_mean_query_builder.py`
- `products/experiments/backend/hogql_queries/experiment_ratio_query_builder.py`
- `products/experiments/backend/hogql_queries/experiment_retention_query_builder.py`

### Tests

Flag-on runner tests cover attribution modes, the limit, and the Other bucket; unit tests cover the injector's AST output. The existing flag-off breakdown suite is untouched, which is the regression guarantee that the old path is unchanged.

- `products/experiments/backend/hogql_queries/test/experiment_query_runner/test_breakdown.py`
- `products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/afcfa7bc-c9eb-48ca-a741-d4891e2a20ad)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session. -->

Model: Opus 4.7 (implementation), Fable 5 (restack and PR description)
Manually refactored: **yes**

Skills used:

- /brainstorming (superpowers)
- /writing-plans (superpowers)
- /writing-tests (local)
- /writing-pull-requests (local)

Relevant decisions:

- Standalone injector instead of subclassing `BreakdownInjector`: the two attribution models share almost nothing, and a clean class makes the eventual deletion of the old injector a pure removal.
- The feature flag is team-scoped and evaluated with `only_evaluate_locally=True`, failing closed to the old behavior when flag definitions aren't cached.
- Per-type migration order (funnels first, then mean, retention, ratio) keeps each PR reviewable and lets the flag gate the whole stack uniformly.