### PR TITLE
docs(cli): clarify ProGuard map ID help

### DIFF
--- a/cli/.sampo/changesets/cli-proguard-map-id-help.md
+++ b/cli/.sampo/changesets/cli-proguard-map-id-help.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Clarify the ProGuard map ID help text.

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -15,8 +15,8 @@ pub struct Args {
     #[arg(short, long)]
     pub path: PathBuf,
 
-    /// This is the identifier posthog will use to look up with mapping file, when it's processing your
-    /// stack traces. Must match with the identifier provided to the posthog SDK at runtime, for this build.
+    /// The identifier PostHog uses to look up this mapping file when processing your stack traces.
+    /// Must match the identifier provided to the PostHog SDK at runtime for this build.
     #[arg(short, long)]
     pub map_id: String,
 


### PR DESCRIPTION
## Summary

- clarify the `proguard upload --map-id` help text
- add a Sampo patch changeset for `posthog-cli`

## Testing

- `cargo run --quiet -- proguard upload --help`
- `cargo fmt --all -- --check`
- `bin/hogli format:markdown cli/.sampo/changesets/cli-proguard-map-id-help.md`

testing #61924 technically
