### PR TITLE
feat(hobby): support BYO AI keys and gate cloud-only replay summaries

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -138,15 +138,18 @@ else
     # script (e.g. ANTHROPIC_API_KEY=... ./deploy-hobby) is used as-is without prompting.
     # Only prompt on an interactive terminal — a piped/non-interactive install
     # (CI, `curl | bash`) skips the prompts and relies on the env vars instead.
+    # Read silently (-s) — these are secrets and shouldn't echo to the terminal/scrollback.
     if [ -t 0 ] && [ -z "$ANTHROPIC_API_KEY" ]; then
         echo ""
         echo "PostHog's AI assistant (Max) runs on an Anthropic API key."
         echo "Enter one to enable Max now, or leave blank to skip (you can add it later):"
-        read -r ANTHROPIC_API_KEY
+        read -rs ANTHROPIC_API_KEY
+        echo
     fi
     if [ -t 0 ] && [ -z "$OPENAI_API_KEY" ]; then
         echo "Optionally enter an OpenAI API key to enable SQL and regex AI assist, or leave blank to skip:"
-        read -r OPENAI_API_KEY
+        read -rs OPENAI_API_KEY
+        echo
     fi
 
     POSTHOG_SECRET=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
@@ -160,9 +163,12 @@ REGISTRY_URL=$REGISTRY_URL
 CADDY_TLS_BLOCK=$TLS_BLOCK
 CADDY_HOST="$DOMAIN, http://, https://"
 POSTHOG_APP_TAG=$POSTHOG_APP_TAG
-ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
-OPENAI_API_KEY=$OPENAI_API_KEY
 EOF
+    # Only persist AI keys that were actually provided — writing a blank line
+    # (ANTHROPIC_API_KEY=) would make bin/upgrade-hobby think the key exists and
+    # skip its add-key prompt.
+    [ -n "$ANTHROPIC_API_KEY" ] && echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" >> .env
+    [ -n "$OPENAI_API_KEY" ] && echo "OPENAI_API_KEY=$OPENAI_API_KEY" >> .env
 fi
 
 # Download GeoLite2-City.mmdb if it doesn't exist

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -164,9 +164,11 @@ CADDY_TLS_BLOCK=$TLS_BLOCK
 CADDY_HOST="$DOMAIN, http://, https://"
 POSTHOG_APP_TAG=$POSTHOG_APP_TAG
 EOF
-    # Only persist AI keys that were actually provided — writing a blank line
-    # (ANTHROPIC_API_KEY=) would make bin/upgrade-hobby think the key exists and
-    # skip its add-key prompt.
+    # Only persist AI keys that were actually provided — skip writing a blank
+    # ANTHROPIC_API_KEY= line that would just clutter .env with an empty assignment.
+    # (A blank value is harmless either way: bin/upgrade-hobby greps for
+    # ^ANTHROPIC_API_KEY=.+, so an empty value counts as missing and the user is
+    # still offered the key on the next upgrade.)
     [ -n "$ANTHROPIC_API_KEY" ] && echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" >> .env
     [ -n "$OPENAI_API_KEY" ] && echo "OPENAI_API_KEY=$OPENAI_API_KEY" >> .env
 fi

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -141,8 +141,8 @@ else
     # Read silently (-s) — these are secrets and shouldn't echo to the terminal/scrollback.
     if [ -t 0 ] && [ -z "$ANTHROPIC_API_KEY" ]; then
         echo ""
-        echo "PostHog's AI assistant (Max) runs on an Anthropic API key."
-        echo "Enter one to enable Max now, or leave blank to skip (you can add it later):"
+        echo "PostHog AI runs on an Anthropic API key."
+        echo "Enter one to enable PostHog AI now, or leave blank to skip (you can add it later):"
         read -rs ANTHROPIC_API_KEY
         echo
     fi

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -132,6 +132,21 @@ fi
 if [ -f .env ]; then
     echo "Existing .env found, preserving configuration"
 else
+    # Optional AI provider keys. PostHog's AI features (the Max assistant, SQL/regex assist)
+    # run on your own LLM provider key. These are safe to leave blank now — you can add them
+    # to .env later and apply with bin/upgrade-hobby. An env var set before running this
+    # script (e.g. ANTHROPIC_API_KEY=... ./deploy-hobby) is used as-is without prompting.
+    if [ -z "$ANTHROPIC_API_KEY" ]; then
+        echo ""
+        echo "PostHog's AI assistant (Max) runs on an Anthropic API key."
+        echo "Enter one to enable Max now, or leave blank to skip (you can add it later):"
+        read -r ANTHROPIC_API_KEY
+    fi
+    if [ -z "$OPENAI_API_KEY" ]; then
+        echo "Optionally enter an OpenAI API key to enable SQL and regex AI assist, or leave blank to skip:"
+        read -r OPENAI_API_KEY
+    fi
+
     POSTHOG_SECRET=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
     ENCRYPTION_SALT_KEYS=$(openssl rand -hex 16)
     cat > .env <<EOF
@@ -143,6 +158,8 @@ REGISTRY_URL=$REGISTRY_URL
 CADDY_TLS_BLOCK=$TLS_BLOCK
 CADDY_HOST="$DOMAIN, http://, https://"
 POSTHOG_APP_TAG=$POSTHOG_APP_TAG
+ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+OPENAI_API_KEY=$OPENAI_API_KEY
 EOF
 fi
 

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -136,13 +136,15 @@ else
     # run on your own LLM provider key. These are safe to leave blank now — you can add them
     # to .env later and apply with bin/upgrade-hobby. An env var set before running this
     # script (e.g. ANTHROPIC_API_KEY=... ./deploy-hobby) is used as-is without prompting.
-    if [ -z "$ANTHROPIC_API_KEY" ]; then
+    # Only prompt on an interactive terminal — a piped/non-interactive install
+    # (CI, `curl | bash`) skips the prompts and relies on the env vars instead.
+    if [ -t 0 ] && [ -z "$ANTHROPIC_API_KEY" ]; then
         echo ""
         echo "PostHog's AI assistant (Max) runs on an Anthropic API key."
         echo "Enter one to enable Max now, or leave blank to skip (you can add it later):"
         read -r ANTHROPIC_API_KEY
     fi
-    if [ -z "$OPENAI_API_KEY" ]; then
+    if [ -t 0 ] && [ -z "$OPENAI_API_KEY" ]; then
         echo "Optionally enter an OpenAI API key to enable SQL and regex AI assist, or leave blank to skip:"
         read -r OPENAI_API_KEY
     fi

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -114,17 +114,21 @@ fi
 # If none is configured yet, offer to add one. Existing keys are never touched — we only append
 # when the key is absent, so this is safe to run on every upgrade.
 # Only prompt on an interactive terminal so a non-interactive upgrade doesn't block on stdin.
-if [ -t 0 ] && ! grep -q "ANTHROPIC_API_KEY" .env; then
+# Match `KEY=<value>` (note the trailing `.+`): a blank `KEY=` counts as missing, so a user who
+# skipped the key at install still gets prompted. Read silently (-s) — these are secrets.
+if [ -t 0 ] && ! grep -qE "^ANTHROPIC_API_KEY=.+" .env; then
     echo ""
     echo "PostHog's AI assistant (Max) runs on an Anthropic API key, which isn't configured yet."
-    read -r -p "Enter an Anthropic API key to enable Max (leave blank to skip): " ANTHROPIC_API_KEY_INPUT
+    read -rsp "Enter an Anthropic API key to enable Max (leave blank to skip): " ANTHROPIC_API_KEY_INPUT
+    echo
     if [ -n "$ANTHROPIC_API_KEY_INPUT" ]; then
         echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY_INPUT" >> .env
         echo "Added ANTHROPIC_API_KEY to .env file"
     fi
 fi
-if [ -t 0 ] && ! grep -q "OPENAI_API_KEY" .env; then
-    read -r -p "Enter an OpenAI API key to enable SQL and regex AI assist (leave blank to skip): " OPENAI_API_KEY_INPUT
+if [ -t 0 ] && ! grep -qE "^OPENAI_API_KEY=.+" .env; then
+    read -rsp "Enter an OpenAI API key to enable SQL and regex AI assist (leave blank to skip): " OPENAI_API_KEY_INPUT
+    echo
     if [ -n "$OPENAI_API_KEY_INPUT" ]; then
         echo "OPENAI_API_KEY=$OPENAI_API_KEY_INPUT" >> .env
         echo "Added OPENAI_API_KEY to .env file"

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -118,8 +118,8 @@ fi
 # skipped the key at install still gets prompted. Read silently (-s) — these are secrets.
 if [ -t 0 ] && ! grep -qE "^ANTHROPIC_API_KEY=.+" .env; then
     echo ""
-    echo "PostHog's AI assistant (Max) runs on an Anthropic API key, which isn't configured yet."
-    read -rsp "Enter an Anthropic API key to enable Max (leave blank to skip): " ANTHROPIC_API_KEY_INPUT
+    echo "PostHog AI runs on an Anthropic API key, which isn't configured yet."
+    read -rsp "Enter an Anthropic API key to enable PostHog AI (leave blank to skip): " ANTHROPIC_API_KEY_INPUT
     echo
     if [ -n "$ANTHROPIC_API_KEY_INPUT" ]; then
         echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY_INPUT" >> .env

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -110,6 +110,26 @@ else
     fi
 fi
 
+# PostHog's AI features (the Max assistant, SQL/regex assist) run on your own LLM provider key.
+# If none is configured yet, offer to add one. Existing keys are never touched — we only append
+# when the key is absent, so this is safe to run on every upgrade.
+if ! grep -q "ANTHROPIC_API_KEY" .env; then
+    echo ""
+    echo "PostHog's AI assistant (Max) runs on an Anthropic API key, which isn't configured yet."
+    read -r -p "Enter an Anthropic API key to enable Max (leave blank to skip): " ANTHROPIC_API_KEY_INPUT
+    if [ -n "$ANTHROPIC_API_KEY_INPUT" ]; then
+        echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY_INPUT" >> .env
+        echo "Added ANTHROPIC_API_KEY to .env file"
+    fi
+fi
+if ! grep -q "OPENAI_API_KEY" .env; then
+    read -r -p "Enter an OpenAI API key to enable SQL and regex AI assist (leave blank to skip): " OPENAI_API_KEY_INPUT
+    if [ -n "$OPENAI_API_KEY_INPUT" ]; then
+        echo "OPENAI_API_KEY=$OPENAI_API_KEY_INPUT" >> .env
+        echo "Added OPENAI_API_KEY to .env file"
+    fi
+fi
+
 # Check if session recording storage migration marker exists
 if ! grep -q "SESSION_RECORDING_STORAGE_MIGRATED_TO_SEAWEEDFS" .env; then
   echo ""

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -113,7 +113,8 @@ fi
 # PostHog's AI features (the Max assistant, SQL/regex assist) run on your own LLM provider key.
 # If none is configured yet, offer to add one. Existing keys are never touched — we only append
 # when the key is absent, so this is safe to run on every upgrade.
-if ! grep -q "ANTHROPIC_API_KEY" .env; then
+# Only prompt on an interactive terminal so a non-interactive upgrade doesn't block on stdin.
+if [ -t 0 ] && ! grep -q "ANTHROPIC_API_KEY" .env; then
     echo ""
     echo "PostHog's AI assistant (Max) runs on an Anthropic API key, which isn't configured yet."
     read -r -p "Enter an Anthropic API key to enable Max (leave blank to skip): " ANTHROPIC_API_KEY_INPUT
@@ -122,7 +123,7 @@ if ! grep -q "ANTHROPIC_API_KEY" .env; then
         echo "Added ANTHROPIC_API_KEY to .env file"
     fi
 fi
-if ! grep -q "OPENAI_API_KEY" .env; then
+if [ -t 0 ] && ! grep -q "OPENAI_API_KEY" .env; then
     read -r -p "Enter an OpenAI API key to enable SQL and regex AI assist (leave blank to skip): " OPENAI_API_KEY_INPUT
     if [ -n "$OPENAI_API_KEY_INPUT" ]; then
         echo "OPENAI_API_KEY=$OPENAI_API_KEY_INPUT" >> .env

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -103,6 +103,9 @@ services:
             PERSONHOG_ADDR: 'personhog-router:50052'
             PERSONHOG_ENABLED: 'true'
             PERSONHOG_ROLLOUT_PERCENTAGE: '100'
+            # AI provider keys for PostHog's AI features. Blank unless set in .env.
+            ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+            OPENAI_API_KEY: ${OPENAI_API_KEY:-}
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
         depends_on:
             db:
@@ -148,6 +151,9 @@ services:
             PERSONHOG_ADDR: 'personhog-router:50052'
             PERSONHOG_ENABLED: 'true'
             PERSONHOG_ROLLOUT_PERCENTAGE: '100'
+            # AI provider keys for PostHog's AI features. Blank unless set in .env.
+            ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+            OPENAI_API_KEY: ${OPENAI_API_KEY:-}
         depends_on:
             - db
             - redis7
@@ -389,6 +395,9 @@ services:
         environment:
             SITE_URL: https://$DOMAIN
             SECRET_KEY: $POSTHOG_SECRET
+            # AI provider keys for PostHog's AI features. Blank unless set in .env.
+            ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+            OPENAI_API_KEY: ${OPENAI_API_KEY:-}
         depends_on:
             - db
             - redis7

--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -29,6 +29,7 @@ import { SidePanelTab } from '~/types'
 
 import { AiFirstMaxInstance } from './components/AiFirstMaxInstance'
 import { AnimatedBackButton } from './components/AnimatedBackButton'
+import { MaxNotConfigured } from './components/MaxNotConfigured'
 import { SidebarQuestionInput } from './components/SidebarQuestionInput'
 import { SidebarQuestionInputWithSuggestions } from './components/SidebarQuestionInputWithSuggestions'
 import { ThreadAutoScroller } from './components/ThreadAutoScroller'
@@ -95,6 +96,7 @@ export const MaxInstance = React.memo(function MaxInstance({ sidePanel, tabId }:
     } = useValues(maxLogic(logicProps))
     const { startNewConversation, goBack } = useActions(maxLogic(logicProps))
     const { openSidePanelMax } = useActions(maxGlobalLogic)
+    const { isMaxAvailable } = useValues(maxGlobalLogic)
 
     const threadProps: MaxThreadLogicProps = {
         ...logicProps,
@@ -104,7 +106,9 @@ export const MaxInstance = React.memo(function MaxInstance({ sidePanel, tabId }:
 
     const { closeSidePanel } = useActions(sidePanelLogic)
 
-    const content = (
+    const content = !isMaxAvailable ? (
+        <MaxNotConfigured />
+    ) : (
         <BindLogic logic={maxLogic} props={logicProps}>
             <BindLogic logic={maxThreadLogic} props={threadProps}>
                 {conversationHistoryVisible ? (

--- a/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
+++ b/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
@@ -15,6 +15,7 @@ import { maxGlobalLogic } from '../maxGlobalLogic'
 import { maxLogic } from '../maxLogic'
 import { MaxThreadLogicProps, maxThreadLogic } from '../maxThreadLogic'
 import { Thread } from '../Thread'
+import { MaxNotConfigured } from './MaxNotConfigured'
 import { SidebarQuestionInputWithSuggestions } from './SidebarQuestionInputWithSuggestions'
 import { ThreadAutoScroller } from './ThreadAutoScroller'
 
@@ -91,6 +92,7 @@ interface AiFirstMaxInstanceProps {
 export function AiFirstMaxInstance({ tabId }: AiFirstMaxInstanceProps): JSX.Element {
     const { threadVisible, threadLogicKey, conversation, conversationId } = useValues(maxLogic({ panelId: tabId }))
     const { startNewConversation } = useActions(maxLogic({ panelId: tabId }))
+    const { isMaxAvailable } = useValues(maxGlobalLogic)
 
     const threadProps: MaxThreadLogicProps = {
         panelId: tabId,
@@ -104,12 +106,16 @@ export function AiFirstMaxInstance({ tabId }: AiFirstMaxInstanceProps): JSX.Elem
                 <BindLogic logic={maxThreadLogic} props={threadProps}>
                     <div className="flex flex-col grow overflow-hidden">
                         <ChatHeader conversationId={conversationId} tabId={tabId} />
-                        <ChatArea
-                            threadVisible={threadVisible}
-                            conversationId={conversationId}
-                            conversation={conversation}
-                            onStartNewConversation={startNewConversation}
-                        />
+                        {isMaxAvailable ? (
+                            <ChatArea
+                                threadVisible={threadVisible}
+                                conversationId={conversationId}
+                                conversation={conversation}
+                                onStartNewConversation={startNewConversation}
+                            />
+                        ) : (
+                            <MaxNotConfigured />
+                        )}
                     </div>
                 </BindLogic>
             </BindLogic>

--- a/frontend/src/scenes/max/components/MaxNotConfigured.tsx
+++ b/frontend/src/scenes/max/components/MaxNotConfigured.tsx
@@ -21,8 +21,8 @@ export function MaxNotConfigured(): JSX.Element {
                     PostHog AI isn't set up yet
                 </h2>
                 <p className="text-sm text-tertiary text-pretty mb-0">
-                    Max runs on your own LLM provider key. Set <code>ANTHROPIC_API_KEY</code> for this instance and
-                    restart PostHog to start chatting.
+                    PostHog AI runs on your own LLM provider key. Set <code>ANTHROPIC_API_KEY</code> for this instance
+                    and restart PostHog to start chatting.
                 </p>
             </div>
             <CodeSnippet language={Language.Bash} className="w-full text-left">

--- a/frontend/src/scenes/max/components/MaxNotConfigured.tsx
+++ b/frontend/src/scenes/max/components/MaxNotConfigured.tsx
@@ -1,4 +1,4 @@
-import { IconKey } from '@posthog/icons'
+import { IconLock } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 
 import { Logomark } from 'lib/brand/Logomark'
@@ -17,7 +17,7 @@ export function MaxNotConfigured(): JSX.Element {
             </div>
             <div>
                 <h2 className="text-xl font-bold mb-2 flex items-center justify-center gap-2">
-                    <IconKey />
+                    <IconLock />
                     PostHog AI isn't set up yet
                 </h2>
                 <p className="text-sm text-tertiary text-pretty mb-0">
@@ -29,8 +29,8 @@ export function MaxNotConfigured(): JSX.Element {
                 ANTHROPIC_API_KEY=sk-ant-...
             </CodeSnippet>
             <p className="text-sm text-tertiary text-pretty mb-0">
-                On a hobby deploy, add the key to your <code>.env</code> file and run{' '}
-                <code>./bin/upgrade-hobby</code>, or set it during install.{' '}
+                On a hobby deploy, add the key to your <code>.env</code> file and run <code>./bin/upgrade-hobby</code>,
+                or set it during install.{' '}
                 <Link
                     to="https://posthog.com/docs/self-host/configure/environment-variables?utm_medium=in-product&utm_campaign=max-not-configured"
                     target="_blank"

--- a/frontend/src/scenes/max/components/MaxNotConfigured.tsx
+++ b/frontend/src/scenes/max/components/MaxNotConfigured.tsx
@@ -35,6 +35,7 @@ export function MaxNotConfigured(): JSX.Element {
                     to="https://posthog.com/docs/self-host/configure/environment-variables?utm_medium=in-product&utm_campaign=max-not-configured"
                     target="_blank"
                     targetBlankIcon
+                    data-attr="max-not-configured-configure-key"
                 >
                     Configuring environment variables
                 </Link>

--- a/frontend/src/scenes/max/components/MaxNotConfigured.tsx
+++ b/frontend/src/scenes/max/components/MaxNotConfigured.tsx
@@ -1,0 +1,44 @@
+import { IconKey } from '@posthog/icons'
+import { Link } from '@posthog/lemon-ui'
+
+import { Logomark } from 'lib/brand/Logomark'
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+
+/**
+ * Shown when PostHog AI (Max) is rendered on a self-hosted instance with no LLM provider key
+ * configured. Max runs on Anthropic, so without ANTHROPIC_API_KEY it would otherwise fail at
+ * call time — here we tell the user how to enable it instead.
+ */
+export function MaxNotConfigured(): JSX.Element {
+    return (
+        <div className="flex flex-col items-center justify-center text-center grow gap-4 px-4 py-8 max-w-prose mx-auto">
+            <div className="flex *:h-full *:w-12 p-2 select-none opacity-60">
+                <Logomark />
+            </div>
+            <div>
+                <h2 className="text-xl font-bold mb-2 flex items-center justify-center gap-2">
+                    <IconKey />
+                    PostHog AI isn't set up yet
+                </h2>
+                <p className="text-sm text-tertiary text-pretty mb-0">
+                    Max runs on your own LLM provider key. Set <code>ANTHROPIC_API_KEY</code> for this instance and
+                    restart PostHog to start chatting.
+                </p>
+            </div>
+            <CodeSnippet language={Language.Bash} className="w-full text-left">
+                ANTHROPIC_API_KEY=sk-ant-...
+            </CodeSnippet>
+            <p className="text-sm text-tertiary text-pretty mb-0">
+                On a hobby deploy, add the key to your <code>.env</code> file and run{' '}
+                <code>./bin/upgrade-hobby</code>, or set it during install.{' '}
+                <Link
+                    to="https://posthog.com/docs/self-host/configure/environment-variables?utm_medium=in-product&utm_campaign=max-not-configured"
+                    target="_blank"
+                    targetBlankIcon
+                >
+                    Configuring environment variables
+                </Link>
+            </p>
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/maxGlobalLogic.test.ts
+++ b/frontend/src/scenes/max/maxGlobalLogic.test.ts
@@ -1,6 +1,8 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
@@ -66,6 +68,27 @@ describe('maxGlobalLogic', () => {
                 sidePanelMax?.unmount()
             }
         )
+    })
+
+    describe('isMaxAvailable selector', () => {
+        it.each([
+            { realm: 'a not-yet-loaded preflight', preflight: null, expected: true },
+            { realm: 'PostHog Cloud', preflight: { cloud: true }, expected: true },
+            {
+                realm: 'self-hosted with an Anthropic key',
+                preflight: { cloud: false, is_debug: false, anthropic_available: true },
+                expected: true,
+            },
+            {
+                realm: 'self-hosted without a key',
+                preflight: { cloud: false, is_debug: false, anthropic_available: false },
+                expected: false,
+            },
+        ])('is $expected on $realm', async ({ preflight, expected }) => {
+            preflightLogic.actions.loadPreflightSuccess(preflight as any)
+
+            await expectLogic(logic).toMatchValues({ isMaxAvailable: expected })
+        })
     })
 
     describe('editInsightToolRegistered selector', () => {

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -240,8 +240,7 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
         // before preflight resolves — once loaded we gate on cloud/dev or the key being present.
         isMaxAvailable: [
             (s) => [s.isCloudOrDev, s.preflight],
-            (isCloudOrDev, preflight): boolean =>
-                !preflight || !!isCloudOrDev || !!preflight.anthropic_available,
+            (isCloudOrDev, preflight): boolean => !preflight || !!isCloudOrDev || !!preflight.anthropic_available,
         ],
         dataProcessingApprovalDisabledReason: [
             (s) => [s.currentOrganization],

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -236,9 +236,12 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
         ],
         // On Cloud/dev a provider key is always present. On a self-hosted (hobby) instance Max only
         // works once ANTHROPIC_API_KEY is configured, so we surface a "set the key" state instead.
+        // Treat a not-yet-loaded preflight (null) as available so the empty-state doesn't flash
+        // before preflight resolves — once loaded we gate on cloud/dev or the key being present.
         isMaxAvailable: [
             (s) => [s.isCloudOrDev, s.preflight],
-            (isCloudOrDev, preflight): boolean => !!isCloudOrDev || !!preflight?.anthropic_available,
+            (isCloudOrDev, preflight): boolean =>
+                !preflight || !!isCloudOrDev || !!preflight.anthropic_available,
         ],
         dataProcessingApprovalDisabledReason: [
             (s) => [s.currentOrganization],

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -9,6 +9,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -89,6 +90,8 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
             ['featureFlags'],
             sidePanelStateLogic,
             ['sidePanelOpen', 'selectedTab'],
+            preflightLogic,
+            ['preflight', 'isCloudOrDev'],
         ],
         actions: [router, ['locationChanged'], sidePanelStateLogic, ['openSidePanel']],
     })),
@@ -230,6 +233,12 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
         dataProcessingAccepted: [
             (s) => [s.currentOrganization],
             (currentOrganization): boolean => !!currentOrganization?.is_ai_data_processing_approved,
+        ],
+        // On Cloud/dev a provider key is always present. On a self-hosted (hobby) instance Max only
+        // works once ANTHROPIC_API_KEY is configured, so we surface a "set the key" state instead.
+        isMaxAvailable: [
+            (s) => [s.isCloudOrDev, s.preflight],
+            (isCloudOrDev, preflight): boolean => !!isCloudOrDev || !!preflight?.anthropic_available,
         ],
         dataProcessingApprovalDisabledReason: [
             (s) => [s.currentOrganization],

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/notebookNodePersonFeedLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/notebookNodePersonFeedLogic.test.ts
@@ -2,6 +2,7 @@ import { MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { expectLogic } from 'kea-test-utils'
 
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SessionSummaryContent } from 'scenes/session-recordings/player/player-meta/types'
 
 import { useMocks } from '~/mocks/jest'
@@ -249,11 +250,16 @@ describe('notebookNodePersonFeedLogic', () => {
     })
 
     describe('canSummarize selector', () => {
-        it('returns true', async () => {
+        // AI session summaries are PostHog Cloud only, so the block is gated on isCloudOrDev.
+        it.each([
+            { realm: 'PostHog Cloud', preflight: { cloud: true }, expected: true },
+            { realm: 'self-hosted', preflight: { cloud: false, is_debug: false }, expected: false },
+        ])('is $expected on $realm', async ({ preflight, expected }) => {
             logic = notebookNodePersonFeedLogic({ personId: 'test-person-123' })
             logic.mount()
+            preflightLogic.actions.loadPreflightSuccess(preflight as any)
 
-            expect(logic.values.canSummarize).toBe(true)
+            expect(logic.values.canSummarize).toBe(expected)
         })
     })
 

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/notebookNodePersonFeedLogic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/notebookNodePersonFeedLogic.ts
@@ -1,8 +1,9 @@
-import { actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 import { pluralize } from 'lib/utils'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SessionSummaryContent } from 'scenes/session-recordings/player/player-meta/types'
 
 import { performQuery } from '~/queries/query'
@@ -21,6 +22,10 @@ export const notebookNodePersonFeedLogic = kea<notebookNodePersonFeedLogicType>(
     props({} as NotebookNodePersonFeedLogicProps),
     path((key) => ['scenes', 'notebooks', 'Notebook', 'Nodes', 'notebookNodePersonFeedLogic', key]),
     key(({ personId }) => personId),
+
+    connect(() => ({
+        values: [preflightLogic, ['isCloudOrDev']],
+    })),
 
     actions({
         summarizeSessions: true,
@@ -90,7 +95,8 @@ export const notebookNodePersonFeedLogic = kea<notebookNodePersonFeedLogicType>(
     })),
 
     selectors({
-        canSummarize: [() => [], () => true],
+        // AI session summaries are PostHog Cloud only, so hide the whole block on self-hosted.
+        canSummarize: [(s) => [s.isCloudOrDev], (isCloudOrDev): boolean => !!isCloudOrDev],
         numSessionsWithRecording: [
             (s) => [s.sessionIdsWithRecording],
             (sessionIdsWithRecording) => sessionIdsWithRecording.length,

--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
@@ -11,6 +11,7 @@ import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerL
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 
 import { sessionRecordingEventUsageLogic } from '../sessionRecordingEventUsageLogic'
@@ -73,6 +74,7 @@ function formatSessionSummary(summary: SessionSummaryContent, sessionId: string)
 
 export function PlayerSummaryDock(): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
+    const { isCloudOrDev } = useValues(preflightLogic)
     const { logicProps, sessionRecordingId, sessionPlayerData } = useValues(sessionRecordingPlayerLogic)
     const {
         sessionSummary,
@@ -156,6 +158,18 @@ export function PlayerSummaryDock(): JSX.Element | null {
                         data-attr="cancel-session-summary"
                     >
                         Cancel summarization
+                    </LemonButton>
+                ) : !isCloudOrDev ? (
+                    // AI session summaries run on PostHog Cloud only — show the standard upsell.
+                    <LemonButton
+                        size="small"
+                        type="secondary"
+                        icon={<IconMagicWand />}
+                        to={urls.moveToPostHogCloud()}
+                        tooltip="AI session summaries are available on PostHog Cloud"
+                        data-attr="session-summary-move-to-cloud"
+                    >
+                        Summarize with PostHog Cloud
                     </LemonButton>
                 ) : (
                     <LemonButton

--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
@@ -166,7 +166,7 @@ export function PlayerSummaryDock(): JSX.Element | null {
                         type="secondary"
                         icon={<IconMagicWand />}
                         to={urls.moveToPostHogCloud()}
-                        tooltip="AI session summaries are available on PostHog Cloud"
+                        tooltip="AI session summaries are a PostHog Cloud feature (separate from Max, which runs on your own provider key)"
                         data-attr="session-summary-move-to-cloud"
                     >
                         Summarize with PostHog Cloud

--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
@@ -166,7 +166,7 @@ export function PlayerSummaryDock(): JSX.Element | null {
                         type="secondary"
                         icon={<IconMagicWand />}
                         to={urls.moveToPostHogCloud()}
-                        tooltip="AI session summaries are a PostHog Cloud feature (separate from Max, which runs on your own provider key)"
+                        tooltip="AI session summaries are a PostHog Cloud feature (separate from PostHog AI, which runs on your own provider key)"
                         data-attr="session-summary-move-to-cloud"
                     >
                         Summarize with PostHog Cloud

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
@@ -26,6 +26,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { colonDelimitedDuration } from 'lib/utils'
 import { DraggableToNotebook } from 'scenes/notebooks/AddToNotebook/DraggableToNotebook'
 import { asDisplay } from 'scenes/persons/person-utils'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SimpleTimeLabel } from 'scenes/session-recordings/components/SimpleTimeLabel'
 import { countryTitleFrom } from 'scenes/session-recordings/player/player-meta/playerMetaLogic'
 import { TimestampFormat, playerSettingsLogic } from 'scenes/session-recordings/player/playerSettingsLogic'
@@ -275,6 +276,7 @@ const RecordingSummaryIcon = memo(function RecordingSummaryIcon({
 }): JSX.Element | null {
     const { loadingBySessionId, summaryBySessionId } = useValues(sessionSummaryProgressLogic)
     const { startSummarization } = useActions(sessionSummaryProgressLogic)
+    const { isCloudOrDev } = useValues(preflightLogic)
 
     const isSummarizing = !!loadingBySessionId[recording.id]
     const summaryOutcome = selectOutcome([summaryBySessionId[recording.id]?.session_outcome, recording.summary_outcome])
@@ -302,6 +304,11 @@ const RecordingSummaryIcon = memo(function RecordingSummaryIcon({
                 </span>
             </Tooltip>
         )
+    }
+    // AI summaries are PostHog Cloud only — hide the per-row trigger on self-hosted. The upsell
+    // lives on the replay page dock (PlayerSummaryDock) rather than repeating per list row.
+    if (!isCloudOrDev) {
+        return null
     }
     return (
         <LemonButton

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4397,6 +4397,7 @@ export interface PreflightStatus {
     is_test?: boolean
     licensed_users_available?: number | null
     openai_available?: boolean
+    anthropic_available?: boolean
     site_url?: string
     instance_preferences?: InstancePreferencesInterface
     buffer_conversion_seconds?: number

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -69,6 +69,7 @@ class TestPreflight(APIBaseTest, QueryMatchingTest):
             # we calculate this here because otherwise it is non-deterministic when running locally
             # it can be overridden in tests by passing in options
             "openai_available": bool(os.environ.get("OPENAI_API_KEY")),
+            "anthropic_available": bool(os.environ.get("ANTHROPIC_API_KEY")),
             "is_test": True,
             **options,
         }

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -242,6 +242,9 @@ def preflight_check(request: HttpRequest) -> JsonResponse:
             if not in_cloud
             else None,
             "openai_available": bool(os.environ.get("OPENAI_API_KEY")),
+            # Max runs on Anthropic, so it needs its own signal — otherwise self-hosted instances
+            # render the assistant but fail at call time with no key configured.
+            "anthropic_available": bool(os.environ.get("ANTHROPIC_API_KEY")),
             "site_url": settings.SITE_URL,
             "instance_preferences": settings.INSTANCE_PREFERENCES,
             "buffer_conversion_seconds": settings.BUFFER_CONVERSION_SECONDS,


### PR DESCRIPTION
## Problem

We advertise PostHog's AI surface on self-hosted (hobby) installs, but it's broken-not-hidden:

- **Max** (the main assistant) runs on Anthropic (`claude-sonnet-*`), reading `ANTHROPIC_API_KEY` from the environment — yet the only AI signal we expose to the frontend is `openai_available`, and the only key any install/upgrade flow prompts for is OpenAI. So on hobby the Max tab renders, the user types a message, and gets a **raw auth error at call time** because no key is configured and nothing told them to set one.
- **Session-replay AI summaries** are Cloud-only on the backend, but the frontend triggers (player dock, per-row playlist icon, notebook person-feed) are visible on self-hosted and surface that restriction as a `lemonToast.error` rather than a proper paywall.

This makes AI on hobby a real bring-your-own-key experience, and replaces the replay error with the standard move-to-cloud upsell.

## Changes

**Make Max work on hobby (BYO key):**

- Backend: add an `anthropic_available` flag to the authenticated preflight (mirrors the existing `openai_available`), since Max needs Anthropic and had no signal at all.
- Frontend: add an `isMaxAvailable` selector to `maxGlobalLogic` (`isCloudOrDev || anthropic_available`) and render a `MaxNotConfigured` empty-state in both Max render paths when it's a self-hosted instance with no key — telling the user to set `ANTHROPIC_API_KEY` and restart, instead of failing silently.
- Install/upgrade DevEx: `bin/deploy-hobby` optionally prompts for Anthropic + OpenAI keys on a fresh install; `bin/upgrade-hobby` offers to append them only when absent (existing keys are never overwritten — the established append-if-missing pattern). The vars are threaded into the `web`, `worker`, and `temporal-django-worker` services in `docker-compose.hobby.yml` via `${VAR:-}` so a blank stays blank.

**Gate replay summaries behind the cloud upsell on hobby:**

- The backend stays the boundary (still Cloud-only). The player dock now shows the standard "move to PostHog Cloud" link instead of the summarize button on self-hosted; the per-row playlist icon and the notebook person-feed summary block are hidden on self-hosted (the dock carries the upsell rather than repeating a paywall per list row).
- Note: a billing-style `PayGateMini` was intentionally **not** used here — this feature isn't billing-gated on Cloud, so the simple `isCloudOrDev` + move-to-cloud link (the same pattern as the Help/Account menus) is the correct gate.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not perform manual UI testing.

- Updated and reviewed `posthog/api/test/test_preflight.py` to assert the new `anthropic_available` field. I could **not** execute the DB-backed test suite in this environment (no local Postgres) — CI should run it; the test change mirrors the existing `openai_available` assertion exactly.
- `bash -n` syntax-checked `bin/deploy-hobby` and `bin/upgrade-hobby`.
- Ran `ruff check`/`ruff format` on the Python changes (clean). The frontend formatter/typecheck could not run here (no `node_modules`); import ordering was set by hand to match oxfmt conventions.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The self-host environment-variables docs may want an entry for `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` enabling AI features — flagging for the docs agent.

## 🤖 Agent context

Authored by the PostHog Slack app agent at a maintainer's request. The ask: propose and implement a solution for setting AI provider keys on hobby installs — DevEx at install/upgrade time plus UI treatment.

Key decisions:
- **Show + prompt, not hide** for Max — keep the surface visible with a clear "set the key" empty-state.
- **Anthropic is the headline gap** — Max can't run without it, and we exposed no signal for it. OpenAI features already had a BYOK path (`openai_available` + existing "set OPENAI_API_KEY" messages), so they're unchanged.
- **Replay summaries stay Cloud-only** per maintainer direction — surfaced as the standard move-to-cloud upsell rather than enabling BYOK for them.
- Rejected `PayGateMini` for the replay gate because it gates by billing plan on Cloud, which would wrongly block Cloud users of a non-billing-gated feature.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
