### PR TITLE
refactor(insights): share view-only trends line chart with MCP app

### DIFF
--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -1,16 +1,11 @@
 import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
-import { DEFAULT_Y_AXIS_ID, TimeSeriesLineChart } from '@posthog/quill-charts'
-import type {
-    PointClickData,
-    Series,
-    TimeSeriesLineChartConfig,
-    TooltipConfig,
-    TooltipContext,
-} from '@posthog/quill-charts'
+import { DEFAULT_Y_AXIS_ID } from '@posthog/quill-charts'
+import type { PointClickData, TooltipConfig, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { ciRanges } from 'lib/statistics'
 import { percentage } from 'lib/utils'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
@@ -25,14 +20,16 @@ import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
+import { ChartDisplayType } from '~/types'
 
 import { AnnotationsLayer } from '../shared/AnnotationsLayer'
 import { makeChartErrorHandler } from '../shared/chartErrorHandler'
 import { handleTrendsChartClick } from '../shared/handleTrendsChartClick'
 import { TrendsAlertOverlays } from '../shared/TrendsAlertOverlays'
+import type { TrendsChartDisplayOptions } from '../shared/trendsChartDisplayOptions'
 import { buildTrendsSeriesMeta, resolveGroupTypeLabel, type TrendsSeriesMeta } from '../shared/trendsSeriesMeta'
 import { TrendsTooltip } from '../shared/TrendsTooltip'
-import { buildTrendsLineTimeSeriesConfig, buildTrendsSeries } from './trendsChartTransforms'
+import { TrendsLineChartView } from './TrendsLineChartView'
 
 interface TrendsLineChartProps {
     context?: QueryContext<InsightVizNode>
@@ -89,25 +86,43 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
         indexedResults[0]?.data &&
         indexedResults.filter((result: IndexedTrendResult) => result.count !== 0).length > 0
 
-    const series: Series<TrendsSeriesMeta>[] = useMemo(
-        () =>
-            buildTrendsSeries<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
-                display: display ?? undefined,
-                showMultipleYAxes: showMultipleYAxes ?? undefined,
-                incompletenessOffsetFromEnd,
-                isStickiness,
-                getColor: getTrendsColor,
-                getHidden: getTrendsHidden,
-                buildMeta: buildTrendsSeriesMeta,
-            }),
+    const displayOptions: TrendsChartDisplayOptions = useMemo(
+        () => ({
+            isArea: display === ChartDisplayType.ActionsAreaGraph,
+            showMultipleYAxes: showMultipleYAxes ?? undefined,
+            isPercentStackView,
+            yAxisScaleType,
+            interval,
+            timezone,
+            allDays: currentPeriodResult?.days ?? [],
+            xAxisLabel: trendsFilter?.xAxisLabel,
+            yAxisLabel: trendsFilter?.yAxisLabel,
+            formatter: trendsFilter,
+            baseCurrency,
+            showValuesOnSeries,
+            showCrosshair: true,
+            showConfidenceIntervals,
+            confidenceLevel,
+            showMovingAverage,
+            movingAverageIntervals,
+            showTrendLines,
+        }),
         [
-            indexedResults,
             display,
-            getTrendsColor,
-            getTrendsHidden,
-            isStickiness,
-            incompletenessOffsetFromEnd,
             showMultipleYAxes,
+            isPercentStackView,
+            yAxisScaleType,
+            interval,
+            timezone,
+            currentPeriodResult?.days,
+            trendsFilter,
+            baseCurrency,
+            showValuesOnSeries,
+            showConfidenceIntervals,
+            confidenceLevel,
+            showMovingAverage,
+            movingAverageIntervals,
+            showTrendLines,
         ]
     )
 
@@ -121,57 +136,6 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
             return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
         },
         [trendsFilter, isPercentStackView, baseCurrency]
-    )
-
-    const chartConfig: TimeSeriesLineChartConfig = useMemo(
-        () =>
-            buildTrendsLineTimeSeriesConfig({
-                results: indexedResults ?? [],
-                trendsFilter,
-                baseCurrency,
-                isPercentStackView,
-                isStickiness,
-                yAxisScaleType,
-                interval,
-                timezone,
-                allDays: currentPeriodResult?.days ?? [],
-                xAxisLabel: trendsFilter?.xAxisLabel,
-                yAxisLabel: trendsFilter?.yAxisLabel,
-                goalLines,
-                incompletenessOffsetFromEnd,
-                getHidden: getTrendsHidden,
-                showConfidenceIntervals,
-                confidenceLevel,
-                showMovingAverage,
-                movingAverageIntervals,
-                showTrendLines,
-                valueLabels: showValuesOnSeries ? { formatter: valueLabelFormatter } : false,
-                showCrosshair: true,
-                tooltip: TOOLTIP_CONFIG,
-            }),
-        [
-            indexedResults,
-            trendsFilter,
-            baseCurrency,
-            isPercentStackView,
-            isStickiness,
-            yAxisScaleType,
-            interval,
-            timezone,
-            currentPeriodResult?.days,
-            trendsFilter?.xAxisLabel,
-            trendsFilter?.yAxisLabel,
-            goalLines,
-            incompletenessOffsetFromEnd,
-            getTrendsHidden,
-            showConfidenceIntervals,
-            confidenceLevel,
-            showMovingAverage,
-            movingAverageIntervals,
-            showTrendLines,
-            showValuesOnSeries,
-            valueLabelFormatter,
-        ]
     )
 
     const indexByResult = useMemo(() => {
@@ -272,12 +236,21 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
     const annotationsDates = currentPeriodResult?.days ?? []
 
     return (
-        <TimeSeriesLineChart<TrendsSeriesMeta>
-            series={series}
+        <TrendsLineChartView<IndexedTrendResult, TrendsSeriesMeta>
+            results={indexedResults ?? []}
             labels={labels}
             theme={theme}
-            config={chartConfig}
+            getColor={getTrendsColor}
+            getHidden={getTrendsHidden}
+            buildMeta={buildTrendsSeriesMeta}
+            displayOptions={displayOptions}
+            goalLines={goalLines}
+            ciRanges={ciRanges}
+            incompletenessOffsetFromEnd={incompletenessOffsetFromEnd}
+            isStickiness={isStickiness}
+            valueLabelFormatter={valueLabelFormatter}
             tooltip={renderTooltip}
+            tooltipConfig={TOOLTIP_CONFIG}
             onPointClick={canHandleClick ? onPointClick : undefined}
             className="LineGraph"
             dataAttr="trend-line-graph"
@@ -294,6 +267,6 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
                 />
             ) : null}
             {showAnnotations && <AnnotationsLayer insightNumericId={insight.id || 'new'} dates={annotationsDates} />}
-        </TimeSeriesLineChart>
+        </TrendsLineChartView>
     )
 }

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChartView.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChartView.tsx
@@ -1,0 +1,134 @@
+import { type ReactElement, type ReactNode, useMemo } from 'react'
+
+import { TimeSeriesLineChart } from '@posthog/quill-charts'
+import type { ChartTheme, PointClickData, TooltipConfig, TooltipContext } from '@posthog/quill-charts'
+
+import type { CiRangesFn, GoalLineLike, TrendsChartDisplayOptions } from '../shared/trendsChartDisplayOptions'
+import { buildTrendsLineTimeSeriesConfig, buildTrendsSeries, type TrendsResultLike } from './trendsChartTransforms'
+
+// Presentational, dependency-neutral trends line chart. No kea, no `lib/*` / `~/*` imports — it
+// turns plain results + display options into a quill `TimeSeriesLineChart`, so both the web trends
+// container and the MCP UI app render the exact same view. Callers inject everything host-specific
+// (theme, colors, tooltip, click handling, overlays).
+export interface TrendsLineChartViewProps<R extends TrendsResultLike, M = unknown> {
+    results: R[]
+    labels: string[]
+    theme: ChartTheme
+    getColor: (r: R, index: number) => string
+    displayOptions?: TrendsChartDisplayOptions
+    getHidden?: (r: R) => boolean
+    buildMeta?: (r: R, index: number) => M
+    goalLines?: GoalLineLike[] | null
+    ciRanges?: CiRangesFn
+    incompletenessOffsetFromEnd?: number
+    isStickiness?: boolean
+    /** Overrides the auto date formatter (hosts without interval/timezone, e.g. MCP). */
+    xAxisTickFormatter?: (value: string, index: number) => string | null
+    valueLabelFormatter?: (value: number) => string
+    tooltip?: (ctx: TooltipContext<M>) => ReactElement
+    tooltipConfig?: TooltipConfig
+    onPointClick?: (data: PointClickData) => void
+    className?: string
+    dataAttr?: string
+    onError?: (error: Error) => void
+    /** Overlays (annotations, alert thresholds) rendered inside the chart's layout context. */
+    children?: ReactNode
+}
+
+export function TrendsLineChartView<R extends TrendsResultLike, M = unknown>({
+    results,
+    labels,
+    theme,
+    getColor,
+    displayOptions = {},
+    getHidden,
+    buildMeta,
+    goalLines,
+    ciRanges,
+    incompletenessOffsetFromEnd,
+    isStickiness,
+    xAxisTickFormatter,
+    valueLabelFormatter,
+    tooltip,
+    tooltipConfig,
+    onPointClick,
+    className,
+    dataAttr,
+    onError,
+    children,
+}: TrendsLineChartViewProps<R, M>): ReactElement {
+    const series = useMemo(
+        () =>
+            buildTrendsSeries<R, M>(results, {
+                isArea: displayOptions.isArea,
+                showMultipleYAxes: displayOptions.showMultipleYAxes,
+                incompletenessOffsetFromEnd,
+                isStickiness,
+                getColor,
+                getHidden,
+                buildMeta,
+            }),
+        [results, displayOptions, incompletenessOffsetFromEnd, isStickiness, getColor, getHidden, buildMeta]
+    )
+
+    const config = useMemo(
+        () =>
+            buildTrendsLineTimeSeriesConfig<R>({
+                results,
+                trendsFilter: displayOptions.formatter,
+                baseCurrency: displayOptions.baseCurrency,
+                isPercentStackView: !!displayOptions.isPercentStackView,
+                isStickiness,
+                yAxisScaleType: displayOptions.yAxisScaleType,
+                interval: displayOptions.interval,
+                timezone: displayOptions.timezone,
+                allDays: displayOptions.allDays,
+                xAxisLabel: displayOptions.xAxisLabel,
+                yAxisLabel: displayOptions.yAxisLabel,
+                xAxisTickFormatter,
+                goalLines,
+                incompletenessOffsetFromEnd,
+                getHidden,
+                showConfidenceIntervals: displayOptions.showConfidenceIntervals,
+                confidenceLevel: displayOptions.confidenceLevel,
+                ciRanges,
+                showMovingAverage: displayOptions.showMovingAverage,
+                movingAverageIntervals: displayOptions.movingAverageIntervals,
+                showTrendLines: displayOptions.showTrendLines,
+                valueLabels:
+                    displayOptions.showValuesOnSeries && valueLabelFormatter
+                        ? { formatter: valueLabelFormatter }
+                        : false,
+                showCrosshair: displayOptions.showCrosshair,
+                tooltip: tooltipConfig,
+            }),
+        [
+            results,
+            displayOptions,
+            goalLines,
+            ciRanges,
+            isStickiness,
+            incompletenessOffsetFromEnd,
+            getHidden,
+            xAxisTickFormatter,
+            valueLabelFormatter,
+            tooltipConfig,
+        ]
+    )
+
+    return (
+        <TimeSeriesLineChart<M>
+            series={series}
+            labels={labels}
+            theme={theme}
+            config={config}
+            tooltip={tooltip}
+            onPointClick={onPointClick}
+            className={className}
+            dataAttr={dataAttr}
+            onError={onError}
+        >
+            {children}
+        </TimeSeriesLineChart>
+    )
+}

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
@@ -1,8 +1,9 @@
 import { DEFAULT_Y_AXIS_ID } from '@posthog/quill-charts'
 import type { TooltipConfig } from '@posthog/quill-charts'
 
+import { ciRanges } from 'lib/statistics'
+
 import type { GoalLine as SchemaGoalLine } from '~/queries/schema/schema-general'
-import { ChartDisplayType } from '~/types'
 
 import {
     buildDerivedConfigs,
@@ -71,10 +72,10 @@ describe('trendsChartTransforms', () => {
             expect(series.stroke).toBeUndefined()
         })
 
-        it('attaches an empty fill object for ActionsAreaGraph display', () => {
+        it('attaches an empty fill object when isArea is set', () => {
             const series = buildMainTrendsSeries(makeResult(), 0, {
                 getColor: () => RED,
-                display: ChartDisplayType.ActionsAreaGraph,
+                isArea: true,
             })
             expect(series.fill).toEqual({})
         })
@@ -175,6 +176,7 @@ describe('trendsChartTransforms', () => {
                 const out = buildDerivedConfigs([makeResult({ id: 'a' }), makeResult({ id: 'b' })], {
                     showConfidenceIntervals: true,
                     confidenceLevel: 95,
+                    ciRanges,
                 })
                 expect(out.confidenceIntervals).toHaveLength(2)
                 expect(out.confidenceIntervals?.[0].seriesKey).toBe('a')
@@ -186,9 +188,16 @@ describe('trendsChartTransforms', () => {
                 const explicit = buildDerivedConfigs([makeResult()], {
                     showConfidenceIntervals: true,
                     confidenceLevel: 95,
+                    ciRanges,
                 })
-                const defaulted = buildDerivedConfigs([makeResult()], { showConfidenceIntervals: true })
+                const defaulted = buildDerivedConfigs([makeResult()], { showConfidenceIntervals: true, ciRanges })
                 expect(defaulted.confidenceIntervals?.[0].lower).toEqual(explicit.confidenceIntervals?.[0].lower)
+            })
+
+            it('omits confidenceIntervals when ciRanges is not provided', () => {
+                expect(
+                    buildDerivedConfigs([makeResult()], { showConfidenceIntervals: true }).confidenceIntervals
+                ).toBeUndefined()
             })
 
             it('omits confidenceIntervals when showConfidenceIntervals is false', () => {
@@ -330,6 +339,7 @@ describe('trendsChartTransforms', () => {
                 goalLines: [{ label: 'goal', value: 10 }] satisfies SchemaGoalLine[],
                 showConfidenceIntervals: true,
                 confidenceLevel: 95,
+                ciRanges,
                 valueLabels: false,
                 showCrosshair: true,
                 tooltip: TOOLTIP,
@@ -359,10 +369,12 @@ describe('trendsChartTransforms', () => {
                     results,
                     showConfidenceIntervals: true,
                     confidenceLevel,
+                    ciRanges,
                 })
                 const direct = buildDerivedConfigs(results, {
                     showConfidenceIntervals: true,
                     confidenceLevel,
+                    ciRanges,
                 })
                 expect(config.confidenceIntervals).toEqual(direct.confidenceIntervals)
             }

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
@@ -3,18 +3,15 @@ import type {
     ConfidenceIntervalConfig,
     MovingAverageConfig,
     Series,
+    TimeInterval,
     TimeSeriesLineChartConfig,
     TooltipConfig,
     TrendLineConfig,
 } from '@posthog/quill-charts'
 
-import { ciRanges } from 'lib/statistics'
-
-import type { CurrencyCode, GoalLine as SchemaGoalLine, TrendsFilter } from '~/queries/schema/schema-general'
-import { ChartDisplayType, type IntervalType } from '~/types'
-
 import { schemaGoalLinesToConfigs } from '../shared/goalLinesAdapter'
 import { buildTrendsYAxisConfig } from '../shared/trendsAxisFormat'
+import type { CiRangesFn, GoalLineLike, YFormatterFields } from '../shared/trendsChartDisplayOptions'
 
 // Shape both IndexedTrendResult (kea) and TrendsResultItem (MCP) satisfy.
 export interface TrendsResultLike {
@@ -30,7 +27,8 @@ export interface TrendsResultLike {
 }
 
 export interface BuildTrendsSeriesOpts<R extends TrendsResultLike, M = unknown> {
-    display?: ChartDisplayType
+    /** Area fill under each series (web maps `display === ActionsAreaGraph`). */
+    isArea?: boolean
     showMultipleYAxes?: boolean
     // Negative number — index from the end where the in-progress tail begins. Omit to skip.
     incompletenessOffsetFromEnd?: number
@@ -71,7 +69,7 @@ export function buildMainTrendsSeries<R extends TrendsResultLike, M = unknown>(
         color: opts.getColor(r, index),
         yAxisId,
         meta,
-        fill: opts.display === ChartDisplayType.ActionsAreaGraph ? {} : undefined,
+        fill: opts.isArea ? {} : undefined,
         stroke: dashedFromIndex !== undefined ? { partial: { fromIndex: dashedFromIndex } } : undefined,
         visibility: excluded ? { excluded: true } : undefined,
     }
@@ -87,6 +85,8 @@ export function buildTrendsSeries<R extends TrendsResultLike, M = unknown>(
 export interface BuildDerivedConfigsOpts<R extends TrendsResultLike> {
     showConfidenceIntervals?: boolean
     confidenceLevel?: number
+    // Injected so the transforms stay free of `lib/statistics`. CI is skipped when omitted.
+    ciRanges?: CiRangesFn
     showMovingAverage?: boolean
     movingAverageIntervals?: number
     showTrendLines?: boolean
@@ -111,8 +111,9 @@ export function buildDerivedConfigs<R extends TrendsResultLike>(
         return out
     }
 
-    if (opts.showConfidenceIntervals) {
+    if (opts.showConfidenceIntervals && opts.ciRanges) {
         const ci = (opts.confidenceLevel ?? 95) / 100
+        const ciRanges = opts.ciRanges
         out.confidenceIntervals = results.map((r) => {
             const [lower, upper] = ciRanges(r.data, ci)
             return { seriesKey: String(r.id), lower, upper }
@@ -169,22 +170,26 @@ export function buildDerivedConfigs<R extends TrendsResultLike>(
 
 export interface BuildTrendsLineTimeSeriesConfigOpts<R extends TrendsResultLike> {
     results: readonly R[]
-    trendsFilter?: TrendsFilter | null
-    baseCurrency?: CurrencyCode
+    trendsFilter?: YFormatterFields | null
+    baseCurrency?: string
     isPercentStackView: boolean
     isStickiness?: boolean
     yAxisScaleType?: string | null
-    interval?: IntervalType | null
+    interval?: TimeInterval | null
     timezone?: string
     allDays?: string[]
     xAxisLabel?: string | null
     yAxisLabel?: string | null
-    goalLines?: SchemaGoalLine[] | null
+    // Explicit x-axis tick formatter. When set it wins over the auto date formatter — used by
+    // hosts (e.g. MCP) that have label strings but no interval/timezone for auto formatting.
+    xAxisTickFormatter?: (value: string, index: number) => string | null
+    goalLines?: GoalLineLike[] | null
     incompletenessOffsetFromEnd?: number
     getHidden?: (r: R) => boolean
 
     showConfidenceIntervals?: boolean
     confidenceLevel?: number
+    ciRanges?: CiRangesFn
     showMovingAverage?: boolean
     movingAverageIntervals?: number
     showTrendLines?: boolean
@@ -206,6 +211,7 @@ export function buildTrendsLineTimeSeriesConfig<R extends TrendsResultLike>(
     const derivedConfigs = buildDerivedConfigs(opts.results, {
         showConfidenceIntervals: opts.showConfidenceIntervals,
         confidenceLevel: opts.confidenceLevel,
+        ciRanges: opts.ciRanges,
         showMovingAverage: opts.showMovingAverage,
         movingAverageIntervals: opts.movingAverageIntervals,
         showTrendLines: opts.showTrendLines,
@@ -219,6 +225,7 @@ export function buildTrendsLineTimeSeriesConfig<R extends TrendsResultLike>(
             timezone: opts.timezone,
             interval: opts.interval ?? 'day',
             allDays: opts.allDays ?? [],
+            tickFormatter: opts.xAxisTickFormatter,
         },
         yAxis: {
             ...yAxis,

--- a/products/product_analytics/frontend/insights/trends/shared/goalLinesAdapter.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/goalLinesAdapter.ts
@@ -1,7 +1,7 @@
 import { buildGoalLineReferenceLines } from '@posthog/quill-charts'
 import type { GoalLineConfig, ReferenceLineProps, Series } from '@posthog/quill-charts'
 
-import type { GoalLine as SchemaGoalLine } from '~/queries/schema/schema-general'
+import type { GoalLineLike as SchemaGoalLine } from './trendsChartDisplayOptions'
 
 export function schemaGoalLineToConfig(line: SchemaGoalLine): GoalLineConfig {
     return {

--- a/products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat.ts
@@ -1,11 +1,11 @@
 import type { YAxisConfig, YFormatterConfig } from '@posthog/quill-charts'
 
-import { CurrencyCode, TrendsFilter } from '~/queries/schema/schema-general'
+import type { YFormatterFields } from './trendsChartDisplayOptions'
 
 export function trendsFilterToYFormatterConfig(
-    trendsFilter: TrendsFilter | null | undefined,
+    trendsFilter: YFormatterFields | null | undefined,
     isPercentStackView: boolean,
-    baseCurrency?: CurrencyCode
+    baseCurrency?: string
 ): YFormatterConfig {
     if (isPercentStackView) {
         // BarChart's percent layout puts the value scale on 0..1, so use the 0..1 formatter.
@@ -22,9 +22,9 @@ export function trendsFilterToYFormatterConfig(
 }
 
 export function buildTrendsYAxisConfig(
-    trendsFilter: TrendsFilter | null | undefined,
+    trendsFilter: YFormatterFields | null | undefined,
     isPercentStackView: boolean,
-    baseCurrency: CurrencyCode | undefined,
+    baseCurrency: string | undefined,
     extras: { yAxisScaleType?: string | null; showGrid?: boolean } = {}
 ): YAxisConfig {
     return {

--- a/products/product_analytics/frontend/insights/trends/shared/trendsChartDisplayOptions.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/trendsChartDisplayOptions.ts
@@ -1,0 +1,54 @@
+import type { TimeInterval, YAxisFormat } from '@posthog/quill-charts'
+
+// Dependency-neutral display config shared by the web trends container and the MCP UI app.
+// Deliberately free of `~/` and `lib/` imports (and kea) so it compiles in the MCP Vite
+// bundle, which only resolves `products/*` and `@posthog/*`. The web side maps its kea-derived
+// `TrendsFilter` into this; the MCP app builds one directly.
+
+// Subset of `TrendsFilter` the y-axis formatter reads. `TrendsFilter` is structurally
+// assignable to this, so web callers can pass it unchanged.
+export interface YFormatterFields {
+    aggregationAxisFormat?: YAxisFormat
+    aggregationAxisPrefix?: string
+    aggregationAxisPostfix?: string
+    decimalPlaces?: number
+    minDecimalPlaces?: number
+}
+
+// Structurally matches the schema `GoalLine`, without importing it.
+export interface GoalLineLike {
+    label: string
+    value: number
+    borderColor?: string
+    displayLabel?: boolean
+    displayIfCrossed?: boolean
+    position?: 'start' | 'end'
+}
+
+// Confidence-interval helper signature. Injected (rather than imported from `lib/statistics`)
+// so the transforms stay free of third-party stats deps the MCP bundle doesn't carry.
+export type CiRangesFn = (data: number[], confidence: number) => [number[], number[]]
+
+// Single source of truth for what the trends line chart can display.
+export interface TrendsChartDisplayOptions {
+    /** Area fill under each series (web: `display === ActionsAreaGraph`). */
+    isArea?: boolean
+    showMultipleYAxes?: boolean
+    isPercentStackView?: boolean
+    yAxisScaleType?: string | null
+    interval?: TimeInterval | null
+    timezone?: string
+    /** Full date list for x-axis tick formatting; falls back to `labels`. */
+    allDays?: string[]
+    xAxisLabel?: string | null
+    yAxisLabel?: string | null
+    formatter?: YFormatterFields | null
+    baseCurrency?: string
+    showValuesOnSeries?: boolean
+    showCrosshair?: boolean
+    showConfidenceIntervals?: boolean
+    confidenceLevel?: number
+    showMovingAverage?: boolean
+    movingAverageIntervals?: number
+    showTrendLines?: boolean
+}

--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -3,9 +3,13 @@ import { type ReactElement, useState } from 'react'
 import { emptyStateIllustration } from '@posthog/mcp-ui'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@posthog/quill'
 
-import { BarChart, BigNumber, LineChart, Select, type Series } from './charts'
+import type { TrendsChartDisplayOptions } from 'products/product_analytics/frontend/insights/trends/shared/trendsChartDisplayOptions'
+import { TrendsLineChartView } from 'products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChartView'
+
+import { BarChart, BigNumber, Select, type Series } from './charts'
+import { CHART_COLORS, CHART_THEME } from './charts/theme'
 import type { TrendsResultItem, TrendsVisualizerProps } from './types'
-import { getDisplayType, getSeriesLabel, isBarChart } from './utils'
+import { formatDate, getDisplayType, getSeriesLabel, isBarChart } from './utils'
 
 type ChartMode = 'line' | 'bar'
 
@@ -77,6 +81,13 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
         return <BigNumber value={total} label={label} />
     }
 
+    const lineDisplayOptions: TrendsChartDisplayOptions = {
+        isArea: displayType === 'ActionsAreaGraph',
+        formatter: query?.trendsFilter,
+        showValuesOnSeries: query?.trendsFilter?.showValuesOnSeries,
+        showCrosshair: true,
+    }
+
     return (
         <div>
             <div className="mb-2 flex justify-end">
@@ -91,11 +102,18 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
                     yAxisFormat={query?.trendsFilter?.aggregationAxisFormat}
                 />
             ) : (
-                <LineChart
-                    series={series}
+                <TrendsLineChartView
+                    results={results.map((item, i) => ({
+                        id: i,
+                        label: getSeriesLabel(item, i),
+                        data: item.data ?? [],
+                        days: item.days,
+                    }))}
                     labels={labels}
-                    yAxisLabel={series.length === 1 ? series[0]?.label : undefined}
-                    yAxisFormat={query?.trendsFilter?.aggregationAxisFormat}
+                    theme={CHART_THEME}
+                    getColor={(_, index) => CHART_COLORS[index % CHART_COLORS.length]!}
+                    displayOptions={lineDisplayOptions}
+                    xAxisTickFormatter={(value) => formatDate(value)}
                 />
             )}
         </div>

--- a/services/mcp/tsconfig.json
+++ b/services/mcp/tsconfig.json
@@ -16,7 +16,6 @@
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,
         "noUncheckedIndexedAccess": true,
-        "exactOptionalPropertyTypes": true,
         "skipLibCheck": true,
         "types": ["node", "./worker-configuration.d.ts", "./types.d.ts", "@cloudflare/vitest-pool-workers"],
         "paths": {

--- a/services/mcp/vite.ui-apps.config.ts
+++ b/services/mcp/vite.ui-apps.config.ts
@@ -51,6 +51,13 @@ export default defineConfig({
                 find: /^@posthog\/quill$/,
                 replacement: resolve(__dirname, '../../packages/quill/packages/quill/dist/index.js'),
             },
+            // quill-charts is consumed as source (its package main is src/index.ts); resolve it
+            // explicitly so files reached via the `products` alias — and the local chart wrappers —
+            // can find it without a node_modules symlink.
+            {
+                find: /^@posthog\/quill-charts$/,
+                replacement: resolve(__dirname, '../../packages/quill/packages/charts/src/index.ts'),
+            },
             // lucide-react isn't a workspace dep at the products/ level, so files
             // resolved via the `products` alias can't find it. Pin to this
             // package's installed copy (matches the version Quill expects).


### PR DESCRIPTION
## Problem

The MCP query-results app rendered trends with a bespoke chart in `services/mcp`, separate from the web UI's trends chart — duplicating logic and diverging visually. The blocker to reusing the web chart was that its (already pure) transform functions imported `lib/statistics` and `~/types` (a runtime enum), neither of which resolves in the MCP Vite bundle (it only aliases `products/*`).

## Changes

- Add `shared/trendsChartDisplayOptions.ts` — a dependency-neutral display-options type used as the single source of truth for both renderers.
- Add `TrendsLineChart/TrendsLineChartView.tsx` — a presentational, kea-free view that turns results + display options into a `@posthog/quill-charts` `TimeSeriesLineChart`. Lives in the product folder, not in quill.
- Neutralize the shared transforms (`trendsChartTransforms.ts`, `trendsAxisFormat.ts`, `goalLinesAdapter.ts`): replace the `ChartDisplayType` runtime check with an `isArea` flag, inject `ciRanges` instead of importing `lib/statistics`, and swap `~/`-schema types for structurally-compatible neutral types. Signatures are preserved so `TrendsBarChart` and other consumers are untouched.
- Render the shared view from the web `TrendsLineChart` container (behaviour unchanged) and from the MCP `TrendsVisualizer` line branch.
- Add a `@posthog/quill-charts` alias to the MCP ui-apps Vite config (mirrors the existing `@posthog/quill` alias) so the bundle resolves it.
- Drop `exactOptionalPropertyTypes` from the MCP tsconfig to match the frontend whose code it now shares.

Supersedes #61558 and #61600 (which put quill chart components directly in `services/mcp`).

## How did you test this code?

I'm an agent. Automated checks I ran locally:

- `pnpm --filter @posthog/mcp run typecheck` — passes (0 errors).
- Frontend type diagnostics (LSP) on all edited files and the downstream consumers (bar/lifecycle/retention charts, alert overlays) — clean.
- `jest` for `trendsChartTransforms.test.ts` (51/51) and the trends line/bar/shared suites — green across repeated runs. (One persons-modal cross-suite failure reproduced identically on unmodified `master`, i.e. a pre-existing test-isolation flake, not introduced here.)
- `pnpm --filter @posthog/mcp run build:ui-apps` — builds `query-results` and all apps successfully.

Visual verification of the rendered chart has not been done yet.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Key decisions:

- Put the shared, trends-aware view in `products/product_analytics`, not in `@posthog/quill-charts` — quill stays product-agnostic, and both the web frontend and the MCP Vite bundle can import from `products/*`.
- Reused the existing pure transforms rather than reimplementing; the only work was removing their `~/`/`lib/` runtime deps so the MCP bundle can compile them.
- Relaxing `exactOptionalPropertyTypes` (vs. making the shared code strict-clean) was chosen to align MCP with the frontend it now shares code from.
- Discovered and fixed a pre-existing gap: the MCP Vite config had no `@posthog/quill-charts` alias, so the local ui-apps build was already broken on the superseded branches (it only built in CI's full install).