### PR TITLE
fix(onboarding): guard wizard heartbeat against unmounted stream logic

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/wizardProgressTrackerLogic.ts
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/wizardProgressTrackerLogic.ts
@@ -234,6 +234,16 @@ export const wizardProgressTrackerLogic = kea<wizardProgressTrackerLogicType>([
         }, 'tick')
         cache.disposables.add(() => {
             const id = window.setInterval(() => {
+                // The kea-disposables plugin pauses timers when the tab is hidden and
+                // re-creates them on resume. That re-created interval can fire during a
+                // window where the connected wizardSessionStreamLogic has been torn down
+                // (e.g. the FAB unmounting after a feature-flag re-evaluation). Reading a
+                // value off an unmounted logic throws
+                // `[KEA] Can not find path "...wizardSessionStreamLogic..." in the store.`,
+                // so bail out unless the stream logic is currently mounted.
+                if (!wizardSessionStreamLogic.findMounted({ workflowId: WORKFLOW_ID })) {
+                    return
+                }
                 // Heartbeat: if the log has gone quiet for HEARTBEAT_QUIET_THRESHOLD_MS
                 // while the wizard is still running, append a "still working" line so
                 // the panel never looks frozen.


### PR DESCRIPTION
## Problem
This  `[KEA] Can not find path "products.wizard.wizardSessionStreamLogic.posthog-integration::*" in the store.`
is now the most[ common exception thrown on the insights page.  
](https://us.posthog.com/project/2/insights/7lgtJbbA)
The "Setup wizard" progress FAB (`WizardProgressFab`) is mounted globally in `AuthenticatedShell`, so for every user in the `ONBOARDING_WIZARD_SYNC` feature flag it runs on **every** authenticated page — insights, settings, dashboards, etc. — not just onboarding.

`wizardProgressTrackerLogic` runs a 30s "heartbeat" `setInterval` that reads `values.latestSession`, a value connected from `wizardSessionStreamLogic`. The `kea-disposables` plugin pauses these timers when the tab is hidden and re-creates them on resume. The re-created interval can fire during a window where the connected `wizardSessionStreamLogic` has been torn down (e.g. the FAB unmounting after a feature-flag re-evaluation). Reading a value off an unmounted logic throws:

```
[KEA] Can not find path "products.wizard.wizardSessionStreamLogic.posthog-integration::*" in the store.
```

This was the single largest *new* exception across the app over the past few days (~17k occurrences, concentrated in a handful of long-lived tabs), surfacing prominently on the insights page because the FAB is global.

## Changes

Bail out of the heartbeat callback unless `wizardSessionStreamLogic` is currently mounted (`findMounted`). Once that guard passes, every subsequent value read in the callback is safe. Minimal, targeted change — no behavior change for the live wizard.

## How did you test this code?

I'm an agent (PostHog Code). I did **not** run the app manually. I traced the symbolicated stack (`wizardProgressTrackerLogic.ts`, heartbeat block) from Error Tracking back to the connected-value read, and confirmed `findMounted({ workflowId })` is the keyed-logic mount-check pattern already used elsewhere in the frontend (e.g. `projectTreeLogic.findMounted(...)`). No automated tests were added; the existing logic has no unit test covering the disposables pause/resume race. Reviewer should sanity-check that skipping a heartbeat tick while the stream logic is briefly unmounted is acceptable (it is — the next tick resumes normally).

## 🤖 Agent context

Authored by the PostHog Slack app (Claude). Investigation started from an Error Tracking insight on `/insights/` exceptions; identified this kea store-path error as a global FAB lifecycle bug rather than anything insights-specific. Chose a defensive `findMounted` guard over restructuring the connected-value reads to keep the change small and low-risk. Requires human review.
