### PR TITLE
feat(data-warehouse): show live row progress on schemas tab

### DIFF
--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -105,9 +105,18 @@ function ManagedSchemasTab({ id }: { id: string }): JSX.Element {
         resyncSchema,
         cancelSchema,
         deleteTable,
+        loadJobs,
     } = useActions(sourceSettingsLogic)
     const { addProductIntentForCrossSell } = useActions(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+
+    // Load (and poll) jobs so the Rows synced column can show live progress for in-progress
+    // syncs, before the warehouse table exists. loadJobsSuccess reschedules itself.
+    useEffect(() => {
+        if (source && source.access_method !== 'direct') {
+            loadJobs()
+        }
+    }, [loadJobs, source])
 
     const showMetrics = !!featureFlags[FEATURE_FLAGS.DWH_SOURCE_METRICS]
     // `id` is the cleaned source id; URLs use the `managed-` prefix
@@ -283,6 +292,7 @@ function ManagedSchemaTable({
     showMetrics,
 }: ManagedSchemaTableProps): JSX.Element {
     const { schemaReloadingById } = useValues(sourceManagementLogic)
+    const { inProgressRowsBySchema } = useValues(sourceSettingsLogic)
     const { setSelectedSchemas } = useActions(sourceSettingsLogic)
     const { disabledReason: editDisabledReason } = useSourceEditorAccess(source)
     const [initialLoad, setInitialLoad] = useState(true)
@@ -404,6 +414,19 @@ function ManagedSchemaTable({
                     render: (_, schema) => {
                         if (schema.table) {
                             return schema.table.row_count?.toLocaleString() ?? 0
+                        }
+                        // First sync: the warehouse table doesn't exist yet, so fall back to the
+                        // running job's rows_synced (updates live as batches flush). Show a spinner
+                        // so a schema still buffering below the flush threshold reads as "syncing",
+                        // not as if nothing is happening.
+                        if (schema.status === 'Running') {
+                            const rows = inProgressRowsBySchema[schema.id] ?? 0
+                            return (
+                                <span className="flex items-center justify-end gap-1">
+                                    <Spinner textColored className="text-sm" />
+                                    {rows.toLocaleString()}
+                                </span>
+                            )
                         }
                         if (schema.status === 'Completed') {
                             return 0

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -28,7 +28,12 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { ExternalDataSourceType, ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
-import { DataWarehouseSyncInterval, ExternalDataSource, ExternalDataSourceSchema } from '~/types'
+import {
+    DataWarehouseSyncInterval,
+    ExternalDataSchemaStatus,
+    ExternalDataSource,
+    ExternalDataSourceSchema,
+} from '~/types'
 
 import { DATA_WAREHOUSE_APP_SOURCE } from 'products/data_warehouse/frontend/shared/components/metrics/DataWarehouseMetrics'
 import {
@@ -415,11 +420,8 @@ function ManagedSchemaTable({
                         if (schema.table) {
                             return schema.table.row_count?.toLocaleString() ?? 0
                         }
-                        // First sync: the warehouse table doesn't exist yet, so fall back to the
-                        // running job's rows_synced (updates live as batches flush). Show a spinner
-                        // so a schema still buffering below the flush threshold reads as "syncing",
-                        // not as if nothing is happening.
-                        if (schema.status === 'Running') {
+                        // No table yet during the first sync — fall back to the running job's live count.
+                        if (schema.status === ExternalDataSchemaStatus.Running) {
                             const rows = inProgressRowsBySchema[schema.id] ?? 0
                             return (
                                 <span className="flex items-center justify-end gap-1">
@@ -428,7 +430,7 @@ function ManagedSchemaTable({
                                 </span>
                             )
                         }
-                        if (schema.status === 'Completed') {
+                        if (schema.status === ExternalDataSchemaStatus.Completed) {
                             return 0
                         }
                         return <span className="text-muted">—</span>

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
@@ -504,6 +504,22 @@ export const sourceSettingsLogic = kea<sourceSettingsLogicType>([
                 return availableSources[source.source_type]
             },
         ],
+        // Live row counts for in-progress syncs, keyed by schema id. Lets the Schemas tab show
+        // progress during the first sync — before the warehouse table (and its row_count) exists,
+        // the table column has nothing to render, so we fall back to the running job's rows_synced.
+        inProgressRowsBySchema: [
+            (s) => [s.jobs],
+            (jobs): Record<string, number> => {
+                const map: Record<string, number> = {}
+                // jobs arrive newest-first; keep the first (latest) running job per schema.
+                for (const job of jobs) {
+                    if (job.status === ExternalDataJobStatus.Running && !(job.schema.id in map)) {
+                        map[job.schema.id] = job.rows_synced
+                    }
+                }
+                return map
+            },
+        ],
         filteredSchemas: [
             (s) => [
                 s.source,


### PR DESCRIPTION
## Problem

During a source's first sync, the Schemas tab showed `—` under "Rows synced" for the entire run, only flipping to real numbers once the sync completed. That column reads `schema.table.row_count`, and the warehouse table isn't created until the sync finishes — so there was no progress feedback, and a long-running sync looked stuck even though it was working. (Live per-job progress was already visible on the Syncs tab, just not here.)

after we show how many rows are actually syncing:

<img width="1292" height="382" alt="Screenshot 2026-06-05 at 4 02 48 PM" src="https://github.com/user-attachments/assets/6fbe332a-a3bb-4070-896a-ef016aa6609e" />
<img width="1271" height="340" alt="Screenshot 2026-06-05 at 4 07 38 PM" src="https://github.com/user-attachments/assets/1d6cb8c9-63b6-4c17-a3ff-3b53960a454c" />

## Changes

- Add an `inProgressRowsBySchema` selector to `sourceSettingsLogic` that maps each schema to its running job's `rows_synced`, derived from the already-polled jobs list.
- On the Schemas tab, when a schema is `Running` and has no warehouse table yet, show a spinner plus the live `rows_synced` instead of `—`, so an in-progress (even still-buffering) sync clearly reads as "syncing". Completed schemas keep showing the table's real row count.
- Trigger jobs polling from the Schemas tab so the count refreshes live (~5s).

Screenshots: frontend-only change — a spinner and a live, increasing row count now appear per running schema; reviewers can add a capture from a running sync.

## How did you test this code?

I'm an agent. No automated tests added for this change. Behavior verified manually in the local dev app: during an in-progress Google Search Console sync, the Schemas tab shows a spinner and a live, increasing row count per running schema, and the final counts match once each schema completes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code. A first attempt put the selector consumption in the wrong component (`ManagedSchemasTab`) when the column actually renders in the sibling `ManagedSchemaTable`; moved it to where the render lives. The generated `sourceSettingsLogicType.ts` is gitignored, so it's intentionally not part of the commit (regenerated by kea-typegen). Considered adding the same live count to the new-source wizard's progress step but left it as-is, since that step already communicates activity with a "Syncing..." status.
