### PR TITLE
chore(tasks): de-flake start=latest stream test by removing fakeredis race

### DIFF
--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3,7 +3,6 @@ import time
 import uuid
 import base64
 import asyncio
-import threading
 from collections.abc import Iterator
 from datetime import timedelta
 from typing import ClassVar, cast
@@ -47,11 +46,7 @@ from products.tasks.backend.services.staged_artifacts import (
     cache_task_staged_artifact,
     get_task_staged_artifacts,
 )
-from products.tasks.backend.stream.redis_stream import (
-    TaskRunRedisStream,
-    get_task_run_stream_key,
-    publish_task_run_stream_event,
-)
+from products.tasks.backend.stream.redis_stream import TaskRunRedisStream, get_task_run_stream_key
 from products.tasks.backend.temporal.process_task.utils import get_cached_github_user_token
 
 
@@ -5123,33 +5118,32 @@ class TestTaskRunStreamAPI(BaseTaskAPITest):
 
     def test_stream_start_latest_only_yields_new_events(self):
         task = self.create_task()
-        run = task.create_run()
+        run = task.create_run()  # publishes a task_run_state event the latest cursor must skip
 
-        def publish_future_events() -> None:
-            time.sleep(0.05)
-            publish_task_run_stream_event(
-                str(run.id),
-                {
-                    "type": "notification",
-                    "timestamp": "2026-01-01T00:00:01Z",
-                    "notification": {
-                        "jsonrpc": "2.0",
-                        "method": "_posthog/console",
-                        "params": {
-                            "sessionId": str(run.id),
-                            "level": "info",
-                            "message": "late hello",
-                        },
-                    },
-                },
-            )
-            self._mark_stream_complete(run)
+        new_event = {
+            "type": "notification",
+            "timestamp": "2026-01-01T00:00:01Z",
+            "notification": {
+                "jsonrpc": "2.0",
+                "method": "_posthog/console",
+                "params": {"sessionId": str(run.id), "level": "info", "message": "late hello"},
+            },
+        }
 
-        publisher = threading.Thread(target=publish_future_events)
-        publisher.start()
-        response = self.client.get(self._stream_url(task, run) + "?start=latest")
-        events = self._collect_sse_events(response)
-        publisher.join()
+        # Append the new event the instant the handler captures the latest cursor, on the
+        # handler's own event loop. A background thread would mutate the shared in-memory
+        # fakeredis concurrently with the reader, which is racy and flakes in CI.
+        real_get_latest = TaskRunRedisStream.get_latest_stream_id
+
+        async def get_latest_then_publish(redis_stream: TaskRunRedisStream) -> str | None:
+            latest_id = await real_get_latest(redis_stream)
+            await redis_stream.write_event(new_event)
+            await redis_stream.mark_complete()
+            return latest_id
+
+        with patch.object(TaskRunRedisStream, "get_latest_stream_id", get_latest_then_publish):
+            response = self.client.get(self._stream_url(task, run) + "?start=latest")
+            events = self._collect_sse_events(response)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreaterEqual(len(events), 1)


### PR DESCRIPTION
## Problem

`TestTaskRunStreamAPI::test_stream_start_latest_only_yields_new_events` flakes in CI with `KeyError: 'notification'`. The failure is a test-only race, not a product bug.

With `?start=latest`, the stream endpoint captures the latest cursor via `get_latest_stream_id()` (an atomic `XREVRANGE ... COUNT 1`) and replays only entries after it, skipping the pre-existing `task_run_state` event (which has no `notification` key). The test wrote the "future" event from a **background thread** while the SSE reader iterated on the **main thread**. In tests, every caller shares a single non-thread-safe `FakeAsyncRedis` instance, so a concurrent `xrevrange` could momentarily observe an empty stream and return `None`. The handler then fell back to `start_id="0"`, replayed from the beginning, and the `task_run_state` event leaked into the results — tripping the `all(... ["notification"] ...)` assertion. On real Redis this is impossible (`XREVRANGE` is atomic), which is why it only failed under CI contention.

## Changes

Rewrote the test to be single-threaded and deterministic while exercising the same `?start=latest` path and assertions. The new event is now appended at the exact moment the handler captures its cursor — inside a patched `get_latest_stream_id`, on the handler's own event loop — guaranteeing it is written strictly after the cursor with no cross-thread fakeredis mutation. Ruff removed the now-unused `threading` and `publish_task_run_stream_event` imports.

The behavioral contract under test is unchanged: the pre-existing `task_run_state` event must be skipped, and only the newer event delivered.

## How did you test this code?

I'm an agent (Claude Code). Automated only:

- Ran the rewritten test once: passes.
- Ran it 25× consecutively: 25/25 passed, confirming the non-determinism is gone.

## 🤖 Agent context

Authored with Claude Code. Diagnosis traced the `KeyError` back through the `start=latest` handler (`api.py`) to the shared `FakeAsyncRedis` in `posthog/redis.py` and concluded the race could only manifest in the fake, not on real Redis. Considered keeping the background thread but making fakeredis access safe (rejected — fakeredis offers no clean serialization hook) and using `Last-Event-ID` instead (rejected — would test a different code path already covered elsewhere). Chose to inject the post-cursor write at the cursor-capture step, which keeps the `start=latest` semantics faithful and removes the thread entirely.
