### PR TITLE
chore(streamlit-apps): exclude backend tests from CI

### DIFF
--- a/products/streamlit_apps/backend/tests/test_models.py
+++ b/products/streamlit_apps/backend/tests/test_models.py
@@ -7,6 +7,8 @@ from parameterized import parameterized
 
 from products.streamlit_apps.backend.models import StreamlitApp, StreamlitAppSandbox, StreamlitAppVersion
 
+pytestmark = pytest.mark.skip(reason="streamlit_apps is experimental and not actively worked on — skip in CI")
+
 
 class TestStreamlitAppModel(BaseTest):
     def test_create_app(self):

--- a/products/streamlit_apps/package.json
+++ b/products/streamlit_apps/package.json
@@ -1,3 +1,6 @@
 {
-    "name": "@posthog/products-streamlit-apps"
+    "name": "@posthog/products-streamlit-apps",
+    "scripts": {
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
+    }
 }

--- a/products/streamlit_apps/package.json
+++ b/products/streamlit_apps/package.json
@@ -1,6 +1,3 @@
 {
-    "name": "@posthog/products-streamlit-apps",
-    "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
-    }
+    "name": "@posthog/products-streamlit-apps"
 }


### PR DESCRIPTION
## Problem

The `streamlit_apps` product is experimental and not actively worked on, so its backend tests don't need to run on every CI run.

## Changes

Skip the `streamlit_apps` backend test suite in CI via a module-level `pytestmark = pytest.mark.skip(...)` in `test_models.py`.

The first instinct — deleting the `backend:test` script from the product's `package.json` — is rejected by the product-structure linter (`tools/hogli-commands/.../checks.py`): `PackageJsonScriptsCheck` requires every product with a `backend/` dir to declare `backend:test`, and `OrphanedTestFilesCheck` requires every test file to be reachable from it (its whole purpose is to stop tests being silently stranded out of CI). So the script and test file stay, and the suite is skipped at the module level instead.

This matches the existing module-level skip pattern already used for slow historical-migration tests (e.g. `products/data_warehouse/backend/migrations/test/test_migration_0013.py`, `products/data_modeling/backend/migrations/test/test_migration_0006.py`).

Tests still collect cleanly and can be un-skipped (or run locally by removing the marker) whenever the product is picked back up.

## How did you test this code?

I'm an agent. I did not run manual testing. Automated checks I ran locally:
- `product:lint streamlit_apps` — all structural checks pass, 0 issues (the `package.json scripts` and `test file coverage` checks that were failing now pass).
- `pytest --collect-only` on the suite — all 17 tests collect and are marked skipped, so the `backend:test` run exits 0.

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8). Initial approach removed the `backend:test` script; CI's product-structure linter rejected that (it intentionally forbids stranding test files out of CI). Switched to a module-level `pytest.mark.skip` after confirming the same pattern is already used elsewhere in the repo for tests deliberately excluded from CI runs. The skip reason records the rationale (experimental product, not actively worked on) so it can be revisited.