### PR TITLE
fix(data-warehouse): stop deleted-source tables shadowing live ones

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1165,7 +1165,13 @@ class Database(BaseModel):
                 tables_query = (
                     DataWarehouseTable.raw_objects.filter(team_id=team.pk)
                     .exclude(deleted=True)
+                    # A table whose source was soft-deleted is an orphan — it must not shadow the
+                    # live table that a re-connected source created under the same name.
+                    .exclude(external_data_source__deleted=True)
                     .select_related("credential", "external_data_source")
+                    # Deterministic tiebreak when two live tables share a name: newest wins, since
+                    # name collisions resolve first-come-first-served when added to the table tree.
+                    .order_by("-created_at")
                 )
                 if database._is_direct_query():
                     tables_query = tables_query.filter(external_data_source_id=database._connection_id)

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -382,6 +382,78 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         assert field.type == "string"
         assert field.schema_valid is True
 
+    def _create_warehouse_table(self, *, name, url_pattern, source=None, credential=None):
+        return DataWarehouseTable.objects.create(
+            name=name,
+            format="Parquet",
+            team=self.team,
+            external_data_source=source,
+            credential=credential,
+            url_pattern=url_pattern,
+            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "Nullable(String)", "schema_valid": True}},
+        )
+
+    def test_create_hogql_database_ignores_tables_of_deleted_sources(self):
+        # A table left behind by a soft-deleted source must not shadow the live table that a
+        # re-connected source created under the same name (the orphan-table resolution bug).
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="k", access_secret="s")
+
+        deleted_source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="old",
+            connection_id="old",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type=ExternalDataSourceType.STRIPE,
+        )
+        # Created first, so without the fix it would win the first-come tree insertion. Mark the
+        # source — not the table — deleted to reproduce the orphan state (table.deleted stays False).
+        self._create_warehouse_table(
+            name="pull_requests", url_pattern="s3://orphan/*", source=deleted_source, credential=credential
+        )
+        deleted_source.deleted = True
+        deleted_source.save()
+
+        live_source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="new",
+            connection_id="new",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type=ExternalDataSourceType.STRIPE,
+        )
+        self._create_warehouse_table(
+            name="pull_requests", url_pattern="s3://live/*", source=live_source, credential=credential
+        )
+
+        database = Database.create_for(team=self.team)
+
+        assert database.has_table("pull_requests")
+        assert database.get_table("pull_requests").url == "s3://live/*"
+
+    def test_create_hogql_database_keeps_self_managed_table_without_source(self):
+        # Guards the deleted-source exclusion against the Django exclude()-with-NULL gotcha:
+        # a self-managed table (no source) must still resolve.
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="k", access_secret="s")
+        self._create_warehouse_table(name="self_managed", url_pattern="s3://self/*", credential=credential)
+
+        database = Database.create_for(team=self.team)
+
+        assert database.has_table("self_managed")
+        assert database.get_table("self_managed").url == "s3://self/*"
+
+    def test_create_hogql_database_resolves_duplicate_live_table_names_to_newest(self):
+        # Two live tables share a name (e.g. a re-sync produced a duplicate): newest wins.
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="k", access_secret="s")
+        older = self._create_warehouse_table(name="pull_requests", url_pattern="s3://older/*", credential=credential)
+        newer = self._create_warehouse_table(name="pull_requests", url_pattern="s3://newer/*", credential=credential)
+
+        # Pin created_at explicitly (bypasses auto_now_add) so the tiebreak is deterministic.
+        DataWarehouseTable.objects.filter(pk=older.pk).update(created_at="2024-01-01T00:00:00+00:00")
+        DataWarehouseTable.objects.filter(pk=newer.pk).update(created_at="2024-06-01T00:00:00+00:00")
+
+        database = Database.create_for(team=self.team)
+
+        assert database.get_table("pull_requests").url == "s3://newer/*"
+
     def test_serialize_database_warehouse_table_source_query_count(self):
         source = ExternalDataSource.objects.create(
             team=self.team,

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1567,37 +1567,20 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             .all()
         )
 
-        # Soft-delete source, schemas, tables, and companion _cdc tables atomically
-        # first so DB state is consistent even if the external cleanup below fails
-        with transaction.atomic():
-            for schema in schemas:
-                if schema.table:
-                    schema.table.soft_delete()
+        # Soft-delete source, schemas, tables, and companion _cdc tables. The cascade lives on
+        # `ExternalDataSource.soft_delete()` (atomic + bulk) so every deletion path stays
+        # consistent and no orphan tables are left behind.
+        instance.soft_delete()
 
-            # Bulk soft-delete the schema rows in a single UPDATE. Per-row soft_delete()
-            # runs a SELECT + UPDATE + activity-log write each, which does not scale to
-            # sources with thousands of schemas (e.g. a Slack workspace with thousands of
-            # channels).
-            deleted_at = datetime.now(UTC)
-            ExternalDataSchema.objects.filter(team_id=self.team_id, id__in=[schema.id for schema in schemas]).update(
-                deleted=True, deleted_at=deleted_at
-            )
-            # Mirror the bulk update onto the in-memory objects so the post-atomic
-            # `schema.delete_table()` save() below doesn't overwrite deleted=True with the
-            # stale in-memory value.
-            for schema in schemas:
-                schema.deleted = True
-                schema.deleted_at = deleted_at
-
-            # Clean up CDC companion tables (e.g. {name}_cdc) — these are standalone
-            # DataWarehouseTable records linked to the source but not to schema.table.
-            DataWarehouseTable.objects.filter(
-                external_data_source_id=instance.id,
-                team_id=self.team_id,
-                deleted=False,
-            ).exclude(id__in=[s.table_id for s in schemas if s.table_id is not None]).update(deleted=True)
-
-            instance.soft_delete()
+        # Mirror the cascade onto the pre-fetched in-memory objects so the post-commit S3 cleanup
+        # (`schema.delete_table()`) skips the now-redundant per-row table soft_delete and its
+        # save() doesn't resurrect the schema rows the cascade just deleted.
+        deleted_at = datetime.now(UTC)
+        for schema in schemas:
+            schema.deleted = True
+            schema.deleted_at = deleted_at
+            if schema.table:
+                schema.table.deleted = True
 
         # Best-effort webhook cleanup — soft-deletes are already committed
         source_type = ExternalDataSourceType(instance.source_type)

--- a/products/data_warehouse/backend/models/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/models/test/test_external_data_source.py
@@ -1,8 +1,12 @@
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from products.data_tools.backend.models.join import DataWarehouseJoin
 from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.models.table import DataWarehouseTable
 
 CLEANUP_PATH = "posthog.temporal.data_imports.sources.postgres.source.PostgresSource.cleanup_cdc_resources_on_deletion"
 
@@ -64,3 +68,54 @@ class TestExternalDataSourceSoftDelete(BaseTest):
         source.refresh_from_db()
         self.assertTrue(source.deleted)
         mock_cleanup.assert_called_once()
+
+    @patch(CLEANUP_PATH)
+    def test_soft_delete_cascades_to_tables_schemas_and_joins(self, _mock_cleanup):
+        source = self._create_source(source_type=ExternalDataSourceType.POSTGRES, job_inputs={"host": "localhost"})
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="k", access_secret="s")
+        table = DataWarehouseTable.objects.create(
+            name="pull_requests",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            external_data_source=source,
+            credential=credential,
+            url_pattern="s3://bucket/*",
+        )
+        schema = ExternalDataSchema.objects.create(name="pull_requests", team=self.team, source=source, table=table)
+        join = DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name="pull_requests",
+            source_table_key="id",
+            joining_table_name="persons",
+            joining_table_key="id",
+            field_name="person",
+        )
+        # Control: an unrelated source's table/join must be untouched by the cascade.
+        other_source = self._create_source(source_type=ExternalDataSourceType.POSTGRES, job_inputs=None)
+        other_table = DataWarehouseTable.objects.create(
+            name="customers",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            external_data_source=other_source,
+            credential=credential,
+            url_pattern="s3://bucket/customers/*",
+        )
+        other_join = DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name="customers",
+            source_table_key="id",
+            joining_table_name="persons",
+            joining_table_key="id",
+            field_name="person",
+        )
+
+        source.soft_delete()
+
+        for obj in (source, table, schema, join):
+            obj.refresh_from_db()
+            self.assertTrue(obj.deleted, f"{type(obj).__name__} should be soft-deleted")
+
+        other_table.refresh_from_db()
+        other_join.refresh_from_db()
+        self.assertFalse(other_table.deleted)
+        self.assertFalse(other_join.deleted)

--- a/products/warehouse_sources/backend/models/external_data_source.py
+++ b/products/warehouse_sources/backend/models/external_data_source.py
@@ -1,7 +1,8 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import UUID
 
-from django.db import models
+from django.db import models, transaction
+from django.db.models import Q
 
 import structlog
 import temporalio
@@ -110,9 +111,38 @@ class ExternalDataSource(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
             return config
 
     def soft_delete(self):
-        self.deleted = True
-        self.deleted_at = datetime.now()
-        self.save()
+        # Lazy imports avoid a circular dependency between the warehouse models.
+        from products.data_tools.backend.models.join import DataWarehouseJoin
+        from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+        from products.warehouse_sources.backend.models.table import DataWarehouseTable
+
+        deleted_at = datetime.now(UTC)
+
+        # Cascade the soft-delete to this source's tables (and their joins) and schemas so a
+        # deleted source never leaves orphan tables behind, whichever code path deletes it. Done
+        # in bulk inside one transaction — per-row deletes don't scale to sources with thousands
+        # of schemas (e.g. a Slack workspace with thousands of channels).
+        with transaction.atomic():
+            tables = DataWarehouseTable.objects.filter(team_id=self.team_id, external_data_source_id=self.id).exclude(
+                deleted=True
+            )
+            table_names = list(tables.values_list("name", flat=True))
+
+            if table_names:
+                DataWarehouseJoin.objects.filter(
+                    Q(team_id=self.team_id)
+                    & (Q(source_table_name__in=table_names) | Q(joining_table_name__in=table_names))
+                ).exclude(deleted=True).update(deleted=True, deleted_at=deleted_at)
+
+            tables.update(deleted=True, deleted_at=deleted_at)
+
+            ExternalDataSchema.objects.filter(team_id=self.team_id, source_id=self.id).exclude(deleted=True).update(
+                deleted=True, deleted_at=deleted_at
+            )
+
+            self.deleted = True
+            self.deleted_at = deleted_at
+            self.save()
 
         # Lazy import to avoid circular: SourceRegistry → helpers.py → this module.
         from posthog.temporal.data_imports.sources.common.registry import SourceRegistry

--- a/products/warehouse_sources/backend/models/util.py
+++ b/products/warehouse_sources/backend/models/util.py
@@ -47,7 +47,11 @@ def get_view_or_table_by_name(team, name) -> Union["DataWarehouseSavedQuery", "D
 
     table: DataWarehouseSavedQuery | DataWarehouseTable | None = (
         DataWarehouseTable.objects.filter(Q(deleted__isnull=True) | Q(deleted=False))
+        # Ignore orphan tables left behind by a soft-deleted source so they don't shadow the live one.
+        .exclude(external_data_source__deleted=True)
         .filter(team=team, name__in=table_names)
+        # Deterministic resolution when more than one live table matches: newest wins.
+        .order_by("-created_at")
         .first()
     )
     if table is None:


### PR DESCRIPTION
## Problem

A re-connected warehouse source (e.g. GitHub `pull_requests`, Stripe) can leave behind a previous source's table that shares the same `(team_id, name)` as the live one. Two things then go wrong:

1. **Queries resolve to the stale orphan.** `create_hogql_database` loaded warehouse tables with no ordering and inserted them into the table tree first-come-first-served (`add_child` defaults to `table_conflict_mode="ignore"`). The older orphan typically won, so `select * from <source>.<table>` returned data frozen at the moment the old source was deleted — even though the live source synced fine. The source's "stale" warning and dependent dashboards looked broken as a result.

2. **Orphans keep getting created.** `ExternalDataSource.soft_delete()` only marked the *source* deleted. The cascade that soft-deletes the source's tables/schemas lived solely in the `destroy` REST viewset, so any other deletion path left tables with `deleted=False` pointing at a `deleted=True` source.

## Changes

**Read path — ignore tables of deleted sources (immediate fix):**
- `create_hogql_database` and `get_view_or_table_by_name` now exclude tables whose `external_data_source` is soft-deleted, so an orphan can never shadow the live table.
- Added a deterministic newest-wins (`order_by("-created_at")`) tiebreak for the rare case of two genuinely live tables sharing a name.

**Prevent recurrence — cascade on the model:**
- Moved the table/schema/join cascade into `ExternalDataSource.soft_delete()` (atomic + bulk, so it scales to sources with thousands of schemas). Every deletion path is now fail-safe.
- The `destroy` viewset delegates to `soft_delete()` and keeps its post-commit best-effort S3 / Temporal-schedule cleanup. Net behaviour of the REST delete is unchanged; the cascade is just centralised.

This intentionally does **not** include the one-off data migration to clean up tables already orphaned in production — that's tracked separately.

## How did you test this code?

I'm an agent; I ran only automated tests (no manual testing).

- New `test_database.py` cases: deleted-source orphan is ignored, self-managed (no-source) table still resolves (guards the Django `exclude()`-with-NULL edge), duplicate live names resolve to newest.
- New model test: `source.soft_delete()` cascades to its tables, schemas and joins, and leaves unrelated sources untouched.
- Re-ran the existing `destroy` API tests and warehouse serialization/query-count tests — all green. `ruff check`/`format` and `ty check` clean.

## 🤖 Agent context

Authored by Claude Code (Opus) at the request of the data warehouse team, after triaging a Slack report of a `pull_requests` source showing stale despite a successful sync.

Root cause was traced to two independent issues (resolution ambiguity + non-cascading `soft_delete`). Considered three fixes; this PR implements the two code fixes (#1 read-path robustness, #2 cascade) and deliberately leaves the prod-data cleanup migration out. For #2, chose to centralise the cascade on the model and have the viewset delegate (rather than duplicate), preserving the viewset's in-memory mirroring so the post-commit `schema.delete_table()` S3 cleanup still skips redundant per-row work. Requires human review; not for self-merge.
