### PR TITLE
chore(quill-charts): extract bar drawing into utils/draw-bar-chart

### DIFF
--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -1,27 +1,8 @@
-import { color as d3Color } from 'd3-color'
 import React, { useCallback, useMemo, useRef } from 'react'
 
-import {
-    bandCenter,
-    type BarChartPrivate,
-    computeBarTrackRect,
-    computeSeriesBars,
-    groupedBarCenter,
-} from '../../core/bar-layout'
-import {
-    BAR_TRACK_HOVER_ALPHA,
-    type BarRect,
-    type BarRoundedCorners,
-    clipToRoundedRects,
-    drawBarHighlight,
-    drawBars,
-    drawBarTracks,
-    drawGrid,
-    type DrawContext,
-} from '../../core/canvas-renderer'
+import { bandCenter, type BarChartPrivate, groupedBarCenter } from '../../core/bar-layout'
 import { Chart } from '../../core/Chart'
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
-import { barColorAt } from '../../core/color-utils'
 import { useLatest } from '../../core/hooks/useLatest'
 import {
     buildSegmentResolveValue,
@@ -47,17 +28,10 @@ import type {
     TooltipContext,
 } from '../../core/types'
 import { DEFAULT_Y_AXIS_ID } from '../../core/types'
-import { computeVisibleXLabels } from '../../overlays/AxisLabels'
 import { BarTooltip } from './BarTooltip'
-import { computeWrapperMinHeight, HORIZONTAL_MIN_BAND_SIZE_DEFAULT, resolveBarShadow } from './utils/bar-config'
-import {
-    barContainsPointOnBandAxis,
-    cursorOutsideBarFillExtent,
-    findVisibleStackedSegment,
-    groupedBandSlotAtCursor,
-    isStackedLayout,
-    iterBarsAtCursor,
-} from './utils/bars-under-cursor'
+import { computeWrapperMinHeight, HORIZONTAL_MIN_BAND_SIZE_DEFAULT } from './utils/bar-config'
+import { groupedBandSlotAtCursor } from './utils/bars-under-cursor'
+import { drawBarChartStatic, drawBarHoverItems, resolveBarHoverItems } from './utils/draw-bar-chart'
 import { resolveClickedBarSeries } from './utils/resolve-clicked-bar-series'
 
 export interface BarChartProps<Meta = unknown> {
@@ -72,37 +46,6 @@ export interface BarChartProps<Meta = unknown> {
     dataAttr?: string
     children?: React.ReactNode
     onError?: (error: Error, info: React.ErrorInfo) => void
-}
-
-const ALL_CORNERS: BarRoundedCorners = { topLeft: true, topRight: true, bottomLeft: true, bottomRight: true }
-
-/** One fully-rounded rect per band, spanning the union of that band's stacked segments — the
- *  pill the bar layer is clipped to for `roundStackEnds`. Bars in the same band share a band-axis
- *  slot (same `dataIndex`), so we group by it and extend along the value axis. */
-function stackPillRects(bars: BarRect[], isHorizontal: boolean): BarRect[] {
-    const byBand = new Map<number, BarRect>()
-    for (const bar of bars) {
-        if (bar.width <= 0 || bar.height <= 0) {
-            continue
-        }
-        const existing = byBand.get(bar.dataIndex)
-        if (!existing) {
-            byBand.set(bar.dataIndex, { ...bar, corners: ALL_CORNERS })
-            continue
-        }
-        if (isHorizontal) {
-            const left = Math.min(existing.x, bar.x)
-            const right = Math.max(existing.x + existing.width, bar.x + bar.width)
-            existing.x = left
-            existing.width = right - left
-        } else {
-            const top = Math.min(existing.y, bar.y)
-            const bottom = Math.max(existing.y + existing.height, bar.y + bar.height)
-            existing.y = top
-            existing.height = bottom - top
-        }
-    }
-    return [...byBand.values()]
 }
 
 export function BarChart<Meta = unknown>({ onError, ...rest }: BarChartProps<Meta>): React.ReactElement {
@@ -296,110 +239,20 @@ function BarChartInner<Meta = unknown>({
     )
 
     const drawStatic = useCallback(
-        ({ ctx, dimensions, scales, series: coloredSeries, labels: drawLabels, theme }: ChartDrawArgs) => {
-            const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
-            if (!d3Scales) {
-                return
-            }
-
-            const baseDrawCtx: DrawContext = {
-                ctx,
-                dimensions,
-                xScale: (label: string) => bandCenter(d3Scales, label),
-                yScale: d3Scales.value,
-                labels: drawLabels,
-            }
-
-            if (showGrid) {
-                // Align cross-axis grid with visible category labels, not every band.
-                let categoryTicks: number[] = []
-                if (isHorizontal) {
-                    for (const label of drawLabels) {
-                        const coord = bandCenter(d3Scales, label)
-                        if (coord != null && isFinite(coord)) {
-                            categoryTicks.push(coord)
-                        }
-                    }
-                } else {
-                    categoryTicks = computeVisibleXLabels(
-                        drawLabels,
-                        (label) => bandCenter(d3Scales, label),
-                        xTickFormatter
-                    ).map((entry) => entry.x)
-                }
-                drawGrid(baseDrawCtx, {
-                    gridColor: theme.gridColor,
-                    orientation: isHorizontal ? 'horizontal' : 'vertical',
-                    categoryTicks,
-                })
-            }
-
-            const seriesBars = coloredSeries
-                .filter((s) => !s.visibility?.excluded)
-                .map((s) => {
-                    const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
-                    const bars = computeSeriesBars({
-                        series: s,
-                        labels: drawLabels,
-                        scales: d3Scales,
-                        layout: barLayout,
-                        isHorizontal,
-                        stackedBand: stackedData?.get(s.key),
-                        isTopOfStack: topStackedKeyByAxis.get(axisId) === s.key,
-                    }).filter((b): b is BarRect => b !== null)
-                    return { series: s, bars }
-                })
-
-            // `roundStackEnds`: round both outer ends of the whole stack into a pill by clipping
-            // the bar layer to a rounded rect spanning each band's full extent, then drawing the
-            // segments square. The clip rounds the outer corners at the full radius even when the
-            // edge segment is a thin sliver (e.g. the last breakdown of a near-100% step), which
-            // per-segment rounding can't — it would clamp the radius to the sliver's half-width.
-            const stackPills = roundStackEnds
-                ? stackPillRects(
-                      seriesBars.flatMap((sb) => sb.bars),
-                      isHorizontal
-                  )
-                : []
-
-            // Tracks are a separate pass so a later series' full-height track can't paint
-            // over an earlier series' bar. Track is "share of a whole" semantics — only
-            // meaningful for grouped layouts; in stacked/percent every layer would paint
-            // a full-height track over the same band with the wrong corners.
-            if (barTrack && barLayout === 'grouped') {
-                const [axisStart = 0, axisEnd = 0] = d3Scales.value.range()
-                for (const { series: s, bars } of seriesBars) {
-                    const tracks = bars.map((b) => computeBarTrackRect(b, axisStart, axisEnd, isHorizontal))
-                    drawBarTracks(baseDrawCtx, s, tracks, barCornerRadius)
-                }
-            }
-
-            const resolvedShadow = resolveBarShadow(barShadow)
-            // Clip to plot area so a 100% bar's upward shadow doesn't bleed past the chart edge.
-            if (resolvedShadow) {
-                ctx.save()
-                ctx.beginPath()
-                ctx.rect(dimensions.plotLeft, dimensions.plotTop, dimensions.plotWidth, dimensions.plotHeight)
-                ctx.clip()
-                ctx.shadowColor = resolvedShadow.color
-                ctx.shadowBlur = resolvedShadow.blur
-                ctx.shadowOffsetX = resolvedShadow.offsetX ?? 0
-                ctx.shadowOffsetY = resolvedShadow.offsetY ?? 0
-            }
-            if (stackPills.length > 0) {
-                ctx.save()
-                clipToRoundedRects(ctx, stackPills, barCornerRadius)
-            }
-            for (const { series: s, bars } of seriesBars) {
-                drawBars(baseDrawCtx, s, bars, stackPills.length > 0 ? 0 : barCornerRadius, barFillStyle)
-            }
-            if (stackPills.length > 0) {
-                ctx.restore()
-            }
-            if (resolvedShadow) {
-                ctx.restore()
-            }
-        },
+        (args: ChartDrawArgs) =>
+            drawBarChartStatic(args, {
+                barLayout,
+                isHorizontal,
+                showGrid,
+                xTickFormatter,
+                stackedData,
+                topStackedKeyByAxis,
+                roundStackEnds,
+                barCornerRadius,
+                barTrack,
+                barShadow,
+                barFillStyle,
+            }),
         [
             showGrid,
             stackedData,
@@ -419,137 +272,34 @@ function BarChartInner<Meta = unknown>({
     const lastHoverKeyRef = useRef<string | null>(null)
 
     const drawHover = useCallback(
-        ({
-            ctx,
-            scales,
-            series: coloredSeries,
-            labels: drawLabels,
-            hoverIndex,
-            hoverPosition,
-            hoverProgress,
-            resetHoverFade,
-        }: ChartDrawArgs): DrawHoverResult => {
+        (args: ChartDrawArgs): DrawHoverResult => {
+            const { ctx, scales, hoverIndex, hoverProgress, resetHoverFade } = args
             const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
             if (!d3Scales || hoverIndex < 0) {
                 lastHoverKeyRef.current = null
                 return false
             }
-            const hoveredLabel = drawLabels[hoverIndex]
-            const [trackAxisStart = 0, trackAxisEnd = 0] = barTrack ? d3Scales.value.range() : []
-            // Key includes bar-vs-track per series so bar → track moves at the same
-            // hoverIndex still trigger a fade restart.
-            type DrawItem = { series: ResolvedSeries; bar: BarRect; isTrackHighlight: boolean }
-            const items: DrawItem[] = []
-            let composition = ''
-            // Stacked: clip the highlight to the visible slice so hover only changes shade,
-            // never z-order. Grouped keeps band-axis containment for cursor-above-bar.
-            const stackedHighlight = isStackedLayout(barLayout)
-            if (stackedHighlight && hoverPosition) {
-                const visible = findVisibleStackedSegment({
-                    series: coloredSeries,
-                    labels: drawLabels,
-                    hoveredLabel,
-                    cursor: hoverPosition,
-                    scales: d3Scales,
-                    layout: barLayout,
-                    isHorizontal,
-                    stackedData,
-                    topStackedKeyByAxis,
-                })
-                if (visible) {
-                    const visibleExtent = isHorizontal ? visible.bar.width : visible.bar.height
-                    const { nextSmallerExtent } = visible
-                    const baselinePx = isHorizontal ? visible.bar.x : visible.bar.y + visible.bar.height
-                    const clippedExtent = Math.max(0, visibleExtent - nextSmallerExtent)
-                    const clipped: BarRect = isHorizontal
-                        ? { ...visible.bar, x: baselinePx + nextSmallerExtent, width: clippedExtent }
-                        : { ...visible.bar, y: baselinePx - visibleExtent, height: clippedExtent }
-                    items.push({ series: visible.series, bar: clipped, isTrackHighlight: false })
-                    composition += 'b'
-                }
-            } else {
-                for (const { series: s, bar } of iterBarsAtCursor<ResolvedSeries>({
-                    series: coloredSeries,
-                    label: hoveredLabel,
-                    dataIndex: hoverIndex,
-                    scales: d3Scales,
-                    layout: barLayout,
-                    isHorizontal,
-                    stackedData,
-                    topStackedKeyByAxis,
-                })) {
-                    if (hoverPosition && !barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)) {
-                        continue
-                    }
-                    const isTrackHighlight =
-                        barTrack === true &&
-                        barLayout === 'grouped' &&
-                        hoverPosition != null &&
-                        cursorOutsideBarFillExtent(bar, hoverPosition, isHorizontal)
-                    items.push({ series: s, bar, isTrackHighlight })
-                    composition += isTrackHighlight ? 't' : 'b'
-                }
-            }
-            if (items.length === 0) {
+            const resolved = resolveBarHoverItems(args, d3Scales, {
+                barLayout,
+                isHorizontal,
+                stackedData,
+                topStackedKeyByAxis,
+                roundStackEnds,
+                barTrack,
+            })
+            if (!resolved) {
                 lastHoverKeyRef.current = null
                 return false
             }
-            const currentKey = `${hoverIndex}:${composition}`
+            // Key on the bar-vs-track composition so a bar → track move at the same hoverIndex
+            // still restarts the fade.
+            const currentKey = `${hoverIndex}:${resolved.composition}`
             let alpha = hoverProgress
             if (currentKey !== lastHoverKeyRef.current) {
                 alpha = resetHoverFade()
                 lastHoverKeyRef.current = currentKey
             }
-            // Match the resting bar's pill clip so the darker highlight rounds at the stack's outer
-            // ends instead of poking square corners past them.
-            const hoveredBandPills = roundStackEnds
-                ? stackPillRects(
-                      [
-                          ...iterBarsAtCursor<ResolvedSeries>({
-                              series: coloredSeries,
-                              label: hoveredLabel,
-                              dataIndex: hoverIndex,
-                              scales: d3Scales,
-                              layout: barLayout,
-                              isHorizontal,
-                              stackedData,
-                              topStackedKeyByAxis,
-                          }),
-                      ].map(({ bar }) => bar),
-                      isHorizontal
-                  )
-                : []
-            const highlightRadius = hoveredBandPills.length > 0 ? 0 : barCornerRadius
-            ctx.save()
-            ctx.globalAlpha = alpha
-            if (hoveredBandPills.length > 0) {
-                clipToRoundedRects(ctx, hoveredBandPills, barCornerRadius)
-            }
-            for (const { series: s, bar, isTrackHighlight } of items) {
-                if (isTrackHighlight) {
-                    const parsed = d3Color(barColorAt(s, bar.dataIndex))
-                    // Always translucent — the bar color direct would paint an opaque full-height
-                    // block if d3 can't parse the color.
-                    let trackColor: string
-                    if (parsed) {
-                        parsed.opacity = BAR_TRACK_HOVER_ALPHA
-                        trackColor = parsed.toString()
-                    } else {
-                        trackColor = `rgba(0,0,0,${BAR_TRACK_HOVER_ALPHA})`
-                    }
-                    drawBarHighlight(
-                        ctx,
-                        computeBarTrackRect(bar, trackAxisStart, trackAxisEnd, isHorizontal),
-                        trackColor,
-                        highlightRadius
-                    )
-                } else {
-                    const barColor = barColorAt(s, bar.dataIndex)
-                    const highlightColor = d3Color(barColor)?.darker(0.6).toString() ?? barColor
-                    drawBarHighlight(ctx, bar, highlightColor, highlightRadius)
-                }
-            }
-            ctx.restore()
+            drawBarHoverItems(ctx, d3Scales, resolved, { alpha, barCornerRadius, barTrack, isHorizontal })
             return true
         },
         [stackedData, barLayout, isHorizontal, topStackedKeyByAxis, roundStackEnds, barCornerRadius, barTrack]

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -31,7 +31,8 @@ import { DEFAULT_Y_AXIS_ID } from '../../core/types'
 import { BarTooltip } from './BarTooltip'
 import { computeWrapperMinHeight, HORIZONTAL_MIN_BAND_SIZE_DEFAULT } from './utils/bar-config'
 import { groupedBandSlotAtCursor } from './utils/bars-under-cursor'
-import { drawBarChartStatic, drawBarHoverItems, resolveBarHoverItems } from './utils/draw-bar-chart'
+import { drawBarChartStatic, drawBarHoverItems } from './utils/draw-bar-chart'
+import { resolveBarHoverItems } from './utils/resolve-bar-hover'
 import { resolveClickedBarSeries } from './utils/resolve-clicked-bar-series'
 
 export interface BarChartProps<Meta = unknown> {

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
@@ -65,7 +65,7 @@ export interface BarAtCursor<S> {
 /** Yields the renderable `{ series, bar }` for every visible series at `(label, dataIndex)`.
  *  Single source of truth shared by drawHover, tooltip narrowing, and click routing —
  *  encapsulates visibility skip, stacked-band lookup, and `computeBarAtIndex`. */
-export function* iterBarsAtCursor<S extends Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'>>(
+export function* barsAtCursor<S extends Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data'>>(
     args: Omit<BarsAtCursorArgs, 'series'> & { series: readonly S[] }
 ): Generator<BarAtCursor<S>> {
     const { series, label, dataIndex, scales, layout, isHorizontal, stackedData, topStackedKeyByAxis } = args
@@ -108,7 +108,7 @@ export function resolveBarsAtCursor(
     const { cursor, isHorizontal } = args
     const hits = new Set<string>()
     let strictHit: string | null = null
-    for (const { series: s, bar } of iterBarsAtCursor(args)) {
+    for (const { series: s, bar } of barsAtCursor(args)) {
         if (barContainsPointOnBandAxis(bar, cursor, isHorizontal)) {
             hits.add(s.key)
         }
@@ -170,7 +170,7 @@ export function findVisibleStackedSegment<S extends Pick<Series, 'key' | 'visibi
         if (labels[dataIndex] !== hoveredLabel) {
             continue
         }
-        for (const { series: s, bar } of iterBarsAtCursor({ ...args, label: labels[dataIndex], dataIndex })) {
+        for (const { series: s, bar } of barsAtCursor({ ...args, label: labels[dataIndex], dataIndex })) {
             const extent = isHorizontal ? bar.width : bar.height
             if (extent <= 0) {
                 continue

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
@@ -5,6 +5,7 @@ import {
     BAR_TRACK_HOVER_ALPHA,
     type BarRect,
     type BarRoundedCorners,
+    type BarShadow,
     clipToRoundedRects,
     drawBarHighlight,
     drawBars,
@@ -14,7 +15,14 @@ import {
 } from '../../../core/canvas-renderer'
 import { barColorAt } from '../../../core/color-utils'
 import type { BarScaleSet, StackedBand } from '../../../core/scales'
-import type { BarChartConfig, BarFillStyle, BarsConfig, ChartDrawArgs, ResolvedSeries } from '../../../core/types'
+import type {
+    BarChartConfig,
+    BarFillStyle,
+    BarsConfig,
+    ChartDimensions,
+    ChartDrawArgs,
+    ResolvedSeries,
+} from '../../../core/types'
 import { DEFAULT_Y_AXIS_ID } from '../../../core/types'
 import { computeVisibleXLabels } from '../../../overlays/AxisLabels'
 import { resolveBarShadow } from './bar-config'
@@ -32,7 +40,7 @@ const ALL_CORNERS: BarRoundedCorners = { topLeft: true, topRight: true, bottomLe
 /** One fully-rounded rect per band, spanning the union of that band's stacked segments — the
  *  pill the bar layer is clipped to for `roundStackEnds`. Bars in the same band share a band-axis
  *  slot (same `dataIndex`), so we group by it and extend along the value axis. */
-export function stackPillRects(bars: BarRect[], isHorizontal: boolean): BarRect[] {
+function stackPillRects(bars: BarRect[], isHorizontal: boolean): BarRect[] {
     const byBand = new Map<number, BarRect>()
     for (const bar of bars) {
         if (bar.width <= 0 || bar.height <= 0) {
@@ -58,7 +66,55 @@ export function stackPillRects(bars: BarRect[], isHorizontal: boolean): BarRect[
     return [...byBand.values()]
 }
 
-export interface DrawBarChartStaticConfig {
+/** Category-axis grid ticks aligned to the visible labels rather than every band: all band
+ *  centers for horizontal charts, the de-duplicated visible x-labels for vertical ones so a
+ *  dense axis stays legible. */
+function computeGridTicks(
+    d3Scales: BarScaleSet,
+    drawLabels: string[],
+    isHorizontal: boolean,
+    xTickFormatter: BarChartConfig['xTickFormatter']
+): number[] {
+    if (isHorizontal) {
+        const ticks: number[] = []
+        for (const label of drawLabels) {
+            const coord = bandCenter(d3Scales, label)
+            if (coord != null && isFinite(coord)) {
+                ticks.push(coord)
+            }
+        }
+        return ticks
+    }
+    return computeVisibleXLabels(drawLabels, (label) => bandCenter(d3Scales, label), xTickFormatter).map(
+        (entry) => entry.x
+    )
+}
+
+/** Run `draw` with the bar drop-shadow active, clipped to the plot area so a 100% bar's upward
+ *  shadow doesn't bleed past the chart edge. No-op wrapper (just calls `draw`) when no shadow. */
+function withBarShadow(
+    ctx: CanvasRenderingContext2D,
+    dimensions: ChartDimensions,
+    shadow: BarShadow | undefined,
+    draw: () => void
+): void {
+    if (!shadow) {
+        draw()
+        return
+    }
+    ctx.save()
+    ctx.beginPath()
+    ctx.rect(dimensions.plotLeft, dimensions.plotTop, dimensions.plotWidth, dimensions.plotHeight)
+    ctx.clip()
+    ctx.shadowColor = shadow.color
+    ctx.shadowBlur = shadow.blur
+    ctx.shadowOffsetX = shadow.offsetX ?? 0
+    ctx.shadowOffsetY = shadow.offsetY ?? 0
+    draw()
+    ctx.restore()
+}
+
+export interface DrawBarChartStaticArgs {
     barLayout: BarLayout
     isHorizontal: boolean
     showGrid: boolean
@@ -89,7 +145,7 @@ export function drawBarChartStatic(
         barTrack,
         barShadow,
         barFillStyle,
-    }: DrawBarChartStaticConfig
+    }: DrawBarChartStaticArgs
 ): void {
     const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
     if (!d3Scales) {
@@ -105,26 +161,10 @@ export function drawBarChartStatic(
     }
 
     if (showGrid) {
-        // Align cross-axis grid with visible category labels, not every band.
-        let categoryTicks: number[] = []
-        if (isHorizontal) {
-            for (const label of drawLabels) {
-                const coord = bandCenter(d3Scales, label)
-                if (coord != null && isFinite(coord)) {
-                    categoryTicks.push(coord)
-                }
-            }
-        } else {
-            categoryTicks = computeVisibleXLabels(
-                drawLabels,
-                (label) => bandCenter(d3Scales, label),
-                xTickFormatter
-            ).map((entry) => entry.x)
-        }
         drawGrid(baseDrawCtx, {
             gridColor: theme.gridColor,
             orientation: isHorizontal ? 'horizontal' : 'vertical',
-            categoryTicks,
+            categoryTicks: computeGridTicks(d3Scales, drawLabels, isHorizontal, xTickFormatter),
         })
     }
 
@@ -168,31 +208,18 @@ export function drawBarChartStatic(
         }
     }
 
-    const resolvedShadow = resolveBarShadow(barShadow)
-    // Clip to plot area so a 100% bar's upward shadow doesn't bleed past the chart edge.
-    if (resolvedShadow) {
-        ctx.save()
-        ctx.beginPath()
-        ctx.rect(dimensions.plotLeft, dimensions.plotTop, dimensions.plotWidth, dimensions.plotHeight)
-        ctx.clip()
-        ctx.shadowColor = resolvedShadow.color
-        ctx.shadowBlur = resolvedShadow.blur
-        ctx.shadowOffsetX = resolvedShadow.offsetX ?? 0
-        ctx.shadowOffsetY = resolvedShadow.offsetY ?? 0
-    }
-    if (stackPills.length > 0) {
-        ctx.save()
-        clipToRoundedRects(ctx, stackPills, barCornerRadius)
-    }
-    for (const { series: s, bars } of seriesBars) {
-        drawBars(baseDrawCtx, s, bars, stackPills.length > 0 ? 0 : barCornerRadius, barFillStyle)
-    }
-    if (stackPills.length > 0) {
-        ctx.restore()
-    }
-    if (resolvedShadow) {
-        ctx.restore()
-    }
+    withBarShadow(ctx, dimensions, resolveBarShadow(barShadow), () => {
+        if (stackPills.length > 0) {
+            ctx.save()
+            clipToRoundedRects(ctx, stackPills, barCornerRadius)
+        }
+        for (const { series: s, bars } of seriesBars) {
+            drawBars(baseDrawCtx, s, bars, stackPills.length > 0 ? 0 : barCornerRadius, barFillStyle)
+        }
+        if (stackPills.length > 0) {
+            ctx.restore()
+        }
+    })
 }
 
 export interface BarHoverItem {
@@ -211,7 +238,7 @@ export interface ResolvedBarHover {
     hoveredBandPills: BarRect[]
 }
 
-export interface ResolveBarHoverConfig {
+export interface ResolveBarHoverArgs {
     barLayout: BarLayout
     isHorizontal: boolean
     stackedData: Map<string, StackedBand> | undefined
@@ -227,7 +254,7 @@ export interface ResolveBarHoverConfig {
 export function resolveBarHoverItems(
     { series: coloredSeries, labels: drawLabels, hoverIndex, hoverPosition }: ChartDrawArgs,
     d3Scales: BarScaleSet,
-    { barLayout, isHorizontal, stackedData, topStackedKeyByAxis, roundStackEnds, barTrack }: ResolveBarHoverConfig
+    { barLayout, isHorizontal, stackedData, topStackedKeyByAxis, roundStackEnds, barTrack }: ResolveBarHoverArgs
 ): ResolvedBarHover | null {
     const hoveredLabel = drawLabels[hoverIndex]
     const items: BarHoverItem[] = []
@@ -306,7 +333,7 @@ export function resolveBarHoverItems(
     return { items, composition, hoveredBandPills }
 }
 
-export interface DrawBarHoverConfig {
+export interface DrawBarHoverArgs {
     alpha: number
     barCornerRadius: number
     barTrack: boolean
@@ -320,7 +347,7 @@ export function drawBarHoverItems(
     ctx: CanvasRenderingContext2D,
     d3Scales: BarScaleSet,
     { items, hoveredBandPills }: ResolvedBarHover,
-    { alpha, barCornerRadius, barTrack, isHorizontal }: DrawBarHoverConfig
+    { alpha, barCornerRadius, barTrack, isHorizontal }: DrawBarHoverArgs
 ): void {
     const [trackAxisStart = 0, trackAxisEnd = 0] = barTrack ? d3Scales.value.range() : []
     const highlightRadius = hoveredBandPills.length > 0 ? 0 : barCornerRadius

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
@@ -1,0 +1,357 @@
+import { color as d3Color } from 'd3-color'
+
+import { bandCenter, type BarChartPrivate, computeBarTrackRect, computeSeriesBars } from '../../../core/bar-layout'
+import {
+    BAR_TRACK_HOVER_ALPHA,
+    type BarRect,
+    type BarRoundedCorners,
+    clipToRoundedRects,
+    drawBarHighlight,
+    drawBars,
+    drawBarTracks,
+    drawGrid,
+    type DrawContext,
+} from '../../../core/canvas-renderer'
+import { barColorAt } from '../../../core/color-utils'
+import type { BarScaleSet, StackedBand } from '../../../core/scales'
+import type { BarChartConfig, BarFillStyle, BarsConfig, ChartDrawArgs, ResolvedSeries } from '../../../core/types'
+import { DEFAULT_Y_AXIS_ID } from '../../../core/types'
+import { computeVisibleXLabels } from '../../../overlays/AxisLabels'
+import { resolveBarShadow } from './bar-config'
+import {
+    type BarLayout,
+    barContainsPointOnBandAxis,
+    cursorOutsideBarFillExtent,
+    findVisibleStackedSegment,
+    isStackedLayout,
+    iterBarsAtCursor,
+} from './bars-under-cursor'
+
+const ALL_CORNERS: BarRoundedCorners = { topLeft: true, topRight: true, bottomLeft: true, bottomRight: true }
+
+/** One fully-rounded rect per band, spanning the union of that band's stacked segments — the
+ *  pill the bar layer is clipped to for `roundStackEnds`. Bars in the same band share a band-axis
+ *  slot (same `dataIndex`), so we group by it and extend along the value axis. */
+export function stackPillRects(bars: BarRect[], isHorizontal: boolean): BarRect[] {
+    const byBand = new Map<number, BarRect>()
+    for (const bar of bars) {
+        if (bar.width <= 0 || bar.height <= 0) {
+            continue
+        }
+        const existing = byBand.get(bar.dataIndex)
+        if (!existing) {
+            byBand.set(bar.dataIndex, { ...bar, corners: ALL_CORNERS })
+            continue
+        }
+        if (isHorizontal) {
+            const left = Math.min(existing.x, bar.x)
+            const right = Math.max(existing.x + existing.width, bar.x + bar.width)
+            existing.x = left
+            existing.width = right - left
+        } else {
+            const top = Math.min(existing.y, bar.y)
+            const bottom = Math.max(existing.y + existing.height, bar.y + bar.height)
+            existing.y = top
+            existing.height = bottom - top
+        }
+    }
+    return [...byBand.values()]
+}
+
+export interface DrawBarChartStaticConfig {
+    barLayout: BarLayout
+    isHorizontal: boolean
+    showGrid: boolean
+    xTickFormatter: BarChartConfig['xTickFormatter']
+    stackedData: Map<string, StackedBand> | undefined
+    topStackedKeyByAxis: Map<string, string>
+    roundStackEnds: boolean
+    barCornerRadius: number
+    barTrack: boolean
+    barShadow: BarsConfig['shadow']
+    barFillStyle: BarFillStyle
+}
+
+/** The full static pass: grid, bars, optional tracks, optional drop shadow and rounded stack
+ *  pills. Reads the d3 scales from the committed `ChartScales._private` slot so it works off a
+ *  self-contained per-render object. No React, no component state. */
+export function drawBarChartStatic(
+    { ctx, dimensions, scales, series: coloredSeries, labels: drawLabels, theme }: ChartDrawArgs,
+    {
+        barLayout,
+        isHorizontal,
+        showGrid,
+        xTickFormatter,
+        stackedData,
+        topStackedKeyByAxis,
+        roundStackEnds,
+        barCornerRadius,
+        barTrack,
+        barShadow,
+        barFillStyle,
+    }: DrawBarChartStaticConfig
+): void {
+    const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
+    if (!d3Scales) {
+        return
+    }
+
+    const baseDrawCtx: DrawContext = {
+        ctx,
+        dimensions,
+        xScale: (label: string) => bandCenter(d3Scales, label),
+        yScale: d3Scales.value,
+        labels: drawLabels,
+    }
+
+    if (showGrid) {
+        // Align cross-axis grid with visible category labels, not every band.
+        let categoryTicks: number[] = []
+        if (isHorizontal) {
+            for (const label of drawLabels) {
+                const coord = bandCenter(d3Scales, label)
+                if (coord != null && isFinite(coord)) {
+                    categoryTicks.push(coord)
+                }
+            }
+        } else {
+            categoryTicks = computeVisibleXLabels(
+                drawLabels,
+                (label) => bandCenter(d3Scales, label),
+                xTickFormatter
+            ).map((entry) => entry.x)
+        }
+        drawGrid(baseDrawCtx, {
+            gridColor: theme.gridColor,
+            orientation: isHorizontal ? 'horizontal' : 'vertical',
+            categoryTicks,
+        })
+    }
+
+    const seriesBars = coloredSeries
+        .filter((s) => !s.visibility?.excluded)
+        .map((s) => {
+            const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
+            const bars = computeSeriesBars({
+                series: s,
+                labels: drawLabels,
+                scales: d3Scales,
+                layout: barLayout,
+                isHorizontal,
+                stackedBand: stackedData?.get(s.key),
+                isTopOfStack: topStackedKeyByAxis.get(axisId) === s.key,
+            }).filter((b): b is BarRect => b !== null)
+            return { series: s, bars }
+        })
+
+    // `roundStackEnds`: round both outer ends of the whole stack into a pill by clipping
+    // the bar layer to a rounded rect spanning each band's full extent, then drawing the
+    // segments square. The clip rounds the outer corners at the full radius even when the
+    // edge segment is a thin sliver (e.g. the last breakdown of a near-100% step), which
+    // per-segment rounding can't — it would clamp the radius to the sliver's half-width.
+    const stackPills = roundStackEnds
+        ? stackPillRects(
+              seriesBars.flatMap((sb) => sb.bars),
+              isHorizontal
+          )
+        : []
+
+    // Tracks are a separate pass so a later series' full-height track can't paint
+    // over an earlier series' bar. Track is "share of a whole" semantics — only
+    // meaningful for grouped layouts; in stacked/percent every layer would paint
+    // a full-height track over the same band with the wrong corners.
+    if (barTrack && barLayout === 'grouped') {
+        const [axisStart = 0, axisEnd = 0] = d3Scales.value.range()
+        for (const { series: s, bars } of seriesBars) {
+            const tracks = bars.map((b) => computeBarTrackRect(b, axisStart, axisEnd, isHorizontal))
+            drawBarTracks(baseDrawCtx, s, tracks, barCornerRadius)
+        }
+    }
+
+    const resolvedShadow = resolveBarShadow(barShadow)
+    // Clip to plot area so a 100% bar's upward shadow doesn't bleed past the chart edge.
+    if (resolvedShadow) {
+        ctx.save()
+        ctx.beginPath()
+        ctx.rect(dimensions.plotLeft, dimensions.plotTop, dimensions.plotWidth, dimensions.plotHeight)
+        ctx.clip()
+        ctx.shadowColor = resolvedShadow.color
+        ctx.shadowBlur = resolvedShadow.blur
+        ctx.shadowOffsetX = resolvedShadow.offsetX ?? 0
+        ctx.shadowOffsetY = resolvedShadow.offsetY ?? 0
+    }
+    if (stackPills.length > 0) {
+        ctx.save()
+        clipToRoundedRects(ctx, stackPills, barCornerRadius)
+    }
+    for (const { series: s, bars } of seriesBars) {
+        drawBars(baseDrawCtx, s, bars, stackPills.length > 0 ? 0 : barCornerRadius, barFillStyle)
+    }
+    if (stackPills.length > 0) {
+        ctx.restore()
+    }
+    if (resolvedShadow) {
+        ctx.restore()
+    }
+}
+
+export interface BarHoverItem {
+    series: ResolvedSeries
+    bar: BarRect
+    isTrackHighlight: boolean
+}
+
+export interface ResolvedBarHover {
+    items: BarHoverItem[]
+    /** Per-series bar-vs-track composition string. The caller keys its fade restart on this so a
+     *  bar → track move at the same `hoverIndex` still restarts the fade. */
+    composition: string
+    /** Rounded pills to clip the highlight to (matches the resting bars under `roundStackEnds`),
+     *  or empty when not rounding stack ends. */
+    hoveredBandPills: BarRect[]
+}
+
+export interface ResolveBarHoverConfig {
+    barLayout: BarLayout
+    isHorizontal: boolean
+    stackedData: Map<string, StackedBand> | undefined
+    topStackedKeyByAxis: Map<string, string>
+    roundStackEnds: boolean
+    barTrack: boolean
+}
+
+/** Resolve which bars (or tracks) the hovered band should highlight, plus the pill clip and a
+ *  composition key. Pure — the stateful fade bookkeeping stays in the caller, which owns the
+ *  alpha and then hands the result to {@link drawBarHoverItems}. Returns `null` when nothing is
+ *  under the cursor. */
+export function resolveBarHoverItems(
+    { series: coloredSeries, labels: drawLabels, hoverIndex, hoverPosition }: ChartDrawArgs,
+    d3Scales: BarScaleSet,
+    { barLayout, isHorizontal, stackedData, topStackedKeyByAxis, roundStackEnds, barTrack }: ResolveBarHoverConfig
+): ResolvedBarHover | null {
+    const hoveredLabel = drawLabels[hoverIndex]
+    const items: BarHoverItem[] = []
+    let composition = ''
+    // Stacked: clip the highlight to the visible slice so hover only changes shade,
+    // never z-order. Grouped keeps band-axis containment for cursor-above-bar.
+    const stackedHighlight = isStackedLayout(barLayout)
+    if (stackedHighlight && hoverPosition) {
+        const visible = findVisibleStackedSegment({
+            series: coloredSeries,
+            labels: drawLabels,
+            hoveredLabel,
+            cursor: hoverPosition,
+            scales: d3Scales,
+            layout: barLayout,
+            isHorizontal,
+            stackedData,
+            topStackedKeyByAxis,
+        })
+        if (visible) {
+            const visibleExtent = isHorizontal ? visible.bar.width : visible.bar.height
+            const { nextSmallerExtent } = visible
+            const baselinePx = isHorizontal ? visible.bar.x : visible.bar.y + visible.bar.height
+            const clippedExtent = Math.max(0, visibleExtent - nextSmallerExtent)
+            const clipped: BarRect = isHorizontal
+                ? { ...visible.bar, x: baselinePx + nextSmallerExtent, width: clippedExtent }
+                : { ...visible.bar, y: baselinePx - visibleExtent, height: clippedExtent }
+            items.push({ series: visible.series, bar: clipped, isTrackHighlight: false })
+            composition += 'b'
+        }
+    } else {
+        for (const { series: s, bar } of iterBarsAtCursor<ResolvedSeries>({
+            series: coloredSeries,
+            label: hoveredLabel,
+            dataIndex: hoverIndex,
+            scales: d3Scales,
+            layout: barLayout,
+            isHorizontal,
+            stackedData,
+            topStackedKeyByAxis,
+        })) {
+            if (hoverPosition && !barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)) {
+                continue
+            }
+            const isTrackHighlight =
+                barTrack === true &&
+                barLayout === 'grouped' &&
+                hoverPosition != null &&
+                cursorOutsideBarFillExtent(bar, hoverPosition, isHorizontal)
+            items.push({ series: s, bar, isTrackHighlight })
+            composition += isTrackHighlight ? 't' : 'b'
+        }
+    }
+    if (items.length === 0) {
+        return null
+    }
+    // Match the resting bar's pill clip so the darker highlight rounds at the stack's outer
+    // ends instead of poking square corners past them.
+    const hoveredBandPills = roundStackEnds
+        ? stackPillRects(
+              [
+                  ...iterBarsAtCursor<ResolvedSeries>({
+                      series: coloredSeries,
+                      label: hoveredLabel,
+                      dataIndex: hoverIndex,
+                      scales: d3Scales,
+                      layout: barLayout,
+                      isHorizontal,
+                      stackedData,
+                      topStackedKeyByAxis,
+                  }),
+              ].map(({ bar }) => bar),
+              isHorizontal
+          )
+        : []
+    return { items, composition, hoveredBandPills }
+}
+
+export interface DrawBarHoverConfig {
+    alpha: number
+    barCornerRadius: number
+    barTrack: boolean
+    isHorizontal: boolean
+}
+
+/** Paint the resolved hover highlight. Track highlights draw a translucent full-extent rect; bar
+ *  highlights draw a darker shade of the bar color. Clips to the pills from
+ *  {@link resolveBarHoverItems} when rounding stack ends. */
+export function drawBarHoverItems(
+    ctx: CanvasRenderingContext2D,
+    d3Scales: BarScaleSet,
+    { items, hoveredBandPills }: ResolvedBarHover,
+    { alpha, barCornerRadius, barTrack, isHorizontal }: DrawBarHoverConfig
+): void {
+    const [trackAxisStart = 0, trackAxisEnd = 0] = barTrack ? d3Scales.value.range() : []
+    const highlightRadius = hoveredBandPills.length > 0 ? 0 : barCornerRadius
+    ctx.save()
+    ctx.globalAlpha = alpha
+    if (hoveredBandPills.length > 0) {
+        clipToRoundedRects(ctx, hoveredBandPills, barCornerRadius)
+    }
+    for (const { series: s, bar, isTrackHighlight } of items) {
+        if (isTrackHighlight) {
+            const parsed = d3Color(barColorAt(s, bar.dataIndex))
+            // Always translucent — the bar color direct would paint an opaque full-height
+            // block if d3 can't parse the color.
+            let trackColor: string
+            if (parsed) {
+                parsed.opacity = BAR_TRACK_HOVER_ALPHA
+                trackColor = parsed.toString()
+            } else {
+                trackColor = `rgba(0,0,0,${BAR_TRACK_HOVER_ALPHA})`
+            }
+            drawBarHighlight(
+                ctx,
+                computeBarTrackRect(bar, trackAxisStart, trackAxisEnd, isHorizontal),
+                trackColor,
+                highlightRadius
+            )
+        } else {
+            const barColor = barColorAt(s, bar.dataIndex)
+            const highlightColor = d3Color(barColor)?.darker(0.6).toString() ?? barColor
+            drawBarHighlight(ctx, bar, highlightColor, highlightRadius)
+        }
+    }
+    ctx.restore()
+}

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
@@ -4,7 +4,6 @@ import { bandCenter, type BarChartPrivate, computeBarTrackRect, computeSeriesBar
 import {
     BAR_TRACK_HOVER_ALPHA,
     type BarRect,
-    type BarRoundedCorners,
     type BarShadow,
     clipToRoundedRects,
     drawBarHighlight,
@@ -15,56 +14,13 @@ import {
 } from '../../../core/canvas-renderer'
 import { barColorAt } from '../../../core/color-utils'
 import type { BarScaleSet, StackedBand } from '../../../core/scales'
-import type {
-    BarChartConfig,
-    BarFillStyle,
-    BarsConfig,
-    ChartDimensions,
-    ChartDrawArgs,
-    ResolvedSeries,
-} from '../../../core/types'
+import type { BarChartConfig, BarFillStyle, BarsConfig, ChartDimensions, ChartDrawArgs } from '../../../core/types'
 import { DEFAULT_Y_AXIS_ID } from '../../../core/types'
 import { computeVisibleXLabels } from '../../../overlays/AxisLabels'
 import { resolveBarShadow } from './bar-config'
-import {
-    type BarLayout,
-    barContainsPointOnBandAxis,
-    cursorOutsideBarFillExtent,
-    findVisibleStackedSegment,
-    isStackedLayout,
-    iterBarsAtCursor,
-} from './bars-under-cursor'
-
-const ALL_CORNERS: BarRoundedCorners = { topLeft: true, topRight: true, bottomLeft: true, bottomRight: true }
-
-/** One fully-rounded rect per band, spanning the union of that band's stacked segments — the
- *  pill the bar layer is clipped to for `roundStackEnds`. Bars in the same band share a band-axis
- *  slot (same `dataIndex`), so we group by it and extend along the value axis. */
-function stackPillRects(bars: BarRect[], isHorizontal: boolean): BarRect[] {
-    const byBand = new Map<number, BarRect>()
-    for (const bar of bars) {
-        if (bar.width <= 0 || bar.height <= 0) {
-            continue
-        }
-        const existing = byBand.get(bar.dataIndex)
-        if (!existing) {
-            byBand.set(bar.dataIndex, { ...bar, corners: ALL_CORNERS })
-            continue
-        }
-        if (isHorizontal) {
-            const left = Math.min(existing.x, bar.x)
-            const right = Math.max(existing.x + existing.width, bar.x + bar.width)
-            existing.x = left
-            existing.width = right - left
-        } else {
-            const top = Math.min(existing.y, bar.y)
-            const bottom = Math.max(existing.y + existing.height, bar.y + bar.height)
-            existing.y = top
-            existing.height = bottom - top
-        }
-    }
-    return [...byBand.values()]
-}
+import { type BarLayout } from './bars-under-cursor'
+import type { ResolvedBarHover } from './resolve-bar-hover'
+import { stackPillRects } from './stack-pills'
 
 /** Category-axis grid ticks aligned to the visible labels rather than every band: all band
  *  centers for horizontal charts, the de-duplicated visible x-labels for vertical ones so a
@@ -222,117 +178,6 @@ export function drawBarChartStatic(
     })
 }
 
-export interface BarHoverItem {
-    series: ResolvedSeries
-    bar: BarRect
-    isTrackHighlight: boolean
-}
-
-export interface ResolvedBarHover {
-    items: BarHoverItem[]
-    /** Per-series bar-vs-track composition string. The caller keys its fade restart on this so a
-     *  bar → track move at the same `hoverIndex` still restarts the fade. */
-    composition: string
-    /** Rounded pills to clip the highlight to (matches the resting bars under `roundStackEnds`),
-     *  or empty when not rounding stack ends. */
-    hoveredBandPills: BarRect[]
-}
-
-export interface ResolveBarHoverArgs {
-    barLayout: BarLayout
-    isHorizontal: boolean
-    stackedData: Map<string, StackedBand> | undefined
-    topStackedKeyByAxis: Map<string, string>
-    roundStackEnds: boolean
-    barTrack: boolean
-}
-
-/** Resolve which bars (or tracks) the hovered band should highlight, plus the pill clip and a
- *  composition key. Pure — the stateful fade bookkeeping stays in the caller, which owns the
- *  alpha and then hands the result to {@link drawBarHoverItems}. Returns `null` when nothing is
- *  under the cursor. */
-export function resolveBarHoverItems(
-    { series: coloredSeries, labels: drawLabels, hoverIndex, hoverPosition }: ChartDrawArgs,
-    d3Scales: BarScaleSet,
-    { barLayout, isHorizontal, stackedData, topStackedKeyByAxis, roundStackEnds, barTrack }: ResolveBarHoverArgs
-): ResolvedBarHover | null {
-    const hoveredLabel = drawLabels[hoverIndex]
-    const items: BarHoverItem[] = []
-    let composition = ''
-    // Stacked: clip the highlight to the visible slice so hover only changes shade,
-    // never z-order. Grouped keeps band-axis containment for cursor-above-bar.
-    const stackedHighlight = isStackedLayout(barLayout)
-    if (stackedHighlight && hoverPosition) {
-        const visible = findVisibleStackedSegment({
-            series: coloredSeries,
-            labels: drawLabels,
-            hoveredLabel,
-            cursor: hoverPosition,
-            scales: d3Scales,
-            layout: barLayout,
-            isHorizontal,
-            stackedData,
-            topStackedKeyByAxis,
-        })
-        if (visible) {
-            const visibleExtent = isHorizontal ? visible.bar.width : visible.bar.height
-            const { nextSmallerExtent } = visible
-            const baselinePx = isHorizontal ? visible.bar.x : visible.bar.y + visible.bar.height
-            const clippedExtent = Math.max(0, visibleExtent - nextSmallerExtent)
-            const clipped: BarRect = isHorizontal
-                ? { ...visible.bar, x: baselinePx + nextSmallerExtent, width: clippedExtent }
-                : { ...visible.bar, y: baselinePx - visibleExtent, height: clippedExtent }
-            items.push({ series: visible.series, bar: clipped, isTrackHighlight: false })
-            composition += 'b'
-        }
-    } else {
-        for (const { series: s, bar } of iterBarsAtCursor<ResolvedSeries>({
-            series: coloredSeries,
-            label: hoveredLabel,
-            dataIndex: hoverIndex,
-            scales: d3Scales,
-            layout: barLayout,
-            isHorizontal,
-            stackedData,
-            topStackedKeyByAxis,
-        })) {
-            if (hoverPosition && !barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)) {
-                continue
-            }
-            const isTrackHighlight =
-                barTrack === true &&
-                barLayout === 'grouped' &&
-                hoverPosition != null &&
-                cursorOutsideBarFillExtent(bar, hoverPosition, isHorizontal)
-            items.push({ series: s, bar, isTrackHighlight })
-            composition += isTrackHighlight ? 't' : 'b'
-        }
-    }
-    if (items.length === 0) {
-        return null
-    }
-    // Match the resting bar's pill clip so the darker highlight rounds at the stack's outer
-    // ends instead of poking square corners past them.
-    const hoveredBandPills = roundStackEnds
-        ? stackPillRects(
-              [
-                  ...iterBarsAtCursor<ResolvedSeries>({
-                      series: coloredSeries,
-                      label: hoveredLabel,
-                      dataIndex: hoverIndex,
-                      scales: d3Scales,
-                      layout: barLayout,
-                      isHorizontal,
-                      stackedData,
-                      topStackedKeyByAxis,
-                  }),
-              ].map(({ bar }) => bar),
-              isHorizontal
-          )
-        : []
-    return { items, composition, hoveredBandPills }
-}
-
 export interface DrawBarHoverArgs {
     alpha: number
     barCornerRadius: number
@@ -342,7 +187,7 @@ export interface DrawBarHoverArgs {
 
 /** Paint the resolved hover highlight. Track highlights draw a translucent full-extent rect; bar
  *  highlights draw a darker shade of the bar color. Clips to the pills from
- *  {@link resolveBarHoverItems} when rounding stack ends. */
+ *  `resolveBarHoverItems` when rounding stack ends. */
 export function drawBarHoverItems(
     ctx: CanvasRenderingContext2D,
     d3Scales: BarScaleSet,

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-bar-hover.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-bar-hover.ts
@@ -4,10 +4,10 @@ import type { ChartDrawArgs, ResolvedSeries } from '../../../core/types'
 import {
     type BarLayout,
     barContainsPointOnBandAxis,
+    barsAtCursor,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
     isStackedLayout,
-    iterBarsAtCursor,
 } from './bars-under-cursor'
 import { stackPillRects } from './stack-pills'
 
@@ -75,7 +75,7 @@ export function resolveBarHoverItems(
             composition += 'b'
         }
     } else {
-        for (const { series: s, bar } of iterBarsAtCursor<ResolvedSeries>({
+        for (const { series: s, bar } of barsAtCursor<ResolvedSeries>({
             series: coloredSeries,
             label: hoveredLabel,
             dataIndex: hoverIndex,
@@ -105,7 +105,7 @@ export function resolveBarHoverItems(
     const hoveredBandPills = roundStackEnds
         ? stackPillRects(
               [
-                  ...iterBarsAtCursor<ResolvedSeries>({
+                  ...barsAtCursor<ResolvedSeries>({
                       series: coloredSeries,
                       label: hoveredLabel,
                       dataIndex: hoverIndex,

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-bar-hover.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-bar-hover.ts
@@ -1,0 +1,123 @@
+import { type BarRect } from '../../../core/canvas-renderer'
+import type { BarScaleSet, StackedBand } from '../../../core/scales'
+import type { ChartDrawArgs, ResolvedSeries } from '../../../core/types'
+import {
+    type BarLayout,
+    barContainsPointOnBandAxis,
+    cursorOutsideBarFillExtent,
+    findVisibleStackedSegment,
+    isStackedLayout,
+    iterBarsAtCursor,
+} from './bars-under-cursor'
+import { stackPillRects } from './stack-pills'
+
+export interface BarHoverItem {
+    series: ResolvedSeries
+    bar: BarRect
+    isTrackHighlight: boolean
+}
+
+export interface ResolvedBarHover {
+    items: BarHoverItem[]
+    /** Per-series bar-vs-track composition string. The caller keys its fade restart on this so a
+     *  bar → track move at the same `hoverIndex` still restarts the fade. */
+    composition: string
+    /** Rounded pills to clip the highlight to (matches the resting bars under `roundStackEnds`),
+     *  or empty when not rounding stack ends. */
+    hoveredBandPills: BarRect[]
+}
+
+export interface ResolveBarHoverArgs {
+    barLayout: BarLayout
+    isHorizontal: boolean
+    stackedData: Map<string, StackedBand> | undefined
+    topStackedKeyByAxis: Map<string, string>
+    roundStackEnds: boolean
+    barTrack: boolean
+}
+
+/** Resolve which bars (or tracks) the hovered band should highlight, plus the pill clip and a
+ *  composition key. Pure — the stateful fade bookkeeping stays in the caller, which owns the
+ *  alpha and then hands the result to `drawBarHoverItems`. Returns `null` when nothing is
+ *  under the cursor. */
+export function resolveBarHoverItems(
+    { series: coloredSeries, labels: drawLabels, hoverIndex, hoverPosition }: ChartDrawArgs,
+    d3Scales: BarScaleSet,
+    { barLayout, isHorizontal, stackedData, topStackedKeyByAxis, roundStackEnds, barTrack }: ResolveBarHoverArgs
+): ResolvedBarHover | null {
+    const hoveredLabel = drawLabels[hoverIndex]
+    const items: BarHoverItem[] = []
+    let composition = ''
+    // Stacked: clip the highlight to the visible slice so hover only changes shade,
+    // never z-order. Grouped keeps band-axis containment for cursor-above-bar.
+    const stackedHighlight = isStackedLayout(barLayout)
+    if (stackedHighlight && hoverPosition) {
+        const visible = findVisibleStackedSegment({
+            series: coloredSeries,
+            labels: drawLabels,
+            hoveredLabel,
+            cursor: hoverPosition,
+            scales: d3Scales,
+            layout: barLayout,
+            isHorizontal,
+            stackedData,
+            topStackedKeyByAxis,
+        })
+        if (visible) {
+            const visibleExtent = isHorizontal ? visible.bar.width : visible.bar.height
+            const { nextSmallerExtent } = visible
+            const baselinePx = isHorizontal ? visible.bar.x : visible.bar.y + visible.bar.height
+            const clippedExtent = Math.max(0, visibleExtent - nextSmallerExtent)
+            const clipped: BarRect = isHorizontal
+                ? { ...visible.bar, x: baselinePx + nextSmallerExtent, width: clippedExtent }
+                : { ...visible.bar, y: baselinePx - visibleExtent, height: clippedExtent }
+            items.push({ series: visible.series, bar: clipped, isTrackHighlight: false })
+            composition += 'b'
+        }
+    } else {
+        for (const { series: s, bar } of iterBarsAtCursor<ResolvedSeries>({
+            series: coloredSeries,
+            label: hoveredLabel,
+            dataIndex: hoverIndex,
+            scales: d3Scales,
+            layout: barLayout,
+            isHorizontal,
+            stackedData,
+            topStackedKeyByAxis,
+        })) {
+            if (hoverPosition && !barContainsPointOnBandAxis(bar, hoverPosition, isHorizontal)) {
+                continue
+            }
+            const isTrackHighlight =
+                barTrack === true &&
+                barLayout === 'grouped' &&
+                hoverPosition != null &&
+                cursorOutsideBarFillExtent(bar, hoverPosition, isHorizontal)
+            items.push({ series: s, bar, isTrackHighlight })
+            composition += isTrackHighlight ? 't' : 'b'
+        }
+    }
+    if (items.length === 0) {
+        return null
+    }
+    // Match the resting bar's pill clip so the darker highlight rounds at the stack's outer
+    // ends instead of poking square corners past them.
+    const hoveredBandPills = roundStackEnds
+        ? stackPillRects(
+              [
+                  ...iterBarsAtCursor<ResolvedSeries>({
+                      series: coloredSeries,
+                      label: hoveredLabel,
+                      dataIndex: hoverIndex,
+                      scales: d3Scales,
+                      layout: barLayout,
+                      isHorizontal,
+                      stackedData,
+                      topStackedKeyByAxis,
+                  }),
+              ].map(({ bar }) => bar),
+              isHorizontal
+          )
+        : []
+    return { items, composition, hoveredBandPills }
+}

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-clicked-bar-series.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-clicked-bar-series.ts
@@ -3,9 +3,9 @@ import type { PointClickData, Series } from '../../../core/types'
 import {
     type BarLayout,
     barContainsPointOnBandAxis,
+    barsAtCursor,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
-    iterBarsAtCursor,
 } from './bars-under-cursor'
 
 export interface ResolveClickedBarSeriesArgs<Meta> {
@@ -53,7 +53,7 @@ export function resolveClickedBarSeries<Meta>({
     })
 
     if (barLayout === 'grouped') {
-        for (const { series: s, bar } of iterBarsAtCursor({
+        for (const { series: s, bar } of barsAtCursor({
             series: crossSeriesData.map((d) => d.series),
             label,
             dataIndex,

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/stack-pills.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/stack-pills.ts
@@ -1,0 +1,32 @@
+import { type BarRect, type BarRoundedCorners } from '../../../core/canvas-renderer'
+
+const ALL_CORNERS: BarRoundedCorners = { topLeft: true, topRight: true, bottomLeft: true, bottomRight: true }
+
+/** One fully-rounded rect per band, spanning the union of that band's stacked segments — the
+ *  pill the bar layer is clipped to for `roundStackEnds`. Bars in the same band share a band-axis
+ *  slot (same `dataIndex`), so we group by it and extend along the value axis. */
+export function stackPillRects(bars: BarRect[], isHorizontal: boolean): BarRect[] {
+    const byBand = new Map<number, BarRect>()
+    for (const bar of bars) {
+        if (bar.width <= 0 || bar.height <= 0) {
+            continue
+        }
+        const existing = byBand.get(bar.dataIndex)
+        if (!existing) {
+            byBand.set(bar.dataIndex, { ...bar, corners: ALL_CORNERS })
+            continue
+        }
+        if (isHorizontal) {
+            const left = Math.min(existing.x, bar.x)
+            const right = Math.max(existing.x + existing.width, bar.x + bar.width)
+            existing.x = left
+            existing.width = right - left
+        } else {
+            const top = Math.min(existing.y, bar.y)
+            const bottom = Math.max(existing.y + existing.height, bar.y + bar.height)
+            existing.y = top
+            existing.height = bottom - top
+        }
+    }
+    return [...byBand.values()]
+}


### PR DESCRIPTION
## Problem

Final of a small stack breaking up the oversized `BarChart.tsx` in `@posthog/quill-charts` (reviving #60913 on the relocated `packages/quill/packages/charts`). See the base PR for the full rationale.

> ⚠️ Stacked on #61972 (→ #61971 → #61970). Review/merge those first.

## Changes

Move the canvas-drawing passes out of `BarChart.tsx` into a co-located `utils/draw-bar-chart.ts`:

- `drawBarChartStatic` — the full static pass (grid, bars, optional tracks, shadow, rounded stack pills).
- `resolveBarHoverItems` / `drawBarHoverItems` — hover **resolution** split from the **paint** loop. The component keeps only the `useRef` hover-fade bookkeeping (the one genuinely stateful piece): it owns the fade alpha and hands the resolved result to the draw step.
- `stackPillRects` (and its `ALL_CORNERS` constant) — the shared band-pill geometry both passes use.

Result: `BarChart.tsx` drops from ~750 → **374 lines** and reads as a thin orchestration layer — config destructuring, the memoized scale builder, and thin `useCallback` wrappers delegating to the extracted draws — matching `LineChart`'s altitude.

No behavior change, no public API change.

## How did you test this code?

I'm an agent (Claude Code); no manual UI testing. The extracted functions are byte-for-byte the same logic with parameters threaded through explicitly, so the existing DOM-level suites exercise every drawing path unchanged. Automated checks run locally:

- `jest` on `BarChart` + `TimeSeriesBarChart` (which composes `BarChart`) — 120 pass.
- Full `packages/quill/packages/charts/src` suite — 1196 pass. (One unrelated suite, `core/theme.test.ts`, can't resolve `@posthog/quill-tokens` in the local jest setup — a pre-existing environment gap, not touched here.)
- `tsc -p tsconfig.build.json --noEmit` — clean.
- `oxlint` / `oxfmt` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed — internal library refactor. Suggest the `skip-inkeep-docs` label.

## 🤖 Agent context

Authored by Claude Code. Final slice of a stacked refactor splitting `BarChart` into focused modules, stacked on the click-routing slice (#61972). The highest-value thing to sanity-check is `draw-bar-chart.ts` against the original `drawStatic`/`drawHover` bodies — the extraction is intended to be mechanical, with the hover split (pure `resolveBarHoverItems` + paint-only `drawBarHoverItems`) the one deliberate restructure so the stateful fade logic stays in the component.
