### PR TITLE
fix(app): release autofill ref on SPA nav to free detached DOM

### DIFF
--- a/frontend/src/lib/memory/autofillReleaseLogic.test.ts
+++ b/frontend/src/lib/memory/autofillReleaseLogic.test.ts
@@ -21,9 +21,20 @@ describe('autofillReleaseLogic', () => {
     })
 
     it('mounts a sink input and removes it on unmount', () => {
-        expect(document.querySelector(SINK_SELECTOR)).not.toBeNull()
+        expect(document.querySelectorAll(SINK_SELECTOR)).toHaveLength(1)
         logic.unmount()
         expect(document.querySelector(SINK_SELECTOR)).toBeNull()
+    })
+
+    it('evicts a stale sink left by a previous instance instead of duplicating it', () => {
+        logic.unmount()
+        const orphan = document.createElement('input')
+        orphan.id = 'autofill-release-sink'
+        document.body.appendChild(orphan)
+
+        logic.mount()
+
+        expect(document.querySelectorAll(SINK_SELECTOR)).toHaveLength(1)
     })
 
     it.each([

--- a/frontend/src/lib/memory/autofillReleaseLogic.test.ts
+++ b/frontend/src/lib/memory/autofillReleaseLogic.test.ts
@@ -1,0 +1,46 @@
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { autofillReleaseLogic } from './autofillReleaseLogic'
+
+const SINK_SELECTOR = '#autofill-release-sink'
+
+describe('autofillReleaseLogic', () => {
+    let logic: ReturnType<typeof autofillReleaseLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = autofillReleaseLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    it('mounts a sink input and removes it on unmount', () => {
+        expect(document.querySelector(SINK_SELECTOR)).not.toBeNull()
+        logic.unmount()
+        expect(document.querySelector(SINK_SELECTOR)).toBeNull()
+    })
+
+    it.each([
+        { change: 'a different pathname', navigate: (): void => router.actions.push('/dashboard'), shouldFocus: true },
+        {
+            change: 'a query-only change',
+            navigate: (): void => router.actions.push('/insights', { search: 'foo' }),
+            shouldFocus: false,
+        },
+    ])('focuses the sink on $change: $shouldFocus', async ({ navigate, shouldFocus }) => {
+        await expectLogic(logic, () => router.actions.push('/insights')).toDispatchActions(['locationChanged'])
+
+        const sink = document.querySelector(SINK_SELECTOR) as HTMLInputElement
+        const focusSpy = jest.spyOn(sink, 'focus')
+
+        await expectLogic(logic, () => navigate()).toDispatchActions(['locationChanged'])
+
+        expect(focusSpy).toHaveBeenCalledTimes(shouldFocus ? 1 : 0)
+    })
+})

--- a/frontend/src/lib/memory/autofillReleaseLogic.ts
+++ b/frontend/src/lib/memory/autofillReleaseLogic.ts
@@ -1,0 +1,77 @@
+import { afterMount, beforeUnmount, connect, kea, listeners, path } from 'kea'
+import { router } from 'kea-router'
+
+import type { autofillReleaseLogicType } from './autofillReleaseLogicType'
+
+const SINK_ID = 'autofill-release-sink'
+
+/**
+ * Workaround for a Chromium AutofillAgent retention bug.
+ *
+ * Blink's AutofillAgent keeps a strong (C++ Persistent) reference to the
+ * last-focused form control, and does not release it when that element is
+ * removed from the DOM. An `autoFocus`'d input inside a scene (e.g. the
+ * saved-insights search box) therefore pins its entire detached subtree —
+ * the whole results table, every row, cell and sparkline — across SPA
+ * navigation. Forced GC cannot reclaim it. Across navigations this is a
+ * large, steady source of detached-DOM growth.
+ *
+ * The agent only drops the reference when a *different* form control is
+ * focused (a new autofill query). Blurring alone does not release it. So on
+ * every scene change we momentarily focus a persistent off-screen sink
+ * input, moving the agent's reference onto a node that never detaches. The
+ * next scene's own `autoFocus` (if any) then takes the reference over from
+ * the sink. We blur the sink immediately so it never holds visible focus.
+ *
+ * Sibling in spirit to `useCancelAnimationsOnUnmount`, which severs the
+ * DocumentTimeline -> animation -> element retention on the same SPA
+ * navigation boundary.
+ *
+ * Upstream Chromium bug: https://issues.chromium.org/issues/342247579
+ * Delete this file once it is fixed.
+ */
+export const autofillReleaseLogic = kea<autofillReleaseLogicType>([
+    path(['lib', 'memory', 'autofillReleaseLogic']),
+    connect(() => ({
+        actions: [router, ['locationChanged']],
+    })),
+    afterMount(({ cache }) => {
+        const sink = document.createElement('input')
+        sink.id = SINK_ID
+        sink.type = 'text'
+        sink.tabIndex = -1
+        sink.setAttribute('aria-hidden', 'true')
+        // off-screen rather than `display:none`/`sr-only` clip: the element
+        // must stay focusable and "visible enough" for the autofill agent to
+        // re-query it, which is what releases the previous element
+        sink.style.position = 'fixed'
+        sink.style.left = '-9999px'
+        sink.style.top = '0'
+        document.body.appendChild(sink)
+        cache.sink = sink
+        cache.lastPathname = router.values.location.pathname
+    }),
+    beforeUnmount(({ cache }) => {
+        const sink = cache.sink as HTMLInputElement | undefined
+        sink?.remove()
+        cache.sink = undefined
+    }),
+    listeners(({ cache }) => ({
+        locationChanged: ({ pathname }) => {
+            // only release on an actual scene change. query/hash updates fire
+            // locationChanged too (scenes sync filters to the URL), and
+            // stealing focus on those would break a scene's own search box
+            // mid-keystroke
+            if (pathname === cache.lastPathname) {
+                return
+            }
+            cache.lastPathname = pathname
+            const sink = cache.sink as HTMLInputElement | undefined
+            if (!sink) {
+                return
+            }
+            sink.focus()
+            sink.blur()
+        },
+    })),
+])

--- a/frontend/src/lib/memory/autofillReleaseLogic.ts
+++ b/frontend/src/lib/memory/autofillReleaseLogic.ts
@@ -46,6 +46,10 @@ export const autofillReleaseLogic = kea<autofillReleaseLogicType>([
         // hidden — pauseOnPageHidden would tear it down and recreate it on show
         cache.disposables.add(
             () => {
+                // evict any sink left behind by a previous instance whose
+                // cleanup was missed (e.g. an HMR module swap), so we never
+                // append a second element with the same id
+                document.getElementById(SINK_ID)?.remove()
                 const sink = document.createElement('input')
                 sink.id = SINK_ID
                 sink.type = 'text'

--- a/frontend/src/lib/memory/autofillReleaseLogic.ts
+++ b/frontend/src/lib/memory/autofillReleaseLogic.ts
@@ -1,4 +1,4 @@
-import { afterMount, beforeUnmount, connect, kea, listeners, path } from 'kea'
+import { afterMount, connect, kea, listeners, path } from 'kea'
 import { router } from 'kea-router'
 
 import type { autofillReleaseLogicType } from './autofillReleaseLogicType'
@@ -23,6 +23,11 @@ const SINK_ID = 'autofill-release-sink'
  * next scene's own `autoFocus` (if any) then takes the reference over from
  * the sink. We blur the sink immediately so it never holds visible focus.
  *
+ * Ordering holds because `locationChanged` fires on the router action, before
+ * React renders the next scene, so the sink's focus/blur runs first and the
+ * incoming scene's mount-time `autoFocus` reclaims focus afterwards — we never
+ * yank focus out of the scene we're navigating to.
+ *
  * Sibling in spirit to `useCancelAnimationsOnUnmount`, which severs the
  * DocumentTimeline -> animation -> element retention on the same SPA
  * navigation boundary.
@@ -36,25 +41,31 @@ export const autofillReleaseLogic = kea<autofillReleaseLogicType>([
         actions: [router, ['locationChanged']],
     })),
     afterMount(({ cache }) => {
-        const sink = document.createElement('input')
-        sink.id = SINK_ID
-        sink.type = 'text'
-        sink.tabIndex = -1
-        sink.setAttribute('aria-hidden', 'true')
-        // off-screen rather than `display:none`/`sr-only` clip: the element
-        // must stay focusable and "visible enough" for the autofill agent to
-        // re-query it, which is what releases the previous element
-        sink.style.position = 'fixed'
-        sink.style.left = '-9999px'
-        sink.style.top = '0'
-        document.body.appendChild(sink)
-        cache.sink = sink
         cache.lastPathname = router.values.location.pathname
-    }),
-    beforeUnmount(({ cache }) => {
-        const sink = cache.sink as HTMLInputElement | undefined
-        sink?.remove()
-        cache.sink = undefined
+        // keep the sink for the whole app lifetime, including while the tab is
+        // hidden — pauseOnPageHidden would tear it down and recreate it on show
+        cache.disposables.add(
+            () => {
+                const sink = document.createElement('input')
+                sink.id = SINK_ID
+                sink.type = 'text'
+                sink.tabIndex = -1
+                sink.setAttribute('aria-hidden', 'true')
+                // off-screen rather than `display:none`/`sr-only` clip: the
+                // element must stay focusable and "visible enough" for the
+                // autofill agent to re-query it, which releases the previous one
+                sink.style.position = 'fixed'
+                sink.style.left = '-9999px'
+                document.body.appendChild(sink)
+                cache.sink = sink
+                return () => {
+                    sink.remove()
+                    cache.sink = undefined
+                }
+            },
+            'autofill-sink',
+            { pauseOnPageHidden: false }
+        )
     }),
     listeners(({ cache }) => ({
         locationChanged: ({ pathname }) => {
@@ -70,7 +81,9 @@ export const autofillReleaseLogic = kea<autofillReleaseLogicType>([
             if (!sink) {
                 return
             }
-            sink.focus()
+            // preventScroll: focusing must never scroll the (off-screen) sink
+            // into view
+            sink.focus({ preventScroll: true })
             sink.blur()
         },
     })),

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -8,6 +8,7 @@ import { useThemedHtml } from 'lib/hooks/useThemedHtml'
 import { KeaDevtools } from 'lib/KeaDevTools'
 import { ToastCloseButton } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
+import { autofillReleaseLogic } from 'lib/memory/autofillReleaseLogic'
 import { appLogic } from 'scenes/appLogic'
 import { appScenes } from 'scenes/appScenes'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -49,6 +50,7 @@ export function App(): JSX.Element | null {
     const { showApp, showingDelayedSpinner, showingDevTools } = useValues(appLogic)
 
     useMountedLogic(sceneLogic({ scenes: appScenes }))
+    useMountedLogic(autofillReleaseLogic)
 
     useThemedHtml()
 


### PR DESCRIPTION
## Problem

Chrome's Blink `AutofillAgent` keeps a strong (C++ `Persistent`) reference to the last-focused form control and does not release it when that element is removed from the DOM. An `autoFocus`'d search input — e.g. the saved-insights search, shared by the `/insights` scene and the "Add insight to dashboard" modal — therefore pins its entire detached subtree (the whole results table, every row and sparkline) across SPA navigation. Forced GC cannot reclaim it, so it shows up as sustained detached-DOM growth, and is one contributor to the `detached_elements` signal we track on the dashboard/insights paths.

Upstream Chromium bug: https://issues.chromium.org/issues/342247579 (Chromium-only; not reproducible on Firefox).

## Changes

- New `lib/memory/autofillReleaseLogic.ts`: mounts one persistent off-screen `<input>` "sink" on `document.body` (outside every scene, so it never detaches). On each scene (pathname) change it momentarily `focus()` + `blur()`s the sink, forcing the AutofillAgent to re-query a node that never detaches and releasing the previous scene's subtree. The next scene's own `autoFocus` (if any) takes the reference back; the immediate blur means the sink never holds visible focus.
- Mounted once at the app root in `App.tsx`, alongside the existing `sceneLogic`. Sibling in spirit to `useCancelAnimationsOnUnmount`, which severs an analogous native (`DocumentTimeline`) retention on the same navigation boundary.
- Fires only on **pathname** changes. Scenes sync filters to the URL (`?search=`), so `locationChanged` also fires on query/hash-only changes — those are ignored to avoid defocusing a scene's own search box mid-keystroke.
- **No scene behaviour change**: `autoFocus` is left intact, so this does not regress UX for a browser bug that may be fixed upstream later.

## How did you test this code?

I'm an agent — no manual testing claimed. Validation is via a Playwright + CDP heap-snapshot harness driving a real dashboard ↔ `/insights` navigation loop (12 cycles, double forced-GC), analyzed with memlab:

| Scenario | Detached DOM nodes retained |
| --- | --- |
| No intervention (current) | ~20,920 (one ~1 MB saved-insights table, pinned via the `AutofillAgent` retainer chain) |
| This fix's behaviour (focus an off-screen sink on navigation) | ~245; DOM-node growth flat |
| Plain blur-on-navigation | ~21,195 — does **not** work; only re-querying a different element releases the agent |

Automated checks that pass on the changed files: `oxlint` and `kea-typegen`.

**Not validated:** the full frontend typecheck and the app running this exact wiring end-to-end (local stack hit a worktree/Vite conflict) — the harness validated the *behaviour* by injecting it into the page, not the built logic. The same-pathname modal open/close case (the add-insight modal) is **not** covered by a pathname-keyed trigger. Production `detached_elements` telemetry is the real bar and should be watched after rollout, ideally as an A/B.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude). Investigation used the PostHog MCP (HogQL over the `detached_elements` event) to attribute the dashboard-path surge, a Playwright + CDP harness against production for heap snapshots, and the memlab MCP for retainer analysis. The retainer trace named `autofill::AutofillAgent` as the GC root pinning an `autoFocus`'d `<input>`, which drags its whole detached subtree.

Decisions along the way:
- Rejected removing `autoFocus` (it changes scene behaviour to work around a browser bug that may be fixed upstream).
- Rejected blur-on-navigation after testing it — the AutofillAgent ignores blur for retention; only focusing a *different* form control releases it.
- Chose a router `locationChanged` listener over a per-unmount hook: focus must move *before* the next scene's `autoFocus` fires, and a passive unmount-cleanup runs *after* it (and would steal focus).
- Added the pathname guard after confirming scenes sync their search box to the URL query string.

This PR is agent-authored and requires human review; do not self-merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
