### PR TITLE
fix(rust): Cargo.lock feature narrowing didnt trigger correct builds

### DIFF
--- a/rust/affected-services/determinator-rules.toml
+++ b/rust/affected-services/determinator-rules.toml
@@ -10,13 +10,14 @@
 
 use-default-rules = true
 
-# Cargo.lock: When two graphs are available (--base-ref mode), the determinator
-# diffs resolved dependency versions directly — no rule needed. When only one
-# graph is available (fallback), compute_affected() handles the rebuild-all
-# logic in code. Either way, this rule is not needed here.
-#
-# The default determinator rule for Cargo.lock is mark-changed = [] (ignore),
-# which is what we want — the diff or the code handles it.
+# Cargo.lock: the determinator diffs resolved package graphs but does NOT
+# detect per-crate feature narrowing as a change — a crate whose enabled
+# feature set shrinks (or grows) only shows up in Cargo.lock, not in the
+# determinator's affected set. Force rebuild-all whenever Cargo.lock changes.
+# This overrides the default determinator rule (mark-changed = []).
+[[path-rule]]
+globs = ["Cargo.lock"]
+mark-changed = "all"
 
 # Dockerfiles and CI image config — cross-cutting build changes.
 [[path-rule]]

--- a/rust/affected-services/tests/integration.rs
+++ b/rust/affected-services/tests/integration.rs
@@ -360,15 +360,16 @@ fn old_graph_no_changed_files_produces_empty() {
 }
 
 #[test]
-fn two_graph_lockfile_with_identical_graphs_is_noop() {
+fn two_graph_lockfile_triggers_rebuild_all() {
     let (graph, images) = load_test_fixtures();
     let result =
         compute_affected(&["rust/Cargo.lock".into()], Some(&graph), &graph, &images).unwrap();
     assert!(
-        !result.rebuild_all,
-        "two identical graphs should detect no dependency changes from Cargo.lock"
+        result.rebuild_all,
+        "Cargo.lock change should force rebuild-all even with two graphs (feature narrowing is invisible to the determinator)"
     );
-    assert!(result.crates.is_empty());
+    let workspace_count = graph.workspace().iter().count();
+    assert_eq!(result.crates.len(), workspace_count);
 }
 
 #[test]

--- a/rust/personhog-replica/Cargo.toml
+++ b/rust/personhog-replica/Cargo.toml
@@ -1,3 +1,4 @@
+# no-op: trigger rebuild
 [package]
 name = "personhog-replica"
 version = "0.1.0"

--- a/rust/personhog-router/Cargo.toml
+++ b/rust/personhog-router/Cargo.toml
@@ -1,3 +1,4 @@
+# no-op: trigger rebuild
 [package]
 name = "personhog-router"
 version = "0.1.0"


### PR DESCRIPTION
## Problem

A recent rust build that narrowed the feature set on a shared workspace lib for a paritcular service (prop-defs-rs), was not properly caught by guppy/determinator to deploy all the services using the `tonic` lib. Seems to be a bug/oversight in the lib.

## Changes

- if Cargo.lock changes mark all crates/services as affected

## How did you test this code?

- integration tests caught the chagne and changed that test


