### PR TITLE
docs(cli): clarify Hermes upload help

### DIFF
--- a/cli/.sampo/changesets/cli-hermes-upload-help.md
+++ b/cli/.sampo/changesets/cli-hermes-upload-help.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Clarify the Hermes upload help text.

--- a/cli/src/sourcemaps/hermes/mod.rs
+++ b/cli/src/sourcemaps/hermes/mod.rs
@@ -14,7 +14,7 @@ pub mod upload;
 pub enum HermesSubcommand {
     /// Inject your bundled chunk with a posthog chunk ID
     Inject(InjectArgs),
-    /// Upload the bundled chunk to PostHog
+    /// Upload bundled Hermes source maps to PostHog
     Upload(upload::Args),
     /// Clone chunk_id and release_id metadata from bundle maps to composed maps
     Clone(clone::CloneArgs),


### PR DESCRIPTION
## Summary

- clarify the `hermes upload` help text so it describes uploading bundled Hermes source maps
- add a Sampo patch changeset for `posthog-cli`

## Testing

- `cargo run --quiet -- hermes --help`
- `cargo fmt --all -- --check`
- `bin/hogli format:markdown cli/.sampo/changesets/cli-hermes-upload-help.md`

Autoreview skipped per request: very small help-text change.
