### PR TITLE
fix: TypeError from from unpin callback when chart not connected

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -630,6 +630,10 @@ const LegacyLineGraph = ({
                     showTooltip()
 
                     pinTooltip(() => {
+                        if (!chart.canvas?.isConnected) {
+                            return
+                        }
+
                         // Hide crosshair on tooltip unpin
                         if ((chart as any).crosshair) {
                             ;(chart as any).crosshair.enabled = false


### PR DESCRIPTION
## Problem

Fixes https://us.posthog.com/project/2/error_tracking/019d20a5-025c-7a92-a760-70387850a5fa?timestamp=2026-06-04%2013%3A47%3A05.444000-07%3A00 as reported in https://posthoghelp.zendesk.com/agent/tickets/59742. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/60590)

Unable to reproduce this locally.

## Changes

Return early from callback if chart canvas has already been disconnected.