### PR TITLE
fix(data-warehouse): cascade source soft-delete to tables and joins

### DIFF
--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1567,37 +1567,20 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             .all()
         )
 
-        # Soft-delete source, schemas, tables, and companion _cdc tables atomically
-        # first so DB state is consistent even if the external cleanup below fails
-        with transaction.atomic():
-            for schema in schemas:
-                if schema.table:
-                    schema.table.soft_delete()
+        # Soft-delete source, schemas, tables, and companion _cdc tables. The cascade lives on
+        # `ExternalDataSource.soft_delete()` (atomic + bulk) so every deletion path stays
+        # consistent and no orphan tables are left behind.
+        instance.soft_delete()
 
-            # Bulk soft-delete the schema rows in a single UPDATE. Per-row soft_delete()
-            # runs a SELECT + UPDATE + activity-log write each, which does not scale to
-            # sources with thousands of schemas (e.g. a Slack workspace with thousands of
-            # channels).
-            deleted_at = datetime.now(UTC)
-            ExternalDataSchema.objects.filter(team_id=self.team_id, id__in=[schema.id for schema in schemas]).update(
-                deleted=True, deleted_at=deleted_at
-            )
-            # Mirror the bulk update onto the in-memory objects so the post-atomic
-            # `schema.delete_table()` save() below doesn't overwrite deleted=True with the
-            # stale in-memory value.
-            for schema in schemas:
-                schema.deleted = True
-                schema.deleted_at = deleted_at
-
-            # Clean up CDC companion tables (e.g. {name}_cdc) — these are standalone
-            # DataWarehouseTable records linked to the source but not to schema.table.
-            DataWarehouseTable.objects.filter(
-                external_data_source_id=instance.id,
-                team_id=self.team_id,
-                deleted=False,
-            ).exclude(id__in=[s.table_id for s in schemas if s.table_id is not None]).update(deleted=True)
-
-            instance.soft_delete()
+        # Mirror the cascade onto the pre-fetched in-memory objects so the post-commit S3 cleanup
+        # (`schema.delete_table()`) skips the now-redundant per-row table soft_delete and its
+        # save() doesn't resurrect the schema rows the cascade just deleted.
+        deleted_at = datetime.now(UTC)
+        for schema in schemas:
+            schema.deleted = True
+            schema.deleted_at = deleted_at
+            if schema.table:
+                schema.table.deleted = True
 
         # Best-effort webhook cleanup — soft-deletes are already committed
         source_type = ExternalDataSourceType(instance.source_type)

--- a/products/data_warehouse/backend/models/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/models/test/test_external_data_source.py
@@ -1,8 +1,12 @@
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from products.data_tools.backend.models.join import DataWarehouseJoin
 from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.models.table import DataWarehouseTable
 
 CLEANUP_PATH = "posthog.temporal.data_imports.sources.postgres.source.PostgresSource.cleanup_cdc_resources_on_deletion"
 
@@ -64,3 +68,54 @@ class TestExternalDataSourceSoftDelete(BaseTest):
         source.refresh_from_db()
         self.assertTrue(source.deleted)
         mock_cleanup.assert_called_once()
+
+    @patch(CLEANUP_PATH)
+    def test_soft_delete_cascades_to_tables_schemas_and_joins(self, _mock_cleanup):
+        source = self._create_source(source_type=ExternalDataSourceType.POSTGRES, job_inputs={"host": "localhost"})
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="k", access_secret="s")
+        table = DataWarehouseTable.objects.create(
+            name="pull_requests",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            external_data_source=source,
+            credential=credential,
+            url_pattern="s3://bucket/*",
+        )
+        schema = ExternalDataSchema.objects.create(name="pull_requests", team=self.team, source=source, table=table)
+        join = DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name="pull_requests",
+            source_table_key="id",
+            joining_table_name="persons",
+            joining_table_key="id",
+            field_name="person",
+        )
+        # Control: an unrelated source's table/join must be untouched by the cascade.
+        other_source = self._create_source(source_type=ExternalDataSourceType.POSTGRES, job_inputs=None)
+        other_table = DataWarehouseTable.objects.create(
+            name="customers",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            external_data_source=other_source,
+            credential=credential,
+            url_pattern="s3://bucket/customers/*",
+        )
+        other_join = DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name="customers",
+            source_table_key="id",
+            joining_table_name="persons",
+            joining_table_key="id",
+            field_name="person",
+        )
+
+        source.soft_delete()
+
+        for obj in (source, table, schema, join):
+            obj.refresh_from_db()
+            self.assertTrue(obj.deleted, f"{type(obj).__name__} should be soft-deleted")
+
+        other_table.refresh_from_db()
+        other_join.refresh_from_db()
+        self.assertFalse(other_table.deleted)
+        self.assertFalse(other_join.deleted)

--- a/products/warehouse_sources/backend/models/external_data_source.py
+++ b/products/warehouse_sources/backend/models/external_data_source.py
@@ -1,7 +1,8 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import UUID
 
-from django.db import models
+from django.db import models, transaction
+from django.db.models import Q
 
 import structlog
 import temporalio
@@ -110,9 +111,38 @@ class ExternalDataSource(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
             return config
 
     def soft_delete(self):
-        self.deleted = True
-        self.deleted_at = datetime.now()
-        self.save()
+        # Lazy imports avoid a circular dependency between the warehouse models.
+        from products.data_tools.backend.models.join import DataWarehouseJoin
+        from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+        from products.warehouse_sources.backend.models.table import DataWarehouseTable
+
+        deleted_at = datetime.now(UTC)
+
+        # Cascade the soft-delete to this source's tables (and their joins) and schemas so a
+        # deleted source never leaves orphan tables behind, whichever code path deletes it. Done
+        # in bulk inside one transaction — per-row deletes don't scale to sources with thousands
+        # of schemas (e.g. a Slack workspace with thousands of channels).
+        with transaction.atomic():
+            tables = DataWarehouseTable.objects.filter(team_id=self.team_id, external_data_source_id=self.id).exclude(
+                deleted=True
+            )
+            table_names = list(tables.values_list("name", flat=True))
+
+            if table_names:
+                DataWarehouseJoin.objects.filter(
+                    Q(team_id=self.team_id)
+                    & (Q(source_table_name__in=table_names) | Q(joining_table_name__in=table_names))
+                ).exclude(deleted=True).update(deleted=True, deleted_at=deleted_at)
+
+            tables.update(deleted=True, deleted_at=deleted_at)
+
+            ExternalDataSchema.objects.filter(team_id=self.team_id, source_id=self.id).exclude(deleted=True).update(
+                deleted=True, deleted_at=deleted_at
+            )
+
+            self.deleted = True
+            self.deleted_at = deleted_at
+            self.save()
 
         # Lazy import to avoid circular: SourceRegistry → helpers.py → this module.
         from posthog.temporal.data_imports.sources.common.registry import SourceRegistry


### PR DESCRIPTION
## Problem

Soft-deleting a warehouse source leaves its tables behind as orphans. `ExternalDataSource.soft_delete()` only marked the *source* deleted — the cascade that soft-deletes the source's tables and schemas lived solely in the `destroy` REST viewset. So any other deletion path left tables with `deleted=False` pointing at a `deleted=True` source.

Those orphans accumulate and, when a source is later re-connected under the same name, shadow the live table at query time (see the companion read-path PR for that symptom).

## Changes

- Moved the table/schema/join cascade into `ExternalDataSource.soft_delete()` (atomic + bulk, so it scales to sources with thousands of schemas). Every deletion path is now fail-safe.
- The `destroy` viewset delegates to `soft_delete()` and keeps its post-commit best-effort S3 / Temporal-schedule cleanup. Net behaviour of the REST delete is unchanged — including its in-memory mirroring so `schema.delete_table()` still skips redundant per-row work — the cascade is just centralised on the model.

Independent of the companion read-path PR (`#61855`): the two touch disjoint files and don't depend on each other. This PR stops *new* orphans from being created; it does not include the one-off migration to clean up tables already orphaned in production (tracked separately).

## How did you test this code?

I'm an agent; I ran only automated tests (no manual testing).

- New model test: `source.soft_delete()` cascades to its tables, schemas and joins, and leaves an unrelated source's table/join untouched.
- Re-ran the existing `destroy` API tests and the `TestExternalDataSourceSoftDelete` suite — all green. `ruff check`/`format` and `ty check` clean.

## 🤖 Agent context

Authored by Claude Code (Opus) for the data warehouse team, after triaging a Slack report of orphaned warehouse tables. Chose to centralise the cascade on the model and have the viewset delegate (rather than duplicate the logic), preserving the viewset's in-memory mirroring so the post-commit `schema.delete_table()` S3 cleanup still skips the now-redundant per-row table soft_delete. Also made the cascade bulk (single UPDATEs) so it scales to sources with thousands of schemas. Requires human review; not for self-merge.
