### PR TITLE
chore(replay): remove unused replay-x-llm-analytics-conversation-view flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -458,7 +458,6 @@ export const FEATURE_FLAGS = {
     REPLAY_UI_REDESIGN_2026: 'replay-ui-redesign-2026', // owner: #team-replay, New UI layout for replay
     REPLAY_VIDEO_BASED_SUMMARIZATION: 'replay-video-based-summarization', // owner: #team-replay
     REPLAY_VISION: 'replay-vision', // owner: #team-replay
-    REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW: 'replay-x-llm-analytics-conversation-view', // owner: @pauldambra #team-replay
     REVENUE_ANALYTICS: 'revenue-analytics', // owner: @rafaeelaudibert #team-customer-analytics
     REVENUE_FIELDS_IN_POWER_USERS_TABLE: 'revenue-fields-in-power-users-table', // owner: @arthurdedeus #team-customer-analytics
     SCENE_MENU_BAR: 'scene-menu-bar', // owner: @adamleithp #team-platform-ux, gates the per-scene MenuBar above SceneTitleSection


### PR DESCRIPTION
## Problem

The `replay-x-llm-analytics-conversation-view` feature flag has been fully rolled out and is being cleaned up.
Its `FEATURE_FLAGS` constant remained defined in `constants.tsx` but the constant was never read anywhere in the codebase — a dead definition.

## Changes

Remove the dead `REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW` entry from `FEATURE_FLAGS`.
No other code referenced it (verified by grepping both the raw flag key and the constant name across the monorepo).
The flag itself has been deleted in PostHog.

## How did you test this code?

I'm an agent — no manual testing performed.
The change only removes an unused constant definition; verification was a repo-wide search confirming zero references to the constant name or the flag key.
CI typecheck/lint covers the rest.

## 🤖 Agent context

Authored with PostHog Code (Claude).
This came out of a session cleaning up fully rolled-out, no-longer-referenced feature flags created by the user.
A batch of taxonomic-filter and replay flags were deleted in PostHog; of that whole set, this was the only flag that still had a stale definition left in code, so this PR removes it.
The constant was confirmed unused via raw-key and constant-name greps before removal.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
