### PR TITLE
refactor(web-analytics): replace pre-agg/lazy booleans with preComputeStrategy enum

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -73,6 +73,7 @@ import {
     SessionAttributionExplorerQuery,
     SessionsQuery,
     TracesQuery,
+    WebAnalyticsPreComputeStrategy,
 } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import {
@@ -185,17 +186,16 @@ export function DataTable({
 
     const canUseWebAnalyticsPreAggregatedTables = useFeatureFlag('SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES')
     const hasCustomerAnalyticsEnabled = useFeatureFlag('CUSTOMER_ANALYTICS')
+    const preComputeStrategy = response && 'preComputeStrategy' in response ? response.preComputeStrategy : undefined
     const usedWebAnalyticsPreAggregatedTables =
         canUseWebAnalyticsPreAggregatedTables &&
+        preComputeStrategy === WebAnalyticsPreComputeStrategy.PreAggregated &&
         response &&
-        'usedPreAggregatedTables' in response &&
-        response.usedPreAggregatedTables &&
-        response?.hogql
-    // Lazy precompute can be on without the v2 pre-agg flag, so check it
-    // independently of `canUseWebAnalyticsPreAggregatedTables`.
-    const usedWebAnalyticsLazyPrecompute = Boolean(
-        response && 'usedLazyPrecompute' in response && response.usedLazyPrecompute
-    )
+        'hogql' in response &&
+        response.hogql
+    // Lazy precompute can be on without the v2 pre-agg flag, so it surfaces a
+    // badge regardless of `canUseWebAnalyticsPreAggregatedTables`.
+    const usedWebAnalyticsLazyPrecompute = preComputeStrategy === WebAnalyticsPreComputeStrategy.LazyPrecompute
 
     const dataTableLogicProps: DataTableLogicProps = {
         query,

--- a/frontend/src/queries/nodes/OverviewGrid/OverviewGrid.tsx
+++ b/frontend/src/queries/nodes/OverviewGrid/OverviewGrid.tsx
@@ -17,7 +17,7 @@ import { formatPercentage, humanFriendlyLargeNumber } from 'lib/utils/numbers'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { EvenlyDistributedRows } from '~/queries/nodes/WebOverview/EvenlyDistributedRows'
-import { WebAnalyticsItemKind } from '~/queries/schema/schema-general'
+import { WebAnalyticsItemKind, WebAnalyticsPreComputeStrategy } from '~/queries/schema/schema-general'
 
 export const NO_BASELINE_CHANGE_SENTINEL = 999999
 
@@ -57,8 +57,7 @@ interface OverviewGridProps {
     loading: boolean
     numSkeletons: number
     samplingRate?: SamplingRate
-    usedPreAggregatedTables?: boolean
-    usedLazyPrecompute?: boolean
+    preComputeStrategy?: WebAnalyticsPreComputeStrategy
     onDisablePrecompute?: () => void
     labelFromKey: (key: string) => string
     filterEmptyItems?: (item: OverviewItem) => boolean
@@ -70,8 +69,7 @@ export function OverviewGrid({
     loading,
     numSkeletons,
     samplingRate,
-    usedPreAggregatedTables = false,
-    usedLazyPrecompute = false,
+    preComputeStrategy,
     onDisablePrecompute,
     labelFromKey,
     filterEmptyItems = () => true,
@@ -96,8 +94,7 @@ export function OverviewGrid({
                           <OverviewItemCell
                               key={item.key}
                               item={item}
-                              usedPreAggregatedTables={usedPreAggregatedTables}
-                              usedLazyPrecompute={usedLazyPrecompute}
+                              preComputeStrategy={preComputeStrategy}
                               onDisablePrecompute={onDisablePrecompute}
                               labelFromKey={labelFromKey}
                               compact={compact}
@@ -149,8 +146,7 @@ const OverviewItemCellSkeleton = ({ compact }: { compact: boolean }): JSX.Elemen
 
 interface OverviewItemCellProps {
     item: OverviewItem
-    usedPreAggregatedTables: boolean
-    usedLazyPrecompute: boolean
+    preComputeStrategy?: WebAnalyticsPreComputeStrategy
     onDisablePrecompute?: () => void
     labelFromKey: (key: string) => string
     compact: boolean
@@ -158,8 +154,7 @@ interface OverviewItemCellProps {
 
 const OverviewItemCell = ({
     item,
-    usedPreAggregatedTables,
-    usedLazyPrecompute,
+    preComputeStrategy,
     onDisablePrecompute,
     labelFromKey,
     compact,
@@ -241,9 +236,9 @@ const OverviewItemCell = ({
         >
             {/* Rendered as a sibling of the Tooltip trigger so hovering the badge
                 does not also surface the cell's metric tooltip. */}
-            {usedLazyPrecompute ? (
+            {preComputeStrategy === WebAnalyticsPreComputeStrategy.LazyPrecompute ? (
                 <PreAggregatedBadge variant="precomputed" onDisable={onDisablePrecompute} />
-            ) : usedPreAggregatedTables ? (
+            ) : preComputeStrategy === WebAnalyticsPreComputeStrategy.PreAggregated ? (
                 <PreAggregatedBadge variant="preagg" />
             ) : null}
             <Tooltip title={tooltip}>

--- a/frontend/src/queries/nodes/OverviewGrid/OverviewMetricCardGrid.tsx
+++ b/frontend/src/queries/nodes/OverviewGrid/OverviewMetricCardGrid.tsx
@@ -11,6 +11,8 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { range } from 'lib/utils/arrays'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { WebAnalyticsPreComputeStrategy } from '~/queries/schema/schema-general'
+
 import { formatItem, NO_BASELINE_CHANGE_SENTINEL, OverviewItem, SamplingNotice, SamplingRate } from './OverviewGrid'
 
 export interface OverviewMetricCardItem extends Omit<OverviewItem, 'value' | 'previous'> {
@@ -23,8 +25,7 @@ interface OverviewMetricCardGridProps {
     loading: boolean
     numSkeletons: number
     samplingRate?: SamplingRate
-    usedPreAggregatedTables?: boolean
-    usedLazyPrecompute?: boolean
+    preComputeStrategy?: WebAnalyticsPreComputeStrategy
     onDisablePrecompute?: () => void
     labelFromKey: (key: string) => string
 }
@@ -34,8 +35,7 @@ export function OverviewMetricCardGrid({
     loading,
     numSkeletons,
     samplingRate,
-    usedPreAggregatedTables = false,
-    usedLazyPrecompute = false,
+    preComputeStrategy,
     onDisablePrecompute,
     labelFromKey,
 }: OverviewMetricCardGridProps): JSX.Element {
@@ -48,8 +48,7 @@ export function OverviewMetricCardGrid({
                           <MetricCardCell
                               key={item.key}
                               item={item}
-                              usedPreAggregatedTables={usedPreAggregatedTables}
-                              usedLazyPrecompute={usedLazyPrecompute}
+                              preComputeStrategy={preComputeStrategy}
                               onDisablePrecompute={onDisablePrecompute}
                               labelFromKey={labelFromKey}
                           />
@@ -62,14 +61,12 @@ export function OverviewMetricCardGrid({
 
 function MetricCardCell({
     item,
-    usedPreAggregatedTables,
-    usedLazyPrecompute,
+    preComputeStrategy,
     onDisablePrecompute,
     labelFromKey,
 }: {
     item: OverviewMetricCardItem
-    usedPreAggregatedTables: boolean
-    usedLazyPrecompute: boolean
+    preComputeStrategy?: WebAnalyticsPreComputeStrategy
     onDisablePrecompute?: () => void
     labelFromKey: (key: string) => string
 }): JSX.Element {
@@ -107,9 +104,9 @@ function MetricCardCell({
             tabIndex={clickable ? 0 : undefined}
             aria-pressed={clickable ? !!item.selected : undefined}
         >
-            {usedLazyPrecompute ? (
+            {preComputeStrategy === WebAnalyticsPreComputeStrategy.LazyPrecompute ? (
                 <PreAggregatedBadge variant="precomputed" position="bottom-right" onDisable={onDisablePrecompute} />
-            ) : usedPreAggregatedTables ? (
+            ) : preComputeStrategy === WebAnalyticsPreComputeStrategy.PreAggregated ? (
                 <PreAggregatedBadge variant="preagg" position="bottom-right" />
             ) : null}
             <MetricCard

--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -46,9 +46,7 @@ export function WebOverview(props: {
 
     const numSkeletons = props.query.conversionGoal ? 4 : 5
 
-    const usedWebAnalyticsPreAggregatedTables =
-        response && 'usedPreAggregatedTables' in response && response.usedPreAggregatedTables
-    const usedWebAnalyticsLazyPrecompute = response && 'usedLazyPrecompute' in response && response.usedLazyPrecompute
+    const preComputeStrategy = webOverviewQueryResponse?.preComputeStrategy
 
     const showWarning = hasReverseProxy === false && !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_EMPTY_ONBOARDING]
 
@@ -76,8 +74,7 @@ export function WebOverview(props: {
                 loading={responseLoading}
                 numSkeletons={numSkeletons}
                 samplingRate={samplingRate}
-                usedPreAggregatedTables={usedWebAnalyticsPreAggregatedTables}
-                usedLazyPrecompute={usedWebAnalyticsLazyPrecompute}
+                preComputeStrategy={preComputeStrategy}
                 onDisablePrecompute={props.context.onDisableWebAnalyticsPrecompute}
                 labelFromKey={labelFromKey}
             />
@@ -90,8 +87,7 @@ export function WebOverview(props: {
             loading={responseLoading}
             numSkeletons={numSkeletons}
             samplingRate={samplingRate}
-            usedPreAggregatedTables={usedWebAnalyticsPreAggregatedTables}
-            usedLazyPrecompute={usedWebAnalyticsLazyPrecompute}
+            preComputeStrategy={preComputeStrategy}
             onDisablePrecompute={props.context.onDisableWebAnalyticsPrecompute}
             labelFromKey={labelFromKey}
         />

--- a/frontend/src/queries/nodes/WebVitals/WebVitalsPathBreakdown.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitalsPathBreakdown.tsx
@@ -10,6 +10,7 @@ import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
 import {
     AnyResponseType,
+    WebAnalyticsPreComputeStrategy,
     WebVitalsMetricBand,
     WebVitalsPathBreakdownQuery,
     WebVitalsPathBreakdownQueryResponse,
@@ -54,7 +55,7 @@ export function WebVitalsPathBreakdown(props: {
 
     return (
         <div className="relative border rounded bg-surface-primary grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x min-h-60 h-full">
-            {webVitalsQueryResponse?.usedLazyPrecompute && (
+            {webVitalsQueryResponse?.preComputeStrategy === WebAnalyticsPreComputeStrategy.LazyPrecompute && (
                 <PreAggregatedBadge variant="precomputed" onDisable={props.context.onDisableWebAnalyticsPrecompute} />
             )}
             <div className="p-4">

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11040,6 +11040,9 @@
                     "format": "date-time",
                     "type": "string"
                 },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                },
                 "query_metadata": {
                     "type": "object"
                 },
@@ -32397,6 +32400,9 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
+                        "preComputeStrategy": {
+                            "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -44947,6 +44953,9 @@
                 "modifiers": {
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
+                },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
                 },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10750,6 +10750,9 @@
                 "offset": {
                     "$ref": "#/definitions/integer"
                 },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                },
                 "query_metadata": {
                     "type": "object"
                 },
@@ -10785,14 +10788,6 @@
                 "types": {
                     "items": {},
                     "type": "array"
-                },
-                "usedLazyPrecompute": {
-                    "description": "Whether the response was served from the lazy precompute path.",
-                    "type": "boolean"
-                },
-                "usedPreAggregatedTables": {
-                    "description": "Whether the response was served from a precomputed table.",
-                    "type": "boolean"
                 },
                 "warnings": {
                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -10849,6 +10844,9 @@
                     "format": "date-time",
                     "type": "string"
                 },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                },
                 "query_metadata": {
                     "type": "object"
                 },
@@ -10882,9 +10880,6 @@
                         "$ref": "#/definitions/QueryTiming"
                     },
                     "type": "array"
-                },
-                "usedPreAggregatedTables": {
-                    "type": "boolean"
                 },
                 "warnings": {
                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -10947,6 +10942,9 @@
                     "format": "date-time",
                     "type": "string"
                 },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                },
                 "query_metadata": {
                     "type": "object"
                 },
@@ -10980,12 +10978,6 @@
                         "$ref": "#/definitions/QueryTiming"
                     },
                     "type": "array"
-                },
-                "usedLazyPrecompute": {
-                    "type": "boolean"
-                },
-                "usedPreAggregatedTables": {
-                    "type": "boolean"
                 },
                 "warnings": {
                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -11147,6 +11139,9 @@
                 "offset": {
                     "$ref": "#/definitions/integer"
                 },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                },
                 "query_metadata": {
                     "type": "object"
                 },
@@ -11182,12 +11177,6 @@
                 "types": {
                     "items": {},
                     "type": "array"
-                },
-                "usedLazyPrecompute": {
-                    "type": "boolean"
-                },
-                "usedPreAggregatedTables": {
-                    "type": "boolean"
                 },
                 "warnings": {
                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -11244,6 +11233,9 @@
                     "format": "date-time",
                     "type": "string"
                 },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                },
                 "query_metadata": {
                     "type": "object"
                 },
@@ -11276,9 +11268,6 @@
                         "$ref": "#/definitions/QueryTiming"
                     },
                     "type": "array"
-                },
-                "usedLazyPrecompute": {
-                    "type": "boolean"
                 },
                 "warnings": {
                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -13036,6 +13025,9 @@
                                     "$ref": "#/definitions/HogQLQueryModifiers",
                                     "description": "Modifiers used when performing the query"
                                 },
+                                "preComputeStrategy": {
+                                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                                },
                                 "query_status": {
                                     "$ref": "#/definitions/QueryStatus",
                                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -13064,12 +13056,6 @@
                                     },
                                     "type": "array"
                                 },
-                                "usedLazyPrecompute": {
-                                    "type": "boolean"
-                                },
-                                "usedPreAggregatedTables": {
-                                    "type": "boolean"
-                                },
                                 "warnings": {
                                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
                                     "items": {
@@ -13109,80 +13095,8 @@
                                 "offset": {
                                     "$ref": "#/definitions/integer"
                                 },
-                                "query_status": {
-                                    "$ref": "#/definitions/QueryStatus",
-                                    "description": "Query status indicates whether next to the provided data, a query is still running."
-                                },
-                                "resolved_compare_date_range": {
-                                    "$ref": "#/definitions/ResolvedDateRangeResponse",
-                                    "description": "The resolved previous/comparison period date range, when comparing against another period"
-                                },
-                                "resolved_date_range": {
-                                    "$ref": "#/definitions/ResolvedDateRangeResponse",
-                                    "description": "The date range used for the query"
-                                },
-                                "results": {
-                                    "items": {},
-                                    "type": "array"
-                                },
-                                "samplingRate": {
-                                    "$ref": "#/definitions/SamplingRate"
-                                },
-                                "timings": {
-                                    "description": "Measured timings for different parts of the query generation process",
-                                    "items": {
-                                        "$ref": "#/definitions/QueryTiming"
-                                    },
-                                    "type": "array"
-                                },
-                                "types": {
-                                    "items": {},
-                                    "type": "array"
-                                },
-                                "usedLazyPrecompute": {
-                                    "type": "boolean"
-                                },
-                                "usedPreAggregatedTables": {
-                                    "type": "boolean"
-                                },
-                                "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
-                                    "items": {
-                                        "$ref": "#/definitions/DataWarehouseSyncWarning"
-                                    },
-                                    "type": "array"
-                                }
-                            },
-                            "required": ["results"],
-                            "type": "object"
-                        },
-                        {
-                            "additionalProperties": false,
-                            "properties": {
-                                "columns": {
-                                    "items": {},
-                                    "type": "array"
-                                },
-                                "error": {
-                                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
-                                    "type": "string"
-                                },
-                                "hasMore": {
-                                    "type": "boolean"
-                                },
-                                "hogql": {
-                                    "description": "Generated HogQL query.",
-                                    "type": "string"
-                                },
-                                "limit": {
-                                    "$ref": "#/definitions/integer"
-                                },
-                                "modifiers": {
-                                    "$ref": "#/definitions/HogQLQueryModifiers",
-                                    "description": "Modifiers used when performing the query"
-                                },
-                                "offset": {
-                                    "$ref": "#/definitions/integer"
+                                "preComputeStrategy": {
+                                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
                                 },
                                 "query_status": {
                                     "$ref": "#/definitions/QueryStatus",
@@ -13283,13 +13197,77 @@
                                     "items": {},
                                     "type": "array"
                                 },
-                                "usedLazyPrecompute": {
-                                    "description": "Whether the response was served from the lazy precompute path.",
+                                "warnings": {
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                                    "items": {
+                                        "$ref": "#/definitions/DataWarehouseSyncWarning"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": ["results"],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "columns": {
+                                    "items": {},
+                                    "type": "array"
+                                },
+                                "error": {
+                                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                                    "type": "string"
+                                },
+                                "hasMore": {
                                     "type": "boolean"
                                 },
-                                "usedPreAggregatedTables": {
-                                    "description": "Whether the response was served from a precomputed table.",
-                                    "type": "boolean"
+                                "hogql": {
+                                    "description": "Generated HogQL query.",
+                                    "type": "string"
+                                },
+                                "limit": {
+                                    "$ref": "#/definitions/integer"
+                                },
+                                "modifiers": {
+                                    "$ref": "#/definitions/HogQLQueryModifiers",
+                                    "description": "Modifiers used when performing the query"
+                                },
+                                "offset": {
+                                    "$ref": "#/definitions/integer"
+                                },
+                                "preComputeStrategy": {
+                                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                                },
+                                "query_status": {
+                                    "$ref": "#/definitions/QueryStatus",
+                                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                                },
+                                "resolved_compare_date_range": {
+                                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                                    "description": "The resolved previous/comparison period date range, when comparing against another period"
+                                },
+                                "resolved_date_range": {
+                                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                                    "description": "The date range used for the query"
+                                },
+                                "results": {
+                                    "items": {},
+                                    "type": "array"
+                                },
+                                "samplingRate": {
+                                    "$ref": "#/definitions/SamplingRate"
+                                },
+                                "timings": {
+                                    "description": "Measured timings for different parts of the query generation process",
+                                    "items": {
+                                        "$ref": "#/definitions/QueryTiming"
+                                    },
+                                    "type": "array"
+                                },
+                                "types": {
+                                    "items": {},
+                                    "type": "array"
                                 },
                                 "warnings": {
                                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -13316,6 +13294,9 @@
                                 "modifiers": {
                                     "$ref": "#/definitions/HogQLQueryModifiers",
                                     "description": "Modifiers used when performing the query"
+                                },
+                                "preComputeStrategy": {
+                                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
                                 },
                                 "query_status": {
                                     "$ref": "#/definitions/QueryStatus",
@@ -13343,9 +13324,6 @@
                                         "$ref": "#/definitions/QueryTiming"
                                     },
                                     "type": "array"
-                                },
-                                "usedLazyPrecompute": {
-                                    "type": "boolean"
                                 },
                                 "warnings": {
                                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -32087,6 +32065,9 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
+                        "preComputeStrategy": {
+                            "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -32115,12 +32096,6 @@
                             },
                             "type": "array"
                         },
-                        "usedLazyPrecompute": {
-                            "type": "boolean"
-                        },
-                        "usedPreAggregatedTables": {
-                            "type": "boolean"
-                        },
                         "warnings": {
                             "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
                             "items": {
@@ -32160,80 +32135,8 @@
                         "offset": {
                             "$ref": "#/definitions/integer"
                         },
-                        "query_status": {
-                            "$ref": "#/definitions/QueryStatus",
-                            "description": "Query status indicates whether next to the provided data, a query is still running."
-                        },
-                        "resolved_compare_date_range": {
-                            "$ref": "#/definitions/ResolvedDateRangeResponse",
-                            "description": "The resolved previous/comparison period date range, when comparing against another period"
-                        },
-                        "resolved_date_range": {
-                            "$ref": "#/definitions/ResolvedDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
-                        "results": {
-                            "items": {},
-                            "type": "array"
-                        },
-                        "samplingRate": {
-                            "$ref": "#/definitions/SamplingRate"
-                        },
-                        "timings": {
-                            "description": "Measured timings for different parts of the query generation process",
-                            "items": {
-                                "$ref": "#/definitions/QueryTiming"
-                            },
-                            "type": "array"
-                        },
-                        "types": {
-                            "items": {},
-                            "type": "array"
-                        },
-                        "usedLazyPrecompute": {
-                            "type": "boolean"
-                        },
-                        "usedPreAggregatedTables": {
-                            "type": "boolean"
-                        },
-                        "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
-                            "items": {
-                                "$ref": "#/definitions/DataWarehouseSyncWarning"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "required": ["results"],
-                    "type": "object"
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "columns": {
-                            "items": {},
-                            "type": "array"
-                        },
-                        "error": {
-                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
-                            "type": "string"
-                        },
-                        "hasMore": {
-                            "type": "boolean"
-                        },
-                        "hogql": {
-                            "description": "Generated HogQL query.",
-                            "type": "string"
-                        },
-                        "limit": {
-                            "$ref": "#/definitions/integer"
-                        },
-                        "modifiers": {
-                            "$ref": "#/definitions/HogQLQueryModifiers",
-                            "description": "Modifiers used when performing the query"
-                        },
-                        "offset": {
-                            "$ref": "#/definitions/integer"
+                        "preComputeStrategy": {
+                            "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
                         },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
@@ -32334,13 +32237,77 @@
                             "items": {},
                             "type": "array"
                         },
-                        "usedLazyPrecompute": {
-                            "description": "Whether the response was served from the lazy precompute path.",
+                        "warnings": {
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                            "items": {
+                                "$ref": "#/definitions/DataWarehouseSyncWarning"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "columns": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hasMore": {
                             "type": "boolean"
                         },
-                        "usedPreAggregatedTables": {
-                            "description": "Whether the response was served from a precomputed table.",
-                            "type": "boolean"
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "limit": {
+                            "$ref": "#/definitions/integer"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "offset": {
+                            "$ref": "#/definitions/integer"
+                        },
+                        "preComputeStrategy": {
+                            "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_compare_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The resolved previous/comparison period date range, when comparing against another period"
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
+                        "results": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "samplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        },
+                        "types": {
+                            "items": {},
+                            "type": "array"
                         },
                         "warnings": {
                             "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -32367,6 +32334,9 @@
                         "modifiers": {
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
+                        },
+                        "preComputeStrategy": {
+                            "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
                         },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
@@ -32394,9 +32364,6 @@
                                 "$ref": "#/definitions/QueryTiming"
                             },
                             "type": "array"
-                        },
-                        "usedLazyPrecompute": {
-                            "type": "boolean"
                         },
                         "warnings": {
                             "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -32497,6 +32464,9 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
+                        "preComputeStrategy": {
+                            "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -32524,9 +32494,6 @@
                                 "$ref": "#/definitions/QueryTiming"
                             },
                             "type": "array"
-                        },
-                        "usedPreAggregatedTables": {
-                            "type": "boolean"
                         },
                         "warnings": {
                             "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -33347,6 +33314,9 @@
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
                         },
+                        "preComputeStrategy": {
+                            "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                        },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
                             "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -33375,12 +33345,6 @@
                             },
                             "type": "array"
                         },
-                        "usedLazyPrecompute": {
-                            "type": "boolean"
-                        },
-                        "usedPreAggregatedTables": {
-                            "type": "boolean"
-                        },
                         "warnings": {
                             "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
                             "items": {
@@ -33420,80 +33384,8 @@
                         "offset": {
                             "$ref": "#/definitions/integer"
                         },
-                        "query_status": {
-                            "$ref": "#/definitions/QueryStatus",
-                            "description": "Query status indicates whether next to the provided data, a query is still running."
-                        },
-                        "resolved_compare_date_range": {
-                            "$ref": "#/definitions/ResolvedDateRangeResponse",
-                            "description": "The resolved previous/comparison period date range, when comparing against another period"
-                        },
-                        "resolved_date_range": {
-                            "$ref": "#/definitions/ResolvedDateRangeResponse",
-                            "description": "The date range used for the query"
-                        },
-                        "results": {
-                            "items": {},
-                            "type": "array"
-                        },
-                        "samplingRate": {
-                            "$ref": "#/definitions/SamplingRate"
-                        },
-                        "timings": {
-                            "description": "Measured timings for different parts of the query generation process",
-                            "items": {
-                                "$ref": "#/definitions/QueryTiming"
-                            },
-                            "type": "array"
-                        },
-                        "types": {
-                            "items": {},
-                            "type": "array"
-                        },
-                        "usedLazyPrecompute": {
-                            "type": "boolean"
-                        },
-                        "usedPreAggregatedTables": {
-                            "type": "boolean"
-                        },
-                        "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
-                            "items": {
-                                "$ref": "#/definitions/DataWarehouseSyncWarning"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "required": ["results"],
-                    "type": "object"
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "columns": {
-                            "items": {},
-                            "type": "array"
-                        },
-                        "error": {
-                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
-                            "type": "string"
-                        },
-                        "hasMore": {
-                            "type": "boolean"
-                        },
-                        "hogql": {
-                            "description": "Generated HogQL query.",
-                            "type": "string"
-                        },
-                        "limit": {
-                            "$ref": "#/definitions/integer"
-                        },
-                        "modifiers": {
-                            "$ref": "#/definitions/HogQLQueryModifiers",
-                            "description": "Modifiers used when performing the query"
-                        },
-                        "offset": {
-                            "$ref": "#/definitions/integer"
+                        "preComputeStrategy": {
+                            "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
                         },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
@@ -33594,13 +33486,77 @@
                             "items": {},
                             "type": "array"
                         },
-                        "usedLazyPrecompute": {
-                            "description": "Whether the response was served from the lazy precompute path.",
+                        "warnings": {
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                            "items": {
+                                "$ref": "#/definitions/DataWarehouseSyncWarning"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "columns": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hasMore": {
                             "type": "boolean"
                         },
-                        "usedPreAggregatedTables": {
-                            "description": "Whether the response was served from a precomputed table.",
-                            "type": "boolean"
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "limit": {
+                            "$ref": "#/definitions/integer"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "offset": {
+                            "$ref": "#/definitions/integer"
+                        },
+                        "preComputeStrategy": {
+                            "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_compare_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The resolved previous/comparison period date range, when comparing against another period"
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
+                        "results": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "samplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        },
+                        "types": {
+                            "items": {},
+                            "type": "array"
                         },
                         "warnings": {
                             "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -33627,6 +33583,9 @@
                         "modifiers": {
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
+                        },
+                        "preComputeStrategy": {
+                            "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
                         },
                         "query_status": {
                             "$ref": "#/definitions/QueryStatus",
@@ -33654,9 +33613,6 @@
                                 "$ref": "#/definitions/QueryTiming"
                             },
                             "type": "array"
-                        },
-                        "usedLazyPrecompute": {
-                            "type": "boolean"
                         },
                         "warnings": {
                             "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -44141,6 +44097,11 @@
             ],
             "type": "string"
         },
+        "WebAnalyticsPreComputeStrategy": {
+            "description": "Which read path served a web analytics response.",
+            "enum": ["pre_aggregated", "lazy_precompute", "live"],
+            "type": "string"
+        },
         "WebAnalyticsPropertyFilter": {
             "anyOf": [
                 {
@@ -44461,6 +44422,9 @@
                 "offset": {
                     "$ref": "#/definitions/integer"
                 },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -44490,14 +44454,6 @@
                 "types": {
                     "items": {},
                     "type": "array"
-                },
-                "usedLazyPrecompute": {
-                    "description": "Whether the response was served from the lazy precompute path.",
-                    "type": "boolean"
-                },
-                "usedPreAggregatedTables": {
-                    "description": "Whether the response was served from a precomputed table.",
-                    "type": "boolean"
                 },
                 "warnings": {
                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -44652,6 +44608,9 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -44679,9 +44638,6 @@
                         "$ref": "#/definitions/QueryTiming"
                     },
                     "type": "array"
-                },
-                "usedPreAggregatedTables": {
-                    "type": "boolean"
                 },
                 "warnings": {
                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -44711,9 +44667,6 @@
                 },
                 "previous": {
                     "type": "number"
-                },
-                "usedPreAggregatedTables": {
-                    "type": "boolean"
                 },
                 "value": {
                     "type": "number"
@@ -44835,6 +44788,9 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -44862,12 +44818,6 @@
                         "$ref": "#/definitions/QueryTiming"
                     },
                     "type": "array"
-                },
-                "usedLazyPrecompute": {
-                    "type": "boolean"
-                },
-                "usedPreAggregatedTables": {
-                    "type": "boolean"
                 },
                 "warnings": {
                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -45205,6 +45155,9 @@
                 "offset": {
                     "$ref": "#/definitions/integer"
                 },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -45234,12 +45187,6 @@
                 "types": {
                     "items": {},
                     "type": "array"
-                },
-                "usedLazyPrecompute": {
-                    "type": "boolean"
-                },
-                "usedPreAggregatedTables": {
-                    "type": "boolean"
                 },
                 "warnings": {
                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
@@ -45416,6 +45363,9 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "preComputeStrategy": {
+                    "$ref": "#/definitions/WebAnalyticsPreComputeStrategy"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
@@ -45442,9 +45392,6 @@
                         "$ref": "#/definitions/QueryTiming"
                     },
                     "type": "array"
-                },
-                "usedLazyPrecompute": {
-                    "type": "boolean"
                 },
                 "warnings": {
                     "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -5423,6 +5423,7 @@ export interface WebPageURLSearchQueryResponse extends AnalyticsQueryResponseBas
     results: PageURL[]
     hasMore?: boolean
     limit?: integer
+    preComputeStrategy?: WebAnalyticsPreComputeStrategy
 }
 
 export type CachedWebPageURLSearchQueryResponse = CachedQueryResponse<WebPageURLSearchQueryResponse>

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2436,8 +2436,16 @@ export interface WebAnalyticsItemBase<T> {
     changeFromPreviousPct?: number
     isIncreaseBad?: boolean
 }
-export interface WebOverviewItem extends WebAnalyticsItemBase<number> {
-    usedPreAggregatedTables?: boolean
+export interface WebOverviewItem extends WebAnalyticsItemBase<number> {}
+
+/** Which read path served a web analytics response. */
+export enum WebAnalyticsPreComputeStrategy {
+    /** Served from the v2 continuously-maintained pre-aggregated tables. */
+    PreAggregated = 'pre_aggregated',
+    /** Served from the on-demand lazy precompute tables. */
+    LazyPrecompute = 'lazy_precompute',
+    /** Computed live from raw events (no precompute). */
+    Live = 'live',
 }
 
 export interface SamplingRate {
@@ -2450,8 +2458,7 @@ export interface WebOverviewQueryResponse extends AnalyticsQueryResponseBase {
     samplingRate?: SamplingRate
     dateFrom?: string
     dateTo?: string
-    usedPreAggregatedTables?: boolean
-    usedLazyPrecompute?: boolean
+    preComputeStrategy?: WebAnalyticsPreComputeStrategy
 }
 
 export type CachedWebOverviewQueryResponse = CachedQueryResponse<WebOverviewQueryResponse>
@@ -2504,8 +2511,7 @@ export interface WebStatsTableQueryResponse extends AnalyticsQueryResponseBase {
     hasMore?: boolean
     limit?: integer
     offset?: integer
-    usedPreAggregatedTables?: boolean
-    usedLazyPrecompute?: boolean
+    preComputeStrategy?: WebAnalyticsPreComputeStrategy
 }
 export type CachedWebStatsTableQueryResponse = CachedQueryResponse<WebStatsTableQueryResponse>
 
@@ -2542,10 +2548,7 @@ export interface WebGoalsQueryResponse extends AnalyticsQueryResponseBase {
     hasMore?: boolean
     limit?: integer
     offset?: integer
-    /** Whether the response was served from a precomputed table. */
-    usedPreAggregatedTables?: boolean
-    /** Whether the response was served from the lazy precompute path. */
-    usedLazyPrecompute?: boolean
+    preComputeStrategy?: WebAnalyticsPreComputeStrategy
 }
 export type CachedWebGoalsQueryResponse = CachedQueryResponse<WebGoalsQueryResponse>
 
@@ -2594,7 +2597,7 @@ export type WebVitalsPathBreakdownResult = Record<WebVitalsMetricBand, WebVitals
 // hence the tuple type rather than a single object.
 export interface WebVitalsPathBreakdownQueryResponse extends AnalyticsQueryResponseBase {
     results: [WebVitalsPathBreakdownResult]
-    usedLazyPrecompute?: boolean
+    preComputeStrategy?: WebAnalyticsPreComputeStrategy
 }
 export type CachedWebVitalsPathBreakdownQueryResponse = CachedQueryResponse<WebVitalsPathBreakdownQueryResponse>
 
@@ -5442,7 +5445,7 @@ export interface WebNotableChangeItem {
 export interface WebNotableChangesQueryResponse extends AnalyticsQueryResponseBase {
     results: WebNotableChangeItem[]
     samplingRate?: SamplingRate
-    usedPreAggregatedTables?: boolean
+    preComputeStrategy?: WebAnalyticsPreComputeStrategy
 }
 
 export type CachedWebNotableChangesQueryResponse = CachedQueryResponse<WebNotableChangesQueryResponse>

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsOverview/MarketingAnalyticsOverview.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsOverview/MarketingAnalyticsOverview.tsx
@@ -87,7 +87,6 @@ export function MarketingAnalyticsOverview(props: {
                 loading={responseLoading}
                 numSkeletons={numSkeletons}
                 samplingRate={samplingRate}
-                usedPreAggregatedTables={false}
                 labelFromKey={labelFromKey}
                 filterEmptyItems={filterEmptyMetrics}
             />

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7807,6 +7807,7 @@ class WebPageURLSearchQueryResponse(BaseModel):
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -12208,6 +12209,7 @@ class CachedWebPageURLSearchQueryResponse(BaseModel):
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     next_allowed_client_refresh: AwareDatetime
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None,
@@ -16867,6 +16869,7 @@ class QueryResponseAlternative28(BaseModel):
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -278,6 +278,7 @@ from posthog.schema_enums import (
     WebAnalyticsItemKind as WebAnalyticsItemKind,
     WebAnalyticsOrderByDirection as WebAnalyticsOrderByDirection,
     WebAnalyticsOrderByFields as WebAnalyticsOrderByFields,
+    WebAnalyticsPreComputeStrategy as WebAnalyticsPreComputeStrategy,
     WebsiteBrowsingHistoryProdInterest as WebsiteBrowsingHistoryProdInterest,
     WebStatsBreakdown as WebStatsBreakdown,
     WebVitalsMetric as WebVitalsMetric,
@@ -2956,7 +2957,6 @@ class WebOverviewItem(BaseModel):
     key: str
     kind: WebAnalyticsItemKind
     previous: float | None = None
-    usedPreAggregatedTables: bool | None = None
     value: float | None = None
 
 
@@ -7673,6 +7673,7 @@ class WebGoalsQueryResponse(BaseModel):
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -7691,14 +7692,6 @@ class WebGoalsQueryResponse(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = None
-    usedLazyPrecompute: bool | None = Field(
-        default=None,
-        description="Whether the response was served from the lazy precompute path.",
-    )
-    usedPreAggregatedTables: bool | None = Field(
-        default=None,
-        description="Whether the response was served from a precomputed table.",
-    )
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -7724,6 +7717,7 @@ class WebNotableChangesQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -7741,7 +7735,6 @@ class WebNotableChangesQueryResponse(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -7769,6 +7762,7 @@ class WebOverviewQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -7786,8 +7780,6 @@ class WebOverviewQueryResponse(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedLazyPrecompute: bool | None = None
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -7860,6 +7852,7 @@ class WebStatsTableQueryResponse(BaseModel):
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -7878,8 +7871,6 @@ class WebStatsTableQueryResponse(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = None
-    usedLazyPrecompute: bool | None = None
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -12050,6 +12041,7 @@ class CachedWebGoalsQueryResponse(BaseModel):
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None,
@@ -12070,14 +12062,6 @@ class CachedWebGoalsQueryResponse(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = None
-    usedLazyPrecompute: bool | None = Field(
-        default=None,
-        description="Whether the response was served from the lazy precompute path.",
-    )
-    usedPreAggregatedTables: bool | None = Field(
-        default=None,
-        description="Whether the response was served from a precomputed table.",
-    )
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -12112,6 +12096,7 @@ class CachedWebNotableChangesQueryResponse(BaseModel):
     last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     next_allowed_client_refresh: AwareDatetime
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None,
@@ -12131,7 +12116,6 @@ class CachedWebNotableChangesQueryResponse(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -12168,6 +12152,7 @@ class CachedWebOverviewQueryResponse(BaseModel):
     last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     next_allowed_client_refresh: AwareDatetime
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None,
@@ -12187,8 +12172,6 @@ class CachedWebOverviewQueryResponse(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedLazyPrecompute: bool | None = None
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -12281,6 +12264,7 @@ class CachedWebStatsTableQueryResponse(BaseModel):
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None,
@@ -12301,8 +12285,6 @@ class CachedWebStatsTableQueryResponse(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = None
-    usedLazyPrecompute: bool | None = None
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -12337,6 +12319,7 @@ class CachedWebVitalsPathBreakdownQueryResponse(BaseModel):
     last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     next_allowed_client_refresh: AwareDatetime
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None,
@@ -12355,7 +12338,6 @@ class CachedWebVitalsPathBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedLazyPrecompute: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -12908,6 +12890,7 @@ class Response4(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -12925,8 +12908,6 @@ class Response4(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedLazyPrecompute: bool | None = None
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -12956,6 +12937,7 @@ class Response5(BaseModel):
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -12974,8 +12956,6 @@ class Response5(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = None
-    usedLazyPrecompute: bool | None = None
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -13052,6 +13032,7 @@ class Response7(BaseModel):
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -13070,14 +13051,6 @@ class Response7(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = None
-    usedLazyPrecompute: bool | None = Field(
-        default=None,
-        description="Whether the response was served from the lazy precompute path.",
-    )
-    usedPreAggregatedTables: bool | None = Field(
-        default=None,
-        description="Whether the response was served from a precomputed table.",
-    )
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -13103,6 +13076,7 @@ class Response8(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -13119,7 +13093,6 @@ class Response8(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedLazyPrecompute: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -16664,6 +16637,7 @@ class QueryResponseAlternative23(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -16681,8 +16655,6 @@ class QueryResponseAlternative23(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedLazyPrecompute: bool | None = None
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -16712,6 +16684,7 @@ class QueryResponseAlternative24(BaseModel):
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -16730,8 +16703,6 @@ class QueryResponseAlternative24(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = None
-    usedLazyPrecompute: bool | None = None
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -16808,6 +16779,7 @@ class QueryResponseAlternative26(BaseModel):
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -16826,14 +16798,6 @@ class QueryResponseAlternative26(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = None
-    usedLazyPrecompute: bool | None = Field(
-        default=None,
-        description="Whether the response was served from the lazy precompute path.",
-    )
-    usedPreAggregatedTables: bool | None = Field(
-        default=None,
-        description="Whether the response was served from a precomputed table.",
-    )
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -16859,6 +16823,7 @@ class QueryResponseAlternative27(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -16875,7 +16840,6 @@ class QueryResponseAlternative27(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedLazyPrecompute: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -16944,6 +16908,7 @@ class QueryResponseAlternative30(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -16961,7 +16926,6 @@ class QueryResponseAlternative30(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -17522,6 +17486,7 @@ class QueryResponseAlternative43(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -17539,8 +17504,6 @@ class QueryResponseAlternative43(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedLazyPrecompute: bool | None = None
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -17570,6 +17533,7 @@ class QueryResponseAlternative44(BaseModel):
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -17588,8 +17552,6 @@ class QueryResponseAlternative44(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = None
-    usedLazyPrecompute: bool | None = None
-    usedPreAggregatedTables: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -17666,6 +17628,7 @@ class QueryResponseAlternative46(BaseModel):
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     offset: int | None = None
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -17684,14 +17647,6 @@ class QueryResponseAlternative46(BaseModel):
         description=("Measured timings for different parts of the query generation process"),
     )
     types: list | None = None
-    usedLazyPrecompute: bool | None = Field(
-        default=None,
-        description="Whether the response was served from the lazy precompute path.",
-    )
-    usedPreAggregatedTables: bool | None = Field(
-        default=None,
-        description="Whether the response was served from a precomputed table.",
-    )
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -17717,6 +17672,7 @@ class QueryResponseAlternative47(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -17733,7 +17689,6 @@ class QueryResponseAlternative47(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedLazyPrecompute: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(
@@ -20507,6 +20462,7 @@ class WebVitalsPathBreakdownQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    preComputeStrategy: WebAnalyticsPreComputeStrategy | None = None
     query_status: QueryStatus | None = Field(
         default=None,
         description=("Query status indicates whether next to the provided data, a query is still running."),
@@ -20523,7 +20479,6 @@ class WebVitalsPathBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Measured timings for different parts of the query generation process"),
     )
-    usedLazyPrecompute: bool | None = None
     warnings: list[DataWarehouseSyncWarning] | None = Field(
         default=None,
         description=(

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3296,6 +3296,12 @@ class WebAnalyticsOrderByFields(StrEnum):
     ERRORS = "Errors"
 
 
+class WebAnalyticsPreComputeStrategy(StrEnum):
+    PRE_AGGREGATED = "pre_aggregated"
+    LAZY_PRECOMPUTE = "lazy_precompute"
+    LIVE = "live"
+
+
 class WebStatsBreakdown(StrEnum):
     PAGE = "Page"
     INITIAL_PAGE = "InitialPage"

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -3280,6 +3280,15 @@ export const WebAnalyticsOrderByDirectionApi = {
     Desc: 'DESC',
 } as const
 
+export type WebAnalyticsPreComputeStrategyApi =
+    (typeof WebAnalyticsPreComputeStrategyApi)[keyof typeof WebAnalyticsPreComputeStrategyApi]
+
+export const WebAnalyticsPreComputeStrategyApi = {
+    PreAggregated: 'pre_aggregated',
+    LazyPrecompute: 'lazy_precompute',
+    Live: 'live',
+} as const
+
 export interface SamplingRateApi {
     denominator?: number | null
     numerator: number
@@ -3296,6 +3305,7 @@ export interface WebStatsTableQueryResponseApi {
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
     offset?: number | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3307,8 +3317,6 @@ export interface WebStatsTableQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -3375,7 +3383,6 @@ export interface WebOverviewItemApi {
     key: string
     kind: WebAnalyticsItemKindApi
     previous?: number | null
-    usedPreAggregatedTables?: boolean | null
     value?: number | null
 }
 
@@ -3388,6 +3395,7 @@ export interface WebOverviewQueryResponseApi {
     hogql?: string | null
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3398,8 +3406,6 @@ export interface WebOverviewQueryResponseApi {
     samplingRate?: SamplingRateApi | null
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -3654,6 +3660,7 @@ export interface Response4Api {
     hogql?: string | null
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3664,8 +3671,6 @@ export interface Response4Api {
     samplingRate?: SamplingRateApi | null
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -3681,6 +3686,7 @@ export interface Response5Api {
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
     offset?: number | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3692,8 +3698,6 @@ export interface Response5Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -3735,6 +3739,7 @@ export interface Response7Api {
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
     offset?: number | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3746,10 +3751,6 @@ export interface Response7Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
-    /** Whether the response was served from the lazy precompute path. */
-    usedLazyPrecompute?: boolean | null
-    /** Whether the response was served from a precomputed table. */
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -3772,6 +3773,7 @@ export interface Response8Api {
     hogql?: string | null
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3785,7 +3787,6 @@ export interface Response8Api {
     results: WebVitalsPathBreakdownResultApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -5635,6 +5636,7 @@ export interface WebGoalsQueryResponseApi {
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
     offset?: number | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -5646,10 +5648,6 @@ export interface WebGoalsQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
-    /** Whether the response was served from the lazy precompute path. */
-    usedLazyPrecompute?: boolean | null
-    /** Whether the response was served from a precomputed table. */
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -5756,6 +5754,7 @@ export interface WebVitalsPathBreakdownQueryResponseApi {
     hogql?: string | null
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -5769,7 +5768,6 @@ export interface WebVitalsPathBreakdownQueryResponseApi {
     results: WebVitalsPathBreakdownResultApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
@@ -127,6 +127,60 @@
                        use_hive_partitioning=0
   '''
 # ---
+# name: TestExperimentMeanMetric.test_conversion_window_extends_to_last_exposure_1_precomputed
+  '''
+  WITH exposures AS
+    (SELECT accurateCastOrNull(t.entity_id, 'UUID') AS entity_id,
+            if(ifNull(greater(uniqExact(t.variant), 1), 0), '$multiple', argMin(t.variant, toTimeZone(t.first_exposure_time, 'UTC'))) AS variant,
+            min(toTimeZone(t.first_exposure_time, 'UTC')) AS first_exposure_time,
+            max(toTimeZone(t.last_exposure_time, 'UTC')) AS last_exposure_time,
+            argMin(t.exposure_event_uuid, toTimeZone(t.first_exposure_time, 'UTC')) AS exposure_event_uuid,
+            argMin(t.exposure_session_id, toTimeZone(t.first_exposure_time, 'UTC')) AS exposure_session_id
+     FROM experiment_exposures_preaggregated AS t
+     WHERE and(equals(t.team_id, 99999), in(t.job_id, ['00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000']), equals(t.team_id, 99999), greaterOrEquals(t.first_exposure_time, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), lessOrEquals(t.first_exposure_time, assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC'))))
+     GROUP BY entity_id),
+       metric_events AS
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+            toTimeZone(events.timestamp, 'UTC') AS timestamp,
+            coalesce(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), 0) AS value
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC')), toIntervalSecond(86400))), equals(events.event, 'purchase'))),
+       entity_metrics AS
+    (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
+            sum(coalesce(accurateCastOrNull(metric_events.value, 'Float64'), 0)) AS value
+     FROM exposures
+     LEFT JOIN metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), and(greaterOrEquals(toTimeZone(metric_events.timestamp, 'UTC'), exposures.first_exposure_time), less(toTimeZone(metric_events.timestamp, 'UTC'), plus(exposures.last_exposure_time, toIntervalSecond(86400)))))
+     GROUP BY exposures.entity_id,
+              exposures.variant)
+  SELECT entity_metrics.variant AS variant,
+         count(entity_metrics.entity_id) AS num_users,
+         sum(entity_metrics.value) AS total_sum,
+         sum(power(entity_metrics.value, 2)) AS total_sum_of_squares
+  FROM entity_metrics
+  GROUP BY entity_metrics.variant
+  LIMIT 50000 SETTINGS join_algorithm='grace_hash',
+                       grace_hash_join_initial_buckets=2,
+                       load_balancing='in_order',
+                       readonly=2,
+                       max_execution_time=600,
+                       allow_experimental_object_type=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=39728447488,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1,
+                       use_hive_partitioning=0
+  '''
+# ---
 # name: TestExperimentMeanMetric.test_count_distinct_property_values_via_hogql_0_direct
   '''
   WITH exposures AS

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
@@ -127,60 +127,6 @@
                        use_hive_partitioning=0
   '''
 # ---
-# name: TestExperimentMeanMetric.test_conversion_window_extends_to_last_exposure_1_precomputed
-  '''
-  WITH exposures AS
-    (SELECT accurateCastOrNull(t.entity_id, 'UUID') AS entity_id,
-            if(ifNull(greater(uniqExact(t.variant), 1), 0), '$multiple', argMin(t.variant, toTimeZone(t.first_exposure_time, 'UTC'))) AS variant,
-            min(toTimeZone(t.first_exposure_time, 'UTC')) AS first_exposure_time,
-            max(toTimeZone(t.last_exposure_time, 'UTC')) AS last_exposure_time,
-            argMin(t.exposure_event_uuid, toTimeZone(t.first_exposure_time, 'UTC')) AS exposure_event_uuid,
-            argMin(t.exposure_session_id, toTimeZone(t.first_exposure_time, 'UTC')) AS exposure_session_id
-     FROM experiment_exposures_preaggregated AS t
-     WHERE and(equals(t.team_id, 99999), in(t.job_id, ['00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000']), equals(t.team_id, 99999), greaterOrEquals(t.first_exposure_time, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), lessOrEquals(t.first_exposure_time, assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC'))))
-     GROUP BY entity_id),
-       metric_events AS
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
-            toTimeZone(events.timestamp, 'UTC') AS timestamp,
-            coalesce(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), 0) AS value
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC')), toIntervalSecond(86400))), equals(events.event, 'purchase'))),
-       entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
-            sum(coalesce(accurateCastOrNull(metric_events.value, 'Float64'), 0)) AS value
-     FROM exposures
-     LEFT JOIN metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), and(greaterOrEquals(toTimeZone(metric_events.timestamp, 'UTC'), exposures.first_exposure_time), less(toTimeZone(metric_events.timestamp, 'UTC'), plus(exposures.last_exposure_time, toIntervalSecond(86400)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
-  SELECT entity_metrics.variant AS variant,
-         count(entity_metrics.entity_id) AS num_users,
-         sum(entity_metrics.value) AS total_sum,
-         sum(power(entity_metrics.value, 2)) AS total_sum_of_squares
-  FROM entity_metrics
-  GROUP BY entity_metrics.variant
-  LIMIT 50000 SETTINGS join_algorithm='grace_hash',
-                       grace_hash_join_initial_buckets=2,
-                       load_balancing='in_order',
-                       readonly=2,
-                       max_execution_time=600,
-                       allow_experimental_object_type=1,
-                       max_ast_elements=4000000,
-                       max_expanded_ast_elements=4000000,
-                       max_bytes_before_external_group_by=39728447488,
-                       transform_null_in=1,
-                       optimize_min_equality_disjunction_chain_length=4294967295,
-                       allow_experimental_join_condition=1,
-                       use_hive_partitioning=0
-  '''
-# ---
 # name: TestExperimentMeanMetric.test_count_distinct_property_values_via_hogql_0_direct
   '''
   WITH exposures AS

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -2799,6 +2799,15 @@ export const WebAnalyticsOrderByDirectionApi = {
     Desc: 'DESC',
 } as const
 
+export type WebAnalyticsPreComputeStrategyApi =
+    (typeof WebAnalyticsPreComputeStrategyApi)[keyof typeof WebAnalyticsPreComputeStrategyApi]
+
+export const WebAnalyticsPreComputeStrategyApi = {
+    PreAggregated: 'pre_aggregated',
+    LazyPrecompute: 'lazy_precompute',
+    Live: 'live',
+} as const
+
 export interface SamplingRateApi {
     denominator?: number | null
     numerator: number
@@ -2815,6 +2824,7 @@ export interface WebStatsTableQueryResponseApi {
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
     offset?: number | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -2826,8 +2836,6 @@ export interface WebStatsTableQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -2894,7 +2902,6 @@ export interface WebOverviewItemApi {
     key: string
     kind: WebAnalyticsItemKindApi
     previous?: number | null
-    usedPreAggregatedTables?: boolean | null
     value?: number | null
 }
 
@@ -2907,6 +2914,7 @@ export interface WebOverviewQueryResponseApi {
     hogql?: string | null
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -2917,8 +2925,6 @@ export interface WebOverviewQueryResponseApi {
     samplingRate?: SamplingRateApi | null
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -3173,6 +3179,7 @@ export interface Response4Api {
     hogql?: string | null
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3183,8 +3190,6 @@ export interface Response4Api {
     samplingRate?: SamplingRateApi | null
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -3200,6 +3205,7 @@ export interface Response5Api {
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
     offset?: number | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3211,8 +3217,6 @@ export interface Response5Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -3254,6 +3258,7 @@ export interface Response7Api {
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
     offset?: number | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3265,10 +3270,6 @@ export interface Response7Api {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
-    /** Whether the response was served from the lazy precompute path. */
-    usedLazyPrecompute?: boolean | null
-    /** Whether the response was served from a precomputed table. */
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -3291,6 +3292,7 @@ export interface Response8Api {
     hogql?: string | null
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3304,7 +3306,6 @@ export interface Response8Api {
     results: WebVitalsPathBreakdownResultApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -5154,6 +5155,7 @@ export interface WebGoalsQueryResponseApi {
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
     offset?: number | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -5165,10 +5167,6 @@ export interface WebGoalsQueryResponseApi {
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
     types?: unknown[] | null
-    /** Whether the response was served from the lazy precompute path. */
-    usedLazyPrecompute?: boolean | null
-    /** Whether the response was served from a precomputed table. */
-    usedPreAggregatedTables?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
@@ -5275,6 +5273,7 @@ export interface WebVitalsPathBreakdownQueryResponseApi {
     hogql?: string | null
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
+    preComputeStrategy?: WebAnalyticsPreComputeStrategyApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */
     query_status?: QueryStatusApi | null
     /** The resolved previous/comparison period date range, when comparing against another period */
@@ -5288,7 +5287,6 @@ export interface WebVitalsPathBreakdownQueryResponseApi {
     results: WebVitalsPathBreakdownResultApi[]
     /** Measured timings for different parts of the query generation process */
     timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
 }

--- a/products/web_analytics/PRECOMPUTATION.md
+++ b/products/web_analytics/PRECOMPUTATION.md
@@ -107,7 +107,7 @@ The read is a single `sync_execute` call (not HogQL — see "Why bypass HogQL" b
 - `load_balancing="in_order"` — paired with the INSERT side's same setting for read-your-writes via Approach E in [CONSISTENCY.md](../../products/analytics_platform/backend/lazy_computation/CONSISTENCY.md).
 - `optimize_skip_unused_shards=1` — `job_id IN (...)` + sharding-by-`sipHash64(job_id)` lets ClickHouse prune to the right shards.
 
-Result is built into the standard `WebOverviewQueryResponse` via `_build_response_from_row`, with `usedPreAggregatedTables=True`.
+Result is built into the standard `WebOverviewQueryResponse` via `_build_response_from_row`, with `preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE`.
 
 #### Why bypass HogQL
 
@@ -180,7 +180,7 @@ Single `sync_execute` over `web_stats_paths_preaggregated` with `uniqMergeIf` / 
 ### Known follow-ups
 
 - INITIAL_PAGE + bounce (entry-pathname tab) is a different SQL shape — separate precompute table or shared one with an entry-only state column.
-- `usedLazyPrecompute` is set on the response; the frontend's `PreAggregatedBadge` already keys off `usedPreAggregatedTables` so users see the badge without further wiring. Distinguishing lazy from v2 in the UI is a separate follow-up.
+- The response's `preComputeStrategy` is set to `WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE`; the frontend's `PreAggregatedBadge` keys off it (a distinct "precomputed" variant) so the lazy path is visually distinguishable from the v2 `PRE_AGGREGATED` path.
 
 ## Lazy computation for the web vitals path-breakdown tile
 

--- a/products/web_analytics/backend/hogql_queries/external_clicks.py
+++ b/products/web_analytics/backend/hogql_queries/external_clicks.py
@@ -4,6 +4,7 @@ from posthog.schema import (
     CachedWebStatsTableQueryResponse,
     WebAnalyticsOrderByDirection,
     WebAnalyticsOrderByFields,
+    WebAnalyticsPreComputeStrategy,
     WebExternalClicksTableQuery,
     WebExternalClicksTableQueryResponse,
     WebStatsTableQueryResponse,
@@ -148,5 +149,6 @@ GROUP BY "context.columns.url"
             types=response.types,
             hogql=response.hogql,
             modifiers=self.modifiers,
+            preComputeStrategy=WebAnalyticsPreComputeStrategy.LIVE,
             **self.paginator.response_params(),
         )

--- a/products/web_analytics/backend/hogql_queries/metrics.py
+++ b/products/web_analytics/backend/hogql_queries/metrics.py
@@ -28,14 +28,14 @@ WEB_ANALYTICS_QUERY_LATENCY_BUCKETS = [
 WEB_ANALYTICS_QUERY_DURATION = Histogram(
     "web_analytics_query_duration_seconds",
     "Web analytics query execution latency in seconds",
-    labelnames=["query_kind", "query_strategy", "used_preaggregated", "breakdown", "has_conversion_goal"],
+    labelnames=["query_kind", "query_strategy", "pre_compute_strategy", "breakdown", "has_conversion_goal"],
     buckets=WEB_ANALYTICS_QUERY_LATENCY_BUCKETS,
 )
 
 WEB_ANALYTICS_QUERY_COUNTER = Counter(
     "web_analytics_query_total",
     "Total number of web analytics queries executed",
-    labelnames=["query_kind", "query_strategy", "used_preaggregated", "breakdown", "has_conversion_goal"],
+    labelnames=["query_kind", "query_strategy", "pre_compute_strategy", "breakdown", "has_conversion_goal"],
 )
 
 WEB_ANALYTICS_QUERY_ERRORS = Counter(

--- a/products/web_analytics/backend/hogql_queries/notable_changes.py
+++ b/products/web_analytics/backend/hogql_queries/notable_changes.py
@@ -6,6 +6,7 @@ import structlog
 from posthog.schema import (
     CachedWebNotableChangesQueryResponse,
     HogQLQueryModifiers,
+    WebAnalyticsPreComputeStrategy,
     WebNotableChangeItem,
     WebNotableChangesQuery,
     WebNotableChangesQueryResponse,
@@ -63,7 +64,7 @@ class WebNotableChangesQueryRunner(WebAnalyticsQueryRunner[WebNotableChangesQuer
         pre_agg_response = self._get_pre_aggregated_response()
         if pre_agg_response is not None:
             response = pre_agg_response
-            used_preagg = True
+            strategy = WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
         else:
             response = execute_hogql_query(
                 query_type="web_notable_changes_query",
@@ -74,14 +75,14 @@ class WebNotableChangesQueryRunner(WebAnalyticsQueryRunner[WebNotableChangesQuer
                 modifiers=self.modifiers,
                 limit_context=self.limit_context,
             )
-            used_preagg = False
+            strategy = WebAnalyticsPreComputeStrategy.LIVE
 
         if not response.results:
             return WebNotableChangesQueryResponse(
                 results=[],
                 samplingRate=self._sample_rate,
                 modifiers=self.modifiers,
-                usedPreAggregatedTables=used_preagg,
+                preComputeStrategy=strategy,
             )
 
         scored_items = self._score_results(response.results)
@@ -92,7 +93,7 @@ class WebNotableChangesQueryRunner(WebAnalyticsQueryRunner[WebNotableChangesQuer
             results=top_items,
             samplingRate=self._sample_rate,
             modifiers=self.modifiers,
-            usedPreAggregatedTables=used_preagg,
+            preComputeStrategy=strategy,
         )
 
     def _get_pre_aggregated_response(self):

--- a/products/web_analytics/backend/hogql_queries/page_url_search_query_runner.py
+++ b/products/web_analytics/backend/hogql_queries/page_url_search_query_runner.py
@@ -1,6 +1,7 @@
 from posthog.schema import (
     CachedWebPageURLSearchQueryResponse,
     PageURL,
+    WebAnalyticsPreComputeStrategy,
     WebPageURLSearchQuery,
     WebPageURLSearchQueryResponse,
 )
@@ -96,4 +97,5 @@ class PageUrlSearchQueryRunner(WebAnalyticsQueryRunner[WebPageURLSearchQueryResp
             hasMore=len(response.results) >= limit,
             hogql=response.hogql,
             modifiers=self.modifiers,
+            preComputeStrategy=WebAnalyticsPreComputeStrategy.LIVE,
         )

--- a/products/web_analytics/backend/hogql_queries/stats_table.py
+++ b/products/web_analytics/backend/hogql_queries/stats_table.py
@@ -10,6 +10,7 @@ from posthog.schema import (
     PersonPropertyFilter,
     WebAnalyticsOrderByDirection,
     WebAnalyticsOrderByFields,
+    WebAnalyticsPreComputeStrategy,
     WebStatsBreakdown,
     WebStatsTableQuery,
     WebStatsTableQueryResponse,
@@ -406,7 +407,7 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
             ],
             results=results,
             modifiers=self.modifiers,
-            usedLazyPrecompute=True,
+            preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE,
             hasMore=result.has_more,
             limit=self.paginator.limit,
             offset=self.paginator.offset,
@@ -434,7 +435,6 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
         )
         if rows is None:
             return None
-        self.used_preaggregated_tables = True
         return self._build_response_from_lazy_rows(rows, limit=limit, offset=offset)
 
     def _maybe_calculate_via_frustration_lazy_precompute(self) -> Optional[WebStatsTableQueryResponse]:
@@ -450,7 +450,6 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
         rows = execute_frustration_lazy_precomputed_read(self, limit=limit + 1, offset=offset)
         if rows is None:
             return None
-        self.used_preaggregated_tables = True
         return self._build_frustration_response_from_lazy_rows(rows, limit=limit, offset=offset)
 
     def _build_frustration_response_from_lazy_rows(
@@ -496,8 +495,7 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
             ],
             results=results,
             modifiers=self.modifiers,
-            usedPreAggregatedTables=True,
-            usedLazyPrecompute=True,
+            preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE,
             hasMore=has_more,
             limit=limit,
             offset=offset,
@@ -555,8 +553,7 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
             columns=columns,
             results=results,
             modifiers=self.modifiers,
-            usedPreAggregatedTables=True,
-            usedLazyPrecompute=True,
+            preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE,
             hasMore=has_more,
             limit=limit,
             offset=offset,
@@ -661,7 +658,11 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner[WebStatsTableQueryRespons
             types=response.types,
             hogql=response.hogql,
             modifiers=self.modifiers,
-            usedPreAggregatedTables=self.used_preaggregated_tables,
+            preComputeStrategy=(
+                WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
+                if self.used_preaggregated_tables
+                else WebAnalyticsPreComputeStrategy.LIVE
+            ),
             **self.paginator.response_params(),
         )
 

--- a/products/web_analytics/backend/hogql_queries/test/test_external_clicks_table.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_external_clicks_table.py
@@ -15,6 +15,7 @@ from posthog.schema import (
     SessionTableVersion,
     WebAnalyticsOrderByDirection,
     WebAnalyticsOrderByFields,
+    WebAnalyticsPreComputeStrategy,
     WebExternalClicksTableQuery,
 )
 
@@ -84,8 +85,10 @@ class TestExternalClicksTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
         return runner.calculate()
 
     def test_no_crash_when_no_data(self):
-        results = self._run_external_clicks_table_query("2023-12-08", "2023-12-15").results
-        self.assertEqual([], results)
+        response = self._run_external_clicks_table_query("2023-12-08", "2023-12-15")
+        self.assertEqual([], response.results)
+        # Always-live runner — never serves from a precompute path.
+        self.assertEqual(response.preComputeStrategy, WebAnalyticsPreComputeStrategy.LIVE)
 
     def test_increase_in_users(
         self,

--- a/products/web_analytics/backend/hogql_queries/test/test_notable_changes.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_notable_changes.py
@@ -45,7 +45,7 @@ class TestWebNotableChangesQueryRunner(ClickhouseTestMixin, APIBaseTest):
             )
             response = runner.calculate()
             self.assertEqual(response.results, [])
-            assert response.preComputeStrategy != WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
+            assert response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LIVE
 
     def test_scoring_high_traffic_high_change_ranks_above_low_traffic(self):
         runner = WebNotableChangesQueryRunner(
@@ -162,7 +162,7 @@ class TestWebNotableChangesQueryRunner(ClickhouseTestMixin, APIBaseTest):
             )
             response = runner.calculate()
 
-            assert response.preComputeStrategy != WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
+            assert response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LIVE
             self.assertGreater(len(response.results), 0)
 
             # Results should be sorted by impact_score descending

--- a/products/web_analytics/backend/hogql_queries/test/test_notable_changes.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_notable_changes.py
@@ -1,7 +1,13 @@
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, snapshot_clickhouse_queries
 
-from posthog.schema import CompareFilter, DateRange, HogQLQueryModifiers, WebNotableChangesQuery
+from posthog.schema import (
+    CompareFilter,
+    DateRange,
+    HogQLQueryModifiers,
+    WebAnalyticsPreComputeStrategy,
+    WebNotableChangesQuery,
+)
 
 from posthog.models.utils import uuid7
 
@@ -39,7 +45,7 @@ class TestWebNotableChangesQueryRunner(ClickhouseTestMixin, APIBaseTest):
             )
             response = runner.calculate()
             self.assertEqual(response.results, [])
-            self.assertFalse(response.usedPreAggregatedTables)
+            assert response.preComputeStrategy != WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
 
     def test_scoring_high_traffic_high_change_ranks_above_low_traffic(self):
         runner = WebNotableChangesQueryRunner(
@@ -156,7 +162,7 @@ class TestWebNotableChangesQueryRunner(ClickhouseTestMixin, APIBaseTest):
             )
             response = runner.calculate()
 
-            self.assertFalse(response.usedPreAggregatedTables)
+            assert response.preComputeStrategy != WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
             self.assertGreater(len(response.results), 0)
 
             # Results should be sorted by impact_score descending

--- a/products/web_analytics/backend/hogql_queries/test/test_page_url_search_query_runner.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_page_url_search_query_runner.py
@@ -1,7 +1,7 @@
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person
 
-from posthog.schema import DateRange, WebPageURLSearchQuery
+from posthog.schema import DateRange, WebAnalyticsPreComputeStrategy, WebPageURLSearchQuery
 
 from posthog.models.utils import uuid7
 
@@ -82,11 +82,13 @@ class TestPageUrlSearchQueryRunner(ClickhouseTestMixin, APIBaseTest):
             return runner.calculate()
 
     def test_no_crash_when_no_data(self):
-        results = self._run_page_url_search_query(
+        response = self._run_page_url_search_query(
             "2025-01-22",
             "2025-01-29",
-        ).results
-        assert [] == results, "Expected empty results when no data is present"
+        )
+        assert [] == response.results, "Expected empty results when no data is present"
+        # Always-live runner — never serves from a precompute path.
+        assert response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LIVE
 
     def test_search_by_term(self):
         s1 = str(uuid7("2025-01-22"))

--- a/products/web_analytics/backend/hogql_queries/test/test_web_analytics_metrics.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_analytics_metrics.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
-from posthog.schema import WebStatsBreakdown
+from posthog.schema import WebAnalyticsPreComputeStrategy, WebStatsBreakdown
 
 from posthog.clickhouse.query_tagging import (
     Feature,
@@ -163,12 +163,12 @@ class TestWebAnalyticsMetrics(TestCase):
         )
 
         fake_response = MagicMock()
-        fake_response.usedPreAggregatedTables = True
+        fake_response.preComputeStrategy = WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
 
         with patch.object(WebAnalyticsQueryRunner.__mro__[1], "calculate", return_value=fake_response):
             WebAnalyticsQueryRunner.calculate(runner)
 
-        label_filter = {**expected_labels, "used_preaggregated": "true"}
+        label_filter = {**expected_labels, "pre_compute_strategy": "pre_aggregated"}
         assert _get_counter_value(WEB_ANALYTICS_QUERY_COUNTER, label_filter) == 1.0
 
     @patch(
@@ -196,7 +196,7 @@ class TestWebAnalyticsMetrics(TestCase):
         counter_filter = {
             "query_kind": "WebStatsTableQuery",
             "query_strategy": "stats_table_simple_breakdown",
-            "used_preaggregated": "unknown",
+            "pre_compute_strategy": "unknown",
         }
         assert _get_counter_value(WEB_ANALYTICS_QUERY_COUNTER, counter_filter) == 1.0
 
@@ -208,7 +208,7 @@ class TestWebAnalyticsMetrics(TestCase):
         runner = _make_runner(query_kind="WebOverviewQuery", breakdown=None, properties=["fake_prop"])
 
         fake_response = MagicMock()
-        fake_response.usedPreAggregatedTables = False
+        fake_response.preComputeStrategy = WebAnalyticsPreComputeStrategy.LIVE
 
         with (
             patch.object(WebAnalyticsQueryRunner.__mro__[1], "calculate", return_value=fake_response),
@@ -226,7 +226,7 @@ class TestWebAnalyticsMetrics(TestCase):
         assert kw["query_strategy"] is None
         assert kw["clickhouse_query_type"] is None
         assert kw["breakdown"] == "none"
-        assert kw["used_preaggregated"] == "false"
+        assert kw["pre_compute_strategy"] == "live"
         assert kw["error"] is False
         assert kw["error_type"] is None
         assert kw["filter_count"] == 1
@@ -242,7 +242,7 @@ class TestWebAnalyticsMetrics(TestCase):
         cast(MagicMock, runner.clickhouse_query_type).return_value = "stats_table_path_bounce_query"
 
         fake_response = MagicMock()
-        fake_response.usedPreAggregatedTables = False
+        fake_response.preComputeStrategy = WebAnalyticsPreComputeStrategy.LIVE
 
         with (
             patch.object(WebAnalyticsQueryRunner.__mro__[1], "calculate", return_value=fake_response),
@@ -260,7 +260,7 @@ class TestWebAnalyticsMetrics(TestCase):
     def test_all_breakdown_values_produce_valid_labels(self, _name, breakdown, _mock_tag):
         runner = _make_runner(breakdown=breakdown)
         fake_response = MagicMock()
-        fake_response.usedPreAggregatedTables = None
+        fake_response.preComputeStrategy = None
 
         with patch.object(WebAnalyticsQueryRunner.__mro__[1], "calculate", return_value=fake_response):
             WebAnalyticsQueryRunner.calculate(runner)
@@ -271,10 +271,10 @@ class TestWebAnalyticsMetrics(TestCase):
     @patch(
         "products.web_analytics.backend.hogql_queries.web_analytics_query_runner.get_query_tag_value", return_value=None
     )
-    def test_preaggregated_none_maps_to_unknown(self, _mock_tag):
+    def test_pre_compute_strategy_none_maps_to_unknown(self, _mock_tag):
         runner = _make_runner()
         fake_response = MagicMock()
-        fake_response.usedPreAggregatedTables = None
+        fake_response.preComputeStrategy = None
 
         with patch.object(WebAnalyticsQueryRunner.__mro__[1], "calculate", return_value=fake_response):
             WebAnalyticsQueryRunner.calculate(runner)
@@ -282,7 +282,7 @@ class TestWebAnalyticsMetrics(TestCase):
         assert (
             _get_counter_value(
                 WEB_ANALYTICS_QUERY_COUNTER,
-                {"query_strategy": "none", "used_preaggregated": "unknown"},
+                {"query_strategy": "none", "pre_compute_strategy": "unknown"},
             )
             == 1.0
         )
@@ -290,7 +290,7 @@ class TestWebAnalyticsMetrics(TestCase):
     @patch(
         "products.web_analytics.backend.hogql_queries.web_analytics_query_runner.get_query_tag_value", return_value=None
     )
-    def test_response_missing_preaggregated_attr_maps_to_unknown(self, _mock_tag):
+    def test_response_missing_pre_compute_strategy_attr_maps_to_unknown(self, _mock_tag):
         runner = _make_runner()
         fake_response = MagicMock(spec=[])  # empty spec = no attributes
 
@@ -300,7 +300,7 @@ class TestWebAnalyticsMetrics(TestCase):
         assert (
             _get_counter_value(
                 WEB_ANALYTICS_QUERY_COUNTER,
-                {"query_strategy": "none", "used_preaggregated": "unknown"},
+                {"query_strategy": "none", "pre_compute_strategy": "unknown"},
             )
             == 1.0
         )
@@ -344,7 +344,7 @@ class TestWebAnalyticsMetrics(TestCase):
         cast(MagicMock, runner.query.model_dump).return_value = {"kind": query_kind}
 
         fake_response = MagicMock()
-        fake_response.usedPreAggregatedTables = False
+        fake_response.preComputeStrategy = WebAnalyticsPreComputeStrategy.LIVE
 
         with patch.object(WebAnalyticsQueryRunner.__mro__[1], "calculate", return_value=fake_response):
             WebAnalyticsQueryRunner.calculate(runner)
@@ -467,7 +467,7 @@ class TestWebAnalyticsMetrics(TestCase):
         cast(MagicMock, runner.query.model_dump).return_value = expected_payload
 
         fake_response = MagicMock()
-        fake_response.usedPreAggregatedTables = False
+        fake_response.preComputeStrategy = WebAnalyticsPreComputeStrategy.LIVE
         with patch.object(WebAnalyticsQueryRunner.__mro__[1], "calculate", return_value=fake_response):
             WebAnalyticsQueryRunner.calculate(runner)
 

--- a/products/web_analytics/backend/hogql_queries/test/test_web_goals_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_goals_lazy_precompute.py
@@ -13,6 +13,7 @@ from posthog.schema import (
     PropertyOperator,
     SessionPropertyFilter,
     SessionsV2JoinMode,
+    WebAnalyticsPreComputeStrategy,
     WebAnalyticsSampling,
     WebGoalsQuery,
 )
@@ -228,8 +229,7 @@ class TestWebGoalsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         with self._enable_lazy():
             lazy_response = self._runner(self._build_query()).calculate()
 
-        assert lazy_response.usedLazyPrecompute is True
-        assert lazy_response.usedPreAggregatedTables is True
+        assert lazy_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
 
         live_by_action = {r[0]: (r[1], r[2], r[3]) for r in live_response.results}
         lazy_by_action = {r[0]: (r[1], r[2], r[3]) for r in lazy_response.results}

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_frustration_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_frustration_lazy_precompute.py
@@ -17,6 +17,7 @@ from posthog.schema import (
     SessionsV2JoinMode,
     WebAnalyticsOrderByDirection,
     WebAnalyticsOrderByFields,
+    WebAnalyticsPreComputeStrategy,
     WebAnalyticsSampling,
     WebStatsBreakdown,
     WebStatsTableQuery,
@@ -267,8 +268,7 @@ class TestWebStatsFrustrationLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.pk, status=PreaggregationJob.Status.READY
         ).count()
         assert ready_jobs > 0, "expected at least one READY precompute job"
-        assert lazy_response.usedLazyPrecompute is True
-        assert lazy_response.usedPreAggregatedTables is True
+        assert lazy_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
 
         lazy_by_path = self._collect_metrics(lazy_response.results)
         assert lazy_by_path == live_by_path, f"lazy/live mismatch: lazy={lazy_by_path}, live={live_by_path}"

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
@@ -332,7 +332,7 @@ class TestWebStatsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             response = self._run(self._build_query(breakdown_by=WebStatsBreakdown.LANGUAGE))
 
         assert self._job_count() > 0
-        assert response.usedLazyPrecompute is True
+        assert response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert self._metrics(response) == [("en-US", (2.0, None), (4.0, None))]
 
     @freeze_time("2024-01-15T12:00:00Z")
@@ -364,7 +364,7 @@ class TestWebStatsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         with self._enable_lazy():
             lazy_response = self._run(self._build_query(breakdown_by=WebStatsBreakdown.LANGUAGE))
 
-        assert lazy_response.usedLazyPrecompute is True
+        assert lazy_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert self._metrics(lazy_response) == raw
 
     @freeze_time("2024-01-15T12:00:00Z")
@@ -396,7 +396,7 @@ class TestWebStatsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         with self._enable_lazy():
             lazy_response = self._run(self._build_query(breakdown_by=WebStatsBreakdown.LANGUAGE))
 
-        assert lazy_response.usedLazyPrecompute is True
+        assert lazy_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert self._metrics(lazy_response) == raw, f"raw={raw} lazy={self._metrics(lazy_response)}"
 
     @freeze_time("2024-01-15T12:00:00Z")

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
@@ -14,6 +14,7 @@ from posthog.schema import (
     PropertyOperator,
     WebAnalyticsOrderByDirection,
     WebAnalyticsOrderByFields,
+    WebAnalyticsPreComputeStrategy,
     WebAnalyticsSampling,
     WebStatsBreakdown,
     WebStatsTableQuery,
@@ -203,7 +204,7 @@ class TestWebStatsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.pk, status=PreaggregationJob.Status.READY
         ).count()
         assert ready_jobs > 0, f"expected a READY precompute job for {breakdown_by}"
-        assert lazy_response.usedLazyPrecompute is True
+        assert lazy_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert lazy == raw, f"lazy/raw mismatch for {breakdown_by}: raw={raw}, lazy={lazy}"
 
     @parameterized.expand(PARITY_BREAKDOWNS)
@@ -243,7 +244,7 @@ class TestWebStatsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         with self._enable_lazy():
             response = self._run(self._build_query(breakdown_by=WebStatsBreakdown.VIEWPORT))
 
-        assert response.usedLazyPrecompute is True
+        assert response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert len(response.results) > 0
         assert all(isinstance(row[0], tuple) and len(row[0]) == 2 for row in response.results)
 
@@ -585,9 +586,9 @@ class TestWebStatsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             response = self._run(query)
 
         assert self._job_count() == 0
-        # Raw path leaves `usedLazyPrecompute` unset; the failure mode we're
-        # guarding against is the lazy path silently serving with a rewritten sort.
-        assert response.usedLazyPrecompute is not True
+        # Raw path leaves `preComputeStrategy` off the lazy strategy; the failure mode
+        # we're guarding against is the lazy path silently serving with a rewritten sort.
+        assert response.preComputeStrategy != WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
 
     @freeze_time("2024-01-15T12:00:00Z")
     def test_pagination_page_two_lazy_matches_raw(self):
@@ -651,7 +652,7 @@ class TestWebStatsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             lazy_response = self._run(query)
 
         lazy_metrics = self._metrics(lazy_response)
-        assert lazy_response.usedLazyPrecompute is True
+        assert lazy_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert lazy_response.hasMore is True, "should report more rows past the requested page"
         assert len(lazy_metrics) == 3
         # Visitors are monotonically non-increasing on the returned page.

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_paths_lazy_precompute.py
@@ -19,6 +19,7 @@ from posthog.schema import (
     SessionsV2JoinMode,
     WebAnalyticsOrderByDirection,
     WebAnalyticsOrderByFields,
+    WebAnalyticsPreComputeStrategy,
     WebAnalyticsSampling,
     WebStatsBreakdown,
     WebStatsTableQuery,
@@ -155,8 +156,7 @@ class TestWebStatsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.pk, status=PreaggregationJob.Status.READY
         ).count()
         assert ready_jobs > 0, "expected at least one READY precompute job"
-        assert lazy_response.usedLazyPrecompute is True
-        assert lazy_response.usedPreAggregatedTables is True
+        assert lazy_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
 
         lazy_by_path = self._collect_metrics(lazy_response.results)
 
@@ -490,7 +490,7 @@ class TestWebStatsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
     )
     @unittest.skip(
         "CI-only flake since #59075 (passes locally on the CI ClickHouse image) — "
-        "lazy path returns None on `usedLazyPrecompute` despite jobs being created "
+        "lazy path returns None on `preComputeStrategy` despite jobs being created "
         "(`test_unfiltered_round_trip_creates_precompute_job` passes). Same root "
         "cause as `test_lazy_result_matches_raw_result`: suspected read-after-write "
         "visibility on the Distributed lazy read. `@unittest.skip` placed AFTER "
@@ -507,7 +507,7 @@ class TestWebStatsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         self._seed_two_sessions()
         with self._enable_lazy():
             response = self._run(self._build_query(order_by=[field, direction]))
-        assert response.usedLazyPrecompute is True
+        assert response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
 
     @unittest.skip(
         "CI-only flake since #59075 (passes locally on the CI ClickHouse image) — "

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_pre_aggregated.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_pre_aggregated.py
@@ -11,6 +11,7 @@ from posthog.schema import (
     EventPropertyFilter,
     HogQLQueryModifiers,
     PropertyOperator,
+    WebAnalyticsPreComputeStrategy,
     WebStatsBreakdown,
     WebStatsTableQuery,
 )
@@ -413,7 +414,7 @@ class TestWebStatsPreAggregated(WebAnalyticsPreAggregatedTestBase):
         ]
 
         assert response.results == expected_results
-        assert response.usedPreAggregatedTables
+        assert response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
 
     def test_breakdown_consistency_preagg_vs_regular(self):
         # Note: PAGE and VIEWPORT breakdowns are excluded. I will add them back in later.
@@ -430,8 +431,8 @@ class TestWebStatsPreAggregated(WebAnalyticsPreAggregatedTestBase):
                 regular_response = self._calculate_breakdown_query(breakdown, use_preagg=False)
 
                 # Verify both queries used their respective query engines
-                assert preagg_response.usedPreAggregatedTables
-                assert not regular_response.usedPreAggregatedTables
+                assert preagg_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
+                assert regular_response.preComputeStrategy != WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
 
                 assert self._sort_results(preagg_response.results) == self._sort_results(regular_response.results)
 
@@ -619,7 +620,7 @@ class TestWebStatsPreAggregated(WebAnalyticsPreAggregatedTestBase):
             assert "subdomain.example.com/pricing" in breakdown_values
             assert "example.com/pricing" in breakdown_values
 
-        assert response.usedPreAggregatedTables
+        assert response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
 
     @parameterized.expand(
         [
@@ -684,7 +685,7 @@ class TestWebStatsPreAggregated(WebAnalyticsPreAggregatedTestBase):
         assert "/landing" in breakdown_values
         assert "example.com/landing" not in breakdown_values
         assert "subdomain.example.com/landing" not in breakdown_values
-        assert response.usedPreAggregatedTables
+        assert response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
 
     def test_include_host_page_breakdown_groups_same_paths_separately(self):
         self._truncate_preaggregated_tables()
@@ -764,8 +765,8 @@ class TestWebStatsPreAggregated(WebAnalyticsPreAggregatedTestBase):
         assert with_host_dict["example.com/landing"][0] == 2
         assert with_host_dict["subdomain.example.com/landing"][0] == 1
         assert without_host_dict["/landing"][0] == 3
-        assert with_host.usedPreAggregatedTables
-        assert without_host.usedPreAggregatedTables
+        assert with_host.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
+        assert without_host.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
 
     # NOTE: test_include_host_consistency_between_preagg_and_regular is not included because
     # pre-aggregated tables have a known limitation where PAGE breakdown doesn't return mid-session pages.

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_pre_aggregated.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_pre_aggregated.py
@@ -432,7 +432,7 @@ class TestWebStatsPreAggregated(WebAnalyticsPreAggregatedTestBase):
 
                 # Verify both queries used their respective query engines
                 assert preagg_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
-                assert regular_response.preComputeStrategy != WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
+                assert regular_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LIVE
 
                 assert self._sort_results(preagg_response.results) == self._sort_results(regular_response.results)
 

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_pre_aggregated_channel_types.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_pre_aggregated_channel_types.py
@@ -399,7 +399,7 @@ class TestWebStatsPreAggregatedChannelTypes(WebAnalyticsPreAggregatedTestBase):
 
         # Verify both queries used their respective query engines
         assert preagg_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
-        assert regular_response.preComputeStrategy != WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
+        assert regular_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LIVE
 
         actual_sorted = sorted(preagg_response.results, key=lambda x: x[0])
         expected_sorted = sorted(regular_response.results, key=lambda x: x[0])
@@ -427,7 +427,7 @@ class TestWebStatsPreAggregatedChannelTypes(WebAnalyticsPreAggregatedTestBase):
 
         # Verify that pre-aggregated tables were used
         assert preagg_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
-        assert regular_response.preComputeStrategy != WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
+        assert regular_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LIVE
 
         preagg_result = preagg_response.results[0]
         regular_result = regular_response.results[0]

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_pre_aggregated_channel_types.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_pre_aggregated_channel_types.py
@@ -1,7 +1,14 @@
 from freezegun import freeze_time
 from posthog.test.base import _create_event, _create_person, flush_persons_and_events
 
-from posthog.schema import DateRange, HogQLQueryModifiers, SessionPropertyFilter, WebStatsBreakdown, WebStatsTableQuery
+from posthog.schema import (
+    DateRange,
+    HogQLQueryModifiers,
+    SessionPropertyFilter,
+    WebAnalyticsPreComputeStrategy,
+    WebStatsBreakdown,
+    WebStatsTableQuery,
+)
 
 from posthog.hogql.database.schema.channel_type import DEFAULT_CHANNEL_TYPES
 
@@ -391,8 +398,8 @@ class TestWebStatsPreAggregatedChannelTypes(WebAnalyticsPreAggregatedTestBase):
         regular_response = self._calculate_channel_type_query(use_preagg=False)
 
         # Verify both queries used their respective query engines
-        assert preagg_response.usedPreAggregatedTables
-        assert not regular_response.usedPreAggregatedTables
+        assert preagg_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
+        assert regular_response.preComputeStrategy != WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
 
         actual_sorted = sorted(preagg_response.results, key=lambda x: x[0])
         expected_sorted = sorted(regular_response.results, key=lambda x: x[0])
@@ -419,8 +426,8 @@ class TestWebStatsPreAggregatedChannelTypes(WebAnalyticsPreAggregatedTestBase):
         )
 
         # Verify that pre-aggregated tables were used
-        assert preagg_response.usedPreAggregatedTables
-        assert not regular_response.usedPreAggregatedTables
+        assert preagg_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
+        assert regular_response.preComputeStrategy != WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
 
         preagg_result = preagg_response.results[0]
         regular_result = regular_response.results[0]
@@ -443,7 +450,7 @@ class TestWebStatsPreAggregatedChannelTypes(WebAnalyticsPreAggregatedTestBase):
         )
         assert len(preagg_response.results) == 1
         assert preagg_response.results[0][1] == (2.0, None)  # 2 visitors
-        assert preagg_response.usedPreAggregatedTables
+        assert preagg_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
 
         # Test "Organic Search" - should get 1 session
         preagg_response = self._calculate_channel_type_query(
@@ -454,7 +461,7 @@ class TestWebStatsPreAggregatedChannelTypes(WebAnalyticsPreAggregatedTestBase):
         )
         assert len(preagg_response.results) == 1
         assert preagg_response.results[0][1] == (1.0, None)  # 1 visitor
-        assert preagg_response.usedPreAggregatedTables
+        assert preagg_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
 
         # Test non-existent channel type - should get no results
         preagg_response = self._calculate_channel_type_query(
@@ -466,4 +473,4 @@ class TestWebStatsPreAggregatedChannelTypes(WebAnalyticsPreAggregatedTestBase):
             ],
         )
         assert len(preagg_response.results) == 0
-        assert preagg_response.usedPreAggregatedTables
+        assert preagg_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.PRE_AGGREGATED

--- a/products/web_analytics/backend/hogql_queries/test/test_web_vitals_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_vitals_paths_lazy_precompute.py
@@ -11,6 +11,7 @@ from posthog.schema import (
     DateRange,
     EventPropertyFilter,
     PropertyOperator,
+    WebAnalyticsPreComputeStrategy,
     WebAnalyticsSampling,
     WebVitalsMetric,
     WebVitalsMetricBand,
@@ -139,7 +140,7 @@ class TestWebVitalsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         self._seed()
         with self._enable_lazy():
             response = self._run(self._build_query())
-        assert response.usedLazyPrecompute is True
+        assert response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert self._job_count() > 0, "expected at least one precompute job to be created"
 
     @parameterized.expand(PARITY_MATRIX)
@@ -155,7 +156,7 @@ class TestWebVitalsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             lazy_response = self._run(self._build_query(metric=metric, percentile=percentile))
         lazy = self._paths_with_values(lazy_response)
 
-        assert lazy_response.usedLazyPrecompute is True
+        assert lazy_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert lazy.keys() == raw.keys(), f"path set mismatch for {metric}/{percentile}: raw={raw}, lazy={lazy}"
         for path in raw:
             raw_band, raw_value = raw[path]
@@ -181,7 +182,7 @@ class TestWebVitalsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             response = self._run(
                 self._build_query(conversion_goal=CustomEventConversionGoal(customEventName="$pageview")),
             )
-        assert response.usedLazyPrecompute is not True
+        assert response.preComputeStrategy != WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert self._job_count() == 0
 
     @freeze_time("2024-01-15T12:00:00Z")
@@ -189,7 +190,7 @@ class TestWebVitalsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         self._seed()
         with self._enable_lazy():
             response = self._run(self._build_query(sampling=WebAnalyticsSampling(enabled=True)))
-        assert response.usedLazyPrecompute is not True
+        assert response.preComputeStrategy != WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert self._job_count() == 0
 
     @parameterized.expand(
@@ -211,7 +212,7 @@ class TestWebVitalsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         query.dateRange = DateRange(date_from=date_from, date_to=date_to, explicitDate=True)
         with self._enable_lazy():
             response = self._run(query)
-        assert response.usedLazyPrecompute is not True
+        assert response.preComputeStrategy != WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert self._job_count() == 0
 
     @freeze_time("2024-01-15T12:00:00Z")
@@ -227,14 +228,14 @@ class TestWebVitalsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             lazy_response = self._run(self._build_query())
         lazy = self._paths_with_values(lazy_response)
 
-        assert lazy_response.usedLazyPrecompute is True
+        assert lazy_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert raw == lazy, f"lazy/raw mismatch in IST: raw={raw}, lazy={lazy}"
 
     @freeze_time("2024-01-15T12:00:00Z")
     def test_query_optin_alone_falls_through_when_org_flag_disabled(self):
         self._seed()
         response = self._run(self._build_query(opt_in_precompute=True))
-        assert response.usedLazyPrecompute is not True
+        assert response.preComputeStrategy != WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert self._job_count() == 0
 
     @freeze_time("2024-01-15T12:00:00Z")
@@ -242,7 +243,7 @@ class TestWebVitalsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         self._seed()
         with self._enable_lazy():
             response = self._run(self._build_query(opt_in_precompute=False))
-        assert response.usedLazyPrecompute is not True
+        assert response.preComputeStrategy != WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
         assert self._job_count() == 0
 
     @freeze_time("2024-01-15T12:00:00Z")

--- a/products/web_analytics/backend/hogql_queries/web_analytics_query_runner.py
+++ b/products/web_analytics/backend/hogql_queries/web_analytics_query_runner.py
@@ -151,17 +151,17 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
                     query_strategy = query_strategy or "strategy_resolution_failed"
                     clickhouse_query_type = clickhouse_query_type or None
 
-                used_preaggregated_label = "unknown"
+                pre_compute_strategy_label = "unknown"
                 if response is not None:
-                    val = getattr(response, "usedPreAggregatedTables", None)
-                    if val is not None:
-                        used_preaggregated_label = str(val).lower()
+                    strategy = getattr(response, "preComputeStrategy", None)
+                    if strategy is not None:
+                        pre_compute_strategy_label = str(strategy)
 
                 query_strategy_label = query_strategy or "none"
                 metric_labels = {
                     "query_kind": query_kind,
                     "query_strategy": query_strategy_label,
-                    "used_preaggregated": used_preaggregated_label,
+                    "pre_compute_strategy": pre_compute_strategy_label,
                     "breakdown": breakdown_label,
                     "has_conversion_goal": has_conversion_goal,
                 }
@@ -187,7 +187,7 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
                     clickhouse_query_type=clickhouse_query_type,
                     breakdown=breakdown_label,
                     has_conversion_goal=has_conversion_goal,
-                    used_preaggregated=used_preaggregated_label,
+                    pre_compute_strategy=pre_compute_strategy_label,
                     duration_s=round(duration_s, 4),
                     error=bool(error_type),
                     error_type=error_type or None,

--- a/products/web_analytics/backend/hogql_queries/web_goals.py
+++ b/products/web_analytics/backend/hogql_queries/web_goals.py
@@ -1,7 +1,13 @@
 from collections.abc import Iterator, Sequence
 from typing import Optional, TypeVar
 
-from posthog.schema import CachedWebGoalsQueryResponse, WebAnalyticsOrderByFields, WebGoalsQuery, WebGoalsQueryResponse
+from posthog.schema import (
+    CachedWebGoalsQueryResponse,
+    WebAnalyticsOrderByFields,
+    WebAnalyticsPreComputeStrategy,
+    WebGoalsQuery,
+    WebGoalsQueryResponse,
+)
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
@@ -194,7 +200,12 @@ WHERE {periods_expression}
         try:
             query = self.to_query()
         except NoActionsError:
-            return WebGoalsQueryResponse(results=[], samplingRate=self._sample_rate, modifiers=self.modifiers)
+            return WebGoalsQueryResponse(
+                results=[],
+                samplingRate=self._sample_rate,
+                modifiers=self.modifiers,
+                preComputeStrategy=WebAnalyticsPreComputeStrategy.LIVE,
+            )
 
         response = execute_hogql_query(
             query_type="web_goals_query",
@@ -258,6 +269,7 @@ WHERE {periods_expression}
             results=results,
             samplingRate=self._sample_rate,
             modifiers=self.modifiers,
+            preComputeStrategy=WebAnalyticsPreComputeStrategy.LIVE,
         )
 
     def _maybe_calculate_via_lazy_precompute(self) -> Optional[WebGoalsQueryResponse]:
@@ -334,8 +346,7 @@ WHERE {periods_expression}
             results=results,
             samplingRate=self._sample_rate,
             modifiers=self.modifiers,
-            usedPreAggregatedTables=True,
-            usedLazyPrecompute=True,
+            preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE,
         )
 
     def event_properties(self) -> ast.Expr:

--- a/products/web_analytics/backend/hogql_queries/web_overview.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview.py
@@ -6,6 +6,7 @@ import structlog
 from posthog.schema import (
     CachedWebOverviewQueryResponse,
     HogQLQueryModifiers,
+    WebAnalyticsPreComputeStrategy,
     WebOverviewQuery,
     WebOverviewQueryResponse,
 )
@@ -88,12 +89,7 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner[WebOverviewQueryResponse]):
             return None
         return execute_lazy_precomputed_read(self)
 
-    def _build_response_from_row(
-        self,
-        row: list,
-        used_pre_aggregated: bool,
-        used_lazy_precompute: bool = False,
-    ) -> WebOverviewQueryResponse:
+    def _build_response_from_row(self, row: list) -> WebOverviewQueryResponse:
         # Only called from the lazy precompute short-circuit; that path's gate
         # already rejects conversionGoal, so we don't need a separate branch
         # here. The v2/raw path builds its response inline in `_calculate`.
@@ -120,14 +116,13 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner[WebOverviewQueryResponse]):
             modifiers=self.modifiers,
             dateFrom=self.query_date_range.date_from_str,
             dateTo=self.query_date_range.date_to_str,
-            usedPreAggregatedTables=used_pre_aggregated,
-            usedLazyPrecompute=used_lazy_precompute,
+            preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE,
         )
 
     def _calculate(self) -> WebOverviewQueryResponse:
         lazy_row = self.get_lazy_precomputed_row()
         if lazy_row is not None:
-            return self._build_response_from_row(lazy_row, used_pre_aggregated=True, used_lazy_precompute=True)
+            return self._build_response_from_row(lazy_row)
 
         pre_aggregated_response = self.get_pre_aggregated_response()
 
@@ -177,7 +172,11 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner[WebOverviewQueryResponse]):
             modifiers=self.modifiers,
             dateFrom=self.query_date_range.date_from_str,
             dateTo=self.query_date_range.date_to_str,
-            usedPreAggregatedTables=response == pre_aggregated_response,
+            preComputeStrategy=(
+                WebAnalyticsPreComputeStrategy.PRE_AGGREGATED
+                if response == pre_aggregated_response
+                else WebAnalyticsPreComputeStrategy.LIVE
+            ),
         )
 
     def all_properties(self) -> ast.Expr:

--- a/products/web_analytics/backend/hogql_queries/web_vitals_path_breakdown.py
+++ b/products/web_analytics/backend/hogql_queries/web_vitals_path_breakdown.py
@@ -1,5 +1,6 @@
 from posthog.schema import (
     CachedWebStatsTableQueryResponse,
+    WebAnalyticsPreComputeStrategy,
     WebVitalsMetricBand,
     WebVitalsPathBreakdownQuery,
     WebVitalsPathBreakdownQueryResponse,
@@ -119,6 +120,7 @@ HAVING value >= 0
             timings=response.timings,
             hogql=response.hogql,
             modifiers=self.modifiers,
+            preComputeStrategy=WebAnalyticsPreComputeStrategy.LIVE,
         )
 
     def _get_results_for_band(

--- a/products/web_analytics/backend/hogql_queries/web_vitals_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_vitals_paths_lazy_precompute.py
@@ -11,6 +11,7 @@ from prometheus_client import Counter
 
 from posthog.schema import (
     HogQLQueryModifiers,
+    WebAnalyticsPreComputeStrategy,
     WebVitalsMetric,
     WebVitalsMetricBand,
     WebVitalsPathBreakdownQueryResponse,
@@ -322,7 +323,7 @@ def _build_response(
         ],
         timings=runner.timings.to_list() if runner.timings else None,
         modifiers=runner.modifiers,
-        usedLazyPrecompute=True,
+        preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE,
     )
 
 

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -63,7 +63,7 @@ import dagster
 import structlog
 from prometheus_client import Counter
 
-from posthog.schema import WebStatsBreakdown
+from posthog.schema import WebAnalyticsPreComputeStrategy, WebStatsBreakdown
 
 from posthog.hogql.constants import LimitContext
 
@@ -278,13 +278,13 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
             EAGER_PRECOMPUTE_BASELINE_WARMED.labels(query_kind=label).inc()
             warmed += 1
             # Self-check the warm actually did its job: the tile must resolve to a
-            # precompute read, not fall through to raw. `usedLazyPrecompute` is only
+            # precompute read, not fall through to raw. `preComputeStrategy == LAZY_PRECOMPUTE` is only
             # True when the read passed the lazy executor's TTL freshness filter
             # (`created_at + TTL >= now`, TTL = 15min today … 7d old), so True is a
             # guarantee the precomputed value is well within the 2h threshold. A tile
             # that comes back `not True` warmed nothing useful — surface it loudly so a
             # stale/missing precompute or a non-precomputable breakdown can't hide.
-            if getattr(response, "usedLazyPrecompute", None) is not True:
+            if getattr(response, "preComputeStrategy", None) != WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE:
                 EAGER_PRECOMPUTE_BASELINE_NOT_PRECOMPUTED.labels(query_kind=label).inc()
                 with _OP_LOG_LOCK:
                     context.log.warning(

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 import dagster
 from structlog.testing import capture_logs
 
-from posthog.schema import WebStatsBreakdown
+from posthog.schema import WebAnalyticsPreComputeStrategy, WebStatsBreakdown
 
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Organization, Team
@@ -101,7 +101,9 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         _make_preagg_job(recent, computed_at=now)
         _make_preagg_job(old, computed_at=now - timedelta(days=2))
         # `never` has no PreaggregationJob row — it should warm first.
-        get_runner.return_value = Mock(run=Mock(return_value=Mock(usedLazyPrecompute=True)))
+        get_runner.return_value = Mock(
+            run=Mock(return_value=Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE))
+        )
 
         # Enrol in reverse-staleness order to prove the sort (not the input) drives it.
         with _eager_audience([recent.pk, old.pk, never.pk]):
@@ -127,7 +129,9 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         _make_preagg_job(genuine, computed_at=now)
         _make_preagg_job(noise_window, computed_at=now, time_range_end=now - timedelta(days=BASELINE_WINDOW_DAYS + 5))
         _make_preagg_job(noise_status, computed_at=now, status=PreaggregationJob.Status.STALE)
-        get_runner.return_value = Mock(run=Mock(return_value=Mock(usedLazyPrecompute=True)))
+        get_runner.return_value = Mock(
+            run=Mock(return_value=Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE))
+        )
 
         with _eager_audience([genuine.pk, noise_window.pk, noise_status.pk]):
             warm_eager_baseline_op(dagster.build_op_context())
@@ -144,7 +148,9 @@ class TestWarmEagerBaselineOp(APIBaseTest):
     @patch(f"{_EAGER_MODULE}.tag_queries")
     @patch(f"{_EAGER_MODULE}.get_query_runner")
     def test_team_logs_carry_processed_total_progress(self, get_runner, _tag, _is_cloud):
-        get_runner.return_value = Mock(run=Mock(return_value=Mock(usedLazyPrecompute=True)))
+        get_runner.return_value = Mock(
+            run=Mock(return_value=Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE))
+        )
         teams = self._enroll_teams(count=3)
         with _eager_audience([t.pk for t in teams]), capture_logs() as cap_logs:
             warm_eager_baseline_op(dagster.build_op_context())
@@ -158,7 +164,7 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         t1, t2 = self._enroll_teams(count=2)
 
         ok_runner = Mock()
-        ok_runner.run.return_value = Mock(usedLazyPrecompute=True)
+        ok_runner.run.return_value = Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE)
         bad_runner = Mock()
         bad_runner.run.side_effect = RuntimeError("boom")
 
@@ -208,7 +214,7 @@ class TestWarmBaselineForTeam(APIBaseTest):
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_warms_full_matrix(self, get_runner, tag_queries_mock):
         runner = Mock()
-        runner.run.return_value = Mock(usedLazyPrecompute=True)
+        runner.run.return_value = Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE)
         get_runner.return_value = runner
 
         warmed, failed = _warm_baseline_for_team(Mock(spec=dagster.OpExecutionContext), self.team)
@@ -225,10 +231,12 @@ class TestWarmBaselineForTeam(APIBaseTest):
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_flags_tiles_that_do_not_resolve_to_precompute(self, get_runner, tag_queries_mock):
-        # A tile whose calculate() does not come back with usedLazyPrecompute=True fell
+        # A tile whose calculate() does not come back with preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE fell
         # through to raw — the warm populated no fresh precompute. It still counts as
         # "warmed" (it ran without error) but must be surfaced as not-precomputed.
-        get_runner.return_value = Mock(run=Mock(return_value=Mock(usedLazyPrecompute=None)))
+        get_runner.return_value = Mock(
+            run=Mock(return_value=Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LIVE))
+        )
 
         with capture_logs() as cap_logs:
             warmed, failed = _warm_baseline_for_team(Mock(spec=dagster.OpExecutionContext), self.team)
@@ -247,7 +255,7 @@ class TestWarmBaselineForTeam(APIBaseTest):
 
         def capture(query, team, limit_context):
             captured.append(query)
-            return Mock(run=Mock(return_value=Mock(usedLazyPrecompute=True)))
+            return Mock(run=Mock(return_value=Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE)))
 
         get_runner.side_effect = capture
         _warm_baseline_for_team(Mock(spec=dagster.OpExecutionContext), self.team)
@@ -295,7 +303,7 @@ class TestWarmBaselineForTeam(APIBaseTest):
 
         def record_get_runner(**kwargs):
             call_order.append("get_runner")
-            return Mock(run=Mock(return_value=Mock(usedLazyPrecompute=True)))
+            return Mock(run=Mock(return_value=Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE)))
 
         tag_queries_mock.side_effect = record_tag
         get_runner.side_effect = record_get_runner
@@ -318,7 +326,9 @@ class TestEagerBaselineLogging(APIBaseTest):
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_emits_structured_lifecycle_events_on_success(self, get_runner, _tag, _is_cloud):
-        get_runner.return_value = Mock(run=Mock(return_value=Mock(usedLazyPrecompute=True)))
+        get_runner.return_value = Mock(
+            run=Mock(return_value=Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE))
+        )
 
         with _eager_audience([self.team.pk]), capture_logs() as cap_logs:
             warm_eager_baseline_op(dagster.build_op_context())

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3155,6 +3155,15 @@ export namespace Schemas {
       Desc: 'DESC',
     } as const;
 
+    export type WebAnalyticsPreComputeStrategy = typeof WebAnalyticsPreComputeStrategy[keyof typeof WebAnalyticsPreComputeStrategy];
+
+
+    export const WebAnalyticsPreComputeStrategy = {
+      PreAggregated: 'pre_aggregated',
+      LazyPrecompute: 'lazy_precompute',
+      Live: 'live',
+    } as const;
+
     export interface SamplingRate {
       denominator?: number | null;
       numerator: number;
@@ -3171,6 +3180,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3182,8 +3192,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      usedLazyPrecompute?: boolean | null;
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -3246,7 +3254,6 @@ export namespace Schemas {
       key: string;
       kind: WebAnalyticsItemKind;
       previous?: number | null;
-      usedPreAggregatedTables?: boolean | null;
       value?: number | null;
     }
 
@@ -3259,6 +3266,7 @@ export namespace Schemas {
       hogql?: string | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -3269,8 +3277,6 @@ export namespace Schemas {
       samplingRate?: SamplingRate | null;
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
-      usedLazyPrecompute?: boolean | null;
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -4290,6 +4296,7 @@ export namespace Schemas {
       hogql?: string | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -4300,8 +4307,6 @@ export namespace Schemas {
       samplingRate?: SamplingRate | null;
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
-      usedLazyPrecompute?: boolean | null;
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -4317,6 +4322,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -4328,8 +4334,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      usedLazyPrecompute?: boolean | null;
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -4371,6 +4375,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -4382,10 +4387,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      /** Whether the response was served from the lazy precompute path. */
-      usedLazyPrecompute?: boolean | null;
-      /** Whether the response was served from a precomputed table. */
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -4408,6 +4409,7 @@ export namespace Schemas {
       hogql?: string | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -4421,7 +4423,6 @@ export namespace Schemas {
       results: WebVitalsPathBreakdownResult[];
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
-      usedLazyPrecompute?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -5370,6 +5371,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -5381,10 +5383,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      /** Whether the response was served from the lazy precompute path. */
-      usedLazyPrecompute?: boolean | null;
-      /** Whether the response was served from a precomputed table. */
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -5475,6 +5473,7 @@ export namespace Schemas {
       hogql?: string | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -5488,7 +5487,6 @@ export namespace Schemas {
       results: WebVitalsPathBreakdownResult[];
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
-      usedLazyPrecompute?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -23882,6 +23880,7 @@ export namespace Schemas {
       hogql?: string | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -23892,7 +23891,6 @@ export namespace Schemas {
       samplingRate?: SamplingRate | null;
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -41285,6 +41283,7 @@ export namespace Schemas {
       hogql?: string | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -41295,8 +41294,6 @@ export namespace Schemas {
       samplingRate?: SamplingRate | null;
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
-      usedLazyPrecompute?: boolean | null;
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -41312,6 +41309,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -41323,8 +41321,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      usedLazyPrecompute?: boolean | null;
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -41366,6 +41362,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -41377,10 +41374,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      /** Whether the response was served from the lazy precompute path. */
-      usedLazyPrecompute?: boolean | null;
-      /** Whether the response was served from a precomputed table. */
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -41392,6 +41385,7 @@ export namespace Schemas {
       hogql?: string | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -41405,7 +41399,6 @@ export namespace Schemas {
       results: WebVitalsPathBreakdownResult[];
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
-      usedLazyPrecompute?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -41447,6 +41440,7 @@ export namespace Schemas {
       hogql?: string | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -41457,7 +41451,6 @@ export namespace Schemas {
       samplingRate?: SamplingRate | null;
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -41764,6 +41757,7 @@ export namespace Schemas {
       hogql?: string | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -41774,8 +41768,6 @@ export namespace Schemas {
       samplingRate?: SamplingRate | null;
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
-      usedLazyPrecompute?: boolean | null;
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -41791,6 +41783,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -41802,8 +41795,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      usedLazyPrecompute?: boolean | null;
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -41845,6 +41836,7 @@ export namespace Schemas {
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       offset?: number | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -41856,10 +41848,6 @@ export namespace Schemas {
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
       types?: unknown[] | null;
-      /** Whether the response was served from the lazy precompute path. */
-      usedLazyPrecompute?: boolean | null;
-      /** Whether the response was served from a precomputed table. */
-      usedPreAggregatedTables?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }
@@ -41871,6 +41859,7 @@ export namespace Schemas {
       hogql?: string | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -41884,7 +41873,6 @@ export namespace Schemas {
       results: WebVitalsPathBreakdownResult[];
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
-      usedLazyPrecompute?: boolean | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
       warnings?: DataWarehouseSyncWarning[] | null;
     }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -23802,6 +23802,7 @@ export namespace Schemas {
       limit?: number | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */
@@ -41412,6 +41413,7 @@ export namespace Schemas {
       limit?: number | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      preComputeStrategy?: WebAnalyticsPreComputeStrategy | null;
       /** Query status indicates whether next to the provided data, a query is still running. */
       query_status?: QueryStatus | null;
       /** The resolved previous/comparison period date range, when comparing against another period */


### PR DESCRIPTION
## Problem

Web analytics query responses carried two parallel, overlapping booleans to describe which read path served them: `usedPreAggregatedTables` (v2 continuously-maintained tables) and `usedLazyPrecompute` (on-demand lazy precompute tables). They were set inconsistently across runners, and the lazy paths were incorrectly reporting `usedPreAggregatedTables=true` — so a response that came from the lazy precompute path was indistinguishable from one served by the v2 pre-aggregated tables, both in the UI badge and in the `used_preaggregated` telemetry label. Adding a third state (raw/live) would have meant yet another boolean.

## Changes

Replaces the two booleans with a single enum, `preComputeStrategy`, across every web analytics response:

- `pre_aggregated` — served from the v2 continuously-maintained pre-aggregated tables
- `lazy_precompute` — served from the on-demand lazy precompute tables
- `live` — computed live from raw events (no precompute)

Each runner now sets the enum on **every** return path (stats table, goals, overview, notable changes, web vitals path breakdown), so the value is always accurate rather than defaulting to "unknown". The dead `usedPreAggregatedTables` field on `WebOverviewItem` is dropped.

Downstream:
- **Frontend** — `OverviewGrid`, `WebOverview`, `DataTable`, `WebVitalsPathBreakdown`, and `MarketingAnalyticsOverview` now key the `PreAggregatedBadge` off `preComputeStrategy` (a distinct "precomputed" variant for lazy vs "preagg" for v2), so the two precompute paths are visually distinguishable.
- **Telemetry** — the metric/log label `used_preaggregated` (`true`/`false`/`unknown`) becomes **`pre_compute_strategy`** (`pre_aggregated`/`lazy_precompute`/`live`/`unknown`), reading the enum directly.
- Schema source (`schema-general.ts`) is the source of truth; `posthog/schema.py`, the OpenAPI-derived `api.schemas.ts` files, and MCP generated types were regenerated.

> ⚠️ **Operational note:** the metric/log label rename (`used_preaggregated` → `pre_compute_strategy`) and its value change will break any existing Grafana dashboards/alerts filtering on `used_preaggregated="true"`. The `evaluating-web-analytics-performance` skill references the old tag vocabulary and should be updated after merge.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual UI testing. Automated tests I actually ran locally, all passing on this branch (off master):

- Full web analytics backend suite for the affected runners — metrics/telemetry, notable changes, overview, all lazy-precompute suites (stats/paths/goals/frustration/overview/web-vitals), and the pre-aggregated + channel-type suites (~280 tests).
- `ruff format` / `ruff check` clean; schema + OpenAPI regeneration ran clean.
- Existing test assertions were converted from the booleans to the enum; the telemetry test verifies the new `pre_compute_strategy` label mapping (including `unknown` for absent/None).

Frontend typecheck passes for the changed files (pre-existing stale-kea-typegen errors in `dataTableLogicType` are unrelated and regenerated by CI).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `products/web_analytics/PRECOMPUTATION.md` to reference the new field. (The lazy-precompute authoring skill that also referenced the old fields lives on a separate branch and is updated there.)

## 🤖 Agent context

Authored by Claude Code (Opus) on behalf of @lricoy. The change started as a bug fix — lazy-precompute responses wrongly reporting `usedPreAggregatedTables=true` — and the maintainer chose to consolidate the two booleans into one strategy enum rather than keep adding flags. Field name `preComputeStrategy` and "all web analytics responses" scope were maintainer decisions.

Notable decision: this branch was rebuilt off `master` after the work was initially committed onto an unrelated branch. Master had since **deleted the web trends runner and its `WebTrendsQueryResponse` schema types entirely**, so the web-trends portion of the original change was dropped and the schema conflict resolved in favor of master's deletion. Generated files were regenerated from scratch against master rather than merged.

Requires human review; not self-merged.
