### PR TITLE
chore(cli): refresh stable installer release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -497,16 +497,36 @@ jobs:
                   # Remove the granular manifests
                   rm -f artifacts/*-dist-manifest.json
             - name: Create GitHub Release
+              shell: bash
               env:
                   PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
                   ANNOUNCEMENT_TITLE: '${{ fromJson(steps.host.outputs.manifest).announcement_title }}'
                   ANNOUNCEMENT_BODY: '${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}'
                   RELEASE_COMMIT: '${{ needs.release.outputs.release-commit }}'
+                  LATEST_RELEASE_TAG: posthog-cli-latest
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
                   # Write and read notes from a file to avoid quoting breaking things
-                  echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
-                  gh release create "${{ needs.plan-release.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+                  echo "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
+                  release_args=()
+                  if [ -n "$PRERELEASE_FLAG" ]; then
+                      release_args+=("$PRERELEASE_FLAG")
+                  fi
+
+                  gh release create "${{ needs.plan-release.outputs.tag }}" --target "$RELEASE_COMMIT" "${release_args[@]}" --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+
+                  if [ -z "$PRERELEASE_FLAG" ]; then
+                      gh release delete "$LATEST_RELEASE_TAG" --yes || true
+                      git push origin ":refs/tags/$LATEST_RELEASE_TAG" || true
+                      gh release create "$LATEST_RELEASE_TAG" \
+                          --target "$RELEASE_COMMIT" \
+                          --title "posthog-cli latest" \
+                          --notes "Same as ${{ needs.plan-release.outputs.tag }}" \
+                          --latest=false \
+                          artifacts/*
+                  else
+                      echo "Skipping $LATEST_RELEASE_TAG update for prerelease ${{ needs.plan-release.outputs.tag }}"
+                  fi
 
     publish-npm:
         needs:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -516,14 +516,26 @@ jobs:
                   gh release create "${{ needs.plan-release.outputs.tag }}" --target "$RELEASE_COMMIT" "${release_args[@]}" --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
                   if [ -z "$PRERELEASE_FLAG" ]; then
-                      gh release delete "$LATEST_RELEASE_TAG" --yes || true
-                      git push origin ":refs/tags/$LATEST_RELEASE_TAG" || true
-                      gh release create "$LATEST_RELEASE_TAG" \
+                      STAGED_RELEASE_TAG="$LATEST_RELEASE_TAG-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+                      gh release delete "$STAGED_RELEASE_TAG" --yes --cleanup-tag || true
+                      gh release create "$STAGED_RELEASE_TAG" \
+                          --target "$RELEASE_COMMIT" \
+                          --title "posthog-cli latest (staged)" \
+                          --notes "Staged replacement for $LATEST_RELEASE_TAG; same as ${{ needs.plan-release.outputs.tag }}" \
+                          --latest=false \
+                          artifacts/*
+
+                      gh release view "$STAGED_RELEASE_TAG" --json assets --jq '.assets[].name' | grep -qx 'posthog-cli-installer.sh'
+
+                      gh release delete "$LATEST_RELEASE_TAG" --yes --cleanup-tag || true
+                      gh release edit "$STAGED_RELEASE_TAG" \
+                          --tag "$LATEST_RELEASE_TAG" \
                           --target "$RELEASE_COMMIT" \
                           --title "posthog-cli latest" \
                           --notes "Same as ${{ needs.plan-release.outputs.tag }}" \
-                          --latest=false \
-                          artifacts/*
+                          --latest=false
+                      git push origin ":refs/tags/$STAGED_RELEASE_TAG" || true
                   else
                       echo "Skipping $LATEST_RELEASE_TAG update for prerelease ${{ needs.plan-release.outputs.tag }}"
                   fi

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -20,7 +20,7 @@ After the pull request merges to `master`, the `Release CLI` workflow:
 4. Updates `cli/Cargo.toml`, `cli/Cargo.lock`, and `cli/CHANGELOG.md`
 5. Commits the release bump to `master`
 6. Runs cargo-dist against the release bump commit
-7. Creates the `posthog-cli/vX.Y.Z` GitHub release and publishes the npm package
+7. Creates the `posthog-cli/vX.Y.Z` GitHub release, refreshes `posthog-cli-latest` for stable releases, and publishes the npm package
 
 Do not run `sampo publish`; cargo-dist owns publishing for `posthog-cli`.
 

--- a/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsStep.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsStep.tsx
@@ -68,7 +68,7 @@ export const OnboardingErrorTrackingSourceMapsStep: OnboardingStepComponentType 
                             </p>
                             <CodeSnippet language={Language.Bash}>
                                 {[
-                                    "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/PostHog/posthog/releases/download/posthog-cli-v0.0.2/posthog-cli-installer.sh | sh",
+                                    "curl --proto '=https' --tlsv1.2 -LsSf https://download.posthog.com/cli | sh",
                                     'posthog-cli-update',
                                 ].join('\n')}
                             </CodeSnippet>

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/IOSSourceMapsInstructions.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/IOSSourceMapsInstructions.tsx
@@ -19,7 +19,7 @@ export function IOSSourceMapsInstructions(): JSX.Element {
             <h4 className="text-sm font-semibold mt-4 mb-2">curl:</h4>
             <CodeSnippet language={Language.Bash}>
                 {[
-                    "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/PostHog/posthog/releases/latest/download/posthog-cli-installer.sh | sh",
+                    "curl --proto '=https' --tlsv1.2 -LsSf https://download.posthog.com/cli | sh",
                     'posthog-cli-update',
                 ].join('\n')}
             </CodeSnippet>


### PR DESCRIPTION
## Problem

The CLI installer redirect currently depends on GitHub's repository-wide latest-release behavior, which is not scoped to CLI releases. That makes the installer URL fragile as other releases are published.

## Changes

- Refresh a stable `posthog-cli-latest` GitHub release from the CLI release workflow after the versioned release is created.
- Skip refreshing `posthog-cli-latest` for prereleases.
- Point source-map onboarding install snippets at `https://download.posthog.com/cli` instead of direct GitHub release URLs.
- Update CLI contributing docs to mention the stable alias refresh.

This does not run the release workflow. Any external redirect that should consume the new alias still needs to be updated separately after the alias exists.

## How did you test this code?

Agent-run checks:

- `pnpm exec oxfmt --check .github/workflows/release-cli.yml frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/IOSSourceMapsInstructions.tsx frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsStep.tsx`
- `git diff --check`
- `pnpm --filter=@posthog/frontend typegen:write`
- `pnpm --filter '@posthog/quill...' build`
- `pnpm --filter @posthog/hogvm build`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter=@posthog/frontend typescript:check`
- Manual workflow-script checks: Bash syntax for the changed block and `gh release` flag availability.

`actionlint .github/workflows/release-cli.yml` still reports pre-existing ShellCheck warnings outside the changed block.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update beyond the CLI contributing note in this PR.

## 🤖 Agent context

Authored with Codex. The implementation keeps the workflow change inside the existing `host-release` job so it can reuse the releaser app token and the already-downloaded release artifacts.

The chosen shape creates a separate stable alias release instead of relying on GitHub's automatic latest-release selection. Prereleases are intentionally excluded so they do not move the stable installer target.
