### PR TITLE
fix(lemon-ui): apply IME guard to consumer onKeyDown

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.test.tsx
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { LemonInput } from './LemonInput'
+
+describe('LemonInput', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    describe('IME composition Enter guard', () => {
+        it('does not call onPressEnter when Enter is pressed during IME composition', () => {
+            const onPressEnter = jest.fn()
+            render(<LemonInput onPressEnter={onPressEnter} value="" />)
+            const input = screen.getByRole('textbox')
+
+            fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
+
+            expect(onPressEnter).not.toHaveBeenCalled()
+        })
+
+        it('calls onPressEnter when Enter is pressed outside of IME composition', () => {
+            const onPressEnter = jest.fn()
+            render(<LemonInput onPressEnter={onPressEnter} value="" />)
+            const input = screen.getByRole('textbox')
+
+            fireEvent.keyDown(input, { key: 'Enter', isComposing: false })
+
+            expect(onPressEnter).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not call consumer onKeyDown for Enter pressed during IME composition', () => {
+            const onKeyDown = jest.fn()
+            render(<LemonInput onKeyDown={onKeyDown} value="" />)
+            const input = screen.getByRole('textbox')
+
+            fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
+
+            expect(onKeyDown).not.toHaveBeenCalled()
+        })
+
+        it('forwards consumer onKeyDown for Enter outside of IME composition', () => {
+            const onKeyDown = jest.fn()
+            render(<LemonInput onKeyDown={onKeyDown} value="" />)
+            const input = screen.getByRole('textbox')
+
+            fireEvent.keyDown(input, { key: 'Enter', isComposing: false })
+
+            expect(onKeyDown).toHaveBeenCalledTimes(1)
+        })
+
+        it('forwards consumer onKeyDown for non-Enter keys even during composition', () => {
+            const onKeyDown = jest.fn()
+            render(<LemonInput onKeyDown={onKeyDown} value="" />)
+            const input = screen.getByRole('textbox')
+
+            fireEvent.keyDown(input, { key: 'a', isComposing: true })
+
+            expect(onKeyDown).toHaveBeenCalledTimes(1)
+        })
+    })
+})

--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
@@ -115,6 +115,7 @@ export const LemonInput = React.forwardRef<HTMLDivElement, LemonInputProps>(func
         disabledReason,
         disabledReasonInteractive,
         badgeText,
+        onKeyDown,
         ...props
     },
     ref
@@ -265,9 +266,15 @@ export const LemonInput = React.forwardRef<HTMLDivElement, LemonInputProps>(func
                         if (stopPropagation) {
                             event.stopPropagation()
                         }
-                        if (onPressEnter && event.key === 'Enter' && !event.nativeEvent.isComposing) {
+                        // IME guard: while composing (e.g. typing CJK candidates), Enter only confirms
+                        // the candidate and must not reach `onPressEnter` or the consumer's `onKeyDown`.
+                        if (event.key === 'Enter' && event.nativeEvent.isComposing) {
+                            return
+                        }
+                        if (onPressEnter && event.key === 'Enter') {
                             onPressEnter(event)
                         }
+                        onKeyDown?.(event)
                     }}
                     {...props}
                 />

--- a/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.test.tsx
@@ -1,0 +1,74 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { LemonTextArea } from './LemonTextArea'
+
+describe('LemonTextArea', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    describe('IME composition Enter guard', () => {
+        it('does not call onPressEnter when Enter is pressed during IME composition', () => {
+            const onPressEnter = jest.fn()
+            render(<LemonTextArea onPressEnter={onPressEnter} value="" />)
+            const textarea = screen.getByRole('textbox')
+
+            fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true })
+
+            expect(onPressEnter).not.toHaveBeenCalled()
+        })
+
+        it('calls onPressEnter when Enter is pressed outside of IME composition', () => {
+            const onPressEnter = jest.fn()
+            render(<LemonTextArea onPressEnter={onPressEnter} value="hello" />)
+            const textarea = screen.getByRole('textbox')
+
+            fireEvent.keyDown(textarea, { key: 'Enter', isComposing: false })
+
+            expect(onPressEnter).toHaveBeenCalledTimes(1)
+            expect(onPressEnter).toHaveBeenCalledWith('hello')
+        })
+
+        it('does not call onPressCmdEnter when Cmd+Enter is pressed during IME composition', () => {
+            const onPressCmdEnter = jest.fn()
+            render(<LemonTextArea onPressCmdEnter={onPressCmdEnter} value="hi" />)
+            const textarea = screen.getByRole('textbox')
+
+            fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true, isComposing: true })
+
+            expect(onPressCmdEnter).not.toHaveBeenCalled()
+        })
+
+        it('does not call consumer onKeyDown for Enter pressed during IME composition', () => {
+            const onKeyDown = jest.fn()
+            render(<LemonTextArea onKeyDown={onKeyDown} onPressCmdEnter={jest.fn()} value="" />)
+            const textarea = screen.getByRole('textbox')
+
+            fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true })
+
+            expect(onKeyDown).not.toHaveBeenCalled()
+        })
+
+        it('forwards consumer onKeyDown for Enter outside of IME composition', () => {
+            const onKeyDown = jest.fn()
+            render(<LemonTextArea onKeyDown={onKeyDown} onPressCmdEnter={jest.fn()} value="" />)
+            const textarea = screen.getByRole('textbox')
+
+            fireEvent.keyDown(textarea, { key: 'Enter', isComposing: false })
+
+            expect(onKeyDown).toHaveBeenCalledTimes(1)
+        })
+
+        it('forwards consumer onKeyDown for non-Enter keys even during composition', () => {
+            const onKeyDown = jest.fn()
+            render(<LemonTextArea onKeyDown={onKeyDown} onPressCmdEnter={jest.fn()} value="" />)
+            const textarea = screen.getByRole('textbox')
+
+            fireEvent.keyDown(textarea, { key: 'a', isComposing: true })
+
+            expect(onKeyDown).toHaveBeenCalledTimes(1)
+        })
+    })
+})

--- a/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.tsx
@@ -85,7 +85,12 @@ export const LemonTextArea = React.forwardRef<HTMLTextAreaElement, LemonTextArea
                     if (stopPropagation) {
                         e.stopPropagation()
                     }
-                    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                    // IME guard: while composing (e.g. typing CJK candidates), Enter only confirms
+                    // the candidate and must not reach the internal Enter handlers or the consumer's `onKeyDown`.
+                    if (e.key === 'Enter' && e.nativeEvent.isComposing) {
+                        return
+                    }
+                    if (e.key === 'Enter') {
                         const target = e.currentTarget
                         // When shift is pressed, we always just want to add a new line
                         if (!e.shiftKey) {


### PR DESCRIPTION
## Problem

PostHog uses `LemonInput` and `LemonTextArea` for many form-style inputs (create-organization modal, invites, person properties, scene/notebook titles, inline-edited fields, dialog forms, and so on). When users type with an IME (Japanese, Chinese, Korean, …), pressing Enter to confirm a candidate also submitted the surrounding form or fired the primary action — sometimes destructively (creating an org, sending an invite, saving a title).

Closes #60044

## Changes

`LemonInput` already had an IME guard, but it only protected `onPressEnter`. The consumer-provided `onKeyDown` was being silently wired through `{...props}` after the internal handler, so any consumer that wired Enter via `onKeyDown` lost the guard. `LemonTextArea` did wrap the consumer `onKeyDown`, but it was always invoked, including for the Enter that confirms an IME candidate.

This PR applies the same wrap-not-replace pattern in both components:

- `LemonInput`: extract `onKeyDown` from props, swallow Enter while `event.nativeEvent.isComposing` is true, and otherwise call `onPressEnter` and the consumer `onKeyDown` as before.
- `LemonTextArea`: short-circuit the internal Enter / Cmd+Enter logic and the consumer `onKeyDown` for the Enter that confirms an IME candidate; non-Enter keys still flow through unchanged.

This is the library-level option (#2) suggested in the issue. Tightening the two shared components fixes the bulk of the listed call sites in one place; the remaining native-input / `TextareaPrimitive` / autocomplete sites listed in the issue are left for follow-up per-site fixes.

## How did you test this code?

I am an agent. I added unit tests, did not run the full Jest suite locally, and did not perform manual IME testing.

Automated tests added:

- `LemonInput.test.tsx` — Enter during composition does not call `onPressEnter` or consumer `onKeyDown`; Enter outside composition still does; non-Enter keys still flow to the consumer even during composition.
- `LemonTextArea.test.tsx` — same matrix, plus Cmd+Enter during composition does not call `onPressCmdEnter`.

The tests use `@testing-library/react` `fireEvent.keyDown` with `isComposing: true|false` to simulate the two states.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change required.

## 🤖 Agent context

Authored by an agent on behalf of @gaurav0107.

The issue itself listed two strategies — per-site `&& !e.nativeEvent.isComposing` annotations across ~25 call sites, or a library-level wrap of `LemonInput` / `LemonTextArea`. I chose the library-level option because it covers the highest-impact form sites in a small, mechanical diff and leaves the remaining lower-impact combobox-style sites for follow-up. The previous fix in #51350 had only routed the guard through `onPressEnter`; this PR closes the gap for `onKeyDown` consumers.

I did not run the repo's Jest, `pnpm typescript:check`, or `ruff` locally — Node 24 / pnpm install on this monorepo did not fit in the agent session. Please rely on CI.