### PR TITLE
fix(error-tracking): drop non-actionable network exceptions before send

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -9,6 +9,42 @@ import { startFramerateTracking } from './framerateTracker'
 
 export const SDK_DEFAULTS_DATE = '2026-05-30'
 
+// Native "the network request never completed" messages. They mean the browser
+// could not reach the server at all (offline, DNS, CORS, ad-blocker, connection
+// reset) — there is no stack to act on and no bug to fix. We deliberately keep
+// "Failed to fetch dynamically imported module …" (a real, fixable stale-chunk
+// error) out of this list.
+const NON_ACTIONABLE_NETWORK_MESSAGES = new Set([
+    'Failed to fetch', // Chrome
+    'TypeError: Failed to fetch',
+    'Load failed', // Safari
+    'TypeError: Load failed',
+    'NetworkError when attempting to fetch resource.', // Firefox
+])
+
+/**
+ * Drop `$exception` events whose only error is a bare network failure.
+ *
+ * Because we enable `error_tracking.__capturePostHogExceptions`, posthog-js also
+ * reports its own internal send failures (session recorder, tracing headers,
+ * network capture). A single tab left open on a flaky connection can emit
+ * thousands of these "Failed to fetch" events, which drown out real, actionable
+ * exceptions in Error Tracking without telling us anything we can fix.
+ */
+const dropNonActionableNetworkExceptions: BeforeSendFn = (event) => {
+    if (!event || event.event !== '$exception') {
+        return event
+    }
+    const exceptionList = event.properties?.$exception_list
+    if (!Array.isArray(exceptionList) || exceptionList.length === 0) {
+        return event
+    }
+    const everyExceptionIsNetworkNoise = exceptionList.every((exception) =>
+        NON_ACTIONABLE_NETWORK_MESSAGES.has(String(exception?.value ?? '').trim())
+    )
+    return everyExceptionIsNetworkNoise ? null : event
+}
+
 const shouldDefer = (): boolean => {
     const sessionId = posthog.get_session_id()
     return sampleOnProperty(sessionId, 0.5)
@@ -55,7 +91,14 @@ export function loadPostHogJS(options: LoadPostHogJSOptions = {}): void {
             error_tracking: {
                 __capturePostHogExceptions: true,
             },
-            before_send: options.beforeSend,
+            before_send: [
+                dropNonActionableNetworkExceptions,
+                ...(Array.isArray(options.beforeSend)
+                    ? options.beforeSend
+                    : options.beforeSend
+                      ? [options.beforeSend]
+                      : []),
+            ],
             loaded: (loadedInstance) => {
                 if (loadedInstance.sessionRecording) {
                     loadedInstance.sessionRecording._forceAllowLocalhostNetworkCapture = true

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -11,10 +11,9 @@ export const SDK_DEFAULTS_DATE = '2026-05-30'
 
 // Native "the network request never completed" messages. They mean the browser
 // could not reach the server at all (offline, DNS, CORS, ad-blocker, connection
-// reset) — there is no stack to act on and no bug to fix. We deliberately keep
-// "Failed to fetch dynamically imported module …" (a real, fixable stale-chunk
-// error) out of this list.
-const NON_ACTIONABLE_NETWORK_MESSAGES = new Set([
+// reset). We deliberately keep "Failed to fetch dynamically imported module …"
+// (a real, fixable stale-chunk error) out of this list.
+const NETWORK_FAILURE_MESSAGES = new Set([
     'Failed to fetch', // Chrome
     'TypeError: Failed to fetch',
     'Load failed', // Safari
@@ -22,16 +21,28 @@ const NON_ACTIONABLE_NETWORK_MESSAGES = new Set([
     'NetworkError when attempting to fetch resource.', // Firefox
 ])
 
+// posthog-js's own internal background traffic — sending session recordings,
+// tracing headers, network capture. A network failure whose stack sits here is
+// the SDK failing to reach us, surfaced only because we enable
+// `error_tracking.__capturePostHogExceptions`. Note this only matches reliably
+// for the lazily-loaded recorder script; the rest of the SDK is bundled into our
+// own chunks and is indistinguishable from app code until server-side
+// symbolication, so a broader sweep belongs in an Error Tracking suppression
+// rule, not here.
+const POSTHOG_SDK_FRAME_RE = /(posthog-recorder\.js|\/recorder\.js|surveys\.js|exception-autocapture)/
+
 /**
- * Drop `$exception` events whose only error is a bare network failure.
+ * Drop `$exception` events that are purely posthog-js's own network-send
+ * failures.
  *
- * Because we enable `error_tracking.__capturePostHogExceptions`, posthog-js also
- * reports its own internal send failures (session recorder, tracing headers,
- * network capture). A single tab left open on a flaky connection can emit
- * thousands of these "Failed to fetch" events, which drown out real, actionable
- * exceptions in Error Tracking without telling us anything we can fix.
+ * We intentionally do NOT drop network failures coming from our application code
+ * (e.g. `lib/api.ts`): a "Failed to fetch" originating in the app can be a real,
+ * our-fault regression — a CORS/CSP misconfig, a removed endpoint, a bad deploy —
+ * and we want those visible. We only drop a network failure when every entry in
+ * the chain is both a bare network message AND attributable to a posthog-js SDK
+ * script, which a flaky/stuck tab can otherwise emit by the thousand.
  */
-const dropNonActionableNetworkExceptions: BeforeSendFn = (event) => {
+const dropSdkNetworkExceptions: BeforeSendFn = (event) => {
     if (!event || event.event !== '$exception') {
         return event
     }
@@ -39,10 +50,18 @@ const dropNonActionableNetworkExceptions: BeforeSendFn = (event) => {
     if (!Array.isArray(exceptionList) || exceptionList.length === 0) {
         return event
     }
-    const everyExceptionIsNetworkNoise = exceptionList.every((exception) =>
-        NON_ACTIONABLE_NETWORK_MESSAGES.has(String(exception?.value ?? '').trim())
-    )
-    return everyExceptionIsNetworkNoise ? null : event
+    const everyExceptionIsSdkNetworkNoise = exceptionList.every((exception) => {
+        if (!NETWORK_FAILURE_MESSAGES.has(String(exception?.value ?? '').trim())) {
+            return false
+        }
+        const frames = exception?.stacktrace?.frames
+        if (!Array.isArray(frames) || frames.length === 0) {
+            // No stack to attribute it to → keep it, to stay on the safe side.
+            return false
+        }
+        return frames.some((frame) => POSTHOG_SDK_FRAME_RE.test(String(frame?.source ?? frame?.filename ?? '')))
+    })
+    return everyExceptionIsSdkNetworkNoise ? null : event
 }
 
 const shouldDefer = (): boolean => {
@@ -92,7 +111,7 @@ export function loadPostHogJS(options: LoadPostHogJSOptions = {}): void {
                 __capturePostHogExceptions: true,
             },
             before_send: [
-                dropNonActionableNetworkExceptions,
+                dropSdkNetworkExceptions,
                 ...(Array.isArray(options.beforeSend)
                     ? options.beforeSend
                     : options.beforeSend


### PR DESCRIPTION
## Problem

On the `/insights/` exceptions view, a bare **"Failed to fetch"** series spiked from ~150/day to **7,289 on one day** (and 3,424 the next), dwarfing every real error. Investigation showed it is **not** an insights regression:

- The events are `handled: true`, `lib: web`, and the stack frames resolve to posthog-js internals (`posthog-recorder.js`, `extensions/replay/external/network-plugin.ts`, `entrypoints/tracing-headers.ts`).
- They are overwhelmingly from **one project's tab left open on `/insights/quick-start`** — that scene does no fetching itself; the errors are the embedded SDK's own background network traffic failing.

We see these because the app initializes posthog-js with `error_tracking.__capturePostHogExceptions: true` (so we can monitor genuine SDK exceptions). A flaky/stuck tab then emits the SDK's send-failures by the thousand and buries actionable errors.

## Changes

Add a `before_send` filter in `loadPostHogJS` that drops a `$exception` only when **every** entry is *both* a bare network-failure message *and* attributable to a posthog-js SDK script.

**Crucially, application-originated network failures are kept.** A "Failed to fetch" coming from our own code (e.g. `lib/api.ts`) can be a real, our-fault regression — a CORS/CSP misconfig, a removed endpoint, a bad deploy — so we leave those visible.

- `"Failed to fetch dynamically imported module …"` (a real, fixable stale-chunk error) is also kept.
- When there's no stack to attribute, the event is kept (safe default).
- Composes with the optional caller-provided `beforeSend` (e.g. the exporter app's token redaction).
- Mirrors the existing `dropReadOnlyExceptions` precedent in `selfReadOnlyModeLogic.ts`.

### Known limitation

`before_send` runs **before** server-side symbolication. posthog-js is largely bundled into our own chunks, so most SDK frames are indistinguishable from app code at this point (they only resolve to `../src/entrypoints/...` paths after symbolication). This client-side filter therefore reliably catches only the **lazily-loaded recorder script**, which was the dominant source of the spike. A complete sweep of all SDK-internal network noise really belongs in an **Error Tracking suppression rule** keyed on the symbolicated `source` frames — happy to set that up instead of / in addition to this if preferred.

## How did you test this code?

I'm an agent (PostHog Code). I did **not** run or build the app (deps weren't installed here). I validated the discriminator against real Error Tracking events: confirmed the SDK frames are marked `in_app: true` (so `in_app` can't distinguish them — hence matching on the recorder script source), and that the app's data-warehouse `loadSources` "Failed to fetch" has in-app `lib/api`-style frames that this filter leaves untouched. No automated test added yet — a unit test analogous to `selfReadOnlyModeLogic`'s `dropReadOnlyExceptions` tests would be a good follow-up.

## 🤖 Agent context

Authored by the PostHog Slack app (Claude). First pass blanket-dropped all bare network messages; revised after reviewer pushback that app-origin "Failed to fetch" can be a legitimate our-fault issue. Considered (a) `in_app` filtering — rejected, posthog-js marks its own bundled frames `in_app: true`; (b) disabling `__capturePostHogExceptions` — rejected, loses real SDK-bug signal; (c) this narrowed source-frame filter — chosen as the safe client-side reduction, with the honest caveat that the robust version is a server-side suppression rule. Requires human review.
