### PR TITLE
feat(llma): drop client $ai_generation events routed through the AI gateway

### DIFF
--- a/nodejs/src/ingestion/ai/gateway-dedup.test.ts
+++ b/nodejs/src/ingestion/ai/gateway-dedup.test.ts
@@ -1,0 +1,71 @@
+import { PluginEvent } from '~/plugin-scaffold'
+
+import { AI_GATEWAY_HOSTS, gatewayHostForClientEvent } from './gateway-dedup'
+
+function createEvent(event: string, properties: Record<string, unknown>): PluginEvent {
+    return {
+        distinct_id: 'user-1',
+        ip: null,
+        site_url: 'http://localhost',
+        team_id: 1,
+        now: '2020-02-23T02:15:00Z',
+        timestamp: '2020-02-23T02:15:00Z',
+        event,
+        uuid: 'test-uuid',
+        properties,
+    }
+}
+
+describe('gatewayHostForClientEvent', () => {
+    it('exposes both regional AI gateway hosts', () => {
+        expect([...AI_GATEWAY_HOSTS].sort()).toEqual(['ai-gateway.eu.posthog.com', 'ai-gateway.us.posthog.com'])
+    })
+
+    it('does not target the older LLM gateway hosts', () => {
+        expect(AI_GATEWAY_HOSTS.has('gateway.us.posthog.com')).toBe(false)
+        expect(AI_GATEWAY_HOSTS.has('gateway.eu.posthog.com')).toBe(false)
+    })
+
+    it.each([
+        ['SDK full URL, US gateway', 'https://ai-gateway.us.posthog.com/v1', 'ai-gateway.us.posthog.com'],
+        ['SDK full URL, EU gateway', 'https://ai-gateway.eu.posthog.com/v1', 'ai-gateway.eu.posthog.com'],
+        ['bare host from OTel server.address', 'ai-gateway.us.posthog.com', 'ai-gateway.us.posthog.com'],
+        ['host with port', 'https://ai-gateway.us.posthog.com:443/v1', 'ai-gateway.us.posthog.com'],
+        ['uppercased host', 'https://AI-GATEWAY.US.POSTHOG.COM/v1', 'ai-gateway.us.posthog.com'],
+    ])('matches a gateway-routed $ai_generation (%s)', (_label, baseUrl, expectedHost) => {
+        const event = createEvent('$ai_generation', { $ai_base_url: baseUrl })
+        expect(gatewayHostForClientEvent(event)).toBe(expectedHost)
+    })
+
+    it.each([
+        [
+            'gateway flag is true (the canonical event)',
+            '$ai_generation',
+            { $ai_base_url: 'https://ai-gateway.us.posthog.com', $ai_gateway: true },
+        ],
+        ['provider host (direct call)', '$ai_generation', { $ai_base_url: 'https://api.anthropic.com' }],
+        ['older LLM gateway host', '$ai_generation', { $ai_base_url: 'https://gateway.us.posthog.com/v1' }],
+        ['non-generation event with gateway host', '$ai_span', { $ai_base_url: 'https://ai-gateway.us.posthog.com' }],
+        ['no base_url', '$ai_generation', {}],
+        ['empty base_url', '$ai_generation', { $ai_base_url: '' }],
+        ['non-string base_url', '$ai_generation', { $ai_base_url: 123 }],
+        ['unparseable base_url', '$ai_generation', { $ai_base_url: 'http://' }],
+        ['lookalike subdomain', '$ai_generation', { $ai_base_url: 'https://ai-gateway.us.posthog.com.evil.com' }],
+    ])('does not match (%s)', (_label, eventName, properties) => {
+        const event = createEvent(eventName, properties)
+        expect(gatewayHostForClientEvent(event)).toBeNull()
+    })
+
+    it('treats a truthy non-boolean $ai_gateway as the canonical event', () => {
+        const event = createEvent('$ai_generation', {
+            $ai_base_url: 'https://ai-gateway.us.posthog.com',
+            $ai_gateway: 'true',
+        })
+        expect(gatewayHostForClientEvent(event)).toBeNull()
+    })
+
+    it('honours a custom host set', () => {
+        const event = createEvent('$ai_generation', { $ai_base_url: 'https://my-proxy.example.com/v1' })
+        expect(gatewayHostForClientEvent(event, new Set(['my-proxy.example.com']))).toBe('my-proxy.example.com')
+    })
+})

--- a/nodejs/src/ingestion/ai/gateway-dedup.test.ts
+++ b/nodejs/src/ingestion/ai/gateway-dedup.test.ts
@@ -1,20 +1,7 @@
-import { PluginEvent } from '~/plugin-scaffold'
-
+import { createTestPluginEvent } from '../../../tests/helpers/plugin-event'
 import { AI_GATEWAY_HOSTS, gatewayHostForClientEvent } from './gateway-dedup'
 
-function createEvent(event: string, properties: Record<string, unknown>): PluginEvent {
-    return {
-        distinct_id: 'user-1',
-        ip: null,
-        site_url: 'http://localhost',
-        team_id: 1,
-        now: '2020-02-23T02:15:00Z',
-        timestamp: '2020-02-23T02:15:00Z',
-        event,
-        uuid: 'test-uuid',
-        properties,
-    }
-}
+const createEvent = (event: string, properties: Record<string, unknown>) => createTestPluginEvent({ event, properties })
 
 describe('gatewayHostForClientEvent', () => {
     it('exposes both regional AI gateway hosts', () => {

--- a/nodejs/src/ingestion/ai/gateway-dedup.ts
+++ b/nodejs/src/ingestion/ai/gateway-dedup.ts
@@ -1,0 +1,47 @@
+import { PluginEvent } from '~/plugin-scaffold'
+
+// AI gateway hosts, distinct from the older LLM gateway (gateway.{us,eu}.posthog.com).
+export const AI_GATEWAY_HOSTS: ReadonlySet<string> = new Set(['ai-gateway.us.posthog.com', 'ai-gateway.eu.posthog.com'])
+
+// `$ai_base_url` is a full URL (posthog-ai SDK) or a bare host (OTel server.address).
+function extractHost(baseUrl: string): string | null {
+    const candidate = baseUrl.includes('://') ? baseUrl : `https://${baseUrl}`
+    try {
+        return new URL(candidate).hostname.toLowerCase()
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Returns the gateway host a client-side `$ai_generation` was routed through (making
+ * it a duplicate of the gateway's own event), or null otherwise. The gateway's own
+ * event is excluded: it sets `$ai_gateway: true` and a provider `$ai_base_url`.
+ */
+export function gatewayHostForClientEvent(
+    event: PluginEvent,
+    gatewayHosts: ReadonlySet<string> = AI_GATEWAY_HOSTS
+): string | null {
+    // Gateway emits only $ai_generation; leave the client's trace/span events alone.
+    if (event.event !== '$ai_generation') {
+        return null
+    }
+
+    const properties = event.properties
+    if (!properties) {
+        return null
+    }
+
+    // The gateway's own event flags itself.
+    if (properties.$ai_gateway) {
+        return null
+    }
+
+    const baseUrl = properties.$ai_base_url
+    if (typeof baseUrl !== 'string' || baseUrl.length === 0) {
+        return null
+    }
+
+    const host = extractHost(baseUrl)
+    return host !== null && gatewayHosts.has(host) ? host : null
+}

--- a/nodejs/src/ingestion/ai/metrics.ts
+++ b/nodejs/src/ingestion/ai/metrics.ts
@@ -53,3 +53,9 @@ export const aiOtelSystemInstructionsCounter = new Counter({
     help: 'Outcome of promoting `gen_ai.system_instructions` into a leading $ai_input system message',
     labelNames: ['outcome'],
 })
+
+export const aiGatewayDedupDroppedCounter = new Counter({
+    name: 'llma_ai_gateway_dedup_dropped_total',
+    help: 'Client-emitted $ai_generation events dropped as duplicates of the gateway-emitted canonical event, labelled by the matched gateway host',
+    labelNames: ['host'],
+})

--- a/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
+++ b/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
@@ -230,4 +230,54 @@ describe('AI event subpipeline integration', () => {
         expect(result.result.type).toBe(PipelineResultType.DROP)
         expect(mockOutputs.produce).not.toHaveBeenCalled()
     })
+
+    it('drops an SDK client generation routed through the AI gateway', async () => {
+        const event = createAiEvent({ properties: { $ai_base_url: 'https://ai-gateway.us.posthog.com/v1' } })
+
+        const { pipeline, mockOutputs } = buildPipeline()
+        const result = await pipeline.process(createOkContext(createInput(event), {}))
+
+        expect(result.result.type).toBe(PipelineResultType.DROP)
+        expect(mockOutputs.produce).not.toHaveBeenCalled()
+    })
+
+    it('drops an OTel client generation routed through the AI gateway (base_url mapped from server.address)', async () => {
+        const event = createAiEvent({
+            properties: { $ai_ingestion_source: 'otel', 'server.address': 'ai-gateway.us.posthog.com' },
+        })
+
+        const { pipeline, mockOutputs } = buildPipeline()
+        const result = await pipeline.process(createOkContext(createInput(event), {}))
+
+        expect(result.result.type).toBe(PipelineResultType.DROP)
+        expect(mockOutputs.produce).not.toHaveBeenCalled()
+    })
+
+    it("keeps the gateway's own event ($ai_gateway: true, provider base_url)", async () => {
+        const event = createAiEvent({
+            properties: {
+                $ai_gateway: true,
+                $ai_ingestion_source: 'gateway',
+                $ai_base_url: 'https://api.anthropic.com',
+            },
+        })
+
+        const { pipeline, mockOutputs } = buildPipeline()
+        const result = await pipeline.process(createOkContext(createInput(event), {}))
+
+        expect(result.result.type).toBe(PipelineResultType.OK)
+        const { properties } = getProduceCall(mockOutputs)
+        expect(properties.$ai_gateway).toBe(true)
+        expect(properties.$ai_base_url).toBe('https://api.anthropic.com')
+    })
+
+    it('keeps a direct provider generation (non-gateway base_url)', async () => {
+        const event = createAiEvent({ properties: { $ai_base_url: 'https://api.openai.com' } })
+
+        const { pipeline, mockOutputs } = buildPipeline()
+        const result = await pipeline.process(createOkContext(createInput(event), {}))
+
+        expect(result.result.type).toBe(PipelineResultType.OK)
+        expect(mockOutputs.produce).toHaveBeenCalledTimes(1)
+    })
 })

--- a/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
+++ b/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
@@ -231,20 +231,14 @@ describe('AI event subpipeline integration', () => {
         expect(mockOutputs.produce).not.toHaveBeenCalled()
     })
 
-    it('drops an SDK client generation routed through the AI gateway', async () => {
-        const event = createAiEvent({ properties: { $ai_base_url: 'https://ai-gateway.us.posthog.com/v1' } })
-
-        const { pipeline, mockOutputs } = buildPipeline()
-        const result = await pipeline.process(createOkContext(createInput(event), {}))
-
-        expect(result.result.type).toBe(PipelineResultType.DROP)
-        expect(mockOutputs.produce).not.toHaveBeenCalled()
-    })
-
-    it('drops an OTel client generation routed through the AI gateway (base_url mapped from server.address)', async () => {
-        const event = createAiEvent({
-            properties: { $ai_ingestion_source: 'otel', 'server.address': 'ai-gateway.us.posthog.com' },
-        })
+    it.each([
+        ['SDK client (base_url set directly)', { $ai_base_url: 'https://ai-gateway.us.posthog.com/v1' }],
+        [
+            'OTel client (base_url mapped from server.address)',
+            { $ai_ingestion_source: 'otel', 'server.address': 'ai-gateway.us.posthog.com' },
+        ],
+    ])('drops a %s generation routed through the AI gateway', async (_label, properties) => {
+        const event = createAiEvent({ properties })
 
         const { pipeline, mockOutputs } = buildPipeline()
         const result = await pipeline.process(createOkContext(createInput(event), {}))

--- a/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.ts
+++ b/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.ts
@@ -26,6 +26,7 @@ import { IngestionOutputs } from '../../outputs/ingestion-outputs'
 import { PipelineBuilder, StartPipelineBuilder } from '../../pipelines/builders/pipeline-builders'
 import { TopHogWrapper, sum, sumOk, sumResult, timer } from '../../pipelines/extensions/tophog'
 import { isDropResult } from '../../pipelines/results'
+import { createDropGatewayRoutedEventsStep } from './steps/drop-gateway-routed-events-step'
 import { createProcessAiEventStep } from './steps/process-ai-event-step'
 
 export interface AiEventSubpipelineInput {
@@ -101,6 +102,7 @@ export function createAiEventSubpipeline<TInput extends AiEventSubpipelineInput,
         )
         .pipe(createNormalizeEventStep())
         .pipe(createProcessAiEventStep())
+        .pipe(createDropGatewayRoutedEventsStep())
         .pipe(createProcessPersonlessStep(personsStore))
         .pipe(
             topHog(createProcessPersonsStep(options, outputs, personsStore), [

--- a/nodejs/src/ingestion/ai/pipelines/steps/drop-gateway-routed-events-step.test.ts
+++ b/nodejs/src/ingestion/ai/pipelines/steps/drop-gateway-routed-events-step.test.ts
@@ -1,0 +1,65 @@
+import { PluginEvent } from '~/plugin-scaffold'
+
+import { PipelineResultType } from '../../../pipelines/results'
+import { createDropGatewayRoutedEventsStep } from './drop-gateway-routed-events-step'
+
+function createEvent(event: string, properties: Record<string, unknown>): PluginEvent {
+    return {
+        distinct_id: 'user-1',
+        ip: null,
+        site_url: 'http://localhost',
+        team_id: 1,
+        now: '2020-02-23T02:15:00Z',
+        timestamp: '2020-02-23T02:15:00Z',
+        event,
+        uuid: 'test-uuid',
+        properties,
+    }
+}
+
+describe('dropGatewayRoutedEventsStep', () => {
+    it('drops a client $ai_generation routed through the gateway', async () => {
+        const step = createDropGatewayRoutedEventsStep()
+        const input = {
+            normalizedEvent: createEvent('$ai_generation', { $ai_base_url: 'https://ai-gateway.us.posthog.com/v1' }),
+        }
+
+        const result = await step(input)
+
+        expect(result.type).toBe(PipelineResultType.DROP)
+        if (result.type === PipelineResultType.DROP) {
+            expect(result.reason).toBe('gateway_routed_duplicate')
+        }
+    })
+
+    it.each([
+        ["the gateway's own event", '$ai_generation', { $ai_base_url: 'https://api.anthropic.com', $ai_gateway: true }],
+        ['a direct provider call', '$ai_generation', { $ai_base_url: 'https://api.openai.com' }],
+        ['a non-generation event', '$ai_span', { $ai_base_url: 'https://ai-gateway.us.posthog.com' }],
+    ])('passes through %s', async (_label, eventName, properties) => {
+        const step = createDropGatewayRoutedEventsStep()
+        const input = { normalizedEvent: createEvent(eventName, properties) }
+
+        const result = await step(input)
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (result.type === PipelineResultType.OK) {
+            expect(result.value).toBe(input)
+        }
+    })
+
+    it('preserves additional input fields when passing through', async () => {
+        const step = createDropGatewayRoutedEventsStep<{ normalizedEvent: PluginEvent; extraField: string }>()
+        const input = {
+            normalizedEvent: createEvent('$ai_generation', { $ai_base_url: 'https://api.openai.com' }),
+            extraField: 'preserved',
+        }
+
+        const result = await step(input)
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (result.type === PipelineResultType.OK) {
+            expect(result.value.extraField).toBe('preserved')
+        }
+    })
+})

--- a/nodejs/src/ingestion/ai/pipelines/steps/drop-gateway-routed-events-step.test.ts
+++ b/nodejs/src/ingestion/ai/pipelines/steps/drop-gateway-routed-events-step.test.ts
@@ -1,21 +1,10 @@
 import { PluginEvent } from '~/plugin-scaffold'
 
+import { createTestPluginEvent } from '../../../../../tests/helpers/plugin-event'
 import { PipelineResultType } from '../../../pipelines/results'
 import { createDropGatewayRoutedEventsStep } from './drop-gateway-routed-events-step'
 
-function createEvent(event: string, properties: Record<string, unknown>): PluginEvent {
-    return {
-        distinct_id: 'user-1',
-        ip: null,
-        site_url: 'http://localhost',
-        team_id: 1,
-        now: '2020-02-23T02:15:00Z',
-        timestamp: '2020-02-23T02:15:00Z',
-        event,
-        uuid: 'test-uuid',
-        properties,
-    }
-}
+const createEvent = (event: string, properties: Record<string, unknown>) => createTestPluginEvent({ event, properties })
 
 describe('dropGatewayRoutedEventsStep', () => {
     it('drops a client $ai_generation routed through the gateway', async () => {

--- a/nodejs/src/ingestion/ai/pipelines/steps/drop-gateway-routed-events-step.ts
+++ b/nodejs/src/ingestion/ai/pipelines/steps/drop-gateway-routed-events-step.ts
@@ -1,0 +1,30 @@
+import { PluginEvent } from '~/plugin-scaffold'
+
+import { drop, ok } from '../../../pipelines/results'
+import { ProcessingStep } from '../../../pipelines/steps'
+import { AI_GATEWAY_HOSTS, gatewayHostForClientEvent } from '../../gateway-dedup'
+import { aiGatewayDedupDroppedCounter } from '../../metrics'
+
+type DropGatewayRoutedEventsInput = {
+    normalizedEvent: PluginEvent
+}
+
+/**
+ * Drops client `$ai_generation` events routed through the AI gateway — the gateway
+ * emits its own canonical event, so the client copy would double-count.
+ *
+ * Must run after `createProcessAiEventStep`, which maps OTel `server.address` to
+ * `$ai_base_url` — the point where it holds the gateway host for both SDK and OTel events.
+ */
+export function createDropGatewayRoutedEventsStep<TInput extends DropGatewayRoutedEventsInput>(
+    gatewayHosts: ReadonlySet<string> = AI_GATEWAY_HOSTS
+): ProcessingStep<TInput, TInput> {
+    return function dropGatewayRoutedEventsStep(input) {
+        const host = gatewayHostForClientEvent(input.normalizedEvent, gatewayHosts)
+        if (host !== null) {
+            aiGatewayDedupDroppedCounter.labels({ host }).inc()
+            return Promise.resolve(drop('gateway_routed_duplicate'))
+        }
+        return Promise.resolve(ok(input))
+    }
+}


### PR DESCRIPTION
## Problem

The AI gateway emits its own canonical `$ai_generation` for every proxied call. A customer who also runs client-side LLM instrumentation (posthog-ai SDK, OTel) and routes through the gateway gets two `$ai_generation` events for one call. We want one.

The two events share no correlation id, so content matching is out. But a client event routed through the gateway records the gateway host in `$ai_base_url`, while the gateway's own event records the provider host and sets `$ai_gateway: true`, so the client copy is identifiable from its own properties alone.

## Changes

New ingestion step in the AI subpipeline that drops a client `$ai_generation` when `$ai_base_url` resolves to an AI gateway host (`ai-gateway.{us,eu}.posthog.com`) and `$ai_gateway` is not set.

Runs right after the AI enrich step, the single point where `$ai_base_url` is populated for both posthog-ai SDK events (set directly) and OTel events (mapped from `server.address`). Scoped to `$ai_generation` only, since that is all the gateway emits. The older LLM gateway (`gateway.{us,eu}.posthog.com`) is deliberately not targeted.

## How did you test this code?

I am an agent. I added and ran unit tests for the discriminator and the step, plus end-to-end subpipeline integration tests covering: SDK client through gateway (dropped), OTel client through gateway with `server.address` mapped to base_url (dropped), the gateway's own event (kept), and a direct provider call (kept). 30 tests pass. No manual or live-traffic testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

Authored with PostHog Code (Claude Opus).

Key decisions:
- Discriminate on the client event's own properties, no correlation id, since the two events share none and content matching would false-merge legitimately identical calls.
- Verified against `PostHog/ai-gateway` source that the canonical event sets `$ai_base_url` to the provider host and `$ai_gateway: true`, so the drop rule cannot catch it (protected two independent ways).
- Confirmed the OTel `server.address` to `$ai_base_url` mapping is server-side (ingestion), which is why the drop step sits after AI enrich rather than before.
- Host list hardcoded (two stable hosts, mirrors `INFRASTRUCTURE_DOMAINS` in `agentsh.py`) rather than threaded as env config; the step takes the set as a param so making it configurable later is a one-file change.

Open question for reviewers: the older LLM gateway also emits its own `$ai_generation`, so clients routing through it have the same duplication today. This PR does not address that (its events carry neither `$ai_base_url` nor `$ai_gateway`, so they need a different signal).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*