### PR TITLE
refactor(frontend): de-key shallow scenes (recordings, dashboards, saved insights, mcp analytics)

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -5,7 +5,6 @@ import { router, urlToAction } from 'kea-router'
 import api, { PaginatedResponse } from 'lib/api'
 import { Sorting } from 'lib/lemon-ui/LemonTable/sorting'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { objectClean } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
@@ -50,7 +49,6 @@ function urlSearchParamToString(value: unknown): string {
 
 export const dashboardsLogic = kea<dashboardsLogicType>([
     path(['scenes', 'dashboard', 'dashboardsLogic']),
-    tabAwareScene(),
     connect(() => ({
         values: [userLogic, ['user'], featureFlagLogic, ['featureFlags'], tagsModel, ['tags']],
     })),

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -8,7 +8,6 @@ import { dayjs } from 'lib/dayjs'
 import { Sorting } from 'lib/lemon-ui/LemonTable'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { PaginationManual } from 'lib/lemon-ui/PaginationControl'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { objectDiffShallow, objectsEqual, toParams } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -85,7 +84,6 @@ export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsight
 
 export const savedInsightsLogic = kea<savedInsightsLogicType>([
     path(['scenes', 'saved-insights', 'savedInsightsLogic']),
-    tabAwareScene(),
     connect(() => ({
         values: [teamLogic, ['currentTeamId'], sceneLogic, ['activeSceneId']],
         logic: [eventUsageLogic],

--- a/frontend/src/scenes/session-recordings/sessionReplaySceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionReplaySceneLogic.ts
@@ -1,7 +1,6 @@
 import { actions, kea, listeners, path, reducers, selectors } from 'kea'
 import { router, urlToAction } from 'kea-router'
 
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { sceneConfigurations } from 'scenes/scenes'
@@ -34,7 +33,6 @@ export const humanFriendlyTabName = (tab: ReplayTabs): string => {
 
 export const sessionReplaySceneLogic = kea<sessionReplaySceneLogicType>([
     path(() => ['scenes', 'session-recordings', 'sessionReplaySceneLogic']),
-    tabAwareScene(),
     actions({
         setTab: (tab: ReplayTabs = ReplayTabs.Home) => ({ tab }),
         hideNewBadge: true,

--- a/products/mcp_analytics/frontend/mcpAnalyticsSceneLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsSceneLogic.ts
@@ -1,7 +1,5 @@
 import { connect, kea, path, selectors } from 'kea'
 
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
-
 import { sceneLogic } from '~/scenes/sceneLogic'
 
 import type { mcpAnalyticsSceneLogicType } from './mcpAnalyticsSceneLogicType'
@@ -25,7 +23,6 @@ const SCENE_KEY_TO_TAB: Record<string, MCPAnalyticsTab> = {
 
 export const mcpAnalyticsSceneLogic = kea<mcpAnalyticsSceneLogicType>([
     path(['products', 'mcp_analytics', 'frontend', 'mcpAnalyticsSceneLogic']),
-    tabAwareScene(),
     connect(() => ({
         values: [sceneLogic, ['sceneKey']],
     })),


### PR DESCRIPTION
## Problem

These four scene logics used `tabAwareScene()` solely to add a kea key derived from `props.tabId`. With only one tab there is nothing to key on — they should be singletons.

## Changes

Remove `tabAwareScene()` and its import from:
- `sessionReplaySceneLogic`
- `dashboardsLogic`
- `savedInsightsLogic`
- `mcpAnalyticsSceneLogic`

These scenes are "shallow": `tabId` was used only for the root key, not threaded into child logics or exposed as a selector.

## How did you test this code?

`hogli test frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts` — 28/28 pass.

## 🤖 Agent context

PR 5 of the in-app tabs removal stack. Shallow de-keys are safe before the `sceneLogic` core collapse because kea ignores extra props on an unkeyed singleton. Note: `@posthog/quill` workspace package must be built (`pnpm --filter '@posthog/quill...' build`) before these tests can load locally.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*