### PR TITLE
fix(mcp): include sql guidelines

### DIFF
--- a/services/mcp/scripts/build-hono.ts
+++ b/services/mcp/scripts/build-hono.ts
@@ -1,6 +1,10 @@
 import { build } from 'esbuild'
 
+import { copyInstructions } from './copy-instructions'
 import { honoEsbuildOptions, honoOutfile } from './hono-esbuild-config'
+
+// Populate `shared/guidelines.md` so esbuild can inline it via `@shared/*`.
+copyInstructions()
 
 build(honoEsbuildOptions())
     .then(() => {

--- a/services/mcp/scripts/copy-instructions.ts
+++ b/services/mcp/scripts/copy-instructions.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env tsx
 /**
- * Copies shared prompt files.
+ * Copies shared prompt files into `shared/` (gitignored) so esbuild can inline
+ * them via the `@shared/*` tsconfig alias at bundle time. Called from
+ * build-hono.ts / dev-hono.ts before bundling, and standalone in CI.
  */
 import { cpSync, mkdirSync } from 'fs'
 import { dirname, resolve } from 'path'
@@ -15,10 +17,17 @@ const PROMPTS = [
     },
 ]
 
-for (const prompt of PROMPTS) {
-    const src = resolve(REPO_ROOT, prompt.src)
-    const dest = resolve(ROOT_DIR, prompt.dest)
-    mkdirSync(dirname(dest), { recursive: true })
-    // `force: true` so watch-mode rebuilds don't EEXIST when the dest already exists.
-    cpSync(src, dest, { recursive: true, force: true })
+export function copyInstructions(): void {
+    for (const prompt of PROMPTS) {
+        const src = resolve(REPO_ROOT, prompt.src)
+        const dest = resolve(ROOT_DIR, prompt.dest)
+        mkdirSync(dirname(dest), { recursive: true })
+        // `force: true` so watch-mode rebuilds don't EEXIST when the dest already exists.
+        cpSync(src, dest, { recursive: true, force: true })
+    }
+}
+
+// Standalone execution: `tsx scripts/copy-instructions.ts` (used in CI).
+if (require.main === module) {
+    copyInstructions()
 }

--- a/services/mcp/scripts/dev-hono.ts
+++ b/services/mcp/scripts/dev-hono.ts
@@ -6,7 +6,11 @@ import { context, type Plugin } from 'esbuild'
 import { existsSync } from 'fs'
 import { resolve } from 'path'
 
+import { copyInstructions } from './copy-instructions'
 import { honoEsbuildOptions, honoOutfile } from './hono-esbuild-config'
+
+// Populate `shared/guidelines.md` so esbuild can inline it via `@shared/*`.
+copyInstructions()
 
 if (existsSync(resolve(process.cwd(), '.env'))) {
     process.loadEnvFile(resolve(process.cwd(), '.env'))

--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -17,6 +17,7 @@ import type {
     PingRequest,
     ReadResourceRequest,
 } from '@modelcontextprotocol/sdk/types.js'
+import GUIDELINES from '@shared/guidelines.md'
 import { randomUUID } from 'node:crypto'
 
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
@@ -34,24 +35,6 @@ import { ToolExecutor } from './tool-executor'
 
 export { McpDispatcher }
 export type { ResolvedState } from './request-state-resolver'
-
-function loadGuidelines(): string {
-    try {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const mod = require('@shared/guidelines.md')
-        return typeof mod === 'string' ? mod : (mod?.default ?? '')
-    } catch {
-        // @shared alias only resolves in the esbuild production bundle.
-        // Fall back to reading from disk (works in Vitest/test contexts).
-    }
-    try {
-        const fs = require('node:fs')
-        const path = require('node:path')
-        return fs.readFileSync(path.resolve(process.cwd(), 'shared/guidelines.md'), 'utf-8')
-    } catch {
-        return ''
-    }
-}
 
 const MAX_BATCH_SIZE = 100
 const MAX_BODY_BYTES = 1_048_576
@@ -115,7 +98,7 @@ class McpDispatcher {
         this.catalog = catalog
         this.resourceCatalog = new ResourceCatalog(env, redis)
         this.stateResolver = new RequestStateResolver(catalog, redis, env)
-        this.instructionsBuilder = new InstructionsBuilder(loadGuidelines())
+        this.instructionsBuilder = new InstructionsBuilder(GUIDELINES)
         this.toolExecutor = new ToolExecutor(catalog, this.instructionsBuilder)
     }
 


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Hono MCP didn't include SQL guidelines in the execute-sql tool.

## Changes

- Fixed the build scripts.

## How did you test this code?

Manual testing

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
