### PR TITLE
fix(batch-exports): coerce config types in destination responses

### DIFF
--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -69,6 +69,7 @@ from products.batch_exports.backend.service import (
     BatchExportWithNoEndNotAllowedError,
     backfill_export,
     cancel_running_batch_export_run,
+    coerce_config_to_declared_types,
     delete_batch_export,
     pause_batch_export,
     sync_batch_export,
@@ -574,7 +575,8 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
 
             return target
 
-        data["config"] = remove_secret_fields_recursive(data["config"])
+        config = remove_secret_fields_recursive(data["config"])
+        data["config"] = coerce_config_to_declared_types(instance.type, config)
 
         return data
 

--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -543,6 +543,34 @@ DESTINATION_WORKFLOWS = {
 }
 
 
+def coerce_config_to_declared_types(destination_type: str, config: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    """Restore stringified config values to the types declared on the destination's workflow inputs.
+
+    EncryptedJSONField stringifies values on write, so bool/int config fields read back as strings.
+    This function mirrors the coercion the worker applies in BaseBatchExportInputs.__post_init__, so
+    API responses return correct JSON types.
+    """
+    if destination_type not in DESTINATION_WORKFLOWS:
+        return config
+
+    _, workflow_inputs = DESTINATION_WORKFLOWS[destination_type]
+    field_by_name = {f.name: f for f in fields(workflow_inputs)}
+
+    coerced: dict[str, typing.Any] = {}
+    for key, value in config.items():
+        field = field_by_name.get(key)
+        if field is not None and isinstance(value, str):
+            if _field_is_type(field, bool):
+                value = value.lower() == "true"
+            elif _field_is_type(field, int):
+                try:
+                    value = int(value)
+                except ValueError:
+                    pass
+        coerced[key] = value
+    return coerced
+
+
 class BatchExportServiceError(Exception):
     """Base class for BatchExport service exceptions."""
 

--- a/products/batch_exports/backend/tests/api/test_get.py
+++ b/products/batch_exports/backend/tests/api/test_get.py
@@ -203,7 +203,13 @@ def test_serialization_of_destination_config(client: HttpClient, temporal, organ
 
     batch_export = response.json()
 
-    # Check that the destination config is returned, except for user and password, which are
-    # sensitive
-    non_sensitive_config = {k: v for k, v in destination_data["config"].items() if k not in {"user", "password"}}
-    assert batch_export["destination"]["config"] == non_sensitive_config
+    # Check that the destination config is returned with correct JSON types, except for user and
+    # password, which are sensitive
+    assert batch_export["destination"]["config"] == {
+        "host": "127.0.0.1",
+        "port": 5432,
+        "schema": "public",
+        "database": "test",
+        "table_name": "batch_export_events",
+        "has_self_signed_cert": False,
+    }

--- a/products/batch_exports/backend/tests/api/test_get.py
+++ b/products/batch_exports/backend/tests/api/test_get.py
@@ -160,3 +160,50 @@ def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, org
 
     response = get_batch_export(client, team.pk, batch_export["id"])
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+
+
+def test_serialization_of_destination_config(client: HttpClient, temporal, organization, team, user):
+    """Test that the destination config is serialized correctly.
+
+    Our destination config is encrypted using EncryptedJSONField, which decrypts most data types
+    (including booleans) into strings. Therefore, we want to ensure these are serialized to their
+    correct JSON types in the response.
+    """
+    destination_data = {
+        "type": "Postgres",
+        "config": {
+            "host": "127.0.0.1",
+            "port": 5432,
+            "user": "test",
+            "password": "test",
+            "schema": "public",
+            "database": "test",
+            "table_name": "batch_export_events",
+            "has_self_signed_cert": False,
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-export",
+        "destination": destination_data,
+        "interval": "day",
+        "timezone": "UTC",
+    }
+
+    client.force_login(user)
+
+    response = create_batch_export_ok(
+        client,
+        team.pk,
+        batch_export_data,
+    )
+
+    response = get_batch_export(client, team.pk, response["id"])
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+    batch_export = response.json()
+
+    # Check that the destination config is returned, except for user and password, which are
+    # sensitive
+    non_sensitive_config = {k: v for k, v in destination_data["config"].items() if k not in {"user", "password"}}
+    assert batch_export["destination"]["config"] == non_sensitive_config


### PR DESCRIPTION
## Problem

A batch export's destination `config` is stored in an `EncryptedJSONField`, which stringifies values on write (e.g. `str(False)` → `"False"`, `str(5432)` → `"5432"`) and returns plain strings on decrypt. The GET/LIST API read path did no type coercion, so booleans and integers leaked back to API consumers as strings (e.g. `"has_self_signed_cert": "False"` instead of `false`).

This was an asymmetry: the write-side validator and the Temporal worker (`BaseBatchExportInputs.__post_init__`) already coerce these values back to their declared types, but the read API did not — so the same field had a different JSON type depending on how it was fetched.

This also causes problems in the frontend; for example it displays a value of `"False"` as a truthy value in a checkbox.

## Changes

- Added `coerce_config_to_declared_types(destination_type, config)` in `service.py`. It uses the destination's workflow-inputs dataclass (`DESTINATION_WORKFLOWS`) as the source of truth and restores stringified `bool`/`int` config values to their declared types, mirroring the worker's `__post_init__`. Already-typed values and unknown/legacy fields are passed through untouched.
- Called it from `BatchExportDestinationSerializer.to_representation` after secret-field stripping. This single read path covers GET, LIST, and create/update responses, so they're now consistent.


## How did you test this code?

- Added a test to reproduce the issue: `test_serialization_of_destination_config`
    - Prior to the fix, this test failed, now it passes.
- Ran the full batch exports API suite (`products/batch_exports/backend/tests/api/`)
- Tested creating and updating a batch export (including setting boolean and integer fields) using the local stack

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.8). Reproduced from a failing test asserting that an encrypted Postgres config round-trips with correct JSON types.

Key decisions:
- Fixed on the **read path** (`to_representation`) rather than at the model/`EncryptedJSONField` layer — the encryption behavior is shared across the codebase, so changing it would be far broader and riskier. The serializer is the right boundary, and it already strips secret fields there.
- Reused the existing dataclass-driven type knowledge (`DESTINATION_WORKFLOWS` + `_field_is_type`) so the read path stays in sync with the validator and worker rather than inventing a value-pattern heuristic.
- Dropped a `float` branch that was initially planned once I confirmed no destination config field is float-typed — avoided shipping dead code.

Requires human review; not self-merged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*