### PR TITLE
feat(hogql): lazy data-warehouse table materialization

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -59,7 +59,13 @@ from posthog.hogql.database.models import (
     VirtualTable,
 )
 from posthog.hogql.database.postgres_table import PostgresTable
-from posthog.hogql.database.postgres_utils import add_postgres_foreign_key_lazy_joins
+from posthog.hogql.database.postgres_utils import (
+    add_postgres_foreign_key_lazy_joins,
+    candidate_target_tables,
+    foreign_key_join_function,
+    get_foreign_keys_from_schemas,
+    reverse_foreign_key_field_name,
+)
 from posthog.hogql.database.s3_table import S3Table
 from posthog.hogql.database.schema.ai_events import AiEventsTable
 from posthog.hogql.database.schema.app_metrics2 import AppMetrics2Table
@@ -168,6 +174,8 @@ if TYPE_CHECKING:
 
     from posthog.models import Team, User
     from posthog.rbac.user_access_control import UserAccessControl
+
+    from products.data_tools.backend.models.join import DataWarehouseJoin
 
 tracer = trace.get_tracer(__name__)
 
@@ -880,6 +888,7 @@ class Database(BaseModel):
         modifiers: HogQLQueryModifiers | None = None,
         timings: HogQLTimings | None = None,
         connection_id: str | None = None,
+        lazy_warehouse_tables: bool | None = None,
     ) -> "Database":
         if timings is None:
             timings = HogQLTimings()
@@ -1073,6 +1082,34 @@ class Database(BaseModel):
                         events_table.fields[mapping["group_type"]] = FieldTraverser(
                             chain=[f"group_{mapping['group_type_index']}"]
                         )
+
+        if lazy_warehouse_tables is None:
+            lazy_warehouse_tables = bool(
+                posthoganalytics.feature_enabled(
+                    "hogql-lazy-warehouse-tables",
+                    str(team.uuid),
+                    groups={"organization": str(team.organization_id), "project": str(team.id)},
+                    group_properties={
+                        "organization": {"id": str(team.organization_id)},
+                        "project": {"id": str(team.id)},
+                    },
+                    only_evaluate_locally=True,
+                    send_feature_flag_events=False,
+                )
+            )
+
+        # Lazy path: register warehouse tables/views as deferred stubs so a query only pays to build
+        # the few tables it touches. Direct-connection queries keep the eager path below.
+        if lazy_warehouse_tables and not database._is_direct_query() and not modifiers.dataWarehouseEventsModifiers:
+            _build_warehouse_lazy(
+                database=database,
+                team=team,
+                modifiers=modifiers,
+                is_managed_viewset_enabled=is_managed_viewset_enabled,
+                timings=timings,
+            )
+            database.apply_schema_scope()
+            return database
 
         warehouse_tables_dot_notation_mapping: dict[str, str] = {}
         warehouse_tables: TableNode = TableNode()
@@ -1468,6 +1505,444 @@ class Database(BaseModel):
         database.apply_schema_scope()
 
         return database
+
+
+class _WarehousePropertiesVirtualTable(VirtualTable):
+    fields: dict[str, FieldOrTable]
+    parent_table: Table
+
+    def to_printed_hogql(self):
+        return self.parent_table.to_printed_hogql()
+
+    def to_printed_clickhouse(self, context):
+        return self.parent_table.to_printed_clickhouse(context)
+
+
+@dataclasses.dataclass(frozen=True)
+class _LazyTableMeta:
+    """Just enough about a warehouse table/view to resolve foreign keys without building it."""
+
+    name: str  # hogql (namespaced) name
+    columns: frozenset[str]
+
+
+def _same_warehouse_scope(source_name: str, target_name: str) -> bool:
+    # Mirrors postgres_utils._is_same_external_scope for the non-direct path: same namespace prefix.
+    if "." not in source_name or "." not in target_name:
+        return False
+    return source_name.rsplit(".", 1)[0] == target_name.rsplit(".", 1)[0]
+
+
+def _resolve_fk_target_name(target_table: str, source_name: str, metas: dict[str, _LazyTableMeta]) -> str | None:
+    name = target_table
+    if source_name and "." in source_name and "." not in name:
+        name = ".".join([*source_name.split(".")[:-1], name])
+    return name if name in metas else None
+
+
+def _emit_one_fk(
+    source: _LazyTableMeta,
+    column: str,
+    target_table: str,
+    target_column: str,
+    metas: dict[str, _LazyTableMeta],
+    fk_specs: dict[str, dict[str, LazyJoin]],
+) -> None:
+    if not column or not target_table or not target_column:
+        return
+    from_field = get_join_field_chain(column)
+    to_field = get_join_field_chain(target_column)
+    if from_field is None or to_field is None:
+        return
+    field_name = column[:-3] if column.endswith("_id") and len(column) > 3 else column
+
+    target_name = _resolve_fk_target_name(target_table, source.name, metas)
+    if target_name is None or not _same_warehouse_scope(source.name, target_name):
+        return
+
+    # Skip the whole FK if the forward field name is already taken (matches the eager early return).
+    if field_name in source.columns or field_name in fk_specs.get(source.name, {}):
+        return
+    fk_specs.setdefault(source.name, {})[field_name] = LazyJoin(
+        from_field=from_field,
+        to_field=to_field,
+        join_table=target_name,
+        join_function=foreign_key_join_function(from_field, to_field),
+    )
+
+    reverse = reverse_foreign_key_field_name(source.name, target_name)
+    target = metas[target_name]
+    if reverse in target.columns or reverse in fk_specs.get(target_name, {}):
+        return
+    fk_specs.setdefault(target_name, {})[reverse] = LazyJoin(
+        from_field=to_field,
+        to_field=from_field,
+        join_table=source.name,
+        join_function=foreign_key_join_function(to_field, from_field),
+    )
+
+
+def _emit_fk_specs_for_table(
+    source: _LazyTableMeta,
+    schemas: Sequence[ExternalDataSchema],
+    metas: dict[str, _LazyTableMeta],
+    fk_specs: dict[str, dict[str, LazyJoin]],
+) -> None:
+    foreign_keys = get_foreign_keys_from_schemas(schemas)
+    if foreign_keys:
+        for fk in foreign_keys:
+            _emit_one_fk(source, fk.column, fk.target_table, fk.target_column, metas, fk_specs)
+        return
+
+    # Inferred foreign keys from *_id columns when no explicit metadata is available.
+    namespace = source.name.split(".")[:-1]
+    for column in source.columns:
+        if not column.endswith("_id") or len(column) <= 3:
+            continue
+        field_name = column[:-3]
+        if field_name in source.columns:
+            continue
+        for candidate in candidate_target_tables(base_name=field_name, namespace=namespace):
+            target = metas.get(candidate)
+            if target is None or candidate == source.name or not _same_warehouse_scope(source.name, candidate):
+                continue
+            target_column = column if column in target.columns else ("id" if "id" in target.columns else None)
+            if target_column is None:
+                continue
+            _emit_one_fk(source, column, candidate, target_column, metas, fk_specs)
+            break
+
+
+def _apply_data_warehouse_join(database: "Database", team: "Team", join: "DataWarehouseJoin") -> None:
+    """Apply a DataWarehouseJoin whose source is a built-in table (e.g. persons). The joining table is
+    referenced by name so it is only materialized if a query actually traverses the join."""
+    if not database.has_table(join.source_table_name) or not database.has_table(join.joining_table_name):
+        return
+    try:
+        source_table = database.get_table(join.source_table_name)
+        from_field = get_join_field_chain(join.source_table_key)
+        to_field = get_join_field_chain(join.joining_table_key)
+        if from_field is None or to_field is None:
+            return
+
+        join_configuration = join.configuration if isinstance(join.configuration, dict) else {}
+        joining_name = join.joining_table_name
+        source_table.fields[join.field_name] = LazyJoin(
+            from_field=from_field,
+            to_field=to_field,
+            join_table=joining_name,
+            join_function=(
+                join.join_function_for_experiments()
+                if "events" == join.joining_table_name and join_configuration.get("experiments_optimized")
+                else join.join_function()
+            ),
+        )
+
+        if join.source_table_name != "persons":
+            return
+
+        events_table = database.get_table("events")
+        person_field = events_table.fields["person"]
+        if isinstance(person_field, ast.FieldTraverser):
+            table_or_field: ast.FieldOrTable = events_table
+            for chain in person_field.chain:
+                if isinstance(table_or_field, ast.LazyJoin):
+                    table_or_field = table_or_field.resolve_table(HogQLContext(team_id=team.pk, database=database))
+                    if table_or_field.has_field(chain):
+                        table_or_field = table_or_field.get_field(chain)
+                        if isinstance(table_or_field, ast.LazyJoin):
+                            table_or_field = table_or_field.resolve_table(
+                                HogQLContext(team_id=team.pk, database=database)
+                            )
+                elif isinstance(table_or_field, ast.Table):
+                    table_or_field = table_or_field.get_field(chain)
+
+            assert isinstance(table_or_field, ast.Table)
+
+            if isinstance(table_or_field, ast.VirtualTable):
+                table_or_field.fields[join.field_name] = ast.FieldTraverser(chain=["..", join.field_name])
+                override_source_table_key = f"person.{join.source_table_key}"
+                source_table_key_node = qualify_join_key_expr(join.source_table_key, "person")
+                if source_table_key_node is not None:
+                    override_source_table_key = source_table_key_node.to_hogql()
+                events_table.fields[join.field_name] = LazyJoin(
+                    from_field=from_field,
+                    to_field=to_field,
+                    join_table=joining_name,
+                    join_function=join.join_function(override_source_table_key=override_source_table_key),
+                )
+            else:
+                table_or_field.fields[join.field_name] = LazyJoin(
+                    from_field=from_field,
+                    to_field=to_field,
+                    join_table=joining_name,
+                    join_function=join.join_function(),
+                )
+        elif isinstance(person_field, ast.LazyJoin):
+            person_field.join_table.fields[join.field_name] = LazyJoin(  # type: ignore
+                from_field=from_field,
+                to_field=to_field,
+                join_table=joining_name,
+                join_function=join.join_function(),
+            )
+    except Exception as e:
+        capture_exception(e)
+
+
+def _build_warehouse_table(
+    table: DataWarehouseTable,
+    modifiers: HogQLQueryModifiers,
+    fk_specs: dict[str, dict[str, LazyJoin]],
+    join_specs: dict[str, dict[str, LazyJoin]],
+    hogql_name: str,
+    database: "Database",
+    now: datetime,
+) -> Table:
+    s3_table = table.hogql_definition(modifiers)
+    if s3_table.fields.get("properties") is None:
+        s3_table.fields["properties"] = _WarehousePropertiesVirtualTable(
+            fields=s3_table.fields, parent_table=s3_table, hidden=True
+        )
+    s3_table.name = hogql_name
+
+    sync_warnings = get_warehouse_sync_warnings(table, now=now)
+    if sync_warnings:
+        database._data_warehouse_sync_warnings[str(table.id)] = sync_warnings
+
+    for field_name, lazy_join in fk_specs.get(hogql_name, {}).items():
+        s3_table.fields.setdefault(field_name, lazy_join)
+    for field_name, lazy_join in join_specs.get(hogql_name, {}).items():
+        s3_table.fields[field_name] = lazy_join
+    return s3_table
+
+
+def _make_table_factory(
+    table: DataWarehouseTable,
+    modifiers: HogQLQueryModifiers,
+    fk_specs: dict[str, dict[str, LazyJoin]],
+    join_specs: dict[str, dict[str, LazyJoin]],
+    hogql_name: str,
+    database: "Database",
+    now: datetime,
+) -> Callable[[], FieldOrTable]:
+    cache: dict[str, FieldOrTable] = {}
+
+    def factory() -> FieldOrTable:
+        # Memoized so the bare-name node and the namespaced node resolve to the same built table.
+        if "table" not in cache:
+            cache["table"] = _build_warehouse_table(table, modifiers, fk_specs, join_specs, hogql_name, database, now)
+        return cache["table"]
+
+    return factory
+
+
+def _make_view_factory(
+    saved_query: Any,
+    modifiers: HogQLQueryModifiers,
+    fk_specs: dict[str, dict[str, LazyJoin]],
+    join_specs: dict[str, dict[str, LazyJoin]],
+    view_name: str,
+) -> Callable[[], FieldOrTable]:
+    cache: dict[str, FieldOrTable] = {}
+
+    def factory() -> FieldOrTable:
+        if "table" not in cache:
+            view_table = saved_query.hogql_definition(modifiers)
+            for field_name, lazy_join in fk_specs.get(view_name, {}).items():
+                view_table.fields.setdefault(field_name, lazy_join)
+            for field_name, lazy_join in join_specs.get(view_name, {}).items():
+                view_table.fields[field_name] = lazy_join
+            cache["table"] = view_table
+        return cache["table"]
+
+    return factory
+
+
+def _build_warehouse_lazy(
+    *,
+    database: "Database",
+    team: "Team",
+    modifiers: HogQLQueryModifiers,
+    is_managed_viewset_enabled: bool,
+    timings: HogQLTimings,
+) -> None:
+    """Register data-warehouse tables and views as deferred stubs.
+
+    Every Postgres fetch stays eager and bulk (no N+1); only the per-table CPU work
+    (hogql_definition + foreign-key/join wiring) is deferred to the first time a query touches a
+    given table. Foreign-key and join field specs are computed up front from metadata so deferring a
+    table never cascades into building its neighbours.
+    """
+    from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+    from products.data_tools.backend.models.join import DataWarehouseJoin
+
+    warehouse_tables = TableNode()
+    self_managed_warehouse_tables = TableNode()
+    views = TableNode()
+
+    with timings.measure("data_warehouse_saved_query", emit_span=True):
+        with timings.measure("select"):
+            saved_query_qs = (
+                DataWarehouseSavedQuery.objects.filter(team_id=team.pk)
+                .exclude(deleted=True)
+                .order_by("name")
+                .select_related("table", "table__credential", "managed_viewset")
+            )
+            if not is_managed_viewset_enabled:
+                saved_query_qs = saved_query_qs.filter(managed_viewset__isnull=True)
+            saved_queries = list(saved_query_qs)
+
+    with timings.measure("endpoint_saved_query", emit_span=True):
+        endpoint_saved_queries: list[Any] = []
+        try:
+            endpoint_saved_queries = list(
+                DataWarehouseSavedQuery.objects.filter(team_id=team.pk)
+                .filter(origin=DataWarehouseSavedQuery.Origin.ENDPOINT)
+                .exclude(deleted=True)
+                .select_related("table", "table__credential")
+            )
+        except Exception as e:
+            capture_exception(e)
+
+    with timings.measure("revenue_analytics_views", emit_span=True):
+        revenue_views: list[RevenueAnalyticsBaseView] = []
+        try:
+            if not is_managed_viewset_enabled:
+                revenue_views = list(build_all_revenue_analytics_views(team, timings))
+        except Exception as e:
+            capture_exception(e)
+
+    with timings.measure("data_warehouse_tables", emit_span=True):
+        with timings.measure("select"):
+            tables = list(
+                DataWarehouseTable.raw_objects.filter(team_id=team.pk)
+                .exclude(deleted=True)
+                .select_related("credential", "external_data_source")
+                .exclude(external_data_source__access_method=ExternalDataSource.AccessMethod.DIRECT)
+            )
+            _preload_active_external_data_schemas(tables)
+
+    with timings.measure("data_warehouse_joins", emit_span=True):
+        with timings.measure("select"):
+            joins = list(DataWarehouseJoin.objects.filter(team_id=team.pk).exclude(deleted=True))
+
+    # ---- metadata for foreign-key / join resolution (no hogql build) ----
+    external_tables: dict[str, DataWarehouseTable] = {}
+    schemas_by_name: dict[str, Sequence[ExternalDataSchema]] = {}
+    for table in tables:
+        if table.external_data_source:
+            name = get_data_warehouse_table_name(table.external_data_source, table.name)
+            external_tables[name] = table
+            schemas_by_name[name] = _get_active_external_data_schemas(table)
+
+    metas: dict[str, _LazyTableMeta] = {}
+    for name, table in external_tables.items():
+        metas[name] = _LazyTableMeta(name=name, columns=frozenset((table.columns or {}).keys()))
+    for table in tables:
+        if not table.external_data_source:
+            metas.setdefault(
+                table.name, _LazyTableMeta(name=table.name, columns=frozenset((table.columns or {}).keys()))
+            )
+    for saved_query in [*saved_queries, *endpoint_saved_queries]:
+        metas.setdefault(
+            saved_query.name,
+            _LazyTableMeta(name=saved_query.name, columns=frozenset((saved_query.columns or {}).keys())),
+        )
+    for view in revenue_views:
+        metas.setdefault(view.name, _LazyTableMeta(name=view.name, columns=frozenset(view.fields.keys())))
+
+    # Specs are populated below but referenced by the factories (which run later), so an empty dict is
+    # registered now and filled in before this function returns.
+    fk_specs: dict[str, dict[str, LazyJoin]] = {}
+    join_specs: dict[str, dict[str, LazyJoin]] = {}
+    now = datetime.now(UTC)
+
+    # ---- register stubs ----
+    for saved_query in saved_queries:
+        views.add_child(
+            TableNode.create_nested_for_chain(
+                saved_query.name.split("."),
+                table_factory=_make_view_factory(saved_query, modifiers, fk_specs, join_specs, saved_query.name),
+            ),
+            table_conflict_mode="ignore",
+        )
+    for saved_query in endpoint_saved_queries:
+        endpoint_node = TableNode(name=saved_query.name)
+        endpoint_node._table_factory = _make_view_factory(
+            saved_query, modifiers, fk_specs, join_specs, saved_query.name
+        )
+        views.add_child(endpoint_node, table_conflict_mode="ignore")
+    for view in revenue_views:
+        try:
+            views.add_child(TableNode.create_nested_for_chain(view.name.split("."), view))
+        except Exception as e:
+            capture_exception(e)
+            continue
+
+    for table in tables:
+        if table.external_data_source:
+            name = get_data_warehouse_table_name(table.external_data_source, table.name)
+            factory = _make_table_factory(table, modifiers, fk_specs, join_specs, name, database, now)
+            bare_node = TableNode(name=table.name)
+            bare_node._table_factory = factory
+            warehouse_tables.add_child(bare_node)
+            warehouse_tables.add_child(
+                TableNode.create_nested_for_chain(name.split("."), table_factory=factory),
+                table_conflict_mode="ignore",
+            )
+        else:
+            self_managed_node = TableNode(name=table.name)
+            self_managed_node._table_factory = _make_table_factory(
+                table, modifiers, fk_specs, join_specs, table.name, database, now
+            )
+            self_managed_warehouse_tables.add_child(self_managed_node)
+
+    database._add_warehouse_tables(warehouse_tables)
+    database._add_warehouse_self_managed_tables(self_managed_warehouse_tables)
+    database._add_views(views)
+
+    # ---- compute field specs (cheap: metadata only, no hogql build) ----
+    for name in external_tables:
+        _emit_fk_specs_for_table(metas[name], schemas_by_name.get(name, []), metas, fk_specs)
+
+    # Map any name a join might reference (bare or namespaced) to the canonical name the table's
+    # factory builds under, so warehouse-source joins emit a spec instead of materializing the table.
+    canonical_name: dict[str, str] = {}
+    for name, table in external_tables.items():
+        canonical_name[name] = name
+        canonical_name[table.name] = name
+    for table in tables:
+        if not table.external_data_source:
+            canonical_name.setdefault(table.name, table.name)
+    for saved_query in [*saved_queries, *endpoint_saved_queries]:
+        canonical_name.setdefault(saved_query.name, saved_query.name)
+    for view in revenue_views:
+        canonical_name.setdefault(view.name, view.name)
+
+    for join in joins:
+        if not database.has_table(join.source_table_name) or not database.has_table(join.joining_table_name):
+            continue
+        source_name = canonical_name.get(join.source_table_name)
+        if source_name is None:
+            # Built-in source (e.g. persons): apply eagerly; the joining table stays a name reference.
+            _apply_data_warehouse_join(database, team, join)
+            continue
+        from_field = get_join_field_chain(join.source_table_key)
+        to_field = get_join_field_chain(join.joining_table_key)
+        if from_field is None or to_field is None:
+            continue
+        join_configuration = join.configuration if isinstance(join.configuration, dict) else {}
+        join_function = (
+            join.join_function_for_experiments()
+            if join.joining_table_name == "events" and join_configuration.get("experiments_optimized")
+            else join.join_function()
+        )
+        join_specs.setdefault(source_name, {})[join.field_name] = LazyJoin(
+            from_field=from_field,
+            to_field=to_field,
+            join_table=join.joining_table_name,
+            join_function=join_function,
+        )
 
 
 def get_data_warehouse_table_name(source: ExternalDataSource | None, table_name: str):

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -552,8 +552,9 @@ class Database(BaseModel):
     def prune_to_table_names(self, allowed_table_names: set[str]) -> None:
         def prune_node(node: TableNode, chain: list[str]) -> bool:
             full_name = ".".join(chain)
-            keep_table = node.table is not None and (
-                full_name in allowed_table_names or (len(chain) > 0 and self._is_helper_function_table(node.table))
+            keep_table = node.has_table() and (
+                full_name in allowed_table_names
+                or (len(chain) > 0 and node.table is not None and self._is_helper_function_table(node.table))
             )
 
             pruned_children: dict[str, TableNode] = {}

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1858,52 +1858,54 @@ def _build_warehouse_lazy(
     now = datetime.now(UTC)
 
     # ---- register stubs ----
-    for saved_query in saved_queries:
-        views.add_child(
-            TableNode.create_nested_for_chain(
-                saved_query.name.split("."),
-                table_factory=_make_view_factory(saved_query, modifiers, fk_specs, join_specs, saved_query.name),
-            ),
-            table_conflict_mode="ignore",
-        )
-    for saved_query in endpoint_saved_queries:
-        endpoint_node = TableNode(name=saved_query.name)
-        endpoint_node._table_factory = _make_view_factory(
-            saved_query, modifiers, fk_specs, join_specs, saved_query.name
-        )
-        views.add_child(endpoint_node, table_conflict_mode="ignore")
-    for view in revenue_views:
-        try:
-            views.add_child(TableNode.create_nested_for_chain(view.name.split("."), view))
-        except Exception as e:
-            capture_exception(e)
-            continue
-
-    for table in tables:
-        if table.external_data_source:
-            name = get_data_warehouse_table_name(table.external_data_source, table.name)
-            factory = _make_table_factory(table, modifiers, fk_specs, join_specs, name, database, now)
-            bare_node = TableNode(name=table.name)
-            bare_node._table_factory = factory
-            warehouse_tables.add_child(bare_node)
-            warehouse_tables.add_child(
-                TableNode.create_nested_for_chain(name.split("."), table_factory=factory),
+    with timings.measure("register_stubs", emit_span=True):
+        for saved_query in saved_queries:
+            views.add_child(
+                TableNode.create_nested_for_chain(
+                    saved_query.name.split("."),
+                    table_factory=_make_view_factory(saved_query, modifiers, fk_specs, join_specs, saved_query.name),
+                ),
                 table_conflict_mode="ignore",
             )
-        else:
-            self_managed_node = TableNode(name=table.name)
-            self_managed_node._table_factory = _make_table_factory(
-                table, modifiers, fk_specs, join_specs, table.name, database, now
+        for saved_query in endpoint_saved_queries:
+            endpoint_node = TableNode(name=saved_query.name)
+            endpoint_node._table_factory = _make_view_factory(
+                saved_query, modifiers, fk_specs, join_specs, saved_query.name
             )
-            self_managed_warehouse_tables.add_child(self_managed_node)
+            views.add_child(endpoint_node, table_conflict_mode="ignore")
+        for view in revenue_views:
+            try:
+                views.add_child(TableNode.create_nested_for_chain(view.name.split("."), view))
+            except Exception as e:
+                capture_exception(e)
+                continue
 
-    database._add_warehouse_tables(warehouse_tables)
-    database._add_warehouse_self_managed_tables(self_managed_warehouse_tables)
-    database._add_views(views)
+        for table in tables:
+            if table.external_data_source:
+                name = get_data_warehouse_table_name(table.external_data_source, table.name)
+                factory = _make_table_factory(table, modifiers, fk_specs, join_specs, name, database, now)
+                bare_node = TableNode(name=table.name)
+                bare_node._table_factory = factory
+                warehouse_tables.add_child(bare_node)
+                warehouse_tables.add_child(
+                    TableNode.create_nested_for_chain(name.split("."), table_factory=factory),
+                    table_conflict_mode="ignore",
+                )
+            else:
+                self_managed_node = TableNode(name=table.name)
+                self_managed_node._table_factory = _make_table_factory(
+                    table, modifiers, fk_specs, join_specs, table.name, database, now
+                )
+                self_managed_warehouse_tables.add_child(self_managed_node)
+
+        database._add_warehouse_tables(warehouse_tables)
+        database._add_warehouse_self_managed_tables(self_managed_warehouse_tables)
+        database._add_views(views)
 
     # ---- compute field specs (cheap: metadata only, no hogql build) ----
-    for name in external_tables:
-        _emit_fk_specs_for_table(metas[name], schemas_by_name.get(name, []), metas, fk_specs)
+    with timings.measure("compute_specs", emit_span=True):
+        for name in external_tables:
+            _emit_fk_specs_for_table(metas[name], schemas_by_name.get(name, []), metas, fk_specs)
 
     # Map any name a join might reference (bare or namespaced) to the canonical name the table's
     # factory builds under, so warehouse-source joins emit a spec instead of materializing the table.

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -7,6 +7,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field as PydanticField,
+    PrivateAttr,
 )
 
 from posthog.hogql.base import Expr
@@ -238,12 +239,25 @@ class TableNode(BaseModel):
     # When True, the table is reachable by the resolver (so other tables can reference it
     # via subqueries) but is omitted from the SQL editor schema and autocomplete lists.
     hidden: bool = False
+    # Deferred builder: when set, the table is constructed lazily on first get(). Lets warehouse
+    # tables register by name without paying their (CPU-heavy) hogql_definition build until a query
+    # actually references them. Private so pydantic doesn't validate/serialize the closure.
+    _table_factory: Callable[[], FieldOrTable] | None = PrivateAttr(default=None)
+
+    def has_table(self) -> bool:
+        """True if this node yields a table — already built, or buildable via a deferred factory."""
+        return self.table is not None or self._table_factory is not None
 
     def get(self) -> FieldOrTable:
         """
         Evaluates and returns the table currently associated with this node.
-        Raises `ResolutionError` if the table is not set.
+        Builds it from the deferred factory on first access. Raises `ResolutionError` if neither
+        a table nor a factory is set.
         """
+        if self.table is None and self._table_factory is not None:
+            self.table = self._table_factory()
+            self._table_factory = None
+
         if self.table is None:
             raise ResolutionError(f"Table is not set at `{self.name}`")
 
@@ -253,7 +267,7 @@ class TableNode(BaseModel):
     # is a valid path to a child table - not just any path.
     def has_child(self, path: list[str]) -> bool:
         if len(path) == 0:
-            return self.table is not None
+            return self.has_table()
 
         first, *rest_of_path = path
         if first not in self.children:
@@ -300,12 +314,16 @@ class TableNode(BaseModel):
         table_conflict_mode: Literal["override", "ignore"] = "ignore",
         children_conflict_mode: Literal["override", "merge", "ignore"] = "merge",
     ):
-        if other.table is not None:
-            if self.table is None:  # Easy case, just set it
+        if other.has_table():
+            # Copy table and factory together so the "built table" / "deferred factory" invariant is
+            # preserved (exactly one of them is set on a well-formed node).
+            if not self.has_table():  # Easy case, just set it
                 self.table = other.table
+                self._table_factory = other._table_factory
             else:  # We have a conflict so check conflict mode to decide what to do here
                 if table_conflict_mode == "override":
                     self.table = other.table
+                    self._table_factory = other._table_factory
                 elif table_conflict_mode == "ignore":
                     pass
 
@@ -317,7 +335,7 @@ class TableNode(BaseModel):
     def resolve_all_table_names(self) -> list[str]:
         names: list[str] = []
 
-        if self.table is not None:
+        if self.has_table():
             names.append(self.name)
 
         for child in self.children.values():
@@ -341,7 +359,7 @@ class TableNode(BaseModel):
         """
         names: list[str] = []
 
-        if self.table is not None and not self.hidden:
+        if self.has_table() and not self.hidden:
             names.append(self.name)
 
         for child in self.children.values():
@@ -357,8 +375,14 @@ class TableNode(BaseModel):
         return names
 
     @staticmethod
-    def create_nested_for_chain(chain: list[str], table: Table) -> "TableNode":
+    def create_nested_for_chain(
+        chain: list[str],
+        table: Optional["Table"] = None,
+        *,
+        table_factory: Callable[[], "FieldOrTable"] | None = None,
+    ) -> "TableNode":
         assert len(chain) > 0
+        assert table is not None or table_factory is not None, "Provide either a table or a table_factory"
 
         # Create a deeply nested table node structure
         start: TableNode = TableNode(name=chain[0])
@@ -368,8 +392,11 @@ class TableNode(BaseModel):
             current.add_child(child)
             current = child
 
-        # Add the table at the end
-        current.table = table
+        # Add the table (or its deferred builder) at the end
+        if table is not None:
+            current.table = table
+        else:
+            current._table_factory = table_factory
 
         return start
 

--- a/posthog/hogql/database/postgres_utils.py
+++ b/posthog/hogql/database/postgres_utils.py
@@ -35,7 +35,7 @@ def add_postgres_foreign_key_lazy_joins(
     database: DatabaseTableLookup,
     schemas: Sequence[ExternalDataSchema],
 ) -> None:
-    foreign_keys = _get_foreign_keys_from_schemas(schemas)
+    foreign_keys = get_foreign_keys_from_schemas(schemas)
 
     for foreign_key in foreign_keys:
         _add_foreign_key_lazy_join(
@@ -87,7 +87,7 @@ def add_postgres_foreign_key_lazy_joins(
         )
 
 
-def _get_foreign_keys_from_schemas(schemas: Sequence[ExternalDataSchema]) -> list[WarehouseForeignKey]:
+def get_foreign_keys_from_schemas(schemas: Sequence[ExternalDataSchema]) -> list[WarehouseForeignKey]:
     schema_with_foreign_keys = next((schema for schema in schemas if _get_foreign_keys(schema)), None)
     return _get_foreign_keys(schema_with_foreign_keys) if schema_with_foreign_keys is not None else []
 
@@ -163,7 +163,7 @@ def _add_foreign_key_lazy_join(
         from_field=from_field,
         to_field=to_field,
         join_table=join_table,
-        join_function=_foreign_key_join_function(from_field, to_field),
+        join_function=foreign_key_join_function(from_field, to_field),
     )
 
     target_table_name = target_hogql_table.name if isinstance(target_hogql_table.name, str) else None
@@ -171,7 +171,7 @@ def _add_foreign_key_lazy_join(
     if target_table_name is None or source_table_name is None:
         return
 
-    reverse_field_name = _reverse_foreign_key_field_name(source_table_name, target_table_name)
+    reverse_field_name = reverse_foreign_key_field_name(source_table_name, target_table_name)
     if target_hogql_table.fields.get(reverse_field_name) is not None:
         return
 
@@ -179,7 +179,7 @@ def _add_foreign_key_lazy_join(
         from_field=to_field,
         to_field=from_field,
         join_table=hogql_table,
-        join_function=_foreign_key_join_function(to_field, from_field),
+        join_function=foreign_key_join_function(to_field, from_field),
     )
 
 
@@ -229,7 +229,7 @@ def _is_same_external_scope(
     return source_table_name.rsplit(".", 1)[0] == target_table_name.rsplit(".", 1)[0]
 
 
-def _foreign_key_join_function(
+def foreign_key_join_function(
     from_field: list[str | int], to_field: list[str | int]
 ) -> Callable[[LazyJoinToAdd, HogQLContext, ast.SelectQuery], ast.JoinExpr]:
     def _join_function(join_to_add: LazyJoinToAdd, context: HogQLContext, node: ast.SelectQuery):
@@ -265,7 +265,7 @@ def _foreign_key_join_function(
     return _join_function
 
 
-def _reverse_foreign_key_field_name(from_table: str, target_table: str) -> str:
+def reverse_foreign_key_field_name(from_table: str, target_table: str) -> str:
     from_base = from_table.split(".")[-1]
     target_base = target_table.split(".")[-1]
 
@@ -291,7 +291,7 @@ def _find_inferred_foreign_key(
 ) -> WarehouseForeignKey | None:
     source_table_name = hogql_table.name if isinstance(hogql_table.name, str) else None
 
-    for candidate in _candidate_target_tables(base_name=base_name, namespace=namespace):
+    for candidate in candidate_target_tables(base_name=base_name, namespace=namespace):
         if not database.has_table(candidate):
             continue
 
@@ -320,7 +320,7 @@ def _find_inferred_target_column(*, column: str, target_hogql_table: Table) -> s
     return None
 
 
-def _candidate_target_tables(*, base_name: str, namespace: list[str]) -> list[str]:
+def candidate_target_tables(*, base_name: str, namespace: list[str]) -> list[str]:
     local_candidates = [base_name, f"{base_name}s", f"posthog_{base_name}"]
     scoped_candidates = [".".join([*namespace, candidate]) for candidate in local_candidates] if namespace else []
     return scoped_candidates or local_candidates

--- a/posthog/hogql/database/test/test_database_lazy_warehouse.py
+++ b/posthog/hogql/database/test/test_database_lazy_warehouse.py
@@ -1,0 +1,154 @@
+from posthog.test.base import BaseTest
+
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
+from posthog.hogql.modifiers import create_default_modifiers_for_team
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_and_print_ast
+
+from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.data_tools.backend.models.join import DataWarehouseJoin
+from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.models.table import DataWarehouseTable
+
+
+def _cols(*names: str) -> dict[str, dict[str, str | bool]]:
+    hogql = {
+        "id": "IntegerDatabaseField",
+        "user_id": "IntegerDatabaseField",
+        "order_id": "IntegerDatabaseField",
+        "amount": "FloatDatabaseField",
+    }
+    clickhouse = {"IntegerDatabaseField": "Int64", "FloatDatabaseField": "Float64", "StringDatabaseField": "String"}
+    out: dict[str, dict[str, str | bool]] = {}
+    for name in names:
+        hogql_type = hogql.get(name, "StringDatabaseField")
+        out[name] = {"clickhouse": clickhouse[hogql_type], "hogql": hogql_type, "valid": True}
+    return out
+
+
+class TestLazyWarehouseEquivalence(BaseTest):
+    """Lazy and eager warehouse builds must produce identical resolved SQL and catalogs."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.credential = DataWarehouseCredential.objects.create(
+            team=self.team, access_key="key", access_secret="secret"
+        )
+        self.source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="src",
+            connection_id="conn",
+            source_type=ExternalDataSourceType.POSTGRES,
+            status="Completed",
+            access_method=ExternalDataSource.AccessMethod.WAREHOUSE,
+        )
+
+        def make_table(name: str, columns: dict, *, foreign_keys: list[dict] | None = None) -> DataWarehouseTable:
+            table = DataWarehouseTable.objects.create(
+                team=self.team,
+                name=name,
+                format=DataWarehouseTable.TableFormat.Parquet,
+                url_pattern=f"s3://bucket/{name}/*.parquet",
+                credential=self.credential,
+                external_data_source=self.source,
+                columns=columns,
+            )
+            ExternalDataSchema.objects.create(
+                team=self.team,
+                source=self.source,
+                name=name,
+                table=table,
+                should_sync=True,
+                sync_type_config={"schema_metadata": {"foreign_keys": foreign_keys}} if foreign_keys else {},
+            )
+            return table
+
+        make_table("users", _cols("id", "name", "email"))
+        make_table("orders", _cols("id", "user_id", "amount"))  # inferred FK orders.user -> users
+        make_table(
+            "line_items",
+            _cols("id", "order_id", "sku"),
+            foreign_keys=[{"column": "order_id", "target_table": "orders", "target_column": "id"}],  # explicit FK
+        )
+        # Self-managed table (no external source) to cover that branch.
+        DataWarehouseTable.objects.create(
+            team=self.team,
+            name="local_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            url_pattern="s3://bucket/local/*.parquet",
+            credential=self.credential,
+            columns=_cols("id", "label"),
+        )
+
+        DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name="postgres.orders",
+            source_table_key="user_id",
+            joining_table_name="postgres.users",
+            joining_table_key="id",
+            field_name="user_join",
+        )
+        DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name="persons",
+            source_table_key="id",
+            joining_table_name="postgres.orders",
+            joining_table_key="user_id",
+            field_name="orders_join",
+        )
+
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="my_view",
+            query={"query": "SELECT 1 AS x"},
+            columns=_cols("x"),
+        )
+
+    def _build(self, *, lazy: bool) -> Database:
+        return Database.create_for(team=self.team, lazy_warehouse_tables=lazy)
+
+    def _print(self, database: Database, sql: str) -> str:
+        context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            database=database,
+            modifiers=create_default_modifiers_for_team(self.team),
+        )
+        printed, _ = prepare_and_print_ast(parse_select(sql), context, dialect="clickhouse")
+        return printed
+
+    def _assert_same_sql(self, sql: str) -> None:
+        # Fresh databases per query so materialization state can't leak between assertions.
+        eager = self._print(self._build(lazy=False), sql)
+        lazy = self._print(self._build(lazy=True), sql)
+        self.assertEqual(eager, lazy, f"eager vs lazy SQL diverged for: {sql}")
+
+    def test_catalog_names_match(self) -> None:
+        eager = self._build(lazy=False)
+        lazy = self._build(lazy=True)
+        self.assertEqual(sorted(eager.get_warehouse_table_names()), sorted(lazy.get_warehouse_table_names()))
+        self.assertEqual(sorted(eager.get_view_names()), sorted(lazy.get_view_names()))
+        self.assertEqual(sorted(eager.get_all_table_names()), sorted(lazy.get_all_table_names()))
+
+    def test_select_star_matches(self) -> None:
+        for table in ["postgres.users", "postgres.orders", "postgres.line_items", "local_table", "my_view"]:
+            self._assert_same_sql(f"SELECT * FROM {table}")
+
+    def test_inferred_foreign_key_join_matches(self) -> None:
+        self._assert_same_sql("SELECT id, user.name, user.email FROM postgres.orders")
+
+    def test_explicit_foreign_key_join_matches(self) -> None:
+        self._assert_same_sql("SELECT id, order.amount FROM postgres.line_items")
+
+    def test_data_warehouse_join_matches(self) -> None:
+        self._assert_same_sql("SELECT id, user_join.email FROM postgres.orders")
+
+    def test_persons_source_join_matches(self) -> None:
+        self._assert_same_sql("SELECT orders_join.amount FROM persons")
+
+    def test_bare_table_name_matches(self) -> None:
+        self._assert_same_sql("SELECT id, amount FROM orders")

--- a/posthog/hogql/database/test/test_database_lazy_warehouse.py
+++ b/posthog/hogql/database/test/test_database_lazy_warehouse.py
@@ -134,6 +134,21 @@ class TestLazyWarehouseEquivalence(BaseTest):
         self.assertEqual(sorted(eager.get_view_names()), sorted(lazy.get_view_names()))
         self.assertEqual(sorted(eager.get_all_table_names()), sorted(lazy.get_all_table_names()))
 
+    def test_serialized_schema_matches(self) -> None:
+        # serialize() backs the SQL editor schema sidebar / autocomplete and force-materializes stubs.
+        eager_db, lazy_db = self._build(lazy=False), self._build(lazy=True)
+        eager_context = HogQLContext(team_id=self.team.pk, database=eager_db)
+        lazy_context = HogQLContext(team_id=self.team.pk, database=lazy_db)
+        eager_schema = eager_db.serialize(eager_context)
+        lazy_schema = lazy_db.serialize(lazy_context)
+        self.assertEqual(sorted(eager_schema.keys()), sorted(lazy_schema.keys()))
+        for name in eager_schema:
+            self.assertEqual(
+                sorted(eager_schema[name].fields),
+                sorted(lazy_schema[name].fields),
+                f"serialized fields diverged for {name}",
+            )
+
     def test_select_star_matches(self) -> None:
         for table in ["postgres.users", "postgres.orders", "postgres.line_items", "local_table", "my_view"]:
             self._assert_same_sql(f"SELECT * FROM {table}")

--- a/posthog/hogql/database/test/test_database_perf.py
+++ b/posthog/hogql/database/test/test_database_perf.py
@@ -1,0 +1,151 @@
+import os
+import statistics
+from collections.abc import Callable
+from time import perf_counter
+from typing import Any
+
+import unittest
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
+from posthog.hogql.modifiers import create_default_modifiers_for_team
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_and_print_ast
+
+from products.data_tools.backend.models.join import DataWarehouseJoin
+from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.models.table import DataWarehouseTable
+
+# Opt-in: this seeds hundreds/thousands of rows and is meant to be run by hand to compare
+# create_hogql_database performance before/after a change, not on every CI run.
+#   RUN_HOGQL_DB_PERF=1 hogli test posthog/hogql/database/test/test_database_perf.py -s
+RUN = os.environ.get("RUN_HOGQL_DB_PERF") == "1"
+
+_HOGQL_TO_CLICKHOUSE = {
+    "StringDatabaseField": "String",
+    "IntegerDatabaseField": "Int64",
+    "DateTimeDatabaseField": "DateTime64(3, 'UTC')",
+    "FloatDatabaseField": "Float64",
+    "BooleanDatabaseField": "Bool",
+}
+_HOGQL_TYPES = list(_HOGQL_TO_CLICKHOUSE.keys())
+
+
+def _make_columns(n_columns: int) -> dict[str, Any]:
+    # A few realistic named columns first (including *_id columns that exercise the inferred
+    # foreign-key path), then filler columns to reach the requested width.
+    named = ["id", "name", "created_at", "amount", "is_active", "customer_id", "order_id", "user_id"]
+    columns: dict[str, Any] = {}
+    for i in range(n_columns):
+        name = named[i] if i < len(named) else f"col_{i}"
+        is_id = name == "id" or name.endswith("_id")
+        hogql_type = "IntegerDatabaseField" if is_id else _HOGQL_TYPES[i % len(_HOGQL_TYPES)]
+        columns[name] = {"clickhouse": _HOGQL_TO_CLICKHOUSE[hogql_type], "hogql": hogql_type, "valid": True}
+    return columns
+
+
+def _time(fn: Callable[[], Any], *, iterations: int) -> tuple[float, float]:
+    samples = []
+    for _ in range(iterations):
+        start = perf_counter()
+        fn()
+        samples.append((perf_counter() - start) * 1000)
+    return min(samples), statistics.median(samples)
+
+
+@unittest.skipUnless(RUN, "perf benchmark; set RUN_HOGQL_DB_PERF=1 to run")
+class TestCreateHogQLDatabasePerf(BaseTest):
+    def _seed(self, *, n_tables: int, n_columns: int = 30, n_sources: int = 5, n_joins: int = 10) -> None:
+        credentials = [
+            DataWarehouseCredential.objects.create(team=self.team, access_key=f"key_{i}", access_secret=f"secret_{i}")
+            for i in range(n_sources)
+        ]
+        sources = [
+            ExternalDataSource.objects.create(
+                team=self.team,
+                source_id=f"src_{i}",
+                connection_id=f"conn_{i}",
+                source_type=ExternalDataSourceType.POSTGRES,
+                status="Completed",
+                access_method=ExternalDataSource.AccessMethod.WAREHOUSE,
+            )
+            for i in range(n_sources)
+        ]
+        columns = _make_columns(n_columns)
+        DataWarehouseTable.objects.bulk_create(
+            [
+                DataWarehouseTable(
+                    team=self.team,
+                    name=f"table_{i}",
+                    format=DataWarehouseTable.TableFormat.Parquet,
+                    url_pattern=f"s3://bucket/table_{i}/*.parquet",
+                    credential=credentials[i % n_sources],
+                    external_data_source=sources[i % n_sources],
+                    columns=columns,
+                )
+                for i in range(n_tables)
+            ]
+        )
+        tables = list(DataWarehouseTable.objects.filter(team=self.team).order_by("id"))
+        ExternalDataSchema.objects.bulk_create(
+            [
+                ExternalDataSchema(
+                    team=self.team, source_id=t.external_data_source_id, name=t.name, table=t, should_sync=True
+                )
+                for t in tables
+            ]
+        )
+        DataWarehouseJoin.objects.bulk_create(
+            [
+                DataWarehouseJoin(
+                    team=self.team,
+                    source_table_name=tables[i].name,
+                    source_table_key="id",
+                    joining_table_name=tables[i + 1].name,
+                    joining_table_key="id",
+                    field_name=f"joined_{i}",
+                )
+                for i in range(min(n_joins, n_tables - 1))
+            ]
+        )
+
+    def _resolve_one_table_query(self) -> int:
+        """Build the database, resolve a query touching a single table, return #tables built."""
+        original = DataWarehouseTable.hogql_definition
+        built = {"count": 0}
+
+        def counting(self, *args, **kwargs):
+            built["count"] += 1
+            return original(self, *args, **kwargs)
+
+        with patch.object(DataWarehouseTable, "hogql_definition", counting):
+            database = Database.create_for(team=self.team)
+            table_name = database.get_warehouse_table_names()[0]
+            context = HogQLContext(
+                team_id=self.team.pk,
+                enable_select_queries=True,
+                database=database,
+                modifiers=create_default_modifiers_for_team(self.team),
+            )
+            prepare_and_print_ast(parse_select(f"SELECT * FROM {table_name} LIMIT 100"), context, dialect="clickhouse")
+        return built["count"]
+
+    @parameterized.expand([(50,), (250,), (1000,)])
+    def test_benchmark(self, n_tables: int) -> None:
+        self._seed(n_tables=n_tables)
+
+        build_min, build_median = _time(lambda: Database.create_for(team=self.team), iterations=5)
+        resolve_min, resolve_median = _time(self._resolve_one_table_query, iterations=5)
+        tables_built = self._resolve_one_table_query()
+
+        print(f"\n=== create_hogql_database perf: {n_tables} warehouse tables ===")  # noqa: T201
+        print(f"  create_for only            min={build_min:8.1f}ms  median={build_median:8.1f}ms")  # noqa: T201
+        print(f"  create_for + resolve 1 tbl min={resolve_min:8.1f}ms  median={resolve_median:8.1f}ms")  # noqa: T201
+        print(f"  tables built to resolve 1  {tables_built} / {n_tables}")  # noqa: T201

--- a/posthog/hogql/database/test/test_database_perf.py
+++ b/posthog/hogql/database/test/test_database_perf.py
@@ -116,7 +116,7 @@ class TestCreateHogQLDatabasePerf(BaseTest):
             ]
         )
 
-    def _resolve_one_table_query(self) -> int:
+    def _resolve_one_table_query(self, *, lazy: bool) -> int:
         """Build the database, resolve a query touching a single table, return #tables built."""
         original = DataWarehouseTable.hogql_definition
         built = {"count": 0}
@@ -126,7 +126,7 @@ class TestCreateHogQLDatabasePerf(BaseTest):
             return original(self, *args, **kwargs)
 
         with patch.object(DataWarehouseTable, "hogql_definition", counting):
-            database = Database.create_for(team=self.team)
+            database = Database.create_for(team=self.team, lazy_warehouse_tables=lazy)
             table_name = database.get_warehouse_table_names()[0]
             context = HogQLContext(
                 team_id=self.team.pk,
@@ -141,11 +141,18 @@ class TestCreateHogQLDatabasePerf(BaseTest):
     def test_benchmark(self, n_tables: int) -> None:
         self._seed(n_tables=n_tables)
 
-        build_min, build_median = _time(lambda: Database.create_for(team=self.team), iterations=5)
-        resolve_min, resolve_median = _time(self._resolve_one_table_query, iterations=5)
-        tables_built = self._resolve_one_table_query()
-
         print(f"\n=== create_hogql_database perf: {n_tables} warehouse tables ===")  # noqa: T201
-        print(f"  create_for only            min={build_min:8.1f}ms  median={build_median:8.1f}ms")  # noqa: T201
-        print(f"  create_for + resolve 1 tbl min={resolve_min:8.1f}ms  median={resolve_median:8.1f}ms")  # noqa: T201
-        print(f"  tables built to resolve 1  {tables_built} / {n_tables}")  # noqa: T201
+        for lazy in (False, True):
+            label = "lazy " if lazy else "eager"
+            build_min, build_median = _time(
+                lambda lazy=lazy: Database.create_for(team=self.team, lazy_warehouse_tables=lazy), iterations=5
+            )
+            resolve_min, resolve_median = _time(
+                lambda lazy=lazy: self._resolve_one_table_query(lazy=lazy), iterations=5
+            )
+            tables_built = self._resolve_one_table_query(lazy=lazy)
+            print(f"  [{label}] create_for only            min={build_min:8.1f}ms  median={build_median:8.1f}ms")  # noqa: T201
+            print(  # noqa: T201
+                f"  [{label}] create_for + resolve 1 tbl min={resolve_min:8.1f}ms  median={resolve_median:8.1f}ms"
+            )
+            print(f"  [{label}] tables built to resolve 1  {tables_built} / {n_tables}")  # noqa: T201

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_funnel_metric.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_funnel_metric.ambr
@@ -65,69 +65,6 @@
                        use_hive_partitioning=0
   '''
 # ---
-# name: TestExperimentFunnelMetric.test_funnel_metric_duplicate_events_1_precomputed
-  '''
-  WITH exposures AS
-    (SELECT accurateCastOrNull(t.entity_id, 'UUID') AS entity_id,
-            if(ifNull(greater(uniqExact(t.variant), 1), 0), '$multiple', argMin(t.variant, toTimeZone(t.first_exposure_time, 'UTC'))) AS variant,
-            min(toTimeZone(t.first_exposure_time, 'UTC')) AS first_exposure_time,
-            max(toTimeZone(t.last_exposure_time, 'UTC')) AS last_exposure_time,
-            argMin(t.exposure_event_uuid, toTimeZone(t.first_exposure_time, 'UTC')) AS exposure_event_uuid,
-            argMin(t.exposure_session_id, toTimeZone(t.first_exposure_time, 'UTC')) AS exposure_session_id
-     FROM experiment_exposures_preaggregated AS t
-     WHERE and(equals(t.team_id, 99999), in(t.job_id, ['00000000-0000-0000-0000-000000000000']), equals(t.team_id, 99999), greaterOrEquals(t.first_exposure_time, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(t.first_exposure_time, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))))
-     GROUP BY entity_id),
-       metric_events AS
-    (SELECT accurateCastOrNull(t.entity_id, 'UUID') AS entity_id,
-            toTimeZone(t.timestamp, 'UTC') AS timestamp,
-            t.event_uuid AS uuid,
-            t.session_id AS session_id,
-            arrayElement(t.steps, 1) AS step_0,
-            arrayElement(t.steps, 2) AS step_1,
-            arrayElement(t.steps, 3) AS step_2
-     FROM experiment_metric_events_preaggregated AS t
-     WHERE and(equals(t.team_id, 99999), in(t.job_id, ['00000000-0000-0000-0000-000000000000']), equals(t.team_id, 99999), greaterOrEquals(t.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(t.timestamp, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))))),
-       entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
-            arraySort(x -> minus(0, x.1), arrayMap(result -> tuple(result.1, if(and(ifNull(greaterOrEquals(result.1, 0), 0), ifNull(greater(length(result.4), result.1), 0)), if(ifNull(greater(length(arrayElement(result.4, plus(result.1, 1))), 0), 0), toString(arrayElement(result.4, plus(result.1, 1))[1]), ''), '')), aggregate_funnel_array(3, 94608000, 'first_touch', 'ordered', array(array('')), [], arraySort(t -> t.1, arrayFilter(t -> and(isNotNull(t.1), isNotNull(t.2)), groupArray(tuple(accurateCastOrNull(toTimeZone(metric_events.timestamp, 'UTC'), 'Float64'), metric_events.uuid, array(''), arrayFilter(x -> ifNull(greater(x, 0), 0), [multiply(1, metric_events.step_0), multiply(2, metric_events.step_1), multiply(3, metric_events.step_2)]))))))))[1] AS value,
-            exposures.exposure_event_uuid AS exposure_event_uuid,
-            exposures.exposure_session_id AS exposure_session_id,
-            exposures.first_exposure_time AS exposure_timestamp,
-            mapFromArrays(groupArray(coalesce(toString(metric_events.uuid), '')), groupArray(coalesce(toString(metric_events.session_id), ''))) AS uuid_to_session,
-            mapFromArrays(groupArray(coalesce(toString(metric_events.uuid), '')), groupArray(coalesce(toTimeZone(metric_events.timestamp, 'UTC'), toDateTime(0, 'UTC')))) AS uuid_to_timestamp
-     FROM exposures
-     LEFT JOIN metric_events ON equals(exposures.entity_id, metric_events.entity_id)
-     GROUP BY exposures.entity_id,
-              exposures.variant,
-              exposures.exposure_event_uuid,
-              exposures.exposure_session_id,
-              exposures.first_exposure_time)
-  SELECT entity_metrics.variant AS variant,
-         count(entity_metrics.entity_id) AS num_users,
-         countIf(ifNull(equals((entity_metrics.value).1, 2), 0)) AS total_sum,
-         countIf(ifNull(equals((entity_metrics.value).1, 2), 0)) AS total_sum_of_squares,
-         tuple(countIf(ifNull(greaterOrEquals((entity_metrics.value).1, 1), 0)), countIf(ifNull(greaterOrEquals((entity_metrics.value).1, 2), 0))) AS step_counts,
-         tuple(groupArraySampleIf(100)(if(ifNull(notEquals((entity_metrics.value).2, ''), 1), tuple(toString(entity_metrics.entity_id), entity_metrics.uuid_to_session[(entity_metrics.value).2], (entity_metrics.value).2, toString(entity_metrics.uuid_to_timestamp[(entity_metrics.value).2])), tuple(toString(entity_metrics.entity_id), toString(entity_metrics.exposure_session_id), toString(entity_metrics.exposure_event_uuid), toString(entity_metrics.exposure_timestamp))), ifNull(equals((entity_metrics.value).1, minus(1, 1)), isNull((entity_metrics.value).1)
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               and isNull(minus(1, 1)))), groupArraySampleIf(100)(if(ifNull(notEquals((entity_metrics.value).2, ''), 1), tuple(toString(entity_metrics.entity_id), entity_metrics.uuid_to_session[(entity_metrics.value).2], (entity_metrics.value).2, toString(entity_metrics.uuid_to_timestamp[(entity_metrics.value).2])), tuple(toString(entity_metrics.entity_id), toString(entity_metrics.exposure_session_id), toString(entity_metrics.exposure_event_uuid), toString(entity_metrics.exposure_timestamp))), ifNull(equals((entity_metrics.value).1, minus(2, 1)), isNull((entity_metrics.value).1)
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(minus(2, 1)))), groupArraySampleIf(100)(if(ifNull(notEquals((entity_metrics.value).2, ''), 1), tuple(toString(entity_metrics.entity_id), entity_metrics.uuid_to_session[(entity_metrics.value).2], (entity_metrics.value).2, toString(entity_metrics.uuid_to_timestamp[(entity_metrics.value).2])), tuple(toString(entity_metrics.entity_id), toString(entity_metrics.exposure_session_id), toString(entity_metrics.exposure_event_uuid), toString(entity_metrics.exposure_timestamp))), ifNull(equals((entity_metrics.value).1, minus(3, 1)), isNull((entity_metrics.value).1)
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     and isNull(minus(3, 1))))) AS steps_event_data
-  FROM entity_metrics
-  WHERE notEmpty(variant)
-  GROUP BY entity_metrics.variant
-  LIMIT 50000 SETTINGS load_balancing='in_order',
-                       readonly=2,
-                       max_execution_time=600,
-                       allow_experimental_object_type=1,
-                       max_ast_elements=4000000,
-                       max_expanded_ast_elements=4000000,
-                       max_bytes_before_external_group_by=39728447488,
-                       transform_null_in=1,
-                       optimize_min_equality_disjunction_chain_length=4294967295,
-                       allow_experimental_join_condition=1,
-                       use_hive_partitioning=0
-  '''
-# ---
 # name: TestExperimentFunnelMetric.test_funnel_metric_events_after_exposure_0_ordered
   '''
   WITH base_events AS

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_funnel_metric.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_funnel_metric.ambr
@@ -65,6 +65,69 @@
                        use_hive_partitioning=0
   '''
 # ---
+# name: TestExperimentFunnelMetric.test_funnel_metric_duplicate_events_1_precomputed
+  '''
+  WITH exposures AS
+    (SELECT accurateCastOrNull(t.entity_id, 'UUID') AS entity_id,
+            if(ifNull(greater(uniqExact(t.variant), 1), 0), '$multiple', argMin(t.variant, toTimeZone(t.first_exposure_time, 'UTC'))) AS variant,
+            min(toTimeZone(t.first_exposure_time, 'UTC')) AS first_exposure_time,
+            max(toTimeZone(t.last_exposure_time, 'UTC')) AS last_exposure_time,
+            argMin(t.exposure_event_uuid, toTimeZone(t.first_exposure_time, 'UTC')) AS exposure_event_uuid,
+            argMin(t.exposure_session_id, toTimeZone(t.first_exposure_time, 'UTC')) AS exposure_session_id
+     FROM experiment_exposures_preaggregated AS t
+     WHERE and(equals(t.team_id, 99999), in(t.job_id, ['00000000-0000-0000-0000-000000000000']), equals(t.team_id, 99999), greaterOrEquals(t.first_exposure_time, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(t.first_exposure_time, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))))
+     GROUP BY entity_id),
+       metric_events AS
+    (SELECT accurateCastOrNull(t.entity_id, 'UUID') AS entity_id,
+            toTimeZone(t.timestamp, 'UTC') AS timestamp,
+            t.event_uuid AS uuid,
+            t.session_id AS session_id,
+            arrayElement(t.steps, 1) AS step_0,
+            arrayElement(t.steps, 2) AS step_1,
+            arrayElement(t.steps, 3) AS step_2
+     FROM experiment_metric_events_preaggregated AS t
+     WHERE and(equals(t.team_id, 99999), in(t.job_id, ['00000000-0000-0000-0000-000000000000']), equals(t.team_id, 99999), greaterOrEquals(t.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(t.timestamp, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))))),
+       entity_metrics AS
+    (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
+            arraySort(x -> minus(0, x.1), arrayMap(result -> tuple(result.1, if(and(ifNull(greaterOrEquals(result.1, 0), 0), ifNull(greater(length(result.4), result.1), 0)), if(ifNull(greater(length(arrayElement(result.4, plus(result.1, 1))), 0), 0), toString(arrayElement(result.4, plus(result.1, 1))[1]), ''), '')), aggregate_funnel_array(3, 94608000, 'first_touch', 'ordered', array(array('')), [], arraySort(t -> t.1, arrayFilter(t -> and(isNotNull(t.1), isNotNull(t.2)), groupArray(tuple(accurateCastOrNull(toTimeZone(metric_events.timestamp, 'UTC'), 'Float64'), metric_events.uuid, array(''), arrayFilter(x -> ifNull(greater(x, 0), 0), [multiply(1, metric_events.step_0), multiply(2, metric_events.step_1), multiply(3, metric_events.step_2)]))))))))[1] AS value,
+            exposures.exposure_event_uuid AS exposure_event_uuid,
+            exposures.exposure_session_id AS exposure_session_id,
+            exposures.first_exposure_time AS exposure_timestamp,
+            mapFromArrays(groupArray(coalesce(toString(metric_events.uuid), '')), groupArray(coalesce(toString(metric_events.session_id), ''))) AS uuid_to_session,
+            mapFromArrays(groupArray(coalesce(toString(metric_events.uuid), '')), groupArray(coalesce(toTimeZone(metric_events.timestamp, 'UTC'), toDateTime(0, 'UTC')))) AS uuid_to_timestamp
+     FROM exposures
+     LEFT JOIN metric_events ON equals(exposures.entity_id, metric_events.entity_id)
+     GROUP BY exposures.entity_id,
+              exposures.variant,
+              exposures.exposure_event_uuid,
+              exposures.exposure_session_id,
+              exposures.first_exposure_time)
+  SELECT entity_metrics.variant AS variant,
+         count(entity_metrics.entity_id) AS num_users,
+         countIf(ifNull(equals((entity_metrics.value).1, 2), 0)) AS total_sum,
+         countIf(ifNull(equals((entity_metrics.value).1, 2), 0)) AS total_sum_of_squares,
+         tuple(countIf(ifNull(greaterOrEquals((entity_metrics.value).1, 1), 0)), countIf(ifNull(greaterOrEquals((entity_metrics.value).1, 2), 0))) AS step_counts,
+         tuple(groupArraySampleIf(100)(if(ifNull(notEquals((entity_metrics.value).2, ''), 1), tuple(toString(entity_metrics.entity_id), entity_metrics.uuid_to_session[(entity_metrics.value).2], (entity_metrics.value).2, toString(entity_metrics.uuid_to_timestamp[(entity_metrics.value).2])), tuple(toString(entity_metrics.entity_id), toString(entity_metrics.exposure_session_id), toString(entity_metrics.exposure_event_uuid), toString(entity_metrics.exposure_timestamp))), ifNull(equals((entity_metrics.value).1, minus(1, 1)), isNull((entity_metrics.value).1)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               and isNull(minus(1, 1)))), groupArraySampleIf(100)(if(ifNull(notEquals((entity_metrics.value).2, ''), 1), tuple(toString(entity_metrics.entity_id), entity_metrics.uuid_to_session[(entity_metrics.value).2], (entity_metrics.value).2, toString(entity_metrics.uuid_to_timestamp[(entity_metrics.value).2])), tuple(toString(entity_metrics.entity_id), toString(entity_metrics.exposure_session_id), toString(entity_metrics.exposure_event_uuid), toString(entity_metrics.exposure_timestamp))), ifNull(equals((entity_metrics.value).1, minus(2, 1)), isNull((entity_metrics.value).1)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(minus(2, 1)))), groupArraySampleIf(100)(if(ifNull(notEquals((entity_metrics.value).2, ''), 1), tuple(toString(entity_metrics.entity_id), entity_metrics.uuid_to_session[(entity_metrics.value).2], (entity_metrics.value).2, toString(entity_metrics.uuid_to_timestamp[(entity_metrics.value).2])), tuple(toString(entity_metrics.entity_id), toString(entity_metrics.exposure_session_id), toString(entity_metrics.exposure_event_uuid), toString(entity_metrics.exposure_timestamp))), ifNull(equals((entity_metrics.value).1, minus(3, 1)), isNull((entity_metrics.value).1)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     and isNull(minus(3, 1))))) AS steps_event_data
+  FROM entity_metrics
+  WHERE notEmpty(variant)
+  GROUP BY entity_metrics.variant
+  LIMIT 50000 SETTINGS load_balancing='in_order',
+                       readonly=2,
+                       max_execution_time=600,
+                       allow_experimental_object_type=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=39728447488,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1,
+                       use_hive_partitioning=0
+  '''
+# ---
 # name: TestExperimentFunnelMetric.test_funnel_metric_events_after_exposure_0_ordered
   '''
   WITH base_events AS


### PR DESCRIPTION
## Problem

`Database.create_for` (`create_hogql_database`) builds a HogQL definition for **every** data-warehouse table on the team, on every query — even though a typical query references one or two of them. For warehouse-heavy teams this dominates query latency: tracing one such team showed `create_hogql_database` at ~1.4s, of which the `data_warehouse_tables` block was ~84% and almost entirely Python (`hogql_definition` per table), not SQL.

The blocker to deferring that work is the foreign-key wiring: it resolves FK targets via `get_table()` and writes reverse-join fields onto target tables, so naively deferring a table's build would cascade into building its neighbours.

## Changes

Behind the `hogql-lazy-warehouse-tables` feature flag (off by default), warehouse tables and saved-query/endpoint views are registered as **deferred stubs** and built only when a query actually references them.

- `TableNode` gains an optional `_table_factory`; `get()` builds and caches on first access, and `has_table()` reports a stub as present so name resolution, pruning, and merging treat it like a built table.
- **Every Postgres fetch stays eager and bulk** — there is no new N+1. Only the per-table CPU work (`hogql_definition`, properties virtual table, sync warnings) is deferred.
- Foreign-key and `DataWarehouseJoin` wiring is computed up front from **metadata** (column names, schema FK metadata, name existence) into per-table field specs that each factory applies on build. Forward joins and join endpoints are stored as name references (resolved lazily), and reverse joins are attached to the target's own spec — so deferring a table never cascades into building another.
- The eager path is untouched: the lazy build is an early-return branch. Direct-connection queries and `dataWarehouseEventsModifiers` queries keep using the eager path.
- Four helper functions in `postgres_utils` were made public (pure rename) so the FK logic has a single source of truth shared by both paths.

This is intentionally scoped as a gated, dual-path change so it can be rolled out and A/B'd per team, with the eager path as a zero-risk fallback. Revenue-analytics views remain eagerly built for now (bulk-constructed; usually empty).

## How did you test this code?

I'm an agent (Claude Code). Automated only — I did not perform manual testing.

- **Differential equivalence test** (`test_database_lazy_warehouse.py`, runs in CI): seeds an FK-rich schema (inferred + explicit foreign keys, warehouse-source and persons-source joins, a self-managed table, a view) and asserts lazy and eager produce **identical resolved ClickHouse SQL** for `SELECT *`, FK traversals, joins, bare names, and views, plus identical warehouse/view/all-table catalogs and identical serialized schema (the SQL-editor surface). 8 passed.
- **Eager-path regression**: `test_database.py` 82 passed, `test_s3_table.py` + `test_view.py` 25 passed, `ty` clean.
- **Benchmark** (`test_database_perf.py`, opt-in via `RUN_HOGQL_DB_PERF=1`): resolving a single-table query builds **1 table instead of N** (e.g. 1/1000 vs 1000/1000). The wall-clock gain scales with per-table column count / `hogql_definition` cost.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact (internal performance change, flag-gated).

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) following an APM investigation that found warehouse-heavy teams spend most of `create_hogql_database` building tables a query never touches.

Key decisions:
- **Dual-path, flag-gated** rather than replacing the eager path, so the default stays byte-identical and rollout is reversible. A differential test pins lazy ≡ eager.
- **Eager bulk fetch, lazy CPU build** — the reviewer-relevant invariant is that nothing inside a deferred factory hits the database; all Django rows (with `select_related` credentials/sources and preloaded schemas) are fetched up front and captured by the factory.
- **FK/join specs computed from metadata up front** to break the materialization cascade that would otherwise defeat laziness. Considered running the existing FK code per-factory but rejected it because resolving/mutating targets there rebuilds the graph.
- Bare and namespaced names for an external table share one memoized factory so both resolve to the same built object (matching eager).

Follow-ups left out of scope: making revenue-analytics views lazy, and extending laziness to direct-connection queries.
