### PR TITLE
refactor(frontend): de-key platform and health scenes

### DIFF
--- a/frontend/src/scenes/exports/exportsSceneLogic.tsx
+++ b/frontend/src/scenes/exports/exportsSceneLogic.tsx
@@ -1,7 +1,6 @@
 import { afterMount, connect, kea, path, selectors } from 'kea'
 
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
 
@@ -11,7 +10,6 @@ import type { exportsSceneLogicType } from './exportsSceneLogicType'
 
 export const exportsSceneLogic = kea<exportsSceneLogicType>([
     path(['scenes', 'exports', 'exportsSceneLogic']),
-    tabAwareScene(),
     connect(() => ({
         actions: [exportsLogic, ['loadExports']],
     })),

--- a/frontend/src/scenes/groups/groupsSceneLogic.ts
+++ b/frontend/src/scenes/groups/groupsSceneLogic.ts
@@ -2,7 +2,6 @@ import { actions, connect, kea, path, reducers, selectors } from 'kea'
 import { urlToAction } from 'kea-router'
 
 import { GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -22,7 +21,6 @@ export type GroupsTab = {
 
 export const groupsSceneLogic = kea<groupsSceneLogicType>([
     path(['scenes', 'groups', 'groupsSceneLogic']),
-    tabAwareScene(),
     connect(() => ({
         values: [groupsModel, ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus']],
     })),

--- a/frontend/src/scenes/health/healthSceneLogic.tsx
+++ b/frontend/src/scenes/health/healthSceneLogic.tsx
@@ -4,7 +4,6 @@ import { loaders } from 'kea-loaders'
 import api, { ApiError } from 'lib/api'
 import { healthSummaryLogic } from 'lib/components/HelpMenu/healthSummaryLogic'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
@@ -25,7 +24,6 @@ export interface HealthIssuesResponse {
 
 export const healthSceneLogic = kea<healthSceneLogicType>([
     path(['scenes', 'health', 'healthSceneLogic']),
-    tabAwareScene(),
     connect({
         values: [teamLogic, ['currentTeamIdStrict']],
     }),

--- a/frontend/src/scenes/health/pipelineStatus/pipelineStatusSceneLogic.tsx
+++ b/frontend/src/scenes/health/pipelineStatus/pipelineStatusSceneLogic.tsx
@@ -3,7 +3,6 @@ import { router } from 'kea-router'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -20,7 +19,6 @@ const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
 
 export const pipelineStatusSceneLogic = kea<pipelineStatusSceneLogicType>([
     path(['scenes', 'health', 'pipelineStatus', 'pipelineStatusSceneLogic']),
-    tabAwareScene(),
     connect({
         values: [pipelineHealthLogic, ['issues'], featureFlagLogic, ['featureFlags']],
     }),

--- a/frontend/src/scenes/onboarding/sdks/sdkDoctorSceneLogic.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdkDoctorSceneLogic.tsx
@@ -1,6 +1,5 @@
 import { kea, path, selectors } from 'kea'
 
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -11,7 +10,6 @@ import type { sdkDoctorSceneLogicType } from './sdkDoctorSceneLogicType'
 
 export const sdkDoctorSceneLogic = kea<sdkDoctorSceneLogicType>([
     path(['scenes', 'onboarding', 'sdks', 'sdkDoctorSceneLogic']),
-    tabAwareScene(),
     selectors({
         breadcrumbs: [
             () => [],

--- a/frontend/src/scenes/subscriptions/subscriptionsSceneLogic.tsx
+++ b/frontend/src/scenes/subscriptions/subscriptionsSceneLogic.tsx
@@ -6,7 +6,6 @@ import { Sorting } from '@posthog/lemon-ui'
 
 import { runSubscriptionTestDelivery } from 'lib/components/Subscriptions/runSubscriptionTestDelivery'
 import { toggleSubscriptionEnabled } from 'lib/components/Subscriptions/toggleSubscriptionEnabled'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { sceneConfigurations } from 'scenes/scenes'
@@ -194,7 +193,6 @@ function buildSubscriptionsListOrdering(sorting: Sorting | null): string {
 
 export const subscriptionsSceneLogic = kea<subscriptionsSceneLogicType>([
     path(['scenes', 'subscriptions', 'subscriptionsSceneLogic']),
-    tabAwareScene(),
     connect(() => ({ values: [userLogic, ['user']] })),
     actions({
         loadSubscriptions: true,


### PR DESCRIPTION
## Problem

Six more scene logics used `tabAwareScene()` only for the root key. Same situation as the previous PR — with one tab they should be singletons.

## Changes

Remove `tabAwareScene()` and its import from:
- `groupsSceneLogic`
- `healthSceneLogic`
- `pipelineStatusSceneLogic`
- `exportsSceneLogic`
- `subscriptionsSceneLogic`
- `sdkDoctorSceneLogic`

## How did you test this code?

`hogli test frontend/src/scenes/subscriptions/subscriptionsSceneLogic.test.ts` — 9/9 pass. Other five scenes have no test files; verified by `oxlint` (clean) and `git grep` for dangling `tabAwareScene` refs.

## 🤖 Agent context

PR 6 of the in-app tabs removal stack. Same shallow de-key pattern as PR #61981.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*