### PR TITLE
ci: add CLI release approval preview

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -125,10 +125,10 @@ jobs:
 
     release:
         name: Prepare CLI release
-        needs: [check-changesets, notify-approval-needed]
+        needs: [check-changesets, cli-release-preview, notify-approval-needed]
         runs-on: ubuntu-latest
         timeout-minutes: 30
-        if: always() && needs.check-changesets.outputs.has-changesets == 'true'
+        if: always() && needs.check-changesets.outputs.has-changesets == 'true' && needs.cli-release-preview.result == 'success'
         environment: Release SDK
         permissions:
             contents: write

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -46,15 +46,82 @@ jobs:
 
     notify-approval-needed:
         name: Notify Slack - Approval Needed
-        needs: check-changesets
+        needs: [check-changesets, cli-release-preview]
         if: needs.check-changesets.outputs.has-changesets == 'true'
-        uses: posthog/.github/.github/workflows/notify-approval-needed.yml@5fc4680761e8ac29a61b212756230eba0e276d8c
+        uses: posthog/.github/.github/workflows/notify-approval-needed.yml@03565438486849ac0d19543de36c248a27d32a2f
         with:
+            checkout_repository: false
             slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
             slack_user_group_id: ${{ vars.GROUP_CLIENT_LIBRARIES_SLACK_GROUP_ID }}
+            tag_pattern: posthog-cli/v*
+            tag_sort: version
         secrets:
             slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
             posthog_project_api_key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+
+    cli-release-preview:
+        name: Generate CLI release preview
+        needs: check-changesets
+        if: needs.check-changesets.outputs.has-changesets == 'true'
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: Write CLI diff summary
+              env:
+                  REPOSITORY: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+
+                  repo_url="https://github.com/$REPOSITORY.git"
+                  base_tag=$(
+                    git ls-remote --tags --refs --sort=-version:refname "$repo_url" 'refs/tags/posthog-cli/v*' |
+                      awk -F 'refs/tags/' 'NR == 1 { print $2 }'
+                  )
+
+                  if [ -z "$base_tag" ]; then
+                    echo "::error::No posthog-cli release tags found"
+                    exit 1
+                  fi
+
+                  mkdir release-preview
+                  cd release-preview
+                  git init -q
+                  git remote add origin "$repo_url"
+
+                  # Fetch the exact tag and branch instead of using actions/checkout,
+                  # which would fetch every branch/tag in this large monorepo.
+                  git fetch --depth=1 --filter=blob:none --no-tags origin \
+                    "refs/tags/$base_tag:refs/tags/$base_tag" \
+                    "refs/heads/master:refs/remotes/origin/master"
+
+                  {
+                    echo "## posthog-cli release preview"
+                    echo
+                    echo "- Base: \`$base_tag\`"
+                    echo "- Head: \`master\`"
+                    echo
+                    echo "### CLI diff"
+                    echo
+                    echo "\`\`\`text"
+                    git diff --shortstat "$base_tag..origin/master" -- cli cli/.sampo || true
+                    echo "\`\`\`"
+                    echo
+                    echo "<details>"
+                    echo "<summary>Changed CLI files</summary>"
+                    echo
+                    echo "\`\`\`text"
+                    git diff --stat "$base_tag..origin/master" -- cli cli/.sampo || true
+                    echo "\`\`\`"
+                    echo "</details>"
+                    echo
+                    echo "<details>"
+                    echo "<summary>Pending CLI changesets</summary>"
+                    echo
+                    echo "\`\`\`text"
+                    git diff --name-only "$base_tag..origin/master" -- ':(glob)cli/.sampo/changesets/*.md' || true
+                    echo "\`\`\`"
+                    echo "</details>"
+                  } >> "$GITHUB_STEP_SUMMARY"
 
     release:
         name: Prepare CLI release
@@ -72,7 +139,7 @@ jobs:
         steps:
             - name: Notify Slack - Approved
               if: needs.notify-approval-needed.outputs.slack_ts != ''
-              uses: posthog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
+              uses: posthog/.github/.github/actions/slack-thread-reply@03565438486849ac0d19543de36c248a27d32a2f
               with:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -206,7 +273,7 @@ jobs:
 
             - name: Notify Slack - Failed
               if: failure() && needs.notify-approval-needed.outputs.slack_ts != ''
-              uses: posthog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
+              uses: posthog/.github/.github/actions/slack-thread-reply@03565438486849ac0d19543de36c248a27d32a2f
               with:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -588,7 +655,7 @@ jobs:
         if: always() && needs.host-release.result == 'success' && (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') && needs.notify-approval-needed.outputs.slack_ts != ''
         steps:
             - name: Notify Slack - Release Published
-              uses: posthog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
+              uses: posthog/.github/.github/actions/slack-thread-reply@03565438486849ac0d19543de36c248a27d32a2f
               with:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -103,14 +103,14 @@ jobs:
                     echo "### CLI diff"
                     echo
                     echo "\`\`\`text"
-                    git diff --shortstat "$base_tag..origin/master" -- cli cli/.sampo || true
+                    git diff --shortstat "$base_tag..origin/master" -- cli cli/.sampo
                     echo "\`\`\`"
                     echo
                     echo "<details>"
                     echo "<summary>Changed CLI files</summary>"
                     echo
                     echo "\`\`\`text"
-                    git diff --stat "$base_tag..origin/master" -- cli cli/.sampo || true
+                    git diff --stat "$base_tag..origin/master" -- cli cli/.sampo
                     echo "\`\`\`"
                     echo "</details>"
                     echo
@@ -118,7 +118,7 @@ jobs:
                     echo "<summary>Pending CLI changesets</summary>"
                     echo
                     echo "\`\`\`text"
-                    git diff --name-only "$base_tag..origin/master" -- ':(glob)cli/.sampo/changesets/*.md' || true
+                    git diff --name-only "$base_tag..origin/master" -- ':(glob)cli/.sampo/changesets/*.md'
                     echo "\`\`\`"
                     echo "</details>"
                   } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- disable repository checkout in the CLI release approval notification now that the reusable workflow supports tag-only lookup
- add a small pre-approval summary job that compares the latest `posthog-cli/v*` tag to `master` for `cli` and `cli/.sampo`
- bump the pinned `PostHog/.github` action/workflow SHA to `03565438486849ac0d19543de36c248a27d32a2f`

## Notes
- The preview job intentionally uses `git ls-remote` plus a shallow blobless fetch instead of `actions/checkout`, because `actions/checkout` would fetch every branch/tag in this large monorepo for a small approval summary.
- `release` now requires the preview job to succeed so a failed preview cannot silently skip Slack notification and still release.

## Validation
- `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/release-cli.yml').read_text()); print('yaml ok')"`
- `UV_CACHE_DIR=.uv-cache uv run ./bin/hogli lint:workflows --workflows-dir .github/workflows`
- `git diff --check HEAD~2..HEAD`
- extracted the committed preview `run:` block and smoke-tested it against `PostHog/posthog`
- `/Users/cat/.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/master`

`actionlint .github/workflows/release-cli.yml` still reports existing shellcheck warnings in unrelated release steps; confirmed the same warnings exist on `origin/master`.
