### PR TITLE
fix(settings): surface backend error when email change is rejected

### DIFF
--- a/frontend/src/scenes/settings/user/UserDetails.tsx
+++ b/frontend/src/scenes/settings/user/UserDetails.tsx
@@ -10,6 +10,8 @@ export function UserDetails(): JSX.Element {
     const { userLoading, isUserDetailsSubmitting, userDetailsChanged, user } = useValues(userLogic)
     const { cancelEmailChangeRequest } = useActions(userLogic)
 
+    const ssoEnforced = !!user?.has_sso_enforcement
+
     return (
         <Form
             logic={userLogic}
@@ -43,9 +45,14 @@ export function UserDetails(): JSX.Element {
                     className="ph-ignore-input"
                     data-attr="settings-update-email"
                     placeholder="email@yourcompany.com"
-                    disabled={userLoading}
+                    disabled={userLoading || ssoEnforced}
                 />
             </LemonField>
+            {ssoEnforced && (
+                <div className="text-secondary text-xs">
+                    You can't change your email because your organization enforces SSO on your email's domain.
+                </div>
+            )}
             {user?.pending_email && (
                 <div className="flex flex-row gap-2">
                     <div className="text-danger text-xs font-medium mt-1.25">

--- a/frontend/src/scenes/userLogic.test.ts
+++ b/frontend/src/scenes/userLogic.test.ts
@@ -195,7 +195,7 @@ describe('userLogic', () => {
         it('dispatches updateUserFailure (not success) when the backend rejects the update', async () => {
             jest.spyOn(api, 'update').mockRejectedValue({
                 status: 400,
-                detail: "You can't change your email because SSO is enforced on your current email's domain.",
+                detail: 'Update rejected by server.',
             })
 
             await expectLogic(userLogic, () => {

--- a/frontend/src/scenes/userLogic.test.ts
+++ b/frontend/src/scenes/userLogic.test.ts
@@ -186,4 +186,33 @@ describe('userLogic', () => {
             })
         })
     })
+
+    describe('updateUser failure handling', () => {
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it('dispatches updateUserFailure (not success) when the backend rejects the update', async () => {
+            jest.spyOn(api, 'update').mockRejectedValue({
+                status: 400,
+                detail: "You can't change your email because SSO is enforced on your current email's domain.",
+            })
+
+            await expectLogic(userLogic, () => {
+                userLogic.actions.updateUser({ email: 'new@example.com' })
+            })
+                .toDispatchActions(['updateUserFailure'])
+                .toNotHaveDispatchedActions(['updateUserSuccess'])
+        })
+
+        it('keeps the existing user when the update fails — no silent revert via success', async () => {
+            jest.spyOn(api, 'update').mockRejectedValue({ status: 400, detail: 'nope' })
+
+            await expectLogic(userLogic, () => {
+                userLogic.actions.updateUser({ email: 'new@example.com' })
+            })
+                .toDispatchActions(['updateUserFailure'])
+                .toMatchValues({ user: userWithLightTheme })
+        })
+    })
 })

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -150,15 +150,11 @@ export const userLogic = kea<userLogicType>([
                     if (!values.user) {
                         throw new Error('Current user has not been loaded yet, so it cannot be updated!')
                     }
-                    try {
-                        const response = await api.update<UserType>('api/users/@me/', user)
-                        successCallback?.()
-                        return response
-                    } catch (error: any) {
-                        console.error(error)
-                        actions.updateUserFailure(error.message)
-                        return values.user
-                    }
+                    // Let failures throw so kea-loaders dispatches `updateUserFailure` — returning the old
+                    // user here would be treated as a success, silently masking backend errors.
+                    const response = await api.update<UserType>('api/users/@me/', user)
+                    successCallback?.()
+                    return response
                 },
                 cancelEmailChangeRequest: async () => {
                     if (!values.user) {
@@ -351,8 +347,9 @@ export const userLogic = kea<userLogicType>([
                 toastId: 'updateUser',
             })
         },
-        updateUserFailure: () => {
-            lemonToast.error(`Error saving preferences`, {
+        updateUserFailure: ({ errorObject }) => {
+            lemonToast.dismiss('updateUser')
+            lemonToast.error(errorObject?.detail || 'Error saving preferences', {
                 toastId: 'updateUser',
             })
         },


### PR DESCRIPTION
## Problem

Changing your email in **Settings → Account** silently failed when the backend rejected the change. You'd click save, the field would snap back to the old email, and a "Preferences saved" toast would appear — even though nothing changed and no "Pending verification" message showed. Backend failures were being rendered as successes.

The common trigger is **SSO enforcement**: the API refuses to move a user off (or onto) a domain where SSO is enforced, returning a 400 with an explanatory message. That message was being swallowed.

## Changes

- **`userLogic` — stop masking failures.** The `updateUser` loader caught errors and `return`ed the previous `user` object. kea-loaders treats any non-thrown return as a success, so it dispatched `updateUserSuccess` (firing the "Preferences saved" toast and resetting the form to the old email) even on a 400. The loader now lets the error propagate so kea-loaders dispatches `updateUserFailure`.
- **`userLogic` — show the real error.** `updateUserFailure` now surfaces the backend's `detail` (e.g. _"You can't change your email because SSO is enforced on your current email's domain."_) instead of a generic "Error saving preferences".
- **`UserDetails` — pre-empt the SSO case in the UI.** When the user's organization enforces SSO (`user.has_sso_enforcement`), the email field is disabled with a short note explaining why, so users aren't left guessing. The toast still covers the remaining server-side rejection cases (e.g. moving *to* an SSO-enforced domain).

## How did you test this code?

I'm an agent (PostHog Slack app). I added and ran automated Jest tests in `userLogic.test.ts` covering the failure path:

- a rejected `updateUser` now dispatches `updateUserFailure` and **not** `updateUserSuccess`
- the existing user is preserved on failure (no silent revert via a fake success)

All 10 tests in the suite pass, and `oxlint` / `oxfmt` are clean on the changed files. I did not perform manual browser testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code). The user reported that email changes silently fail with a success toast and suspected SSO enforcement as the cause.

Root cause: a `try/catch` in the `updateUser` kea loader returned `values.user` on error, which kea-loaders interprets as a successful load — so the success toast fired, the form reset, and the backend error was lost. Fix is to let the loader throw so the failure action runs, then render the backend `detail` in the toast.

The UI guard uses `has_sso_enforcement` (computed per the user's current organization). This covers the "current email is SSO-enforced" case proactively; the "target email is SSO-enforced" case can't be predicted client-side, so the now-correct error toast handles it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*