### PR TITLE
chore(ci): bound + retry wedged semgrep scans

### DIFF
--- a/.github/scripts/semgrep-ci.sh
+++ b/.github/scripts/semgrep-ci.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Run a semgrep scan with a wall-clock watchdog and a single retry.
+#
+# Why this exists: semgrep-core can spin in target discovery (the Semgrepignore
+# v2 path walk) far past --timeout, which only bounds per-rule *matching*. A
+# wedged worker pins one CPU with no further output until the job hits its
+# timeout-minutes — a recurring, nondeterministic CI false-failure that has hit
+# every semgrep job (and master). The per-rule --timeout does not cover this
+# phase, so we bound it externally here.
+#
+# On a wedge this logs the stuck worker's open source paths (to pin the
+# offending file for an upstream report), kills it, and retries once — the hang
+# is nondeterministic, so a retry almost always succeeds. Real findings (exit 1)
+# and other errors propagate unchanged. Cap is overridable via SEMGREP_CAP_SECONDS.
+
+CAP="${SEMGREP_CAP_SECONDS:-900}"
+attempt=1
+
+while :; do
+    semgrep "$@" &
+    sp=$!
+
+    # Watchdog: snapshot + kill the run if it exceeds CAP seconds.
+    (
+        e=0
+        while kill -0 "$sp" 2>/dev/null; do
+            sleep 15
+            e=$((e + 15))
+            [ "$e" -lt "$CAP" ] && continue
+            echo "::warning::semgrep exceeded ${CAP}s (attempt ${attempt}) — capturing the stuck worker, then killing"
+            core=$(ps -o pid,stat,args | awk '/[s]emgrep-core/ && $2 ~ /R/ { print $1; exit }')
+            if [ -n "$core" ]; then
+                echo "stuck semgrep-core pid=${core} — open source paths (likely the trigger):"
+                for fd in /proc/"$core"/fd/*; do readlink "$fd"; done 2>/dev/null \
+                    | grep -Ev 'pipe:|socket:|/dev/|anon_' || true
+            fi
+            kill -9 "$sp" 2>/dev/null || true
+            for p in $(ps -o pid,args | awk '/[s]emgrep-core/ { print $1 }'); do
+                kill -9 "$p" 2>/dev/null || true
+            done
+            break
+        done
+    ) &
+    wd=$!
+
+    wait "$sp" && rc=0 || rc=$?
+    kill "$wd" 2>/dev/null || true
+
+    # 137 = SIGKILL from our watchdog (a wedge). Retry once; everything else
+    # (0 success, 1 findings, 2 error) propagates so real failures still block.
+    if [ "$rc" -eq 137 ] && [ "$attempt" -lt 2 ]; then
+        attempt=2
+        echo "::warning::retrying semgrep once after wedge"
+        continue
+    fi
+    exit "$rc"
+done

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -26,7 +26,8 @@ jobs:
 
             - name: Run Semgrep
               run: |
-                  semgrep \
+                  SG=semgrep; [ -f .github/scripts/semgrep-ci.sh ] && SG="sh .github/scripts/semgrep-ci.sh"
+                  SEMGREP_CAP_SECONDS=900 $SG \
                     --config "p/python" \
                     --config "p/owasp-top-ten" \
                     --config "p/security-audit" \
@@ -52,7 +53,8 @@ jobs:
 
             - name: Run Semgrep
               run: |
-                  semgrep \
+                  SG=semgrep; [ -f .github/scripts/semgrep-ci.sh ] && SG="sh .github/scripts/semgrep-ci.sh"
+                  SEMGREP_CAP_SECONDS=300 $SG \
                     --config "p/golang" \
                     --config "p/owasp-top-ten" \
                     --config "p/security-audit" \
@@ -76,7 +78,8 @@ jobs:
 
             - name: Run Semgrep
               run: |
-                  semgrep \
+                  SG=semgrep; [ -f .github/scripts/semgrep-ci.sh ] && SG="sh .github/scripts/semgrep-ci.sh"
+                  SEMGREP_CAP_SECONDS=300 $SG \
                     --config "p/rust" \
                     --config "p/owasp-top-ten" \
                     --config "p/security-audit" \
@@ -102,7 +105,8 @@ jobs:
 
             - name: Run Semgrep
               run: |
-                  semgrep \
+                  SG=semgrep; [ -f .github/scripts/semgrep-ci.sh ] && SG="sh .github/scripts/semgrep-ci.sh"
+                  SEMGREP_CAP_SECONDS=600 $SG \
                     --config ".semgrep/rules/" \
                     --config "p/javascript" \
                     --config "p/owasp-top-ten" \
@@ -129,7 +133,8 @@ jobs:
             # product-specific rules land, extend the --config list explicitly.
             - name: Run Semgrep
               run: |
-                  semgrep \
+                  SG=semgrep; [ -f .github/scripts/semgrep-ci.sh ] && SG="sh .github/scripts/semgrep-ci.sh"
+                  SEMGREP_CAP_SECONDS=360 $SG \
                     --config ".semgrep/rules/prefer-codegen-api.yaml" \
                     --error \
                     --metrics=off \
@@ -150,7 +155,8 @@ jobs:
             # exclude all directories already scanned by other jobs
             - name: Run Semgrep
               run: |
-                  semgrep \
+                  SG=semgrep; [ -f .github/scripts/semgrep-ci.sh ] && SG="sh .github/scripts/semgrep-ci.sh"
+                  SEMGREP_CAP_SECONDS=600 $SG \
                     --config "p/owasp-top-ten" \
                     --config "p/security-audit" \
                     --config "p/trailofbits" \
@@ -195,7 +201,8 @@ jobs:
             # up here.
             - name: Warnings (informational)
               run: |
-                  semgrep \
+                  SG=semgrep; [ -f .github/scripts/semgrep-ci.sh ] && SG="sh .github/scripts/semgrep-ci.sh"
+                  SEMGREP_CAP_SECONDS=360 $SG \
                     --config ".semgrep/devex-rules/" \
                     --severity=WARNING \
                     --metrics=off \
@@ -206,7 +213,8 @@ jobs:
             # job — regression guards live here.
             - name: Errors (blocking)
               run: |
-                  semgrep \
+                  SG=semgrep; [ -f .github/scripts/semgrep-ci.sh ] && SG="sh .github/scripts/semgrep-ci.sh"
+                  SEMGREP_CAP_SECONDS=360 $SG \
                     --config ".semgrep/devex-rules/" \
                     --severity=ERROR \
                     --error \


### PR DESCRIPTION
## Problem

The semgrep jobs in `ci-security.yaml` intermittently hang to their full `timeout-minutes` and get cancelled — a recurring, nondeterministic CI false-failure that blocks PRs and burns runner credits. It hits every scan job and master (~3% of runs in a recent window), each costing the full job timeout plus a forced re-run.

Root cause (confirmed by capturing a live wedged process): a single `semgrep-core` worker spins at 100% CPU in **target discovery** — the Semgrepignore v2 path-walk that runs *before* matching — and the per-rule `--timeout` does not bound that phase (it only caps a rule running on a single file). The Python orchestrator and sibling workers then block on it until the job timeout kills everything. The symptom in the log is `running N rules` followed by silence. Bumping the image doesn't help (1.164.0 reproduces it too); it isn't memory (a healthy run peaks ~5 GB of 16 GB). The exact input trigger is nondeterministic and ephemeral (registry rulesets are fetched live each run), so the fix is mechanism-level rather than trigger-specific.

## Changes

- New `.github/scripts/semgrep-ci.sh`: a thin wrapper that runs `semgrep "$@"` under a wall-clock watchdog. If a run exceeds its cap (the wedge), it logs the stuck `semgrep-core` worker's open source paths — so the next real CI wedge finally pins the offending file for an upstream report — then SIGKILLs it and **retries once**. A wedge (our SIGKILL → 137) retries; real findings (1) and errors (2) propagate unchanged, so nothing is masked.
- `ci-security.yaml`: every scan invocation now dispatches through the wrapper *if present*, else falls back to plain `semgrep`:

  ```sh
  SG=semgrep; [ -f .github/scripts/semgrep-ci.sh ] && SG="sh .github/scripts/semgrep-ci.sh"
  SEMGREP_CAP_SECONDS=<cap> $SG \
    --config ...
  ```

  The graceful fallback keeps in-flight PRs that haven't rebased (and so lack the new script) on the current behavior — no hard dependency on a new file. Per-job caps sit between normal runtime and `timeout-minutes`, leaving room for one retry (python 900s, js/general 600, products-frontend/devex 360, go/rust 300). Existing `timeout-minutes` stay as a backstop.

A nondeterministic wedge now self-heals on retry instead of red-flagging the PR, and we capture diagnostics the one time it doesn't.

## How did you test this code?

I'm an agent (Claude Code). No manual UI testing. Automated checks I actually ran, all in the pinned `semgrep/semgrep:1.163.0` image under the CI step shell (`sh -e`):

- Wrapper control flow: success → exit 0; findings (exit 1) → propagated, no retry; error (exit 2) → propagated; simulated wedge → watchdog snapshot + SIGKILL + one retry → exit 137.
- The CI dispatch line end-to-end: wrapper-present path runs a real scan and exits 0; script-absent path falls back to plain `semgrep`.
- `.github/scripts/semgrep-ci.sh` itself scans clean (0 findings) under the security configs, so it doesn't trip the jobs that scan it.
- `ci-security.yaml` parses; all 8 scan invocations wrapped; `semgrep --test` left untouched.

The watchdog's live-worker snapshot path can only be fully exercised by a real wedge, which is rare — that path is logged, not retried-away, so it surfaces in CI when it next fires.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

Authored by Claude Code at the human author's request. The investigation started from a hung `semgrep-python` run; I confirmed the mechanism by reproducing the scan locally under the pinned image and introspecting a live wedged container with `docker top` + `/proc` (R-state `semgrep-core` worker, pure CPU spin, idle Python parent). Along the way I rejected several hypotheses with data: memory/OOM (healthy run peaks ~5 GB), per-file timeout cascade (capped by `--timeout-threshold`), an image-version bug (1.164.0 also hangs), and a local node_modules symlink trigger (a red herring not present in CI; a CI-faithful clean tree didn't reproduce). With the exact input trigger nondeterministic/ephemeral, I chose a mechanism-level fix — bound the run, retry once, capture diagnostics on wedge — over chasing a specific rule/file. The script lives under `.github/scripts/` (CI-helper convention) rather than `bin/` to avoid hogli command registration, and the `[ -f ... ]` dispatch keeps it backwards-compatible with unrebased PRs.
