### PR TITLE
feat(quill): add Heading and Text typography primitives

### DIFF
--- a/packages/quill/apps/storybook/stories/typography.stories.tsx
+++ b/packages/quill/apps/storybook/stories/typography.stories.tsx
@@ -12,13 +12,30 @@ export const Default: Story = {
     render: () => {
         return (
             <div className="space-y-6">
-                <h1 className="text-2xl font-bold">Text-2xl - largest</h1>
-                <h2 className="text-xl font-bold">Text-xl - large</h2>
-                <h3 className="text-lg font-bold">Text-lg - medium</h3>
-                <h4 className="text-base font-bold">Text-base - normal</h4>
-                <h5 className="text-sm font-bold">Text-sm - smaller</h5>
-                <p className="text-xs">Text-xs - small</p>
-                <small className="text-xxs">Text-xxs - super small</small>
+                <div className="space-y-6">
+                    <h1 className="text-2xl font-bold">Text-2xl - largest</h1>
+                    <h2 className="text-xl font-bold">Text-xl - large</h2>
+                    <h3 className="text-lg font-bold">Text-lg - medium</h3>
+                    <h4 className="text-base font-bold">Text-base - normal</h4>
+                    <h5 className="text-sm font-bold">Text-sm - smaller</h5>
+                    <p className="text-xs">Text-xs - small</p>
+                    <small className="text-xxs">Text-xxs - super small</small>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                    These are the raw type tokens. For components that apply them, see the{' '}
+                    <a
+                        className="underline"
+                        target="_top"
+                        href="./?path=/docs/typography-heading--docs"
+                    >
+                        Heading
+                    </a>{' '}
+                    and{' '}
+                    <a className="underline" target="_top" href="./?path=/docs/typography-text--docs">
+                        Text
+                    </a>{' '}
+                    primitives.
+                </p>
             </div>
         )
     },

--- a/packages/quill/packages/blocks/package.json
+++ b/packages/quill/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-blocks",
-    "version": "0.3.0-beta.13",
+    "version": "0.3.0-beta.14",
     "private": true,
     "description": "Internal workspace package (private, not published). The highest layer of the quill design system — product-level patterns made of components + primitives (e.g. a PageHeader with title + breadcrumb + action slot, an EmptyState with icon + copy + CTA, a CommandPalette, a user-menu dropdown). Opinionated and shape-stable across products so they feel consistent. Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/components/package.json
+++ b/packages/quill/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-components",
-    "version": "0.3.0-beta.13",
+    "version": "0.3.0-beta.14",
     "private": true,
     "description": "Internal workspace package (private, not published). The middle layer of the quill design system — higher-level compositions of primitives that wire several of them together with sensible defaults (e.g. a FormField that composes Label + Input + validation state, or a ConfirmDialog that composes Dialog + Button + destructive variant). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/primitives/package.json
+++ b/packages/quill/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-primitives",
-    "version": "0.3.0-beta.13",
+    "version": "0.3.0-beta.14",
     "private": true,
     "description": "Internal workspace package (private, not published). The lowest layer of the quill design system — unstyled Base UI primitives wrapped with quill's Tailwind classes (Button, Card, Dialog, Input, Popover, Combobox, etc.). Bundled into @posthog/quill at build time; consumers should import from @posthog/quill instead.",
     "license": "MIT",

--- a/packages/quill/packages/primitives/src/heading.stories.tsx
+++ b/packages/quill/packages/primitives/src/heading.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Heading } from './heading'
+
+const meta = {
+    title: 'Typography/Heading',
+    component: Heading,
+    tags: ['autodocs'],
+    argTypes: {
+        size: {
+            control: 'select',
+            options: ['2xl', 'xl', 'lg', 'base', 'sm'],
+        },
+    },
+} satisfies Meta<typeof Heading>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Sizes = {
+    render: () => (
+        <div className="flex flex-col gap-3">
+            <Heading size="2xl">Heading 2xl</Heading>
+            <Heading size="xl">Heading xl</Heading>
+            <Heading size="lg">Heading lg</Heading>
+            <Heading size="base">Heading base</Heading>
+            <Heading size="sm">Heading sm</Heading>
+        </div>
+    ),
+} satisfies Story
+
+export const SemanticLevels = {
+    render: () => (
+        <div className="flex flex-col gap-3">
+            {/* Visual size decoupled from the heading level — pick the tag for document outline */}
+            <Heading size="2xl" render={<h1 />}>
+                Page title (h1)
+            </Heading>
+            <Heading size="lg" render={<h2 />}>
+                Section (h2)
+            </Heading>
+            <Heading size="sm" render={<h3 />}>
+                Subsection (h3)
+            </Heading>
+        </div>
+    ),
+} satisfies Story

--- a/packages/quill/packages/primitives/src/heading.tsx
+++ b/packages/quill/packages/primitives/src/heading.tsx
@@ -1,0 +1,48 @@
+import { mergeProps } from '@base-ui/react/merge-props'
+import { useRender } from '@base-ui/react/use-render'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+
+import { cn } from './lib/utils'
+
+// Visual size is decoupled from the semantic element. Pick `size` for looks
+// and `render` (e.g. <h1 />) for document outline / accessibility.
+const headingVariants = cva('text-foreground font-semibold text-balance', {
+    variants: {
+        size: {
+            '2xl': 'text-2xl tracking-tight',
+            xl: 'text-xl tracking-tight',
+            lg: 'text-lg',
+            base: 'text-base',
+            sm: 'text-sm',
+        },
+    },
+    defaultVariants: {
+        size: 'lg',
+    },
+})
+
+function Heading({
+    className,
+    size = 'lg',
+    render,
+    ...props
+}: useRender.ComponentProps<'h2'> & VariantProps<typeof headingVariants>): React.ReactElement {
+    return useRender({
+        defaultTagName: 'h2',
+        props: mergeProps<'h2'>(
+            {
+                'data-quill': '',
+                className: cn(headingVariants({ size }), className),
+            } as Omit<React.ComponentProps<'h2'>, 'ref'>,
+            props
+        ),
+        render,
+        state: {
+            slot: 'heading',
+            size,
+        },
+    })
+}
+
+export { Heading, headingVariants }

--- a/packages/quill/packages/primitives/src/index.ts
+++ b/packages/quill/packages/primitives/src/index.ts
@@ -124,6 +124,7 @@ export {
     FieldContent,
     FieldTitle,
 } from './field'
+export { Heading, headingVariants } from './heading'
 export { Input } from './input'
 export {
     NumberFieldRoot,
@@ -231,6 +232,7 @@ export { Spinner } from './spinner'
 export { Switch } from './switch'
 export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption } from './table'
 export { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs'
+export { Text, textVariants } from './text'
 export { Textarea } from './textarea'
 export { Toggle, toggleVariants } from './toggle'
 export { ToggleGroup, ToggleGroupItem } from './toggle-group'

--- a/packages/quill/packages/primitives/src/text.stories.tsx
+++ b/packages/quill/packages/primitives/src/text.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Text } from './text'
+
+const meta = {
+    title: 'Typography/Text',
+    component: Text,
+    tags: ['autodocs'],
+    argTypes: {
+        size: {
+            control: 'select',
+            options: ['lg', 'base', 'sm', 'xs', 'xxs'],
+        },
+        variant: {
+            control: 'select',
+            options: ['default', 'muted', 'destructive'],
+        },
+        weight: {
+            control: 'select',
+            options: ['normal', 'medium', 'semibold'],
+        },
+    },
+} satisfies Meta<typeof Text>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Sizes = {
+    render: () => (
+        <div className="flex flex-col gap-2">
+            <Text size="lg">Text lg</Text>
+            <Text size="base">Text base</Text>
+            <Text size="sm">Text sm</Text>
+            <Text size="xs">Text xs</Text>
+            <Text size="xxs">Text xxs</Text>
+        </div>
+    ),
+} satisfies Story
+
+export const Variants = {
+    render: () => (
+        <div className="flex flex-col gap-2">
+            <Text variant="default">Default body text</Text>
+            <Text variant="muted">Muted caption text</Text>
+            <Text variant="destructive">Destructive error text</Text>
+        </div>
+    ),
+} satisfies Story
+
+export const Weights = {
+    render: () => (
+        <div className="flex flex-col gap-2">
+            <Text weight="normal">Normal weight</Text>
+            <Text weight="medium">Medium weight</Text>
+            <Text weight="semibold">Semibold weight</Text>
+        </div>
+    ),
+} satisfies Story
+
+export const Inline = {
+    render: () => (
+        <Text>
+            Body copy with an{' '}
+            <Text render={<span />} weight="semibold">
+                inline emphasis
+            </Text>{' '}
+            and a{' '}
+            <Text render={<span />} variant="muted">
+                muted aside
+            </Text>
+            .
+        </Text>
+    ),
+} satisfies Story

--- a/packages/quill/packages/primitives/src/text.tsx
+++ b/packages/quill/packages/primitives/src/text.tsx
@@ -1,0 +1,63 @@
+import { mergeProps } from '@base-ui/react/merge-props'
+import { useRender } from '@base-ui/react/use-render'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+
+import { cn } from './lib/utils'
+
+// Body / caption / label text. Defaults to a block <p>; pass render=<span /> for inline.
+const textVariants = cva('', {
+    variants: {
+        size: {
+            lg: 'text-lg',
+            base: 'text-base',
+            sm: 'text-sm',
+            xs: 'text-xs',
+            xxs: 'text-xxs',
+        },
+        variant: {
+            default: 'text-foreground',
+            muted: 'text-muted-foreground',
+            destructive: 'text-destructive-foreground',
+        },
+        weight: {
+            normal: 'font-normal',
+            medium: 'font-medium',
+            semibold: 'font-semibold',
+        },
+    },
+    defaultVariants: {
+        size: 'base',
+        variant: 'default',
+        weight: 'normal',
+    },
+})
+
+function Text({
+    className,
+    size = 'base',
+    variant = 'default',
+    weight = 'normal',
+    render,
+    ...props
+}: useRender.ComponentProps<'p'> & VariantProps<typeof textVariants>): React.ReactElement {
+    return useRender({
+        defaultTagName: 'p',
+        props: mergeProps<'p'>(
+            {
+                'data-quill': '',
+                className: cn(textVariants({ size, variant, weight }), className),
+            } as Omit<React.ComponentProps<'p'>, 'ref'>,
+            props
+        ),
+        render,
+        state: {
+            slot: 'text',
+            size,
+            variant,
+            weight,
+        },
+    })
+}
+
+export { Text, textVariants }

--- a/packages/quill/packages/quill/package.json
+++ b/packages/quill/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill",
-    "version": "0.3.0-beta.13",
+    "version": "0.3.0-beta.14",
     "description": "PostHog's unified design system — primitives, components, and blocks designed to be compiled by the consumer's Tailwind v4.",
     "license": "MIT",
     "repository": {

--- a/packages/quill/packages/tokens/package.json
+++ b/packages/quill/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-tokens",
-    "version": "0.3.0-beta.13",
+    "version": "0.3.0-beta.14",
     "license": "MIT",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Problem

Quill had typography *tokens* (`--text-*` scale) but no general-purpose typography *components*. Free-floating copy in product scenes and the blocks layer had to hand-roll Tailwind classes, and there was no agreed naming for headings vs body text.

## Changes

- Add two primitives — **`Heading`** and **`Text`** — using the existing `useRender` + CVA pattern (`data-quill`, `cn()`, semantic color tokens).
  - **Visual size is decoupled from the semantic element**: pick `size` for looks, `render={<h1 />}` for the document outline. This avoids the `H1`/`H2`-as-component a11y trap (one `<h1>` per page regardless of visual size).
  - `Heading`: `size` (2xl…sm), defaults to `<h2>`.
  - `Text`: `size` (lg…xxs), `variant` (default/muted/destructive), `weight` (normal/medium/semibold), defaults to `<p>`.
  - Both reuse the existing `--text-*` token scale — no new scale introduced.
- Compound-component titles (`CardTitle`, `DialogTitle`, `ItemTitle`, `EmptyTitle`, …) are intentionally **left as-is** — they carry load-bearing `data-slot` contracts, Base UI aria wiring, and context-tuned scoped CSS. `Heading`/`Text` fill the gap where there was no primitive, rather than replacing those.
- Storybook: group both under a **`Typography/`** folder and link to them from the existing token typography story.
- Bump the five publishable quill packages to `0.3.0-beta.14`.

## How did you test this code?

I'm an agent. Automated checks I actually ran:

- `pnpm --filter @posthog/quill-primitives build` — passes (bundle + `.d.ts` generation clean) after adding both components and exports.

No manual Storybook walkthrough was performed.

## Docs update

No docs change needed.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Key decisions:

- Surveyed major design systems (Radix Themes, Chakra, Primer, Atlassian, MUI, Ant, Polaris) and chose the converged `Heading` + `Text` naming over `H1/H2` (couples visual size to semantics, breaks a11y) or `Title/Subtitle` (too few names, ambiguous "subtitle").
- Considered refactoring existing compound-component titles to render through the new primitives; rejected it because their `data-slot` + aria + scoped-CSS contracts are load-bearing and the churn carries no user-facing benefit.
- Cross-package deps use `workspace:*`/`^`, so the version bump needs no range edits and the lockfile is unaffected (verified no `0.3.0-beta.13` pins in `pnpm-lock.yaml`).
