### PR TITLE
fix(ingestion): retry transient team-load failures in the lazy loader

### DIFF
--- a/nodejs/src/servers/ingestion-general-server.ts
+++ b/nodejs/src/servers/ingestion-general-server.ts
@@ -150,7 +150,12 @@ export class IngestionGeneralServer implements NodeServer {
         this.pubsub = new PubSub(this.redisPool)
         await this.pubsub.start()
 
-        const teamManager = new TeamManager(this.postgres)
+        // Retry transient team-load failures (e.g. a Postgres pooler scale-down returning
+        // ECONNREFUSED). The team loader runs detached in the LazyLoader buffer, so an un-retried
+        // transient failure can surface as an unhandled rejection and restart the worker.
+        const teamManager = new TeamManager(this.postgres, {
+            loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
+        })
 
         // 2. Ingestion + CDP shared services (geoip, repos, encryption)
         const geoipService = new GeoIPService(this.config.MMDB_FILE_LOCATION)

--- a/nodejs/src/utils/lazy-loader.test.ts
+++ b/nodejs/src/utils/lazy-loader.test.ts
@@ -19,7 +19,7 @@ describe('LazyLoader', () => {
     })
 
     afterEach(() => {
-        jest.spyOn(Date, 'now').mockRestore()
+        jest.restoreAllMocks()
     })
 
     describe('constructor', () => {
@@ -430,13 +430,13 @@ describe('LazyLoader', () => {
         })
 
         it('gives up and rethrows once maxElapsedMs is exceeded', async () => {
-            let now = start
-            jest.spyOn(Date, 'now').mockImplementation(() => now)
+            let elapsed = 0
+            jest.spyOn(performance, 'now').mockImplementation(() => elapsed)
 
             const { retryLoader, retryLazyLoader } = makeRetryLoader()
             // Each attempt advances the clock by 600ms; the 1000ms budget allows only one retry.
             retryLoader.mockImplementation(() => {
-                now += 600
+                elapsed += 600
                 return Promise.reject(retriable('blip'))
             })
 
@@ -450,6 +450,34 @@ describe('LazyLoader', () => {
 
             await expect(noRetryLazyLoader.get('key1')).rejects.toThrow('blip')
             expect(noRetryLoader).toHaveBeenCalledTimes(1)
+        })
+
+        it('serves a get() for a different key while the loader is retrying, without hanging', async () => {
+            const { retryLoader, retryLazyLoader } = makeRetryLoader()
+
+            let allowAToSucceed = false
+            retryLoader.mockImplementation((keys: string[]) => {
+                if (keys.includes('A')) {
+                    return allowAToSucceed ? Promise.resolve({ A: 'valueA' }) : Promise.reject(retriable('blip'))
+                }
+                return Promise.resolve({ B: 'valueB' })
+            })
+
+            // Start A; it fails and enters the retry loop (its buffer has already fired and cleared).
+            const aPromise = retryLazyLoader.get('A')
+            for (let i = 0; i < 100 && !retryLoader.mock.calls.some((c) => c[0].includes('A')); i++) {
+                await delay(2)
+            }
+
+            // A get() for a different key must resolve on its own buffer, not block on A's retry.
+            await expect(retryLazyLoader.get('B')).resolves.toBe('valueB')
+
+            // A still completes once its dependency recovers.
+            allowAToSucceed = true
+            await expect(aPromise).resolves.toBe('valueA')
+
+            // B was loaded by its own independent loader call, not merged into A's retry.
+            expect(retryLoader).toHaveBeenCalledWith(['B'])
         })
     })
 })

--- a/nodejs/src/utils/lazy-loader.test.ts
+++ b/nodejs/src/utils/lazy-loader.test.ts
@@ -391,4 +391,65 @@ describe('LazyLoader', () => {
             // Just verify we have exactly 2 entries
         })
     })
+
+    describe('loaderRetry', () => {
+        const retriable = (message: string) => Object.assign(new Error(message), { isRetriable: true })
+
+        const makeRetryLoader = () => {
+            const retryLoader = jest.fn()
+            return {
+                retryLoader,
+                retryLazyLoader: new LazyLoader<string>({
+                    name: 'test-retry',
+                    loader: retryLoader,
+                    loaderRetry: { retryIntervalMs: 1, retryJitterMs: 0, maxElapsedMs: 1000 },
+                }),
+            }
+        }
+
+        it('retries a retriable loader failure and then succeeds', async () => {
+            const { retryLoader, retryLazyLoader } = makeRetryLoader()
+            retryLoader.mockRejectedValueOnce(retriable('blip'))
+            retryLoader.mockResolvedValueOnce({ key1: 'value1' })
+
+            const result = await retryLazyLoader.get('key1')
+
+            expect(result).toBe('value1')
+            expect(retryLoader).toHaveBeenCalledTimes(2)
+            // Re-invoked with the keys on every attempt (re-evaluated fresh at retry time)
+            expect(retryLoader).toHaveBeenNthCalledWith(1, ['key1'])
+            expect(retryLoader).toHaveBeenNthCalledWith(2, ['key1'])
+        })
+
+        it('does not retry a non-retriable loader failure', async () => {
+            const { retryLoader, retryLazyLoader } = makeRetryLoader()
+            retryLoader.mockRejectedValue(new Error('boom'))
+
+            await expect(retryLazyLoader.get('key1')).rejects.toThrow('boom')
+            expect(retryLoader).toHaveBeenCalledTimes(1)
+        })
+
+        it('gives up and rethrows once maxElapsedMs is exceeded', async () => {
+            let now = start
+            jest.spyOn(Date, 'now').mockImplementation(() => now)
+
+            const { retryLoader, retryLazyLoader } = makeRetryLoader()
+            // Each attempt advances the clock by 600ms; the 1000ms budget allows only one retry.
+            retryLoader.mockImplementation(() => {
+                now += 600
+                return Promise.reject(retriable('blip'))
+            })
+
+            await expect(retryLazyLoader.get('key1')).rejects.toThrow('blip')
+            expect(retryLoader).toHaveBeenCalledTimes(2)
+        })
+
+        it('does not retry when no loaderRetry is configured', async () => {
+            const noRetryLoader = jest.fn().mockRejectedValue(retriable('blip'))
+            const noRetryLazyLoader = new LazyLoader<string>({ name: 'test-no-retry', loader: noRetryLoader })
+
+            await expect(noRetryLazyLoader.get('key1')).rejects.toThrow('blip')
+            expect(noRetryLoader).toHaveBeenCalledTimes(1)
+        })
+    })
 })

--- a/nodejs/src/utils/lazy-loader.ts
+++ b/nodejs/src/utils/lazy-loader.ts
@@ -343,15 +343,23 @@ export class LazyLoader<T> {
             return await this.options.loader(keys)
         }
 
-        const deadline = Date.now() + retry.maxElapsedMs
+        const deadline = performance.now() + retry.maxElapsedMs
         let attempt = 0
         for (;;) {
             try {
                 return await this.options.loader(keys)
             } catch (error) {
                 attempt++
-                if (error?.isRetriable !== true || Date.now() >= deadline) {
-                    // Only retry known-transient failures; rethrow anything else (and on budget exhaustion).
+                if (error?.isRetriable !== true) {
+                    // Non-transient: rethrow immediately so genuine bugs surface rather than being masked.
+                    throw error
+                }
+                if (performance.now() >= deadline) {
+                    logger.warn('🔁', `[LazyLoader:${this.options.name}] Loader retries exhausted, giving up`, {
+                        attempt,
+                        keys: keys.length,
+                        error: String(error),
+                    })
                     throw error
                 }
                 const jitter = retry.retryJitterMs ? Math.floor(Math.random() * retry.retryJitterMs) : 0

--- a/nodejs/src/utils/lazy-loader.ts
+++ b/nodejs/src/utils/lazy-loader.ts
@@ -4,6 +4,7 @@ import { instrumentFn } from '~/common/tracing/tracing-utils'
 
 import { defaultConfig } from '../config/config'
 import { logger } from './logger'
+import { sleep } from './utils'
 
 const lazyLoaderCacheHits = new Counter({
     name: 'lazy_loader_cache_hits',
@@ -48,10 +49,27 @@ const lazyLoaderCacheSize = new Gauge({
  * - Parallel loading defense - multiple calls for the same value in parallel only loads once
  */
 
+/**
+ * Retry policy for the loader. When set, a loader call that throws a retriable error
+ * (`error.isRetriable === true`) is retried until `maxElapsedMs` is exhausted. Useful for absorbing
+ * transient dependency blips (e.g. a Postgres pooler scale-down) so a single failed background load
+ * doesn't propagate to every caller — including fire-and-forget ones, where it would crash the process.
+ */
+export type LoaderRetryOptions = {
+    /** Base delay between attempts. */
+    retryIntervalMs: number
+    /** Random extra delay in `[0, retryJitterMs)` added to each interval to avoid a thundering herd. */
+    retryJitterMs?: number
+    /** Total time budget for retrying. Once exceeded, the last error is rethrown. */
+    maxElapsedMs: number
+}
+
 export type LazyLoaderOptions<T> = {
     name: string
     /** Function to load the values */
     loader: (key: string[]) => Promise<Record<string, T | null | undefined>>
+    /** Retry policy for transient loader failures. Off by default (no retry). */
+    loaderRetry?: LoaderRetryOptions
     /** How long to cache the value */
     refreshAgeMs?: number
     /** How long to cache null values */
@@ -264,7 +282,7 @@ export class LazyLoader<T> {
                         .then((keys) => {
                             // Pull out the keys to load and clear the buffer
                             logger.debug('[LazyLoader]', this.options.name, 'Loading: ', keys)
-                            return this.options.loader(keys)
+                            return this.invokeLoader(keys)
                         })
                         .then((map) => {
                             this.setValues(map)
@@ -310,6 +328,41 @@ export class LazyLoader<T> {
             result[key] = this.cache[key] ?? null
         }
         return result
+    }
+
+    /**
+     * Invoke the loader, optionally retrying transient failures.
+     *
+     * Each attempt re-invokes `loader(keys)` so the ids/tokens are re-evaluated against the source at
+     * retry time rather than reusing a stale result. Only retriable errors (`error.isRetriable === true`)
+     * are retried; anything else is rethrown immediately so genuine bugs surface rather than being masked.
+     */
+    private async invokeLoader(keys: string[]): Promise<LazyLoaderMap<T>> {
+        const retry = this.options.loaderRetry
+        if (!retry) {
+            return await this.options.loader(keys)
+        }
+
+        const deadline = Date.now() + retry.maxElapsedMs
+        let attempt = 0
+        for (;;) {
+            try {
+                return await this.options.loader(keys)
+            } catch (error) {
+                attempt++
+                if (error?.isRetriable !== true || Date.now() >= deadline) {
+                    // Only retry known-transient failures; rethrow anything else (and on budget exhaustion).
+                    throw error
+                }
+                const jitter = retry.retryJitterMs ? Math.floor(Math.random() * retry.retryJitterMs) : 0
+                logger.warn('🔁', `[LazyLoader:${this.options.name}] Loader failed, retrying`, {
+                    attempt,
+                    keys: keys.length,
+                    error: String(error),
+                })
+                await sleep(retry.retryIntervalMs + jitter)
+            }
+        }
     }
 
     private evictLRU(): void {

--- a/nodejs/src/utils/team-manager.ts
+++ b/nodejs/src/utils/team-manager.ts
@@ -2,21 +2,30 @@ import { Properties } from '~/plugin-scaffold'
 
 import { OrganizationAvailableFeature, ProjectId, Team } from '../types'
 import { PostgresRouter, PostgresUse } from './db/postgres'
-import { LazyLoader } from './lazy-loader'
+import { LazyLoader, LoaderRetryOptions } from './lazy-loader'
 import { captureTeamEvent } from './posthog'
 
 type RawTeam = Omit<Team, 'available_features'> & {
     available_product_features: { key: string; name: string }[]
 }
 
+export interface TeamManagerOptions {
+    /** Retry transient team-load failures (e.g. a Postgres pooler blip) instead of letting them propagate. */
+    loaderRetry?: LoaderRetryOptions
+}
+
 export class TeamManager {
     private lazyLoader: LazyLoader<Team>
 
-    constructor(private postgres: PostgresRouter) {
+    constructor(
+        private postgres: PostgresRouter,
+        options?: TeamManagerOptions
+    ) {
         this.lazyLoader = new LazyLoader({
             name: 'TeamManager',
             refreshAgeMs: 2 * 60 * 1000, // 2 minute
             refreshJitterMs: 30 * 1000, // 30 seconds
+            loaderRetry: options?.loaderRetry,
             loader: async (teamIdOrTokens: string[]) => {
                 return await this.fetchTeams(teamIdOrTokens)
             },


### PR DESCRIPTION
## Problem

`ingestion-analytics-main` workers were restarting on transient persons/common-Postgres pooler blips (`connect ECONNREFUSED …:6543`). The crash is an **unhandled promise rejection**:

- There is exactly one `TeamManager` in the analytics process (`ingestion-general-server.ts`), shared by the ingestion consumer (team resolution), `GroupTypeManager`, and the hog transformer's `HogWatcher`.
- Its `LazyLoader` runs the only `fetchTeams` call **detached inside the batching buffer** (`load()` schedules `loader([...])` via `setTimeout`). When that one background load rejects on a transient blip, a caller that doesn't await it surfaces the rejection as an unhandled rejection → `base-server.ts` → `process.exit(1)` → restart.

The crash stack roots at `dist/utils/lazy-loader.js:147` with no caller frames above it — the signature of a detached promise.

## Changes

- Add an **opt-in, configurable retry policy** to `LazyLoader` (`LoaderRetryOptions`): `retryIntervalMs`, `retryJitterMs`, `maxElapsedMs`. When set, a loader call that throws a **retriable** error (`error.isRetriable === true`) is retried until the time budget is exhausted, sleeping `interval + random(jitter)` between attempts.
- Each attempt **re-invokes the loader with the keys**, so the ids/tokens are re-evaluated against the database at retry time rather than reusing a stale result.
- **Non-retriable errors are rethrown immediately** (no masking of genuine bugs), and the original error is rethrown once the budget is exceeded.
- Forward the policy through `TeamManager` (new optional `TeamManagerOptions`), and **enable it only in the ingestion general server** (`{ retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 }`). All other `LazyLoader`/`TeamManager` consumers are unchanged (no retry).

Because all three consumers funnel into the same loader, retrying there absorbs a transient blip before it can reject — fixing both the unhandled-rejection crash and the awaited-path failures in one place.

## How did you test this code?

I'm an agent. Added unit tests in `lazy-loader.test.ts`: retries a retriable failure then succeeds (asserting the loader is re-invoked with the keys each attempt), does not retry a non-retriable failure, gives up and rethrows once `maxElapsedMs` is exceeded, and does not retry when unconfigured. Ran the `lazy-loader` suite (23 pass), plus `pnpm build` and `pnpm lint` clean. The `team-manager` suite needs a live Redis/Postgres so I couldn't run it locally; the constructor change is backwards compatible (options are optional). No manual/production testing performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Diagnosed from a 24h log export: 3 crashes, each a single `ECONNREFUSED` to the same pooler IP, spread across different pods — a transient pooler blip caught by whichever pod ran the background team load at the time. Established there is only one `fetchTeams` call (the LazyLoader loader) and one shared `TeamManager`, so the fix belongs at the loader rather than per-caller. Recovery is gated on `error.isRetriable === true` (the codebase's retry convention; only `DependencyUnavailableError` qualifies here) so an unflagged error still surfaces. The retry interval/jitter/budget were chosen to ride out a short pooler scale-down (~5s) without a thundering herd across pods.
