### PR TITLE
fix(signals): harden source config validation for MCP writes

### DIFF
--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -108,8 +108,24 @@ class SignalSourceConfigSerializer(serializers.ModelSerializer):
     def validate(self, attrs: dict) -> dict:
         source_product = attrs.get("source_product", getattr(self.instance, "source_product", None))
         source_type = attrs.get("source_type", getattr(self.instance, "source_type", None))
-        enabled = attrs.get("enabled", getattr(self.instance, "enabled", False))
+        # On create `self.instance` is None and `enabled` is optional; fall back to the model
+        # default (True), not False — otherwise omitting `enabled` skips the approval gate below
+        # while the model still saves the row enabled.
+        enabled = attrs.get("enabled", getattr(self.instance, "enabled", True))
         config = attrs.get("config", {})
+        # `source_product` / `source_type` are the row's identity (unique together with team) and are
+        # immutable after creation — repointing an existing row at a different source would leave it
+        # enabled without that source's setup/backfill, which only run on a false→true `enabled` flip.
+        if self.instance is not None:
+            for identity_field in ("source_product", "source_type"):
+                if identity_field in attrs and attrs[identity_field] != getattr(self.instance, identity_field):
+                    raise serializers.ValidationError(
+                        {identity_field: f"{identity_field} cannot be changed after creation."}
+                    )
+        # `config` is a JSONField so the API accepts any JSON value; require an object so the
+        # per-product checks below (and downstream consumers) can rely on a mapping.
+        if "config" in attrs and not isinstance(config, dict):
+            raise serializers.ValidationError({"config": "config must be a JSON object."})
         if source_product == SignalSourceConfig.SourceProduct.SESSION_REPLAY and config:
             recording_filters = config.get("recording_filters")
             if recording_filters is not None and not isinstance(recording_filters, dict):

--- a/products/signals/backend/test/test_signal_source_config_api.py
+++ b/products/signals/backend/test/test_signal_source_config_api.py
@@ -127,6 +127,20 @@ class TestSignalSourceConfigAPI(APIBaseTest):
         )
         assert response.status_code == status.HTTP_201_CREATED
 
+    def test_create_session_analysis_cluster_omitting_enabled_rejected_without_consent(self):
+        # `enabled` is optional and defaults to True at the model level, so omitting it must still
+        # hit the approval gate — not silently save an enabled session-analysis source.
+        self.organization.is_ai_data_processing_approved = False
+        self.organization.save(update_fields=["is_ai_data_processing_approved"])
+        response = self.client.post(
+            self._url(),
+            data={"source_product": "session_replay", "source_type": "session_analysis_cluster"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert "AI data processing" in str(response.json())
+        assert not SignalSourceConfig.objects.filter(team=self.team, source_type="session_analysis_cluster").exists()
+
     def test_create_duplicate_source_type_per_team_rejected(self):
         SignalSourceConfig.objects.create(
             team=self.team,
@@ -165,6 +179,8 @@ class TestSignalSourceConfigAPI(APIBaseTest):
             ("valid_recording_filters", {"recording_filters": {"duration_min": 5}}, status.HTTP_201_CREATED),
             ("empty_config", {}, status.HTTP_201_CREATED),
             ("recording_filters_not_dict", {"recording_filters": "bad"}, status.HTTP_400_BAD_REQUEST),
+            ("config_is_string", "not-an-object", status.HTTP_400_BAD_REQUEST),
+            ("config_is_list", [1, 2, 3], status.HTTP_400_BAD_REQUEST),
         ]
     )
     def test_create_config_validation(self, _name, config, expected_status):
@@ -304,23 +320,29 @@ class TestSignalSourceConfigAPI(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "recording_filters must be a JSON object" in str(response.json())
 
-    def test_update_source_type_is_not_writable(self):
+    @parameterized.expand(
+        [
+            ("source_type", "issue"),
+            ("source_product", "github"),
+        ]
+    )
+    def test_update_identity_field_is_immutable(self, field, new_value):
         config = SignalSourceConfig.objects.create(
             team=self.team,
             source_product="session_replay",
             source_type="session_analysis_cluster",
             created_by=self.user,
         )
+        original = getattr(config, field)
         response = self.client.patch(
             self._url(str(config.id)),
-            data={"source_type": "nonexistent_type"},
+            data={field: new_value},
             format="json",
         )
-        # source_type is not read_only in serializer, so this may succeed
-        # but the value is validated
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert f"{field} cannot be changed after creation" in str(response.json())
         config.refresh_from_db()
-        # Should either be rejected or keep original value
-        assert config.source_type == "session_analysis_cluster" or response.status_code == status.HTTP_400_BAD_REQUEST
+        assert getattr(config, field) == original
 
     def test_delete_other_teams_config_forbidden(self):
         other_team = Team.objects.create(organization=self.organization, name="Other Team")


### PR DESCRIPTION
## Problem

PR #61851 exposed the `SignalSourceConfig` write tools (`create` / `update` / `partial-update`) over MCP. A review of that PR (codex) surfaced three pre-existing validation gaps in `SignalSourceConfigSerializer` — they existed on the REST API already, but exposing the writes to agents widens who can hit them, so they're worth closing.

## Changes

All three fixes live in `SignalSourceConfigSerializer.validate` (backend-only; no schema or generated-type changes):

| Gap | Fix |
|-----|-----|
| **Consent bypass (P1).** `enabled` is optional and defaults to `True` at the model level, but `validate()` fell back to `False` on create — so omitting `enabled` on a `session_analysis_cluster` create skipped the org AI-data-processing approval gate while the row still saved **enabled**. | Fall back to the model default (`True`) on create, so the approval check always runs when the row will actually be enabled. |
| **Non-object `config` → 500.** `config` is a `JSONField` (accepts any JSON value); a string/array reached `config.get(...)` and raised `AttributeError` (500 instead of 400). | Require `config` to be a JSON object, returning a 400. |
| **Mutable identity fields.** `source_product` / `source_type` are the row's identity (unique together with `team`); a `partial-update` could repoint an existing row at a different source, leaving it enabled without that source's setup/backfill (those only fire on a false→true `enabled` flip). | Make `source_product` / `source_type` immutable after creation (400 on change). |

These harden the plain REST API as well, not just the MCP surface.

## How did you test this code?

I'm an agent (Claude Code). Added/updated tests in `test_signal_source_config_api.py`:

- `test_create_session_analysis_cluster_omitting_enabled_rejected_without_consent` — the P1 case: omit `enabled`, no org approval → 400, and no row persisted.
- Extended the `test_create_config_validation` parametrize with `config_is_string` and `config_is_list` → 400.
- Replaced the loose `test_update_source_type_is_not_writable` with a parameterized `test_update_identity_field_is_immutable` over `source_type` and `source_product` → 400 with the immutability message, value unchanged.

Full file passes (33). `ruff check` / `ruff format` clean. No serializer field shape changed, so no `hogli build:openapi` regeneration was needed (verified git status shows only the two backend files).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code, following the `improving-drf-endpoints` skill. Follow-up to #61851: the three fixes correspond to codex review comments on that PR (1× P1 consent bypass, 2× P2). All are backend serializer fixes rather than MCP-YAML changes, since the root cause is backend validation that the REST API shared. A fourth codex comment — validating `source_product`/`source_type` *pairs* (e.g. rejecting github + session_analysis_cluster) — is intentionally **not** included here; it needs a canonical valid-pairs table and is better tracked as separate hardening. Agent-authored; requires human review.
