### PR TITLE
fix(test): stabilize flaky trends tab switch

### DIFF
--- a/playwright/e2e/product-analytics/insights/trends.spec.ts
+++ b/playwright/e2e/product-analytics/insights/trends.spec.ts
@@ -340,6 +340,10 @@ test.describe('Trends insights', () => {
 
         await test.step('switch insight type to Funnels and back, then discard', async () => {
             await insight.edit()
+            // Wait for the insight to settle in edit mode before switching tabs.
+            // The active tab is derived from the query, so a late post-save reload
+            // can clobber the tab click and revert it to Trends if we click too soon.
+            await insight.trends.waitForChart()
             await page.locator('[data-attr="insight-funnels-tab"]').click()
             await expect(insight.activeTab).toContainText('Funnels')
             await page.locator('[data-attr="insight-trends-tab"]').click()


### PR DESCRIPTION
## Problem

Playwright e2e `trends.spec.ts › Save an insight, make changes, discard them, and save a copy` flakes on master at the Funnels tab-switch step — passed and failed across adjacent master runs with no test change, the signature of a timing race. Long-latent step, surfaced once an earlier discard-step fix stopped failing ahead of it.

Root cause: the active tab is derived from the query (`insightNavLogic` `activeView`). The step clicks Funnels immediately after `insight.edit()`; if the post-save reload is still settling, its late `setQuery` clobbers the funnels query and the tab snaps back to Trends, timing out the assertion.

## Changes

- Wait for the chart to settle (`insight.trends.waitForChart()`) after `insight.edit()`, before the tab click.
- Matches the sync convention already used at every other query-changing step in this test.

## How did you test this code?

Agent-authored; the full Playwright suite was not run (impractical locally). `oxfmt` reports no changes and `waitForChart()` is an existing helper used throughout this file. Correctness rationale is above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact (test-only change).

## 🤖 Agent context

Claude Code (Opus), from a CI-flake insight (~45% confidence) treated as a hypothesis and verified independently: confirmed the failure plus later clean master runs (flake, not determinism), and traced tab state to `activeView` deriving from `query`.

Rejected an app-side guard against in-flight reloads as over-engineering — a user never clicks a tab within milliseconds of entering edit mode, and the file's convention is to wait for the chart. Chose the minimal test-sync fix.

Out of scope: concurrent `funnels.spec.ts` `waitForResponse` timeouts — a separate infra/slow-query symptom (later runs passed).
