### PR TITLE
fix(navigation): stop AI side panel auto-opening on app return

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.test.ts
@@ -7,7 +7,7 @@ import { SidePanelTab } from '~/types'
 
 import { sidePanelStateLogic } from './sidePanelStateLogic'
 
-describe('sidePanelStateLogic - onSceneTabChanged', () => {
+describe('sidePanelStateLogic', () => {
     let logic: ReturnType<typeof sidePanelStateLogic.build>
 
     beforeEach(() => {
@@ -17,97 +17,39 @@ describe('sidePanelStateLogic - onSceneTabChanged', () => {
         logic.mount()
     })
 
-    it('does not crash when featureFlagLogic is not mounted', async () => {
-        featureFlagLogic.unmount()
+    it('starts closed', async () => {
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: false, selectedTab: null })
+    })
 
+    it('opens only on an explicit openSidePanel trigger', async () => {
         logic.actions.openSidePanel(SidePanelTab.Max)
-        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
-
         await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
     })
 
-    it('saves and restores side panel state when switching between tabs', async () => {
-        // Open panel on tab-a
-        logic.actions.openSidePanel(SidePanelTab.Max)
-        await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
-
-        // Switch to tab-b: saves tab-a state, tab-b has no saved state so panel stays as-is
-        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
-        await expectLogic(logic).toMatchValues({ sidePanelOpen: true })
-
-        // Close panel on tab-b
-        logic.actions.closeSidePanel()
-        await expectLogic(logic).toMatchValues({ sidePanelOpen: false })
-
-        // Switch back to tab-a: restores open state
-        logic.actions.onSceneTabChanged('tab-b', 'tab-a')
-        await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
-    })
-
-    it('restores closed state for tabs that were explicitly closed', async () => {
-        // Open panel on tab-a
-        logic.actions.openSidePanel(SidePanelTab.Max)
-
-        // Switch to tab-b
-        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
-
-        // Close panel on tab-b, then switch to tab-c
-        logic.actions.closeSidePanel()
-        logic.actions.onSceneTabChanged('tab-b', 'tab-c')
-
-        // Switch back to tab-b: should restore the closed state
-        logic.actions.onSceneTabChanged('tab-c', 'tab-b')
-        await expectLogic(logic).toMatchValues({ sidePanelOpen: false })
-    })
-
-    it('preserves current state for never-visited tabs', async () => {
-        // Open panel
-        logic.actions.openSidePanel(SidePanelTab.Max)
-        await expectLogic(logic).toMatchValues({ sidePanelOpen: true })
-
-        // Switch to a brand-new tab: no saved state, should preserve current panel state
-        logic.actions.onSceneTabChanged('tab-a', 'tab-new')
-        await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
-    })
-
-    it('restores selectedTabOptions along with the tab', async () => {
+    it('carries selectedTabOptions when opening', async () => {
         logic.actions.openSidePanel(SidePanelTab.Activity, 'bug:analytics')
         await expectLogic(logic).toMatchValues({
             sidePanelOpen: true,
             selectedTab: SidePanelTab.Activity,
             selectedTabOptions: 'bug:analytics',
         })
-
-        // Switch away and back
-        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
-        logic.actions.closeSidePanel()
-        logic.actions.onSceneTabChanged('tab-b', 'tab-a')
-
-        await expectLogic(logic).toMatchValues({
-            sidePanelOpen: true,
-            selectedTab: SidePanelTab.Activity,
-            selectedTabOptions: 'bug:analytics',
-        })
     })
 
-    it('deduplicates identical transitions from activateTab and setScene', async () => {
+    it('closes when closeSidePanel is called with no tab', async () => {
         logic.actions.openSidePanel(SidePanelTab.Max)
-
-        // First dispatch (from activateTab): saves tab-a state, tab-b has no saved state
-        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
-        await expectLogic(logic).toMatchValues({ sidePanelOpen: true })
-
-        // Close the panel on tab-b
         logic.actions.closeSidePanel()
         await expectLogic(logic).toMatchValues({ sidePanelOpen: false })
+    })
 
-        // Second dispatch (from setScene) with same transition: should be skipped
-        // If it weren't skipped, it would overwrite tab-a's saved state with {open: false}
-        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
+    it('only closes for the currently selected tab when a tab is passed', async () => {
+        logic.actions.openSidePanel(SidePanelTab.Max)
+
+        // Closing a different tab leaves the panel open
+        logic.actions.closeSidePanel(SidePanelTab.Activity)
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: true })
+
+        // Closing the selected tab closes the panel
+        logic.actions.closeSidePanel(SidePanelTab.Max)
         await expectLogic(logic).toMatchValues({ sidePanelOpen: false })
-
-        // Switch back to tab-a: should still have the original open state
-        logic.actions.onSceneTabChanged('tab-b', 'tab-a')
-        await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
     })
 })

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.tsx
@@ -17,19 +17,6 @@ export const sidePanelStateLogic = kea<sidePanelStateLogicType>([
         setSidePanelOpen: (open: boolean) => ({ open }),
         setSidePanelOptions: (options: string | null) => ({ options }),
         setSidePanelAvailable: (available: boolean) => ({ available }),
-        onSceneTabChanged: (previousTabId: string | null, newTabId: string) => ({ previousTabId, newTabId }),
-        // Restores side panel state for a scene tab without touching the URL. Unlike openSidePanel/
-        // closeSidePanel this has no actionToUrl, so it can't navigate the active tab to a stale
-        // location mid-tab-switch. The tab's own stored URL hash already carries `#panel=…`.
-        restoreSidePanelStateForTab: (
-            open: boolean,
-            selectedTab: SidePanelTab | null,
-            selectedTabOptions: string | null
-        ) => ({
-            open,
-            selectedTab,
-            selectedTabOptions,
-        }),
     }),
 
     reducers(() => ({
@@ -44,7 +31,6 @@ export const sidePanelStateLogic = kea<sidePanelStateLogicType>([
             { persist: true },
             {
                 openSidePanel: (_, { tab }) => tab,
-                restoreSidePanelStateForTab: (state, { open, selectedTab }) => (open ? selectedTab : state),
             },
         ],
 
@@ -54,22 +40,21 @@ export const sidePanelStateLogic = kea<sidePanelStateLogicType>([
                 openSidePanel: (_, { options }) => options ?? null,
                 setSidePanelOptions: (_, { options }) => options ?? null,
                 closeSidePanel: () => null,
-                restoreSidePanelStateForTab: (_, { open, selectedTabOptions }) => (open ? selectedTabOptions : null),
             },
         ],
+        // Not persisted: the panel must only open from an explicit trigger (click or URL #panel hash),
+        // never auto-reopen on returning to the app.
         sidePanelOpen: [
             false,
-            { persist: true },
             {
                 setSidePanelOpen: (_, { open }) => open,
-                restoreSidePanelStateForTab: (_, { open }) => open,
             },
         ],
     })),
     windowValues(() => ({
         modalMode: (window: Window) => window?.innerWidth < 992, // Sync width threshold with Sass variable $lg!
     })),
-    listeners(({ actions, values, cache }) => ({
+    listeners(({ actions, values }) => ({
         // NOTE: We explicitly reference the actions instead of connecting so that people don't accidentally
         // use this logic instead of sidePanelStateLogic
         openSidePanel: ({ tab }) => {
@@ -84,41 +69,6 @@ export const sidePanelStateLogic = kea<sidePanelStateLogicType>([
             } else if (values.selectedTab === tab) {
                 // Otherwise we only close it if the tab is the currently open one
                 actions.setSidePanelOpen(false)
-            }
-        },
-        onSceneTabChanged: ({ previousTabId, newTabId }) => {
-            // Skip if we already processed this exact transition (activateTab fires early, setScene fires later)
-            const transitionKey = `${previousTabId}->${newTabId}`
-            if (cache.lastProcessedTransition === transitionKey) {
-                return
-            }
-            cache.lastProcessedTransition = transitionKey
-
-            if (!cache.sidePanelStateByTab) {
-                cache.sidePanelStateByTab = {}
-            }
-
-            // Save current side panel state for the previous tab
-            if (previousTabId) {
-                cache.sidePanelStateByTab[previousTabId] = {
-                    open: values.sidePanelOpen,
-                    selectedTab: values.selectedTab,
-                    selectedTabOptions: values.selectedTabOptions,
-                }
-            }
-
-            // Restore state for the new tab (preserve current state for never-visited tabs
-            // so the URL hash handler can set it if needed). Use restoreSidePanelStateForTab
-            // rather than openSidePanel/closeSidePanel: those carry an actionToUrl that would
-            // replace() the active tab's URL using the stale (pre-switch) router location,
-            // overwriting the just-activated tab with the previous tab's pathname.
-            const savedState = cache.sidePanelStateByTab[newTabId]
-            if (savedState) {
-                actions.restoreSidePanelStateForTab(
-                    !!(savedState.open && savedState.selectedTab),
-                    savedState.selectedTab,
-                    savedState.selectedTabOptions
-                )
             }
         },
     })),

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -38,7 +38,6 @@ import {
 import { urls } from 'scenes/urls'
 
 import { isSharedView } from '~/exporter/exporterViewLogic'
-import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { FileSystemIconType, ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel } from '~/types'
 
@@ -840,11 +839,7 @@ export const sceneLogic = kea<sceneLogicType>([
             }
         },
         setTabs: () => persistTabs(values.tabs, values.homepage),
-        activateTab: ({ tab }, _, __, previousState) => {
-            const previousActiveTabId = selectors.activeTabId(previousState)
-            if (previousActiveTabId && previousActiveTabId !== tab.id) {
-                sidePanelStateLogic.findMounted()?.actions.onSceneTabChanged(previousActiveTabId, tab.id)
-            }
+        activateTab: () => {
             persistTabs(values.tabs, values.homepage)
         },
         duplicateTab: () => persistTabs(values.tabs, values.homepage),
@@ -1017,10 +1012,6 @@ export const sceneLogic = kea<sceneLogicType>([
             }
 
             if (tabId !== lastTabId) {
-                if (lastTabId) {
-                    sidePanelStateLogic.findMounted()?.actions.onSceneTabChanged(lastTabId, tabId)
-                }
-
                 const scrollTop = values.tabScrollDepths[tabId] ?? 0
                 window.setTimeout(() => restoreMainContentScrollTop(scrollTop, tabId), 1)
                 window.setTimeout(() => restoreMainContentScrollTop(scrollTop, tabId), 10)


### PR DESCRIPTION
## Problem

Users reported the PostHog AI side panel opening by itself when returning to the app, without anyone clicking a trigger.

Two mechanisms reopened the panel implicitly:

1. The `sidePanelOpen` reducer was persisted to localStorage, so `open=true` was restored on every reload/return.
2. Per-scene-tab restore logic (`onSceneTabChanged` + `restoreSidePanelStateForTab`) saved each tab's panel state in a cache and re-opened it on tab switches.

## Changes

- Dropped `persist: true` on `sidePanelOpen` — the panel now defaults closed and never auto-restores its open state.
- Removed the per-scene-tab save/restore logic from `sidePanelStateLogic` (the `onSceneTabChanged` and `restoreSidePanelStateForTab` actions, their reducer cases, the listener, and the `cache.sidePanelStateByTab` bookkeeping).
- Removed both call sites in `sceneLogic` (in `activateTab` and the scene-change listener) and the now-unused import.

The panel now opens only via an explicit trigger: clicking a side panel button (`openSidePanel`) or an explicit `#panel=…` URL hash (shareable deep-link). `selectedTab` still persists, so the last-used tab is remembered for the next time the user opens the panel — but the panel stays closed until they do.

## How did you test this code?

I'm an agent. Automated tests only:

- Rewrote `sidePanelStateLogic.test.ts` to assert the explicit-open contract (starts closed, opens only via `openSidePanel`, correct close behavior). All 5 pass.
- `pnpm typescript:check` clean; kea types regenerated.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The user reported the side panel auto-opening and asked to remove the tab-restore behavior and prevent any non-explicit open.

Investigated the side panel logic and traced two independent causes: persisted open state and the per-tab restore cache. Considered also stripping the `#panel=` URL-hash reopen, but kept it — that path is an explicit, shareable deep-link and a fresh return to the app carries no hash, so it does not cause the reported behavior.
