### PR TITLE
feat(mcp): log redacted token on rate-limit block

### DIFF
--- a/services/mcp/src/hono/rate-limit-telemetry.ts
+++ b/services/mcp/src/hono/rate-limit-telemetry.ts
@@ -1,4 +1,5 @@
 import type { RequestProperties } from '@/lib/request-properties'
+import { redactToken } from '@/lib/utils'
 import type { State } from '@/tools/types'
 
 import { RedisCache, type RedisLike } from './cache/RedisCache'
@@ -44,6 +45,13 @@ export async function recordRateLimitBlock(
         }
     }
     rateLimitBlockedByTeam.inc({ scope: result.scope, team_id: normalizeTeamId(teamId) })
+
+    // Log so we can trace which token is hitting the limit; the token is redacted
+    // to its last 4 chars so the line is useless to anyone who shouldn't have it.
+    console.warn(
+        '[RateLimiter] rate limited',
+        JSON.stringify({ scope: result.scope, projectId: teamId ?? null, token: redactToken(props.apiToken) })
+    )
 }
 
 // test-only: reset the process-lifetime cardinality cap between cases

--- a/services/mcp/src/lib/utils.ts
+++ b/services/mcp/src/lib/utils.ts
@@ -7,6 +7,15 @@ export function hash(data: string): string {
     return crypto.pbkdf2Sync(data, salt, 100000, 32, 'sha256').toString('hex')
 }
 
+// Redact an API token for logs: keep only the last 4 chars, mask the rest.
+// Tokens of 4 chars or fewer (or empty) are fully masked so nothing useful leaks.
+export function redactToken(token: string): string {
+    if (token.length <= 4) {
+        return '****'
+    }
+    return `****${token.slice(-4)}`
+}
+
 export function formatPrompt(template: string, vars: Record<string, string>): string {
     // Use a function replacement so `$` sequences (`$&`, `$$`, `` $` ``, `$'`) inside a
     // value are NOT interpreted as replacement-pattern escapes. Otherwise values containing

--- a/services/mcp/tests/hono/rate-limit-telemetry.test.ts
+++ b/services/mcp/tests/hono/rate-limit-telemetry.test.ts
@@ -56,6 +56,21 @@ describe('recordRateLimitBlock', () => {
         expect(await teamValue('unresolved')).toBe(1)
     })
 
+    it('logs the block with the project id and a token redacted to its last 4 chars', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const get = vi.fn()
+        await recordRateLimitBlock(
+            { get } as never,
+            makeProps({ projectId: '123', apiToken: 'phx_secrettoken9876' }),
+            blocked('mcp_burst')
+        )
+        expect(warn).toHaveBeenCalledWith(
+            '[RateLimiter] rate limited',
+            JSON.stringify({ scope: 'mcp_burst', projectId: '123', token: '****9876' })
+        )
+        warn.mockRestore()
+    })
+
     it.each([['not-a-number'], ['12345678901234567890'], ['1; DROP']])(
         'buckets a non-numeric or oversized project id %j as unresolved',
         async (projectId) => {

--- a/services/mcp/tests/unit/utils.test.ts
+++ b/services/mcp/tests/unit/utils.test.ts
@@ -1,10 +1,25 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatPrompt, sanitizeHeaderValue } from '@/lib/utils'
+import { formatPrompt, redactToken, sanitizeHeaderValue } from '@/lib/utils'
 import { omitResponseFields, pickResponseFields, withPostHogUrl } from '@/tools/tool-utils'
 import type { Context } from '@/tools/types'
 
 describe('utils', () => {
+    describe('redactToken', () => {
+        it('keeps only the last 4 chars and masks the rest', () => {
+            expect(redactToken('phx_abcdefgh1234')).toBe('****1234')
+        })
+
+        it('fully masks tokens of 4 chars or fewer', () => {
+            expect(redactToken('1234')).toBe('****')
+            expect(redactToken('ab')).toBe('****')
+        })
+
+        it('fully masks an empty token', () => {
+            expect(redactToken('')).toBe('****')
+        })
+    })
+
     describe('formatPrompt', () => {
         it('substitutes placeholders with values', () => {
             expect(formatPrompt('Hello {name}, welcome to {place}', { name: 'world', place: 'earth' })).toBe(


### PR DESCRIPTION
## Problem

When the MCP server rate-limits a user, we report the project id (via the `rate_limit_blocked_by_team` metric), but there is no way to tell *which token* within a project is driving the limit. That makes it hard to track down the specific caller causing rate-limit issues.

## Changes

On the rate-limit block path (`recordRateLimitBlock`), alongside the existing project-id metric, emit a log line that includes the offending token redacted to its last 4 characters:

```
[RateLimiter] rate limited {"scope":"mcp_sustained","projectId":"1492","token":"****9876"}
```

- Added a `redactToken` helper in `services/mcp/src/lib/utils.ts` — keeps only the last 4 chars and masks the rest. Tokens of 4 chars or fewer (or empty) are fully masked (`****`) so nothing useful leaks.
- The log line reuses the same resolved project id used for the metric (falls back to `null` when unresolved) and the request scope (burst/sustained).

Note: this logs one `console.warn` per blocked request — the same frequency as the existing metric increment, so no new metric cardinality, just log volume. Happy to throttle it (e.g. once per token per minute) if reviewers prefer.

## How did you test this code?

I'm an agent (PostHog Slack app). I ran the automated tests for the affected files only:

- `tests/unit/utils.test.ts` — added `redactToken` cases (last-4 redaction, short/empty tokens). 38 passed.
- `tests/hono/rate-limit-telemetry.test.ts` — added an assertion on the exact log line with a redacted token. 9 passed.

I did not perform manual end-to-end testing against a running MCP server.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed — this is an internal operational log line.

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) at a user's request: "log 'rate limited' with the last 4 chars of the token when we rate limit a user in the MCP server; rest of the token should be redacted."

Key decisions:
- Placed the log in `recordRateLimitBlock`, which already owns the project-id reporting, rather than at the call site in `streamable-handler.ts` — keeps all rate-limit-block telemetry co-located.
- Added a small reusable `redactToken` helper in `lib/utils` rather than inlining, and fully masked short/empty tokens so nothing useful leaks for edge-case values.
- Reused the already-resolved project id (header or cached fallback) so the log and the metric agree.

Requires human review before merge.
