### PR TITLE
fix(data-modeling): POST row count query to avoid URL field limit

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -840,7 +840,12 @@ async def get_query_row_count(query: str, team: Team, logger: FilteringBoundLogg
     await logger.adebug(f"Running count query: {printed}")
 
     async with get_client() as client:
-        result = await client.read_query(printed, query_parameters=context.values)
+        async with client.apost_query(
+            query=printed,
+            query_parameters=context.values,
+            query_id=str(uuid.uuid4()),
+        ) as response:
+            result = await response.content.read()
         count = int(result.decode("utf-8").strip())
         return count
 


### PR DESCRIPTION
## Problem

Endpoint materialization was emitting `Poco::Exception … HTML Form Exception: Field value too long`. Before materializing, the v1 data-modeling run workflow fetches an expected row count, and that count query was sent over **GET** — which puts the whole query in a URL field. For large endpoint queries (e.g. variable-materialized ones) the field exceeds ClickHouse's Poco field-value limit and the request is rejected at HTTP-parse time.

This is the v1 counterpart to #61398, which fixed the same issue on the v2 path. Most teams still run v1, so the error kept showing up. Bumping `max_query_size` didn't help — that governs the SQL parser on the body, not the URL field limit.

Note: the count failure is currently swallowed (`materialize_model` continues without progress tracking), so the practical impact today is lost `rows_expected` and noisy errors rather than failed data.

## Changes

`get_query_row_count` now uses `apost_query`, so the query rides in the request body instead of a URL field.

## How did you test this code?

I'm an agent. No automated test in this PR. The fix is a one-line transport change mirroring #61398, and the call site was confirmed from prod Temporal logs that showed the GET count query failing with `Field value too long` immediately before the swallowed warning. No manual prod testing.

## 🤖 Agent context

Traced the recurring Poco error from error-tracking and prod Temporal logs down to the `get_query_row_count` count query in `run_workflow.py` (v1) — the log showed the GET going out and the swallowed `Field value too long` right after. Mirrored the existing v2 fix (#61398) rather than hardening the shared client, to keep the change minimal and consistent. Separately flagged — but did not touch — that the row-count and materialize passes execute the (potentially heavy) query twice; that's a follow-up.
