### PR TITLE
chore(quill-charts): extract bar band geometry into core/bar-layout

### DIFF
--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -1,7 +1,13 @@
 import { color as d3Color } from 'd3-color'
 import React, { useCallback, useMemo, useRef } from 'react'
 
-import { type BarChartPrivate, computeBarTrackRect, computeSeriesBars } from '../../core/bar-layout'
+import {
+    bandCenter,
+    type BarChartPrivate,
+    computeBarTrackRect,
+    computeSeriesBars,
+    groupedBarCenter,
+} from '../../core/bar-layout'
 import {
     BAR_TRACK_HOVER_ALPHA,
     type BarRect,
@@ -27,7 +33,6 @@ import {
     computePercentStackData,
     computeStackData,
     createBarScales,
-    groupedBandSlot,
     type StackedBand,
     yTickCountForHeight,
 } from '../../core/scales'
@@ -57,19 +62,6 @@ import {
     isStackedLayout,
     iterBarsAtCursor,
 } from './utils/bars-under-cursor'
-
-function bandCenter(scales: BarChartPrivate['__barChart'], label: string): number | undefined {
-    const start = scales.band(label)
-    return start == null ? undefined : start + scales.band.bandwidth() / 2
-}
-
-/** Center of a specific series's bar within a band. Used by overlays (e.g. annotations)
- *  to anchor on the current-period bar in compare-against-previous grouped layouts.
- *  Returns undefined when the layout isn't grouped or the series isn't in the group scale. */
-function groupedBarCenter(scales: BarChartPrivate['__barChart'], label: string, seriesKey: string): number | undefined {
-    const slot = groupedBandSlot(scales, label, seriesKey)
-    return slot && slot.x + slot.width / 2
-}
 
 export interface BarChartProps<Meta = unknown> {
     series: Series<Meta>[]

--- a/packages/quill/packages/charts/src/core/bar-layout.test.ts
+++ b/packages/quill/packages/charts/src/core/bar-layout.test.ts
@@ -477,13 +477,7 @@ describe('hog-charts bar-layout', () => {
         })
     })
 
-    describe('bandCenter', () => {
-        // Two bands across 200px → band width 100, centers at 50 and 150.
-        it.each([
-            { label: 'a', expected: 50 },
-            { label: 'b', expected: 150 },
-        ])('returns the pixel center $expected for band $label', ({ label, expected }) => {
-            const s = makeSeries({ key: 's', data: [10, 20] })
+
     describe('bandCenter', () => {
         it.each([
             { label: 'a', expected: 50 },
@@ -505,6 +499,7 @@ describe('hog-charts bar-layout', () => {
             expect(bandCenter(scales, 'missing')).toBeUndefined()
         })
     })
+
 
     describe('groupedBarCenter', () => {
         it.each([

--- a/packages/quill/packages/charts/src/core/bar-layout.test.ts
+++ b/packages/quill/packages/charts/src/core/bar-layout.test.ts
@@ -484,11 +484,18 @@ describe('hog-charts bar-layout', () => {
             { label: 'b', expected: 150 },
         ])('returns the pixel center $expected for band $label', ({ label, expected }) => {
             const s = makeSeries({ key: 's', data: [10, 20] })
+    describe('bandCenter', () => {
+        it.each([
+            { label: 'a', expected: 50 },
+            { label: 'b', expected: 150 },
+        ])('returns the pixel center $expected for label $label', ({ label, expected }) => {
+            const s = makeSeries({ key: 's', data: [10, 20] })
             const scales = createBarScales([s], ['a', 'b'], PIXEL_TEST_DIMENSIONS, {
                 barLayout: 'grouped',
                 bandPadding: 0,
                 groupPadding: 0,
             })
+            // Two bands across 200px → band width 100, centers at 50 and 150.
             expect(bandCenter(scales, label)).toBeCloseTo(expected, 5)
         })
 
@@ -500,23 +507,20 @@ describe('hog-charts bar-layout', () => {
     })
 
     describe('groupedBarCenter', () => {
-        // a@L1 slot x:0 w:50 → center 25; b@L1 slot x:50 w:50 → center 75 (see grouped pixel case).
         it.each([
             { seriesKey: 'a', expected: 25 },
             { seriesKey: 'b', expected: 75 },
-        ])(
-            "returns the center $expected for series $seriesKey's sub-band in a grouped layout",
-            ({ seriesKey, expected }) => {
-                const a = makeSeries({ key: 'a', data: [10, 20] })
-                const b = makeSeries({ key: 'b', data: [20, 10] })
-                const scales = createBarScales([a, b], ['L1', 'L2'], PIXEL_TEST_DIMENSIONS, {
-                    barLayout: 'grouped',
-                    bandPadding: 0,
-                    groupPadding: 0,
-                })
-                expect(groupedBarCenter(scales, 'L1', seriesKey)).toBeCloseTo(expected, 5)
-            }
-        )
+        ])("returns the center $expected for series $seriesKey's sub-band in a grouped layout", ({ seriesKey, expected }) => {
+            const a = makeSeries({ key: 'a', data: [10, 20] })
+            const b = makeSeries({ key: 'b', data: [20, 10] })
+            const scales = createBarScales([a, b], ['L1', 'L2'], PIXEL_TEST_DIMENSIONS, {
+                barLayout: 'grouped',
+                bandPadding: 0,
+                groupPadding: 0,
+            })
+            // a@L1 slot x:0 w:50 → center 25; b@L1 slot x:50 w:50 → center 75 (see grouped pixel case).
+            expect(groupedBarCenter(scales, 'L1', seriesKey)).toBeCloseTo(expected, 5)
+        })
 
         it('returns undefined when the series is not in the group scale', () => {
             const a = makeSeries({ key: 'a', data: [10] })

--- a/packages/quill/packages/charts/src/core/bar-layout.test.ts
+++ b/packages/quill/packages/charts/src/core/bar-layout.test.ts
@@ -478,16 +478,18 @@ describe('hog-charts bar-layout', () => {
     })
 
     describe('bandCenter', () => {
-        it('returns the pixel center of each band', () => {
+        // Two bands across 200px → band width 100, centers at 50 and 150.
+        it.each([
+            { label: 'a', expected: 50 },
+            { label: 'b', expected: 150 },
+        ])('returns the pixel center $expected for band $label', ({ label, expected }) => {
             const s = makeSeries({ key: 's', data: [10, 20] })
             const scales = createBarScales([s], ['a', 'b'], PIXEL_TEST_DIMENSIONS, {
                 barLayout: 'grouped',
                 bandPadding: 0,
                 groupPadding: 0,
             })
-            // Two bands across 200px → band width 100, centers at 50 and 150.
-            expect(bandCenter(scales, 'a')).toBeCloseTo(50, 5)
-            expect(bandCenter(scales, 'b')).toBeCloseTo(150, 5)
+            expect(bandCenter(scales, label)).toBeCloseTo(expected, 5)
         })
 
         it('returns undefined for an unknown band', () => {
@@ -498,18 +500,23 @@ describe('hog-charts bar-layout', () => {
     })
 
     describe('groupedBarCenter', () => {
-        it("returns the center of a series' sub-band in a grouped layout", () => {
-            const a = makeSeries({ key: 'a', data: [10, 20] })
-            const b = makeSeries({ key: 'b', data: [20, 10] })
-            const scales = createBarScales([a, b], ['L1', 'L2'], PIXEL_TEST_DIMENSIONS, {
-                barLayout: 'grouped',
-                bandPadding: 0,
-                groupPadding: 0,
-            })
-            // a@L1 slot x:0 w:50 → center 25; b@L1 slot x:50 w:50 → center 75 (see grouped pixel case).
-            expect(groupedBarCenter(scales, 'L1', 'a')).toBeCloseTo(25, 5)
-            expect(groupedBarCenter(scales, 'L1', 'b')).toBeCloseTo(75, 5)
-        })
+        // a@L1 slot x:0 w:50 → center 25; b@L1 slot x:50 w:50 → center 75 (see grouped pixel case).
+        it.each([
+            { seriesKey: 'a', expected: 25 },
+            { seriesKey: 'b', expected: 75 },
+        ])(
+            "returns the center $expected for series $seriesKey's sub-band in a grouped layout",
+            ({ seriesKey, expected }) => {
+                const a = makeSeries({ key: 'a', data: [10, 20] })
+                const b = makeSeries({ key: 'b', data: [20, 10] })
+                const scales = createBarScales([a, b], ['L1', 'L2'], PIXEL_TEST_DIMENSIONS, {
+                    barLayout: 'grouped',
+                    bandPadding: 0,
+                    groupPadding: 0,
+                })
+                expect(groupedBarCenter(scales, 'L1', seriesKey)).toBeCloseTo(expected, 5)
+            }
+        )
 
         it('returns undefined when the series is not in the group scale', () => {
             const a = makeSeries({ key: 'a', data: [10] })

--- a/packages/quill/packages/charts/src/core/bar-layout.test.ts
+++ b/packages/quill/packages/charts/src/core/bar-layout.test.ts
@@ -1,5 +1,12 @@
 import { dimensions, makeSeries } from '../testing'
-import { type ComputeSeriesBarsOptions, computeBarTrackRect, computeSeriesBars, cornersFor } from './bar-layout'
+import {
+    bandCenter,
+    type ComputeSeriesBarsOptions,
+    computeBarTrackRect,
+    computeSeriesBars,
+    cornersFor,
+    groupedBarCenter,
+} from './bar-layout'
 import type { BarRect } from './canvas-renderer'
 import { computeStackData, createBarScales } from './scales'
 import type { ChartDimensions } from './types'
@@ -467,6 +474,51 @@ describe('hog-charts bar-layout', () => {
                 corners: {},
                 dataIndex: 0,
             })
+        })
+    })
+
+    describe('bandCenter', () => {
+        it('returns the pixel center of each band', () => {
+            const s = makeSeries({ key: 's', data: [10, 20] })
+            const scales = createBarScales([s], ['a', 'b'], PIXEL_TEST_DIMENSIONS, {
+                barLayout: 'grouped',
+                bandPadding: 0,
+                groupPadding: 0,
+            })
+            // Two bands across 200px → band width 100, centers at 50 and 150.
+            expect(bandCenter(scales, 'a')).toBeCloseTo(50, 5)
+            expect(bandCenter(scales, 'b')).toBeCloseTo(150, 5)
+        })
+
+        it('returns undefined for an unknown band', () => {
+            const s = makeSeries({ key: 's', data: [10] })
+            const scales = createBarScales([s], ['a'], PIXEL_TEST_DIMENSIONS, { barLayout: 'grouped' })
+            expect(bandCenter(scales, 'missing')).toBeUndefined()
+        })
+    })
+
+    describe('groupedBarCenter', () => {
+        it("returns the center of a series' sub-band in a grouped layout", () => {
+            const a = makeSeries({ key: 'a', data: [10, 20] })
+            const b = makeSeries({ key: 'b', data: [20, 10] })
+            const scales = createBarScales([a, b], ['L1', 'L2'], PIXEL_TEST_DIMENSIONS, {
+                barLayout: 'grouped',
+                bandPadding: 0,
+                groupPadding: 0,
+            })
+            // a@L1 slot x:0 w:50 → center 25; b@L1 slot x:50 w:50 → center 75 (see grouped pixel case).
+            expect(groupedBarCenter(scales, 'L1', 'a')).toBeCloseTo(25, 5)
+            expect(groupedBarCenter(scales, 'L1', 'b')).toBeCloseTo(75, 5)
+        })
+
+        it('returns undefined when the series is not in the group scale', () => {
+            const a = makeSeries({ key: 'a', data: [10] })
+            const scales = createBarScales([a], ['L1'], PIXEL_TEST_DIMENSIONS, {
+                barLayout: 'grouped',
+                bandPadding: 0,
+                groupPadding: 0,
+            })
+            expect(groupedBarCenter(scales, 'L1', 'missing')).toBeUndefined()
         })
     })
 })

--- a/packages/quill/packages/charts/src/core/bar-layout.ts
+++ b/packages/quill/packages/charts/src/core/bar-layout.ts
@@ -205,3 +205,17 @@ export function computeBarTrackRect(
           }
         : { x: bar.x, y: valueMin, width: bar.width, height: valueSize, corners: bar.corners, dataIndex: bar.dataIndex }
 }
+
+/** Pixel center of a band along the band axis — the anchor for band-level tooltips and grid ticks. */
+export function bandCenter(scales: BarScaleSet, label: string): number | undefined {
+    const start = scales.band(label)
+    return start == null ? undefined : start + scales.band.bandwidth() / 2
+}
+
+/** Center of a specific series's bar within a band. Used by overlays (e.g. annotations)
+ *  to anchor on the current-period bar in compare-against-previous grouped layouts.
+ *  Returns undefined when the layout isn't grouped or the series isn't in the group scale. */
+export function groupedBarCenter(scales: BarScaleSet, label: string, seriesKey: string): number | undefined {
+    const slot = groupedBandSlot(scales, label, seriesKey)
+    return slot && slot.x + slot.width / 2
+}


### PR DESCRIPTION
## Problem

`BarChart.tsx` in `@posthog/quill-charts` had grown to ~750 lines — far past its `LineChart` sibling. A single file held the React orchestration, both canvas-drawing passes, config resolution, band geometry, and click routing, making the hot paths hard to read and test in isolation.

This is the **first of a small stack** of pure refactors that break the component into focused modules, reviving the intent of #60913 (which was written against the old `frontend/src/lib/hog-charts` path, before the library was renamed and relocated to `packages/quill/packages/charts`).

## Changes

Move the two band-center geometry helpers — `bandCenter` and `groupedBarCenter` — out of `BarChart.tsx` and into `core/bar-layout.ts`, beside the other bar geometry (`computeSeriesBars`, `computeBarTrackRect`). `CONTRIBUTING.md` places pure geometry in `core/` and tests it directly there, so this adds co-located unit tests in `core/bar-layout.test.ts`.

No behavior change, no public API change — nothing new is added to the library `index.ts`.

## How did you test this code?

I'm an agent (Claude Code); no manual UI testing. Automated checks run locally:

- `jest packages/quill/packages/charts/src/core/bar-layout.test.ts` and the `BarChart` DOM suite — pass.
- `tsc -p tsconfig.build.json --noEmit` — clean.
- `oxlint` / `oxfmt` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed — internal library refactor. Suggest the `skip-inkeep-docs` label.

## 🤖 Agent context

Authored by Claude Code at a maintainer's request to break up the oversized `BarChart` component into several small PRs of a few hundred lines each. The original PR (#60913) went stale because the whole `hog-charts` library was renamed to `@posthog/quill-charts` and moved under `packages/quill/`; this stack re-targets the same four extractions (geometry, config, click-routing, drawing) onto the current location. This PR is the geometry slice; the config, click-routing, and drawing slices stack on top.
