### PR TITLE
fix(data-warehouse): ignore deleted-source tables when resolving names

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -703,8 +703,13 @@ class Database(BaseModel):
                     to_attr="latest_completed_job",
                 ),
             )
-            .filter(Q(deleted=False) | Q(deleted__isnull=True), team_id=context.team_id)
-            .order_by("external_data_source__prefix", "external_data_source__source_type", "name")
+            # `queryable()` drops soft-deleted tables and orphans of a soft-deleted source, so an
+            # orphan can't shadow the live table sharing its name in the SQL editor catalog.
+            .queryable()
+            .filter(team_id=context.team_id)
+            # The catalog is built last-write-wins per table key, so order created_at ascending to
+            # land the newest row last when two live tables share a name — matching tree resolution.
+            .order_by("external_data_source__prefix", "external_data_source__source_type", "name", "created_at")
         )
         if self._is_direct_query():
             warehouse_tables_query = warehouse_tables_query.filter(external_data_source_id=self._connection_id)

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1163,9 +1163,14 @@ class Database(BaseModel):
 
             with timings.measure("select"):
                 tables_query = (
+                    # `queryable()` drops soft-deleted tables and orphans left by a soft-deleted
+                    # source, so an orphan can't shadow the live table sharing its name.
                     DataWarehouseTable.raw_objects.filter(team_id=team.pk)
-                    .exclude(deleted=True)
+                    .queryable()
                     .select_related("credential", "external_data_source")
+                    # Deterministic tiebreak when two live tables share a name: newest wins, since
+                    # name collisions resolve first-come-first-served when added to the table tree.
+                    .order_by("-created_at")
                 )
                 if database._is_direct_query():
                     tables_query = tables_query.filter(external_data_source_id=database._connection_id)

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -237,8 +237,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestDatabase.test_database_with_warehouse_tables_and_saved_queries_n_plus_1.4
@@ -469,8 +472,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestDatabase.test_database_with_warehouse_tables_and_saved_queries_n_plus_1.9

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -382,6 +382,78 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         assert field.type == "string"
         assert field.schema_valid is True
 
+    def _create_warehouse_table(self, *, name, url_pattern, source=None, credential=None):
+        return DataWarehouseTable.objects.create(
+            name=name,
+            format="Parquet",
+            team=self.team,
+            external_data_source=source,
+            credential=credential,
+            url_pattern=url_pattern,
+            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "Nullable(String)", "schema_valid": True}},
+        )
+
+    def test_create_hogql_database_ignores_tables_of_deleted_sources(self):
+        # A table left behind by a soft-deleted source must not shadow the live table that a
+        # re-connected source created under the same name (the orphan-table resolution bug).
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="k", access_secret="s")
+
+        deleted_source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="old",
+            connection_id="old",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type=ExternalDataSourceType.STRIPE,
+        )
+        # Created first, so without the fix it would win the first-come tree insertion. Mark the
+        # source — not the table — deleted to reproduce the orphan state (table.deleted stays False).
+        self._create_warehouse_table(
+            name="pull_requests", url_pattern="s3://orphan/*", source=deleted_source, credential=credential
+        )
+        deleted_source.deleted = True
+        deleted_source.save()
+
+        live_source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="new",
+            connection_id="new",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type=ExternalDataSourceType.STRIPE,
+        )
+        self._create_warehouse_table(
+            name="pull_requests", url_pattern="s3://live/*", source=live_source, credential=credential
+        )
+
+        database = Database.create_for(team=self.team)
+
+        assert database.has_table("pull_requests")
+        assert database.get_table("pull_requests").url == "s3://live/*"
+
+    def test_create_hogql_database_keeps_self_managed_table_without_source(self):
+        # Guards the deleted-source exclusion against the Django exclude()-with-NULL gotcha:
+        # a self-managed table (no source) must still resolve.
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="k", access_secret="s")
+        self._create_warehouse_table(name="self_managed", url_pattern="s3://self/*", credential=credential)
+
+        database = Database.create_for(team=self.team)
+
+        assert database.has_table("self_managed")
+        assert database.get_table("self_managed").url == "s3://self/*"
+
+    def test_create_hogql_database_resolves_duplicate_live_table_names_to_newest(self):
+        # Two live tables share a name (e.g. a re-sync produced a duplicate): newest wins.
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="k", access_secret="s")
+        older = self._create_warehouse_table(name="pull_requests", url_pattern="s3://older/*", credential=credential)
+        newer = self._create_warehouse_table(name="pull_requests", url_pattern="s3://newer/*", credential=credential)
+
+        # Pin created_at explicitly (bypasses auto_now_add) so the tiebreak is deterministic.
+        DataWarehouseTable.objects.filter(pk=older.pk).update(created_at="2024-01-01T00:00:00+00:00")
+        DataWarehouseTable.objects.filter(pk=newer.pk).update(created_at="2024-06-01T00:00:00+00:00")
+
+        database = Database.create_for(team=self.team)
+
+        assert database.get_table("pull_requests").url == "s3://newer/*"
+
     def test_serialize_database_warehouse_table_source_query_count(self):
         source = ExternalDataSource.objects.create(
             team=self.team,

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -37,6 +37,7 @@ from posthog.hogql.database.models import (
     TableNode,
 )
 from posthog.hogql.database.postgres_table import PostgresTable
+from posthog.hogql.database.s3_table import DataWarehouseTable as HogQLDataWarehouseTable
 from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_expr, parse_select
@@ -427,7 +428,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         database = Database.create_for(team=self.team)
 
         assert database.has_table("pull_requests")
-        assert database.get_table("pull_requests").url == "s3://live/*"
+        assert cast(HogQLDataWarehouseTable, database.get_table("pull_requests")).url == "s3://live/*"
 
     def test_create_hogql_database_keeps_self_managed_table_without_source(self):
         # Guards the deleted-source exclusion against the Django exclude()-with-NULL gotcha:
@@ -438,7 +439,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         database = Database.create_for(team=self.team)
 
         assert database.has_table("self_managed")
-        assert database.get_table("self_managed").url == "s3://self/*"
+        assert cast(HogQLDataWarehouseTable, database.get_table("self_managed")).url == "s3://self/*"
 
     def test_create_hogql_database_resolves_duplicate_live_table_names_to_newest(self):
         # Two live tables share a name (e.g. a re-sync produced a duplicate): newest wins.
@@ -452,7 +453,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
 
         database = Database.create_for(team=self.team)
 
-        assert database.get_table("pull_requests").url == "s3://newer/*"
+        assert cast(HogQLDataWarehouseTable, database.get_table("pull_requests")).url == "s3://newer/*"
 
     def test_serialize_database_warehouse_table_source_query_count(self):
         source = ExternalDataSource.objects.create(

--- a/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
@@ -1271,8 +1271,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.34
@@ -2509,8 +2512,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.57

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -146,8 +146,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_returns_newest_first.11
@@ -965,8 +968,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.11
@@ -1780,8 +1786,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_1_multiple_snapshots.11
@@ -2591,8 +2600,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.11
@@ -3402,8 +3414,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.11
@@ -4217,8 +4232,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.11
@@ -5032,8 +5050,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.11
@@ -5901,8 +5922,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.102
@@ -6855,8 +6879,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.118
@@ -7764,8 +7791,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.134
@@ -8725,8 +8755,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.15
@@ -9652,8 +9685,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.166
@@ -10302,8 +10338,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.22
@@ -11151,8 +11190,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.38
@@ -12048,8 +12090,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.54
@@ -12919,8 +12964,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.7
@@ -13820,8 +13868,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.86
@@ -14078,8 +14129,11 @@
   WHERE ("posthog_datawarehousetable"."team_id" = 99999
          AND NOT ("posthog_datawarehousetable"."deleted"
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
+         AND NOT ("posthog_externaldatasource"."deleted"
+                  AND "posthog_externaldatasource"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
+  ORDER BY "posthog_datawarehousetable"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.90

--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -2,7 +2,7 @@ import csv
 import time
 from datetime import datetime
 from io import StringIO
-from typing import TYPE_CHECKING, Any, NotRequired, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, Optional, TypedDict, cast
 from uuid import UUID
 
 from django.db import models
@@ -94,20 +94,29 @@ class DataWarehouseTableIntrospectedColumn(TypedDict):
 type DataWarehouseTableIntrospectedColumns = dict[str, DataWarehouseTableIntrospectedColumn]
 
 
-class DataWarehouseTableQuerySet(models.QuerySet):
-    def queryable(self):
+class DataWarehouseTableQuerySet(models.QuerySet["DataWarehouseTable"]):
+    def queryable(self) -> "DataWarehouseTableQuerySet":
         # A table you can actually query: not soft-deleted, and not orphaned by a soft-deleted source.
         return self.exclude(deleted=True).exclude(external_data_source__deleted=True)
 
 
-class DataWarehouseTableManager(models.Manager.from_queryset(DataWarehouseTableQuerySet)):
-    def get_queryset(self):
-        return (
+# `Manager.from_queryset(...)` can't be used as a base class here because it also overrides
+# `get_queryset()` — mypy/django-stubs can't model that dynamic base. Wire the queryset class in
+# manually instead so `objects.queryable()` and the eager-loading `get_queryset()` both work.
+class DataWarehouseTableManager(models.Manager["DataWarehouseTable"]):
+    _queryset_class = DataWarehouseTableQuerySet
+
+    def get_queryset(self) -> DataWarehouseTableQuerySet:
+        return cast(
+            DataWarehouseTableQuerySet,
             super()
             .get_queryset()
             .select_related("created_by", "external_data_source")
-            .prefetch_related("externaldataschema_set")
+            .prefetch_related("externaldataschema_set"),
         )
+
+    def queryable(self) -> DataWarehouseTableQuerySet:
+        return self.get_queryset().queryable()
 
 
 class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, DeletedMetaFields):

--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -94,7 +94,13 @@ class DataWarehouseTableIntrospectedColumn(TypedDict):
 type DataWarehouseTableIntrospectedColumns = dict[str, DataWarehouseTableIntrospectedColumn]
 
 
-class DataWarehouseTableManager(models.Manager):
+class DataWarehouseTableQuerySet(models.QuerySet):
+    def queryable(self):
+        # A table you can actually query: not soft-deleted, and not orphaned by a soft-deleted source.
+        return self.exclude(deleted=True).exclude(external_data_source__deleted=True)
+
+
+class DataWarehouseTableManager(models.Manager.from_queryset(DataWarehouseTableQuerySet)):
     def get_queryset(self):
         return (
             super()
@@ -111,7 +117,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
     objects = DataWarehouseTableManager()
 
     # Use if it's certain externaldataschemas aren't needed
-    raw_objects = models.Manager()
+    raw_objects = DataWarehouseTableQuerySet.as_manager()
 
     class TableFormat(models.TextChoices):
         CSV = "CSV", "CSV"

--- a/products/warehouse_sources/backend/models/util.py
+++ b/products/warehouse_sources/backend/models/util.py
@@ -4,8 +4,6 @@ from ipaddress import IPv6Address, ip_address
 from typing import TYPE_CHECKING, Any, Protocol, Union
 from urllib.parse import urlparse
 
-from django.db.models import Q
-
 from posthog.hogql.database.models import (
     BooleanDatabaseField,
     DatabaseField,
@@ -46,8 +44,11 @@ def get_view_or_table_by_name(team, name) -> Union["DataWarehouseSavedQuery", "D
             table_names = [f"{chain[1]}_{chain[0]}_{chain[2]}", f"{chain[1]}{chain[0]}_{chain[2]}"]
 
     table: DataWarehouseSavedQuery | DataWarehouseTable | None = (
-        DataWarehouseTable.objects.filter(Q(deleted__isnull=True) | Q(deleted=False))
+        # `queryable()` ignores soft-deleted tables and orphans of a soft-deleted source.
+        DataWarehouseTable.objects.queryable()
         .filter(team=team, name__in=table_names)
+        # Deterministic resolution when more than one live table matches: newest wins.
+        .order_by("-created_at")
         .first()
     )
     if table is None:

--- a/products/warehouse_sources/backend/tests/test_util.py
+++ b/products/warehouse_sources/backend/tests/test_util.py
@@ -1,0 +1,82 @@
+from posthog.test.base import BaseTest
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.models.util import get_view_or_table_by_name
+
+
+class TestGetViewOrTableByName(BaseTest):
+    def _create_warehouse_table(self, *, name, url_pattern, source=None, credential=None) -> DataWarehouseTable:
+        return DataWarehouseTable.objects.create(
+            name=name,
+            format="Parquet",
+            team=self.team,
+            external_data_source=source,
+            credential=credential,
+            url_pattern=url_pattern,
+            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "Nullable(String)", "schema_valid": True}},
+        )
+
+    def test_ignores_tables_of_deleted_sources(self):
+        # A table orphaned by a soft-deleted source must not shadow the live table re-created under
+        # the same name — this is the path that feeds joins and series table resolution.
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="k", access_secret="s")
+
+        deleted_source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="old",
+            connection_id="old",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type=ExternalDataSourceType.STRIPE,
+        )
+        self._create_warehouse_table(
+            name="pull_requests", url_pattern="s3://orphan/*", source=deleted_source, credential=credential
+        )
+        deleted_source.deleted = True
+        deleted_source.save()
+
+        live_source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="new",
+            connection_id="new",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type=ExternalDataSourceType.STRIPE,
+        )
+        live_table = self._create_warehouse_table(
+            name="pull_requests", url_pattern="s3://live/*", source=live_source, credential=credential
+        )
+
+        resolved = get_view_or_table_by_name(self.team, "pull_requests")
+
+        assert isinstance(resolved, DataWarehouseTable)
+        assert resolved.pk == live_table.pk
+        assert resolved.url_pattern == "s3://live/*"
+
+    def test_keeps_self_managed_table_without_source(self):
+        # Guards the deleted-source exclusion against the Django exclude()-with-NULL gotcha:
+        # a self-managed table (no source) must still resolve.
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="k", access_secret="s")
+        table = self._create_warehouse_table(name="self_managed", url_pattern="s3://self/*", credential=credential)
+
+        resolved = get_view_or_table_by_name(self.team, "self_managed")
+
+        assert isinstance(resolved, DataWarehouseTable)
+        assert resolved.pk == table.pk
+
+    def test_resolves_duplicate_live_table_names_to_newest(self):
+        # Two live tables share a name (e.g. a re-sync produced a duplicate): newest wins.
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="k", access_secret="s")
+        older = self._create_warehouse_table(name="pull_requests", url_pattern="s3://older/*", credential=credential)
+        newer = self._create_warehouse_table(name="pull_requests", url_pattern="s3://newer/*", credential=credential)
+
+        # Pin created_at explicitly (bypasses auto_now_add) so the tiebreak is deterministic.
+        DataWarehouseTable.objects.filter(pk=older.pk).update(created_at="2024-01-01T00:00:00+00:00")
+        DataWarehouseTable.objects.filter(pk=newer.pk).update(created_at="2024-06-01T00:00:00+00:00")
+
+        resolved = get_view_or_table_by_name(self.team, "pull_requests")
+
+        assert isinstance(resolved, DataWarehouseTable)
+        assert resolved.pk == newer.pk
+        assert resolved.url_pattern == "s3://newer/*"


### PR DESCRIPTION
## Problem

A re-connected warehouse source (e.g. GitHub `pull_requests`, Stripe) can leave behind a previous source's table that shares the same `(team_id, name)` as the live one. When that happens, queries resolve to the **stale orphan** instead of the live table:

`create_hogql_database` loaded warehouse tables with no ordering and inserted them into the table tree first-come-first-served (`add_child` defaults to `table_conflict_mode="ignore"`). The older orphan typically won, so `select * from <source>.<table>` returned data frozen at the moment the old source was deleted — even though the live source synced fine. The source's "stale" warning and dependent dashboards looked broken as a result.

## Changes

- `create_hogql_database` and `get_view_or_table_by_name` now exclude tables whose `external_data_source` is soft-deleted, so an orphan can never shadow the live table.
- Added a deterministic newest-wins (`order_by("-created_at")`) tiebreak for the rare case of two genuinely live tables sharing a name.

This is the read-path half of the fix and is independently shippable. A companion PR centralises the source-deletion cascade so new orphans stop being created in the first place; the two do not depend on each other and touch disjoint files.

This PR does **not** include the one-off data migration to clean up tables already orphaned in production — that's tracked separately. With this change, queries resolve correctly even while those rows still exist.

## How did you test this code?

I'm an agent; I ran only automated tests (no manual testing).

- New `test_database.py` cases: deleted-source orphan is ignored, self-managed (no-source) table still resolves (guards the Django `exclude()`-with-NULL edge), duplicate live names resolve to newest.
- Re-ran existing warehouse serialization/query-count tests — all green. `ruff check`/`format` and `ty check` clean.

## 🤖 Agent context

Authored by Claude Code (Opus) for the data warehouse team, after triaging a Slack report of a `pull_requests` source showing stale despite a successful sync. Root cause traced to name-collision resolution ambiguity. Considered excluding orphans vs. only re-ordering — chose both (exclusion is the correctness fix; ordering is a belt-and-suspenders tiebreak). Requires human review; not for self-merge.
