### PR TITLE
fix(tasks): salvage agent turn when closing end_turn never arrives

### DIFF
--- a/products/tasks/backend/services/custom_prompt_internals.py
+++ b/products/tasks/backend/services/custom_prompt_internals.py
@@ -29,15 +29,12 @@ OutputFn = Callable[[str], object] | None
 POLL_INTERVAL_SECONDS = 10
 MAX_POLL_SECONDS = 30 * 60  # 30 minutes (matches sandbox TTL)
 MAX_CONSECUTIVE_STORAGE_ERRORS = 3
-# Salvage threshold for a turn whose closing end_turn never arrives. The sandbox SDK
-# intermittently emits the agent's final message (and a final usage_update with a null
-# cost — cost is only computed at turn finalization) but never the ACP end_turn result,
-# so neither _check_logs nor the relay ever marks the turn finished. After this many
-# seconds of zero new log lines with a captured assistant message in hand, accept that
-# message as a degraded turn-end instead of polling until MAX_POLL_SECONDS and failing a
-# run that actually completed. Kept well above the gap between log lines during genuine
-# work (tool calls and thinking both stream events, resetting staleness) so a merely slow
-# step is never mistaken for a dropped turn; prod hangs sit silent for tens of minutes.
+# Salvage threshold for a turn whose closing end_turn never arrives. The sandbox emits the
+# agent's final message and a null-cost usage_update (cost is computed only at finalization)
+# but no end_turn, so the turn never reads as finished. After this many seconds of silence
+# carrying that fingerprint we accept the last message rather than polling to
+# MAX_POLL_SECONDS and failing a run that actually completed. Well above the gap between log
+# lines during genuine work, so a slow step is never mistaken for a dropped turn.
 STALE_TURN_SALVAGE_SECONDS = 300
 
 # Notification method the sandbox agent emits on a terminal failure. The agent
@@ -209,13 +206,18 @@ async def poll_for_turn(
                 total_lines=total_lines,
                 printed_lines=printed_lines,
             )
-        # Salvage a turn whose closing end_turn never arrives (see STALE_TURN_SALVAGE_SECONDS).
-        # We have the agent's final message and the log has gone silent long enough to be
-        # conclusive, so accept it rather than burning the full MAX_POLL_SECONDS and failing.
-        if latest_assistant_text is not None and stale_seconds >= STALE_TURN_SALVAGE_SECONDS:
+        # Salvage only the dropped-finalization case: we have the agent's final message, the
+        # log tail is the null-cost usage_update fingerprint, and it's been silent long enough
+        # to be conclusive. Requiring the tail (not just any cached text) keeps a mid-turn
+        # tool/model gap from being cut off early. See STALE_TURN_SALVAGE_SECONDS.
+        if (
+            latest_assistant_text is not None
+            and stale_seconds >= STALE_TURN_SALVAGE_SECONDS
+            and _ended_on_pending_finalization(full_log)
+        ):
             logger.warning(
-                "custom_prompt - poll_for_turn: no end_turn but agent message present and log "
-                "stale for %ds — accepting last message as turn-end, run=%s total_lines=%d",
+                "custom_prompt - poll_for_turn: end_turn missing but turn-accounting tail present "
+                "and log stale for %ds — salvaging last message, run=%s total_lines=%d",
                 stale_seconds,
                 task_run.id,
                 total_lines,
@@ -468,6 +470,32 @@ def _check_logs(task_run, skip_lines: int = 0) -> tuple[bool, str | None, str | 
     if agent_finished and latest_text is None:
         return False, None, log_content, total_lines, True
     return agent_finished, latest_text, log_content, total_lines, False
+
+
+def _ended_on_pending_finalization(full_log: str | None) -> bool:
+    """True when the log's last activity is a null-cost usage_update — the sandbox ran turn
+    accounting but the closing end_turn was dropped. A mid-turn tool/model gap ends on other
+    activity (or no usage_update at all), so it won't match."""
+    if not full_log:
+        return False
+    for line in reversed(full_log.strip().split("\n")):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            notification = json.loads(line).get("notification")
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(notification, dict):
+            continue
+        params = notification.get("params")
+        update = params.get("update") if isinstance(params, dict) else None
+        if isinstance(update, dict):
+            return update.get("sessionUpdate") == "usage_update" and update.get("cost") is None
+        # A trailing result (end_turn or otherwise) means the turn isn't sitting on accounting.
+        if isinstance(notification.get("result"), dict):
+            return False
+    return False
 
 
 def _extract_text(update: dict) -> str | None:

--- a/products/tasks/backend/services/custom_prompt_internals.py
+++ b/products/tasks/backend/services/custom_prompt_internals.py
@@ -29,13 +29,12 @@ OutputFn = Callable[[str], object] | None
 POLL_INTERVAL_SECONDS = 10
 MAX_POLL_SECONDS = 30 * 60  # 30 minutes (matches sandbox TTL)
 MAX_CONSECUTIVE_STORAGE_ERRORS = 3
-# Salvage threshold for a turn whose closing end_turn never arrives. The sandbox emits the
-# agent's final message and a null-cost usage_update (cost is computed only at finalization)
-# but no end_turn, so the turn never reads as finished. After this many seconds of silence
-# carrying that fingerprint we accept the last message rather than polling to
-# MAX_POLL_SECONDS and failing a run that actually completed. Well above the gap between log
-# lines during genuine work, so a slow step is never mistaken for a dropped turn.
-STALE_TURN_SALVAGE_SECONDS = 300
+# After this many seconds of silence carrying the null-cost usage_update fingerprint, accept
+# the last message instead of polling to MAX_POLL_SECONDS and failing a run that completed.
+# Set to the relay's continuous-silence ceiling (relay_sandbox_events.py: MAX_RECONNECT_ATTEMPTS
+# * SSE_READ_TIMEOUT_SECONDS = 5 * 300) so we never cut off a turn the relay still treats as
+# active; past that the relay has given up and the run is terminal. Keep in sync if those change.
+STALE_TURN_SALVAGE_SECONDS = 1500
 
 # Notification method the sandbox agent emits on a terminal failure. The agent
 # classifies upstream failures (rate limits, stream/connection drops, provider

--- a/products/tasks/backend/services/custom_prompt_internals.py
+++ b/products/tasks/backend/services/custom_prompt_internals.py
@@ -29,6 +29,16 @@ OutputFn = Callable[[str], object] | None
 POLL_INTERVAL_SECONDS = 10
 MAX_POLL_SECONDS = 30 * 60  # 30 minutes (matches sandbox TTL)
 MAX_CONSECUTIVE_STORAGE_ERRORS = 3
+# Salvage threshold for a turn whose closing end_turn never arrives. The sandbox SDK
+# intermittently emits the agent's final message (and a final usage_update with a null
+# cost — cost is only computed at turn finalization) but never the ACP end_turn result,
+# so neither _check_logs nor the relay ever marks the turn finished. After this many
+# seconds of zero new log lines with a captured assistant message in hand, accept that
+# message as a degraded turn-end instead of polling until MAX_POLL_SECONDS and failing a
+# run that actually completed. Kept well above the gap between log lines during genuine
+# work (tool calls and thinking both stream events, resetting staleness) so a merely slow
+# step is never mistaken for a dropped turn; prod hangs sit silent for tens of minutes.
+STALE_TURN_SALVAGE_SECONDS = 300
 
 # Notification method the sandbox agent emits on a terminal failure. The agent
 # classifies upstream failures (rate limits, stream/connection drops, provider
@@ -199,6 +209,18 @@ async def poll_for_turn(
                 total_lines=total_lines,
                 printed_lines=printed_lines,
             )
+        # Salvage a turn whose closing end_turn never arrives (see STALE_TURN_SALVAGE_SECONDS).
+        # We have the agent's final message and the log has gone silent long enough to be
+        # conclusive, so accept it rather than burning the full MAX_POLL_SECONDS and failing.
+        if latest_assistant_text is not None and stale_seconds >= STALE_TURN_SALVAGE_SECONDS:
+            logger.warning(
+                "custom_prompt - poll_for_turn: no end_turn but agent message present and log "
+                "stale for %ds — accepting last message as turn-end, run=%s total_lines=%d",
+                stale_seconds,
+                task_run.id,
+                total_lines,
+            )
+            return latest_assistant_text, full_log, total_lines, printed_lines
         # Keep the cursor monotonic — S3 eventual-consistency can briefly return
         # fewer lines than the prior poll; without the clamp we'd re-parse old lines.
         skip_lines = max(skip_lines, total_lines)

--- a/products/tasks/backend/services/custom_prompt_internals.py
+++ b/products/tasks/backend/services/custom_prompt_internals.py
@@ -473,9 +473,12 @@ def _check_logs(task_run, skip_lines: int = 0) -> tuple[bool, str | None, str | 
 
 
 def _ended_on_pending_finalization(full_log: str | None) -> bool:
-    """True when the log's last activity is a null-cost usage_update — the sandbox ran turn
-    accounting but the closing end_turn was dropped. A mid-turn tool/model gap ends on other
-    activity (or no usage_update at all), so it won't match."""
+    """True when the log's last notification is a usage_update carrying an explicit null cost —
+    the sandbox ran turn accounting but the closing end_turn was dropped. The cost key must be
+    present and null: older usage_update lines omit it entirely and are not this fingerprint.
+    Any other trailing notification (an end_turn/result, a `_posthog/error`, a mid-turn update)
+    is decisive that this is not the dropped-finalization case, so we don't salvage and let the
+    normal completion / terminal-status drain handle it."""
     if not full_log:
         return False
     for line in reversed(full_log.strip().split("\n")):
@@ -490,11 +493,10 @@ def _ended_on_pending_finalization(full_log: str | None) -> bool:
             continue
         params = notification.get("params")
         update = params.get("update") if isinstance(params, dict) else None
-        if isinstance(update, dict):
-            return update.get("sessionUpdate") == "usage_update" and update.get("cost") is None
-        # A trailing result (end_turn or otherwise) means the turn isn't sitting on accounting.
-        if isinstance(notification.get("result"), dict):
+        if not isinstance(update, dict):
+            # The last notification is a result/error/other — not a turn sitting on accounting.
             return False
+        return update.get("sessionUpdate") == "usage_update" and "cost" in update and update["cost"] is None
     return False
 
 

--- a/products/tasks/backend/tests/agent_log_fixtures.py
+++ b/products/tasks/backend/tests/agent_log_fixtures.py
@@ -56,8 +56,8 @@ def _agent_error_line(message: str, category: str | None = None) -> str:
 
 
 def _usage_update_line(used: int = 1000, cost: float | None = None) -> str:
-    # cost is null until the turn finalizes; a null-cost tail with no end_turn is the
-    # dropped-finalization fingerprint poll_for_turn salvages on.
+    # cost is null until the turn finalizes; an explicit null-cost tail with no end_turn is
+    # the dropped-finalization fingerprint poll_for_turn salvages on.
     return json.dumps(
         {
             "notification": {
@@ -69,6 +69,18 @@ def _usage_update_line(used: int = 1000, cost: float | None = None) -> str:
                         "cost": cost,
                     }
                 },
+            }
+        }
+    )
+
+
+def _cost_less_usage_update_line(used: int = 1000) -> str:
+    # Older sandbox builds omit cost entirely — must NOT read as the null-cost fingerprint.
+    return json.dumps(
+        {
+            "notification": {
+                "method": "session/update",
+                "params": {"update": {"sessionUpdate": "usage_update", "used": used}},
             }
         }
     )

--- a/products/tasks/backend/tests/agent_log_fixtures.py
+++ b/products/tasks/backend/tests/agent_log_fixtures.py
@@ -55,7 +55,9 @@ def _agent_error_line(message: str, category: str | None = None) -> str:
     return json.dumps({"notification": {"method": "_posthog/error", "params": params}})
 
 
-def _usage_update_line(used: int = 1000) -> str:
+def _usage_update_line(used: int = 1000, cost: float | None = None) -> str:
+    # cost is null until the turn finalizes; a null-cost tail with no end_turn is the
+    # dropped-finalization fingerprint poll_for_turn salvages on.
     return json.dumps(
         {
             "notification": {
@@ -64,6 +66,7 @@ def _usage_update_line(used: int = 1000) -> str:
                     "update": {
                         "sessionUpdate": "usage_update",
                         "used": used,
+                        "cost": cost,
                     }
                 },
             }

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -160,31 +160,54 @@ class TestPollForTurnStaleSalvage:
         assert total_lines == 2
 
     @pytest.mark.asyncio
-    async def test_does_not_salvage_while_log_is_still_growing(self):
-        """An active turn that keeps streaming new lines must NOT be salvaged early —
-        staleness resets on each new line, so the real end_turn is what completes it."""
-        poll_1 = [_agent_message_line("working")]
-        poll_2 = [*poll_1, _agent_message_line("still working")]
-        poll_3 = [*poll_2, _agent_message_line("final answer"), _end_turn_line()]
-        logs = ["\n".join(poll_1), "\n".join(poll_2), "\n".join(poll_3)]
+    async def test_does_not_salvage_while_log_approaches_threshold(self):
+        # New lines arrive after 2 silent polls (stale climbs to 20, one poll short of the
+        # 30s threshold) and each tail carries the null-cost usage_update fingerprint. So the
+        # ONLY thing keeping this still-active turn from being salvaged is the staleness
+        # reset on each new line — it completes via its real end_turn, not the salvage path.
+        c1 = [_agent_message_line("working"), _usage_update_line()]
+        c2 = [*c1, _agent_message_line("still working"), _usage_update_line()]
+        final = [*c2, _agent_message_line("final answer"), _end_turn_line()]
+        logs = ["\n".join(c1)] * 3 + ["\n".join(c2)] * 3 + ["\n".join(final)]
         poll_iter = iter(logs)
 
         def next_log(*_args, **_kwargs):
-            return next(poll_iter)
+            return next(poll_iter, "\n".join(final))
 
         fake = FakeTaskRun()
         with (
             patch("posthog.storage.object_storage.read", side_effect=next_log),
             patch("asyncio.sleep", new=AsyncMock()),
             patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
-            # Threshold below per-poll elapsed: proves staleness reset (not a high threshold) is what holds.
-            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 5),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 30),
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
 
         assert last_message == "final answer"
-        assert total_lines == len(poll_3)
+        assert total_lines == len(final)
+
+    @parameterized.expand(
+        [
+            ("no_usage_update_tail", []),
+            ("populated_cost_tail", [_usage_update_line(1000, cost=0.42)]),
+        ]
+    )
+    async def test_does_not_salvage_without_finalization_fingerprint(self, _name, tail_lines):
+        # Agent message present and the log is long-stale, but the tail is not a null-cost
+        # usage_update — a genuine mid-turn gap, not a dropped finalization. Must keep polling
+        # (here to the cap) rather than salvage an unfinished turn.
+        log = "\n".join([_agent_message_line("intermediate"), *tail_lines])
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", return_value=log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 600),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 30),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                await poll_for_turn(fake, skip_lines=0)
 
 
 class TestPollForTurnTerminalDrain:

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -135,6 +135,58 @@ class TestPollForTurnEmptyEndTurn:
         assert printed_lines == len(poll_3_lines)
 
 
+class TestPollForTurnStaleSalvage:
+    """When the sandbox SDK never emits the closing end_turn after the agent's final
+    message (an intermittent race — the turn's cost is left null and the log goes quiet),
+    poll_for_turn must salvage the last message once the log is conclusively stale rather
+    than polling until MAX_POLL_SECONDS and failing a run that actually completed."""
+
+    @pytest.mark.asyncio
+    async def test_salvages_last_message_when_end_turn_never_arrives(self):
+        # Agent's close-out message + a final usage_update, but no end_turn line — the
+        # exact shape of the prod failures (no result of any stopReason ever written).
+        log = "\n".join([_agent_message_line("close-out summary"), _usage_update_line(165000)])
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", return_value=log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 30),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "close-out summary"
+        assert total_lines == 2
+
+    @pytest.mark.asyncio
+    async def test_does_not_salvage_while_log_is_still_growing(self):
+        """An active turn that keeps streaming new lines must NOT be salvaged early —
+        staleness resets on each new line, so the real end_turn is what completes it."""
+        poll_1 = [_agent_message_line("working")]
+        poll_2 = [*poll_1, _agent_message_line("still working")]
+        poll_3 = [*poll_2, _agent_message_line("final answer"), _end_turn_line()]
+        logs = ["\n".join(poll_1), "\n".join(poll_2), "\n".join(poll_3)]
+        poll_iter = iter(logs)
+
+        def next_log(*_args, **_kwargs):
+            return next(poll_iter)
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            # Threshold below per-poll elapsed: proves staleness reset (not a high threshold) is what holds.
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 5),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "final answer"
+        assert total_lines == len(poll_3)
+
+
 class TestPollForTurnTerminalDrain:
     """Terminal-status drain must recover an agent_message from *this* turn only.
 

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -25,6 +25,7 @@ from products.tasks.backend.tests.agent_log_fixtures import (
     FakeTaskRun,
     _agent_error_line,
     _agent_message_line,
+    _cost_less_usage_update_line,
     _end_turn_line,
     _usage_update_line,
     _user_message_line,
@@ -191,12 +192,15 @@ class TestPollForTurnStaleSalvage:
         [
             ("no_usage_update_tail", []),
             ("populated_cost_tail", [_usage_update_line(1000, cost=0.42)]),
+            ("cost_key_absent", [_cost_less_usage_update_line()]),
+            ("error_after_usage_update", [_usage_update_line(), _agent_error_line("provider 500", "provider_error")]),
         ]
     )
     async def test_does_not_salvage_without_finalization_fingerprint(self, _name, tail_lines):
-        # Agent message present and the log is long-stale, but the tail is not a null-cost
-        # usage_update — a genuine mid-turn gap, not a dropped finalization. Must keep polling
-        # (here to the cap) rather than salvage an unfinished turn.
+        # Agent message present and the log is long-stale, but the tail is not an explicit
+        # null-cost usage_update — a mid-turn gap, an old cost-less usage line, or a terminal
+        # error after accounting. None are the dropped-finalization case, so keep polling
+        # (here to the cap) rather than salvage an unfinished or failed turn.
         log = "\n".join([_agent_message_line("intermediate"), *tail_lines])
         fake = FakeTaskRun()
         with (


### PR DESCRIPTION
## Problem

The Signals scout (and any sandbox agent run through the multi-turn runner) can be marked `failed` even when the agent finished its work correctly.

`poll_for_turn` only treats a turn as complete when it sees `result.stopReason == "end_turn"` (or the synthetic `_posthog/turn_complete`). Intermittently the sandbox SDK emits the agent's final message and a final `usage_update` — but never the closing `end_turn` result. The dead-giveaway is a `null` cost on that last `usage_update` (cost is only computed at turn finalization). When this happens, neither `_check_logs` nor the relay's `is_turn_complete` ever fires, so `poll_for_turn` polls the full `MAX_POLL_SECONDS` (30 min) and raises `poll_for_turn: timed out after 1800s`, flipping a functionally-successful run to `failed` and discarding its result.

Observed while dogfooding scouts: in one 8-run batch, 2 runs hit this. Both had produced a complete close-out (and one a high-confidence finding) within ~5 minutes, then sat idle for ~24 minutes until the hard cap fired. It is nondeterministic — not correlated with token volume (a failed run used fewer tokens than a completed one).

## Changes

Recover the completed turn instead of timing out, gated on positive evidence of the dropped-finalization case. The salvage runs on the **poll-timeout path** (when `elapsed` reaches `MAX_POLL_SECONDS`), not on an in-loop staleness timer — so it recovers a dropped-finalization turn regardless of when the turn went quiet, and only once the poll budget (which coincides with the relay's continuous-silence ceiling) is exhausted.

When the budget runs out, `poll_for_turn`:

1. **Refreshes `TaskRun` status.** If terminal (`COMPLETED`/`FAILED`/`CANCELLED`) it drains through `_drain_final_log`, so a cancelled or failed run surfaces its real outcome instead of being reported as a successful salvage.
2. **Otherwise calls `_salvage_dropped_finalization`**, which re-reads from the start-of-turn cursor and salvages only when the log tail is the dropped-finalization fingerprint (last notification a `usage_update` with an *explicit* `null` cost — `_ended_on_pending_finalization`) and a message is recoverable. Re-reading from start-of-turn reassembles a response split across `agent_message_chunk` slices in full, not just the last slice that happened to land in the most recent poll window. Any other tail — a mid-turn gap, an older cost-less `usage_update`, or a `_posthog/error` — falls through.
3. **Otherwise** raises the timeout as before.

### Why the timeout path (addresses review on the rebased commit)

- **Late completions are now salvageable.** The earlier in-loop threshold (`STALE_TURN_SALVAGE_SECONDS = 1500`) sat only 300s below `MAX_POLL_SECONDS = 1800`, so the salvage could only fire if the turn went quiet within the first ~5 minutes. A turn that did real work past that and *then* dropped `end_turn` could never accumulate enough silence before the wall and still false-failed. Salvaging at the deadline removes that 300-second window.
- **The relay ceiling was off by one.** Its continuous-silence ceiling is **6** read windows, not 5: `while reconnect_count <= MAX_RECONNECT_ATTEMPTS` runs `reconnect_count` `0..5` with a 300s read timeout each = 1800s. 1500s was inside the window the relay still treats as active, so firing there risked truncating a live turn. Acting at the poll deadline (1800s) is the right place, and the magic constant is gone.
- **No cancellation race.** Refreshing `TaskRun` status before salvaging (and removing the in-loop salvage entirely) means a cancelled/failed run always drains through the terminal handler rather than being accepted as a successful response.

This stays the layer-1 stopgap. The deeper fix — keying the salvage off a real terminal signal (the relay declaring the run done / a synthetic `turn_complete` at source) rather than the poll deadline — remains a good follow-up and is out of scope here.

## How did you test this code?

I'm an agent (Claude Code). Tests drive the timeout path by patching `MAX_POLL_SECONDS` to a small value, so they're independent of the production budget:

- `test_salvages_last_message_when_end_turn_never_arrives` — final `agent_message` + null-cost `usage_update`, no `end_turn`; salvaged once the budget is exhausted.
- `test_salvages_dropped_finalization_after_active_work` — the turn does work across several polls and only *then* drops `end_turn`; regression for the old stale-window approach, which couldn't salvage a late completion.
- `test_salvage_reassembles_chunked_message` — a response split across `agent_message_chunk` slices is reassembled in full, not just the last chunk.
- `test_terminal_status_at_timeout_drains_instead_of_salvaging` — a run marked terminal by the deadline drains (raises the real failure) instead of being salvaged as success.
- `test_active_turn_completes_via_end_turn_not_salvage` — a still-active turn completes via its real `end_turn`, never via salvage.
- `test_does_not_salvage_without_finalization_fingerprint` — parameterized over a missing tail, a populated-cost tail, a cost-less `usage_update`, and a trailing `_posthog/error`; none is salvaged (raises timeout), proving the terminal-evidence gate.
- `hogli test products/tasks/backend/tests/test_multi_turn_session.py products/tasks/backend/tests/test_check_logs.py` → **52 passed**. ruff + `ty check` clean.

The root cause was confirmed against real production run logs (failed runs had no `result` of any stopReason and a `null` final cost; completed runs had `end_turn` and a populated cost).

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Andy's direction while investigating why dogfood scout runs for team 2 were showing as `failed`. The investigation read scout run rows and S3 transcripts (read-only) to pin the mechanism, then traced `poll_for_turn` / `_check_logs` (`custom_prompt_internals.py`).

Decisions: chose the poller-side salvage (layer 1) over the sandbox/relay synthetic-`turn_complete` fix (layer 2) for this PR because it's self-contained and low-risk; layer 2 is noted as follow-up.

After a rebase onto master, a fresh Codex pass raised P2s showing the in-loop timer approach was squeezed from both sides — the 1500s threshold could not salvage turns that completed after the first ~5 minutes (the `STALE_TURN_SALVAGE_SECONDS` vs `MAX_POLL_SECONDS` gap), and 1500s was actually *inside* the relay's still-active window (the ceiling is 6×300s, not 5×300s). Reworked the salvage onto the poll-timeout path, removed the threshold constant, added a `TaskRun`-status refresh before salvaging (cancellation race), and reparse from the start-of-turn cursor (chunked-message recovery). Verified independently before the bot flagged the same window math.

Requires human review; not self-merged.
