### PR TITLE
feat(signals): add MCP tool to set scout emit posture

### DIFF
--- a/products/signals/backend/scout_harness/serializers.py
+++ b/products/signals/backend/scout_harness/serializers.py
@@ -845,3 +845,65 @@ class SignalScoutConfigSerializer(serializers.ModelSerializer):
         model = SignalScoutConfig
         fields = ["id", "skill_name", "enabled", "emit", "run_interval_minutes", "last_run_at", "created_at"]
         read_only_fields = ["id", "created_at"]
+
+
+class SignalScoutSetEmitSerializer(serializers.Serializer):
+    """Request to flip scout `emit` for one scout or every scout on the project."""
+
+    emit = serializers.BooleanField(
+        help_text=(
+            "Target emit posture. True lets the scout(s) write findings to the inbox; False is "
+            "dry-run — the scout still runs and records findings but emits nothing."
+        )
+    )
+    skill_name = serializers.CharField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text=(
+            "A single `signals-scout-*` skill to target. Omit or pass null to apply to every scout "
+            "config on the project."
+        ),
+    )
+    ensure_source = serializers.BooleanField(
+        required=False,
+        default=True,
+        help_text=(
+            "When enabling emit, also enable the project's `signals_scout` / `cross_source_issue` "
+            "SignalSourceConfig — the team-level source gate that emit also requires. Ignored when "
+            "emit is False."
+        ),
+    )
+
+
+class SignalScoutConfigEmitStatusSerializer(serializers.Serializer):
+    """One scout's emit posture after a set-emit call."""
+
+    skill_name = serializers.CharField(help_text="The `signals-scout-*` skill this status is for.")
+    emit = serializers.BooleanField(help_text="The scout's emit posture after the update.")
+
+
+class SignalScoutSetEmitResponseSerializer(serializers.Serializer):
+    """Emit-readiness for the project after a set-emit call — the three gates emit requires."""
+
+    configs = SignalScoutConfigEmitStatusSerializer(
+        many=True, help_text="Per-scout emit posture after the update, for the targeted scouts, ordered by skill name."
+    )
+    source_enabled = serializers.BooleanField(
+        help_text=(
+            "Whether the project's `signals_scout` / `cross_source_issue` SignalSourceConfig is enabled "
+            "(the team-level source gate)."
+        )
+    )
+    ai_processing_approved = serializers.BooleanField(
+        help_text=(
+            "Whether the project's organization has approved AI data processing. Emit also requires this; "
+            "it is an org setting and is not changed by this endpoint."
+        )
+    )
+    emit_effective = serializers.BooleanField(
+        help_text=(
+            "Whether emitted findings will actually reach the inbox: true only when at least one scout on "
+            "the project has emit=True and both `source_enabled` and `ai_processing_approved` hold."
+        )
+    )

--- a/products/signals/backend/scout_harness/views.py
+++ b/products/signals/backend/scout_harness/views.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 import uuid
 
+from django.db import transaction
+
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import exceptions, status, viewsets
 from rest_framework.decorators import action
@@ -37,9 +39,10 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 # password-only user in a 2FA-enforced org read scout runs/scratchpad without
 # completing 2FA.
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
+from posthog.models import Team
 from posthog.permissions import APIScopePermission
 
-from products.signals.backend.models import SignalProjectProfile, SignalScoutConfig, SignalScoutRun
+from products.signals.backend.models import SignalProjectProfile, SignalScoutConfig, SignalScoutRun, SignalSourceConfig
 from products.signals.backend.scout_harness.serializers import (
     EmitFindingRequestSerializer,
     EmitFindingResponseSerializer,
@@ -55,6 +58,8 @@ from products.signals.backend.scout_harness.serializers import (
     SignalScoutConfigSerializer,
     SignalScoutRunDetailSerializer,
     SignalScoutRunSummarySerializer,
+    SignalScoutSetEmitResponseSerializer,
+    SignalScoutSetEmitSerializer,
 )
 from products.signals.backend.scout_harness.tools.emit import EvidenceEntry, InvalidEmitError, emit_finding_sync
 from products.signals.backend.scout_harness.tools.profile import get_project_profile
@@ -546,3 +551,71 @@ class SignalScoutConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             save_kwargs["enabled_by"] = request.user
         instance = serializer.save(**save_kwargs)
         return Response(SignalScoutConfigSerializer(instance).data)
+
+    @extend_schema(
+        request=SignalScoutSetEmitSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=SignalScoutSetEmitResponseSerializer,
+                description="Emit posture applied; the project's emit-readiness is returned.",
+            ),
+            404: OpenApiResponse(description="No matching scout config for this project."),
+        },
+        summary="Set scout emit posture",
+        description=(
+            "Flip `emit` on one scout (`skill_name`) or every scout on the project in one call. When "
+            "enabling, optionally also enable the project's `signals_scout` / `cross_source_issue` source "
+            "gate (`ensure_source`, default true) that emit requires. Returns the project's full "
+            "emit-readiness, including the org AI-data-processing approval that emit also requires but this "
+            "endpoint cannot set. Emitting drives spend, so config changes are activity-logged."
+        ),
+        operation_id="signals_scout_set_emit",
+    )
+    @action(detail=False, methods=["post"], url_path="set-emit", required_scopes=["signal_scout:write"])
+    def set_emit(self, request: Request, *args, **kwargs) -> Response:
+        serializer = SignalScoutSetEmitSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        emit = serializer.validated_data["emit"]
+        skill_name = serializer.validated_data["skill_name"]
+        ensure_source = serializer.validated_data["ensure_source"]
+        team_id = _canonical_team_id(self)
+
+        configs_qs = SignalScoutConfig.objects.unscoped().filter(team_id=team_id)
+        if skill_name:
+            configs_qs = configs_qs.filter(skill_name=skill_name)
+        configs = list(configs_qs.order_by("skill_name"))
+        if not configs:
+            raise exceptions.NotFound("No matching scout config for this project.")
+
+        with transaction.atomic():
+            for config in configs:
+                if config.emit != emit:
+                    config.emit = emit
+                    config.save()  # full save so ModelActivityMixin logs the emit change
+            if emit and ensure_source:
+                source, created = SignalSourceConfig.objects.get_or_create(
+                    team_id=team_id,
+                    source_product=SignalSourceConfig.SourceProduct.SIGNALS_SCOUT,
+                    source_type=SignalSourceConfig.SourceType.CROSS_SOURCE_ISSUE,
+                    defaults={"enabled": True, "created_by": request.user},
+                )
+                if not created and not source.enabled:
+                    source.enabled = True
+                    source.save(update_fields=["enabled", "updated_at"])
+
+        source_enabled = SignalSourceConfig.is_source_enabled(
+            team_id,
+            SignalSourceConfig.SourceProduct.SIGNALS_SCOUT,
+            SignalSourceConfig.SourceType.CROSS_SOURCE_ISSUE,
+        )
+        ai_processing_approved = bool(
+            Team.objects.values_list("organization__is_ai_data_processing_approved", flat=True).get(id=team_id)
+        )
+        any_emit = SignalScoutConfig.objects.unscoped().filter(team_id=team_id, emit=True).exists()
+        payload = {
+            "configs": [{"skill_name": config.skill_name, "emit": config.emit} for config in configs],
+            "source_enabled": source_enabled,
+            "ai_processing_approved": ai_processing_approved,
+            "emit_effective": any_emit and source_enabled and ai_processing_approved,
+        }
+        return Response(SignalScoutSetEmitResponseSerializer(payload).data)

--- a/products/signals/backend/scout_harness/views.py
+++ b/products/signals/backend/scout_harness/views.py
@@ -583,11 +583,14 @@ class SignalScoutConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         configs_qs = SignalScoutConfig.objects.unscoped().filter(team_id=team_id)
         if skill_name:
             configs_qs = configs_qs.filter(skill_name=skill_name)
-        configs = list(configs_qs.order_by("skill_name"))
-        if not configs:
-            raise exceptions.NotFound("No matching scout config for this project.")
 
         with transaction.atomic():
+            # Lock the rows and re-read inside the transaction: `save()` writes the full row, so a
+            # concurrent PATCH (e.g. run_interval_minutes) between a pre-fetch and the save would be
+            # clobbered. select_for_update serializes against those writes.
+            configs = list(configs_qs.select_for_update().order_by("skill_name"))
+            if not configs:
+                raise exceptions.NotFound("No matching scout config for this project.")
             for config in configs:
                 if config.emit != emit:
                     config.emit = emit

--- a/products/signals/backend/test/test_scout_harness_api.py
+++ b/products/signals/backend/test/test_scout_harness_api.py
@@ -18,7 +18,13 @@ from posthog.temporal.oauth import (
     create_oauth_access_token_for_user,
 )
 
-from products.signals.backend.models import SignalProjectProfile, SignalScoutConfig, SignalScoutRun, SignalScratchpad
+from products.signals.backend.models import (
+    SignalProjectProfile,
+    SignalScoutConfig,
+    SignalScoutRun,
+    SignalScratchpad,
+    SignalSourceConfig,
+)
 from products.signals.backend.scout_harness.tools.profile import compute_project_profile
 from products.tasks.backend.models import Task, TaskRun
 
@@ -524,4 +530,106 @@ class TestScoutHarnessConfigAPI(APIBaseTest):
         other_team = Team.objects.create(organization=self.organization, name="other")
         config = SignalScoutConfig.all_teams.create(team=other_team, skill_name="signals-scout-foo")
         response = self.client.patch(self._detail_url(str(config.id)), data={"enabled": False}, format="json")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def _set_emit_url(self) -> str:
+        return f"/api/projects/{self.team.id}/signals/scout/configs/set-emit/"
+
+    def _approve_ai(self) -> None:
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
+    def _scout_source(self) -> SignalSourceConfig | None:
+        return SignalSourceConfig.objects.filter(
+            team_id=self.team.id,
+            source_product=SignalSourceConfig.SourceProduct.SIGNALS_SCOUT,
+            source_type=SignalSourceConfig.SourceType.CROSS_SOURCE_ISSUE,
+        ).first()
+
+    def test_set_emit_all_scouts_enables_emit_and_source(self) -> None:
+        self._approve_ai()
+        SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-alpha")
+        SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-beta")
+
+        response = self.client.post(self._set_emit_url(), data={"emit": True}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert [(c["skill_name"], c["emit"]) for c in body["configs"]] == [
+            ("signals-scout-alpha", True),
+            ("signals-scout-beta", True),
+        ]
+        assert body["source_enabled"] is True
+        assert body["ai_processing_approved"] is True
+        assert body["emit_effective"] is True
+        assert SignalScoutConfig.objects.filter(team_id=self.team.id, emit=True).count() == 2
+        source = self._scout_source()
+        assert source is not None and source.enabled is True
+
+    def test_set_emit_targets_a_single_scout_by_skill_name(self) -> None:
+        self._approve_ai()
+        alpha = SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-alpha")
+        beta = SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-beta")
+
+        response = self.client.post(
+            self._set_emit_url(), data={"emit": True, "skill_name": "signals-scout-alpha"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [c["skill_name"] for c in response.json()["configs"]] == ["signals-scout-alpha"]
+        alpha.refresh_from_db()
+        beta.refresh_from_db()
+        assert alpha.emit is True
+        assert beta.emit is False
+
+    def test_set_emit_false_is_dry_run_and_leaves_source_untouched(self) -> None:
+        self._approve_ai()
+        config = SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-alpha", emit=True)
+        SignalSourceConfig.objects.create(
+            team=self.team,
+            source_product=SignalSourceConfig.SourceProduct.SIGNALS_SCOUT,
+            source_type=SignalSourceConfig.SourceType.CROSS_SOURCE_ISSUE,
+            enabled=True,
+        )
+
+        response = self.client.post(self._set_emit_url(), data={"emit": False}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        config.refresh_from_db()
+        assert config.emit is False
+        assert body["emit_effective"] is False  # nothing emits now
+        # disabling emit doesn't touch the source row
+        source = self._scout_source()
+        assert source is not None and source.enabled is True
+
+    def test_set_emit_ensure_source_false_does_not_create_source(self) -> None:
+        self._approve_ai()
+        SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-alpha")
+
+        response = self.client.post(self._set_emit_url(), data={"emit": True, "ensure_source": False}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["source_enabled"] is False
+        assert body["emit_effective"] is False  # source gate still closed
+        assert self._scout_source() is None
+
+    def test_set_emit_emit_effective_false_without_org_approval(self) -> None:
+        self.organization.is_ai_data_processing_approved = False
+        self.organization.save()
+        SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-alpha")
+
+        response = self.client.post(self._set_emit_url(), data={"emit": True}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["source_enabled"] is True
+        assert body["ai_processing_approved"] is False
+        assert body["emit_effective"] is False  # org approval gate closed
+
+    def test_set_emit_no_matching_config_returns_404(self) -> None:
+        response = self.client.post(
+            self._set_emit_url(), data={"emit": True, "skill_name": "signals-scout-missing"}, format="json"
+        )
         assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/products/signals/backend/test/test_scout_harness_api.py
+++ b/products/signals/backend/test/test_scout_harness_api.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 from django.conf import settings
 from django.test import override_settings
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.api.oauth.test_dcr import generate_rsa_key
@@ -546,7 +547,7 @@ class TestScoutHarnessConfigAPI(APIBaseTest):
             source_type=SignalSourceConfig.SourceType.CROSS_SOURCE_ISSUE,
         ).first()
 
-    def test_set_emit_all_scouts_enables_emit_and_source(self) -> None:
+    def test_set_emit_all_scouts_flips_every_config(self) -> None:
         self._approve_ai()
         SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-alpha")
         SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-beta")
@@ -554,17 +555,11 @@ class TestScoutHarnessConfigAPI(APIBaseTest):
         response = self.client.post(self._set_emit_url(), data={"emit": True}, format="json")
 
         assert response.status_code == status.HTTP_200_OK
-        body = response.json()
-        assert [(c["skill_name"], c["emit"]) for c in body["configs"]] == [
+        assert [(c["skill_name"], c["emit"]) for c in response.json()["configs"]] == [
             ("signals-scout-alpha", True),
             ("signals-scout-beta", True),
         ]
-        assert body["source_enabled"] is True
-        assert body["ai_processing_approved"] is True
-        assert body["emit_effective"] is True
         assert SignalScoutConfig.objects.filter(team_id=self.team.id, emit=True).count() == 2
-        source = self._scout_source()
-        assert source is not None and source.enabled is True
 
     def test_set_emit_targets_a_single_scout_by_skill_name(self) -> None:
         self._approve_ai()
@@ -603,30 +598,32 @@ class TestScoutHarnessConfigAPI(APIBaseTest):
         source = self._scout_source()
         assert source is not None and source.enabled is True
 
-    def test_set_emit_ensure_source_false_does_not_create_source(self) -> None:
-        self._approve_ai()
-        SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-alpha")
-
-        response = self.client.post(self._set_emit_url(), data={"emit": True, "ensure_source": False}, format="json")
-
-        assert response.status_code == status.HTTP_200_OK
-        body = response.json()
-        assert body["source_enabled"] is False
-        assert body["emit_effective"] is False  # source gate still closed
-        assert self._scout_source() is None
-
-    def test_set_emit_emit_effective_false_without_org_approval(self) -> None:
-        self.organization.is_ai_data_processing_approved = False
+    @parameterized.expand(
+        [
+            # name, ensure_source, ai_approved, expected_source_enabled, expected_emit_effective
+            ("all_gates_open", True, True, True, True),
+            ("source_gate_closed", False, True, False, False),
+            ("org_gate_closed", True, False, True, False),
+        ]
+    )
+    def test_set_emit_emit_effective_reflects_all_gates(
+        self, _name, ensure_source, ai_approved, expected_source_enabled, expected_emit_effective
+    ) -> None:
+        self.organization.is_ai_data_processing_approved = ai_approved
         self.organization.save()
         SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-alpha")
 
-        response = self.client.post(self._set_emit_url(), data={"emit": True}, format="json")
+        response = self.client.post(
+            self._set_emit_url(), data={"emit": True, "ensure_source": ensure_source}, format="json"
+        )
 
         assert response.status_code == status.HTTP_200_OK
         body = response.json()
-        assert body["source_enabled"] is True
-        assert body["ai_processing_approved"] is False
-        assert body["emit_effective"] is False  # org approval gate closed
+        assert body["ai_processing_approved"] is ai_approved
+        assert body["source_enabled"] is expected_source_enabled
+        assert body["emit_effective"] is expected_emit_effective
+        # source row exists iff the source gate is reported open
+        assert (self._scout_source() is not None) is expected_source_enabled
 
     def test_set_emit_no_matching_config_returns_404(self) -> None:
         response = self.client.post(

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -198,6 +198,45 @@ export interface PatchedSignalScoutConfigApi {
 }
 
 /**
+ * Request to flip scout `emit` for one scout or every scout on the project.
+ */
+export interface SignalScoutSetEmitApi {
+    /** Target emit posture. True lets the scout(s) write findings to the inbox; False is dry-run — the scout still runs and records findings but emits nothing. */
+    emit: boolean
+    /**
+     * A single `signals-scout-*` skill to target. Omit or pass null to apply to every scout config on the project.
+     * @nullable
+     */
+    skill_name?: string | null
+    /** When enabling emit, also enable the project's `signals_scout` / `cross_source_issue` SignalSourceConfig — the team-level source gate that emit also requires. Ignored when emit is False. */
+    ensure_source?: boolean
+}
+
+/**
+ * One scout's emit posture after a set-emit call.
+ */
+export interface SignalScoutConfigEmitStatusApi {
+    /** The `signals-scout-*` skill this status is for. */
+    skill_name: string
+    /** The scout's emit posture after the update. */
+    emit: boolean
+}
+
+/**
+ * Emit-readiness for the project after a set-emit call — the three gates emit requires.
+ */
+export interface SignalScoutSetEmitResponseApi {
+    /** Per-scout emit posture after the update, for the targeted scouts, ordered by skill name. */
+    configs: SignalScoutConfigEmitStatusApi[]
+    /** Whether the project's `signals_scout` / `cross_source_issue` SignalSourceConfig is enabled (the team-level source gate). */
+    source_enabled: boolean
+    /** Whether the project's organization has approved AI data processing. Emit also requires this; it is an org setting and is not changed by this endpoint. */
+    ai_processing_approved: boolean
+    /** Whether emitted findings will actually reach the inbox: true only when at least one scout on the project has emit=True and both `source_enabled` and `ai_processing_approved` hold. */
+    emit_effective: boolean
+}
+
+/**
  * `inventory.project_context` — free-form orientation about the project's product.
  */
 export interface ProjectContextApi {

--- a/products/signals/frontend/generated/api.ts
+++ b/products/signals/frontend/generated/api.ts
@@ -28,6 +28,8 @@ import type {
     SignalScoutConfigApi,
     SignalScoutRunDetailApi,
     SignalScoutRunSummaryApi,
+    SignalScoutSetEmitApi,
+    SignalScoutSetEmitResponseApi,
     SignalSourceConfigApi,
     SignalUserAutonomyConfigApi,
     SignalsProcessingListParams,
@@ -236,6 +238,27 @@ export const signalsScoutConfigUpdate = async (
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(patchedSignalScoutConfigApi),
+    })
+}
+
+export const getSignalsScoutSetEmitUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/signals/scout/configs/set-emit/`
+}
+
+/**
+ * Flip `emit` on one scout (`skill_name`) or every scout on the project in one call. When enabling, optionally also enable the project's `signals_scout` / `cross_source_issue` source gate (`ensure_source`, default true) that emit requires. Returns the project's full emit-readiness, including the org AI-data-processing approval that emit also requires but this endpoint cannot set. Emitting drives spend, so config changes are activity-logged.
+ * @summary Set scout emit posture
+ */
+export const signalsScoutSetEmit = async (
+    projectId: string,
+    signalScoutSetEmitApi: SignalScoutSetEmitApi,
+    options?: RequestInit
+): Promise<SignalScoutSetEmitResponseApi> => {
+    return apiMutator<SignalScoutSetEmitResponseApi>(getSignalsScoutSetEmitUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(signalScoutSetEmitApi),
     })
 }
 

--- a/products/signals/frontend/generated/api.zod.ts
+++ b/products/signals/frontend/generated/api.zod.ts
@@ -100,6 +100,34 @@ export const SignalsScoutConfigUpdateBody = /* @__PURE__ */ zod
     )
 
 /**
+ * Flip `emit` on one scout (`skill_name`) or every scout on the project in one call. When enabling, optionally also enable the project's `signals_scout` / `cross_source_issue` source gate (`ensure_source`, default true) that emit requires. Returns the project's full emit-readiness, including the org AI-data-processing approval that emit also requires but this endpoint cannot set. Emitting drives spend, so config changes are activity-logged.
+ * @summary Set scout emit posture
+ */
+export const signalsScoutSetEmitBodyEnsureSourceDefault = true
+
+export const SignalsScoutSetEmitBody = /* @__PURE__ */ zod
+    .object({
+        emit: zod
+            .boolean()
+            .describe(
+                'Target emit posture. True lets the scout(s) write findings to the inbox; False is dry-run — the scout still runs and records findings but emits nothing.'
+            ),
+        skill_name: zod
+            .string()
+            .nullish()
+            .describe(
+                'A single `signals-scout-\*` skill to target. Omit or pass null to apply to every scout config on the project.'
+            ),
+        ensure_source: zod
+            .boolean()
+            .default(signalsScoutSetEmitBodyEnsureSourceDefault)
+            .describe(
+                "When enabling emit, also enable the project's `signals_scout` \/ `cross_source_issue` SignalSourceConfig — the team-level source gate that emit also requires. Ignored when emit is False."
+            ),
+    })
+    .describe('Request to flip scout `emit` for one scout or every scout on the project.')
+
+/**
  * Fire `emit_signal` with `source_product = signals_scout`. The `finding_id` is baked into the deterministic `Signal.source_id = run:<id>:finding:<id>` for traceability, but this is NOT idempotent — a second call with the same `finding_id` emits a second signal, so do not retry an emit that may have already succeeded.
  * @summary Emit a finding for a run
  */

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -168,6 +168,22 @@ tools:
             Tune one scout by its config `id`: change its schedule (`run_interval_minutes`, 10–43200), `enabled`, or
             `emit` (false = dry-run: the scout runs and logs but writes nothing to the inbox). `skill_name` is fixed.
             Enabling records who flipped it on and is activity-logged, since running a scout drives spend.
+    signals-scout-set-emit:
+        operation: signals_scout_set_emit
+        enabled: true
+        scopes:
+            - signal_scout:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Set scout emit posture
+        description: >
+            Turn scout emitting on or off for this project in one call. Set `emit` true to let scouts write findings to
+            the inbox, false for dry-run. Target one scout with `skill_name`, or every scout when omitted. When enabling,
+            `ensure_source` (default true) also opens the project's `signals_scout` source gate that emit requires.
+            Returns the project's emit-readiness — including the org AI-data-processing approval that emit also needs but
+            this tool cannot set; `emit_effective` is true only when all gates are open.
     signals-scout-emit-signal:
         operation: signals_scout_emit_signal
         enabled: true

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -168,22 +168,6 @@ tools:
             Tune one scout by its config `id`: change its schedule (`run_interval_minutes`, 10–43200), `enabled`, or
             `emit` (false = dry-run: the scout runs and logs but writes nothing to the inbox). `skill_name` is fixed.
             Enabling records who flipped it on and is activity-logged, since running a scout drives spend.
-    signals-scout-set-emit:
-        operation: signals_scout_set_emit
-        enabled: true
-        scopes:
-            - signal_scout:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: true
-        title: Set scout emit posture
-        description: >
-            Turn scout emitting on or off for this project in one call. Set `emit` true to let scouts write findings to
-            the inbox, false for dry-run. Target one scout with `skill_name`, or every scout when omitted. When enabling,
-            `ensure_source` (default true) also opens the project's `signals_scout` source gate that emit requires.
-            Returns the project's emit-readiness — including the org AI-data-processing approval that emit also needs but
-            this tool cannot set; `emit_effective` is true only when all gates are open.
     signals-scout-emit-signal:
         operation: signals_scout_emit_signal
         enabled: true
@@ -287,6 +271,22 @@ tools:
         description: >
             Return `SignalScratchpad` entries for this project, newest first. Pass `text` for a case-insensitive
             substring match on the entry's `content` and `key`. Results capped at 100.
+    signals-scout-set-emit:
+        operation: signals_scout_set_emit
+        enabled: true
+        scopes:
+            - signal_scout:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Set scout emit posture
+        description: >
+            Turn scout emitting on or off for this project in one call. Set `emit` true to let scouts write findings to
+            the inbox, false for dry-run. Target one scout with `skill_name`, or every scout when omitted. When
+            enabling, `ensure_source` (default true) also opens the project's `signals_scout` source gate that emit
+            requires. Returns the project's emit-readiness — including the org AI-data-processing approval that emit
+            also needs but this tool cannot set; `emit_effective` is true only when all gates are open.
     users-signal-autonomy-create:
         operation: users_signal_autonomy_create
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4815,6 +4815,20 @@
             "readOnlyHint": true
         }
     },
+    "signals-scout-set-emit": {
+        "description": "Turn scout emitting on or off for this project in one call. Set `emit` true to let scouts write findings to the inbox, false for dry-run. Target one scout with `skill_name`, or every scout when omitted. When enabling, `ensure_source` (default true) also opens the project's `signals_scout` source gate that emit requires. Returns the project's emit-readiness — including the org AI-data-processing approval that emit also needs but this tool cannot set; `emit_effective` is true only when all gates are open.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Set scout emit posture",
+        "title": "Set scout emit posture",
+        "required_scopes": ["signal_scout:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "sql-variables-create": {
         "description": "Create a reusable SQL variable for HogQL queries. Provide a human-readable name and type. The code_name is generated from the name and is referenced in SQL as {variables.code_name}. For List variables, provide values as the allowed options.",
         "category": "Data warehouse",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5142,6 +5142,20 @@
             "readOnlyHint": true
         }
     },
+    "signals-scout-set-emit": {
+        "description": "Turn scout emitting on or off for this project in one call. Set `emit` true to let scouts write findings to the inbox, false for dry-run. Target one scout with `skill_name`, or every scout when omitted. When enabling, `ensure_source` (default true) also opens the project's `signals_scout` source gate that emit requires. Returns the project's emit-readiness — including the org AI-data-processing approval that emit also needs but this tool cannot set; `emit_effective` is true only when all gates are open.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Set scout emit posture",
+        "title": "Set scout emit posture",
+        "required_scopes": ["signal_scout:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "sql-variables-create": {
         "description": "Create a reusable SQL variable for HogQL queries. Provide a human-readable name and type. The code_name is generated from the name and is referenced in SQL as {variables.code_name}. For List variables, provide values as the allowed options.",
         "category": "Data warehouse",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37447,6 +37447,16 @@ export namespace Schemas {
     }
 
     /**
+     * One scout's emit posture after a set-emit call.
+     */
+    export interface SignalScoutConfigEmitStatus {
+      /** The `signals-scout-*` skill this status is for. */
+      skill_name: string;
+      /** The scout's emit posture after the update. */
+      emit: boolean;
+    }
+
+    /**
      * Full `SignalScoutRun` projection used by `get-run`. Same shape as the summary
     today; kept distinct so future detail-only extensions (linked Signal rows,
     LLMA token-cost join) can land here without bloating the list response.
@@ -37524,6 +37534,35 @@ export namespace Schemas {
       task_url?: string | null;
       /** One-paragraph close-out the scout wrote at end-of-run. Empty string for runs that errored before close-out. The dedupe key for non-emitting runs. */
       summary: string;
+    }
+
+    /**
+     * Request to flip scout `emit` for one scout or every scout on the project.
+     */
+    export interface SignalScoutSetEmit {
+      /** Target emit posture. True lets the scout(s) write findings to the inbox; False is dry-run — the scout still runs and records findings but emits nothing. */
+      emit: boolean;
+      /**
+         * A single `signals-scout-*` skill to target. Omit or pass null to apply to every scout config on the project.
+         * @nullable
+         */
+      skill_name?: string | null;
+      /** When enabling emit, also enable the project's `signals_scout` / `cross_source_issue` SignalSourceConfig — the team-level source gate that emit also requires. Ignored when emit is False. */
+      ensure_source?: boolean;
+    }
+
+    /**
+     * Emit-readiness for the project after a set-emit call — the three gates emit requires.
+     */
+    export interface SignalScoutSetEmitResponse {
+      /** Per-scout emit posture after the update, for the targeted scouts, ordered by skill name. */
+      configs: SignalScoutConfigEmitStatus[];
+      /** Whether the project's `signals_scout` / `cross_source_issue` SignalSourceConfig is enabled (the team-level source gate). */
+      source_enabled: boolean;
+      /** Whether the project's organization has approved AI data processing. Emit also requires this; it is an org setting and is not changed by this endpoint. */
+      ai_processing_approved: boolean;
+      /** Whether emitted findings will actually reach the inbox: true only when at least one scout on the project has emit=True and both `source_enabled` and `ai_processing_approved` hold. */
+      emit_effective: boolean;
     }
 
     export interface _User {

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 14 enabled ops
+ * PostHog API - MCP 15 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -171,6 +171,42 @@ export const SignalsScoutConfigUpdateBody = /* @__PURE__ */ zod
     .describe(
         'Per-(team, skill) scout config: schedule, enablement, and emit posture.\n\nOne row per `signals-scout-*` skill on the team. The coordinator auto-creates a row\nwhen it discovers a scout skill; this serializer lets agents tune the row.'
     )
+
+/**
+ * Flip `emit` on one scout (`skill_name`) or every scout on the project in one call. When enabling, optionally also enable the project's `signals_scout` / `cross_source_issue` source gate (`ensure_source`, default true) that emit requires. Returns the project's full emit-readiness, including the org AI-data-processing approval that emit also requires but this endpoint cannot set. Emitting drives spend, so config changes are activity-logged.
+ * @summary Set scout emit posture
+ */
+export const SignalsScoutSetEmitParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const signalsScoutSetEmitBodyEnsureSourceDefault = true
+
+export const SignalsScoutSetEmitBody = /* @__PURE__ */ zod
+    .object({
+        emit: zod
+            .boolean()
+            .describe(
+                'Target emit posture. True lets the scout(s) write findings to the inbox; False is dry-run — the scout still runs and records findings but emits nothing.'
+            ),
+        skill_name: zod
+            .string()
+            .nullish()
+            .describe(
+                'A single `signals-scout-*` skill to target. Omit or pass null to apply to every scout config on the project.'
+            ),
+        ensure_source: zod
+            .boolean()
+            .default(signalsScoutSetEmitBodyEnsureSourceDefault)
+            .describe(
+                "When enabling emit, also enable the project's `signals_scout` / `cross_source_issue` SignalSourceConfig — the team-level source gate that emit also requires. Ignored when emit is False."
+            ),
+    })
+    .describe('Request to flip scout `emit` for one scout or every scout on the project.')
 
 /**
  * Return the team's deterministic project profile. For the internal scout token the response reflects the newest non-expired cached row or a freshly-built one (lazy compute on cache miss); `force_refresh=true` skips the cache and rebuilds from authoritative sources. Public read callers (session auth or a `signal_scout:read` PAK) get the newest cached profile, or 404 if none has been built yet — they never trigger a rebuild. Read this at the start of a run to orient on the team's product mix, integrations, warehouse sources, signal coverage, and existing inbox surface.

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -232,32 +232,6 @@ const signalsScoutConfigUpdate = (): ToolBase<
     },
 })
 
-const SignalsScoutSetEmitSchema = SignalsScoutSetEmitBody
-
-const signalsScoutSetEmit = (): ToolBase<typeof SignalsScoutSetEmitSchema, Schemas.SignalScoutSetEmitResponse> => ({
-    name: 'signals-scout-set-emit',
-    schema: SignalsScoutSetEmitSchema,
-    handler: async (context: Context, params: z.infer<typeof SignalsScoutSetEmitSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.emit !== undefined) {
-            body['emit'] = params.emit
-        }
-        if (params.skill_name !== undefined) {
-            body['skill_name'] = params.skill_name
-        }
-        if (params.ensure_source !== undefined) {
-            body['ensure_source'] = params.ensure_source
-        }
-        const result = await context.api.request<Schemas.SignalScoutSetEmitResponse>({
-            method: 'POST',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/scout/configs/set-emit/`,
-            body,
-        })
-        return result
-    },
-})
-
 const SignalsScoutEmitSignalSchema = SignalsScoutEmitSignalParams.omit({ project_id: true }).extend(
     SignalsScoutEmitSignalBody.shape
 )
@@ -441,6 +415,32 @@ const signalsScoutScratchpadSearch = (): ToolBase<
     },
 })
 
+const SignalsScoutSetEmitSchema = SignalsScoutSetEmitBody
+
+const signalsScoutSetEmit = (): ToolBase<typeof SignalsScoutSetEmitSchema, Schemas.SignalScoutSetEmitResponse> => ({
+    name: 'signals-scout-set-emit',
+    schema: SignalsScoutSetEmitSchema,
+    handler: async (context: Context, params: z.infer<typeof SignalsScoutSetEmitSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.emit !== undefined) {
+            body['emit'] = params.emit
+        }
+        if (params.skill_name !== undefined) {
+            body['skill_name'] = params.skill_name
+        }
+        if (params.ensure_source !== undefined) {
+            body['ensure_source'] = params.ensure_source
+        }
+        const result = await context.api.request<Schemas.SignalScoutSetEmitResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/scout/configs/set-emit/`,
+            body,
+        })
+        return result
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'inbox-reports-list': inboxReportsList,
     'inbox-reports-retrieve': inboxReportsRetrieve,
@@ -449,7 +449,6 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'inbox-source-configs-retrieve': inboxSourceConfigsRetrieve,
     'signals-scout-config-list': signalsScoutConfigList,
     'signals-scout-config-update': signalsScoutConfigUpdate,
-    'signals-scout-set-emit': signalsScoutSetEmit,
     'signals-scout-emit-signal': signalsScoutEmitSignal,
     'signals-scout-project-profile-get': signalsScoutProjectProfileGet,
     'signals-scout-runs-list': signalsScoutRunsList,
@@ -457,4 +456,5 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'signals-scout-scratchpad-forget': signalsScoutScratchpadForget,
     'signals-scout-scratchpad-remember': signalsScoutScratchpadRemember,
     'signals-scout-scratchpad-search': signalsScoutScratchpadSearch,
+    'signals-scout-set-emit': signalsScoutSetEmit,
 }

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -17,6 +17,7 @@ import {
     SignalsScoutScratchpadForgetBody,
     SignalsScoutScratchpadRememberBody,
     SignalsScoutScratchpadSearchQueryParams,
+    SignalsScoutSetEmitBody,
     SignalsSourceConfigsListQueryParams,
     SignalsSourceConfigsRetrieveParams,
 } from '@/generated/signals/api'
@@ -231,6 +232,32 @@ const signalsScoutConfigUpdate = (): ToolBase<
     },
 })
 
+const SignalsScoutSetEmitSchema = SignalsScoutSetEmitBody
+
+const signalsScoutSetEmit = (): ToolBase<typeof SignalsScoutSetEmitSchema, Schemas.SignalScoutSetEmitResponse> => ({
+    name: 'signals-scout-set-emit',
+    schema: SignalsScoutSetEmitSchema,
+    handler: async (context: Context, params: z.infer<typeof SignalsScoutSetEmitSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.emit !== undefined) {
+            body['emit'] = params.emit
+        }
+        if (params.skill_name !== undefined) {
+            body['skill_name'] = params.skill_name
+        }
+        if (params.ensure_source !== undefined) {
+            body['ensure_source'] = params.ensure_source
+        }
+        const result = await context.api.request<Schemas.SignalScoutSetEmitResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/scout/configs/set-emit/`,
+            body,
+        })
+        return result
+    },
+})
+
 const SignalsScoutEmitSignalSchema = SignalsScoutEmitSignalParams.omit({ project_id: true }).extend(
     SignalsScoutEmitSignalBody.shape
 )
@@ -422,6 +449,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'inbox-source-configs-retrieve': inboxSourceConfigsRetrieve,
     'signals-scout-config-list': signalsScoutConfigList,
     'signals-scout-config-update': signalsScoutConfigUpdate,
+    'signals-scout-set-emit': signalsScoutSetEmit,
     'signals-scout-emit-signal': signalsScoutEmitSignal,
     'signals-scout-project-profile-get': signalsScoutProjectProfileGet,
     'signals-scout-runs-list': signalsScoutRunsList,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-set-emit.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-set-emit.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Request to flip scout `emit` for one scout or every scout on the project.",
+    "properties": {
+        "emit": {
+            "description": "Target emit posture. True lets the scout(s) write findings to the inbox; False is dry-run — the scout still runs and records findings but emits nothing.",
+            "type": "boolean"
+        },
+        "ensure_source": {
+            "default": true,
+            "description": "When enabling emit, also enable the project's `signals_scout` / `cross_source_issue` SignalSourceConfig — the team-level source gate that emit also requires. Ignored when emit is False.",
+            "type": "boolean"
+        },
+        "skill_name": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "A single `signals-scout-*` skill to target. Omit or pass null to apply to every scout config on the project."
+        }
+    },
+    "required": ["emit"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Turning a Signals scout from dry-run (`emit=False`) to actually emitting into the inbox is a deliberate operator step with three gates: per-scout `SignalScoutConfig.emit=True`, the team-level `SignalSourceConfig(signals_scout, cross_source_issue, enabled=True)` source row, and the org's AI-data-processing approval. The first two were only reachable as separate, generically-named MCP calls (`signals-scout-config-update` per scout + `inbox-source-configs-create`), so enabling emit for a team meant several calls across two tool families — easy to flip `emit=True` but forget the source row and silently get no emits.

## Changes

Add a focused **`signals-scout-set-emit`** MCP tool (`signals_scout_set_emit` endpoint, a `POST` action on `SignalScoutConfigViewSet`) that does the whole emit posture change in one call:

- Flips `emit` on **one scout** (`skill_name`) or **every scout** on the project.
- When enabling, optionally (`ensure_source`, default true) creates/enables the team's `signals_scout` / `cross_source_issue` `SignalSourceConfig` — the source gate emit also requires.
- Returns the project's full **emit-readiness**: per-scout emit posture, `source_enabled`, `ai_processing_approved` (the org gate this endpoint can't set), and `emit_effective` (true only when all three gates are open) — so a caller can see exactly what, if anything, still blocks emits.

Scoped to `signal_scout:write` (the user-grantable write scope, same as `signals-scout-config-update`); not gated by the `signals-scout` feature flag. Disabling (`emit=False`) leaves the source row untouched. Per-scout config changes are activity-logged since emitting drives spend.

## How did you test this code?

I'm an agent (Claude Code). Added endpoint tests in `TestScoutHarnessConfigAPI` for `set-emit`: bulk enable (all scouts flipped in one call), single-scout targeting, dry-run/disable leaving the source row untouched, a parameterized `emit_effective` truth-table over `(ensure_source, ai_approved)` → `(source_enabled, emit_effective)`, and a 404 for an unmatched `skill_name`. Full `test_scout_harness_api.py` passes (45). `hogli build:openapi` regenerated the OpenAPI spec, frontend types, and MCP tool/handler/schema; `lint-tool-names` passes; `ruff`/`ty check` clean via lint-staged.

I also verified the generated tool live against the running local dev stack: authenticated the local PostHog MCP with `signal_scout:read`/`:write` against project 1 and exercised the tool end-to-end — `signals-scout-set-emit` on a single scout (flipped `emit`, created + enabled the `signals_scout` / `cross_source_issue` source row, `emit_effective: true`), the bulk path (all 8 scouts in one call), and the revert (`emit: false` → `emit_effective: false`, source row left in place) — alongside the existing `signals-scout-config-list` and per-scout `signals-scout-config-update`. The description and params came through the full Django → OpenAPI → Zod → MCP pipeline intact. As a final end-to-end check I turned the whole 8-scout fleet on against project 1 — bulk `set-emit {emit: true}` (all 8 → emit, `emit_effective: true`) then per-scout `signals-scout-config-update {enabled: true}` on the disabled ones — and confirmed the resulting `enabled`/`emit` state via `config-list`.

## 🤖 Agent context

Authored with Claude Code. Implemented after confirming both emit gates were *already* individually MCP-controllable — this PR is purely the ergonomic one-call composite (the "enable scout emit for this team" operator action), not new capability. Followed the `improving-drf-endpoints` and `implementing-mcp-tools` skills: typed request/response serializers with `help_text` so the generated Zod/tool descriptions are informative, `required_scopes` declared on the custom `@action` (this file's convention), response is a typed serializer. The org `is_ai_data_processing_approved` flag is intentionally left non-settable via MCP (a consent boundary) and is surfaced read-only in the response instead. Agent-authored; requires human review.


