### PR TITLE
feat(mcp): default Devin client to single-exec CLI mode

### DIFF
--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -59,6 +59,9 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
     'aider',
     'copilot',
     'gemini-cli',
+    // Devin self-reports `clientInfo.name` as `Devin`; it's a coding agent and
+    // benefits from the same single-exec mode.
+    'devin',
     // LibreChat is a general MCP client, but benefits from the same CLI-shaped
     // single-exec mode as coding agents.
     'librechat',

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -25,6 +25,7 @@ describe('isCodingAgentClient', () => {
             ['zed'],
             ['aider'],
             ['copilot'],
+            ['devin'],
             ['librechat'],
             ['notion'],
         ])('returns true for %s', (clientName) => {
@@ -49,6 +50,7 @@ describe('isCodingAgentClient', () => {
             ['LibreChat/1.2.3'],
             ['notion-mcp-client'],
             ['Notion'],
+            ['Devin'],
         ])('returns true for variant %s (case-insensitive substring match)', (clientName) => {
             expect(isCodingAgentClient(clientName)).toBe(true)
         })


### PR DESCRIPTION
## Problem

Devin connects to the PostHog MCP server as a coding agent, but it was falling back to `tools` mode (one MCP tool per PostHog tool) instead of single-exec `cli` mode. Coding agents work better with the single-exec wrapper (one dispatcher tool taking a `call <tool> ...` command), which is why the other coding agents are already opted in.

Devin self-reports its MCP `clientInfo.name` as `Devin`, but `devin` was missing from `CODING_AGENT_CLIENT_NAME_FRAGMENTS`, so client detection never matched it. Production MCP traffic confirms every recent Devin session ran in `tools` mode.

## Changes

- Add `devin` to `CODING_AGENT_CLIENT_NAME_FRAGMENTS` in `services/mcp/src/lib/client-detection.ts`. Matching is case-insensitive and separator-agnostic, so the fragment `devin` matches the reported `Devin`.
- Extend the existing parameterized cases in `tests/unit/client-detection.test.ts` to cover `devin` (exact fragment) and `Devin` (realistic reported variant).

## How did you test this code?

I'm an agent. I ran the affected unit suite locally:

```
pnpm exec vitest run tests/unit/client-detection.test.ts
# 133 passed (133)
```

No manual end-to-end testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code agent) at the request of a maintainer. The task was to "find the MCP client name of Devin and enable CLI mode for it."

The client name was identified empirically from PostHog analytics: the `mcp_initialize` event's `$mcp_client_name` property shows `Devin` (≈117 initialize events over the trailing 180 days), and `$mcp_mode` for those sessions was uniformly `tools`. From there, `services/mcp/src/lib/client-detection.ts` was the single place where coding-agent → single-exec mode is decided, so the fix is a one-line fragment addition plus test coverage matching the surrounding style.
