### PR TITLE
fix(navigation): resolve scene title on hidden background tabs

### DIFF
--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.test.ts
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.test.ts
@@ -56,7 +56,9 @@ describe('breadcrumbsLogic', () => {
         expect(global.document.title).toEqual('Dashboards • PostHog')
     })
 
-    it('does not update the default document.title while hidden during startup', async () => {
+    it('resolves the title of a hidden tab the user has never looked at', async () => {
+        // A freshly-loaded background tab (duplicated tab, restored session, cmd+click) should
+        // settle on its scene title even while hidden, so it's identifiable in the tab strip.
         global.document.title = 'PostHog'
         Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden', writable: true })
 
@@ -65,11 +67,19 @@ describe('breadcrumbsLogic', () => {
 
         router.actions.push(urls.savedInsights())
         await expectLogic(logic).delay(1).toMatchValues({ documentTitle: 'Product analytics • PostHog' })
-        expect(global.document.title).toEqual('PostHog')
+        expect(global.document.title).toEqual('Product analytics • PostHog')
+
+        // Once the user has focused the tab, later hidden updates are deferred (Chrome keepalive).
+        Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible', writable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+        Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden', writable: true })
+
+        router.actions.push(urls.dashboards())
+        await expectLogic(logic).delay(1).toMatchValues({ documentTitle: 'Dashboards • PostHog' })
+        expect(global.document.title).toEqual('Product analytics • PostHog')
 
         Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible', writable: true })
         document.dispatchEvent(new Event('visibilitychange'))
-
-        expect(global.document.title).toEqual('Product analytics • PostHog')
+        expect(global.document.title).toEqual('Dashboards • PostHog')
     })
 })

--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
@@ -208,12 +208,20 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>([
     })),
     afterMount(({ cache }) => {
         cache.syncTitle = (): void => {
+            const isVisible = document.visibilityState === 'visible'
+            if (isVisible) {
+                cache.hasBeenVisible = true
+            }
             if (cache.desiredTitle == null || document.title === cache.desiredTitle) {
                 return
             }
-            // Chrome treats background title updates as a reason to keep a tab alive,
-            // so we always defer syncing until the page is visible again.
-            if (document.visibilityState === 'visible') {
+            // Chrome treats background title updates as a reason to keep a tab alive, so we
+            // defer syncing while hidden — except for a tab the user has never looked at yet
+            // (duplicated tab, restored session, cmd+click). That tab is still settling on its
+            // title and should reflect the scene so it's identifiable in the strip. The keepalive
+            // abuse case is a tab that was viewed then churns its title in the background, which
+            // this still defers.
+            if (isVisible || !cache.hasBeenVisible) {
                 document.title = cache.desiredTitle
             }
         }


### PR DESCRIPTION
## Problem

Opening a PostHog page in a background tab — duplicating a tab, restoring a session, or cmd+clicking a link — left the browser tab title stuck on the default `PostHog` instead of the scene name. The user can't tell those tabs apart in the tab strip without focusing each one.

This is a regression from #56054, which deferred *all* `document.title` updates while a tab is hidden (to stop Chrome's discard heuristic from treating background title churn as a reason to keep idle tabs alive). That correctly fixed long-lived backgrounded tabs, but it also blocked the legitimate one-time title resolution of a tab that was *just* opened in the background and never looked at.

--- 

Before:
<img width="1888" height="764" alt="2026-06-06 17 17 29" src="https://github.com/user-attachments/assets/264167c7-bcab-4e92-8021-a6654dccf99d" />

After:
<img width="1888" height="764" alt="2026-06-06 17 16 31" src="https://github.com/user-attachments/assets/9464dd3d-10ea-4ee8-af8b-034125e5b529" />

Same spike in network, but at least we get titles resolving.

---

## Changes

`breadcrumbsLogic` now tracks whether the tab has ever been visible (`cache.hasBeenVisible`). The title sync rule becomes:

- **Visible** → update (unchanged).
- **Hidden, never been focused** → update. A freshly-loaded background tab settles on its scene title so it's identifiable in the strip.
- **Hidden, but was focused before** → defer (unchanged). This is the Chrome keepalive case #56054 targeted — those tabs stay discardable.

This is a strictly narrower widening than the old behavior: it only affects tabs that have never been seen, and only during their brief initial scene settle. Most logics pause polling while hidden (`pauseOnPageHidden`), so a hidden tab doesn't keep recomputing its title afterward.

No tracking/analytics impact — `document.title` is pure DOM and PostHog events key off URL/history, not the title. Favicon handling is untouched.

## How did you test this code?

I'm an agent (Claude Code). I did not manually test in a browser. I ran the existing Jest suite for `breadcrumbsLogic`, updated the startup test to assert the new behavior, and confirmed all three cases pass:

- sets `document.title` when page is visible
- defers update when page is hidden (after the tab has been viewed)
- resolves the title of a hidden tab the user has never looked at, then defers later hidden updates once it has been focused

```
hogli test frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.test.ts
✓ 3 passed
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Traced the bug to #56054 removing an earlier escape hatch. The first attempt restored that PR's `isDefault` guard (update while hidden only when the title is still `PostHog`/`PostHog Demo`), but a test surfaced that it latches onto a transient intermediate breadcrumb (e.g. `Not found`) before the scene resolves. Switched to a `hasBeenVisible` gate instead, which lets the title settle to its final value and matches the keepalive intent more precisely (the abuse case is a *viewed* tab churning its title, not a never-seen one settling once).
