### PR TITLE
test(dashboards): fix flaky dashboardLogic jest timeout

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -24,8 +24,7 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { examples } from '~/queries/examples'
 import { variableDataLogic } from '~/queries/nodes/DataVisualization/Components/Variables/variableDataLogic'
-import { getQueryBasedDashboard } from '~/queries/nodes/InsightViz/utils'
-import { DashboardFilter, HogQLVariable, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { HogQLVariable, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
     DashboardPlacement,
@@ -36,30 +35,7 @@ import {
     QueryBasedInsightModel,
 } from '~/types'
 
-import _dashboardJson from './__mocks__/dashboard.json'
-
-const dashboardJson = getQueryBasedDashboard(_dashboardJson as any as DashboardType)!
-
-export function insightOnDashboard(
-    insightId: number,
-    dashboardsRelation: number[],
-    insight: Partial<QueryBasedInsightModel> = {}
-): QueryBasedInsightModel {
-    const tiles = dashboardJson.tiles.filter((tile) => !!tile.insight && tile.insight?.id === insightId)
-    let tile = dashboardJson.tiles[0]
-    if (tiles.length) {
-        tile = tiles[0]
-    }
-    if (!tile.insight) {
-        throw new Error('tile has no insight')
-    }
-    return {
-        ...tile.insight,
-        dashboards: dashboardsRelation,
-        dashboard_tiles: dashboardsRelation.map((dashboardId) => ({ id: insight.id!, dashboard_id: dashboardId })),
-        query: { ...tile.insight.query, ...insight.query, kind: (tile.insight.query?.kind || insight.query?.kind)! },
-    }
-}
+import { dashboardResult, insightOnDashboard, tileFromInsight } from './dashboardLogic.testHelpers'
 
 const TEXT_TILE: DashboardTile<QueryBasedInsightModel> = {
     id: 4,
@@ -80,30 +56,6 @@ const WIDGET_TILE_WITH_CUSTOM_NAME: DashboardTile<QueryBasedInsightModel> = {
     widget: { id: '2', widget_type: 'error_tracking_list', config: {}, name: 'Critical errors' },
     layouts: {},
     color: null,
-}
-
-let tileId = 0
-export const tileFromInsight = (
-    insight: QueryBasedInsightModel,
-    id: number = tileId++
-): DashboardTile<QueryBasedInsightModel> => ({
-    id: id,
-    layouts: {},
-    color: null,
-    insight: insight,
-})
-
-export const dashboardResult = (
-    dashboardId: number,
-    tiles: DashboardTile<QueryBasedInsightModel>[],
-    filters: Partial<DashboardFilter> = {}
-): DashboardType<QueryBasedInsightModel> => {
-    return {
-        ...dashboardJson,
-        filters: { ...dashboardJson.filters, ...filters },
-        id: dashboardId,
-        tiles,
-    }
 }
 
 const uncached = (insight: QueryBasedInsightModel): QueryBasedInsightModel => ({

--- a/frontend/src/scenes/dashboard/dashboardLogic.testHelpers.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.testHelpers.ts
@@ -1,0 +1,52 @@
+import { getQueryBasedDashboard } from '~/queries/nodes/InsightViz/utils'
+import { DashboardFilter } from '~/queries/schema/schema-general'
+import { DashboardTile, DashboardType, QueryBasedInsightModel } from '~/types'
+
+import _dashboardJson from './__mocks__/dashboard.json'
+
+const dashboardJson = getQueryBasedDashboard(_dashboardJson as any as DashboardType)!
+
+export function insightOnDashboard(
+    insightId: number,
+    dashboardsRelation: number[],
+    insight: Partial<QueryBasedInsightModel> = {}
+): QueryBasedInsightModel {
+    const tiles = dashboardJson.tiles.filter((tile) => !!tile.insight && tile.insight?.id === insightId)
+    let tile = dashboardJson.tiles[0]
+    if (tiles.length) {
+        tile = tiles[0]
+    }
+    if (!tile.insight) {
+        throw new Error('tile has no insight')
+    }
+    return {
+        ...tile.insight,
+        dashboards: dashboardsRelation,
+        dashboard_tiles: dashboardsRelation.map((dashboardId) => ({ id: insight.id!, dashboard_id: dashboardId })),
+        query: { ...tile.insight.query, ...insight.query, kind: (tile.insight.query?.kind || insight.query?.kind)! },
+    }
+}
+
+let tileId = 0
+export const tileFromInsight = (
+    insight: QueryBasedInsightModel,
+    id: number = tileId++
+): DashboardTile<QueryBasedInsightModel> => ({
+    id: id,
+    layouts: {},
+    color: null,
+    insight: insight,
+})
+
+export const dashboardResult = (
+    dashboardId: number,
+    tiles: DashboardTile<QueryBasedInsightModel>[],
+    filters: Partial<DashboardFilter> = {}
+): DashboardType<QueryBasedInsightModel> => {
+    return {
+        ...dashboardJson,
+        filters: { ...dashboardJson.filters, ...filters },
+        id: dashboardId,
+        tiles,
+    }
+}

--- a/frontend/src/scenes/dashboard/dashboardQuickFiltersDebounce.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardQuickFiltersDebounce.test.ts
@@ -13,7 +13,7 @@ import { QuickFilterContext } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { InsightShortId, PropertyOperator, QueryBasedInsightModel, QuickFilterOption } from '~/types'
 
-import { dashboardResult, insightOnDashboard, tileFromInsight } from './dashboardLogic.test'
+import { dashboardResult, insightOnDashboard, tileFromInsight } from './dashboardLogic.testHelpers'
 import { QUICK_FILTER_DEBOUNCE_MS } from './dashboardUtils'
 
 const mockOption: QuickFilterOption = {


### PR DESCRIPTION
## Problem

`dashboardQuickFiltersDebounce.test.ts` imported fixtures from `dashboardLogic.test.ts`. Importing a `.test.ts` runs its `describe()` blocks as a side effect, so the full `dashboardLogic` suite (60+ tests) re-ran inside the debounce worker — pushing the timing-sensitive `hasUnsavedLayoutChanges` test past the 5000ms timeout.

Recurring `master` flake (Frontend CI, `push`): runs [27006684384](https://github.com/PostHog/posthog/actions/runs/27006684384), [26965398446](https://github.com/PostHog/posthog/actions/runs/26965398446). Cross-import dates to the quick filters PR (#47271).

## Changes

- Move shared fixtures to `dashboardLogic.testHelpers.ts` — not matched by Jest's `testMatch`, so it doesn't register as a suite.
- Both tests import from the helper module instead of from each other.

No production code touched.

## How did you test this code?

Agent-run, automated only:

- `jest dashboardLogic.test.ts dashboardQuickFiltersDebounce.test.ts` → both green.
- `jest dashboardQuickFiltersDebounce.test.ts` alone now runs 3 tests (its own), not the full `dashboardLogic` suite — side-effect import is gone.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Add `skip-inkeep-docs` — test-only change.

## 🤖 Agent context

Authored by Claude Code (Opus) from a CI-flake insight flagging the `.test.ts` → `.test.ts` cross-import. Verified independently: import on `master` since #47271 (`git blame`/`merge-base`), both failing runs were `push` on `master`.

Chose fixture extraction over loosening the timeout/assertion — the real defect is accidental suite duplication, and this fixes the cause with a minimal diff. File named `*.testHelpers.ts` to match the repo convention and avoid a `.test.` substring.
