### PR TITLE
chore(mcp): add quill-charts plumbing for ui-apps

### DIFF
--- a/packages/quill/packages/charts/package.json
+++ b/packages/quill/packages/charts/package.json
@@ -19,9 +19,11 @@
         "./story-helpers": "./src/story-helpers.tsx",
         "./package.json": "./package.json"
     },
+    "scripts": {
+        "build": "tsc -p tsconfig.build.json"
+    },
     "dependencies": {
         "@floating-ui/react": "^0.27.19",
-        "@testing-library/dom": ">=9.3.4",
         "d3-array": "^3.2.4",
         "d3-color": "^3.1.0",
         "d3-scale": "^4.0.2",
@@ -31,6 +33,7 @@
     },
     "devDependencies": {
         "@storybook/react": "catalog:",
+        "@testing-library/dom": ">=9.3.4",
         "@testing-library/react": "^14.3.1",
         "@types/d3-array": "^3.2.1",
         "@types/d3-color": "^3.1.3",
@@ -39,7 +42,8 @@
         "@types/jest": "catalog:",
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.7",
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "typescript": "catalog:"
     },
     "peerDependencies": {
         "react": "^18.3.1 || ^19.0.0",

--- a/packages/quill/packages/charts/tsconfig.build.json
+++ b/packages/quill/packages/charts/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": false,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "rootDir": "src",
+        "outDir": "dist"
+    },
+    "include": ["src/index.ts"],
+    "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/testing", "src/story-helpers.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,7 +343,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -1899,9 +1899,6 @@ importers:
       '@floating-ui/react':
         specifier: ^0.27.19
         version: 0.27.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@testing-library/dom':
-        specifier: '>=9.3.4'
-        version: 9.3.4
       d3-array:
         specifier: ^3.2.4
         version: 3.2.4
@@ -1930,6 +1927,9 @@ importers:
       '@storybook/react':
         specifier: 'catalog:'
         version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)
+      '@testing-library/dom':
+        specifier: '>=9.3.4'
+        version: 9.3.4
       '@testing-library/react':
         specifier: ^14.3.1
         version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1957,6 +1957,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/quill/packages/components:
     dependencies:
@@ -3772,6 +3775,9 @@ importers:
       '@posthog/quill':
         specifier: workspace:*
         version: link:../../packages/quill/packages/quill
+      '@posthog/quill-charts':
+        specifier: workspace:*
+        version: link:../../packages/quill/packages/charts
       '@toon-format/toon':
         specifier: ^2.1.0
         version: 2.1.0
@@ -31959,7 +31965,7 @@ snapshots:
       '@swc/core': 1.15.18
       '@swc/jest': 0.2.37(@swc/core@1.15.18)
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      jest: 29.7.0
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -39030,6 +39036,25 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  jest-cli@29.7.0:
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
@@ -39672,7 +39697,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      jest: 29.7.0
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -40107,7 +40132,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.6.2
-      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      jest: 29.7.0
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -40178,6 +40203,18 @@ snapshots:
       - supports-color
       - ts-node
       - utf-8-validate
+
+  jest@29.7.0:
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -45,6 +45,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@posthog/mcp-analytics": "npm:@posthog/mcp@0.0.9",
         "@posthog/quill": "workspace:*",
+        "@posthog/quill-charts": "workspace:*",
         "@toon-format/toon": "^2.1.0",
         "agents": "0.10.2",
         "ai": "^6.0.0",

--- a/services/mcp/src/ui-apps/components/charts/theme.ts
+++ b/services/mcp/src/ui-apps/components/charts/theme.ts
@@ -1,0 +1,26 @@
+import { type ChartTheme } from '@posthog/quill-charts'
+
+// PostHog brand palette. Canvas can't read CSS custom properties, so we hand the
+// chart concrete hexes. The chart picks one per series by index; legends use the
+// same array to stay in sync.
+export const CHART_COLORS = [
+    '#1d4aff', // PostHog blue
+    '#621da6', // PostHog purple
+    '#00d683', // PostHog green
+    '#f54e00', // PostHog orange
+    '#f7a501', // PostHog yellow
+    '#dc2626', // red
+]
+
+// Single mid-gray for axis labels — readable on both light and dark hosts. Claude
+// Desktop's iframe doesn't set `prefers-color-scheme`, so we can't detect the host
+// theme and adapt at runtime.
+export const CHART_THEME: ChartTheme = {
+    colors: CHART_COLORS,
+    backgroundColor: '#ffffff',
+    axisColor: '#9ca3af',
+    gridColor: 'rgba(128, 128, 128, 0.2)',
+    crosshairColor: 'rgba(128, 128, 128, 0.5)',
+    tooltipBackground: '#ffffff',
+    tooltipColor: '#111827',
+}

--- a/services/mcp/tsconfig.json
+++ b/services/mcp/tsconfig.json
@@ -16,7 +16,6 @@
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,
         "noUncheckedIndexedAccess": true,
-        "exactOptionalPropertyTypes": true,
         "skipLibCheck": true,
         "types": ["node", "./worker-configuration.d.ts", "./types.d.ts", "@cloudflare/vitest-pool-workers"],
         "paths": {
@@ -26,6 +25,7 @@
             "@posthog/mcp-ui": ["./src/ui-apps/lib/index.ts"],
             "@posthog/mcp-ui/*": ["./src/ui-apps/lib/*"],
             "@posthog/quill": ["../../packages/quill/packages/quill/dist/index.d.ts"],
+            "@posthog/quill-charts": ["../../packages/quill/packages/charts/dist/index.d.ts"],
             "lucide-react": ["./node_modules/lucide-react"],
             "@common/*": ["../../common/*"]
         }

--- a/services/mcp/vite.ui-apps.config.ts
+++ b/services/mcp/vite.ui-apps.config.ts
@@ -51,6 +51,13 @@ export default defineConfig({
                 find: /^@posthog\/quill$/,
                 replacement: resolve(__dirname, '../../packages/quill/packages/quill/dist/index.js'),
             },
+            // quill-charts is consumed as source (its package main is src/index.ts); resolve it
+            // explicitly so files reached via the `products` alias — and the local chart wrappers —
+            // can find it without a node_modules symlink.
+            {
+                find: /^@posthog\/quill-charts$/,
+                replacement: resolve(__dirname, '../../packages/quill/packages/charts/src/index.ts'),
+            },
             // lucide-react isn't a workspace dep at the products/ level, so files
             // resolved via the `products` alias can't find it. Pin to this
             // package's installed copy (matches the version Quill expects).


### PR DESCRIPTION
## Problem

MCP UI apps render charts with bespoke renderers in `services/mcp`, separate from the web app's charts. To let the product's chart views be shared between web and MCP, the MCP ui-apps bundle first needs to be able to resolve and render `@posthog/quill-charts` — which it currently can't (it only aliases `products/*`, and quill-charts isn't a dependency).

This PR is just that bridge. Nothing renders differently yet; it's the foundation for stacked PRs that move each insight chart into a shared view.

## Changes

- Add `@posthog/quill-charts` as a `services/mcp` workspace dependency.
- Add a `build` script + `typescript` devDep + `tsconfig.build.json` to the quill-charts package so its declarations build (also fixes `tsc: not found` in the image build).
- Add the `@posthog/quill-charts` tsconfig path and a matching vite alias so the ui-apps bundle resolves it (mirrors the existing `@posthog/quill` alias).
- Drop `exactOptionalPropertyTypes` from the MCP tsconfig to match the frontend, whose chart code will be shared in.
- Add a shared MCP chart palette/theme (`charts/theme.ts`).

## How did you test this code?

I'm an agent. Automated checks run locally:

- `pnpm --filter @posthog/mcp run typecheck` — passes (0 errors); `charts/theme.ts` resolves `@posthog/quill-charts` types via the new path.
- `pnpm install --lockfile-only` — lockfile regenerated cleanly from the package.json changes.

No runtime behavior changes in this PR (no app imports quill-charts yet), so there's nothing visual to verify here.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). This is the foundation of a stack: a trends line-chart shared-view PR is stacked on top, and bar/funnel/retention/etc. follow. It replaces the closed #61558/#61600, which put quill chart *components* directly in `services/mcp`; the new direction keeps charts in `products/product_analytics` as shared kea-free views and leaves `services/mcp` to just map data into them.