### PR TITLE
fix(revenue-analytics): Aggregate persons revenue by person_id

### DIFF
--- a/posthog/hogql/database/schema/persons_revenue_analytics.py
+++ b/posthog/hogql/database/schema/persons_revenue_analytics.py
@@ -151,10 +151,25 @@ def _select_from_persons_revenue_analytics_table(context: HogQLContext) -> ast.S
 
     if not queries:
         return ast.SelectQuery.empty(columns=FIELDS)
-    elif len(queries) == 1:
-        return queries[0]
-    else:
-        return ast.SelectSetQuery.create_from_queries(queries, set_operator="UNION ALL")
+
+    inner_query: ast.SelectQuery | ast.SelectSetQuery = (
+        queries[0] if len(queries) == 1 else ast.SelectSetQuery.create_from_queries(queries, set_operator="UNION ALL")
+    )
+
+    # A person can map to more than one customer -- duplicate customer records sharing an email, or
+    # customers spread across multiple revenue sources -- and each mapping is its own row above.
+    # Aggregating by `person_id` keeps this table at one row per person so the `persons` join can't
+    # fan out the persons table. Mirrors what `groups_revenue_analytics` already does per group.
+    return ast.SelectQuery(
+        select=[
+            ast.Alias(alias="team_id", expr=ast.Constant(value=context.team_id)),
+            ast.Alias(alias="person_id", expr=ast.Field(chain=["person_id"])),
+            ast.Alias(alias="revenue", expr=ast.Call(name="sum", args=[ast.Field(chain=["revenue"])])),
+            ast.Alias(alias="mrr", expr=ast.Call(name="sum", args=[ast.Field(chain=["mrr"])])),
+        ],
+        select_from=ast.JoinExpr(table=inner_query),
+        group_by=[ast.Field(chain=["person_id"])],
+    )
 
 
 class PersonsRevenueAnalyticsTable(LazyTable):

--- a/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
@@ -15,180 +15,186 @@
      HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT toString(persons.id) AS id,
-               'revenue_analytics.events.purchase' AS source_label,
-               persons.created_at AS timestamp,
-               persons.properties___name AS name,
-               persons.properties___email AS email,
-               persons.properties___phone AS phone,
-               persons.properties___address AS address,
-               persons.properties___metadata AS metadata,
-               persons.`properties___$geoip_country_name` AS country,
-               formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
-               NULL AS initial_coupon,
-               NULL AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
-                  toTimeZone(person.created_at, 'UTC') AS created_at
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
-        INNER JOIN
-          (SELECT DISTINCT events__person.id AS person_id
-           FROM events
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id
-              FROM person
-              WHERE equals(person.team_id, 99999)
-              GROUP BY person.id
-              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-           WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
-        ORDER BY persons.created_at DESC) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT toString(events.uuid) AS id,
-                  toString(events.uuid) AS invoice_item_id,
+          (SELECT toString(persons.id) AS id,
                   'revenue_analytics.events.purchase' AS source_label,
-                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                  timestamp AS created_at,
-                  0 AS is_recurring,
-                  NULL AS product_id,
-                  toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                  events.`$group_0` AS group_0_key,
-                  events.`$group_1` AS group_1_key,
-                  events.`$group_2` AS group_2_key,
-                  events.`$group_3` AS group_3_key,
-                  events.`$group_4` AS group_4_key,
-                  NULL AS invoice_id,
-                  NULL AS subscription_id,
-                  toString(events.`$session_id`) AS session_id,
-                  events.event AS event_name,
-                  NULL AS coupon,
-                  coupon AS coupon_id,
-                  'USD' AS original_currency,
-                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'USD' AS currency,
-                    if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-           FROM events
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-           ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-               sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
+                  persons.created_at AS timestamp,
+                  persons.properties___name AS name,
+                  persons.properties___email AS email,
+                  persons.properties___phone AS phone,
+                  persons.properties___address AS address,
+                  persons.properties___metadata AS metadata,
+                  persons.`properties___$geoip_country_name` AS country,
+                  formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
+                  NULL AS initial_coupon,
+                  NULL AS initial_coupon_id
            FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
+                     toTimeZone(person.created_at, 'UTC') AS created_at
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
+           INNER JOIN
+             (SELECT DISTINCT events__person.id AS person_id
+              FROM events
+              LEFT OUTER JOIN
+                (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id
+                 FROM person
+                 WHERE equals(person.team_id, 99999)
+                 GROUP BY person.id
+                 HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+              WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
+           ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT toString(events.uuid) AS id,
+                     toString(events.uuid) AS invoice_item_id,
+                     'revenue_analytics.events.purchase' AS source_label,
+                     toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                     timestamp AS created_at,
+                     0 AS is_recurring,
+                     NULL AS product_id,
+                     toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                     events.`$group_0` AS group_0_key,
+                     events.`$group_1` AS group_1_key,
+                     events.`$group_2` AS group_2_key,
+                     events.`$group_3` AS group_3_key,
+                     events.`$group_4` AS group_4_key,
+                     NULL AS invoice_id,
+                     NULL AS subscription_id,
+                     toString(events.`$session_id`) AS session_id,
+                     events.event AS event_name,
+                     NULL AS coupon,
+                     coupon AS coupon_id,
+                     'USD' AS original_currency,
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'USD' AS currency,
+                       if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+              FROM events
+              LEFT OUTER JOIN
+                (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+              WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+              ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                  sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
               FROM
-                (SELECT toString(events.uuid) AS id,
-                        toString(events.uuid) AS invoice_item_id,
-                        'revenue_analytics.events.purchase' AS source_label,
-                        toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                        timestamp AS created_at,
-                        0 AS is_recurring,
-                        NULL AS product_id,
-                        toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                        events.`$group_0` AS group_0_key,
-                        events.`$group_1` AS group_1_key,
-                        events.`$group_2` AS group_2_key,
-                        events.`$group_3` AS group_3_key,
-                        events.`$group_4` AS group_4_key,
-                        NULL AS invoice_id,
-                        NULL AS subscription_id,
-                        toString(events.`$session_id`) AS session_id,
-                        events.event AS event_name,
-                        NULL AS coupon,
-                        coupon AS coupon_id,
-                        'USD' AS original_currency,
-                        accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'USD' AS currency,
-                          if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                 FROM events
-                 LEFT OUTER JOIN
-                   (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                           person_distinct_id_overrides.distinct_id AS distinct_id
-                    FROM person_distinct_id_overrides
-                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                    GROUP BY person_distinct_id_overrides.distinct_id
-                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                 ORDER BY timestamp DESC) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                               toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
-              FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT toString(events.uuid) AS id,
+                           toString(events.uuid) AS invoice_item_id,
+                           'revenue_analytics.events.purchase' AS source_label,
+                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                           timestamp AS created_at,
+                           0 AS is_recurring,
+                           NULL AS product_id,
+                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                           events.`$group_0` AS group_0_key,
+                           events.`$group_1` AS group_1_key,
+                           events.`$group_2` AS group_2_key,
+                           events.`$group_3` AS group_3_key,
+                           events.`$group_4` AS group_4_key,
+                           NULL AS invoice_id,
+                           NULL AS subscription_id,
+                           toString(events.`$session_id`) AS session_id,
+                           events.event AS event_name,
+                           NULL AS coupon,
+                           coupon AS coupon_id,
+                           'USD' AS original_currency,
+                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'USD' AS currency,
+                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                    FROM events
+                    LEFT OUTER JOIN
+                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                              person_distinct_id_overrides.distinct_id AS distinct_id
+                       FROM person_distinct_id_overrides
+                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                       GROUP BY person_distinct_id_overrides.distinct_id
+                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                    ORDER BY timestamp DESC) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+                 WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   WHERE ifNull(equals(persons.id, '00000000-0000-0000-0000-000000000000'), 0)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -215,220 +221,226 @@
      HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__persons.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__persons.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT persons.id AS id,
-               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
-        FROM
-          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
-                  person.id AS id
-           FROM person
-           WHERE equals(person.team_id, 99999)
-           GROUP BY person.id
-           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
-        LEFT JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                  person_distinct_id2.distinct_id AS distinct_id
-           FROM person_distinct_id2
-           WHERE equals(person_distinct_id2.team_id, 99999)
-           GROUP BY person_distinct_id2.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.email, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT persons.id AS id,
+                  persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+           FROM
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+           LEFT JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.email, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons__revenue_analytics.revenue ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -455,220 +467,226 @@
      HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__persons.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__persons.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT persons.id AS id,
-               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
-        FROM
-          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
-                  person.id AS id
-           FROM person
-           WHERE equals(person.team_id, 99999)
-           GROUP BY person.id
-           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
-        LEFT JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                  person_distinct_id2.distinct_id AS distinct_id
-           FROM person_distinct_id2
-           WHERE equals(person_distinct_id2.team_id, 99999)
-           GROUP BY person_distinct_id2.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.email, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT persons.id AS id,
+                  persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+           FROM
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+           LEFT JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.email, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons__revenue_analytics.revenue ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -697,220 +715,226 @@
      HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__persons.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__persons.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT persons.id AS id,
-               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
-        FROM
-          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
-                  person.id AS id
-           FROM person
-           WHERE equals(person.team_id, 99999)
-           GROUP BY person.id
-           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
-        LEFT JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                  person_distinct_id2.distinct_id AS distinct_id
-           FROM person_distinct_id2
-           WHERE equals(person_distinct_id2.team_id, 99999)
-           GROUP BY person_distinct_id2.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.email, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT persons.id AS id,
+                  persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+           FROM
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+           LEFT JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.email, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -938,220 +962,226 @@
      HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__persons.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__persons.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT persons.id AS id,
-               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
-        FROM
-          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
-                  person.id AS id
-           FROM person
-           WHERE equals(person.team_id, 99999)
-           GROUP BY person.id
-           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
-        LEFT JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                  person_distinct_id2.distinct_id AS distinct_id
-           FROM person_distinct_id2
-           WHERE equals(person_distinct_id2.team_id, 99999)
-           GROUP BY person_distinct_id2.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT persons.id AS id,
+                  persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+           FROM
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+           LEFT JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -1179,220 +1209,226 @@
      HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__persons.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__persons.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT persons.id AS id,
-               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
-        FROM
-          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
-                  person.id AS id
-           FROM person
-           WHERE equals(person.team_id, 99999)
-           GROUP BY person.id
-           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
-        LEFT JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                  person_distinct_id2.distinct_id AS distinct_id
-           FROM person_distinct_id2
-           WHERE equals(person_distinct_id2.team_id, 99999)
-           GROUP BY person_distinct_id2.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT persons.id AS id,
+                  persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+           FROM
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+           LEFT JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -1421,220 +1457,226 @@
      HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__persons.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__persons.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT persons.id AS id,
-               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
-        FROM
-          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
-                  person.id AS id
-           FROM person
-           WHERE equals(person.team_id, 99999)
-           GROUP BY person.id
-           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
-        LEFT JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                  person_distinct_id2.distinct_id AS distinct_id
-           FROM person_distinct_id2
-           WHERE equals(person_distinct_id2.team_id, 99999)
-           GROUP BY person_distinct_id2.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(JSONExtractString(revenue_analytics_customer.metadata, 'id'), revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT persons.id AS id,
+                  persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+           FROM
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+           LEFT JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(JSONExtractString(revenue_analytics_customer.metadata, 'id'), revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -1656,177 +1698,145 @@
          persons_revenue_analytics.mrr AS mrr
   FROM
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT toString(persons.id) AS id,
-               'revenue_analytics.events.purchase' AS source_label,
-               persons.created_at AS timestamp,
-               persons.properties___name AS name,
-               persons.properties___email AS email,
-               persons.properties___phone AS phone,
-               persons.properties___address AS address,
-               persons.properties___metadata AS metadata,
-               persons.`properties___$geoip_country_name` AS country,
-               formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
-               NULL AS initial_coupon,
-               NULL AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
-                  toTimeZone(person.created_at, 'UTC') AS created_at
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
-        INNER JOIN
-          (SELECT DISTINCT events__person.id AS person_id
-           FROM events
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id
-              FROM person
-              WHERE equals(person.team_id, 99999)
-              GROUP BY person.id
-              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-           WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
-        ORDER BY persons.created_at DESC) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT toString(events.uuid) AS id,
-                  toString(events.uuid) AS invoice_item_id,
+          (SELECT toString(persons.id) AS id,
                   'revenue_analytics.events.purchase' AS source_label,
-                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                  timestamp AS created_at,
-                  isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
-                  NULL AS product_id,
-                  toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                  events.`$group_0` AS group_0_key,
-                  events.`$group_1` AS group_1_key,
-                  events.`$group_2` AS group_2_key,
-                  events.`$group_3` AS group_3_key,
-                  events.`$group_4` AS group_4_key,
-                  NULL AS invoice_id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
-                  toString(events.`$session_id`) AS session_id,
-                  events.event AS event_name,
-                  NULL AS coupon,
-                  coupon AS coupon_id,
-                  'USD' AS original_currency,
-                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'USD' AS currency,
-                    if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-           FROM events
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-           ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-               sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
+                  persons.created_at AS timestamp,
+                  persons.properties___name AS name,
+                  persons.properties___email AS email,
+                  persons.properties___phone AS phone,
+                  persons.properties___address AS address,
+                  persons.properties___metadata AS metadata,
+                  persons.`properties___$geoip_country_name` AS country,
+                  formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
+                  NULL AS initial_coupon,
+                  NULL AS initial_coupon_id
            FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
+                     toTimeZone(person.created_at, 'UTC') AS created_at
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
+           INNER JOIN
+             (SELECT DISTINCT events__person.id AS person_id
+              FROM events
+              LEFT OUTER JOIN
+                (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id
+                 FROM person
+                 WHERE equals(person.team_id, 99999)
+                 GROUP BY person.id
+                 HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+              WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
+           ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT toString(events.uuid) AS id,
+                     toString(events.uuid) AS invoice_item_id,
+                     'revenue_analytics.events.purchase' AS source_label,
+                     toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                     timestamp AS created_at,
+                     isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
+                     NULL AS product_id,
+                     toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                     events.`$group_0` AS group_0_key,
+                     events.`$group_1` AS group_1_key,
+                     events.`$group_2` AS group_2_key,
+                     events.`$group_3` AS group_3_key,
+                     events.`$group_4` AS group_4_key,
+                     NULL AS invoice_id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                     toString(events.`$session_id`) AS session_id,
+                     events.event AS event_name,
+                     NULL AS coupon,
+                     coupon AS coupon_id,
+                     'USD' AS original_currency,
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'USD' AS currency,
+                       if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+              FROM events
+              LEFT OUTER JOIN
+                (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+              WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+              ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                  sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
               FROM
-                (SELECT toString(events.uuid) AS id,
-                        toString(events.uuid) AS invoice_item_id,
-                        'revenue_analytics.events.purchase' AS source_label,
-                        toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                        timestamp AS created_at,
-                        isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
-                        NULL AS product_id,
-                        toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                        events.`$group_0` AS group_0_key,
-                        events.`$group_1` AS group_1_key,
-                        events.`$group_2` AS group_2_key,
-                        events.`$group_3` AS group_3_key,
-                        events.`$group_4` AS group_4_key,
-                        NULL AS invoice_id,
-                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
-                        toString(events.`$session_id`) AS session_id,
-                        events.event AS event_name,
-                        NULL AS coupon,
-                        coupon AS coupon_id,
-                        'USD' AS original_currency,
-                        accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'USD' AS currency,
-                          if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                 FROM events
-                 LEFT OUTER JOIN
-                   (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                           person_distinct_id_overrides.distinct_id AS distinct_id
-                    FROM person_distinct_id_overrides
-                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                    GROUP BY person_distinct_id_overrides.distinct_id
-                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                 ORDER BY timestamp DESC) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                               toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
-              FROM
-                (SELECT subscription_id AS id,
-                        'revenue_analytics.events.purchase' AS source_label,
-                        NULL AS plan_id,
-                        product_id AS product_id,
-                        toString(person_id) AS customer_id,
-                        NULL AS status,
-                        min_timestamp AS started_at,
-                        if(ifNull(greater(max_timestamp_plus_dropoff_days, today()), 0), NULL, max_timestamp_plus_dropoff_days) AS ended_at,
-                        NULL AS metadata
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
                  FROM
-                   (SELECT events__person.id AS person_id,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                   (SELECT toString(events.uuid) AS id,
+                           toString(events.uuid) AS invoice_item_id,
+                           'revenue_analytics.events.purchase' AS source_label,
+                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                           timestamp AS created_at,
+                           isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
                            NULL AS product_id,
-                           min(toTimeZone(events.timestamp, 'UTC')) AS min_timestamp,
-                           max(toTimeZone(events.timestamp, 'UTC')) AS max_timestamp,
-                           addDays(max_timestamp, 45.0) AS max_timestamp_plus_dropoff_days
+                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                           events.`$group_0` AS group_0_key,
+                           events.`$group_1` AS group_1_key,
+                           events.`$group_2` AS group_2_key,
+                           events.`$group_3` AS group_3_key,
+                           events.`$group_4` AS group_4_key,
+                           NULL AS invoice_id,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                           toString(events.`$session_id`) AS session_id,
+                           events.event AS event_name,
+                           NULL AS coupon,
+                           coupon AS coupon_id,
+                           'USD' AS original_currency,
+                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'USD' AS currency,
+                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
                     FROM events
                     LEFT OUTER JOIN
                       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
@@ -1835,25 +1845,63 @@
                        WHERE equals(person_distinct_id_overrides.team_id, 99999)
                        GROUP BY person_distinct_id_overrides.distinct_id
                        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                    LEFT JOIN
-                      (SELECT person.id AS id
-                       FROM person
-                       WHERE equals(person.team_id, 99999)
-                       GROUP BY person.id
-                       HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-                    WHERE and(equals(events.team_id, 99999), and(1, isNotNull(subscription_id)))
-                    GROUP BY subscription_id,
-                             person_id)
-                 ORDER BY started_at DESC) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons_revenue_analytics
+                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                    ORDER BY timestamp DESC) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT subscription_id AS id,
+                           'revenue_analytics.events.purchase' AS source_label,
+                           NULL AS plan_id,
+                           product_id AS product_id,
+                           toString(person_id) AS customer_id,
+                           NULL AS status,
+                           min_timestamp AS started_at,
+                           if(ifNull(greater(max_timestamp_plus_dropoff_days, today()), 0), NULL, max_timestamp_plus_dropoff_days) AS ended_at,
+                           NULL AS metadata
+                    FROM
+                      (SELECT events__person.id AS person_id,
+                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                              NULL AS product_id,
+                              min(toTimeZone(events.timestamp, 'UTC')) AS min_timestamp,
+                              max(toTimeZone(events.timestamp, 'UTC')) AS max_timestamp,
+                              addDays(max_timestamp, 45.0) AS max_timestamp_plus_dropoff_days
+                       FROM events
+                       LEFT OUTER JOIN
+                         (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                       LEFT JOIN
+                         (SELECT person.id AS id
+                          FROM person
+                          WHERE equals(person.team_id, 99999)
+                          GROUP BY person.id
+                          HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+                       WHERE and(equals(events.team_id, 99999), and(1, isNotNull(subscription_id)))
+                       GROUP BY subscription_id,
+                                person_id)
+                    ORDER BY started_at DESC) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+                 WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons_revenue_analytics
   ORDER BY persons_revenue_analytics.person_id ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -1875,222 +1923,931 @@
          persons_revenue_analytics.mrr AS mrr
   FROM
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__persons.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__persons.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT persons.id AS id,
-               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
-        FROM
-          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
-                  person.id AS id
-           FROM person
-           WHERE equals(person.team_id, 99999)
-           GROUP BY person.id
-           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
-        LEFT JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                  person_distinct_id2.distinct_id AS distinct_id
-           FROM person_distinct_id2
-           WHERE equals(person_distinct_id2.team_id, 99999)
-           GROUP BY person_distinct_id2.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT persons.id AS id,
+                  persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+           FROM
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+           LEFT JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons_revenue_analytics
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons_revenue_analytics
   ORDER BY persons_revenue_analytics.mrr DESC,
            persons_revenue_analytics.revenue DESC
+  LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
+                     readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalytics.test_revenue_aggregated_per_person_across_multiple_customers
+  '''
+  SELECT persons_revenue_analytics.person_id AS person_id,
+         persons_revenue_analytics.revenue AS revenue,
+         persons_revenue_analytics.mrr AS mrr
+  FROM
+    (SELECT 99999 AS team_id,
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
+     FROM
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__persons.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+        FROM
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id, ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
+           FROM
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
+              FROM
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+                 FROM
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT persons.id AS id,
+                  persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+           FROM
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+           LEFT JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+              FROM
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons_revenue_analytics
+  WHERE ifNull(equals(persons_revenue_analytics.person_id, toUUIDOrNull('00000000-0000-4000-8000-000000000000')), 0)
+  LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
+                     readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalytics.test_revenue_aggregated_per_person_across_multiple_customers.1
+  '''
+  SELECT persons.id AS id,
+         persons__revenue_analytics.revenue AS `$virt_revenue`,
+         persons__revenue_analytics.mrr AS `$virt_mrr`
+  FROM (
+  SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                                                                person.id AS id
+  FROM person
+  WHERE and(equals(person.team_id,
+                   99999), in(id, (
+    SELECT where_optimization.id AS id
+    FROM person AS where_optimization WHERE and(equals(where_optimization.team_id,
+                                                       99999), equals(where_optimization.id,
+                                                                      toUUIDOrNull('00000000-0000-4000-8000-000000000000'))))))
+  GROUP BY person.id
+  HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at,
+                                                                                                                                                       'UTC')), person.version), 1), plus(now64(6,
+                                                                                                                                                                                                'UTC'), toIntervalDay(1))), 0))) AS persons
+  LEFT JOIN (
+  SELECT 99999 AS team_id,
+         person_id AS person_id,
+         sum(revenue) AS revenue,
+             sum(mrr) AS mrr
+  FROM (
+  SELECT 99999 AS team_id,
+         revenue_analytics_customer__persons.id AS person_id,
+         coalesce(revenue_agg.revenue,
+                  accurateCastOrNull(0,
+                                     'Decimal64(10)')) AS revenue,
+                                                     coalesce(mrr_agg.mrr,
+                                                              accurateCastOrNull(0,
+                                                                                 'Decimal64(10)')) AS mrr
+  FROM (
+  SELECT inner.id AS id,
+         inner.source_label AS source_label,
+         inner.timestamp AS timestamp,
+         inner.name AS name,
+         inner.email AS email,
+         inner.phone AS phone,
+         inner.address AS address,
+         if(notEquals(JSONExtractString(inner.metadata,
+                                        'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata,
+                                                                                                                                        '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata,
+                                                                                                                                                                                       '{}'), k), JSONExtractKeys(ifNull(inner.metadata,
+                                                                                                                                                                                                                         '{}')))), map('posthog_person_distinct_id_source',
+                                                                                                                                                                                                                                       'customer'))), if(ifNull(notEquals(inner.resolved_distinct_id,
+                                                                                                                                                                                                                                                                          ''), 1), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata,
+                                                                                                                                                                                                                                                                                                                                               '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata,
+                                                                                                                                                                                                                                                                                                                                                                                              '{}'), k), JSONExtractKeys(ifNull(inner.metadata,
+                                                                                                                                                                                                                                                                                                                                                                                                                                '{}')))), map('posthog_person_distinct_id',
+                                                                                                                                                                                                                                                                                                                                                                                                                                              inner.resolved_distinct_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                                              'posthog_person_distinct_id_source',
+                                                                                                                                                                                                                                                                                                                                                                                                                                              inner.resolved_source))), inner.metadata)) AS metadata,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       inner.country AS country,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       inner.cohort AS cohort,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       inner.initial_coupon AS initial_coupon,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       inner.initial_coupon_id AS initial_coupon_id
+  FROM (
+  SELECT outer.id AS id,
+         'stripe.posthog_test' AS source_label,
+         parseDateTime64BestEffortOrNull(toString(outer.created), 6,
+                                                                  'UTC') AS timestamp,
+                                                                       outer.name AS name,
+                                                                       outer.email AS email,
+                                                                       outer.phone AS phone,
+                                                                       outer.address AS address,
+                                                                       outer.metadata AS metadata,
+                                                                       JSONExtractString(address,
+                                                                                         'country') AS country,
+                                                                                                  cohort_inner.cohort AS cohort,
+                                                                                                  cohort_inner.initial_coupon AS initial_coupon,
+                                                                                                  cohort_inner.initial_coupon_id AS initial_coupon_id,
+                                                                                                  ifNull(resolved.resolved_distinct_id,
+                                                                                                         '') AS resolved_distinct_id,
+                                                                                                           ifNull(resolved.resolved_source,
+                                                                                                                  '') AS resolved_source
+  FROM (
+  SELECT *
+  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv',
+          'object_storage_root_user',
+          'object_storage_root_password',
+          'CSVWithNames',
+          '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+  LEFT JOIN (
+  SELECT invoice.customer AS customer_id,
+         formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6,
+                                                                                                      'UTC'))), '%Y-%m') AS cohort,
+                                                                                                                       argMin(JSONExtractString(invoice.discount,
+                                                                                                                                                'coupon',
+                                                                                                                                                'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6,
+                                                                                                                                                                                                                    'UTC')) AS initial_coupon,
+                                                                                                                                                                                                                          argMin(JSONExtractString(invoice.discount,
+                                                                                                                                                                                                                                                   'coupon',
+                                                                                                                                                                                                                                                   'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6,
+                                                                                                                                                                                                                                                                                                                     'UTC')) AS initial_coupon_id
+  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv',
+          'object_storage_root_user',
+          'object_storage_root_password',
+          'CSVWithNames',
+          '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+  GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id,
+                                                       outer.id)
+  LEFT JOIN (
+  SELECT child_meta.customer_id AS customer_id,
+         argMax(child_meta.distinct_id,
+                child_meta.created_at) AS resolved_distinct_id,
+                argMax(child_meta.source_ref,
+                       child_meta.created_at) AS resolved_source
+  FROM (
+  SELECT posthog_test_stripe_invoice.customer AS customer_id,
+         JSONExtractString(posthog_test_stripe_invoice.metadata,
+                           'posthog_person_distinct_id') AS distinct_id,
+                                                       concat('invoice',
+                                                              '::',
+                                                              ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                                                                                                                  parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6,
+                                                                                                                                                                                                 'UTC') AS created_at
+  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv',
+          'object_storage_root_user',
+          'object_storage_root_password',
+          'CSVWithNames',
+          '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+  WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata,
+                                    'posthog_person_distinct_id'), '')) AS child_meta
+  GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id,
+                                                         outer.id)) AS inner) AS revenue_analytics_customer
+  LEFT JOIN (
+  SELECT persons.id AS id,
+         persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+  FROM (
+  SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                                                                person.id AS id
+  FROM person
+  WHERE equals(person.team_id,
+               99999)
+  GROUP BY person.id
+  HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at,
+                                                                                                                                                       'UTC')), person.version), 1), plus(now64(6,
+                                                                                                                                                                                                'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+  LEFT JOIN (
+  SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                                                                                                 person_distinct_id2.distinct_id AS distinct_id
+  FROM person_distinct_id2
+  WHERE equals(person_distinct_id2.team_id,
+               99999)
+  GROUP BY person_distinct_id2.distinct_id
+  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id,
+                                                                                                                                                                                               persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id,
+                                                                                                                                                                                                                                                                         revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+  LEFT JOIN (
+  SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+         sum(revenue_analytics_revenue_item.amount) AS revenue
+  FROM (
+  SELECT if(ifNull(greater(invoice.period_months,
+                           1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_',
+                                                                                         ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                                                                                                                                     invoice.invoice_item_id AS invoice_item_id,
+                                                                                                                                     'stripe.posthog_test' AS source_label,
+                                                                                                                                     addMonths(invoice.timestamp,
+                                                                                                                                               invoice.month_index) AS timestamp,
+                                                                                                                                               invoice.created_at AS created_at,
+                                                                                                                                               ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                                                                                                                                                                                         invoice.product_id AS product_id,
+                                                                                                                                                                                         invoice.customer_id AS customer_id,
+                                                                                                                                                                                         NULL AS group_0_key,
+                                                                                                                                                                                         NULL AS group_1_key,
+                                                                                                                                                                                         NULL AS group_2_key,
+                                                                                                                                                                                         NULL AS group_3_key,
+                                                                                                                                                                                         NULL AS group_4_key,
+                                                                                                                                                                                         invoice.id AS invoice_id,
+                                                                                                                                                                                         invoice.subscription_id AS subscription_id,
+                                                                                                                                                                                         NULL AS session_id,
+                                                                                                                                                                                         NULL AS event_name,
+                                                                                                                                                                                         JSONExtractString(invoice.discount,
+                                                                                                                                                                                                           'coupon',
+                                                                                                                                                                                                           'name') AS coupon,
+                                                                                                                                                                                                                 JSONExtractString(invoice.discount,
+                                                                                                                                                                                                                                   'coupon',
+                                                                                                                                                                                                                                   'id') AS coupon_id,
+                                                                                                                                                                                                                                       upper(invoice.currency) AS original_currency,
+                                                                                                                                                                                                                                             accurateCastOrNull(invoice.amount_captured,
+                                                                                                                                                                                                                                                                'Decimal64(10)') AS original_amount,
+                                                                                                                                                                                                                                                                               in(original_currency,
+                                                                                                                                                                                                                                                                                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                                                                                                                                                                                                                                                                                  if(enable_currency_aware_divider,
+                                                                                                                                                                                                                                                                                     accurateCastOrNull(1,
+                                                                                                                                                                                                                                                                                                        'Decimal64(10)'), accurateCastOrNull(100,
+                                                                                                                                                                                                                                                                                                                                             'Decimal64(10)')) AS currency_aware_divider,
+                                                                                                                                                                                                                                                                                                                                                             divideDecimal(original_amount,
+                                                                                                                                                                                                                                                                                                                                                                           currency_aware_divider) AS currency_aware_amount,
+                                                                                                                                                                                                                                                                                                                                                                           'GBP' AS currency,
+                                                                                                                                                                                                                                                                                                                                                                           divideDecimal(if(equals(original_currency,
+                                                                                                                                                                                                                                                                                                                                                                                                   currency), toDecimal64(currency_aware_amount,
+                                                                                                                                                                                                                                                                                                                                                                                                                          10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                   'rate',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                   original_currency,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                   toDate(ifNull(timestamp, toDateTime(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       'UTC'))), toDecimal64(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             10)) = 0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    toDecimal64(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        'rate',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        original_currency,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        toDate(ifNull(timestamp, toDateTime(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            'UTC'))), toDecimal64(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  10)) = 0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         toDecimal64(1,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           'rate',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           original_currency,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           toDate(ifNull(timestamp, toDateTime(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               'UTC'))), toDecimal64(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              'rate',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              currency,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              toDate(ifNull(timestamp, toDateTime(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  'UTC'))), toDecimal64(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        10))))), accurateCastOrNull(invoice.period_months,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    'Decimal64(10)')) AS amount
+  FROM (
+  SELECT posthog_test_stripe_invoice.id AS id,
+         parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6,
+                                                                                        'UTC') AS created_at,
+                                                                                             posthog_test_stripe_invoice.customer AS customer_id,
+                                                                                             posthog_test_stripe_invoice.subscription AS subscription_id,
+                                                                                             posthog_test_stripe_invoice.discount AS discount,
+                                                                                             arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines,
+                                                                                                                                                                                       'data'), ''), 'null'), '^"|"$',
+                                                                                                                                                                                                              '')))) AS data,
+                                                                                                                                                                                                                   JSONExtractString(data,
+                                                                                                                                                                                                                                     'id') AS invoice_item_id,
+                                                                                                                                                                                                                                         JSONExtractUInt(data,
+                                                                                                                                                                                                                                                         'amount') AS amount_before_discount,
+                                                                                                                                                                                                                                                                 coalesce(arraySum(arrayMap(x -> JSONExtractInt(x,
+                                                                                                                                                                                                                                                                                                                'amount'), JSONExtractArrayRaw(data,
+                                                                                                                                                                                                                                                                                                                                               'discount_amounts'))), 0) AS discount_amount,
+                                                                                                                                                                                                                                                                                                                                                                      greatest(minus(amount_before_discount,
+                                                                                                                                                                                                                                                                                                                                                                                     discount_amount), 0) AS amount_captured,
+                                                                                                                                                                                                                                                                                                                                                                                                       JSONExtractString(data,
+                                                                                                                                                                                                                                                                                                                                                                                                                         'currency') AS currency,
+                                                                                                                                                                                                                                                                                                                                                                                                                                   JSONExtractString(data,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                     'price',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                     'product') AS product_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                              fromUnixTimestamp(JSONExtractUInt(data,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                'period',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                'start')) AS period_start,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        fromUnixTimestamp(JSONExtractUInt(data,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          'period',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          'end')) AS period_end,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                greatest(toInt16(round(divide(dateDiff('day',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       ifNull(period_start,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             'UTC')), ifNull(period_end,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            'UTC'))), 30.44))), 1) AS period_months,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                arrayJoin(range(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                period_months)) AS month_index,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ifNull(period_start,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    'UTC')) AS timestamp
+  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv',
+          'object_storage_root_user',
+          'object_storage_root_password',
+          'CSVWithNames',
+          '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+  WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+  GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id,
+                                                 revenue_agg.customer_id)
+  LEFT JOIN (
+  SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+         sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+  FROM (
+  SELECT union.source_label AS source_label,
+         union.customer_id AS customer_id,
+         union.subscription_id AS subscription_id,
+         argMax(union.amount,
+                union.timestamp) AS mrr
+  FROM (
+  SELECT revenue_item.source_label AS source_label,
+         revenue_item.customer_id AS customer_id,
+         revenue_item.subscription_id AS subscription_id,
+         toStartOfMonth(toTimeZone(revenue_item.timestamp,
+                                   'UTC')) AS timestamp,
+                                         sum(revenue_item.amount) AS amount
+  FROM (
+  SELECT if(ifNull(greater(invoice.period_months,
+                           1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_',
+                                                                                         ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                                                                                                                                     invoice.invoice_item_id AS invoice_item_id,
+                                                                                                                                     'stripe.posthog_test' AS source_label,
+                                                                                                                                     addMonths(invoice.timestamp,
+                                                                                                                                               invoice.month_index) AS timestamp,
+                                                                                                                                               invoice.created_at AS created_at,
+                                                                                                                                               ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                                                                                                                                                                                         invoice.product_id AS product_id,
+                                                                                                                                                                                         invoice.customer_id AS customer_id,
+                                                                                                                                                                                         NULL AS group_0_key,
+                                                                                                                                                                                         NULL AS group_1_key,
+                                                                                                                                                                                         NULL AS group_2_key,
+                                                                                                                                                                                         NULL AS group_3_key,
+                                                                                                                                                                                         NULL AS group_4_key,
+                                                                                                                                                                                         invoice.id AS invoice_id,
+                                                                                                                                                                                         invoice.subscription_id AS subscription_id,
+                                                                                                                                                                                         NULL AS session_id,
+                                                                                                                                                                                         NULL AS event_name,
+                                                                                                                                                                                         JSONExtractString(invoice.discount,
+                                                                                                                                                                                                           'coupon',
+                                                                                                                                                                                                           'name') AS coupon,
+                                                                                                                                                                                                                 JSONExtractString(invoice.discount,
+                                                                                                                                                                                                                                   'coupon',
+                                                                                                                                                                                                                                   'id') AS coupon_id,
+                                                                                                                                                                                                                                       upper(invoice.currency) AS original_currency,
+                                                                                                                                                                                                                                             accurateCastOrNull(invoice.amount_captured,
+                                                                                                                                                                                                                                                                'Decimal64(10)') AS original_amount,
+                                                                                                                                                                                                                                                                               in(original_currency,
+                                                                                                                                                                                                                                                                                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                                                                                                                                                                                                                                                                                  if(enable_currency_aware_divider,
+                                                                                                                                                                                                                                                                                     accurateCastOrNull(1,
+                                                                                                                                                                                                                                                                                                        'Decimal64(10)'), accurateCastOrNull(100,
+                                                                                                                                                                                                                                                                                                                                             'Decimal64(10)')) AS currency_aware_divider,
+                                                                                                                                                                                                                                                                                                                                                             divideDecimal(original_amount,
+                                                                                                                                                                                                                                                                                                                                                                           currency_aware_divider) AS currency_aware_amount,
+                                                                                                                                                                                                                                                                                                                                                                           'GBP' AS currency,
+                                                                                                                                                                                                                                                                                                                                                                           divideDecimal(if(equals(original_currency,
+                                                                                                                                                                                                                                                                                                                                                                                                   currency), toDecimal64(currency_aware_amount,
+                                                                                                                                                                                                                                                                                                                                                                                                                          10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                   'rate',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                   original_currency,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                   toDate(ifNull(timestamp, toDateTime(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       'UTC'))), toDecimal64(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             10)) = 0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    toDecimal64(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        'rate',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        original_currency,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        toDate(ifNull(timestamp, toDateTime(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            'UTC'))), toDecimal64(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  10)) = 0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         toDecimal64(1,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           'rate',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           original_currency,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           toDate(ifNull(timestamp, toDateTime(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               'UTC'))), toDecimal64(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              'rate',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              currency,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              toDate(ifNull(timestamp, toDateTime(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  'UTC'))), toDecimal64(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        10))))), accurateCastOrNull(invoice.period_months,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    'Decimal64(10)')) AS amount
+  FROM (
+  SELECT posthog_test_stripe_invoice.id AS id,
+         parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6,
+                                                                                        'UTC') AS created_at,
+                                                                                             posthog_test_stripe_invoice.customer AS customer_id,
+                                                                                             posthog_test_stripe_invoice.subscription AS subscription_id,
+                                                                                             posthog_test_stripe_invoice.discount AS discount,
+                                                                                             arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines,
+                                                                                                                                                                                       'data'), ''), 'null'), '^"|"$',
+                                                                                                                                                                                                              '')))) AS data,
+                                                                                                                                                                                                                   JSONExtractString(data,
+                                                                                                                                                                                                                                     'id') AS invoice_item_id,
+                                                                                                                                                                                                                                         JSONExtractUInt(data,
+                                                                                                                                                                                                                                                         'amount') AS amount_before_discount,
+                                                                                                                                                                                                                                                                 coalesce(arraySum(arrayMap(x -> JSONExtractInt(x,
+                                                                                                                                                                                                                                                                                                                'amount'), JSONExtractArrayRaw(data,
+                                                                                                                                                                                                                                                                                                                                               'discount_amounts'))), 0) AS discount_amount,
+                                                                                                                                                                                                                                                                                                                                                                      greatest(minus(amount_before_discount,
+                                                                                                                                                                                                                                                                                                                                                                                     discount_amount), 0) AS amount_captured,
+                                                                                                                                                                                                                                                                                                                                                                                                       JSONExtractString(data,
+                                                                                                                                                                                                                                                                                                                                                                                                                         'currency') AS currency,
+                                                                                                                                                                                                                                                                                                                                                                                                                                   JSONExtractString(data,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                     'price',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                     'product') AS product_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                              fromUnixTimestamp(JSONExtractUInt(data,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                'period',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                'start')) AS period_start,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        fromUnixTimestamp(JSONExtractUInt(data,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          'period',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          'end')) AS period_end,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                greatest(toInt16(round(divide(dateDiff('day',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       ifNull(period_start,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             'UTC')), ifNull(period_end,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            'UTC'))), 30.44))), 1) AS period_months,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                arrayJoin(range(0,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                period_months)) AS month_index,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ifNull(period_start,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    'UTC')) AS timestamp
+  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv',
+          'object_storage_root_user',
+          'object_storage_root_password',
+          'CSVWithNames',
+          '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+  WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item WHERE and(revenue_item.is_recurring,
+                                                                                isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000',
+                                                                                                                                                                                        6,
+                                                                                                                                                                                        'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000',
+                                                                                                                                                                                                                                             6,
+                                                                                                                                                                                                                                             'UTC')))
+  GROUP BY revenue_item.source_label,
+           revenue_item.customer_id,
+           revenue_item.subscription_id, timestamp
+  ORDER BY timestamp DESC
+  UNION ALL
+  SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+         `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+         `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+         toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at,
+                    'UTC') AS timestamp,
+                         accurateCastOrNull(0,
+                                            'Decimal64(10)') AS amount
+  FROM (
+  SELECT '' AS id,
+         '' AS source_label,
+         '' AS plan_id,
+         '' AS product_id,
+         '' AS customer_id,
+         '' AS status,
+         toDateTime64('1970-01-01 00:00:00.000000',
+                      6,
+                      'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000',
+                                        6,
+                                        'UTC') AS ended_at,
+                                             '' AS metadata
+  WHERE 0) AS `stripe.posthog_test.subscription_revenue_view` WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000',
+                                                                                                                                       6,
+                                                                                                                                       'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000',
+                                                                                                                                                                                            6,
+                                                                                                                                                                                            'UTC')))
+  ORDER BY timestamp DESC) AS
+  union
+  GROUP BY source_label,
+           customer_id,
+           subscription_id
+  ORDER BY customer_id ASC,
+           subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id,
+                                             mrr_agg.customer_id))
+  GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+  WHERE ifNull(equals(persons.id,
+                      toUUIDOrNull('00000000-0000-4000-8000-000000000000')), 0)
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
                      max_execution_time=60,
@@ -2146,6 +2903,8 @@
   GROUP BY person.id
   HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__pdi__person ON equals(e__pdi.e__pdi___person_id, e__pdi__person.e__pdi__person___id)
   LEFT JOIN (
+  SELECT 99999 AS team_id, person_id AS person_id, sum(revenue) AS revenue, sum(mrr) AS mrr
+  FROM (
   SELECT 99999 AS team_id, revenue_analytics_customer.id AS person_id, coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue, coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
   FROM (
   SELECT toString(persons.id) AS id, 'revenue_analytics.events.purchase' AS source_label, persons.created_at AS timestamp, persons.properties___name AS name, persons.properties___email AS email, persons.properties___phone AS phone, persons.properties___address AS address, persons.properties___metadata AS metadata, persons.`properties___$geoip_country_name` AS country, formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort, NULL AS initial_coupon, NULL AS initial_coupon_id
@@ -2217,7 +2976,8 @@
   union
   GROUP BY source_label, customer_id, subscription_id
   ORDER BY customer_id ASC, subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__pdi__person__revenue_analytics ON equals(toString(e__pdi__person.e__pdi__person___id), toString(e__pdi__person__revenue_analytics.person_id))
+  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+  GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(toString(e__pdi__person.e__pdi__person___id), toString(e__pdi__person__revenue_analytics.person_id))
   WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
   GROUP BY day_start, breakdown_value_1)
   GROUP BY day_start, breakdown_value_1
@@ -2270,153 +3030,159 @@
            FROM events AS e
            LEFT JOIN
              (SELECT 99999 AS team_id,
-                     revenue_analytics_customer.id AS person_id,
-                     coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-                     coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+                     person_id AS person_id,
+                     sum(revenue) AS revenue,
+                     sum(mrr) AS mrr
               FROM
-                (SELECT toString(persons.id) AS id,
-                        'revenue_analytics.events.purchase' AS source_label,
-                        persons.created_at AS timestamp,
-                        persons.properties___name AS name,
-                        persons.properties___email AS email,
-                        persons.properties___phone AS phone,
-                        persons.properties___address AS address,
-                        persons.properties___metadata AS metadata,
-                        persons.`properties___$geoip_country_name` AS country,
-                        formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
-                        NULL AS initial_coupon,
-                        NULL AS initial_coupon_id
+                (SELECT 99999 AS team_id,
+                        revenue_analytics_customer.id AS person_id,
+                        coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+                        coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
                  FROM
-                   (SELECT person.id AS id,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
-                           toTimeZone(person.created_at, 'UTC') AS created_at
-                    FROM person
-                    WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                                  (SELECT person.id AS id, max(person.version) AS version
-                                                                   FROM person
-                                                                   WHERE equals(person.team_id, 99999)
-                                                                   GROUP BY person.id
-                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
-                 INNER JOIN
-                   (SELECT DISTINCT events.person_id AS person_id
-                    FROM events
-                    WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
-                 ORDER BY persons.created_at DESC) AS revenue_analytics_customer
-              LEFT JOIN
-                (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-                        sum(revenue_analytics_revenue_item.amount) AS revenue
-                 FROM
-                   (SELECT toString(events.uuid) AS id,
-                           toString(events.uuid) AS invoice_item_id,
+                   (SELECT toString(persons.id) AS id,
                            'revenue_analytics.events.purchase' AS source_label,
-                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                           timestamp AS created_at,
-                           0 AS is_recurring,
-                           NULL AS product_id,
-                           toString(events.person_id) AS customer_id,
-                           events.`$group_0` AS group_0_key,
-                           events.`$group_1` AS group_1_key,
-                           events.`$group_2` AS group_2_key,
-                           events.`$group_3` AS group_3_key,
-                           events.`$group_4` AS group_4_key,
-                           NULL AS invoice_id,
-                           NULL AS subscription_id,
-                           toString(events.`$session_id`) AS session_id,
-                           events.event AS event_name,
-                           NULL AS coupon,
-                           coupon AS coupon_id,
-                           'USD' AS original_currency,
-                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                           in(original_currency,
-                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                             'USD' AS currency,
-                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                    FROM events
-                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                    ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                 GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-              LEFT JOIN
-                (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-                        sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-                 FROM
-                   (SELECT union.source_label AS source_label,
-                           union.customer_id AS customer_id,
-                           union.subscription_id AS subscription_id,
-                           argMax(union.amount, union.timestamp) AS mrr
+                           persons.created_at AS timestamp,
+                           persons.properties___name AS name,
+                           persons.properties___email AS email,
+                           persons.properties___phone AS phone,
+                           persons.properties___address AS address,
+                           persons.properties___metadata AS metadata,
+                           persons.`properties___$geoip_country_name` AS country,
+                           formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
+                           NULL AS initial_coupon,
+                           NULL AS initial_coupon_id
                     FROM
-                      (SELECT revenue_item.source_label AS source_label,
-                              revenue_item.customer_id AS customer_id,
-                              revenue_item.subscription_id AS subscription_id,
-                              toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                              sum(revenue_item.amount) AS amount
+                      (SELECT person.id AS id,
+                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
+                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
+                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
+                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
+                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
+                              toTimeZone(person.created_at, 'UTC') AS created_at
+                       FROM person
+                       WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                                     (SELECT person.id AS id, max(person.version) AS version
+                                                                      FROM person
+                                                                      WHERE equals(person.team_id, 99999)
+                                                                      GROUP BY person.id
+                                                                      HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
+                    INNER JOIN
+                      (SELECT DISTINCT events.person_id AS person_id
+                       FROM events
+                       WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
+                    ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+                 LEFT JOIN
+                   (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                           sum(revenue_analytics_revenue_item.amount) AS revenue
+                    FROM
+                      (SELECT toString(events.uuid) AS id,
+                              toString(events.uuid) AS invoice_item_id,
+                              'revenue_analytics.events.purchase' AS source_label,
+                              toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                              timestamp AS created_at,
+                              0 AS is_recurring,
+                              NULL AS product_id,
+                              toString(events.person_id) AS customer_id,
+                              events.`$group_0` AS group_0_key,
+                              events.`$group_1` AS group_1_key,
+                              events.`$group_2` AS group_2_key,
+                              events.`$group_3` AS group_3_key,
+                              events.`$group_4` AS group_4_key,
+                              NULL AS invoice_id,
+                              NULL AS subscription_id,
+                              toString(events.`$session_id`) AS session_id,
+                              events.event AS event_name,
+                              NULL AS coupon,
+                              coupon AS coupon_id,
+                              'USD' AS original_currency,
+                              accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                              in(original_currency,
+                                 ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                                if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                                divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                                'USD' AS currency,
+                                if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                       FROM events
+                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                       ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+                    GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+                 LEFT JOIN
+                   (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                           sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+                    FROM
+                      (SELECT union.source_label AS source_label,
+                              union.customer_id AS customer_id,
+                              union.subscription_id AS subscription_id,
+                              argMax(union.amount, union.timestamp) AS mrr
                        FROM
-                         (SELECT toString(events.uuid) AS id,
-                                 toString(events.uuid) AS invoice_item_id,
-                                 'revenue_analytics.events.purchase' AS source_label,
-                                 toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                                 timestamp AS created_at,
-                                 0 AS is_recurring,
-                                 NULL AS product_id,
-                                 toString(events.person_id) AS customer_id,
-                                 events.`$group_0` AS group_0_key,
-                                 events.`$group_1` AS group_1_key,
-                                 events.`$group_2` AS group_2_key,
-                                 events.`$group_3` AS group_3_key,
-                                 events.`$group_4` AS group_4_key,
-                                 NULL AS invoice_id,
-                                 NULL AS subscription_id,
-                                 toString(events.`$session_id`) AS session_id,
-                                 events.event AS event_name,
-                                 NULL AS coupon,
-                                 coupon AS coupon_id,
-                                 'USD' AS original_currency,
-                                 accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                                 in(original_currency,
-                                    ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                                   if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                                   divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                                   'USD' AS currency,
-                                   if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                          FROM events
-                          WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                          ORDER BY timestamp DESC) AS revenue_item
-                       WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-                       GROUP BY revenue_item.source_label,
-                                revenue_item.customer_id,
-                                revenue_item.subscription_id, timestamp
-                       ORDER BY timestamp DESC
-                       UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                                        toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                                        accurateCastOrNull(0, 'Decimal64(10)') AS amount
-                       FROM
-                         (SELECT '' AS id,
-                                 '' AS source_label,
-                                 '' AS plan_id,
-                                 '' AS product_id,
-                                 '' AS customer_id,
-                                 '' AS status,
-                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                                 '' AS metadata
-                          WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-                       WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-                       ORDER BY timestamp DESC) AS
-                    union
-                    GROUP BY source_label,
-                             customer_id,
-                             subscription_id
-                    ORDER BY customer_id ASC,
-                             subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-                 GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__poe__revenue_analytics ON equals(toString(e.person_id), toString(e__poe__revenue_analytics.person_id))
+                         (SELECT revenue_item.source_label AS source_label,
+                                 revenue_item.customer_id AS customer_id,
+                                 revenue_item.subscription_id AS subscription_id,
+                                 toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                                 sum(revenue_item.amount) AS amount
+                          FROM
+                            (SELECT toString(events.uuid) AS id,
+                                    toString(events.uuid) AS invoice_item_id,
+                                    'revenue_analytics.events.purchase' AS source_label,
+                                    toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                                    timestamp AS created_at,
+                                    0 AS is_recurring,
+                                    NULL AS product_id,
+                                    toString(events.person_id) AS customer_id,
+                                    events.`$group_0` AS group_0_key,
+                                    events.`$group_1` AS group_1_key,
+                                    events.`$group_2` AS group_2_key,
+                                    events.`$group_3` AS group_3_key,
+                                    events.`$group_4` AS group_4_key,
+                                    NULL AS invoice_id,
+                                    NULL AS subscription_id,
+                                    toString(events.`$session_id`) AS session_id,
+                                    events.event AS event_name,
+                                    NULL AS coupon,
+                                    coupon AS coupon_id,
+                                    'USD' AS original_currency,
+                                    accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                                    in(original_currency,
+                                       ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                                      if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                                      divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                                      'USD' AS currency,
+                                      if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                             FROM events
+                             WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                             ORDER BY timestamp DESC) AS revenue_item
+                          WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                          GROUP BY revenue_item.source_label,
+                                   revenue_item.customer_id,
+                                   revenue_item.subscription_id, timestamp
+                          ORDER BY timestamp DESC
+                          UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                                           `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                                           `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                                           toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                           accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                          FROM
+                            (SELECT '' AS id,
+                                    '' AS source_label,
+                                    '' AS plan_id,
+                                    '' AS product_id,
+                                    '' AS customer_id,
+                                    '' AS status,
+                                    toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                                    toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                                    '' AS metadata
+                             WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+                          WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+                          ORDER BY timestamp DESC) AS
+                       union
+                       GROUP BY source_label,
+                                customer_id,
+                                subscription_id
+                       ORDER BY customer_id ASC,
+                                subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                    GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+              GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(e.person_id), toString(e__poe__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
                     breakdown_value_1)
@@ -2461,384 +3227,101 @@
 # ---
 # name: TestPersonsRevenueAnalytics.test_virtual_property_in_trend_2_person_id_override_properties_on_events.1
   '''
-  SELECT groupArray(1)(date)[1] AS date,
-                             arrayFold((acc,
-                                        x) -> arrayMap(i -> plus(acc[i], x[i]), range(1,
-                                                                                      plus(length(date), 1))), groupArray(ifNull(total,
-                                                                                                                                 0)), arrayWithConstant(length(date), reinterpretAsFloat64(0))) AS total,
-                                                                                                                                                                                              arrayMap(i -> if(ifNull(ifNull(greaterOrEquals(row_number,
-                                                                                                                                                                                                                                             25), 0), 0), '$$_posthog_breakdown_other_$$',
-                                                                                                                                                                                                                                                          i), breakdown_value) AS breakdown_value
+  SELECT groupArray(1)(date)[1] AS date, arrayFold((acc, x) -> arrayMap(i -> plus(acc[i], x[i]), range(1, plus(length(date), 1))), groupArray(ifNull(total, 0)), arrayWithConstant(length(date), reinterpretAsFloat64(0))) AS total, arrayMap(i -> if(ifNull(ifNull(greaterOrEquals(row_number, 25), 0), 0), '$$_posthog_breakdown_other_$$', i), breakdown_value) AS breakdown_value
   FROM (
-  SELECT arrayMap(number -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00',
-                                                                            'UTC')), toIntervalDay(1)), toIntervalDay(number)), range(0,
-                                                                                                                                      plus(coalesce(dateDiff('day',
-                                                                                                                                                             toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00',
-                                                                                                                                                                                                        'UTC')), toIntervalDay(1)), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 23:59:59',
-                                                                                                                                                                                                                                                                               'UTC')), toIntervalDay(1)))), 1))) AS date,
-                                                                                                                                                                                                                                                                                                                arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count,
-                                                                                                                                                                                                                                                                                                                                                                              0)), indexOf(groupArray(day_start) AS _days_for_count,
-                                                                                                                                                                                                                                                                                                                                                                                                      _match_date) AS _index,
-                                                                                                                                                                                                                                                                                                                                                                                                      plus(minus(arrayLastIndex(x -> ifNull(equals(x,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                   _match_date), isNull(x)
-  and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total,
-                                                                 breakdown_value AS breakdown_value,
-                                                                 rowNumberInAllBlocks() AS row_number
+  SELECT arrayMap(number -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1)), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC')), toIntervalDay(1)))), 1))) AS date, arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
+  and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total, breakdown_value AS breakdown_value, rowNumberInAllBlocks() AS row_number
   FROM (
-  SELECT sum(total) AS count,
-             day_start AS day_start,
-             [ifNull(toString(breakdown_value_1), '$$_posthog_breakdown_null_$$')] AS breakdown_value
+  SELECT sum(total) AS count, day_start AS day_start, [ifNull(toString(breakdown_value_1), '$$_posthog_breakdown_null_$$')] AS breakdown_value
   FROM (
-  SELECT count() AS total,
-               toStartOfDay(toTimeZone(e.timestamp,
-                                       'UTC')) AS day_start,
-                                             ifNull(nullIf(leftUTF8(toString(e__poe__revenue_analytics.revenue), 400), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
+  SELECT count() AS total, toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start, ifNull(nullIf(leftUTF8(toString(e__poe__revenue_analytics.revenue), 400), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
   FROM events AS e
   LEFT OUTER JOIN (
-  SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                                                                                                                   person_distinct_id_overrides.distinct_id AS distinct_id
+  SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id
   FROM person_distinct_id_overrides
-  WHERE equals(person_distinct_id_overrides.team_id,
-               99999)
+  WHERE equals(person_distinct_id_overrides.team_id, 99999)
   GROUP BY person_distinct_id_overrides.distinct_id
-  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id,
-                                                                                                                                                                                                                e__override.distinct_id)
+  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
   LEFT JOIN (
-  SELECT 99999 AS team_id,
-         revenue_analytics_customer.id AS person_id,
-         coalesce(revenue_agg.revenue,
-                  accurateCastOrNull(0,
-                                     'Decimal64(10)')) AS revenue,
-                                                     coalesce(mrr_agg.mrr,
-                                                              accurateCastOrNull(0,
-                                                                                 'Decimal64(10)')) AS mrr
+  SELECT 99999 AS team_id, person_id AS person_id, sum(revenue) AS revenue, sum(mrr) AS mrr
   FROM (
-  SELECT toString(persons.id) AS id,
-                  'revenue_analytics.events.purchase' AS source_label,
-                  persons.created_at AS timestamp,
-                  persons.properties___name AS name,
-                  persons.properties___email AS email,
-                  persons.properties___phone AS phone,
-                  persons.properties___address AS address,
-                  persons.properties___metadata AS metadata,
-                  persons.`properties___$geoip_country_name` AS country,
-                  formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
-                                                                            NULL AS initial_coupon,
-                                                                            NULL AS initial_coupon_id
+  SELECT 99999 AS team_id, revenue_analytics_customer.id AS person_id, coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue, coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
   FROM (
-  SELECT person.id AS id,
-         replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties,
-                                                       'name'), ''), 'null'), '^"|"$',
-                                                                              '') AS properties___name,
-                                                                                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties,
-                                                                                                                              'email'), ''), 'null'), '^"|"$',
-                                                                                                                                                      '') AS properties___email,
-                                                                                                                                                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties,
-                                                                                                                                                                                                      'phone'), ''), 'null'), '^"|"$',
-                                                                                                                                                                                                                              '') AS properties___phone,
-                                                                                                                                                                                                                                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties,
-                                                                                                                                                                                                                                                                              'address'), ''), 'null'), '^"|"$',
-                                                                                                                                                                                                                                                                                                        '') AS properties___address,
-                                                                                                                                                                                                                                                                                                          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties,
-                                                                                                                                                                                                                                                                                                                                                        'metadata'), ''), 'null'), '^"|"$',
-                                                                                                                                                                                                                                                                                                                                                                                   '') AS properties___metadata,
-                                                                                                                                                                                                                                                                                                                                                                                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties,
-                                                                                                                                                                                                                                                                                                                                                                                                                                   '$geoip_country_name'), ''), 'null'), '^"|"$',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                         '') AS `properties___$geoip_country_name`,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                           toTimeZone(person.created_at,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'UTC') AS created_at
+  SELECT toString(persons.id) AS id, 'revenue_analytics.events.purchase' AS source_label, persons.created_at AS timestamp, persons.properties___name AS name, persons.properties___email AS email, persons.properties___phone AS phone, persons.properties___address AS address, persons.properties___metadata AS metadata, persons.`properties___$geoip_country_name` AS country, formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort, NULL AS initial_coupon, NULL AS initial_coupon_id
+  FROM (
+  SELECT person.id AS id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`, toTimeZone(person.created_at, 'UTC') AS created_at
   FROM person
-  WHERE and(equals(person.team_id,
-                   99999), in(tuple(person.id,
-                                    person.version), (
-    SELECT person.id AS id,
-           max(person.version) AS version
-    FROM person WHERE equals(person.team_id,
-                             99999)
+  WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version), (
+    SELECT person.id AS id, max(person.version) AS version
+    FROM person WHERE equals(person.team_id, 99999)
   GROUP BY person.id
-  HAVING and(ifNull(equals(argMax(person.is_deleted,
-                                  person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at,
-                                                                                         'UTC'), person.version), plus(now64(6,
-                                                                                                                             'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
+  HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
   INNER JOIN (
-  SELECT DISTINCT if(not(empty(events__override.distinct_id)), events__override.person_id,
-                                                               events.person_id) AS person_id
+  SELECT DISTINCT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id
   FROM events
   LEFT OUTER JOIN (
-  SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                                                                                                                   person_distinct_id_overrides.distinct_id AS distinct_id
+  SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id
   FROM person_distinct_id_overrides
-  WHERE equals(person_distinct_id_overrides.team_id,
-               99999)
+  WHERE equals(person_distinct_id_overrides.team_id, 99999)
   GROUP BY person_distinct_id_overrides.distinct_id
-  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id,
-                                                                                                                                                                                                                     events__override.distinct_id)
-  WHERE equals(events.team_id,
-               99999)) AS events ON equals(persons.id,
-                                           events.person_id)
+  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
   ORDER BY persons.created_at DESC) AS revenue_analytics_customer
   LEFT JOIN (
-  SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-         sum(revenue_analytics_revenue_item.amount) AS revenue
+  SELECT revenue_analytics_revenue_item.customer_id AS customer_id, sum(revenue_analytics_revenue_item.amount) AS revenue
   FROM (
-  SELECT toString(events.uuid) AS id,
-                  toString(events.uuid) AS invoice_item_id,
-                           'revenue_analytics.events.purchase' AS source_label,
-                           toTimeZone(events.timestamp,
-                                      'UTC') AS timestamp,
-                                           timestamp AS created_at,
-                                           0 AS is_recurring,
-                                           NULL AS product_id,
-                                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id,
-                                                                                                 events.person_id)) AS customer_id,
-                                                                                                                  events.`$group_0` AS group_0_key,
-                                                                                                                  events.`$group_1` AS group_1_key,
-                                                                                                                  events.`$group_2` AS group_2_key,
-                                                                                                                  events.`$group_3` AS group_3_key,
-                                                                                                                  events.`$group_4` AS group_4_key,
-                                                                                                                  NULL AS invoice_id,
-                                                                                                                  NULL AS subscription_id,
-                                                                                                                  toString(events.`$session_id`) AS session_id,
-                                                                                                                           events.event AS event_name,
-                                                                                                                           NULL AS coupon,
-                                                                                                                           coupon AS coupon_id,
-                                                                                                                           'USD' AS original_currency,
-                                                                                                                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties,
-                                                                                                                                                                                            'revenue'), ''), 'null'), '^"|"$',
-                                                                                                                                                                                                                      ''), 'Decimal64(10)') AS original_amount,
-                                                                                                                                                                                                                                          in(original_currency,
-                                                                                                                                                                                                                                             ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                                                                                                                                                                                                                                             if(enable_currency_aware_divider,
-                                                                                                                                                                                                                                                accurateCastOrNull(1,
-                                                                                                                                                                                                                                                                   'Decimal64(10)'), accurateCastOrNull(100,
-                                                                                                                                                                                                                                                                                                        'Decimal64(10)')) AS currency_aware_divider,
-                                                                                                                                                                                                                                                                                                                        divideDecimal(original_amount,
-                                                                                                                                                                                                                                                                                                                                      currency_aware_divider) AS currency_aware_amount,
-                                                                                                                                                                                                                                                                                                                                      'USD' AS currency,
-                                                                                                                                                                                                                                                                                                                                      if(isNull('USD'), accurateCastOrNull(currency_aware_amount,
-                                                                                                                                                                                                                                                                                                                                                                           'Decimal64(10)'), if(equals('USD',
-                                                                                                                                                                                                                                                                                                                                                                                                       'USD'), toDecimal64(currency_aware_amount,
-                                                                                                                                                                                                                                                                                                                                                                                                                           10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    'rate',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    'USD',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    toDate(toTimeZone(events.timestamp,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'UTC')), toDecimal64(0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           10)) = 0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  toDecimal64(0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'rate',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'USD',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      toDate(toTimeZone(events.timestamp,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        'UTC')), toDecimal64(0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             10)) = 0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    toDecimal64(1,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'rate',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'USD',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      toDate(toTimeZone(events.timestamp,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        'UTC')), toDecimal64(0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'rate',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'USD',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      toDate(toTimeZone(events.timestamp,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        'UTC')), toDecimal64(0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             10)))))) AS amount
+  SELECT toString(events.uuid) AS id, toString(events.uuid) AS invoice_item_id, 'revenue_analytics.events.purchase' AS source_label, toTimeZone(events.timestamp, 'UTC') AS timestamp, timestamp AS created_at, 0 AS is_recurring, NULL AS product_id, toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id, events.`$group_0` AS group_0_key, events.`$group_1` AS group_1_key, events.`$group_2` AS group_2_key, events.`$group_3` AS group_3_key, events.`$group_4` AS group_4_key, NULL AS invoice_id, NULL AS subscription_id, toString(events.`$session_id`) AS session_id, events.event AS event_name, NULL AS coupon, coupon AS coupon_id, 'USD' AS original_currency, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount, in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider, if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider, divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount, 'USD' AS currency, if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
   FROM events
   LEFT OUTER JOIN (
-  SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                                                                                                                   person_distinct_id_overrides.distinct_id AS distinct_id
+  SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id
   FROM person_distinct_id_overrides
-  WHERE equals(person_distinct_id_overrides.team_id,
-               99999)
+  WHERE equals(person_distinct_id_overrides.team_id, 99999)
   GROUP BY person_distinct_id_overrides.distinct_id
-  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id,
-                                                                                                                                                                                                                     events__override.distinct_id)
-  WHERE and(equals(events.team_id,
-                   99999), and(equals(events.event,
-                                      'purchase'), 1,
-                                                   isNotNull(amount)))
+  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
   ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-  GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id,
-                                                 revenue_agg.customer_id)
+  GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
   LEFT JOIN (
-  SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-         sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+  SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id, sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
   FROM (
-  SELECT union.source_label AS source_label,
-         union.customer_id AS customer_id,
-         union.subscription_id AS subscription_id,
-         argMax(union.amount,
-                union.timestamp) AS mrr
+  SELECT union.source_label AS source_label, union.customer_id AS customer_id, union.subscription_id AS subscription_id, argMax(union.amount, union.timestamp) AS mrr
   FROM (
-  SELECT revenue_item.source_label AS source_label,
-         revenue_item.customer_id AS customer_id,
-         revenue_item.subscription_id AS subscription_id,
-         toStartOfMonth(toTimeZone(revenue_item.timestamp,
-                                   'UTC')) AS timestamp,
-                                         sum(revenue_item.amount) AS amount
+  SELECT revenue_item.source_label AS source_label, revenue_item.customer_id AS customer_id, revenue_item.subscription_id AS subscription_id, toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp, sum(revenue_item.amount) AS amount
   FROM (
-  SELECT toString(events.uuid) AS id,
-                  toString(events.uuid) AS invoice_item_id,
-                           'revenue_analytics.events.purchase' AS source_label,
-                           toTimeZone(events.timestamp,
-                                      'UTC') AS timestamp,
-                                           timestamp AS created_at,
-                                           0 AS is_recurring,
-                                           NULL AS product_id,
-                                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id,
-                                                                                                 events.person_id)) AS customer_id,
-                                                                                                                  events.`$group_0` AS group_0_key,
-                                                                                                                  events.`$group_1` AS group_1_key,
-                                                                                                                  events.`$group_2` AS group_2_key,
-                                                                                                                  events.`$group_3` AS group_3_key,
-                                                                                                                  events.`$group_4` AS group_4_key,
-                                                                                                                  NULL AS invoice_id,
-                                                                                                                  NULL AS subscription_id,
-                                                                                                                  toString(events.`$session_id`) AS session_id,
-                                                                                                                           events.event AS event_name,
-                                                                                                                           NULL AS coupon,
-                                                                                                                           coupon AS coupon_id,
-                                                                                                                           'USD' AS original_currency,
-                                                                                                                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties,
-                                                                                                                                                                                            'revenue'), ''), 'null'), '^"|"$',
-                                                                                                                                                                                                                      ''), 'Decimal64(10)') AS original_amount,
-                                                                                                                                                                                                                                          in(original_currency,
-                                                                                                                                                                                                                                             ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                                                                                                                                                                                                                                             if(enable_currency_aware_divider,
-                                                                                                                                                                                                                                                accurateCastOrNull(1,
-                                                                                                                                                                                                                                                                   'Decimal64(10)'), accurateCastOrNull(100,
-                                                                                                                                                                                                                                                                                                        'Decimal64(10)')) AS currency_aware_divider,
-                                                                                                                                                                                                                                                                                                                        divideDecimal(original_amount,
-                                                                                                                                                                                                                                                                                                                                      currency_aware_divider) AS currency_aware_amount,
-                                                                                                                                                                                                                                                                                                                                      'USD' AS currency,
-                                                                                                                                                                                                                                                                                                                                      if(isNull('USD'), accurateCastOrNull(currency_aware_amount,
-                                                                                                                                                                                                                                                                                                                                                                           'Decimal64(10)'), if(equals('USD',
-                                                                                                                                                                                                                                                                                                                                                                                                       'USD'), toDecimal64(currency_aware_amount,
-                                                                                                                                                                                                                                                                                                                                                                                                                           10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    'rate',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    'USD',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    toDate(toTimeZone(events.timestamp,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'UTC')), toDecimal64(0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           10)) = 0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  toDecimal64(0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'rate',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'USD',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      toDate(toTimeZone(events.timestamp,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        'UTC')), toDecimal64(0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             10)) = 0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    toDecimal64(1,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'rate',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'USD',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      toDate(toTimeZone(events.timestamp,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        'UTC')), toDecimal64(0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'rate',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      'USD',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      toDate(toTimeZone(events.timestamp,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        'UTC')), toDecimal64(0,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             10)))))) AS amount
+  SELECT toString(events.uuid) AS id, toString(events.uuid) AS invoice_item_id, 'revenue_analytics.events.purchase' AS source_label, toTimeZone(events.timestamp, 'UTC') AS timestamp, timestamp AS created_at, 0 AS is_recurring, NULL AS product_id, toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id, events.`$group_0` AS group_0_key, events.`$group_1` AS group_1_key, events.`$group_2` AS group_2_key, events.`$group_3` AS group_3_key, events.`$group_4` AS group_4_key, NULL AS invoice_id, NULL AS subscription_id, toString(events.`$session_id`) AS session_id, events.event AS event_name, NULL AS coupon, coupon AS coupon_id, 'USD' AS original_currency, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount, in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider, if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider, divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount, 'USD' AS currency, if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
   FROM events
   LEFT OUTER JOIN (
-  SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                                                                                                                   person_distinct_id_overrides.distinct_id AS distinct_id
+  SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id
   FROM person_distinct_id_overrides
-  WHERE equals(person_distinct_id_overrides.team_id,
-               99999)
+  WHERE equals(person_distinct_id_overrides.team_id, 99999)
   GROUP BY person_distinct_id_overrides.distinct_id
-  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id,
-                                                                                                                                                                                                                     events__override.distinct_id)
-  WHERE and(equals(events.team_id,
-                   99999), and(equals(events.event,
-                                      'purchase'), 1,
-                                                   isNotNull(amount)))
+  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
   ORDER BY timestamp DESC) AS revenue_item
-  WHERE and(revenue_item.is_recurring,
-            isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp',
-                                                                                                                    6,
-                                                                                                                    'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp',
-                                                                                                                                                                         6,
-                                                                                                                                                                         'UTC')))
-  GROUP BY revenue_item.source_label,
-           revenue_item.customer_id,
-           revenue_item.subscription_id, timestamp
+  WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
+  GROUP BY revenue_item.source_label, revenue_item.customer_id, revenue_item.subscription_id, timestamp
   ORDER BY timestamp DESC
   UNION ALL
-  SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-         `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-         `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-         toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at,
-                    'UTC') AS timestamp,
-                         accurateCastOrNull(0,
-                                            'Decimal64(10)') AS amount
+  SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label, `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id, `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id, toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp, accurateCastOrNull(0, 'Decimal64(10)') AS amount
   FROM (
-  SELECT '' AS id,
-         '' AS source_label,
-         '' AS plan_id,
-         '' AS product_id,
-         '' AS customer_id,
-         '' AS status,
-         toDateTime64('1970-01-01 00:00:00.000000',
-                      6,
-                      'UTC') AS started_at,
-                           toDateTime64('1970-01-01 00:00:00.000000',
-                                        6,
-                                        'UTC') AS ended_at,
-                                             '' AS metadata
-  WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view` WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp',
-                                                                                                                                                            6,
-                                                                                                                                                            'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp',
-                                                                                                                                                                                                                 6,
-                                                                                                                                                                                                                 'UTC')))
+  SELECT '' AS id, '' AS source_label, '' AS plan_id, '' AS product_id, '' AS customer_id, '' AS status, toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at, toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at, '' AS metadata
+  WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view` WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
   ORDER BY timestamp DESC) AS
   union
-  GROUP BY source_label,
-           customer_id,
-           subscription_id
-  ORDER BY customer_id ASC,
-           subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id,
-                                             mrr_agg.customer_id)) AS e__poe__revenue_analytics ON equals(toString(if(not(empty(e__override.distinct_id)), e__override.person_id,
-                                                                                                                                                           e.person_id)), toString(e__poe__revenue_analytics.person_id))
-  WHERE and(equals(e.team_id,
-                   99999), greaterOrEquals(e.timestamp,
-                                           toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00',
-                                                                                      'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp,
-                                                                                                                                assumeNotNull(toDateTime('2025-05-30 23:59:59',
-                                                                                                                                                         'UTC'))), equals(e.event,
-                                                                                                                                                                          '$pageview'))
-  GROUP BY day_start,
-           breakdown_value_1)
-  GROUP BY day_start,
-           breakdown_value_1
-  ORDER BY day_start ASC,
-           breakdown_value ASC)
+  GROUP BY source_label, customer_id, subscription_id
+  ORDER BY customer_id ASC, subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+  GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), toString(e__poe__revenue_analytics.person_id))
+  WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
+  GROUP BY day_start, breakdown_value_1)
+  GROUP BY day_start, breakdown_value_1
+  ORDER BY day_start ASC, breakdown_value ASC)
   GROUP BY breakdown_value
-  ORDER BY if(has(breakdown_value,
-                  '$$_posthog_breakdown_other_$$'), 2,
-                                                    if(has(breakdown_value,
-                                                           '$$_posthog_breakdown_null_$$'), 1,
-                                                                                            0)) ASC, arraySum(total) DESC, breakdown_value ASC)
+  ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC)
   WHERE arrayExists(x -> isNotNull(x), breakdown_value)
   GROUP BY breakdown_value
-  ORDER BY if(has(breakdown_value,
-                  '$$_posthog_breakdown_other_$$'), 2,
-                                                    if(has(breakdown_value,
-                                                           '$$_posthog_breakdown_null_$$'), 1,
-                                                                                            0)) ASC, arraySum(total) DESC, breakdown_value ASC
-  LIMIT 50000 SETTINGS readonly=2,
-                       max_execution_time=60,
-                       allow_experimental_object_type=1,
-                       max_ast_elements=4000000,
-                       max_expanded_ast_elements=4000000,
-                       max_bytes_before_external_group_by=0,
-                       transform_null_in=1,
-                       optimize_min_equality_disjunction_chain_length=4294967295,
-                       allow_experimental_join_condition=1,
-                       use_hive_partitioning=0
+  ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+  LIMIT 50000 SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0
   '''
 # ---
 # name: TestPersonsRevenueAnalytics.test_virtual_property_in_trend_3_person_id_override_properties_joined
@@ -2883,6 +3366,8 @@
   GROUP BY person.id
   HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.e__person___id)
   LEFT JOIN (
+  SELECT 99999 AS team_id, person_id AS person_id, sum(revenue) AS revenue, sum(mrr) AS mrr
+  FROM (
   SELECT 99999 AS team_id, revenue_analytics_customer.id AS person_id, coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue, coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
   FROM (
   SELECT toString(persons.id) AS id, 'revenue_analytics.events.purchase' AS source_label, persons.created_at AS timestamp, persons.properties___name AS name, persons.properties___email AS email, persons.properties___phone AS phone, persons.properties___address AS address, persons.properties___metadata AS metadata, persons.`properties___$geoip_country_name` AS country, formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort, NULL AS initial_coupon, NULL AS initial_coupon_id
@@ -2954,7 +3439,8 @@
   union
   GROUP BY source_label, customer_id, subscription_id
   ORDER BY customer_id ASC, subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
+  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+  GROUP BY person_id) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
   WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
   GROUP BY day_start, breakdown_value_1)
   GROUP BY day_start, breakdown_value_1
@@ -2983,22 +3469,28 @@
      HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT *
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-               sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+        FROM
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                  sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   WHERE ifNull(equals(persons.id, '00000000-0000-0000-0000-000000000000'), 0)
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -3026,39 +3518,45 @@
      HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__persons.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT *
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT persons.id AS id,
-               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__persons.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
-                  person.id AS id
-           FROM person
-           WHERE equals(person.team_id, 99999)
-           GROUP BY person.id
-           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
-        INNER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                  person_distinct_id2.distinct_id AS distinct_id
-           FROM person_distinct_id2
-           WHERE equals(person_distinct_id2.team_id, 99999)
-           GROUP BY person_distinct_id2.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT persons.id AS id,
+                  persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+           FROM
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+           INNER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -3086,39 +3584,45 @@
      HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__persons.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT *
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT persons.id AS id,
-               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__persons.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
-                  person.id AS id
-           FROM person
-           WHERE equals(person.team_id, 99999)
-           GROUP BY person.id
-           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
-        INNER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                  person_distinct_id2.distinct_id AS distinct_id
-           FROM person_distinct_id2
-           WHERE equals(person_distinct_id2.team_id, 99999)
-           GROUP BY person_distinct_id2.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT persons.id AS id,
+                  persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+           FROM
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+           INNER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -3140,22 +3644,28 @@
          persons_revenue_analytics.mrr AS mrr
   FROM
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT *
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-               sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons_revenue_analytics
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+        FROM
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                  sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons_revenue_analytics
   ORDER BY persons_revenue_analytics.person_id ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -3177,39 +3687,45 @@
          persons_revenue_analytics.mrr AS mrr
   FROM
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__persons.id AS person_id,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            person_id AS person_id,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT *
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT persons.id AS id,
-               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__persons.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
-                  person.id AS id
-           FROM person
-           WHERE equals(person.team_id, 99999)
-           GROUP BY person.id
-           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
-        INNER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                  person_distinct_id2.distinct_id AS distinct_id
-           FROM person_distinct_id2
-           WHERE equals(person_distinct_id2.team_id, 99999)
-           GROUP BY person_distinct_id2.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons_revenue_analytics
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT persons.id AS id,
+                  persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+           FROM
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+           INNER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+     GROUP BY person_id) AS persons_revenue_analytics
   ORDER BY persons_revenue_analytics.mrr DESC,
            persons_revenue_analytics.revenue DESC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -3275,22 +3791,28 @@
               HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__pdi__person ON equals(e__pdi.e__pdi___person_id, e__pdi__person.e__pdi__person___id)
            LEFT JOIN
              (SELECT 99999 AS team_id,
-                     revenue_analytics_customer.id AS person_id,
-                     coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-                     coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+                     person_id AS person_id,
+                     sum(revenue) AS revenue,
+                     sum(mrr) AS mrr
               FROM
-                (SELECT *
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-              LEFT JOIN
-                (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-                        sum(revenue_analytics_revenue_item.amount) AS revenue
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-                 GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-              LEFT JOIN
-                (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-                        sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-                 GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__pdi__person__revenue_analytics ON equals(toString(e__pdi__person.e__pdi__person___id), toString(e__pdi__person__revenue_analytics.person_id))
+                (SELECT 99999 AS team_id,
+                        revenue_analytics_customer.id AS person_id,
+                        coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+                        coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+                 FROM
+                   (SELECT *
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+                 LEFT JOIN
+                   (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                           sum(revenue_analytics_revenue_item.amount) AS revenue
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+                    GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+                 LEFT JOIN
+                   (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                           sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                    GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+              GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(toString(e__pdi__person.e__pdi__person___id), toString(e__pdi__person__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
                     breakdown_value_1)
@@ -3406,22 +3928,28 @@
            FROM events AS e
            LEFT JOIN
              (SELECT 99999 AS team_id,
-                     revenue_analytics_customer.id AS person_id,
-                     coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-                     coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+                     person_id AS person_id,
+                     sum(revenue) AS revenue,
+                     sum(mrr) AS mrr
               FROM
-                (SELECT *
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-              LEFT JOIN
-                (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-                        sum(revenue_analytics_revenue_item.amount) AS revenue
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-                 GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-              LEFT JOIN
-                (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-                        sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-                 GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__poe__revenue_analytics ON equals(toString(e.person_id), toString(e__poe__revenue_analytics.person_id))
+                (SELECT 99999 AS team_id,
+                        revenue_analytics_customer.id AS person_id,
+                        coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+                        coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+                 FROM
+                   (SELECT *
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+                 LEFT JOIN
+                   (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                           sum(revenue_analytics_revenue_item.amount) AS revenue
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+                    GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+                 LEFT JOIN
+                   (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                           sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                    GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+              GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(e.person_id), toString(e__poe__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
                     breakdown_value_1)
@@ -3544,22 +4072,28 @@
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
            LEFT JOIN
              (SELECT 99999 AS team_id,
-                     revenue_analytics_customer.id AS person_id,
-                     coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-                     coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+                     person_id AS person_id,
+                     sum(revenue) AS revenue,
+                     sum(mrr) AS mrr
               FROM
-                (SELECT *
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-              LEFT JOIN
-                (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-                        sum(revenue_analytics_revenue_item.amount) AS revenue
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-                 GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-              LEFT JOIN
-                (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-                        sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-                 GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__poe__revenue_analytics ON equals(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), toString(e__poe__revenue_analytics.person_id))
+                (SELECT 99999 AS team_id,
+                        revenue_analytics_customer.id AS person_id,
+                        coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+                        coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+                 FROM
+                   (SELECT *
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+                 LEFT JOIN
+                   (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                           sum(revenue_analytics_revenue_item.amount) AS revenue
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+                    GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+                 LEFT JOIN
+                   (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                           sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                    GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+              GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), toString(e__poe__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
                     breakdown_value_1)
@@ -3689,22 +4223,28 @@
               HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.e__person___id)
            LEFT JOIN
              (SELECT 99999 AS team_id,
-                     revenue_analytics_customer.id AS person_id,
-                     coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-                     coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+                     person_id AS person_id,
+                     sum(revenue) AS revenue,
+                     sum(mrr) AS mrr
               FROM
-                (SELECT *
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-              LEFT JOIN
-                (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-                        sum(revenue_analytics_revenue_item.amount) AS revenue
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-                 GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-              LEFT JOIN
-                (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-                        sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-                 GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
+                (SELECT 99999 AS team_id,
+                        revenue_analytics_customer.id AS person_id,
+                        coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+                        coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+                 FROM
+                   (SELECT *
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+                 LEFT JOIN
+                   (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                           sum(revenue_analytics_revenue_item.amount) AS revenue
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+                    GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+                 LEFT JOIN
+                   (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                           sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                    GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id))
+              GROUP BY person_id) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
                     breakdown_value_1)

--- a/posthog/hogql/database/schema/test/test_persons_revenue_analytics.py
+++ b/posthog/hogql/database/schema/test/test_persons_revenue_analytics.py
@@ -291,6 +291,39 @@ class TestPersonsRevenueAnalytics(TestPersonsRevenueAnalyticsMixin):
 
             self.assertEqual(response.results, [(Decimal("283.8496260553"),), (None,)])
 
+    def test_revenue_aggregated_per_person_across_multiple_customers(self):
+        self.setup_schema_sources()
+        self.join.source_table_key = "id"
+        self.join.save()
+
+        # One person owns two distinct IDs, each matching a different Stripe customer. Without
+        # per-person aggregation this maps to two rows and fans the persons table out on join.
+        person = _create_person(team_id=self.team.pk, distinct_ids=["cus_1", "cus_2"])
+
+        expected_revenue = Decimal("766.0654934005")  # cus_1 283.8496260553 + cus_2 482.2158673452
+        expected_mrr = Decimal("63.7684363904")  # cus_1 22.9631447238 + cus_2 40.8052916666
+
+        with freeze_time(self.QUERY_TIMESTAMP):
+            table_results = execute_hogql_query(
+                parse_select(
+                    "SELECT person_id, revenue, mrr FROM persons_revenue_analytics WHERE person_id = {id}",
+                    placeholders={"id": ast.Constant(value=person.uuid)},
+                ),
+                self.team,
+                modifiers=self.MODIFIERS,
+            )
+            self.assertEqual(table_results.results, [(person.uuid, expected_revenue, expected_mrr)])
+
+            persons_results = execute_hogql_query(
+                parse_select(
+                    "SELECT id, $virt_revenue, $virt_mrr FROM persons WHERE id = {id}",
+                    placeholders={"id": ast.Constant(value=person.uuid)},
+                ),
+                self.team,
+                modifiers=self.MODIFIERS,
+            )
+            self.assertEqual(persons_results.results, [(person.uuid, expected_revenue, expected_mrr)])
+
     def test_query_revenue_analytics_table_sources(self):
         self.setup_schema_sources()
         self.join.source_table_key = "id"


### PR DESCRIPTION
## Problem

Querying `persons` (or `persons_revenue_analytics`) returns duplicate rows for a person who maps to more than one revenue-analytics customer (e.g. duplicate Stripe customers sharing an email).

The ticket has queries showcasing the bug.

Fixes https://posthoghelp.zendesk.com/agent/tickets/57454 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/61296)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Aggregate `persons_revenue_analytics` by `person_id` (`sum` revenue/mrr) so it returns one row per person
- Collapses multiple customers per person — duplicate customer records, or customers across revenue sources — into a single summed row
- Mirrors the per-group aggregation `groups_revenue_analytics` already does (which assumed persons was 1:1 customer→person)
- Add regression test: two customers on one person → one summed row, on both `persons_revenue_analytics` and `persons.$virt_revenue`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests — `test_persons_revenue_analytics.py` (20 tests) plus regenerated query snapshots; `test_database`/`test_resolver`/`test_property` unaffected.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Authored by PostHog Code (Claude Code).

`persons_revenue_analytics` is a query-time HogQL lazy table, not stored data — the fix takes effect on the next query with no backfill or rematerialization. Known related gap left out of scope: `groups_revenue_analytics` aggregates per-source then `UNION ALL`s, so a group with customers across multiple revenue sources can still fan out the groups table.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
