### PR TITLE
chore(replay): use public tracing_headers config in loadPostHogJS

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -161,7 +161,7 @@ export function loadPostHogJS(options: LoadPostHogJSOptions = {}): void {
                 ...options.sessionRecording,
             },
             person_profiles: 'always',
-            __add_tracing_headers: ['eu.posthog.com', 'us.posthog.com'],
+            tracing_headers: ['eu.posthog.com', 'us.posthog.com'],
             __preview_disable_xhr_credentials: true,
             capture_performance: {
                 //disabling to investigate if this is associated with memory leak in the posthog app


### PR DESCRIPTION
## Problem

posthog-js [#3715](https://github.com/PostHog/posthog-js/pull/3715) (released in v1.380.0) promoted the browser tracing-header configuration to the public `tracing_headers` option and deprecated the old preview key `__add_tracing_headers`. Our own app's SDK init in `loadPostHogJS.tsx` was still using the deprecated key.

These tracing headers (`X-POSTHOG-DISTINCT-ID`, `X-POSTHOG-SESSION-ID`, `X-POSTHOG-WINDOW-ID`) are what let backend events be filtered against session recordings — the exact behaviour that prompted this cleanup.

## Changes

Switch `loadPostHogJS.tsx` from the deprecated `__add_tracing_headers` to the public `tracing_headers` option. Same value (`['eu.posthog.com', 'us.posthog.com']`), same behaviour — `__add_tracing_headers` is still a working deprecated alias, so this is behaviourally a no-op that just moves off the preview key.

Our `posthog-js` catalog pin (`^1.380.1`) already includes `tracing_headers`, so the option is available and type-checks.

## How did you test this code?

I'm an agent (PostHog Code). I did not run the app manually. The change is a one-line config-key rename to a type that ships in the pinned posthog-js version; correctness rests on the type being present in `@posthog/types@^1.380.1` and the deprecated alias being an exact equivalent. No automated tests were added or run for this trivial rename — reviewer should rely on TypeScript CI to confirm the option type-checks.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by PostHog Code (Slack app) at the request of @pauldambra, as follow-up to the posthog-js change that promoted `tracing_headers` out of preview. The posthog-js library work was already complete and released (#3715, v1.380.0); this PR only migrates the monorepo's own consumption of the SDK off the deprecated `__add_tracing_headers` preview key. Verified the monorepo's `posthog-js` catalog pin is `^1.380.1` so the public option is available.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*