### PR TITLE
chore(dev): reap orphaned vite subtree when start-frontend exits

### DIFF
--- a/bin/start-frontend
+++ b/bin/start-frontend
@@ -11,5 +11,45 @@ export DEBUG=0
 # Auto-accept corepack download prompts (hangs in non-interactive contexts)
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
+# Recursively collect every descendant PID of the given pid, deepest first.
+# turbo's launcher re-parents the vite subtree into its own process group, so the
+# sibling `kill -- -$$` process-group idiom (start-go-service/start-rust-service)
+# misses it — we have to walk the tree by PID instead.
+collect_descendants() {
+    local parent=$1 child
+    for child in $(pgrep -P "$parent" 2>/dev/null); do
+        collect_descendants "$child"
+        echo "$child"
+    done
+}
+
+# When the process manager stops us (q / SIGTERM / SIGINT) bash would otherwise
+# exit without forwarding the signal to turbo, orphaning the whole
+# turbo → concurrently → vite (+ toolbar esbuild) subtree — leaving vite
+# squatting port 8234 across sessions. Tear the entire descendant tree down.
+shutdown() {
+    trap - INT TERM EXIT
+    local pids
+    pids=$(collect_descendants $$)
+    # shellcheck disable=SC2086
+    kill -TERM $pids 2>/dev/null || true
+    # Give the tree a moment to exit gracefully, then force-kill survivors.
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        pids=$(collect_descendants $$)
+        [ -z "$pids" ] && break
+        sleep 0.3
+    done
+    # shellcheck disable=SC2086
+    kill -KILL $pids 2>/dev/null || true
+}
+trap shutdown INT TERM EXIT
+
 pnpm --filter=@posthog/frontend... install
-bin/turbo --filter=@posthog/frontend start-vite
+
+# Run turbo in the background and wait on it so the trap above can fire while
+# turbo is running (a foreground child would keep bash blocked in turbo's own
+# wait, delaying signal handling). `wait` returns when turbo exits or when a
+# trapped signal interrupts it, at which point shutdown() reaps the subtree.
+bin/turbo --filter=@posthog/frontend start-vite &
+turbo_pid=$!
+wait "$turbo_pid"


### PR DESCRIPTION
## Problem

Starting a fresh worktree with `hogli start` served a broken app at http://localhost:8010/. The page loaded but the frontend was stale or blank.

The cause was orphaned frontend processes left behind by other worktrees. When the process manager stops `bin/start-frontend` (pressing `q`, or SIGTERM/SIGINT), bash exited without forwarding the signal to turbo. turbo had re-parented the `turbo`, `concurrently`, `vite`, and toolbar esbuild subtree into its own process group, so it survived as an orphan and kept running across sessions. The orphaned vite held port 8234, so a newly started worktree's vite fell forward to the next free port and the app proxy at :8010 kept pointing at the stale orphan on 8234. These piled up over time: I found eight orphaned trees, one to three days old, across four worktrees.

## Changes

`bin/start-frontend` now runs turbo in the background and installs a `shutdown` trap on INT, TERM, and EXIT. On stop it walks the descendant PID tree and tears it down with SIGTERM, waits a short grace period (up to about three seconds), then SIGKILLs any survivors.

The teardown walks the tree by PID with `pgrep -P` instead of the sibling `kill -- -$$` process-group idiom used by `start-go-service` and `start-rust-service`. turbo detaches the vite subtree into its own process group, which a single process-group kill misses. A comment in the script spells this out so the walk does not get simplified back into the broken one-liner.

This only stops the leak going forward. Orphans created before this change still have to be killed by hand.

## How did you test this code?

- `shellcheck bin/start-frontend` passes clean. The two `SC2086` word-splitting cases are intentional and annotated.
- Ran `hogli start` in this worktree and pressed `q`. This worktree's frontend subtree was reaped and port 8234 was freed. The only survivors were unrelated orphans from other worktrees that predate this change.
- Checked the trap behavior on bash 3.2 and 5.3: `shutdown` fires once on a signal rather than twice, `set -e` does not suppress the EXIT trap, and the unquoted PID list word-splits correctly into `kill`.

No automated test is added. There is no bash test harness in the repo, and signal and process-tree teardown cannot be exercised faithfully by a unit test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?