### PR TITLE
fix(data-warehouse): wire incremental sync for Slack channel schemas

### DIFF
--- a/posthog/temporal/data_imports/sources/slack/settings.py
+++ b/posthog/temporal/data_imports/sources/slack/settings.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFormat, PartitionMode
 
-from products.data_warehouse.backend.types import IncrementalField
+from products.data_warehouse.backend.types import IncrementalField, IncrementalFieldType
 
 
 @dataclass
@@ -22,8 +22,23 @@ ENDPOINTS: dict[str, EndpointConfig] = {
 
 
 def messages_endpoint_config() -> EndpointConfig:
+    # The runtime path in slack.py already wires incremental polling against the
+    # `timestamp` column — it reads `db_incremental_field_last_value.timestamp()`
+    # and passes it to Slack's `oldest` param on `conversations.history` (slack.py
+    # ~line 433). Declaring `incremental_fields` here is what the schema layer
+    # uses (source.py:201-204) to flip `supports_incremental` / `supports_append`
+    # to True, so the channel schema can offer those sync modes in the UI instead
+    # of forcing every refresh to be a full re-pull of `conversations.history`.
     return EndpointConfig(
         primary_keys=["channel_id", "ts"],
+        incremental_fields=[
+            {
+                "label": "timestamp",
+                "type": IncrementalFieldType.DateTime,
+                "field": "timestamp",
+                "field_type": IncrementalFieldType.DateTime,
+            }
+        ],
         partition_keys=["timestamp"],
         partition_mode="datetime",
         partition_format="week",

--- a/posthog/temporal/data_imports/sources/slack/test_slack.py
+++ b/posthog/temporal/data_imports/sources/slack/test_slack.py
@@ -393,6 +393,41 @@ class TestSlackSourceGetSchemasForceRefresh:
         assert channel_names(cached) == {"C1"}
         assert channel_names(forced) == {"C2"}
 
+    def test_channel_schemas_advertise_incremental_sync(self) -> None:
+        """
+        Regression for posthog/posthog#59460. The runtime path in slack.py already
+        passes `db_incremental_field_last_value.timestamp()` to Slack's `oldest`
+        param, but the schema layer only flips `supports_incremental` /
+        `supports_append` when `messages_endpoint_config().incremental_fields` is
+        non-empty — so an empty list silently forces every channel to full-refresh.
+        """
+        from posthog.temporal.data_imports.sources.slack.source import SlackSource
+
+        from products.data_warehouse.backend.types import IncrementalFieldType
+
+        config, integration = self._build_mocks()
+        source = SlackSource()
+
+        with (
+            patch.object(source, "get_oauth_integration", return_value=integration),
+            patch(
+                "posthog.temporal.data_imports.sources.slack.slack._fetch_all_channels",
+                return_value=[{"id": "C1", "name": "general"}],
+            ),
+            patch(
+                "posthog.temporal.data_imports.sources.slack.source.is_webhook_feature_flag_enabled",
+                return_value=False,
+            ),
+        ):
+            schemas = source.get_schemas(config, team_id=1)
+
+        channel_schema = next(s for s in schemas if s.name == "C1")
+        assert channel_schema.supports_incremental is True
+        assert channel_schema.supports_append is True
+        assert len(channel_schema.incremental_fields) == 1
+        assert channel_schema.incremental_fields[0]["field"] == "timestamp"
+        assert channel_schema.incremental_fields[0]["field_type"] == IncrementalFieldType.DateTime
+
 
 class TestSlackSourceChannelsEndpoint:
     def setup_method(self) -> None:


### PR DESCRIPTION
## Problem

Closes #59460.

The Slack data warehouse source (alpha, behind \`slack-dwh\`) advertises only **Full refresh** as a sync type when picking a channel schema. For busy channels that means re-pulling the entire \`conversations.history\` every sync interval, predictably bumping Slack's Tier-2 rate limit.

The cause sits in two adjacent files:

- \`posthog/temporal/data_imports/sources/slack/settings.py\` — \`messages_endpoint_config()\` left \`incremental_fields=[]\`.
- \`posthog/temporal/data_imports/sources/slack/source.py:201-204\` — derives \`supports_incremental\` / \`supports_append\` from \`len(msg_config.incremental_fields) > 0\`. Empty list → both False → UI hides both options.

But the **runtime path is already wired for incremental polling**. In \`slack.py:433-439\`:

\`\`\`python
oldest_ts: str | None = None
if should_use_incremental_field and db_incremental_field_last_value is not None:
    oldest_ts = str(db_incremental_field_last_value.timestamp())
\`\`\`

…which then feeds Slack's \`oldest\` parameter on \`conversations.history\`. So the engine has always known how to do incremental — only the schema declaration was missing the field the UI needs to expose the option.

## Changes

\`posthog/temporal/data_imports/sources/slack/settings.py\`:

- Add a single \`incremental_fields\` entry for the \`timestamp\` column on the messages endpoint (DateTime type, partition key already \`["timestamp"]\`, fields generator at \`slack.py:303-307\` emits the ISO datetime).
- Inline comment cross-references both ends of the wiring so a future refactor doesn't drop one half.

No runtime change — just unlocks the UI affordance for the path that already exists.

## How did you test this code?

- Added `test_channel_schemas_advertise_incremental_sync` to `test_slack.py` that constructs `SlackSource.get_schemas(...)` against a mocked Slack client and asserts the channel schema reports `supports_incremental=True`, `supports_append=True`, and a single `timestamp` `IncrementalFieldType.DateTime` entry — exactly the state the UI uses to render Incremental / Append.
- `ruff check` and `ruff format` clean on the changed files.

## Publish to changelog?

no

## Docs update

No docs change — Slack DWH source is still gated behind the \`slack-dwh\` flag and the existing docs page describes the planned sync types in terms of the standard data warehouse story.

## 🤖 Agent context

Reporter's analysis already identified the exact files and the exact fix. The PR is the one-declaration follow-through plus a regression test that pins the UI-affordance contract so a future refactor of \`get_schemas\` can't silently drop incremental support back to False.