### PR TITLE
fix(layout): use standard styling on project access removed page

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4719,13 +4719,13 @@ snapshots:
     scenes-app-data-warehouse-settings-schemas--default--light:
         hash: v1.k794b7964.18626812d4b56d76787437924e1bc585c0d290b2d3d5a82acef06ad862687d31.T90_pbE7tLkoXwZml5VYlGjFqOKnGtCJsNfB3J76Xio
     scenes-app-error-project-unavailable--access-revoked--dark:
-        hash: v1.k794b7964.551951688a4131cbd9c0d08e553c79238fb9831c6e227e3854eb3596a95d5725.lEJkOr35uSHLqc-IqIYv7Z2bc4-rjbJut0zmTNBae6Y
+        hash: v1.k794b7964.0574501d1036cac7563c61590dfb8b3d64192e239cbad126d754b9905b4f3ee1._MDyv82QyHN-dApRaQoppTvESKRRZP_p6MB5PKLrjeg
     scenes-app-error-project-unavailable--access-revoked--light:
-        hash: v1.k794b7964.9bf467c52f2cce1e67483f7cb56ea651d1e8b673cc4f0db80a9d9f71dae13da4.15Ara4t3237epYtxe7UqB1hsh-6cVexokOTbDZ2wgXI
+        hash: v1.k794b7964.049275e2a4082aeaf3adacbfb1cb8f336583c29824193e8711b51c54e22c3fb6.t0OnW8D_qZ6V3y1IEVbZptyaAWA-zPjbRRUGy7FYqXY
     scenes-app-error-project-unavailable--no-selectable-projects--dark:
-        hash: v1.k794b7964.59e0c88e3f489946f8beea3a64fe1c10366c0241cfb3247e91412933f560d7c8.PmFI9SQu-BmDZKyGJm75wOvMiQe5vIRc_hYbN49F0ps
+        hash: v1.k794b7964.4b86109312eacfb0a2935943b1eb44627db419347065f1b4991d16afa6c1dcd0.dL2KRYy7fg2Zu8j6KOaCeyRkNcFBiQFQ9DNYeC-gKQg
     scenes-app-error-project-unavailable--no-selectable-projects--light:
-        hash: v1.k794b7964.481d253ac770b475315f72305fa5b2a7b130e4af6e01f1004890f100ead896cc.Zjd5lM7ZRgfmBCNcsxfTbTyV54MFbOC2EAPAdj5r7aY
+        hash: v1.k794b7964.4074c66e2c5048cf0574b95b4b53a81601be50bc733531b969eae030c6ced45d.xc0jzMCgimBXCdpIGauT6qHYv4aZP669O9mBqXnH7TU
     scenes-app-errortracking--group-page--dark:
         hash: v1.k794b7964.c8e6860882c2adc15d79721f8790d613bded5df4d64424016547083a73b00b6a.2HqMTs3tTi5AWTdmpXCXHJF8_hZSC9pUVrodRXR1eZk
     scenes-app-errortracking--group-page--light:

--- a/frontend/src/layout/ErrorProjectUnavailable.tsx
+++ b/frontend/src/layout/ErrorProjectUnavailable.tsx
@@ -44,23 +44,31 @@ export function ErrorProjectUnavailable(): JSX.Element {
         </>
     )
 
+    if (!user?.organization) {
+        return <CreateOrganizationModal isVisible inline />
+    }
+
+    const accessRemoved =
+        (user?.team && !user.organization?.teams.some((team) => team.id === user?.team?.id || user.team)) ||
+        currentTeam?.user_access_level === 'none'
+
     return (
-        <div>
-            {!user?.organization ? (
-                <CreateOrganizationModal isVisible inline />
-            ) : (user?.team && !user.organization?.teams.some((team) => team.id === user?.team?.id || user.team)) ||
-              currentTeam?.user_access_level === 'none' ? (
+        <div className="flex flex-col items-center max-w-2xl p-4 mx-auto my-24 text-center">
+            {accessRemoved ? (
                 <>
-                    <h1>Project access has been removed</h1>
-                    <p>
-                        Someone in your organization has removed your access to this project. You can
-                        {listOptions()}.
+                    <h1 className="text-3xl font-bold mt-4 mb-0">Project access has been removed</h1>
+                    <p className="text-sm mt-3 mb-0">
+                        Someone in your organization has removed your access to this project. You can{listOptions()}.
                     </p>
                 </>
             ) : (
                 <>
-                    <h1>Welcome to {user?.organization?.name} on PostHog</h1>
-                    <p>You do not have access to any projects in this organization. You can {listOptions()}.</p>
+                    <h1 className="text-3xl font-bold mt-4 mb-0">
+                        Welcome to {user?.organization?.name} on PostHog
+                    </h1>
+                    <p className="text-sm mt-3 mb-0">
+                        You do not have access to any projects in this organization. You can{listOptions()}.
+                    </p>
                 </>
             )}
         </div>

--- a/frontend/src/layout/ErrorProjectUnavailable.tsx
+++ b/frontend/src/layout/ErrorProjectUnavailable.tsx
@@ -63,9 +63,7 @@ export function ErrorProjectUnavailable(): JSX.Element {
                 </>
             ) : (
                 <>
-                    <h1 className="text-3xl font-bold mt-4 mb-0">
-                        Welcome to {user?.organization?.name} on PostHog
-                    </h1>
+                    <h1 className="text-3xl font-bold mt-4 mb-0">Welcome to {user?.organization?.name} on PostHog</h1>
                     <p className="text-sm mt-3 mb-0">
                         You do not have access to any projects in this organization. You can{listOptions()}.
                     </p>


### PR DESCRIPTION
## Problem

The "Project access has been removed" page (`ErrorProjectUnavailable` scene) had poor padding and font sizing. It rendered a bare `<div>` with unstyled `<h1>` and `<p>` tags, so it looked off compared to the rest of the app and didn't use our standard layout conventions.

## Changes

Restyled the scene to match the existing `AccessDenied` component:

- Centered, max-width container with consistent padding and top margin (`flex flex-col items-center max-w-2xl p-4 mx-auto my-24 text-center`)
- Standard heading (`text-3xl font-bold`) and body text (`text-sm`) sizes with proper vertical spacing

Also flattened the early-return for the no-organization case (`CreateOrganizationModal`) into a guard clause to reduce nesting. The three rendered states (no org, access removed, no selectable projects) and the underlying logic are unchanged — the existing Storybook stories (`AccessRevoked`, `NoSelectableProjects`) still exercise both branches.

## How did you test this code?

I'm an agent. I did not run the frontend tooling (`pnpm format` / `typescript:check`) — dependencies aren't installed in this environment. The change is styling-only and follows the existing `AccessDenied` conventions and the file's formatting. Visual verification can be done via the existing Storybook stories under `Scenes-App/Error Project Unavailable`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code). The user reported padding/font-size issues on the project-access-removed page and asked to use standard components.

I located the scene at `frontend/src/layout/ErrorProjectUnavailable.tsx`, compared it against the sibling `AccessDenied` component (which already uses the standard centered/padded layout), and applied the same Tailwind utility classes for container, heading, and body text rather than introducing a new pattern. No logic or copy changed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
