### PR TITLE
feat(signals): thread optional remediation field through the pipeline

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11775,6 +11775,9 @@
                 "extra": {
                     "$ref": "#/definitions/ConversationsTicketSignalExtra"
                 },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
+                },
                 "source_id": {
                     "type": "string"
                 },
@@ -15921,6 +15924,9 @@
                 "extra": {
                     "$ref": "#/definitions/EndpointExecutionFailedSignalExtra"
                 },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
+                },
                 "source_id": {
                     "type": "string"
                 },
@@ -17478,6 +17484,9 @@
                 },
                 "extra": {
                     "$ref": "#/definitions/ErrorTrackingSignalExtra"
+                },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
                 },
                 "source_id": {
                     "type": "string"
@@ -21840,6 +21849,9 @@
                 "extra": {
                     "$ref": "#/definitions/GithubIssueSignalExtra"
                 },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
+                },
                 "source_id": {
                     "type": "string"
                 },
@@ -24492,6 +24504,9 @@
                 "extra": {
                     "$ref": "#/definitions/LinearIssueSignalExtra"
                 },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
+                },
                 "source_id": {
                     "type": "string"
                 },
@@ -24592,6 +24607,9 @@
                 "extra": {
                     "$ref": "#/definitions/LlmEvalReportSignalExtra"
                 },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
+                },
                 "source_id": {
                     "type": "string"
                 },
@@ -24618,6 +24636,9 @@
                 },
                 "extra": {
                     "$ref": "#/definitions/LlmEvalSignalExtra"
+                },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
                 },
                 "source_id": {
                     "type": "string"
@@ -25111,6 +25132,9 @@
                 },
                 "extra": {
                     "$ref": "#/definitions/LogsAlertStateChangeSignalExtra"
+                },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
                 },
                 "source_id": {
                     "type": "string"
@@ -29136,6 +29160,9 @@
                 },
                 "extra": {
                     "$ref": "#/definitions/PgAnalyzeIssueSignalExtra"
+                },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
                 },
                 "source_id": {
                     "type": "string"
@@ -38548,6 +38575,9 @@
                 "extra": {
                     "$ref": "#/definitions/SessionProblemSignalExtra"
                 },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
+                },
                 "source_id": {
                     "type": "string"
                 },
@@ -39206,6 +39236,22 @@
                 }
             ]
         },
+        "SignalRemediation": {
+            "additionalProperties": false,
+            "properties": {
+                "agent": {
+                    "description": "Agent-facing guidance: how to investigate (which MCP tools to call) and, where the fix lives in the user's codebase, how to apply it. The research agent treats this as authoritative — it still investigates and produces findings, but follows this instead of starting cold.",
+                    "type": "string"
+                },
+                "priority": {
+                    "description": "Suggested report priority (advisory — the research agent may override).",
+                    "enum": ["P0", "P1", "P2", "P3", "P4"],
+                    "type": "string"
+                }
+            },
+            "required": ["agent"],
+            "type": "object"
+        },
         "SignalReviewerUserInfo": {
             "additionalProperties": false,
             "properties": {
@@ -39361,6 +39407,9 @@
                 },
                 "extra": {
                     "$ref": "#/definitions/SignalsScoutSignalExtra"
+                },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
                 },
                 "source_id": {
                     "type": "string"
@@ -44649,6 +44698,9 @@
                 },
                 "extra": {
                     "$ref": "#/definitions/ZendeskTicketSignalExtra"
+                },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
                 },
                 "source_id": {
                     "type": "string"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -39275,13 +39275,17 @@
                     "description": "Agent-facing guidance: how to investigate (which MCP tools to call) and, where the fix lives in the user's codebase, how to apply it. The research agent treats this as authoritative — it still investigates and produces findings, but follows this instead of starting cold.",
                     "type": "string"
                 },
+                "human": {
+                    "description": "Human-facing fix steps (PostHog UI / alert destinations). Surfaced in the report for the reader.",
+                    "type": "string"
+                },
                 "priority": {
-                    "description": "Suggested report priority (advisory — the research agent may override).",
+                    "description": "Suggested report priority; advisory, the research agent may override.",
                     "enum": ["P0", "P1", "P2", "P3", "P4"],
                     "type": "string"
                 }
             },
-            "required": ["agent"],
+            "required": ["human", "agent"],
             "type": "object"
         },
         "SignalReviewerUserInfo": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11793,7 +11793,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "ConversionGoalFilter": {
@@ -15942,7 +15942,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "EndpointLastExecutionTimesRequest": {
@@ -17503,7 +17503,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "ErrorTrackingSimilarIssuesQuery": {
@@ -21867,7 +21867,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "GoalLine": {
@@ -24522,7 +24522,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "LinkedinAdsDefaultSources": {
@@ -24625,7 +24625,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "LlmEvaluationSignalInput": {
@@ -24655,7 +24655,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "LoadingBlock": {
@@ -25151,7 +25151,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "LogsOrderBy": {
@@ -29179,7 +29179,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "PinterestAdsDefaultSources": {
@@ -38593,7 +38593,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "SessionPropertyFilter": {
@@ -39196,6 +39196,10 @@
             },
             "type": "object"
         },
+        "SignalExtraBase": {
+            "additionalProperties": false,
+            "type": "object"
+        },
         "SignalInput": {
             "anyOf": [
                 {
@@ -39235,6 +39239,34 @@
                     "$ref": "#/definitions/LogsAlertStateChangeSignalInput"
                 }
             ]
+        },
+        "SignalInputBase": {
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "extra": {
+                    "$ref": "#/definitions/SignalExtraBase"
+                },
+                "remediation": {
+                    "$ref": "#/definitions/SignalRemediation"
+                },
+                "source_id": {
+                    "type": "string"
+                },
+                "source_product": {
+                    "type": "string"
+                },
+                "source_type": {
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "number"
+                }
+            },
+            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "type": "object"
         },
         "SignalRemediation": {
             "additionalProperties": false,
@@ -39426,7 +39458,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "SimilarIssue": {
@@ -44717,7 +44749,7 @@
                     "type": "number"
                 }
             },
-            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "required": ["description", "extra", "source_id", "source_product", "source_type", "weight"],
             "type": "object"
         },
         "getEffectiveExcludedColumns": {

--- a/frontend/src/queries/schema/schema-signals.ts
+++ b/frontend/src/queries/schema/schema-signals.ts
@@ -33,16 +33,20 @@ export enum SignalSourceType {
 
 // ── Shared optional remediation ──────────────────────────────────────────────────
 // A known fix attached to a signal. Optional and separate from `extra`: `extra` is product-specific
-// evidence; `remediation` is guidance for the research agent. When present, the signal is treated as
-// actionable and the agent follows the guidance rather than investigating from scratch — it still
-// runs, produces findings, and writes the human-facing report. Every variant may carry it.
+// evidence; `remediation` is the fix guidance. Mirrors the health-checks `Remediation(human, agent)`
+// constant so a check's remediation maps straight onto a signal. When present, the signal is treated
+// as actionable: the research agent follows the `agent` guidance rather than investigating from
+// scratch — it still runs, produces findings, and writes the human-facing report. Every variant may
+// carry it.
 
 export interface SignalRemediation {
+    /** Human-facing fix steps (PostHog UI / alert destinations). Surfaced in the report for the reader. */
+    human: string
     /** Agent-facing guidance: how to investigate (which MCP tools to call) and, where the fix lives
      *  in the user's codebase, how to apply it. The research agent treats this as authoritative — it
      *  still investigates and produces findings, but follows this instead of starting cold. */
     agent: string
-    /** Suggested report priority (advisory — the research agent may override). */
+    /** Suggested report priority; advisory, the research agent may override. */
     priority?: 'P0' | 'P1' | 'P2' | 'P3' | 'P4'
 }
 

--- a/frontend/src/queries/schema/schema-signals.ts
+++ b/frontend/src/queries/schema/schema-signals.ts
@@ -31,6 +31,21 @@ export enum SignalSourceType {
     ALERT_STATE_CHANGE = 'alert_state_change',
 }
 
+// ── Shared optional remediation ──────────────────────────────────────────────────
+// A known fix attached to a signal. Optional and separate from `extra`: `extra` is product-specific
+// evidence; `remediation` is guidance for the research agent. When present, the signal is treated as
+// actionable and the agent follows the guidance rather than investigating from scratch — it still
+// runs, produces findings, and writes the human-facing report. Every variant may carry it.
+
+export interface SignalRemediation {
+    /** Agent-facing guidance: how to investigate (which MCP tools to call) and, where the fix lives
+     *  in the user's codebase, how to apply it. The research agent treats this as authoritative — it
+     *  still investigates and produces findings, but follows this instead of starting cold. */
+    agent: string
+    /** Suggested report priority (advisory — the research agent may override). */
+    priority?: 'P0' | 'P1' | 'P2' | 'P3' | 'P4'
+}
+
 // ── Per-product signal extras & inputs ──────────────────────────────────────────
 
 // Session replay problem (emitted per-session for problem-indicating segments)
@@ -65,6 +80,7 @@ export interface SessionProblemSignalInput {
     description: string
     weight: number
     extra: SessionProblemSignalExtra
+    remediation?: SignalRemediation
 }
 
 /** @deprecated No longer emitted. */
@@ -119,6 +135,7 @@ export interface LlmEvaluationSignalInput {
     description: string
     weight: number
     extra: LlmEvalSignalExtra
+    remediation?: SignalRemediation
 }
 
 // LLM evaluation report (one signal per report run, distilled from many results)
@@ -140,6 +157,7 @@ export interface LlmEvaluationReportSignalInput {
     description: string
     weight: number
     extra: LlmEvalReportSignalExtra
+    remediation?: SignalRemediation
 }
 
 // Zendesk ticket
@@ -160,6 +178,7 @@ export interface ZendeskTicketSignalInput {
     description: string
     weight: number
     extra: ZendeskTicketSignalExtra
+    remediation?: SignalRemediation
 }
 
 // GitHub issue
@@ -181,6 +200,7 @@ export interface GithubIssueSignalInput {
     description: string
     weight: number
     extra: GithubIssueSignalExtra
+    remediation?: SignalRemediation
 }
 
 // Linear issue
@@ -206,6 +226,7 @@ export interface LinearIssueSignalInput {
     description: string
     weight: number
     extra: LinearIssueSignalExtra
+    remediation?: SignalRemediation
 }
 
 // Conversations ticket
@@ -227,6 +248,7 @@ export interface ConversationsTicketSignalInput {
     description: string
     weight: number
     extra: ConversationsTicketSignalExtra
+    remediation?: SignalRemediation
 }
 
 // Error tracking
@@ -242,6 +264,7 @@ export interface ErrorTrackingSignalInput {
     description: string
     weight: number
     extra: ErrorTrackingSignalExtra
+    remediation?: SignalRemediation
 }
 
 // pganalyze issue (database performance finding)
@@ -269,6 +292,7 @@ export interface PgAnalyzeIssueSignalInput {
     description: string
     weight: number
     extra: PgAnalyzeIssueSignalExtra
+    remediation?: SignalRemediation
 }
 
 // Endpoint execution failure
@@ -289,6 +313,7 @@ export interface EndpointExecutionFailedSignalInput {
     description: string
     weight: number
     extra: EndpointExecutionFailedSignalExtra
+    remediation?: SignalRemediation
 }
 
 // Signals scout — cross-source findings emitted by the headless Signals scout harness.
@@ -333,6 +358,7 @@ export interface SignalsScoutSignalInput {
     description: string
     weight: number
     extra: SignalsScoutSignalExtra
+    remediation?: SignalRemediation
 }
 
 // Logs alert notification (firing / broken)
@@ -357,6 +383,7 @@ export interface LogsAlertStateChangeSignalInput {
     description: string
     weight: number
     extra: LogsAlertStateChangeSignalExtra
+    remediation?: SignalRemediation
 }
 
 // ── Report reviewer types ────────────────────────────────────────────────────────

--- a/frontend/src/queries/schema/schema-signals.ts
+++ b/frontend/src/queries/schema/schema-signals.ts
@@ -46,6 +46,24 @@ export interface SignalRemediation {
     priority?: 'P0' | 'P1' | 'P2' | 'P3' | 'P4'
 }
 
+// ── Shared signal extra & input base ───────────────────────────────────────────────
+// Marker base every per-source `extra` payload extends. Empty today: it gives the input base a
+// single `extra` type to reference and is where any future cross-source extra field would live.
+export interface SignalExtraBase {}
+
+// Top-level fields every variant carries. Concrete variants narrow `source_type`, `source_product`,
+// and `extra` to their specific literal/payload types (those narrowings discriminate the union).
+// `remediation` is source-agnostic: any signal may carry it, even though only some sources emit it today.
+export interface SignalInputBase {
+    source_type: string
+    source_product: string
+    source_id: string
+    description: string
+    weight: number
+    extra: SignalExtraBase
+    remediation?: SignalRemediation
+}
+
 // ── Per-product signal extras & inputs ──────────────────────────────────────────
 
 // Session replay problem (emitted per-session for problem-indicating segments)
@@ -58,7 +76,7 @@ export interface SessionProblemEventEntry {
     interaction_text?: string
 }
 
-export interface SessionProblemSignalExtra {
+export interface SessionProblemSignalExtra extends SignalExtraBase {
     session_id: string
     segment_title: string
     start_time: string
@@ -73,14 +91,10 @@ export interface SessionProblemSignalExtra {
     event_history?: SessionProblemEventEntry[]
 }
 
-export interface SessionProblemSignalInput {
+export interface SessionProblemSignalInput extends SignalInputBase {
     source_type: 'session_problem'
     source_product: 'session_replay'
-    source_id: string
-    description: string
-    weight: number
     extra: SessionProblemSignalExtra
-    remediation?: SignalRemediation
 }
 
 /** @deprecated No longer emitted. */
@@ -100,7 +114,7 @@ export interface SessionSegmentClusterMetrics {
 }
 
 /** @deprecated No longer emitted. */
-export interface SessionSegmentClusterSignalExtra {
+export interface SessionSegmentClusterSignalExtra extends SignalExtraBase {
     label_title: string
     actionable: boolean
     segments: SessionReplaySegment[]
@@ -119,7 +133,7 @@ export interface SessionSegmentClusterSignalInput {
 
 // LLM evaluation
 
-export interface LlmEvalSignalExtra {
+export interface LlmEvalSignalExtra extends SignalExtraBase {
     evaluation_id: string
     target_event_id?: string
     target_event_type?: string
@@ -128,19 +142,15 @@ export interface LlmEvalSignalExtra {
     provider?: string
 }
 
-export interface LlmEvaluationSignalInput {
+export interface LlmEvaluationSignalInput extends SignalInputBase {
     source_type: 'evaluation'
     source_product: 'llm_analytics'
-    source_id: string
-    description: string
-    weight: number
     extra: LlmEvalSignalExtra
-    remediation?: SignalRemediation
 }
 
 // LLM evaluation report (one signal per report run, distilled from many results)
 
-export interface LlmEvalReportSignalExtra {
+export interface LlmEvalReportSignalExtra extends SignalExtraBase {
     evaluation_id: string
     evaluation_name: string
     evaluation_description: string
@@ -150,19 +160,15 @@ export interface LlmEvalReportSignalExtra {
     period_end: string
 }
 
-export interface LlmEvaluationReportSignalInput {
+export interface LlmEvaluationReportSignalInput extends SignalInputBase {
     source_type: 'evaluation_report'
     source_product: 'llm_analytics'
-    source_id: string
-    description: string
-    weight: number
     extra: LlmEvalReportSignalExtra
-    remediation?: SignalRemediation
 }
 
 // Zendesk ticket
 
-export interface ZendeskTicketSignalExtra {
+export interface ZendeskTicketSignalExtra extends SignalExtraBase {
     url: string
     type: string | null
     tags: string[]
@@ -171,19 +177,15 @@ export interface ZendeskTicketSignalExtra {
     status: string
 }
 
-export interface ZendeskTicketSignalInput {
+export interface ZendeskTicketSignalInput extends SignalInputBase {
     source_type: 'ticket'
     source_product: 'zendesk'
-    source_id: string
-    description: string
-    weight: number
     extra: ZendeskTicketSignalExtra
-    remediation?: SignalRemediation
 }
 
 // GitHub issue
 
-export interface GithubIssueSignalExtra {
+export interface GithubIssueSignalExtra extends SignalExtraBase {
     html_url: string
     number: number
     labels: string[]
@@ -193,19 +195,15 @@ export interface GithubIssueSignalExtra {
     state: string
 }
 
-export interface GithubIssueSignalInput {
+export interface GithubIssueSignalInput extends SignalInputBase {
     source_type: 'issue'
     source_product: 'github'
-    source_id: string
-    description: string
-    weight: number
     extra: GithubIssueSignalExtra
-    remediation?: SignalRemediation
 }
 
 // Linear issue
 
-export interface LinearIssueSignalExtra {
+export interface LinearIssueSignalExtra extends SignalExtraBase {
     url: string
     identifier: string
     number: number
@@ -219,19 +217,15 @@ export interface LinearIssueSignalExtra {
     updated_at: string
 }
 
-export interface LinearIssueSignalInput {
+export interface LinearIssueSignalInput extends SignalInputBase {
     source_type: 'issue'
     source_product: 'linear'
-    source_id: string
-    description: string
-    weight: number
     extra: LinearIssueSignalExtra
-    remediation?: SignalRemediation
 }
 
 // Conversations ticket
 
-export interface ConversationsTicketSignalExtra {
+export interface ConversationsTicketSignalExtra extends SignalExtraBase {
     ticket_number: number
     channel_source: string
     channel_detail: string | null
@@ -241,30 +235,22 @@ export interface ConversationsTicketSignalExtra {
     email_subject: string | null
 }
 
-export interface ConversationsTicketSignalInput {
+export interface ConversationsTicketSignalInput extends SignalInputBase {
     source_type: 'ticket'
     source_product: 'conversations'
-    source_id: string
-    description: string
-    weight: number
     extra: ConversationsTicketSignalExtra
-    remediation?: SignalRemediation
 }
 
 // Error tracking
 
-export interface ErrorTrackingSignalExtra {
+export interface ErrorTrackingSignalExtra extends SignalExtraBase {
     fingerprint: string
 }
 
-export interface ErrorTrackingSignalInput {
+export interface ErrorTrackingSignalInput extends SignalInputBase {
     source_type: 'issue_created' | 'issue_reopened' | 'issue_spiking'
     source_product: 'error_tracking'
-    source_id: string
-    description: string
-    weight: number
     extra: ErrorTrackingSignalExtra
-    remediation?: SignalRemediation
 }
 
 // pganalyze issue (database performance finding)
@@ -276,7 +262,7 @@ export interface PgAnalyzeIssueReference {
     queryText: string | null
 }
 
-export interface PgAnalyzeIssueSignalExtra {
+export interface PgAnalyzeIssueSignalExtra extends SignalExtraBase {
     severity: string | null
     references: PgAnalyzeIssueReference[]
     database_id: string | null
@@ -285,19 +271,15 @@ export interface PgAnalyzeIssueSignalExtra {
     synced_at: string
 }
 
-export interface PgAnalyzeIssueSignalInput {
+export interface PgAnalyzeIssueSignalInput extends SignalInputBase {
     source_type: 'issue'
     source_product: 'pganalyze'
-    source_id: string
-    description: string
-    weight: number
     extra: PgAnalyzeIssueSignalExtra
-    remediation?: SignalRemediation
 }
 
 // Endpoint execution failure
 
-export interface EndpointExecutionFailedSignalExtra {
+export interface EndpointExecutionFailedSignalExtra extends SignalExtraBase {
     endpoint_name: string
     endpoint_version: number | null
     materialized: boolean
@@ -306,14 +288,10 @@ export interface EndpointExecutionFailedSignalExtra {
     error_message: string
 }
 
-export interface EndpointExecutionFailedSignalInput {
+export interface EndpointExecutionFailedSignalInput extends SignalInputBase {
     source_type: 'endpoint_execution_failed'
     source_product: 'endpoints'
-    source_id: string
-    description: string
-    weight: number
     extra: EndpointExecutionFailedSignalExtra
-    remediation?: SignalRemediation
 }
 
 // Signals scout — cross-source findings emitted by the headless Signals scout harness.
@@ -327,7 +305,7 @@ export interface SignalsScoutEvidenceEntry {
     summary: string
 }
 
-export interface SignalsScoutSignalExtra {
+export interface SignalsScoutSignalExtra extends SignalExtraBase {
     scout_run_id: string
     /** The `tasks.TaskRun` id the scout span ran inside. Join key into the `signals_scouts_runs`
      * LLM-analytics view, which is keyed on `task_run_id` (the `scout_run_id` bridge row is not). */
@@ -351,19 +329,15 @@ export interface SignalsScoutSignalExtra {
     mcp_trace_id?: string
 }
 
-export interface SignalsScoutSignalInput {
+export interface SignalsScoutSignalInput extends SignalInputBase {
     source_type: 'cross_source_issue'
     source_product: 'signals_scout'
-    source_id: string
-    description: string
-    weight: number
     extra: SignalsScoutSignalExtra
-    remediation?: SignalRemediation
 }
 
 // Logs alert notification (firing / broken)
 
-export interface LogsAlertStateChangeSignalExtra {
+export interface LogsAlertStateChangeSignalExtra extends SignalExtraBase {
     alert_id: string
     alert_name: string
     action: 'firing' | 'broken'
@@ -376,14 +350,10 @@ export interface LogsAlertStateChangeSignalExtra {
     url: string
 }
 
-export interface LogsAlertStateChangeSignalInput {
+export interface LogsAlertStateChangeSignalInput extends SignalInputBase {
     source_type: 'alert_state_change'
     source_product: 'logs'
-    source_id: string
-    description: string
-    weight: number
     extra: LogsAlertStateChangeSignalExtra
-    remediation?: SignalRemediation
 }
 
 // ── Report reviewer types ────────────────────────────────────────────────────────

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1144,18 +1144,6 @@ class ConversationsTicketSignalExtra(BaseModel):
     ticket_number: float
 
 
-class ConversationsTicketSignalInput(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: str
-    extra: ConversationsTicketSignalExtra
-    source_id: str
-    source_product: Literal["conversations"] = "conversations"
-    source_type: Literal["ticket"] = "ticket"
-    weight: float
-
-
 class CoreEventCategory(StrEnum):
     ACQUISITION = "acquisition"
     ACTIVATION = "activation"
@@ -1671,18 +1659,6 @@ class EndpointExecutionFailedSignalExtra(BaseModel):
     saved_query_id: str | None = None
 
 
-class EndpointExecutionFailedSignalInput(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: str
-    extra: EndpointExecutionFailedSignalExtra
-    source_id: str
-    source_product: Literal["endpoints"] = "endpoints"
-    source_type: Literal["endpoint_execution_failed"] = "endpoint_execution_failed"
-    weight: float
-
-
 class EndpointLastExecutionTimesRequest(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1867,18 +1843,6 @@ class SourceType(StrEnum):
     ISSUE_CREATED = "issue_created"
     ISSUE_REOPENED = "issue_reopened"
     ISSUE_SPIKING = "issue_spiking"
-
-
-class ErrorTrackingSignalInput(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: str
-    extra: ErrorTrackingSignalExtra
-    source_id: str
-    source_product: Literal["error_tracking"] = "error_tracking"
-    source_type: SourceType
-    weight: float
 
 
 class EventDefinition(BaseModel):
@@ -2534,18 +2498,6 @@ class GithubIssueSignalExtra(BaseModel):
     updated_at: str
 
 
-class GithubIssueSignalInput(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: str
-    extra: GithubIssueSignalExtra
-    source_id: str
-    source_product: Literal["github"] = "github"
-    source_type: Literal["issue"] = "issue"
-    weight: float
-
-
 class Position(StrEnum):
     START = "start"
     END = "end"
@@ -2900,18 +2852,6 @@ class LinearIssueSignalExtra(BaseModel):
     url: str
 
 
-class LinearIssueSignalInput(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: str
-    extra: LinearIssueSignalExtra
-    source_id: str
-    source_product: Literal["linear"] = "linear"
-    source_type: Literal["issue"] = "issue"
-    weight: float
-
-
 class LinkedinAdsDefaultSources(StrEnum):
     LINKEDIN = "linkedin"
     LI = "li"
@@ -2948,30 +2888,6 @@ class LlmEvalSignalExtra(BaseModel):
     target_event_id: str | None = None
     target_event_type: str | None = None
     trace_id: str
-
-
-class LlmEvaluationReportSignalInput(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: str
-    extra: LlmEvalReportSignalExtra
-    source_id: str
-    source_product: Literal["llm_analytics"] = "llm_analytics"
-    source_type: Literal["evaluation_report"] = "evaluation_report"
-    weight: float
-
-
-class LlmEvaluationSignalInput(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: str
-    extra: LlmEvalSignalExtra
-    source_id: str
-    source_product: Literal["llm_analytics"] = "llm_analytics"
-    source_type: Literal["evaluation"] = "evaluation"
-    weight: float
 
 
 class LoadingBlock(BaseModel):
@@ -3050,18 +2966,6 @@ class LogsAlertStateChangeSignalExtra(BaseModel):
     threshold_operator: ThresholdOperator
     url: str
     window_minutes: float
-
-
-class LogsAlertStateChangeSignalInput(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: str
-    extra: LogsAlertStateChangeSignalExtra
-    source_id: str
-    source_product: Literal["logs"] = "logs"
-    source_type: Literal["alert_state_change"] = "alert_state_change"
-    weight: float
 
 
 class LogsOrderBy(StrEnum):
@@ -3880,18 +3784,6 @@ class PgAnalyzeIssueSignalExtra(BaseModel):
     synced_at: str
 
 
-class PgAnalyzeIssueSignalInput(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: str
-    extra: PgAnalyzeIssueSignalExtra
-    source_id: str
-    source_product: Literal["pganalyze"] = "pganalyze"
-    source_type: Literal["issue"] = "issue"
-    weight: float
-
-
 class PinterestAdsDefaultSources(StrEnum):
     PINTEREST = "pinterest"
 
@@ -4566,18 +4458,6 @@ class SessionProblemSignalExtra(BaseModel):
     start_time: str
 
 
-class SessionProblemSignalInput(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: str
-    extra: SessionProblemSignalExtra
-    source_id: str
-    source_product: Literal["session_replay"] = "session_replay"
-    source_type: Literal["session_problem"] = "session_problem"
-    weight: float
-
-
 class SessionPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4695,6 +4575,33 @@ class SharingConfigurationSettings(BaseModel):
     whitelabel: bool | None = None
 
 
+class Priority(StrEnum):
+    P0 = "P0"
+    P1 = "P1"
+    P2 = "P2"
+    P3 = "P3"
+    P4 = "P4"
+
+
+class SignalRemediation(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    agent: str = Field(
+        ...,
+        description=(
+            "Agent-facing guidance: how to investigate (which MCP tools to call) and,"
+            " where the fix lives in the user's codebase, how to apply it. The research"
+            " agent treats this as authoritative — it still investigates and produces"
+            " findings, but follows this instead of starting cold."
+        ),
+    )
+    priority: Priority | None = Field(
+        default=None,
+        description=("Suggested report priority (advisory — the research agent may override)."),
+    )
+
+
 class SignalReviewerUserInfo(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4806,6 +4713,7 @@ class SignalsScoutSignalInput(BaseModel):
     )
     description: str
     extra: SignalsScoutSignalExtra
+    remediation: SignalRemediation | None = None
     source_id: str
     source_product: Literal["signals_scout"] = "signals_scout"
     source_type: Literal["cross_source_issue"] = "cross_source_issue"
@@ -5515,6 +5423,7 @@ class ZendeskTicketSignalInput(BaseModel):
     )
     description: str
     extra: ZendeskTicketSignalExtra
+    remediation: SignalRemediation | None = None
     source_id: str
     source_product: Literal["zendesk"] = "zendesk"
     source_type: Literal["ticket"] = "ticket"
@@ -6861,6 +6770,19 @@ class CohortPropertyFilter(BaseModel):
     value: int
 
 
+class ConversationsTicketSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: ConversationsTicketSignalExtra
+    remediation: SignalRemediation | None = None
+    source_id: str
+    source_product: Literal["conversations"] = "conversations"
+    source_type: Literal["ticket"] = "ticket"
+    weight: float
+
+
 class CustomChannelCondition(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -7006,6 +6928,19 @@ class EmbeddingDistance(BaseModel):
     result: EmbeddingRecord
 
 
+class EndpointExecutionFailedSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: EndpointExecutionFailedSignalExtra
+    remediation: SignalRemediation | None = None
+    source_id: str
+    source_product: Literal["endpoints"] = "endpoints"
+    source_type: Literal["endpoint_execution_failed"] = "endpoint_execution_failed"
+    weight: float
+
+
 class EndpointsUsageOverviewItem(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -7071,6 +7006,19 @@ class ErrorTrackingPendingFingerprintIssueStateUpdate(BaseModel):
         ...,
         description=("Client-stamped monotonic version (`Date.now()` ms at mutation success)."),
     )
+
+
+class ErrorTrackingSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: ErrorTrackingSignalExtra
+    remediation: SignalRemediation | None = None
+    source_id: str
+    source_product: Literal["error_tracking"] = "error_tracking"
+    source_type: SourceType
+    weight: float
 
 
 class EventMetadataPropertyFilter(BaseModel):
@@ -7559,6 +7507,19 @@ class FunnelsFilterLegacy(BaseModel):
     layout: FunnelLayout | None = None
 
 
+class GithubIssueSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: GithubIssueSignalExtra
+    remediation: SignalRemediation | None = None
+    source_id: str
+    source_product: Literal["github"] = "github"
+    source_type: Literal["issue"] = "issue"
+    weight: float
+
+
 class GroupPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -7768,6 +7729,45 @@ class LifecycleFilterLegacy(BaseModel):
     toggledLifecycles: list[LifecycleToggle] | None = None
 
 
+class LinearIssueSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: LinearIssueSignalExtra
+    remediation: SignalRemediation | None = None
+    source_id: str
+    source_product: Literal["linear"] = "linear"
+    source_type: Literal["issue"] = "issue"
+    weight: float
+
+
+class LlmEvaluationReportSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: LlmEvalReportSignalExtra
+    remediation: SignalRemediation | None = None
+    source_id: str
+    source_product: Literal["llm_analytics"] = "llm_analytics"
+    source_type: Literal["evaluation_report"] = "evaluation_report"
+    weight: float
+
+
+class LlmEvaluationSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: LlmEvalSignalExtra
+    remediation: SignalRemediation | None = None
+    source_id: str
+    source_product: Literal["llm_analytics"] = "llm_analytics"
+    source_type: Literal["evaluation"] = "evaluation"
+    weight: float
+
+
 class LogEntryPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -7809,6 +7809,19 @@ class LogPropertyFilter(BaseModel):
     operator: PropertyOperator
     type: LogPropertyFilterType
     value: list[str | float | bool] | str | float | bool | None = None
+
+
+class LogsAlertStateChangeSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: LogsAlertStateChangeSignalExtra
+    remediation: SignalRemediation | None = None
+    source_id: str
+    source_product: Literal["logs"] = "logs"
+    source_type: Literal["alert_state_change"] = "alert_state_change"
+    weight: float
 
 
 class MarketingAnalyticsItem(BaseModel):
@@ -8030,6 +8043,19 @@ class PersonPropertyFilter(BaseModel):
     operator: PropertyOperator
     type: Literal["person"] = Field(default="person", description="Person properties")
     value: list[str | float | bool] | str | float | bool | None = None
+
+
+class PgAnalyzeIssueSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: PgAnalyzeIssueSignalExtra
+    remediation: SignalRemediation | None = None
+    source_id: str
+    source_product: Literal["pganalyze"] = "pganalyze"
+    source_type: Literal["issue"] = "issue"
+    weight: float
 
 
 class PlanningStep(BaseModel):
@@ -8819,6 +8845,19 @@ class SessionBatchEventsQueryResponse(BaseModel):
             " HogQL queries."
         ),
     )
+
+
+class SessionProblemSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: SessionProblemSignalExtra
+    remediation: SignalRemediation | None = None
+    source_id: str
+    source_product: Literal["session_replay"] = "session_replay"
+    source_type: Literal["session_problem"] = "session_problem"
+    weight: float
 
 
 class SessionRecordingType(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4575,6 +4575,13 @@ class SharingConfigurationSettings(BaseModel):
     whitelabel: bool | None = None
 
 
+class SignalExtraBase(BaseModel):
+    pass
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+
+
 class Priority(StrEnum):
     P0 = "P0"
     P1 = "P1"
@@ -9031,6 +9038,19 @@ class SignalInput(
         | SignalsScoutSignalInput
         | LogsAlertStateChangeSignalInput
     )
+
+
+class SignalInputBase(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: SignalExtraBase
+    remediation: SignalRemediation | None = None
+    source_id: str
+    source_product: str
+    source_type: str
+    weight: float
 
 
 class SourceFieldFileUploadConfig(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4603,9 +4603,15 @@ class SignalRemediation(BaseModel):
             " findings, but follows this instead of starting cold."
         ),
     )
+    human: str = Field(
+        ...,
+        description=(
+            "Human-facing fix steps (PostHog UI / alert destinations). Surfaced in the report for the reader."
+        ),
+    )
     priority: Priority | None = Field(
         default=None,
-        description=("Suggested report priority (advisory — the research agent may override)."),
+        description=("Suggested report priority; advisory, the research agent may override."),
     )
 
 

--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -9,7 +9,7 @@ import structlog
 import temporalio
 import posthoganalytics
 
-from posthog.schema import SignalInput
+from posthog.schema import SignalInput, SignalRemediation
 
 from posthog.event_usage import groups
 from posthog.helpers.tiktoken_encoding import LLM_TOKEN_COUNT_PROXY_MODEL, get_tiktoken_encoding_for_model
@@ -87,7 +87,7 @@ async def emit_signal(
     description: str,
     weight: float = 0.5,
     extra: dict | None = None,
-    remediation: str | None = None,
+    remediation: SignalRemediation | None = None,
 ) -> None:
     """
     Emit a signal for grouping and potential report generation, fire-and-forget.
@@ -108,9 +108,10 @@ async def emit_signal(
             `_telemetry_props_from_extra` — so per-source attribution (e.g. the scout harness's
             `scout_run_id` / `skill_name`) is queryable downstream without a schema change.
             Nested lists/dicts are never forwarded.
-        remediation: Optional top-level fix hint (separate from extra). When set, it is surfaced to the
-            investigating agent, which treats the signal as actionable and follows it. Not required by
-            any existing source.
+        remediation: Optional fix guidance (separate from extra), validated against the
+            `SignalRemediation` schema. When set, the signal is treated as actionable: the guidance
+            is surfaced to the research agent as authoritative direction, which it follows instead of
+            investigating from scratch. Not required by any existing source.
 
     Example:
         await emit_signal(
@@ -161,8 +162,10 @@ async def emit_signal(
                 }
             ],
         )
-    # `remediation` is an optional top-level field; only include it in the payload when set so
-    # variants that don't declare it (every source except health checks today) still validate.
+    # Carry the remediation as a plain dict from here on (like `extra`) so it survives the
+    # Temporal/S3 JSON round-trip; `model_validate` below re-checks it against the variant's
+    # declared `remediation: SignalRemediation | None` field.
+    remediation_dict = remediation.model_dump(mode="json", exclude_none=True) if remediation is not None else None
     payload_to_validate: dict = {
         "source_product": source_product,
         "source_type": source_type,
@@ -170,9 +173,8 @@ async def emit_signal(
         "description": description,
         "weight": weight,
         "extra": extra or {},
+        "remediation": remediation_dict,
     }
-    if remediation is not None:
-        payload_to_validate["remediation"] = remediation
     variant_model.model_validate(payload_to_validate)
 
     # Fire a "started" marker so direct callers (error tracking, AI observability evals, etc.)
@@ -209,7 +211,7 @@ async def emit_signal(
         description=description,
         weight=weight,
         extra=extra or {},
-        remediation=remediation,
+        remediation=remediation_dict,
     )
 
     # Ensure the buffer workflow is running (idempotent)

--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -22,6 +22,11 @@ from products.signals.backend.models import SignalSourceConfig
 logger = structlog.get_logger(__name__)
 
 MAX_SIGNAL_DESCRIPTION_TOKENS = 8000
+MAX_SIGNAL_REMEDIATION_TOKENS = 16000
+
+
+def _token_count(text: str) -> int:
+    return len(get_tiktoken_encoding_for_model(LLM_TOKEN_COUNT_PROXY_MODEL).encode(text))
 
 
 def dismiss_report_from_slack(team_id: int, report_id: str, *, slack_user_id: str | None = None) -> bool:
@@ -109,7 +114,8 @@ async def emit_signal(
             `scout_run_id` / `skill_name`) is queryable downstream without a schema change.
             Nested lists/dicts are never forwarded.
         remediation: Optional fix guidance (separate from extra), validated against the
-            `SignalRemediation` schema. When set, the signal is treated as actionable: the guidance
+            `SignalRemediation` schema and capped at MAX_SIGNAL_REMEDIATION_TOKENS tokens
+            (`human` + `agent` combined). When set, the signal is treated as actionable: the guidance
             is surfaced to the research agent as authoritative direction, which it follows instead of
             investigating from scratch. Not required by any existing source.
 
@@ -141,12 +147,20 @@ async def emit_signal(
     if not is_enabled:
         return
 
-    token_count = len(get_tiktoken_encoding_for_model(LLM_TOKEN_COUNT_PROXY_MODEL).encode(description))
-    if token_count > MAX_SIGNAL_DESCRIPTION_TOKENS:
+    description_tokens = _token_count(description)
+    if description_tokens > MAX_SIGNAL_DESCRIPTION_TOKENS:
         raise ValueError(
-            f"Signal description exceeds {MAX_SIGNAL_DESCRIPTION_TOKENS} tokens ({token_count} tokens). "
+            f"Signal description exceeds {MAX_SIGNAL_DESCRIPTION_TOKENS} tokens ({description_tokens} tokens). "
             f"Truncate the description before calling emit_signal."
         )
+
+    if remediation is not None:
+        remediation_tokens = _token_count(f"{remediation.human}\n{remediation.agent}")
+        if remediation_tokens > MAX_SIGNAL_REMEDIATION_TOKENS:
+            raise ValueError(
+                f"Signal remediation exceeds {MAX_SIGNAL_REMEDIATION_TOKENS} tokens ({remediation_tokens} tokens). "
+                f"Trim the remediation guidance before calling emit_signal."
+            )
 
     # Validate the signal against the matching schema variant
     variant_model = _SIGNAL_VARIANT_LOOKUP.get((source_product, source_type))

--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -87,6 +87,7 @@ async def emit_signal(
     description: str,
     weight: float = 0.5,
     extra: dict | None = None,
+    remediation: str | None = None,
 ) -> None:
     """
     Emit a signal for grouping and potential report generation, fire-and-forget.
@@ -107,6 +108,9 @@ async def emit_signal(
             `_telemetry_props_from_extra` — so per-source attribution (e.g. the scout harness's
             `scout_run_id` / `skill_name`) is queryable downstream without a schema change.
             Nested lists/dicts are never forwarded.
+        remediation: Optional top-level fix hint (separate from extra). When set, it is surfaced to the
+            investigating agent, which treats the signal as actionable and follows it. Not required by
+            any existing source.
 
     Example:
         await emit_signal(
@@ -157,16 +161,19 @@ async def emit_signal(
                 }
             ],
         )
-    variant_model.model_validate(
-        {
-            "source_product": source_product,
-            "source_type": source_type,
-            "source_id": source_id,
-            "description": description,
-            "weight": weight,
-            "extra": extra or {},
-        }
-    )
+    # `remediation` is an optional top-level field; only include it in the payload when set so
+    # variants that don't declare it (every source except health checks today) still validate.
+    payload_to_validate: dict = {
+        "source_product": source_product,
+        "source_type": source_type,
+        "source_id": source_id,
+        "description": description,
+        "weight": weight,
+        "extra": extra or {},
+    }
+    if remediation is not None:
+        payload_to_validate["remediation"] = remediation
+    variant_model.model_validate(payload_to_validate)
 
     # Fire a "started" marker so direct callers (error tracking, AI observability evals, etc.)
     # that don't go through the data-source pipeline still have a top-of-funnel event. The
@@ -202,6 +209,7 @@ async def emit_signal(
         description=description,
         weight=weight,
         extra=extra or {},
+        remediation=remediation,
     )
 
     # Ensure the buffer workflow is running (idempotent)

--- a/products/signals/backend/report_generation/research.py
+++ b/products/signals/backend/report_generation/research.py
@@ -261,7 +261,11 @@ def _render_signal_for_research(signal: SignalData, index: int, total: int) -> s
     lines.append(f"- **Timestamp:** {signal.timestamp}")
     lines.append(f"- **Description:** {signal.content}")
     if signal.remediation:
-        lines.append(f"- **Remediation:** {signal.remediation}")
+        lines.append("- **Remediation (authoritative guidance — follow it, then verify):**")
+        if agent := signal.remediation.get("agent"):
+            lines.append(f"    - **Guidance:** {agent}")
+        if priority := signal.remediation.get("priority"):
+            lines.append(f"    - **Suggested priority:** {priority}")
     if signal.extra:
         lines.append("#### Extras")
         lines.extend(_render_extra_to_text(signal.extra))
@@ -285,7 +289,7 @@ You have two investigation tools:
 
 When a signal includes **Attached images**, the URLs are publicly reachable — fetch them directly to inspect screenshots, UI issues, or other visual evidence.
 
-When a signal includes a **`remediation`** field, it describes a concrete, known fix and where it lives — for instrumentation issues that is the repository where the PostHog SDK is initialized (or its dependency manifest); for PostHog-side issues it is project configuration. Treat such signals as actionable: locate that code or config, follow the remediation, and use the PostHog MCP to confirm the problem and verify the fix (e.g. query whether the expected events now arrive)."""
+When a signal includes a **`remediation`** field, treat its guidance as authoritative — it tells you exactly how to fix the issue (which MCP tools to call and, where the fix lives in the user's codebase, how to apply it). Do not re-derive the fix from scratch: follow the guidance, then still do the work a good report needs — locate the relevant code, identify the causative commits, confirm the problem via the PostHog MCP, and verify the fix (e.g. query whether the expected events now arrive)."""
 
 _RESEARCH_PROTOCOL = """## Research protocol
 

--- a/products/signals/backend/report_generation/research.py
+++ b/products/signals/backend/report_generation/research.py
@@ -260,6 +260,8 @@ def _render_signal_for_research(signal: SignalData, index: int, total: int) -> s
     lines.append(f"- **Weight:** {signal.weight}")
     lines.append(f"- **Timestamp:** {signal.timestamp}")
     lines.append(f"- **Description:** {signal.content}")
+    if signal.remediation:
+        lines.append(f"- **Remediation:** {signal.remediation}")
     if signal.extra:
         lines.append("#### Extras")
         lines.extend(_render_extra_to_text(signal.extra))
@@ -281,7 +283,9 @@ You have two investigation tools:
 1. **The codebase** — the full PostHog repository is available on disk. Use file search, grep, and code reading.
 2. **PostHog MCP** — you can query PostHog analytics data via MCP tools like `execute-sql`, `query-run`, `read-data-schema`, `insights-get-all`, `experiment-get`, `list-errors`, `feature-flag-get-all`, etc.
 
-When a signal includes **Attached images**, the URLs are publicly reachable — fetch them directly to inspect screenshots, UI issues, or other visual evidence."""
+When a signal includes **Attached images**, the URLs are publicly reachable — fetch them directly to inspect screenshots, UI issues, or other visual evidence.
+
+When a signal includes a **`remediation`** field, it describes a concrete, known fix and where it lives — for instrumentation issues that is the repository where the PostHog SDK is initialized (or its dependency manifest); for PostHog-side issues it is project configuration. Treat such signals as actionable: locate that code or config, follow the remediation, and use the PostHog MCP to confirm the problem and verify the fix (e.g. query whether the expected events now arrive)."""
 
 _RESEARCH_PROTOCOL = """## Research protocol
 

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -654,6 +654,7 @@ class AssignAndEmitSignalInput:
     match_result: MatchResult
     timestamp: Optional[datetime] = None
     updated_title: Optional[str] = None
+    remediation: Optional[str] = None
 
 
 @dataclass
@@ -696,6 +697,7 @@ async def assign_and_emit_signal_activity(input: AssignAndEmitSignalInput) -> As
                         "weight": input.weight,
                         "report_id": report_id,
                         "extra": input.extra,
+                        "remediation": input.remediation,
                         "deleted": True,
                     }
                     metadata["match_metadata"] = asdict(match_result.match_metadata)
@@ -760,6 +762,7 @@ async def assign_and_emit_signal_activity(input: AssignAndEmitSignalInput) -> As
                 "weight": input.weight,
                 "report_id": report_id,
                 "extra": input.extra,
+                "remediation": input.remediation,
             }
 
             metadata["match_metadata"] = asdict(match_result.match_metadata)
@@ -1149,6 +1152,7 @@ async def _process_signal_batch(
                     embedding=signal_embeddings[i].embedding,
                     match_result=match_result,
                     updated_title=updated_title,
+                    remediation=signal.remediation,
                 ),
                 start_to_close_timeout=timedelta(minutes=5),
                 retry_policy=RetryPolicy(maximum_attempts=3),

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -654,7 +654,7 @@ class AssignAndEmitSignalInput:
     match_result: MatchResult
     timestamp: Optional[datetime] = None
     updated_title: Optional[str] = None
-    remediation: Optional[str] = None
+    remediation: Optional[dict] = None
 
 
 @dataclass

--- a/products/signals/backend/temporal/parallel_grouping.py
+++ b/products/signals/backend/temporal/parallel_grouping.py
@@ -240,6 +240,7 @@ async def _process_signal(
             embedding=signal_embedding,
             match_result=match_result,
             updated_title=updated_title,
+            remediation=signal.remediation,
         ),
         start_to_close_timeout=timedelta(minutes=5),
         retry_policy=RetryPolicy(maximum_attempts=3),

--- a/products/signals/backend/temporal/reingestion.py
+++ b/products/signals/backend/temporal/reingestion.py
@@ -199,6 +199,7 @@ async def process_team_signals_batch_activity(input: ProcessTeamSignalsBatchInpu
                 weight=metadata.get("weight", 0.0),
                 timestamp=_ensure_tz_aware(timestamp_raw),
                 extra=metadata.get("extra", {}),
+                remediation=metadata.get("remediation"),
                 metadata=dict(metadata),
             )
         )

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -117,6 +117,7 @@ def _parse_signal_row(row: tuple) -> SignalData:
         weight=metadata.get("weight", 0.0),
         timestamp=timestamp_raw,
         extra=metadata.get("extra", {}),
+        remediation=metadata.get("remediation"),
     )
 
 

--- a/products/signals/backend/temporal/types.py
+++ b/products/signals/backend/temporal/types.py
@@ -12,9 +12,11 @@ class EmitSignalInputs:
     description: str
     weight: float = 0.5
     extra: dict = field(default_factory=dict)
-    # Optional top-level fix hint (separate from `extra`). Surfaced to the investigating agent
-    # when present; not required by any source.
-    remediation: Optional[str] = None
+    # Optional fix guidance (separate from `extra`), shaped by the `SignalRemediation` schema and
+    # validated against it at the emit boundary. Carried as a plain dict like `extra` so it survives
+    # the Temporal/S3 JSON round-trip. Surfaced to the research agent as authoritative direction when
+    # present; not required by any source.
+    remediation: Optional[dict] = None
 
 
 @dataclass
@@ -181,8 +183,8 @@ class SignalData:
     timestamp: datetime
     extra: dict = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
-    # Optional top-level fix hint (separate from `extra`); see EmitSignalInputs.remediation.
-    remediation: Optional[str] = None
+    # Optional fix guidance (separate from `extra`); see EmitSignalInputs.remediation.
+    remediation: Optional[dict] = None
 
 
 def _render_extra_to_text(extra: dict) -> list[str]:
@@ -199,6 +201,16 @@ def _render_extra_to_text(extra: dict) -> list[str]:
     return lines
 
 
+def _render_remediation_to_text(remediation: dict) -> list[str]:
+    """Render a remediation (SignalRemediation shape) to text lines for LLM consumption."""
+    lines = ["- Remediation (authoritative guidance — follow it, then verify via the PostHog MCP):"]
+    if agent := remediation.get("agent"):
+        lines.append(f"  - Guidance: {agent}")
+    if priority := remediation.get("priority"):
+        lines.append(f"  - Suggested priority: {priority}")
+    return lines
+
+
 def render_signal_to_text(
     signal: SignalData,
     index: Optional[int] = None,
@@ -210,7 +222,7 @@ def render_signal_to_text(
     lines.append(f"- Timestamp: {signal.timestamp.isoformat()}")
     lines.append(f"- Description: {signal.content}")
     if signal.remediation:
-        lines.append(f"- Remediation (actionable — follow this and verify via the PostHog MCP): {signal.remediation}")
+        lines.extend(_render_remediation_to_text(signal.remediation))
     if signal.extra:
         lines.extend(_render_extra_to_text(signal.extra))
     return "\n".join(lines)

--- a/products/signals/backend/temporal/types.py
+++ b/products/signals/backend/temporal/types.py
@@ -12,6 +12,9 @@ class EmitSignalInputs:
     description: str
     weight: float = 0.5
     extra: dict = field(default_factory=dict)
+    # Optional top-level fix hint (separate from `extra`). Surfaced to the investigating agent
+    # when present; not required by any source.
+    remediation: Optional[str] = None
 
 
 @dataclass
@@ -178,6 +181,8 @@ class SignalData:
     timestamp: datetime
     extra: dict = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
+    # Optional top-level fix hint (separate from `extra`); see EmitSignalInputs.remediation.
+    remediation: Optional[str] = None
 
 
 def _render_extra_to_text(extra: dict) -> list[str]:
@@ -204,6 +209,8 @@ def render_signal_to_text(
     lines.append(f"- Weight: {signal.weight}")
     lines.append(f"- Timestamp: {signal.timestamp.isoformat()}")
     lines.append(f"- Description: {signal.content}")
+    if signal.remediation:
+        lines.append(f"- Remediation (actionable — follow this and verify via the PostHog MCP): {signal.remediation}")
     if signal.extra:
         lines.extend(_render_extra_to_text(signal.extra))
     return "\n".join(lines)

--- a/products/signals/backend/test/test_api.py
+++ b/products/signals/backend/test/test_api.py
@@ -6,7 +6,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pydantic
 import temporalio.exceptions
 
-from products.signals.backend.facade.api import _MAX_TELEMETRY_STR_LEN, _telemetry_props_from_extra, emit_signal
+from posthog.schema import SignalRemediation
+
+from products.signals.backend.facade.api import (
+    _MAX_TELEMETRY_STR_LEN,
+    MAX_SIGNAL_REMEDIATION_TOKENS,
+    _telemetry_props_from_extra,
+    emit_signal,
+)
 from products.signals.backend.models import SignalSourceConfig
 from products.signals.backend.temporal.buffer import BufferSignalsWorkflow
 from products.signals.backend.temporal.emitter import SignalEmitterWorkflow
@@ -131,6 +138,49 @@ class TestEmitSignalValidation:
                 )
 
         client.start_workflow.assert_not_awaited()
+
+    async def test_emit_signal_rejects_oversized_remediation(self, team_stub):
+        client = AsyncMock()
+
+        with (
+            patch("products.signals.backend.facade.api.async_connect", return_value=client),
+            patch.object(SignalSourceConfig, "is_source_enabled", return_value=True),
+        ):
+            with pytest.raises(ValueError, match="remediation exceeds"):
+                await emit_signal(
+                    team=team_stub,
+                    source_product="github",
+                    source_type="issue",
+                    source_id="test-id-1",
+                    description="A valid signal",
+                    extra=GITHUB_ISSUE_EXTRA,
+                    remediation=SignalRemediation(human="fix it", agent="step " * (MAX_SIGNAL_REMEDIATION_TOKENS + 1)),
+                )
+
+        client.start_workflow.assert_not_awaited()
+
+    async def test_emit_signal_accepts_remediation_within_limit(self, team_stub):
+        client = AsyncMock()
+        client.start_workflow.side_effect = [
+            temporalio.exceptions.WorkflowAlreadyStartedError("already started", "buffer-signals-1"),
+            AsyncMock(),
+        ]
+
+        with (
+            patch("products.signals.backend.facade.api.async_connect", return_value=client),
+            patch.object(SignalSourceConfig, "is_source_enabled", return_value=True),
+        ):
+            await emit_signal(
+                team=team_stub,
+                source_product="github",
+                source_type="issue",
+                source_id="test-id-1",
+                description="A valid signal",
+                extra=GITHUB_ISSUE_EXTRA,
+                remediation=SignalRemediation(human="Re-run the materialization.", agent="Open the model and retry."),
+            )
+
+        assert client.start_workflow.await_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Signals carry a free-form `description` and a product-specific `extra` blob, but there's
no first-class, cross-source place for "how do you fix this?". We want emitters to be able
without overloading `extra` (product metadata) or the `description` (which is embedded for
grouping/dedup).
  
## Changes

Adds an optional, top-level `remediation: str | None` field that rides through the whole
signal pipeline, separate from `extra` and not required by any source:

- `emit_signal(...)` gains a `remediation` param → `EmitSignalInputs` → grouping
  (`AssignAndEmitSignalInput`, both the legacy v1 construction and the live v2 path) →
  ClickHouse signal metadata (a sibling key of `extra`) → read back into `SignalData`.
- Surfaced to the report-research agent: rendered as a dedicated per-signal line, with a
  preamble note telling the agent to treat signals that have it as actionable and to verify
  the fix via the PostHog MCP.

Backward-compatible and inert on its own: it defaults to `None`, is only included in schema
validation when set, and old rows without the key read back as `None`. No source emits it
yet — the first caller arrives in the stacked PR.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). No manual testing. Automated:

- Ran the signals pipeline tests (`products/signals/backend/test/test_assign_and_emit_signal.py`,
  16 passed), which exercise the grouping → assign/emit → metadata path the new field threads through.

There is no behavior change for existing sources; the field is purely additive plumbing.
  
## Automatic notifications
  
- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8).
  
- **Why a top-level field, not `extra`:** requested explicitly — `extra` is product-specific
  structured metadata, whereas `remediation` is a generic, cross-source concept the agent should
  always be able to read when present.
- **No grouping impact:** confirmed grouping/dedup embeds only `description`, so adding
  `remediation` to the metadata envelope doesn't affect clustering — no new pipeline version needed.
- **Coverage:** threaded both grouping generations (live v2 in `parallel_grouping.py`, legacy v1
  construction in `grouping.py`) plus the shared `assign_and_emit_signal_activity` so no path drops
  the field.