### PR TITLE
fix(vision): observation detail progress stuck and page refreshing

### DIFF
--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
@@ -69,60 +69,6 @@
                        use_hive_partitioning=0
   '''
 # ---
-# name: TestExperimentMeanMetric.test_conversion_window_extends_to_last_exposure_1_precomputed
-  '''
-  WITH exposures AS
-    (SELECT accurateCastOrNull(t.entity_id, 'UUID') AS entity_id,
-            if(ifNull(greater(uniqExact(t.variant), 1), 0), '$multiple', argMin(t.variant, toTimeZone(t.first_exposure_time, 'UTC'))) AS variant,
-            min(toTimeZone(t.first_exposure_time, 'UTC')) AS first_exposure_time,
-            max(toTimeZone(t.last_exposure_time, 'UTC')) AS last_exposure_time,
-            argMin(t.exposure_event_uuid, toTimeZone(t.first_exposure_time, 'UTC')) AS exposure_event_uuid,
-            argMin(t.exposure_session_id, toTimeZone(t.first_exposure_time, 'UTC')) AS exposure_session_id
-     FROM experiment_exposures_preaggregated AS t
-     WHERE and(equals(t.team_id, 99999), in(t.job_id, ['00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000']), equals(t.team_id, 99999), greaterOrEquals(t.first_exposure_time, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), lessOrEquals(t.first_exposure_time, assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC'))))
-     GROUP BY entity_id),
-       metric_events AS
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
-            toTimeZone(events.timestamp, 'UTC') AS timestamp,
-            coalesce(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), 0) AS value
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC')), toIntervalSecond(86400))), equals(events.event, 'purchase'))),
-       entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
-            sum(coalesce(accurateCastOrNull(metric_events.value, 'Float64'), 0)) AS value
-     FROM exposures
-     LEFT JOIN metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), and(greaterOrEquals(toTimeZone(metric_events.timestamp, 'UTC'), exposures.first_exposure_time), less(toTimeZone(metric_events.timestamp, 'UTC'), plus(exposures.last_exposure_time, toIntervalSecond(86400)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
-  SELECT entity_metrics.variant AS variant,
-         count(entity_metrics.entity_id) AS num_users,
-         sum(entity_metrics.value) AS total_sum,
-         sum(power(entity_metrics.value, 2)) AS total_sum_of_squares
-  FROM entity_metrics
-  GROUP BY entity_metrics.variant
-  LIMIT 50000 SETTINGS join_algorithm='grace_hash',
-                       grace_hash_join_initial_buckets=2,
-                       load_balancing='in_order',
-                       readonly=2,
-                       max_execution_time=600,
-                       allow_experimental_object_type=1,
-                       max_ast_elements=4000000,
-                       max_expanded_ast_elements=4000000,
-                       max_bytes_before_external_group_by=39728447488,
-                       transform_null_in=1,
-                       optimize_min_equality_disjunction_chain_length=4294967295,
-                       allow_experimental_join_condition=1,
-                       use_hive_partitioning=0
-  '''
-# ---
 # name: TestExperimentMeanMetric.test_count_distinct_property_values_via_hogql_0_direct
   '''
   WITH exposures AS

--- a/products/replay_vision/backend/api/observations.py
+++ b/products/replay_vision/backend/api/observations.py
@@ -506,7 +506,7 @@ class SessionReplayObservationViewSet(ReplayObservationViewSet):
         raise NotFound()
 
     @extend_schema(exclude=True)
-    @action(detail=True, methods=["GET"], url_path="progress")
+    @action(detail=True, methods=["GET"], url_path="progress", renderer_classes=[ServerSentEventRenderer])
     def progress(self, request: Request, **kwargs: Any) -> StreamingHttpResponse:
         """Stream live progress (phase + rendering frame counts) for one in-flight observation as SSE.
 

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -4,6 +4,7 @@ from typing import Any
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -542,6 +543,21 @@ class TestReplayObservationViewSet(_VisionAPITestCase):
         resp = self.client.get(self.observations_url(str(self.scanner.id)))
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.json()["results"]), 2)
+
+    @override_settings(SERVER_GATEWAY_INTERFACE="ASGI")
+    @patch("products.replay_vision.backend.api.observations.stream_observation_progress")
+    def test_progress_endpoint_accepts_event_stream_accept_header(self, mock_stream: MagicMock) -> None:
+        # The SSE client sends `Accept: text/event-stream`; without ServerSentEventRenderer on the action,
+        # DRF content negotiation rejects it with 406 before the view runs, so no progress ever reaches the
+        # page and it falls back to polling. Guard that the negotiated stream stays reachable.
+        mock_stream.return_value = iter(["event: observation-complete\ndata: {}\n\n"])
+        obs = self._create_observation(status=ObservationStatus.SUCCEEDED, completed_at=timezone.now())
+        url = f"/api/projects/{self.team.id}/vision/observations/{obs.id}/progress/"
+        resp = self.client.get(url, HTTP_ACCEPT="text/event-stream")
+        # A 406 here would mean content negotiation rejected the SSE Accept header before the view ran.
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["content-type"], "text/event-stream")
+        mock_stream.assert_called_once()
 
     def test_malformed_scanner_id_returns_404(self) -> None:
         resp = self.client.get(self.observations_url("not-a-uuid"))

--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -100,7 +100,7 @@ export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): J
 
     const { observation, observationLoading } = useValues(observationLogic)
 
-    if (observationLoading) {
+    if (observationLoading && !observation) {
         return (
             <SceneContent>
                 <SceneTitleSection name="Loading…" resourceType={{ type: 'replay_vision' }} />


### PR DESCRIPTION
## Problem

On the Replay Vision observation detail page, two things were broken while an observation was in flight:

1. The page refreshed the entire scene every ~3 seconds (the in-flight poll fallback), which remounted the progress bar and reset its animation.
2. The progress bar never advanced past "Queued" — it sat there until the result suddenly "flashed in".

## Changes

- **Stop the full-scene refresh:** the scene returned a bare "Loading…" skeleton whenever `observationLoading` was true, so every 3s poll blew away the rendered page (progress bar + recording player). Now the skeleton only shows on the _initial_ load (`observationLoading && !observation`); subsequent polls update the page in place.
- **Fix the stuck progress bar (the real culprit):** the SSE progress endpoint set the `text/event-stream` content type but never added `ServerSentEventRenderer` to the action's `renderer_classes`. DRF content negotiation therefore rejected the browser's `Accept: text/event-stream` with **406** _before the view ran_, so the frontend's `fetch` bailed out with zero events and `progress` stayed `null` (the bar defaults to step 0 = "Queued"). The result only appeared because the poll fallback eventually landed it. Adding the renderer — matching the established pattern in tasks/notebooks/dashboards/ai_observability — lets the stream through, so per-phase progress events now reach the page.

## How did you test this code?

Now that i ca test locally, saw the actual stages progress:   
![Screenshot 2026-06-05 at 11.12.47 AM.png](https://app.graphite.com/user-attachments/assets/e9aa68db-5ddf-4f0e-97fa-5b3450c838a3.png)



- Added and ran a backend regression test asserting the progress endpoint accepts `Accept: text/event-stream` (returns 200 + `text/event-stream`, not 406): `test_progress_endpoint_accepts_event_stream_accept_header` — passes.
- Existing progress tests still pass (`test_progress_stream_completes_immediately_for_terminal_observation`, `test_workflow_get_progress_advances_through_phases`).
- Verified live against the local granian/ASGI server: the endpoint returned **406** before the change and **401** (auth required, negotiation passing) after — confirming content negotiation now accepts the SSE stream.
- ruff + ty checks pass via lint-staged on commit.

## 🤖 Agent context

Authored with PostHog Code (Claude). The reported symptom was the 3s refresh; the loading-guard change fixed that, but the progress bar still never advanced. Traced the data flow: the precise symptom ("Queued", not "Fetching") implied `progress` was never set on the frontend, i.e. no SSE events arriving. Ruled out gzip buffering (path-scoped middleware doesn't cover the endpoint), URL mismatch (hand-built URL matches the registered route exactly), and the ASGI guard (granian serves ASGI locally), then found the endpoint returning 406 on `Accept: text/event-stream` — the missing `ServerSentEventRenderer`. The poll fallback on this branch was effectively masking the broken stream by landing the final result.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)