### PR TITLE
feat(signals): expose inbox source config write MCP tools

### DIFF
--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -89,7 +89,25 @@ tools:
             again later. Returns 409 if the transition is not allowed from the report's current status.
     inbox-source-configs-create:
         operation: signals_source_configs_create
-        enabled: false
+        enabled: true
+        scopes:
+            - task:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create signal source config
+        description: >
+            Create a signal source config for the current project, switching an inbox signal source on. A source ties a
+            `source_product` to a `source_type` and an `enabled` flag. Valid `source_product` values: session_replay,
+            llm_analytics, github, linear, zendesk, conversations, error_tracking, pganalyze, signals_scout, logs. Valid
+            `source_type` values: session_analysis_cluster, evaluation, issue, ticket, issue_created, issue_reopened,
+            issue_spiking, cross_source_issue, alert_state_change. To turn the Signals scout source on for a project,
+            create `source_product=signals_scout`, `source_type=cross_source_issue`, `enabled=true` — this is the
+            team-level source gate that scout emit also requires (the per-scout `emit` flag is set separately via
+            `signals-scout-config-update`). There is at most one config per (source_product, source_type) per project;
+            if one already exists, update it instead. Enabling the session_analysis_cluster source requires the
+            organization to have approved AI data processing.
     inbox-source-configs-destroy:
         operation: signals_source_configs_destroy
         enabled: false
@@ -120,7 +138,19 @@ tools:
                 - updated_at
     inbox-source-configs-partial-update:
         operation: signals_source_configs_partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - task:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Update signal source config
+        description: >
+            Partially update an existing signal source config by ID — typically to flip its `enabled` flag on or off, or
+            to adjust its `config`. Only the fields you pass are changed. To turn the Signals scout source off for a
+            project, set `enabled=false` on its `signals_scout` / `cross_source_issue` config. Enabling the
+            session_analysis_cluster source requires the organization to have approved AI data processing.
     inbox-source-configs-retrieve:
         operation: signals_source_configs_retrieve
         enabled: true
@@ -136,7 +166,19 @@ tools:
             enabled flag, configuration JSON, and current status of the underlying data import or workflow.
     inbox-source-configs-update:
         operation: signals_source_configs_update
-        enabled: false
+        enabled: true
+        scopes:
+            - task:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Replace signal source config
+        description: >
+            Replace an existing signal source config by ID (full update — all writable fields are required:
+            `source_product`, `source_type`, `enabled`, and `config`). Prefer `inbox-source-configs-partial-update` when
+            you only need to flip `enabled` or tweak `config`. Enabling the session_analysis_cluster source requires the
+            organization to have approved AI data processing.
     signals-scout-config-list:
         operation: signals_scout_config_list
         enabled: true

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -175,10 +175,10 @@ tools:
             idempotent: true
         title: Replace signal source config
         description: >
-            Replace an existing signal source config by ID (full update — all writable fields are required:
-            `source_product`, `source_type`, `enabled`, and `config`). Prefer `inbox-source-configs-partial-update` when
-            you only need to flip `enabled` or tweak `config`. Enabling the session_analysis_cluster source requires the
-            organization to have approved AI data processing.
+            Replace an existing signal source config by ID (full update — `source_product` and `source_type` are
+            required; `enabled` and `config` are optional and keep their current values if omitted). Prefer
+            `inbox-source-configs-partial-update` when you only need to flip `enabled` or tweak `config`. Enabling the
+            session_analysis_cluster source requires the organization to have approved AI data processing.
     signals-scout-config-list:
         operation: signals_scout_config_list
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2670,7 +2670,7 @@
         }
     },
     "inbox-source-configs-update": {
-        "description": "Replace an existing signal source config by ID (full update — all writable fields are required: `source_product`, `source_type`, `enabled`, and `config`). Prefer `inbox-source-configs-partial-update` when you only need to flip `enabled` or tweak `config`. Enabling the session_analysis_cluster source requires the organization to have approved AI data processing.",
+        "description": "Replace an existing signal source config by ID (full update — `source_product` and `source_type` are required; `enabled` and `config` are optional and keep their current values if omitted). Prefer `inbox-source-configs-partial-update` when you only need to flip `enabled` or tweak `config`. Enabling the session_analysis_cluster source requires the organization to have approved AI data processing.",
         "category": "Signals",
         "feature": "signals",
         "summary": "Replace signal source config",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2613,6 +2613,20 @@
             "readOnlyHint": false
         }
     },
+    "inbox-source-configs-create": {
+        "description": "Create a signal source config for the current project, switching an inbox signal source on. A source ties a `source_product` to a `source_type` and an `enabled` flag. Valid `source_product` values: session_replay, llm_analytics, github, linear, zendesk, conversations, error_tracking, pganalyze, signals_scout, logs. Valid `source_type` values: session_analysis_cluster, evaluation, issue, ticket, issue_created, issue_reopened, issue_spiking, cross_source_issue, alert_state_change. To turn the Signals scout source on for a project, create `source_product=signals_scout`, `source_type=cross_source_issue`, `enabled=true` — this is the team-level source gate that scout emit also requires (the per-scout `emit` flag is set separately via `signals-scout-config-update`). There is at most one config per (source_product, source_type) per project; if one already exists, update it instead. Enabling the session_analysis_cluster source requires the organization to have approved AI data processing.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Create signal source config",
+        "title": "Create signal source config",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "inbox-source-configs-list": {
         "description": "List the configured signal sources for the current project. A signal source ties a product (e.g. error_tracking, session_replay, github, linear, zendesk) and a source_type to an enabled flag and configuration. The 'status' field reflects the current state of the underlying data import or workflow (running, completed, failed) when applicable.",
         "category": "Signals",
@@ -2627,6 +2641,20 @@
             "readOnlyHint": true
         }
     },
+    "inbox-source-configs-partial-update": {
+        "description": "Partially update an existing signal source config by ID — typically to flip its `enabled` flag on or off, or to adjust its `config`. Only the fields you pass are changed. To turn the Signals scout source off for a project, set `enabled=false` on its `signals_scout` / `cross_source_issue` config. Enabling the session_analysis_cluster source requires the organization to have approved AI data processing.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Update signal source config",
+        "title": "Update signal source config",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "inbox-source-configs-retrieve": {
         "description": "Get a single signal source config by ID. Returns the full record including source_product, source_type, enabled flag, configuration JSON, and current status of the underlying data import or workflow.",
         "category": "Signals",
@@ -2639,6 +2667,20 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        }
+    },
+    "inbox-source-configs-update": {
+        "description": "Replace an existing signal source config by ID (full update — all writable fields are required: `source_product`, `source_type`, `enabled`, and `config`). Prefer `inbox-source-configs-partial-update` when you only need to flip `enabled` or tweak `config`. Enabling the session_analysis_cluster source requires the organization to have approved AI data processing.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Replace signal source config",
+        "title": "Replace signal source config",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
         }
     },
     "insight-create": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2853,6 +2853,20 @@
             "readOnlyHint": false
         }
     },
+    "inbox-source-configs-create": {
+        "description": "Create a signal source config for the current project, switching an inbox signal source on. A source ties a `source_product` to a `source_type` and an `enabled` flag. Valid `source_product` values: session_replay, llm_analytics, github, linear, zendesk, conversations, error_tracking, pganalyze, signals_scout, logs. Valid `source_type` values: session_analysis_cluster, evaluation, issue, ticket, issue_created, issue_reopened, issue_spiking, cross_source_issue, alert_state_change. To turn the Signals scout source on for a project, create `source_product=signals_scout`, `source_type=cross_source_issue`, `enabled=true` — this is the team-level source gate that scout emit also requires (the per-scout `emit` flag is set separately via `signals-scout-config-update`). There is at most one config per (source_product, source_type) per project; if one already exists, update it instead. Enabling the session_analysis_cluster source requires the organization to have approved AI data processing.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Create signal source config",
+        "title": "Create signal source config",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "inbox-source-configs-list": {
         "description": "List the configured signal sources for the current project. A signal source ties a product (e.g. error_tracking, session_replay, github, linear, zendesk) and a source_type to an enabled flag and configuration. The 'status' field reflects the current state of the underlying data import or workflow (running, completed, failed) when applicable.",
         "category": "Signals",
@@ -2867,6 +2881,20 @@
             "readOnlyHint": true
         }
     },
+    "inbox-source-configs-partial-update": {
+        "description": "Partially update an existing signal source config by ID — typically to flip its `enabled` flag on or off, or to adjust its `config`. Only the fields you pass are changed. To turn the Signals scout source off for a project, set `enabled=false` on its `signals_scout` / `cross_source_issue` config. Enabling the session_analysis_cluster source requires the organization to have approved AI data processing.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Update signal source config",
+        "title": "Update signal source config",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "inbox-source-configs-retrieve": {
         "description": "Get a single signal source config by ID. Returns the full record including source_product, source_type, enabled flag, configuration JSON, and current status of the underlying data import or workflow.",
         "category": "Signals",
@@ -2879,6 +2907,20 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        }
+    },
+    "inbox-source-configs-update": {
+        "description": "Replace an existing signal source config by ID (full update — all writable fields are required: `source_product`, `source_type`, `enabled`, and `config`). Prefer `inbox-source-configs-partial-update` when you only need to flip `enabled` or tweak `config`. Enabling the session_analysis_cluster source requires the organization to have approved AI data processing.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Replace signal source config",
+        "title": "Replace signal source config",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
         }
     },
     "insight-create": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2910,7 +2910,7 @@
         }
     },
     "inbox-source-configs-update": {
-        "description": "Replace an existing signal source config by ID (full update — all writable fields are required: `source_product`, `source_type`, `enabled`, and `config`). Prefer `inbox-source-configs-partial-update` when you only need to flip `enabled` or tweak `config`. Enabling the session_analysis_cluster source requires the organization to have approved AI data processing.",
+        "description": "Replace an existing signal source config by ID (full update — `source_product` and `source_type` are required; `enabled` and `config` are optional and keep their current values if omitted). Prefer `inbox-source-configs-partial-update` when you only need to flip `enabled` or tweak `config`. Enabling the session_analysis_cluster source requires the organization to have approved AI data processing.",
         "category": "Signals",
         "feature": "signals",
         "summary": "Replace signal source config",

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 14 enabled ops
+ * PostHog API - MCP 17 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -437,6 +437,50 @@ export const SignalsSourceConfigsListQueryParams = /* @__PURE__ */ zod.object({
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
 })
 
+export const SignalsSourceConfigsCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const SignalsSourceConfigsCreateBody = /* @__PURE__ */ zod.object({
+    source_product: zod
+        .enum([
+            'session_replay',
+            'llm_analytics',
+            'github',
+            'linear',
+            'zendesk',
+            'conversations',
+            'error_tracking',
+            'pganalyze',
+            'signals_scout',
+            'logs',
+        ])
+        .describe(
+            '* `session_replay` - Session replay\n* `llm_analytics` - LLM analytics\n* `github` - GitHub\n* `linear` - Linear\n* `zendesk` - Zendesk\n* `conversations` - Conversations\n* `error_tracking` - Error tracking\n* `pganalyze` - pganalyze\n* `signals_scout` - Signals scout\n* `logs` - Logs'
+        ),
+    source_type: zod
+        .enum([
+            'session_analysis_cluster',
+            'evaluation',
+            'issue',
+            'ticket',
+            'issue_created',
+            'issue_reopened',
+            'issue_spiking',
+            'cross_source_issue',
+            'alert_state_change',
+        ])
+        .describe(
+            '* `session_analysis_cluster` - Session analysis cluster\n* `evaluation` - Evaluation\n* `issue` - Issue\n* `ticket` - Ticket\n* `issue_created` - Issue created\n* `issue_reopened` - Issue reopened\n* `issue_spiking` - Issue spiking\n* `cross_source_issue` - Cross source issue\n* `alert_state_change` - Alert state change'
+        ),
+    enabled: zod.boolean().optional(),
+    config: zod.unknown().optional(),
+})
+
 export const SignalsSourceConfigsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this signal source config.'),
     project_id: zod
@@ -444,4 +488,96 @@ export const SignalsSourceConfigsRetrieveParams = /* @__PURE__ */ zod.object({
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
+})
+
+export const SignalsSourceConfigsUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this signal source config.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const SignalsSourceConfigsUpdateBody = /* @__PURE__ */ zod.object({
+    source_product: zod
+        .enum([
+            'session_replay',
+            'llm_analytics',
+            'github',
+            'linear',
+            'zendesk',
+            'conversations',
+            'error_tracking',
+            'pganalyze',
+            'signals_scout',
+            'logs',
+        ])
+        .describe(
+            '* `session_replay` - Session replay\n* `llm_analytics` - LLM analytics\n* `github` - GitHub\n* `linear` - Linear\n* `zendesk` - Zendesk\n* `conversations` - Conversations\n* `error_tracking` - Error tracking\n* `pganalyze` - pganalyze\n* `signals_scout` - Signals scout\n* `logs` - Logs'
+        ),
+    source_type: zod
+        .enum([
+            'session_analysis_cluster',
+            'evaluation',
+            'issue',
+            'ticket',
+            'issue_created',
+            'issue_reopened',
+            'issue_spiking',
+            'cross_source_issue',
+            'alert_state_change',
+        ])
+        .describe(
+            '* `session_analysis_cluster` - Session analysis cluster\n* `evaluation` - Evaluation\n* `issue` - Issue\n* `ticket` - Ticket\n* `issue_created` - Issue created\n* `issue_reopened` - Issue reopened\n* `issue_spiking` - Issue spiking\n* `cross_source_issue` - Cross source issue\n* `alert_state_change` - Alert state change'
+        ),
+    enabled: zod.boolean().optional(),
+    config: zod.unknown().optional(),
+})
+
+export const SignalsSourceConfigsPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this signal source config.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const SignalsSourceConfigsPartialUpdateBody = /* @__PURE__ */ zod.object({
+    source_product: zod
+        .enum([
+            'session_replay',
+            'llm_analytics',
+            'github',
+            'linear',
+            'zendesk',
+            'conversations',
+            'error_tracking',
+            'pganalyze',
+            'signals_scout',
+            'logs',
+        ])
+        .optional()
+        .describe(
+            '* `session_replay` - Session replay\n* `llm_analytics` - LLM analytics\n* `github` - GitHub\n* `linear` - Linear\n* `zendesk` - Zendesk\n* `conversations` - Conversations\n* `error_tracking` - Error tracking\n* `pganalyze` - pganalyze\n* `signals_scout` - Signals scout\n* `logs` - Logs'
+        ),
+    source_type: zod
+        .enum([
+            'session_analysis_cluster',
+            'evaluation',
+            'issue',
+            'ticket',
+            'issue_created',
+            'issue_reopened',
+            'issue_spiking',
+            'cross_source_issue',
+            'alert_state_change',
+        ])
+        .optional()
+        .describe(
+            '* `session_analysis_cluster` - Session analysis cluster\n* `evaluation` - Evaluation\n* `issue` - Issue\n* `ticket` - Ticket\n* `issue_created` - Issue created\n* `issue_reopened` - Issue reopened\n* `issue_spiking` - Issue spiking\n* `cross_source_issue` - Cross source issue\n* `alert_state_change` - Alert state change'
+        ),
+    enabled: zod.boolean().optional(),
+    config: zod.unknown().optional(),
 })

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -17,8 +17,13 @@ import {
     SignalsScoutScratchpadForgetBody,
     SignalsScoutScratchpadRememberBody,
     SignalsScoutScratchpadSearchQueryParams,
+    SignalsSourceConfigsCreateBody,
     SignalsSourceConfigsListQueryParams,
+    SignalsSourceConfigsPartialUpdateBody,
+    SignalsSourceConfigsPartialUpdateParams,
     SignalsSourceConfigsRetrieveParams,
+    SignalsSourceConfigsUpdateBody,
+    SignalsSourceConfigsUpdateParams,
 } from '@/generated/signals/api'
 import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
@@ -127,6 +132,35 @@ const inboxReportsSetState = (): ToolBase<typeof InboxReportsSetStateSchema, Wit
     },
 })
 
+const InboxSourceConfigsCreateSchema = SignalsSourceConfigsCreateBody
+
+const inboxSourceConfigsCreate = (): ToolBase<typeof InboxSourceConfigsCreateSchema, Schemas.SignalSourceConfig> => ({
+    name: 'inbox-source-configs-create',
+    schema: InboxSourceConfigsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof InboxSourceConfigsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.source_product !== undefined) {
+            body['source_product'] = params.source_product
+        }
+        if (params.source_type !== undefined) {
+            body['source_type'] = params.source_type
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        if (params.config !== undefined) {
+            body['config'] = params.config
+        }
+        const result = await context.api.request<Schemas.SignalSourceConfig>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/source_configs/`,
+            body,
+        })
+        return result
+    },
+})
+
 const InboxSourceConfigsListSchema = SignalsSourceConfigsListQueryParams
 
 const inboxSourceConfigsList = (): ToolBase<
@@ -163,6 +197,40 @@ const inboxSourceConfigsList = (): ToolBase<
     },
 })
 
+const InboxSourceConfigsPartialUpdateSchema = SignalsSourceConfigsPartialUpdateParams.omit({ project_id: true }).extend(
+    SignalsSourceConfigsPartialUpdateBody.shape
+)
+
+const inboxSourceConfigsPartialUpdate = (): ToolBase<
+    typeof InboxSourceConfigsPartialUpdateSchema,
+    Schemas.SignalSourceConfig
+> => ({
+    name: 'inbox-source-configs-partial-update',
+    schema: InboxSourceConfigsPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof InboxSourceConfigsPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.source_product !== undefined) {
+            body['source_product'] = params.source_product
+        }
+        if (params.source_type !== undefined) {
+            body['source_type'] = params.source_type
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        if (params.config !== undefined) {
+            body['config'] = params.config
+        }
+        const result = await context.api.request<Schemas.SignalSourceConfig>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/source_configs/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        return result
+    },
+})
+
 const InboxSourceConfigsRetrieveSchema = SignalsSourceConfigsRetrieveParams.omit({ project_id: true })
 
 const inboxSourceConfigsRetrieve = (): ToolBase<
@@ -176,6 +244,37 @@ const inboxSourceConfigsRetrieve = (): ToolBase<
         const result = await context.api.request<Schemas.SignalSourceConfig>({
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/source_configs/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const InboxSourceConfigsUpdateSchema = SignalsSourceConfigsUpdateParams.omit({ project_id: true }).extend(
+    SignalsSourceConfigsUpdateBody.shape
+)
+
+const inboxSourceConfigsUpdate = (): ToolBase<typeof InboxSourceConfigsUpdateSchema, Schemas.SignalSourceConfig> => ({
+    name: 'inbox-source-configs-update',
+    schema: InboxSourceConfigsUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof InboxSourceConfigsUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.source_product !== undefined) {
+            body['source_product'] = params.source_product
+        }
+        if (params.source_type !== undefined) {
+            body['source_type'] = params.source_type
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        if (params.config !== undefined) {
+            body['config'] = params.config
+        }
+        const result = await context.api.request<Schemas.SignalSourceConfig>({
+            method: 'PUT',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/source_configs/${encodeURIComponent(String(params.id))}/`,
+            body,
         })
         return result
     },
@@ -418,8 +517,11 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'inbox-reports-list': inboxReportsList,
     'inbox-reports-retrieve': inboxReportsRetrieve,
     'inbox-reports-set-state': inboxReportsSetState,
+    'inbox-source-configs-create': inboxSourceConfigsCreate,
     'inbox-source-configs-list': inboxSourceConfigsList,
+    'inbox-source-configs-partial-update': inboxSourceConfigsPartialUpdate,
     'inbox-source-configs-retrieve': inboxSourceConfigsRetrieve,
+    'inbox-source-configs-update': inboxSourceConfigsUpdate,
     'signals-scout-config-list': signalsScoutConfigList,
     'signals-scout-config-update': signalsScoutConfigUpdate,
     'signals-scout-emit-signal': signalsScoutEmitSignal,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-source-configs-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-source-configs-create.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "config": {},
+        "enabled": {
+            "type": "boolean"
+        },
+        "source_product": {
+            "description": "* `session_replay` - Session replay\n* `llm_analytics` - LLM analytics\n* `github` - GitHub\n* `linear` - Linear\n* `zendesk` - Zendesk\n* `conversations` - Conversations\n* `error_tracking` - Error tracking\n* `pganalyze` - pganalyze\n* `signals_scout` - Signals scout\n* `logs` - Logs",
+            "enum": [
+                "session_replay",
+                "llm_analytics",
+                "github",
+                "linear",
+                "zendesk",
+                "conversations",
+                "error_tracking",
+                "pganalyze",
+                "signals_scout",
+                "logs"
+            ],
+            "type": "string"
+        },
+        "source_type": {
+            "description": "* `session_analysis_cluster` - Session analysis cluster\n* `evaluation` - Evaluation\n* `issue` - Issue\n* `ticket` - Ticket\n* `issue_created` - Issue created\n* `issue_reopened` - Issue reopened\n* `issue_spiking` - Issue spiking\n* `cross_source_issue` - Cross source issue\n* `alert_state_change` - Alert state change",
+            "enum": [
+                "session_analysis_cluster",
+                "evaluation",
+                "issue",
+                "ticket",
+                "issue_created",
+                "issue_reopened",
+                "issue_spiking",
+                "cross_source_issue",
+                "alert_state_change"
+            ],
+            "type": "string"
+        }
+    },
+    "required": ["source_product", "source_type"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-source-configs-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-source-configs-partial-update.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "config": {},
+        "enabled": {
+            "type": "boolean"
+        },
+        "id": {
+            "description": "A UUID string identifying this signal source config.",
+            "type": "string"
+        },
+        "source_product": {
+            "description": "* `session_replay` - Session replay\n* `llm_analytics` - LLM analytics\n* `github` - GitHub\n* `linear` - Linear\n* `zendesk` - Zendesk\n* `conversations` - Conversations\n* `error_tracking` - Error tracking\n* `pganalyze` - pganalyze\n* `signals_scout` - Signals scout\n* `logs` - Logs",
+            "enum": [
+                "session_replay",
+                "llm_analytics",
+                "github",
+                "linear",
+                "zendesk",
+                "conversations",
+                "error_tracking",
+                "pganalyze",
+                "signals_scout",
+                "logs"
+            ],
+            "type": "string"
+        },
+        "source_type": {
+            "description": "* `session_analysis_cluster` - Session analysis cluster\n* `evaluation` - Evaluation\n* `issue` - Issue\n* `ticket` - Ticket\n* `issue_created` - Issue created\n* `issue_reopened` - Issue reopened\n* `issue_spiking` - Issue spiking\n* `cross_source_issue` - Cross source issue\n* `alert_state_change` - Alert state change",
+            "enum": [
+                "session_analysis_cluster",
+                "evaluation",
+                "issue",
+                "ticket",
+                "issue_created",
+                "issue_reopened",
+                "issue_spiking",
+                "cross_source_issue",
+                "alert_state_change"
+            ],
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-source-configs-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-source-configs-update.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "config": {},
+        "enabled": {
+            "type": "boolean"
+        },
+        "id": {
+            "description": "A UUID string identifying this signal source config.",
+            "type": "string"
+        },
+        "source_product": {
+            "description": "* `session_replay` - Session replay\n* `llm_analytics` - LLM analytics\n* `github` - GitHub\n* `linear` - Linear\n* `zendesk` - Zendesk\n* `conversations` - Conversations\n* `error_tracking` - Error tracking\n* `pganalyze` - pganalyze\n* `signals_scout` - Signals scout\n* `logs` - Logs",
+            "enum": [
+                "session_replay",
+                "llm_analytics",
+                "github",
+                "linear",
+                "zendesk",
+                "conversations",
+                "error_tracking",
+                "pganalyze",
+                "signals_scout",
+                "logs"
+            ],
+            "type": "string"
+        },
+        "source_type": {
+            "description": "* `session_analysis_cluster` - Session analysis cluster\n* `evaluation` - Evaluation\n* `issue` - Issue\n* `ticket` - Ticket\n* `issue_created` - Issue created\n* `issue_reopened` - Issue reopened\n* `issue_spiking` - Issue spiking\n* `cross_source_issue` - Cross source issue\n* `alert_state_change` - Alert state change",
+            "enum": [
+                "session_analysis_cluster",
+                "evaluation",
+                "issue",
+                "ticket",
+                "issue_created",
+                "issue_reopened",
+                "issue_spiking",
+                "cross_source_issue",
+                "alert_state_change"
+            ],
+            "type": "string"
+        }
+    },
+    "required": ["id", "source_product", "source_type"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

The inbox signal source configs (`SignalSourceConfig`) are how a project switches each inbox signal source on or off — error tracking, session replay, GitHub, Linear, Zendesk, the Signals scout source, and so on. Over MCP these have been **read-only**: `inbox-source-configs-list` and `inbox-source-configs-retrieve` are enabled, but `create`, `update`, and `partial-update` were intentionally held back with `enabled: false`. So an agent can *see* the source gates but can't *change* them — enabling or disabling a source means dropping out to the UI.

This is the general capability behind a recurring need: e.g. turning the Signals scout source gate on for a project (`signals_scout` / `cross_source_issue`, `enabled=true`) is the team-level gate that scout emit requires, and it had no MCP write path.

## Changes

Enable the write tools for `SignalSourceConfig` over MCP, with proper scopes, annotations, and descriptions:

- **`inbox-source-configs-create`** — create a source config (switch a source on)
- **`inbox-source-configs-partial-update`** — flip `enabled` / tweak `config` on an existing config
- **`inbox-source-configs-update`** — full replace

All three are scoped to `task:write` (the viewset's `scope_object`). `destroy` is **left disabled** — deleting a source config is destructive and isn't needed for the on/off workflow.

No backend changes: `SignalSourceConfigViewSet` is an existing `ModelViewSet` with a typed serializer (including the existing org-AI-approval guard on the `session_analysis_cluster` source), so the tools generate cleanly from the OpenAPI spec. The generated MCP tool/handler/schema, OpenAPI spec, and frontend types were regenerated via `hogli build:openapi`.

## How did you test this code?

I'm an agent (Claude Code). This is a config-only change (`tools.yaml` + regenerated artifacts), so:

- `hogli build:openapi` regenerated the OpenAPI spec, MCP tool/handler/schema, and frontend types cleanly (signals: 17 enabled ops).
- `pnpm --filter=@posthog/mcp lint-tool-names` passes.
- Verified the generated `inbox-source-configs-create` handler POSTs to `/api/projects/{id}/signals/source_configs/` with a fully-populated schema (`source_product`, `source_type`, `enabled`, `config`) — not an empty `z.object({})` — and that annotations came through (`readOnlyHint: false`, correct `idempotentHint` per op). `destroy` correctly stays absent.
- lint-staged (`ruff`/yaml/js format) clean on commit.

I did not exercise the tools against a live MCP in this change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code, following the `implementing-mcp-tools` skill. This PR came out of reviewing #61826 (a scout-specific `set-emit` composite): investigation showed the per-scout `emit` flag was already MCP-writable via `signals-scout-config-update`, and the only missing piece was a write path for the shared source gate — which is generic across all inbox source products, not scout-specific. Enabling the existing (intentionally-disabled) source-config write tools is the cleaner, more general fix, so #61826 is being closed in favor of this. Left `destroy` disabled deliberately. Agent-authored; requires human review.
