### PR TITLE
chore: add CLI soft code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,6 +40,9 @@ CODEOWNERS @PostHog/team-security
 .github/workflows/pr-approval-agent.yml @PostHog/team-security
 tools/pr-approval-agent/** @PostHog/team-security
 
+# Error Tracking team owns the PostHog CLI upload flows
+cli/** @PostHog/team-error-tracking
+
 # Ingestion team owns persons migrations
 rust/persons_migrations/** @PostHog/team-ingestion
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,9 +40,6 @@ CODEOWNERS @PostHog/team-security
 .github/workflows/pr-approval-agent.yml @PostHog/team-security
 tools/pr-approval-agent/** @PostHog/team-security
 
-# Error Tracking team owns the PostHog CLI upload flows
-cli/** @PostHog/team-error-tracking
-
 # Ingestion team owns persons migrations
 rust/persons_migrations/** @PostHog/team-ingestion
 

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -111,6 +111,7 @@ products/error_tracking/backend/** @PostHog/team-error-tracking
 products/error_tracking/frontend/** @PostHog/team-error-tracking
 products/error_tracking/mcp/** @PostHog/team-error-tracking
 products/error_tracking/skills/** @PostHog/team-error-tracking
+cli/** @PostHog/team-error-tracking
 posthog/hogql_queries/error_tracking/error_tracking_query_runner.py @PostHog/team-error-tracking
 posthog/hogql_queries/error_tracking/error_tracking_issue_correlation_query_runner.py @PostHog/team-error-tracking
 rust/cymbal/** @PostHog/team-error-tracking


### PR DESCRIPTION
## Summary

- Add the CLI directory to CODEOWNERS-soft for @PostHog/team-error-tracking.

## Validation

- git diff --check

## Notes

- Autoreview skipped per request.
