### PR TITLE
chore(quill-charts): extract bar config resolution into utils/bar-config

### DIFF
--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -12,7 +12,6 @@ import {
     BAR_TRACK_HOVER_ALPHA,
     type BarRect,
     type BarRoundedCorners,
-    type BarShadow,
     clipToRoundedRects,
     drawBarHighlight,
     drawBars,
@@ -23,7 +22,6 @@ import {
 import { Chart } from '../../core/Chart'
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
 import { barColorAt } from '../../core/color-utils'
-import { DEFAULT_MARGINS, X_AXIS_TITLE_MARGIN } from '../../core/hooks/useChartMargins'
 import { useLatest } from '../../core/hooks/useLatest'
 import {
     buildSegmentResolveValue,
@@ -38,7 +36,6 @@ import {
 } from '../../core/scales'
 import type {
     BarChartConfig,
-    BarsConfig,
     ChartDimensions,
     ChartDrawArgs,
     ChartScales,
@@ -53,6 +50,7 @@ import type {
 import { DEFAULT_Y_AXIS_ID } from '../../core/types'
 import { computeVisibleXLabels } from '../../overlays/AxisLabels'
 import { BarTooltip } from './BarTooltip'
+import { computeWrapperMinHeight, HORIZONTAL_MIN_BAND_SIZE_DEFAULT, resolveBarShadow } from './utils/bar-config'
 import {
     type BarLayout,
     barContainsPointOnBandAxis,
@@ -76,14 +74,6 @@ export interface BarChartProps<Meta = unknown> {
     children?: React.ReactNode
     onError?: (error: Error, info: React.ErrorInfo) => void
 }
-
-// Negative offsetY casts the shadow upward onto the visible track above the bar.
-const DEFAULT_BAR_SHADOW: BarShadow = { color: 'rgba(0,0,0,0.30)', blur: 12, offsetY: -4 }
-
-// Horizontal floor: each row gets at least this much px so tick labels don't crush; wrapper scrolls.
-const HORIZONTAL_MIN_BAND_SIZE_DEFAULT = 24
-// Reserve room for chart-edge margins + worst-case x-axis title margin (matches useChartMargins).
-const HORIZONTAL_CHART_MARGIN_PX = DEFAULT_MARGINS.top + DEFAULT_MARGINS.bottom + X_AXIS_TITLE_MARGIN
 
 const ALL_CORNERS: BarRoundedCorners = { topLeft: true, topRight: true, bottomLeft: true, bottomRight: true }
 
@@ -114,16 +104,6 @@ function stackPillRects(bars: BarRect[], isHorizontal: boolean): BarRect[] {
         }
     }
     return [...byBand.values()]
-}
-
-function resolveBarShadow(barShadow: BarsConfig['shadow']): BarShadow | undefined {
-    if (barShadow === true) {
-        return DEFAULT_BAR_SHADOW
-    }
-    if (barShadow === false || barShadow == null) {
-        return undefined
-    }
-    return barShadow
 }
 
 export function BarChart<Meta = unknown>({ onError, ...rest }: BarChartProps<Meta>): React.ReactElement {
@@ -167,18 +147,10 @@ function BarChartInner<Meta = unknown>({
     const isHorizontal = axisOrientation === 'horizontal'
 
     const resolvedMinBandSize = minBandSize ?? (isHorizontal ? HORIZONTAL_MIN_BAND_SIZE_DEFAULT : 0)
-    // Fit-to-height drops overflow rows instead of growing the container, so it never sets a
-    // wrapper floor — the chart fills whatever height the tile gives it.
-    const wrapperMinHeight = useMemo(() => {
-        if (!isHorizontal || fitToHeight || resolvedMinBandSize <= 0) {
-            return undefined
-        }
-        const uniqueBands = new Set(labels).size
-        if (uniqueBands === 0) {
-            return undefined
-        }
-        return uniqueBands * resolvedMinBandSize + HORIZONTAL_CHART_MARGIN_PX
-    }, [isHorizontal, fitToHeight, resolvedMinBandSize, labels])
+    const wrapperMinHeight = useMemo(
+        () => computeWrapperMinHeight({ isHorizontal, fitToHeight, resolvedMinBandSize, labels }),
+        [isHorizontal, fitToHeight, resolvedMinBandSize, labels]
+    )
 
     const stackedData = useMemo((): Map<string, StackedBand> | undefined => {
         if (barLayout === 'percent') {

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bar-config.test.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bar-config.test.ts
@@ -1,0 +1,52 @@
+import { DEFAULT_MARGINS, X_AXIS_TITLE_MARGIN } from '../../../core/hooks/useChartMargins'
+import { computeWrapperMinHeight, HORIZONTAL_MIN_BAND_SIZE_DEFAULT, resolveBarShadow } from './bar-config'
+
+const CHART_MARGIN_PX = DEFAULT_MARGINS.top + DEFAULT_MARGINS.bottom + X_AXIS_TITLE_MARGIN
+
+describe('bar-config', () => {
+    describe('resolveBarShadow', () => {
+        it('returns the default upward shadow when true', () => {
+            expect(resolveBarShadow(true)).toEqual({ color: 'rgba(0,0,0,0.30)', blur: 12, offsetY: -4 })
+        })
+
+        it.each([
+            { desc: 'false', value: false as const },
+            { desc: 'undefined', value: undefined },
+        ])('returns undefined when $desc', ({ value }) => {
+            expect(resolveBarShadow(value)).toBeUndefined()
+        })
+
+        it('passes an explicit shadow object through unchanged', () => {
+            const custom = { color: 'red', blur: 2, offsetX: 1, offsetY: 3 }
+            expect(resolveBarShadow(custom)).toBe(custom)
+        })
+    })
+
+    describe('computeWrapperMinHeight', () => {
+        const base = {
+            isHorizontal: true,
+            fitToHeight: false,
+            resolvedMinBandSize: HORIZONTAL_MIN_BAND_SIZE_DEFAULT,
+            labels: ['a', 'b', 'c'],
+        }
+
+        it('reserves the min band size per unique band plus chart margins', () => {
+            expect(computeWrapperMinHeight(base)).toBe(3 * HORIZONTAL_MIN_BAND_SIZE_DEFAULT + CHART_MARGIN_PX)
+        })
+
+        it('counts unique bands only', () => {
+            expect(computeWrapperMinHeight({ ...base, labels: ['a', 'a', 'b'] })).toBe(
+                2 * HORIZONTAL_MIN_BAND_SIZE_DEFAULT + CHART_MARGIN_PX
+            )
+        })
+
+        it.each([
+            { desc: 'vertical', override: { isHorizontal: false } },
+            { desc: 'fit-to-height', override: { fitToHeight: true } },
+            { desc: 'min band size is zero', override: { resolvedMinBandSize: 0 } },
+            { desc: 'there are no bands', override: { labels: [] } },
+        ])('returns undefined when $desc', ({ override }) => {
+            expect(computeWrapperMinHeight({ ...base, ...override })).toBeUndefined()
+        })
+    })
+})

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bar-config.test.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bar-config.test.ts
@@ -30,14 +30,19 @@ describe('bar-config', () => {
             labels: ['a', 'b', 'c'],
         }
 
-        it('reserves the min band size per unique band plus chart margins', () => {
-            expect(computeWrapperMinHeight(base)).toBe(3 * HORIZONTAL_MIN_BAND_SIZE_DEFAULT + CHART_MARGIN_PX)
-        })
-
-        it('counts unique bands only', () => {
-            expect(computeWrapperMinHeight({ ...base, labels: ['a', 'a', 'b'] })).toBe(
-                2 * HORIZONTAL_MIN_BAND_SIZE_DEFAULT + CHART_MARGIN_PX
-            )
+        it.each([
+            {
+                desc: '3 distinct labels',
+                labels: ['a', 'b', 'c'],
+                expected: 3 * HORIZONTAL_MIN_BAND_SIZE_DEFAULT + CHART_MARGIN_PX,
+            },
+            {
+                desc: 'duplicate labels counted once',
+                labels: ['a', 'a', 'b'],
+                expected: 2 * HORIZONTAL_MIN_BAND_SIZE_DEFAULT + CHART_MARGIN_PX,
+            },
+        ])('reserves the min band size per unique band plus chart margins ($desc)', ({ labels, expected }) => {
+            expect(computeWrapperMinHeight({ ...base, labels })).toBe(expected)
         })
 
         it.each([

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bar-config.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bar-config.ts
@@ -10,8 +10,6 @@ export const HORIZONTAL_MIN_BAND_SIZE_DEFAULT = 24
 // Reserve room for chart-edge margins + worst-case x-axis title margin (matches useChartMargins).
 const HORIZONTAL_CHART_MARGIN_PX = DEFAULT_MARGINS.top + DEFAULT_MARGINS.bottom + X_AXIS_TITLE_MARGIN
 
-/** Resolve the `bars.shadow` config to a concrete shadow or `undefined` (no shadow): `true`
- *  selects the default upward shadow, `false`/absent disables it, an object is used as-is. */
 export function resolveBarShadow(barShadow: BarsConfig['shadow']): BarShadow | undefined {
     if (barShadow === true) {
         return DEFAULT_BAR_SHADOW
@@ -29,10 +27,7 @@ export interface WrapperMinHeightOptions {
     labels: string[]
 }
 
-/** Minimum wrapper height for horizontal bar charts so per-row tick labels don't crush — the
- *  wrapper scrolls past it. Returns `undefined` when no floor applies (vertical, fit-to-height
- *  which drops overflow rows instead of growing, or no bands), letting the chart fill whatever
- *  height the tile gives it. */
+// fit-to-height returns no floor: it drops overflow rows instead of growing the wrapper.
 export function computeWrapperMinHeight({
     isHorizontal,
     fitToHeight,

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bar-config.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bar-config.ts
@@ -1,0 +1,50 @@
+import type { BarShadow } from '../../../core/canvas-renderer'
+import { DEFAULT_MARGINS, X_AXIS_TITLE_MARGIN } from '../../../core/hooks/useChartMargins'
+import type { BarsConfig } from '../../../core/types'
+
+// Negative offsetY casts the shadow upward onto the visible track above the bar.
+const DEFAULT_BAR_SHADOW: BarShadow = { color: 'rgba(0,0,0,0.30)', blur: 12, offsetY: -4 }
+
+// Horizontal floor: each row gets at least this much px so tick labels don't crush; wrapper scrolls.
+export const HORIZONTAL_MIN_BAND_SIZE_DEFAULT = 24
+// Reserve room for chart-edge margins + worst-case x-axis title margin (matches useChartMargins).
+const HORIZONTAL_CHART_MARGIN_PX = DEFAULT_MARGINS.top + DEFAULT_MARGINS.bottom + X_AXIS_TITLE_MARGIN
+
+/** Resolve the `bars.shadow` config to a concrete shadow or `undefined` (no shadow): `true`
+ *  selects the default upward shadow, `false`/absent disables it, an object is used as-is. */
+export function resolveBarShadow(barShadow: BarsConfig['shadow']): BarShadow | undefined {
+    if (barShadow === true) {
+        return DEFAULT_BAR_SHADOW
+    }
+    if (barShadow === false || barShadow == null) {
+        return undefined
+    }
+    return barShadow
+}
+
+export interface WrapperMinHeightOptions {
+    isHorizontal: boolean
+    fitToHeight: boolean
+    resolvedMinBandSize: number
+    labels: string[]
+}
+
+/** Minimum wrapper height for horizontal bar charts so per-row tick labels don't crush — the
+ *  wrapper scrolls past it. Returns `undefined` when no floor applies (vertical, fit-to-height
+ *  which drops overflow rows instead of growing, or no bands), letting the chart fill whatever
+ *  height the tile gives it. */
+export function computeWrapperMinHeight({
+    isHorizontal,
+    fitToHeight,
+    resolvedMinBandSize,
+    labels,
+}: WrapperMinHeightOptions): number | undefined {
+    if (!isHorizontal || fitToHeight || resolvedMinBandSize <= 0) {
+        return undefined
+    }
+    const uniqueBands = new Set(labels).size
+    if (uniqueBands === 0) {
+        return undefined
+    }
+    return uniqueBands * resolvedMinBandSize + HORIZONTAL_CHART_MARGIN_PX
+}


### PR DESCRIPTION
## Problem

Second of a small stack breaking up the oversized `BarChart.tsx` in `@posthog/quill-charts` (reviving #60913 on the relocated `packages/quill/packages/charts`). See the base PR for the full rationale.

> ⚠️ Stacked on #61970 — review/merge that first. The diff against `master` will shrink to just this slice once the base lands.

## Changes

Move the pure config resolution out of `BarChart.tsx` into a co-located `utils/bar-config.ts`:

- `resolveBarShadow` — resolves the `bars.shadow` config to a concrete shadow or `undefined`.
- The shadow / min-band-size constants (`HORIZONTAL_MIN_BAND_SIZE_DEFAULT`, the chart-margin reservation).
- `computeWrapperMinHeight` — a new pure helper lifted out of the inline `wrapperMinHeight` memo.

Adds a co-located `bar-config.test.ts`. No behavior change, no public API change.

## How did you test this code?

I'm an agent (Claude Code); no manual UI testing. Automated checks run locally:

- `jest` on the new `bar-config.test.ts` and the `BarChart` DOM suite — pass.
- `tsc -p tsconfig.build.json --noEmit` — clean.
- `oxlint` / `oxfmt` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed — internal library refactor. Suggest the `skip-inkeep-docs` label.

## 🤖 Agent context

Authored by Claude Code. Part of a stacked refactor splitting `BarChart` into focused modules; this is the config slice, stacked on the geometry slice (#61970). Pure extraction — the constants and functions move byte-for-byte; `computeWrapperMinHeight` is the inline memo body lifted into a tested helper.
