### PR TITLE
fix(propdefs): revert accept gzip for personhog calls

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10691,7 +10691,6 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "flate2",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",

--- a/rust/property-defs-rs/Cargo.toml
+++ b/rust/property-defs-rs/Cargo.toml
@@ -28,7 +28,7 @@ uuid = { workspace = true }
 rand = { workspace = true }
 anyhow = { workspace = true }
 personhog-proto = { path = "../personhog-proto" }
-tonic = { workspace = true, features = ["gzip"] }
+tonic = { workspace = true }
 thiserror.workspace = true
 regex.workspace = true
 

--- a/rust/property-defs-rs/src/group_type_resolver.rs
+++ b/rust/property-defs-rs/src/group_type_resolver.rs
@@ -4,7 +4,6 @@ use personhog_proto::personhog::{
 };
 use quick_cache::sync::Cache;
 use std::collections::HashMap;
-use tonic::codec::CompressionEncoding;
 use tonic::transport::Channel;
 use tracing::{info, warn};
 
@@ -39,10 +38,7 @@ impl GroupTypeResolver {
                         connect_timeout_ms = config.personhog_connect_timeout_ms,
                         "Created personhog gRPC client"
                     );
-                    Some(
-                        PersonHogServiceClient::new(channel)
-                            .accept_compressed(CompressionEncoding::Gzip),
-                    )
+                    Some(PersonHogServiceClient::new(channel))
                 }
                 Err(e) => {
                     warn!(


### PR DESCRIPTION
Reverts PostHog/posthog#61716 - importing gzip default enables tonic's gzip compression in personhog