### PR TITLE
fix(logs): copy log link that opens the viewer tab

### DIFF
--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -1,12 +1,12 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
+
 import { useMocks } from '~/mocks/jest'
 import { LogMessage } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 
 import { ParsedLogMessage } from 'products/logs/frontend/types'
-
-import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import { logsViewerConfigLogic } from './config/logsViewerConfigLogic'
 import { logsViewerDataLogic } from './data/logsViewerDataLogic'

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -6,10 +6,16 @@ import { initKeaTests } from '~/test/init'
 
 import { ParsedLogMessage } from 'products/logs/frontend/types'
 
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
+
 import { logsViewerConfigLogic } from './config/logsViewerConfigLogic'
 import { logsViewerDataLogic } from './data/logsViewerDataLogic'
 import { logsViewerFiltersLogic } from './Filters/logsViewerFiltersLogic'
 import { logsViewerLogic } from './logsViewerLogic'
+
+jest.mock('lib/utils/copyToClipboard', () => ({
+    copyToClipboard: jest.fn().mockResolvedValue(true),
+}))
 
 const createMockRawLog = (uuid: string): LogMessage => ({
     uuid,
@@ -719,6 +725,24 @@ describe('logsViewerLogic', () => {
             await expectLogic(logic).toFinishAllListeners()
 
             expect(logic.values.linkToLogId).toBeNull()
+        })
+    })
+
+    describe('copyLinkToLog', () => {
+        beforeEach(() => {
+            ;({ logic } = mountWithLogs())
+            jest.mocked(copyToClipboard).mockClear()
+        })
+
+        it('copies a link pointing at the viewer tab even when copied from another tab', async () => {
+            window.history.replaceState({}, '', '/project/1/logs?activeTab=services')
+
+            logic.actions.copyLinkToLog('log-2')
+            await expectLogic(logic).toFinishAllListeners()
+
+            const copiedUrl = new URL(jest.mocked(copyToClipboard).mock.calls[0][0])
+            expect(copiedUrl.searchParams.get('activeTab')).toEqual('viewer')
+            expect(copiedUrl.searchParams.get('linkToLogId')).toEqual('log-2')
         })
     })
 

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -517,6 +517,9 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         copyLinkToLog: ({ logId }) => {
             posthog.capture('logs link copied')
             const url = new URL(window.location.href)
+            // Linked logs only open in the Viewer tab, so always point the shared link there
+            // regardless of which tab the link was copied from.
+            url.searchParams.set('activeTab', 'viewer')
             url.searchParams.set('linkToLogId', logId)
             if (values.visibleLogsTimeRange) {
                 url.searchParams.set(


### PR DESCRIPTION
## Problem

The "copy link to log" action in Logs copies a URL built from the current page location. When a user copies the link while on the **Services** tab (or any non-Viewer tab), the URL keeps `activeTab=services`. The deep-link handler that opens a specific log in the side panel (`tryOpenLinkedLog`) only runs on the **Viewer** tab, so opening a shared link landed on the wrong tab and silently did nothing — the log never popped open. Users had to manually switch to Viewer for it to work, which defeats the point of sharing a direct link with a teammate.

## Changes

`copyLinkToLog` now always sets `activeTab=viewer` on the copied URL, alongside the existing `linkToLogId`, date range, and limit params. The shared link therefore opens the Viewer tab and auto-surfaces the linked log in the details panel regardless of which tab it was copied from.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not perform manual browser testing. Automated coverage I added and ran:

- Added a `copyLinkToLog` test to `logsViewerLogic.test.ts` asserting that a link copied while on `activeTab=services` comes out pointing at `activeTab=viewer` with the correct `linkToLogId`.
- Ran the full `logsViewerLogic.test.ts` suite: **84 passed**.
- oxlint clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) in response to a support report: a copied log link pointed at the `services` tab and didn't open the log panel, while manually navigating to the `viewer` tab worked. Root cause was `copyLinkToLog` deriving the URL from `window.location.href`, preserving whatever tab the user was on. Chosen fix is the minimal one — force `activeTab=viewer` in the copied URL — rather than making the deep-link handler tab-agnostic, since linked logs are a Viewer-tab concept. Importing the tab constant from `logsSceneLogic` would create a circular dependency, so the literal `'viewer'` is used. Requires human review.
