### PR TITLE
feat(funnels): add toggle to hide incomplete conversion-window periods

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -20,6 +20,7 @@ import { DEFAULT_DECIMAL_PLACES } from 'lib/utils'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { axisLabel } from 'scenes/insights/aggregationAxisFormat'
 import { AxisLabelsFilter } from 'scenes/insights/EditorFilters/AxisLabelsFilter'
+import { HideIncompleteConversionWindowPeriodsFilter } from 'scenes/insights/EditorFilters/HideIncompleteConversionWindowPeriodsFilter'
 import { HideWeekendsFilter } from 'scenes/insights/EditorFilters/HideWeekendsFilter'
 import { LifecycleStackingFilter } from 'scenes/insights/EditorFilters/LifecycleStackingFilter'
 import { PercentStackViewFilter } from 'scenes/insights/EditorFilters/PercentStackViewFilter'
@@ -223,6 +224,9 @@ export function InsightDisplayConfig(): JSX.Element {
                                 ...(showMultipleYAxesConfig ? [{ label: () => <ShowMultipleYAxesFilter /> }] : []),
                                 ...((isTrends || isRetention || isTrendsFunnel) && !isNonTimeSeriesDisplay
                                     ? [{ label: () => <ShowTrendLinesFilter /> }]
+                                    : []),
+                                ...(isTrendsFunnel && !isNonTimeSeriesDisplay
+                                    ? [{ label: () => <HideIncompleteConversionWindowPeriodsFilter /> }]
                                     : []),
                                 ...(isTrends && !isNonTimeSeriesDisplay && hideWeekendsEnabled
                                     ? [{ label: () => <HideWeekendsFilter /> }]

--- a/frontend/src/scenes/insights/EditorFilters/HideIncompleteConversionWindowPeriodsFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/HideIncompleteConversionWindowPeriodsFilter.tsx
@@ -1,0 +1,44 @@
+import { useActions, useValues } from 'kea'
+
+import { IconInfo } from '@posthog/icons'
+import { LemonCheckbox, Tooltip } from '@posthog/lemon-ui'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+import { isFunnelsQuery } from '~/queries/utils'
+
+import { insightVizDataLogic } from '../insightVizDataLogic'
+
+export function HideIncompleteConversionWindowPeriodsFilter(): JSX.Element | null {
+    const { insightProps } = useValues(insightLogic)
+    const { querySource } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    if (!isFunnelsQuery(querySource)) {
+        return null
+    }
+
+    const hideIncompleteConversionWindowPeriods =
+        querySource.funnelsFilter?.hideIncompleteConversionWindowPeriods ?? false
+
+    return (
+        <LemonCheckbox
+            className="p-1 px-2"
+            onChange={() =>
+                updateInsightFilter({
+                    hideIncompleteConversionWindowPeriods: !hideIncompleteConversionWindowPeriods,
+                })
+            }
+            checked={hideIncompleteConversionWindowPeriods}
+            label={
+                <span className="font-normal inline-flex items-center gap-1">
+                    Hide incomplete periods
+                    <Tooltip title="Hides recent periods whose conversion window hasn't fully elapsed, so the trend isn't dragged down by entrants who still have time to convert.">
+                        <IconInfo className="relative top-0.5 text-base text-secondary" />
+                    </Tooltip>
+                </span>
+            }
+            size="small"
+        />
+    )
+}


### PR DESCRIPTION
## Problem

Funnel trends has no UI control for the backend `hideIncompleteConversionWindowPeriods` option added in #61682, so users can't hide the misleading recent tail of the trend.

## Changes

<img width="417" height="255" alt="Screenshot 2026-06-05 at 11 40 59" src="https://github.com/user-attachments/assets/b26ce983-3dc2-44d7-b46b-ee5dd00ed7b4" />


Adds a trends-only "Hide incomplete periods" checkbox (with an info tooltip) to the insight display options, wired to `FunnelsFilter.hideIncompleteConversionWindowPeriods` via `updateInsightFilter`.

Stacked on #61682 (the backend PR) — merge that first.

## How did you test this code?

Agent-authored. Verified the toggle renders for trends funnels and the value is sent in the query payload; lint + typecheck clean on the changed files.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Follows the existing `ValueOnSeriesFilter`/`ShowTrendLinesFilter` pattern; gated on `isTrendsFunnel` since the option only affects trends. Label kept short with details in the tooltip.
