### PR TITLE
fix(cdp): restore api token auth on hog function templates

### DIFF
--- a/products/cdp/backend/api/hog_function_template.py
+++ b/products/cdp/backend/api/hog_function_template.py
@@ -6,6 +6,8 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import mixins, permissions, serializers, viewsets
 from rest_framework.request import Request
 
+from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
+
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cdp.backend.models.hog_functions import HogFunction
 
@@ -87,6 +89,15 @@ class PublicHogFunctionTemplateViewSet(
     serializer_class = HogFunctionTemplateSerializer
     queryset = HogFunctionTemplate.objects.all()
     lookup_field = "template_id"
+    # Plain GenericViewSet doesn't inherit TeamAndOrgViewSetMixin's authenticators, so the global
+    # default (SessionAuthentication only) applies. Declare the API-token authenticators explicitly
+    # so personal API key / OAuth callers (the MCP server, public API) can reach the authenticated
+    # project-nested mount — without these, IsAuthenticated rejects every non-cookie request as 401.
+    authentication_classes = [
+        OAuthAccessTokenAuthentication,
+        PersonalAPIKeyAuthentication,
+        SessionAuthentication,
+    ]
 
     def get_permissions(self):
         # The dedicated public catalog endpoint is intentionally anonymous. The project-nested

--- a/products/cdp/backend/api/hog_function_template.py
+++ b/products/cdp/backend/api/hog_function_template.py
@@ -1,12 +1,18 @@
+from functools import cached_property
+
 from django.db.models import Count, QuerySet
 
 import structlog
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import mixins, permissions, serializers, viewsets
+from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
+from posthog.models.team import Team
+from posthog.models.user import User
+from posthog.permissions import APIScopePermission
 
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cdp.backend.models.hog_functions import HogFunction
@@ -99,13 +105,32 @@ class PublicHogFunctionTemplateViewSet(
         SessionAuthentication,
     ]
 
+    @cached_property
+    def team(self) -> Team:
+        # APIScopePermission resolves `view.team` to enforce a token's `scoped_teams`/`scoped_organizations`
+        # and org-level key restrictions. This viewset isn't a TeamAndOrgViewSetMixin, so provide the
+        # minimal resolution from the project-nested URL kwarg ourselves.
+        project_id = self.kwargs.get("parent_lookup_project_id")
+        if project_id == "@current":
+            user = self.request.user
+            if isinstance(user, User) and user.team is not None:
+                return user.team
+            raise NotFound("Project not found.")
+        try:
+            return Team.objects.select_related("organization").get(id=project_id)
+        except (Team.DoesNotExist, ValueError, TypeError):
+            raise NotFound("Project not found.")
+
     def get_permissions(self):
         # The dedicated public catalog endpoint is intentionally anonymous. The project-nested
         # mount is part of the authenticated app and must not expose templates (including hidden
         # ones) to anonymous callers.
         if self.request.path.startswith("/api/public_hog_function_templates"):
             return [permissions.AllowAny()]
-        return [permissions.IsAuthenticated()]
+        # IsAuthenticated blocks anonymous callers; APIScopePermission enforces the `hog_function`
+        # scope (and team/org scoping) for personal API key / OAuth tokens. IsAuthenticated must stay
+        # first — APIScopePermission alone treats credential-less requests as session auth and allows them.
+        return [permissions.IsAuthenticated(), APIScopePermission()]
 
     def filter_queryset(self, queryset: QuerySet) -> QuerySet:
         if self.action == "list":

--- a/products/cdp/backend/api/test/test_hog_function_templates.py
+++ b/products/cdp/backend/api/test/test_hog_function_templates.py
@@ -8,6 +8,8 @@ from rest_framework import status
 
 from posthog.cdp.templates.hog_function_template import sync_template_to_db
 from posthog.cdp.templates.slack.template_slack import template as template_slack
+from posthog.models.personal_api_key import PersonalAPIKey
+from posthog.models.utils import generate_random_token_personal, hash_key_value
 
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
@@ -321,3 +323,29 @@ class TestHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMatchingTe
         response = self.client.get(f"/api/projects/{self.team.id}/hog_function_templates/")
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert "template-hidden" not in [template["id"] for template in response.json()["results"]]
+
+    @parameterized.expand(
+        [
+            ("list", "/hog_function_templates/"),
+            ("retrieve", "/hog_function_templates/template-slack"),
+        ]
+    )
+    def test_project_route_authenticates_personal_api_key(self, _name, suffix):
+        # The project-nested mount requires authentication but isn't a TeamAndOrgViewSetMixin, so it
+        # must declare the API-token authenticators itself. Guard against a regression to session-only
+        # auth that would 401 the MCP server and public API.
+        key_value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="Test key",
+            user=self.user,
+            secure_value=hash_key_value(key_value),
+            scopes=["hog_function:read"],
+        )
+        self.client.logout()
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}{suffix}",
+            headers={"authorization": f"Bearer {key_value}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()

--- a/products/cdp/backend/api/test/test_hog_function_templates.py
+++ b/products/cdp/backend/api/test/test_hog_function_templates.py
@@ -324,6 +324,21 @@ class TestHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMatchingTe
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert "template-hidden" not in [template["id"] for template in response.json()["results"]]
 
+    def _get_with_pak(self, suffix, scopes, scoped_teams=None):
+        key_value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="Test key",
+            user=self.user,
+            secure_value=hash_key_value(key_value),
+            scopes=scopes,
+            scoped_teams=scoped_teams or [],
+        )
+        self.client.logout()
+        return self.client.get(
+            f"/api/projects/{self.team.id}{suffix}",
+            headers={"authorization": f"Bearer {key_value}"},
+        )
+
     @parameterized.expand(
         [
             ("list", "/hog_function_templates/"),
@@ -334,18 +349,19 @@ class TestHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMatchingTe
         # The project-nested mount requires authentication but isn't a TeamAndOrgViewSetMixin, so it
         # must declare the API-token authenticators itself. Guard against a regression to session-only
         # auth that would 401 the MCP server and public API.
-        key_value = generate_random_token_personal()
-        PersonalAPIKey.objects.create(
-            label="Test key",
-            user=self.user,
-            secure_value=hash_key_value(key_value),
-            scopes=["hog_function:read"],
-        )
-        self.client.logout()
-
-        response = self.client.get(
-            f"/api/projects/{self.team.id}{suffix}",
-            headers={"authorization": f"Bearer {key_value}"},
-        )
-
+        response = self._get_with_pak(suffix, ["hog_function:read"])
         assert response.status_code == status.HTTP_200_OK, response.json()
+
+    def test_project_route_enforces_hog_function_scope(self):
+        # A token without the hog_function scope is rejected — scope_object is enforced, not decorative.
+        response = self._get_with_pak("/hog_function_templates/", ["feature_flag:read"])
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
+
+    def test_project_route_allows_key_scoped_to_this_project(self):
+        response = self._get_with_pak("/hog_function_templates/", ["hog_function:read"], scoped_teams=[self.team.id])
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
+    def test_project_route_rejects_key_scoped_to_another_project(self):
+        other_team = self.create_team_with_organization(self.organization)
+        response = self._get_with_pak("/hog_function_templates/", ["hog_function:read"], scoped_teams=[other_team.id])
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()


### PR DESCRIPTION
## Problem

`/api/projects/:id/hog_function_templates/` returned 401 for personal-API-key and OAuth callers, breaking the MCP server's `cdp-function-templates` tools and API-token consumers of the route. The MCP CI integration suite went red across PRs.

The viewset is a plain DRF `GenericViewSet`, so it only inherited the default session authenticator and stopped recognizing API tokens once [#61901](https://github.com/PostHog/posthog/pull/61901) tightened the mount from `AllowAny` to `IsAuthenticated`. The tests there authenticate via session cookie, so the token path went uncovered.

## Changes

- Declare the API-token authenticators on the viewset so personal-API-key / OAuth callers authenticate again. The anonymous public catalog route is unaffected.
- Enforce the viewset's declared `hog_function` scope (and `scoped_teams` / `scoped_organizations`) via `APIScopePermission`, resolving the project from the URL. Anonymous callers remain blocked.
- Add tests for the token paths: valid scope, missing scope, and project-scoped keys on their own vs. another project.

No serializer/schema changes; generated types unaffected.

## How did you test this code?

Agent-authored (Claude Code), automated only: ran the full `test_hog_function_templates.py` suite plus the new auth/scope cases locally against Postgres + ClickHouse — all pass. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by Claude Code for the human author, starting from a red MCP CI job. Traced the regression to [#61901](https://github.com/PostHog/posthog/pull/61901) tightening this mount without the viewset carrying the API-token authenticators. Scope enforcement was added after an automated security review noted the declared scope wasn't being applied; the viewset resolves its team from the URL rather than adopting the full team/org mixin, which would disturb the route's anonymous public mount.
