### PR TITLE
perf(hogql): share the default channel-type AST when no custom rules

### DIFF
--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -81,6 +81,40 @@ if(
     )
 
 
+def _channel_source_exprs(properties_path: list[str]) -> ChannelTypeExprs:
+    return ChannelTypeExprs(
+        campaign=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_utm_campaign"])]),
+        medium=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_utm_medium"])]),
+        source=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_utm_source"])]),
+        referring_domain=ast.Call(
+            name="toString", args=[ast.Field(chain=[*properties_path, "$initial_referring_domain"])]
+        ),
+        url=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_current_url"])]),
+        hostname=ast.Call(
+            name="domain",
+            args=[ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_hostname"])])],
+        ),
+        pathname=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_pathname"])]),
+        has_gclid=ast.Call(
+            name="isNotNull",
+            args=[wrap_with_null_if_empty(ast.Field(chain=[*properties_path, "$initial_gclid"]))],
+        ),
+        has_fbclid=ast.Call(
+            name="isNotNull",
+            args=[wrap_with_null_if_empty(ast.Field(chain=[*properties_path, "$initial_fbclid"]))],
+        ),
+        gad_source=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_gad_source"])]),
+    )
+
+
+@cache
+def _default_channel_type_expr(properties_path: tuple[str, ...]) -> ast.Expr:
+    # With no custom rules (the common case) the channel-type AST is a process-wide constant for a given
+    # properties_path. Build it once and share it: consumers clone_expr() the expr before use, so the
+    # shared node is never mutated. Custom rules are per-team, so those still build fresh below.
+    return create_channel_type_expr(source_exprs=_channel_source_exprs(list(properties_path)), custom_rules=None)
+
+
 def create_initial_channel_type(
     name: str,
     custom_rules: Optional[list["CustomChannelRule"]] = None,
@@ -89,37 +123,13 @@ def create_initial_channel_type(
 ) -> ExpressionField:
     if not properties_path:
         properties_path = ["properties"]
-    return ExpressionField(
-        name=name,
-        expr=create_channel_type_expr(
-            source_exprs=ChannelTypeExprs(
-                campaign=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_utm_campaign"])]),
-                medium=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_utm_medium"])]),
-                source=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_utm_source"])]),
-                referring_domain=ast.Call(
-                    name="toString", args=[ast.Field(chain=[*properties_path, "$initial_referring_domain"])]
-                ),
-                url=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_current_url"])]),
-                hostname=ast.Call(
-                    name="domain",
-                    args=[ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_hostname"])])],
-                ),
-                pathname=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_pathname"])]),
-                has_gclid=ast.Call(
-                    name="isNotNull",
-                    args=[wrap_with_null_if_empty(ast.Field(chain=[*properties_path, "$initial_gclid"]))],
-                ),
-                has_fbclid=ast.Call(
-                    name="isNotNull",
-                    args=[wrap_with_null_if_empty(ast.Field(chain=[*properties_path, "$initial_fbclid"]))],
-                ),
-                gad_source=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_gad_source"])]),
-            ),
-            custom_rules=custom_rules,
-            timings=timings,
-        ),
-        isolate_scope=True,
-    )
+    if not custom_rules:
+        expr: ast.Expr = _default_channel_type_expr(tuple(properties_path))
+    else:
+        expr = create_channel_type_expr(
+            source_exprs=_channel_source_exprs(properties_path), custom_rules=custom_rules, timings=timings
+        )
+    return ExpressionField(name=name, expr=expr, isolate_scope=True)
 
 
 def custom_condition_to_expr(

--- a/posthog/hogql/database/schema/test/test_channel_type.py
+++ b/posthog/hogql/database/schema/test/test_channel_type.py
@@ -1,3 +1,4 @@
+import copy
 import uuid
 from urllib.parse import parse_qs, urlparse
 
@@ -6,6 +7,7 @@ from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _
 from posthog.schema import CustomChannelCondition, CustomChannelRule, FilterLogicalOperator, HogQLQueryModifiers
 
 from posthog.hogql import ast
+from posthog.hogql.database.schema.channel_type import _default_channel_type_expr
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
@@ -104,6 +106,16 @@ class TestChannelType(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
         return (person_response.results or [])[0][0]
+
+    def test_shared_default_channel_type_expr_is_not_mutated_by_resolution(self):
+        shared = _default_channel_type_expr(("properties",))
+        snapshot = copy.deepcopy(shared)
+
+        # Resolution must not mutate the shared cached AST (resolver clones it first); this single-process test guards that.
+        self._get_person_initial_channel_type({"$initial_utm_source": "google"})
+
+        assert _default_channel_type_expr(("properties",)) is shared
+        assert shared == snapshot, "resolution mutated the shared channel-type AST in place"
 
     def _get_person_initial_channel_type_with_rules(self, properties=None, custom_channel_rules=None):
         person_id = str(uuid.uuid4())


### PR DESCRIPTION
## Problem

Every HogQL query builds the table catalog (`Database.create_for`). Inside it, `_use_virtual_fields` rebuilds the `$virt_initial_channel_type` field for both `persons` and the persons-on-events virtual table on every build, by running `replace_placeholders` over the large channel-type template AST. The template *parse* is already memoized (`_initial_default_channel_rules_expr`, `@cache`), so the per-build cost is not the parse, it is cloning that big AST. Locally that is ~3 ms per build, and `virtual_fields` is one of the larger slices of `create_for` in production.

## Changes

When a team has no custom channel-type rules (the common case), the default channel-type AST is a process-wide constant for a given `properties_path` (only two variants exist). We build it once (`@cache`) and **share** it instead of re-deriving it every build. The resolver `clone_expr()`s an `ExpressionField`'s expr before use, so the shared node is never mutated. Teams with custom rules still build fresh.

Worth noting: the obvious "cache the result, deepcopy on handout" does not help, deepcopy costs the same as `replace_placeholders` (both clone the big AST). The win comes specifically from *sharing* the node, not copying it.

Local impact: `create_for` ~21.8 ms to ~18.0 ms (~17%); the channel-type build itself ~1.9 ms to ~0.0015 ms for no-custom-rules teams.

Because this shares a mutable pydantic AST (the catalog freeze only protects table-field dicts, not arbitrary AST nodes) and CI shards the printer/resolver suites into separate processes, I added a single-process guard test that asserts resolution does not mutate the shared AST. It is verified to have teeth (a deliberate mutation fails it).

## How did you test this code?

I am an agent (Claude Code); I did not do manual testing. Automated tests run locally:

- `posthog/hogql/database/schema/test/test_channel_type.py`: 45 passed (default classification, the custom-rules path, and the new guard test).
- `test_printer.py` + `test_resolver.py` in one process (the cross-process leak detector that CI's sharding cannot run): byte-identical, 834 passed, 210 snapshots. This proves the shared AST is not mutated across builds.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal performance change with no user-facing or API surface; no docs update needed.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8), reviewed interactively.

- Confirmed via `HogQLTimings` that the channel-type *parse* is already cached (~0 ms) and the per-build cost is `replace_placeholders` cloning the template (~3 ms/build for persons + poe).
- Measured that the naive "memoize the substituted AST + deepcopy on handout" saves ~0% (deepcopy == replace_placeholders), so the only real win is sharing the node immutably.
- Validated safety with the combined-process printer+resolver run (byte-identical snapshots), since CI shards those suites and would not otherwise catch a cross-build mutation. Added a single-process guard test so any future clone-before-mutate regression is caught in CI.
- Independent of the in-flight copy-on-write catalog change (#60901); only touches `channel_type.py`.
