### PR TITLE
fix(cdp): honor auto.offset.reset override in v2 consumer topic config

### DIFF
--- a/nodejs/src/kafka/consumer/consumer-v2.test.ts
+++ b/nodejs/src/kafka/consumer/consumer-v2.test.ts
@@ -177,6 +177,22 @@ describe('KafkaConsumerV2', () => {
         await delay(2)
     }
 
+    // auto.offset.reset is a topic-level librdkafka property — a value only in the global config
+    // is ignored, so the override must be mirrored into the topic config (2nd ctor arg).
+    it('mirrors an auto.offset.reset override into the topic config', () => {
+        const RdKafkaCtor = jest.mocked(require('node-rdkafka').KafkaConsumer)
+        new KafkaConsumerV2({ groupId: 'g', topic: 't' }, { 'auto.offset.reset': 'latest' } as any)
+        const topicConfig = RdKafkaCtor.mock.calls.at(-1)![1] as any
+        expect(topicConfig['auto.offset.reset']).toBe('latest')
+    })
+
+    it('defaults the topic-config auto.offset.reset to earliest with no override', () => {
+        const RdKafkaCtor = jest.mocked(require('node-rdkafka').KafkaConsumer)
+        new KafkaConsumerV2({ groupId: 'g', topic: 't' })
+        const topicConfig = RdKafkaCtor.mock.calls.at(-1)![1] as any
+        expect(topicConfig['auto.offset.reset']).toBe('earliest')
+    })
+
     it('Smoke: connect → consume → eachBatch → offsets stored', async () => {
         const eachBatch = jest.fn(() => Promise.resolve({}))
         await startConsuming(eachBatch)

--- a/nodejs/src/kafka/consumer/consumer-v2.ts
+++ b/nodejs/src/kafka/consumer/consumer-v2.ts
@@ -533,7 +533,12 @@ export class KafkaConsumerV2 {
     // === RdKafkaConsumer construction + event wiring ===
 
     private createConsumer(): RdKafkaConsumer {
-        const consumer = new RdKafkaConsumer(this.rdKafkaConfig, { 'auto.offset.reset': 'earliest' })
+        // auto.offset.reset is a topic-level property: a value in the global config is ignored by
+        // librdkafka unless mirrored into the topic config here. Honor an override carried on the
+        // resolved config (e.g. `latest`) and default to earliest.
+        const consumer = new RdKafkaConsumer(this.rdKafkaConfig, {
+            'auto.offset.reset': (this.rdKafkaConfig['auto.offset.reset'] as string) ?? 'earliest',
+        })
 
         consumer.on('event.log', (log) => logger.info('📝', 'kafka_consumer_v2_librdkafka_log', { log }))
         consumer.on('event.error', (error: LibrdKafkaError) => {


### PR DESCRIPTION
## Problem
`auto.offset.reset` is a **topic-level** librdkafka property — a value set only in the global consumer config is ignored. `KafkaConsumerV2.createConsumer()` hardcoded `{ 'auto.offset.reset': 'earliest' }` in the **topic config** (2nd arg to `RdKafkaConsumer`), which silently overrode any value a caller put in the global config via the override argument. So a consumer that opts into `latest` (e.g. a real-time waker that should start at the head, not replay the topic backlog) was still pinned to `earliest`.

## Fix
Mirror the resolved `auto.offset.reset` from the consumer config into the topic config, defaulting to `earliest`:
```ts
new RdKafkaConsumer(this.rdKafkaConfig, {
    'auto.offset.reset': (this.rdKafkaConfig['auto.offset.reset'] as string) ?? 'earliest',
})
```
No behavior change for existing consumers (they don't set an override → still `earliest`); only consumers that explicitly opt into `latest` are affected.

## Tests
Added two tests asserting the override reaches the topic config (`latest`) and that it defaults to `earliest` without one — the gap the original override change missed.

## Note
`auto.offset.reset` only applies to a group with no committed offset (new) or an out-of-range offset. A group that already committed at `earliest` won't move just from this fix — it needs the group to be reset/recreated separately.