### PR TITLE
fix(data-warehouse): force microsecond precision for snowflake arrow batches

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/snowflake.py
@@ -446,7 +446,14 @@ class SnowflakeImplementation(
 
                     # We cant control the batch size from snowflake when using the arrow function
                     # https://github.com/snowflakedb/snowflake-connector-python/issues/1712
-                    yield from streaming_cursor.fetch_arrow_batches()
+                    #
+                    # Force microsecond precision so every batch shares one timestamp unit.
+                    # Otherwise the connector picks the unit per batch from the data — `ns` for
+                    # values in the nanosecond range (~1677–2262) and `us` for anything outside it
+                    # (e.g. a `0001-01-01`/`9999-12-31` sentinel) — and the mixed units make
+                    # pyarrow fail to assemble the batches ("Schema at index N was different").
+                    # The pipeline normalizes timestamps to `us` downstream regardless.
+                    yield from streaming_cursor.fetch_arrow_batches(force_microsecond_precision=True)
 
         name = NamingConvention.normalize_identifier(table_name)
 

--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -369,3 +369,5 @@ class TestBuildPipeline:
             assert response.primary_keys == ["id"]
             assert response.rows_to_sync == 5
             assert list(response.items()) == [b"batch-1", b"batch-2"]
+            # Pin a single timestamp unit so mixed ns/us batches don't break pyarrow assembly.
+            streaming_cursor.fetch_arrow_batches.assert_called_once_with(force_microsecond_precision=True)


### PR DESCRIPTION
## Problem

Snowflake table syncs fail with a PyArrow error when a timestamp column contains a value outside the nanosecond-representable range (roughly years 1677–2262, e.g. a `0001-01-01` / `9999-12-31` sentinel):

```
ArrowInvalid: Schema at index 1 was different:
  CREATED_DATETIME: timestamp[us]  ...  (vs)
  CREATED_DATETIME: timestamp[ns]  ...
```

`SnowflakeCursor.fetch_arrow_batches()` chooses each batch's Arrow timestamp unit from the data in that batch: `timestamp[ns]` when every value fits the nanosecond range, and `timestamp[us]` for any batch containing an out-of-range value. A single read of a table that has both kinds of value therefore yields a mix of `ns` and `us` batches, and PyArrow cannot assemble batches whose schemas disagree — so the import dies before the rows are ever written.

This is independent of sync method (full refresh hits it too — it just takes one out-of-range row anywhere in the table) and independent of the incremental-field config. The existing `evolve_pyarrow_schema` normalizes `ns → us`, but only per already-assembled table; the failure happens earlier, at batch assembly, so that normalization never gets the chance to run.

## Changes

Pass `force_microsecond_precision=True` to `fetch_arrow_batches()` in the Snowflake source. The connector exposes this flag specifically for this case — it pins every batch to `timestamp[us]` so all batches share one schema and assemble cleanly. The downstream pipeline already normalizes timestamps to microseconds, so this only makes explicit what the rest of the pipeline already assumes. The flag truncates sub-microsecond precision (Snowflake scale 7–9), which matches existing downstream behavior.

One line of behavior, plus a regression assertion on the existing `build_pipeline` streaming test.

`snowflake-connector-python` is pinned at `4.3.0`, which supports the kwarg.

## How did you test this code?

I'm an agent. I ran the existing Snowflake source unit tests (`TestBuildPipeline`) with an added assertion that `fetch_arrow_batches` is called with `force_microsecond_precision=True`; the suite passes. `ruff check` / `ruff format` and the pre-commit type check pass. I did **not** run an end-to-end sync against a live Snowflake instance with out-of-range timestamp data — that should be verified before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by Claude during a debugging session that traced a stuck managed-Snowflake sync. Production worker logs (`temporal-worker-data-warehouse`) showed two alternating failures as the schema's incremental-field config was toggled: a Snowflake `invalid identifier` error (incremental field stored lowercase, quoted case-sensitively against an uppercase column) and, once the field resolved, this `ns`/`us` Arrow batch mismatch — the actual blocker.

Approach considered and rejected: replicating the discovery-time "probe the source type" pattern used for unconstrained Postgres `numeric` columns (#54688). That fix works because decimal batches are individually concatenable and only clash at the Delta append, so getting the declared type right up front solves it. Here the batches fail to *assemble* upstream of the Delta layer, and the connector already offers a direct knob to stabilize the unit — so the proportional fix is to use it rather than add a probe.
