### PR TITLE
feat(data-warehouse): add copy view name to sql editor view menu

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -669,7 +669,6 @@ export const QueryDatabase = ({
                     item.record?.type === 'managed-view'
                 ) {
                     const editLabel = item.record.type === 'endpoint' ? 'Edit endpoint' : 'Edit view'
-                    const copyNameLabel = item.record.type === 'endpoint' ? 'Copy endpoint name' : 'Copy view name'
                     const addJoinSourceTableName = getSidebarAddJoinSourceTableName(
                         item.record.type,
                         item.name,
@@ -786,15 +785,17 @@ export const QueryDatabase = ({
                                     </ButtonPrimitive>
                                 </DropdownMenuItem>
                             ) : null}
-                            <DropdownMenuItem
-                                asChild
-                                onClick={(e) => {
-                                    e.stopPropagation()
-                                    void copyToClipboard(item.name)
-                                }}
-                            >
-                                <ButtonPrimitive menuItem>{copyNameLabel}</ButtonPrimitive>
-                            </DropdownMenuItem>
+                            {item.record.type !== 'endpoint' ? (
+                                <DropdownMenuItem
+                                    asChild
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        void copyToClipboard(item.name)
+                                    }}
+                                >
+                                    <ButtonPrimitive menuItem>Copy view name</ButtonPrimitive>
+                                </DropdownMenuItem>
+                            ) : null}
                         </DropdownMenuGroup>
                     )
                 }

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -669,6 +669,7 @@ export const QueryDatabase = ({
                     item.record?.type === 'managed-view'
                 ) {
                     const editLabel = item.record.type === 'endpoint' ? 'Edit endpoint' : 'Edit view'
+                    const copyNameLabel = item.record.type === 'endpoint' ? 'Copy endpoint name' : 'Copy view name'
                     const addJoinSourceTableName = getSidebarAddJoinSourceTableName(
                         item.record.type,
                         item.name,
@@ -785,6 +786,15 @@ export const QueryDatabase = ({
                                     </ButtonPrimitive>
                                 </DropdownMenuItem>
                             ) : null}
+                            <DropdownMenuItem
+                                asChild
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    void copyToClipboard(item.name)
+                                }}
+                            >
+                                <ButtonPrimitive menuItem>{copyNameLabel}</ButtonPrimitive>
+                            </DropdownMenuItem>
                         </DropdownMenuGroup>
                     )
                 }


### PR DESCRIPTION
## Problem

In the SQL editor sidebar, the three-dot menu for tables has a "Copy table name" action, but views have no equivalent. Users working with views had no quick way to grab the view's name to reference it in a query.

## Changes

Adds a **"Copy view name"** item to the three-dot menu for views (and managed views) in the SQL editor sidebar, mirroring the existing "Copy table name" behavior on tables. It reuses the same `copyToClipboard(item.name)` helper.

The menu block is shared with endpoints, but endpoints intentionally do **not** get a copy action.

<!-- screenshots to be added by reviewer/author -->

## How did you test this code?

I'm an agent (PostHog Slack app). I have not run the app manually. The change is a small, self-contained addition to an existing menu block that reuses the already-imported `copyToClipboard` helper and the existing `item.name` value (the same pattern used by the adjacent "Copy table name" item). No automated tests were added or run for this UI string/handler change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) at a user's request to add a "Copy view name" action matching the existing "Copy table name" on tables.

The relevant menu (`QueryDatabase.tsx`) renders views, managed views, and endpoints from one shared block. The "Copy view name" item is gated to non-endpoint types (`item.record.type !== 'endpoint'`) and placed at the end of the menu group, consistent with where "Copy table name" sits for tables. An earlier revision also added "Copy endpoint name" for endpoints; that was dropped per review feedback. Requires human review before merge.
