### PR TITLE
fix: scrollbar saved filters

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -264,14 +264,13 @@ export const RecordingsUniversalFiltersEmbed = ({ ...props }: ReplayUniversalFil
 
     return (
         <div className="relative">
-            <div className="absolute top-0 right-0 z-1">
-                <LemonButton icon={<IconX />} size="small" onClick={() => setIsFiltersExpanded(false)} />
-            </div>
             <LemonTabs
                 activeKey={activeFilterTab}
                 onChange={(activeKey) => setActiveFilterTab(activeKey)}
                 size="small"
                 tabs={tabs}
+                barClassName="sticky top-0 z-10 bg-primary"
+                rightSlot={<LemonButton icon={<IconX />} size="small" onClick={() => setIsFiltersExpanded(false)} />}
             />
         </div>
     )

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -199,7 +199,7 @@ function PlayerWrapper({
             style={style}
         >
             {isFiltersExpanded && (
-                <div className="h-full rounded border">
+                <div className="h-full overflow-y-auto rounded border">
                     <RecordingsUniversalFiltersEmbed
                         resetFilters={resetFilters}
                         filters={filters}


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/59735 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/60589) 
can'\t scroll saved filters list 

## Changes

adds scroll

## How did you test this code?

ran locally

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
