### PR TITLE
fix(taxonomic-filter): save SQL expression in rebuilt filter menu

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -907,6 +907,10 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
             categoryLabel: () => 'SQL expression',
             type: TaxonomicFilterGroupType.HogQLExpression,
             render: InlineHogQLEditor,
+            // The headless menu derives the committed value via group.getValue(item);
+            // without this the SQL expression resolves to null and the selection is
+            // silently dropped on save.
+            getValue: (option) => (option as { value?: TaxonomicFilterValue }).value ?? option.name,
             getPopoverHeader: () => 'SQL expression',
             componentProps: { metadataSource, ...hogQLExpressionComponentProps },
         },


### PR DESCRIPTION
## Problem

In the rebuilt taxonomic filter menu, picking **SQL expression** and saving did nothing — the filter was silently dropped. The legacy filter menu saves SQL expressions fine.

## Changes

The rebuilt menu (`buildTaxonomicGroups.tsx`) commits a selection via `group.getValue(item)`. The `HogQLExpression` group was missing `getValue`, so the committed value resolved to `null` and the selection never reached `setFilter`. Added the same `getValue` the legacy `taxonomicFilterLogic.tsx` already uses, extracting the expression string from the committed item.

<img width="785" height="476" alt="image" src="https://github.com/user-attachments/assets/8aa9713f-136c-45e6-842d-f1fe682232c6" />


## How did you test this code?

I'm an agent. Ran `tsc --noEmit` (changed file compiles clean; only a pre-existing unrelated quill-charts error remains) and `oxlint` on the changed file (0 errors). No manual UI testing performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Explore agent to locate the divergence between the legacy `taxonomicFilterLogic.tsx` SQL-expression group and the rebuilt `buildTaxonomicGroups.tsx` one). The legacy group already carried the `getValue` fix with an explanatory comment; the rebuilt group was a near-copy that dropped it. Fix is to port `getValue` over so the headless menu can derive the committed value.
