### PR TITLE
chore(replay): remove LLM conversation preview from inspector

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -458,7 +458,6 @@ export const FEATURE_FLAGS = {
     REPLAY_UI_REDESIGN_2026: 'replay-ui-redesign-2026', // owner: #team-replay, New UI layout for replay
     REPLAY_VIDEO_BASED_SUMMARIZATION: 'replay-video-based-summarization', // owner: #team-replay
     REPLAY_VISION: 'replay-vision', // owner: #team-replay
-    REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW: 'replay-x-llm-analytics-conversation-view', // owner: @pauldambra #team-replay
     REVENUE_ANALYTICS: 'revenue-analytics', // owner: @rafaeelaudibert #team-customer-analytics
     REVENUE_FIELDS_IN_POWER_USERS_TABLE: 'revenue-fields-in-power-users-table', // owner: @arthurdedeus #team-customer-analytics
     SCENE_MENU_BAR: 'scene-menu-bar', // owner: @adamleithp #team-platform-ux, gates the per-scene MenuBar above SceneTitleSection

--- a/frontend/src/scenes/session-recordings/player/inspector/components/AIEventItems.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/AIEventItems.tsx
@@ -1,8 +1,5 @@
-import { IconPerson } from '@posthog/icons'
-
 import { JSONViewer } from 'lib/components/JSONViewer'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-import { IconExclamation, IconRobot } from 'lib/lemon-ui/icons'
+import { IconExclamation } from 'lib/lemon-ui/icons'
 import { isObject } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 
@@ -73,25 +70,7 @@ export function AIEventExpanded({ event }: { event: Record<string, any> }): JSX.
     )
 }
 
-const isHumanMessage = (message: Record<string, any>): boolean => {
-    return message.type === 'human' || message.role === 'user' || message.role === 'human'
-}
-
-const isAIMessage = (message: Record<string, any>): boolean => {
-    return (
-        (message.type === 'ai' || message.role === 'assistant' || message.role === 'ai') &&
-        !!message.content?.length &&
-        message.visible !== false
-    )
-}
-
-const isDisplayableAIMessage = (message: Record<string, any>): boolean => {
-    return isHumanMessage(message) || isAIMessage(message)
-}
-
 export function AIEventSummary({ event }: { event: Record<string, any> }): JSX.Element | null {
-    const showConversation = useFeatureFlag('REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW')
-
     if (event.properties.$ai_is_error) {
         return (
             <div className="flex items-center gap-1 text-danger">
@@ -101,54 +80,5 @@ export function AIEventSummary({ event }: { event: Record<string, any> }): JSX.E
         )
     }
 
-    if (!showConversation) {
-        return null
-    }
-
-    const inputMessages = (
-        (event.properties?.$ai_input_state?.messages as Record<string, any>[] | undefined) ??
-        (event.properties?.$ai_input as Record<string, any>[] | undefined) ??
-        []
-    ).filter(isDisplayableAIMessage)
-    const outputMessages = (
-        (event.properties?.$ai_output_state?.messages as Record<string, any>[] | undefined) ??
-        (event.properties?.$ai_output_choices as Record<string, any>[] | undefined) ??
-        []
-    ).filter(isDisplayableAIMessage)
-    const seen = new Set<string>()
-    const messageChain: Array<{ id: string; content: string; role: string }> = []
-
-    for (const m of [...inputMessages, ...outputMessages]) {
-        if (typeof m.content !== 'string') {
-            continue
-        }
-
-        const role = m.role && !m.type ? (m.role === 'user' ? 'human' : 'ai') : m.type
-        const key = `${role}:${m.content}`
-
-        if (!seen.has(key)) {
-            seen.add(key)
-            messageChain.push({ id: m.id, content: m.content, role })
-        }
-    }
-
-    return (
-        <div className="hidden @sm:flex flex-col items-center gap-1 text-muted-alt">
-            {messageChain.map((m) => (
-                <div
-                    className={cn(
-                        'flex flex-row w-full items-center',
-                        isHumanMessage(m) ? 'justify-end' : 'justify-start'
-                    )}
-                    key={m.id}
-                >
-                    {isAIMessage(m) && <IconRobot className="mr-1 text-2xl" />}
-                    <div className="max-w-2/3 border rounded px-2 py-1 text-wrap text-sm bg-surface-primary">
-                        {m.content}
-                    </div>
-                    {isHumanMessage(m) && <IconPerson className="ml-1 text-2xl" />}
-                </div>
-            ))}
-        </div>
-    )
+    return null
 }


### PR DESCRIPTION
## Problem

The `replay-x-llm-analytics-conversation-view` flag gated an inline LLM-conversation preview in the session replay inspector: AI-event rows (`$ai_generation` / `$ai_span` / `$ai_trace`) rendered a compact chat-bubble transcript of the prompt/response built from `$ai_input` / `$ai_output_choices`.
It was gated to the PostHog Team cohort from Sep 2025 and never rolled wider — an internal trial that didn't graduate. We're removing the feature.

## Changes

- Remove the collapsed-row conversation preview and its helpers from `AIEventItems.tsx`.
- Keep `AIEventSummary`, reduced to the **Error** indicator only — failed AI events still show the red "Error" pill in the collapsed inspector row (this behaviour was independent of the flag).
- The expanded LLM view (`AIEventExpanded` / `ConversationMessagesDisplay`) is **unaffected** — clicking into an AI event still shows full input/output.
- Drop the now-unused `REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW` entry from `FEATURE_FLAGS` and the unused `IconRobot` / `IconPerson` / `useFeatureFlag` imports.

`ItemEvent.tsx` is unchanged (it still calls `AIEventSummary`, which now returns the error pill or `null`).

## How did you test this code?

I'm an agent — no manual testing performed.
Ran `tsc --noEmit` (frontend): zero errors in the changed/affected files (`AIEventItems.tsx`, `constants.tsx`, `ItemEvent.tsx`); the only failures were pre-existing, unrelated `products/workflows/` issues on the base.
Verified repo-wide that no references to the flag constant or key remain.

## 🤖 Agent context

Authored with PostHog Code (Claude).
Came out of a feature-flag cleanup session: the flag was initially mis-classified as unused and deleted, but CI typechecking caught a live reference via the `useFeatureFlag('REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW')` string form (which the earlier grep-based check missed). The flag was restored, then the decision was made to remove the feature entirely rather than keep maintaining it.
Decision point during the work: keep the AI-error "Error" pill (it predates and is independent of the conversation-preview experiment) — confirmed yes, so `AIEventSummary` was slimmed rather than deleted outright.

Follow-up after merge: delete the `replay-x-llm-analytics-conversation-view` flag in PostHog (kept live until this lands so the change can't strand the flag mid-rollout).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
