### PR TITLE
refactor(quill): shared inline-styled chart tooltip surface

### DIFF
--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -59,6 +59,10 @@ jobs:
                   npm version "$BUMP_TYPE" --no-git-tag-version
                   QUILL_V=$(node -p "require('./package.json').version")
                   echo "Bumped @posthog/quill to $QUILL_V ($BUMP_TYPE)"
+                  cd ../charts
+                  npm version "$BUMP_TYPE" --no-git-tag-version
+                  CHARTS_V=$(node -p "require('./package.json').version")
+                  echo "Bumped @posthog/quill-charts to $CHARTS_V ($BUMP_TYPE)"
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile --filter "@posthog/quill..." --filter "@posthog/quill-tokens" --filter "@posthog/quill-charts..."
@@ -141,10 +145,11 @@ jobs:
 
             - name: Commit version bump
               run: |
-                  git add packages/quill/packages/tokens/package.json packages/quill/packages/quill/package.json
+                  git add packages/quill/packages/tokens/package.json packages/quill/packages/quill/package.json packages/quill/packages/charts/package.json
                   TOKENS_V=$(node -p "require('./packages/quill/packages/tokens/package.json').version")
                   QUILL_V=$(node -p "require('./packages/quill/packages/quill/package.json').version")
-                  git commit -m "chore(quill): bump quill-tokens to $TOKENS_V, quill to $QUILL_V [skip ci]"
+                  CHARTS_V=$(node -p "require('./packages/quill/packages/charts/package.json').version")
+                  git commit -m "chore(quill): bump quill-tokens to $TOKENS_V, quill to $QUILL_V, quill-charts to $CHARTS_V [skip ci]"
                   if ! git push; then
                     echo "::warning::git push failed (likely branch protection). Versions were published successfully but package.json not updated in repo. A manual bump or PR may be needed."
                   fi

--- a/packages/quill/apps/storybook/.storybook/storybook.css
+++ b/packages/quill/apps/storybook/.storybook/storybook.css
@@ -65,6 +65,7 @@
 @source "../../../packages/primitives/src/**/*.{ts,tsx}";
 @source "../../../packages/components/src/**/*.{ts,tsx}";
 @source "../../../packages/blocks/src/**/*.{ts,tsx}";
+@source "../../../packages/charts/src/**/*.{ts,tsx}";
 
 @layer base {
     * {

--- a/packages/quill/packages/charts/src/README.md
+++ b/packages/quill/packages/charts/src/README.md
@@ -13,6 +13,17 @@ const THEME: ChartTheme = { colors: ['#1f77b4'], backgroundColor: '#ffffff' }
 ;<LineChart series={SERIES} labels={LABELS} theme={THEME} />
 ```
 
+## Setup
+
+**Tokens (optional but recommended)** — load `@posthog/quill-tokens/color-system.css`
+so `useChartTheme()` resolves the real quill palette and chrome. Without it you get
+a sensible built-in fallback palette (see below), not the brand colors.
+
+The built-in tooltip styles itself inline, so it renders correctly with no extra
+setup. The rest of the library's chrome uses Tailwind utility classes — if you want
+those generated for a non-PostHog host, add this package to your Tailwind
+`@source`/content globs.
+
 ## Theme
 
 Charts are **headless about color** — every chart takes a `ChartTheme` (`colors`

--- a/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlotTooltip.tsx
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlotTooltip.tsx
@@ -1,12 +1,9 @@
 import React from 'react'
 
-import { useChartLayout } from '../../core/chart-context'
 import type { TooltipContext } from '../../core/types'
+import { TooltipSurface, TooltipSwatch } from '../../overlays/TooltipSurface'
 import type { BoxPlotAdaptedMeta } from './BoxPlot'
 import type { BoxPlotDatum } from './computeBoxLayout'
-
-const DEFAULT_TOOLTIP_BG = '#1d2330'
-const DEFAULT_TOOLTIP_COLOR = '#ffffff'
 
 /** Rows shown per box, in the same order the legacy BoxPlotChart used. */
 const ROWS: { label: string; key: keyof BoxPlotDatum }[] = [
@@ -38,8 +35,6 @@ export function BoxPlotTooltip<Meta = unknown>({
     userTooltip,
     grouped,
 }: BoxPlotTooltipProps<Meta>): React.ReactElement | null {
-    const { theme } = useChartLayout()
-
     if (userTooltip) {
         return <>{userTooltip(ctx)}</>
     }
@@ -65,25 +60,13 @@ export function BoxPlotTooltip<Meta = unknown>({
     }
 
     return (
-        <div
-            className="px-3 py-2 rounded-lg shadow-lg text-[13px]"
-            // eslint-disable-next-line react/forbid-dom-props
-            style={{
-                backgroundColor: theme.tooltipBackground ?? DEFAULT_TOOLTIP_BG,
-                color: theme.tooltipColor ?? DEFAULT_TOOLTIP_COLOR,
-            }}
-            data-attr="hog-chart-boxplot-tooltip"
-        >
+        <TooltipSurface data-attr="hog-chart-boxplot-tooltip">
             <div className="font-semibold mb-1">{ctx.label}</div>
             {entries.map((entry, i) => (
                 <div key={entry.key} className={i > 0 ? 'mt-2' : undefined}>
                     {grouped && (
                         <div className="flex items-center gap-2 mb-1">
-                            <span
-                                className="inline-block size-2 rounded-full"
-                                // eslint-disable-next-line react/forbid-dom-props
-                                style={{ backgroundColor: entry.color }}
-                            />
+                            <TooltipSwatch color={entry.color} />
                             <span className="font-semibold">{entry.label}</span>
                         </div>
                     )}
@@ -101,6 +84,6 @@ export function BoxPlotTooltip<Meta = unknown>({
                     </table>
                 </div>
             ))}
-        </div>
+        </TooltipSurface>
     )
 }

--- a/packages/quill/packages/charts/src/charts/PieChart/PieTooltip.tsx
+++ b/packages/quill/packages/charts/src/charts/PieChart/PieTooltip.tsx
@@ -1,16 +1,13 @@
 import React from 'react'
 
-import { useChartLayout } from '../../core/chart-context'
 import type { TooltipContext } from '../../core/types'
+import { TooltipSurface, TooltipSwatch } from '../../overlays/TooltipSurface'
 
 export interface PieTooltipProps<Meta> {
     ctx: TooltipContext<Meta>
     valueFormatter?: (value: number) => string
     isPercent?: boolean
 }
-
-const DEFAULT_TOOLTIP_BG = '#1d2330'
-const DEFAULT_TOOLTIP_COLOR = '#ffffff'
 
 function defaultFormatter(v: number): string {
     return v.toLocaleString()
@@ -25,7 +22,6 @@ export function PieTooltip<Meta>({
     valueFormatter = defaultFormatter,
     isPercent = false,
 }: PieTooltipProps<Meta>): React.ReactElement | null {
-    const { theme } = useChartLayout()
     const entry = ctx.seriesData[0]
     if (!entry) {
         return null
@@ -33,26 +29,15 @@ export function PieTooltip<Meta>({
     const share = entry.fraction ?? 0
 
     return (
-        <div
-            className="px-3 py-2 rounded-lg shadow-lg text-[13px]"
-            // eslint-disable-next-line react/forbid-dom-props
-            style={{
-                backgroundColor: theme.tooltipBackground ?? DEFAULT_TOOLTIP_BG,
-                color: theme.tooltipColor ?? DEFAULT_TOOLTIP_COLOR,
-            }}
-        >
+        <TooltipSurface>
             <div className="flex items-center gap-2 mb-1">
-                <span
-                    className="inline-block size-2 rounded-full"
-                    // eslint-disable-next-line react/forbid-dom-props
-                    style={{ backgroundColor: entry.color }}
-                />
+                <TooltipSwatch color={entry.color} />
                 <span className="font-semibold">{entry.series.label}</span>
             </div>
             <div className="flex items-center gap-2">
                 <strong>{isPercent ? formatPercent(share) : valueFormatter(entry.value)}</strong>
                 {!isPercent && share > 0 ? <span className="opacity-70">({formatPercent(share)})</span> : null}
             </div>
-        </div>
+        </TooltipSurface>
     )
 }

--- a/packages/quill/packages/charts/src/core/theme.test.ts
+++ b/packages/quill/packages/charts/src/core/theme.test.ts
@@ -56,6 +56,15 @@ describe('chart theme', () => {
         expect(themeFromCssVars({ root }).backgroundColor).toBe(expected)
     })
 
+    it('maps the tooltip to quill inverse surface tokens', () => {
+        const root = rootWithVars({ '--foreground': '#0b0b0b', '--background': '#fafafa' })
+
+        const theme = themeFromCssVars({ root })
+
+        expect(theme.tooltipBackground).toBe('#0b0b0b')
+        expect(theme.tooltipColor).toBe('#fafafa')
+    })
+
     it('falls back to DEFAULT_CHART_COLORS for unset color vars', () => {
         const root = rootWithVars({})
 

--- a/packages/quill/packages/charts/src/core/theme.ts
+++ b/packages/quill/packages/charts/src/core/theme.ts
@@ -78,8 +78,10 @@ export function themeFromCssVars(options: ThemeFromCssOptions = {}): ChartTheme 
         axisColor: readCssVar(style, '--color-graph-axis-label'),
         gridColor: readCssVar(style, '--color-graph-axis-line'),
         crosshairColor: readCssVar(style, '--color-graph-crosshair'),
-        tooltipBackground: readCssVar(style, '--card') ?? readCssVar(style, '--color-bg-surface-tooltip'),
-        tooltipColor: readCssVar(style, '--foreground') ?? readCssVar(style, '--color-text-primary-inverse'),
+        // quill's tooltip is an inverse panel (`.quill-tooltip__content`):
+        // foreground-colored surface, background-colored text.
+        tooltipBackground: readCssVar(style, '--foreground') ?? readCssVar(style, '--color-bg-surface-tooltip'),
+        tooltipColor: readCssVar(style, '--background') ?? readCssVar(style, '--color-text-primary-inverse'),
     }
 }
 

--- a/packages/quill/packages/charts/src/index.ts
+++ b/packages/quill/packages/charts/src/index.ts
@@ -87,6 +87,8 @@ export type { ThemeFromCssOptions } from './core/theme'
 
 // Built-in tooltip (for reference or extension)
 export { DefaultTooltip } from './overlays/DefaultTooltip'
+// Shared tooltip surface — reuse to build custom tooltips with the quill look
+export { TooltipSurface, TooltipSwatch, TOOLTIP_FALLBACK_BG, TOOLTIP_FALLBACK_COLOR } from './overlays/TooltipSurface'
 
 // Optional overlays
 export { ReferenceLine, ReferenceLines } from './overlays/ReferenceLine'

--- a/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
+++ b/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
@@ -1,32 +1,17 @@
-import { useChartLayout } from '../core/chart-context'
 import type { TooltipContext } from '../core/types'
-
-const DEFAULT_TOOLTIP_BG = '#1d2330'
-const DEFAULT_TOOLTIP_COLOR = '#ffffff'
+import { TooltipSurface, TooltipSwatch } from './TooltipSurface'
 
 export function DefaultTooltip({ label, seriesData }: TooltipContext): React.ReactElement {
-    const { theme } = useChartLayout()
     return (
-        <div
-            className="px-3 py-2 rounded-lg shadow-lg text-[13px]"
-            // eslint-disable-next-line react/forbid-dom-props
-            style={{
-                backgroundColor: theme.tooltipBackground ?? DEFAULT_TOOLTIP_BG,
-                color: theme.tooltipColor ?? DEFAULT_TOOLTIP_COLOR,
-            }}
-        >
+        <TooltipSurface>
             <div className="font-semibold mb-1">{label}</div>
             {seriesData.map((s) => (
                 <div key={s.series.key} className="flex items-center gap-2">
-                    <span
-                        className="inline-block size-2 rounded-full"
-                        // eslint-disable-next-line react/forbid-dom-props
-                        style={{ backgroundColor: s.color }}
-                    />
+                    <TooltipSwatch color={s.color} />
                     <span>{s.series.label}:</span>
                     <strong>{s.value.toLocaleString()}</strong>
                 </div>
             ))}
-        </div>
+        </TooltipSurface>
     )
 }

--- a/packages/quill/packages/charts/src/overlays/ReferenceLine.tsx
+++ b/packages/quill/packages/charts/src/overlays/ReferenceLine.tsx
@@ -2,6 +2,7 @@
 import React, { useMemo } from 'react'
 
 import { useChartLayout } from '../core/chart-context'
+import { TOOLTIP_FALLBACK_BG, TOOLTIP_FALLBACK_COLOR } from './TooltipSurface'
 
 export type ReferenceLineOrientation = 'horizontal' | 'vertical'
 export type ReferenceLineVariant = 'goal' | 'alert' | 'marker'
@@ -64,11 +65,6 @@ const VARIANT_DEFAULTS: Record<ReferenceLineVariant, ResolvedStyle> = {
 const LABEL_HEIGHT = 20
 /** Padding between the label and the plot edge. */
 const LABEL_PADDING = 4
-
-// Match the chart tooltip look (see DefaultTooltip) so the label bubble reads as part of the
-// chart's own theming rather than depending on the host app's CSS variables.
-const DEFAULT_TOOLTIP_BG = '#1d2330'
-const DEFAULT_TOOLTIP_COLOR = '#ffffff'
 
 function resolveStyle(variant: ReferenceLineVariant, style: ReferenceLineStyle | undefined): ResolvedStyle {
     const defaults = VARIANT_DEFAULTS[variant]
@@ -309,8 +305,8 @@ function ReferenceLineView({
     const { theme } = useChartLayout()
     const resolvedLabelStyle: React.CSSProperties = {
         ...labelStyle,
-        backgroundColor: theme.tooltipBackground ?? DEFAULT_TOOLTIP_BG,
-        color: theme.tooltipColor ?? DEFAULT_TOOLTIP_COLOR,
+        backgroundColor: theme.tooltipBackground ?? TOOLTIP_FALLBACK_BG,
+        color: theme.tooltipColor ?? TOOLTIP_FALLBACK_COLOR,
     }
     return (
         <>

--- a/packages/quill/packages/charts/src/overlays/TooltipSurface.tsx
+++ b/packages/quill/packages/charts/src/overlays/TooltipSurface.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+
+import { useChartLayout } from '../core/chart-context'
+
+/**
+ * Fallback tooltip colors for hosts that don't supply them on `ChartTheme`.
+ * An inverse panel (dark surface, light text), matching quill's tooltip — when
+ * the quill theme reader is used these come from `--foreground` / `--background`.
+ */
+export const TOOLTIP_FALLBACK_BG = '#1d2330'
+export const TOOLTIP_FALLBACK_COLOR = '#ffffff'
+
+function joinClasses(...parts: Array<string | undefined>): string {
+    return parts.filter(Boolean).join(' ')
+}
+
+interface TooltipSurfaceProps {
+    children: React.ReactNode
+    className?: string
+    /** Forwarded onto the panel — used for test/automation selectors. */
+    'data-attr'?: string
+}
+
+/**
+ * Shared surface for the built-in chart tooltips. Mirrors quill's tooltip
+ * (`.quill-tooltip__content`): an inverse panel at `radius-sm`, compact padding,
+ * `text-xs`. Colors stay theme-driven so non-quill hosts can still restyle it.
+ * The shadow is the one intentional deviation from the primitive — chart
+ * tooltips float over dense data and need the extra separation.
+ */
+export function TooltipSurface({
+    children,
+    className,
+    'data-attr': dataAttr,
+}: TooltipSurfaceProps): React.ReactElement {
+    const { theme } = useChartLayout()
+    return (
+        <div
+            className={joinClasses('rounded-sm px-3 py-1.5 text-xs shadow-md', className)}
+            data-attr={dataAttr}
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{
+                backgroundColor: theme.tooltipBackground ?? TOOLTIP_FALLBACK_BG,
+                color: theme.tooltipColor ?? TOOLTIP_FALLBACK_COLOR,
+            }}
+        >
+            {children}
+        </div>
+    )
+}
+
+/** Round series-color swatch used in tooltip rows. */
+export function TooltipSwatch({ color }: { color: string }): React.ReactElement {
+    return (
+        <span
+            className="inline-block size-2 rounded-full"
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{ backgroundColor: color }}
+        />
+    )
+}

--- a/packages/quill/packages/charts/src/overlays/TooltipSurface.tsx
+++ b/packages/quill/packages/charts/src/overlays/TooltipSurface.tsx
@@ -10,10 +10,6 @@ import { useChartLayout } from '../core/chart-context'
 export const TOOLTIP_FALLBACK_BG = '#1d2330'
 export const TOOLTIP_FALLBACK_COLOR = '#ffffff'
 
-function joinClasses(...parts: Array<string | undefined>): string {
-    return parts.filter(Boolean).join(' ')
-}
-
 interface TooltipSurfaceProps {
     children: React.ReactNode
     className?: string
@@ -22,11 +18,12 @@ interface TooltipSurfaceProps {
 }
 
 /**
- * Shared surface for the built-in chart tooltips. Mirrors quill's tooltip
- * (`.quill-tooltip__content`): an inverse panel at `radius-sm`, compact padding,
- * `text-xs`. Colors stay theme-driven so non-quill hosts can still restyle it.
- * The shadow is the one intentional deviation from the primitive — chart
- * tooltips float over dense data and need the extra separation.
+ * Shared surface for the built-in chart tooltips. Geometry mirrors quill's
+ * tooltip (`.quill-tooltip__content`: inverse panel, `radius-sm`, compact
+ * padding, `text-xs`) but is applied inline — no shipped stylesheet, no Tailwind
+ * scan needed, so the floating panel renders correctly regardless of the
+ * consumer's setup. Dimensions reference quill token vars with literal
+ * fallbacks; colors stay theme-driven so non-quill hosts can restyle.
  */
 export function TooltipSurface({
     children,
@@ -36,10 +33,20 @@ export function TooltipSurface({
     const { theme } = useChartLayout()
     return (
         <div
-            className={joinClasses('rounded-sm px-3 py-1.5 text-xs shadow-md', className)}
+            className={className}
             data-attr={dataAttr}
             // eslint-disable-next-line react/forbid-dom-props
             style={{
+                width: 'fit-content',
+                maxWidth: '20rem',
+                paddingBlock: '0.375rem',
+                paddingInline: '0.75rem',
+                fontSize: 'var(--text-xs, 0.75rem)',
+                lineHeight: 1.4,
+                borderRadius: 'var(--radius-sm, 0.375rem)',
+                // Soft float shadow for separation over dense chart data — the
+                // one intentional addition over quill's flat in-page tooltip.
+                boxShadow: '0 2px 8px rgb(0 0 0 / 18%)',
                 backgroundColor: theme.tooltipBackground ?? TOOLTIP_FALLBACK_BG,
                 color: theme.tooltipColor ?? TOOLTIP_FALLBACK_COLOR,
             }}
@@ -53,9 +60,15 @@ export function TooltipSurface({
 export function TooltipSwatch({ color }: { color: string }): React.ReactElement {
     return (
         <span
-            className="inline-block size-2 rounded-full"
             // eslint-disable-next-line react/forbid-dom-props
-            style={{ backgroundColor: color }}
+            style={{
+                display: 'inline-block',
+                flex: 'none',
+                width: '0.5rem',
+                height: '0.5rem',
+                borderRadius: '9999px',
+                backgroundColor: color,
+            }}
         />
     )
 }

--- a/packages/quill/packages/tokens/package.json
+++ b/packages/quill/packages/tokens/package.json
@@ -14,10 +14,10 @@
     "type": "module",
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "types": "./dist/src/index.d.ts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.ts",
+            "types": "./dist/src/index.d.ts",
             "import": "./dist/index.js",
             "require": "./dist/index.cjs",
             "default": "./dist/index.js"


### PR DESCRIPTION
## Problem

A design-system review of the chart tooltips from a **consumer's** perspective turned up two issues:

1. The tooltip surface was hand-rolled in four places (`DefaultTooltip`, `PieTooltip`, `BoxPlotTooltip`, `ReferenceLine`), each repeating `px-3 py-2 rounded-lg shadow-lg text-[13px]` + inline colors + the `#1d2330`/`#fff` constants + the swatch — and none of it matched quill's own tooltip (`.quill-tooltip__content`).
2. More seriously: the tooltip's box geometry (padding, radius, font size, shadow, swatch shape) was built from Tailwind utility classes, which only render if the consumer's Tailwind build scans this package. Tailwind v4 doesn't scan `node_modules`, so a real consumer of `@posthog/quill-charts` would get an **unstyled blob with no error**.

<img width="1306" height="838" alt="2026-06-09 10 05 11" src="https://github.com/user-attachments/assets/e0bca2d0-fcf9-4383-a4fb-e54befb1f5e8" />


## Changes

- **One shared `TooltipSurface` + `TooltipSwatch`** mirroring quill's tooltip dimensions (inverse panel, `radius-sm`, compact padding, `text-xs`). The three tooltips compose it, and `ReferenceLine` shares the fallback colors. Both are exported so consumers can build custom tooltips with the same look.
- **Tooltip geometry is applied inline**, not via Tailwind classes. This is the key robustness fix: the floating panel renders correctly with **zero consumer setup** — no shipped stylesheet, no Tailwind `node_modules` scan, no import step. Dimensions reference quill token vars **with literal fallbacks** (`var(--radius-sm, 0.375rem)`), so the surface is correct with or without `@posthog/quill-tokens` loaded. Colors stay theme-driven (set inline from the `ChartTheme`), so non-quill hosts can restyle.
- **Fixed the theme reader's tooltip mapping** to quill's inverse surface (`--foreground` bg / `--background` text) instead of a light `--card` panel.
- **Fixed `@posthog/quill-tokens` `types` path** — it pointed at `dist/index.d.ts`, which the build never emits (declarations land in `dist/src/`), so consumers importing the package got `any`. Point `types`/`exports` at the real path.

### Why inline, not a shipped stylesheet?

The bug isn't about colors — those are already applied inline from the theme and resolved from tokens vars when present. The bug is missing **box geometry**, which previously lived in Tailwind utilities the consumer won't generate. The tooltip is static (no pseudo-states, no media queries) and its geometry isn't meant to be themeable (colors are, via the `ChartTheme` prop). So inlining removes the entire CSS-shipping surface — stylesheet, export, `sideEffects`, Tailwind scan, consumer import — and makes the component fully self-contained. A shipped stylesheet only earns its keep once **all** chart chrome moves off consumer-Tailwind (a larger effort, out of scope here).

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Automated only:
- 1220 charts tests pass under the frontend jest project (theme, BarChart, BoxPlot, Pie, ReferenceLine, overlays); a test asserts the inverse tooltip mapping.
- `vite build` is clean and emits **no CSS** (charts is back to a pure JS/canvas build); the dts build resolves the touched files.

A human should eyeball the tooltips in light/dark in storybook.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Started as "review the tooltips, can we reuse quill's styling?" and widened into a consumer-risk review.

Key decision: the surface was first shipped as a real CSS file (`@posthog/quill-charts/styles.css`). On review we chose to **inline the geometry instead** — the tooltip is static and self-contained, so a stylesheet added a consumer setup step and a tree-shaking/`sideEffects` concern for no benefit over inline styles. Charts therefore keeps no CSS pipeline.

This branch was also rebased onto master, which had meanwhile published `@posthog/quill-charts` (now `0.3.0-beta.15`, no longer private) with a real Vite `dist/` build — resolving an earlier follow-up about the package being private/`0.0.0` on its own.
