### PR TITLE
chore(signals): run scout coordinator every 30 min instead of 15

### DIFF
--- a/products/signals/ARCHITECTURE.md
+++ b/products/signals/ARCHITECTURE.md
@@ -21,7 +21,7 @@ Several additional Signals workflows also exist but are not part of the main rep
 
 - `backfill-error-tracking` (`backend/temporal/backfill_error_tracking.py`) — backfills recent error tracking issues as signals
 - `emit-eval-signal` (`backend/temporal/emit_eval_signal.py`) — converts LLMA evaluation results into Signals inputs on the Signals worker queue
-- `run-signals-scout-coordinator` (`backend/temporal/agentic/scout_coordinator.py`) — periodic tick (every `COORDINATOR_INTERVAL_MINUTES = 15`) that fans out scheduled `signals-scout-*` scout runs per (team, skill). Spec'd separately below.
+- `run-signals-scout-coordinator` (`backend/temporal/agentic/scout_coordinator.py`) — periodic tick (every `COORDINATOR_INTERVAL_MINUTES = 30`) that fans out scheduled `signals-scout-*` scout runs per (team, skill). Spec'd separately below.
 - `RunSignalsScoutWorkflow` (`backend/temporal/agentic/scout_scheduler.py`) — child workflow per planned run; thin wrapper around the harness activity. Spec'd separately below.
 
 ### Activity decoration
@@ -285,7 +285,7 @@ This shares the same activities as reingestion; the only difference is that it s
 
 Polling coordinator for the headless **Signals agent**. Driven by a Temporal Schedule
 defined in `backend/temporal/agentic/schedule.py` with `every=COORDINATOR_INTERVAL_MINUTES`
-(15min) and `ScheduleOverlapPolicy.SKIP` to drop ticks rather than queue them. The tick
+(30min) and `ScheduleOverlapPolicy.SKIP` to drop ticks rather than queue them. The tick
 is just polling granularity — each scout's own `run_interval_minutes` schedule decides
 when it actually runs.
 
@@ -1062,7 +1062,7 @@ Signal {index}:
 | `BUFFER_MAX_SIZE`                        | `20`                          | Max signals buffered in memory before flush to S3                                                |
 | `BUFFER_FLUSH_TIMEOUT_SECONDS`           | `5`                           | Max seconds to wait for buffer to fill before flushing                                           |
 | S3 prefix                                | `signals/signal_batches/`     | Object storage path for signal batch files (cleaned up by S3 lifecycle policies)                 |
-| `COORDINATOR_INTERVAL_MINUTES`           | `15`                          | Signals agent coordinator poll cadence (Temporal schedule, `SKIP` overlap policy)                |
+| `COORDINATOR_INTERVAL_MINUTES`           | `30`                          | Signals agent coordinator poll cadence (Temporal schedule, `SKIP` overlap policy)                |
 | `MAX_RUNS_PER_TICK`                      | `50`                          | Hard cap on planned runs per coordinator tick (most-overdue-first, truncated after sort)         |
 | `SignalScoutConfig.run_interval_minutes` | `1440`                        | Per-scout default schedule in minutes (daily); due-check, no sampling (`10`–`43200`)             |
 | `SignalScoutConfig.emit`                 | `False`                       | Per-scout dry-run gate — scout runs and logs, but `emit_finding` writes nothing until flipped on |

--- a/products/signals/backend/scout_harness/AGENTS.md
+++ b/products/signals/backend/scout_harness/AGENTS.md
@@ -11,7 +11,7 @@ _what_ to investigate from scratch, and pushes new signals into the same pipelin
 than acting on existing ones.
 
 In production it is driven by `SignalsScoutCoordinatorWorkflow` (periodic tick every
-`COORDINATOR_INTERVAL_MINUTES = 15` → fan out per-(team, skill) child workflows). Locally
+`COORDINATOR_INTERVAL_MINUTES = 30` → fan out per-(team, skill) child workflows). Locally
 it is exercised via the `run_signals_scout` management command (see `../management/AGENTS.md`).
 
 ## What lives here
@@ -112,7 +112,7 @@ one sandbox session → zero or more emitted signals.
 ## Where the rest of the system meets this directory
 
 - **Coordinator** — `temporal/agentic/scout_coordinator.py` and `scout_scheduler.py`.
-  Polls every `COORDINATOR_INTERVAL_MINUTES = 15`; dispatches each scout whose
+  Polls every `COORDINATOR_INTERVAL_MINUTES = 30`; dispatches each scout whose
   per-scout schedule (`run_interval_minutes`, default daily) is due, most-overdue
   first, hard cap `MAX_RUNS_PER_TICK = 50` per tick, `ScheduleOverlapPolicy.SKIP` to
   drop ticks rather than queue them.

--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -36,7 +36,7 @@ MAX_RUNS_PER_TICK = 50
 
 # Coordinator tick cadence. Per-scout schedules are enforced via the due-check, so this is
 # just the polling granularity — the floor on how often any scout can run.
-COORDINATOR_INTERVAL_MINUTES = 15
+COORDINATOR_INTERVAL_MINUTES = 30
 
 
 @dataclass


### PR DESCRIPTION
## Problem

The Signals scout coordinator ticks every 15 minutes, but the tick is only polling granularity — each scout's own `run_interval_minutes` (default 1440 = daily) decides when it actually runs. At a daily per-scout cadence, 15-minute polling wakes the coordinator twice as often as it needs to for no latency benefit.

## Changes

Bump `COORDINATOR_INTERVAL_MINUTES` from 15 to 30 (and the doc references to it). A scout still runs within 30 minutes of becoming due, which is immaterial for a daily schedule, and the coordinator's wake-ups are halved.

Takes effect on the next `python manage.py schedule_temporal_workflows` run — the schedule registration is idempotent and updates the existing schedule's interval. `ScheduleOverlapPolicy.SKIP` and the per-scout due-check are unchanged.

## How did you test this code?

I'm an agent (Claude Code). This is a single constant value change plus its doc references; there is no behavior to unit-test (the value only sets the Temporal schedule interval). `ruff` and `ty check` pass via lint-staged. No tests reference the constant value.

## 🤖 Agent context

Authored with Claude Code. Trivial tuning change split out as its own PR (separate from the in-flight flag-payload enrollment work) so it can land independently. The constant is consumed in `schedule.py` (`ScheduleIntervalSpec(every=timedelta(minutes=COORDINATOR_INTERVAL_MINUTES))`); doc references in `ARCHITECTURE.md` and `scout_harness/AGENTS.md` were updated to match. Agent-authored; requires human review.
