### PR TITLE
fix(frontend): treat WebKit "Importing a module script failed" as chunk-load error

### DIFF
--- a/frontend/src/lib/utils/isChunkLoadError.test.ts
+++ b/frontend/src/lib/utils/isChunkLoadError.test.ts
@@ -19,6 +19,11 @@ describe('isChunkLoadError', () => {
             { name: 'TypeError', message: 'error loading dynamically imported module: /static/chunk.js' },
             true,
         ],
+        [
+            'WebKit module-script load failure',
+            { name: 'TypeError', message: 'Importing a module script failed.' },
+            true,
+        ],
         ['generic TypeError', { name: 'TypeError', message: 'undefined is not a function' }, false],
         ['unrelated Error', { name: 'Error', message: 'something else' }, false],
         ['error with no name or message', {}, false],

--- a/frontend/src/lib/utils/isChunkLoadError.test.ts
+++ b/frontend/src/lib/utils/isChunkLoadError.test.ts
@@ -20,8 +20,13 @@ describe('isChunkLoadError', () => {
             true,
         ],
         [
-            'WebKit module-script load failure',
+            'WebKit module-script load failure (TypeError)',
             { name: 'TypeError', message: 'Importing a module script failed.' },
+            true,
+        ],
+        [
+            'WebKit module-script load failure (plain Error, not TypeError)',
+            { name: 'Error', message: 'Importing a module script failed.' },
             true,
         ],
         ['generic TypeError', { name: 'TypeError', message: 'undefined is not a function' }, false],

--- a/frontend/src/lib/utils/isChunkLoadError.ts
+++ b/frontend/src/lib/utils/isChunkLoadError.ts
@@ -5,6 +5,7 @@
  *   - Safari: native `TypeError: Load failed` (no JS stack — see load-failed.tsx known exception)
  *   - Firefox: native `TypeError: NetworkError when attempting to fetch resource.`
  *   - Firefox: native `TypeError: error loading dynamically imported module: <url>` (deferred import of a now-deleted chunk after a deploy)
+ *   - WebKit/Safari: `Importing a module script failed.` (module script fails to load, e.g. transient network failure)
  */
 export function isChunkLoadError(error: unknown): boolean {
     if (!error || typeof error !== 'object') {
@@ -16,6 +17,7 @@ export function isChunkLoadError(error: unknown): boolean {
     return (
         err.name === 'ChunkLoadError' ||
         message.includes('Failed to fetch dynamically imported module') ||
+        message.includes('Importing a module script failed') ||
         (isTypeError && message.includes('Load failed')) ||
         (isTypeError && message.includes('NetworkError when attempting to fetch resource')) ||
         (isTypeError && message.includes('error loading dynamically imported module'))


### PR DESCRIPTION
## Problem

After a deploy, stale lazy-loaded chunks can fail to load. The frontend recovers from this by reloading the page once (guarded against reload loops). Recovery is gated on a single classifier, `isChunkLoadError()`, consulted by both reload paths — the React `ChunkLoadErrorBoundary` and the async scene-navigation catch in `sceneLogic.tsx`.

WebKit/Safari, on a transient network failure while fetching a module script, throws an error whose message is `"Importing a module script failed."`. This variant was not recognized by `isChunkLoadError()` (the only Safari case handled was `TypeError: Load failed`), so these failures bypassed reload-recovery entirely and instead bubbled to the generic error-reporter UI — the user saw a crash screen instead of an automatic reload.

## Changes

- Added `message.includes('Importing a module script failed')` to `isChunkLoadError()`, matched directly (not gated behind a `TypeError` name check), consistent with the other unambiguous message-based matches. Because this helper is the single source of truth, the fix flows to both reload paths automatically.
- Documented the WebKit case in the function's JSDoc.
- Added a parameterized test row for the WebKit message.

## How did you test this code?

I'm an agent. I ran the automated unit test suite for the helper (`isChunkLoadError.test.ts`) — all 13 cases pass, including the new WebKit row. I ran the frontend formatter (clean, scoped to the two changed files) and `tsc --noEmit` (no errors in the changed file). No manual browser testing was performed.

## 🤖 Agent context

Authored with PostHog Code (Claude Code). The reporter suspected WebKit's "Importing a module script failed" errors were bypassing chunk-load reload-recovery. I confirmed it via codebase exploration: `isChunkLoadError()` is the shared classifier for both the React error boundary and the kea scene-loading catch, and the WebKit message string appeared nowhere in `frontend/src`. Chose to match the message directly rather than gate it behind the `TypeError` name, since the string is specific to module loading and WebKit may report it as a plain `Error` — gating risked missing it. Scoped the change to the single classifier to avoid duplicating logic across the two consumers.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
