### PR TITLE
feat(signals): add authoring-signals-scouts skill

### DIFF
--- a/products/signals/skills/AGENTS.md
+++ b/products/signals/skills/AGENTS.md
@@ -2,11 +2,14 @@
 
 Two distinct skill families live in this directory:
 
-1. **Official PostHog skills** — `signals/`, `inbox-exploration/`. First-party PostHog
-   skills published via `products/posthog_ai/dist/skills/` and loaded by users through
-   the PostHog MCP. They teach a caller how to query, browse, and reason about signals
-   data. They are not part of the automated agent path — humans (and human-driven
-   agents) reach for them on demand.
+1. **Official PostHog skills** — `signals/`, `inbox-exploration/`,
+   `authoring-signals-scouts/`. First-party PostHog skills published via
+   `products/posthog_ai/dist/skills/` and loaded by users through the PostHog MCP. They
+   teach a caller how to query, browse, and reason about signals data —
+   `authoring-signals-scouts/` is the meta one: it teaches a user's agent how to write,
+   edit, and adapt the scout fleet itself (per-team via the skills store, or canonically
+   in this directory). They are not part of the automated agent path — humans (and
+   human-driven agents) reach for them on demand.
 2. **Scout fleet** — `signals-scout-*/`. Canonical default skills that the headless
    Signals agent loads into its system prompt at runtime. These are also the first
    example of PostHog shipping templated skills _into a user's PostHog Skills Store_:

--- a/products/signals/skills/authoring-signals-scouts/SKILL.md
+++ b/products/signals/skills/authoring-signals-scouts/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: authoring-signals-scouts
+description: >
+  How to author, edit, and adapt PostHog Signals scouts — the scheduled agents that
+  scan a project and emit findings into the Signals inbox. Use when a user wants to
+  customize a canonical scout for their own setup (narrow its scope, retune its
+  thresholds, add disqualifiers), tweak a scout's schedule or dry-run posture, or
+  write a brand-new scout from scratch for a specific use case (a custom event, a
+  product surface no canonical scout covers). Covers the scout SKILL.md anatomy, the
+  emit contract, the dedupe + scratchpad-memory conventions, the per-team skills-store
+  path vs the canonical in-repo path, and the dry-run-first test loop. Trigger on
+  "write/edit/customize a signals scout", "new scout for X", "tune my scout schedule",
+  "make a scout that watches <event>".
+metadata:
+  owner_team: signals
+---
+
+# Authoring Signals scouts
+
+A **scout** is a scheduled agent that wakes on its own interval, looks at one PostHog
+project, decides what's genuinely worth surfacing, and emits it as a **finding** into
+the Signals inbox — or closes out empty, which is a real outcome. PostHog ships a fleet
+of **canonical scouts** (a cross-product generalist plus per-surface specialists). This
+skill helps you and your agent **adapt those canonical scouts to a specific project**, or
+**author new scouts from scratch** for a use case the fleet doesn't cover.
+
+A scout is just an `LLMSkill` whose name starts with `signals-scout-`. The harness
+discovers scouts by globbing `signals-scout-*` over the project's skills, loads the body
+**verbatim** as the agent's system prompt, and progressively reads any bundled reference
+files on demand. **The `signals-scout-` name prefix is load-bearing: a skill named
+anything else will never run as a scout.**
+
+## The job before the writing
+
+Don't write a scout in the abstract. Ground it in the target project first — a scout is
+only as good as its fit to the data it watches.
+
+1. **Read the project.** `posthog:signals-scout-project-profile-get` returns the
+   deterministic snapshot the scout itself cold-starts from: products in use, top events
+   with reach/burst metrics, integrations, existing inbox counts. If the scout watches a
+   specific event, confirm it exists and check its shape with `posthog:read-data-schema`.
+   A scout for an event the project doesn't capture is dead on arrival.
+2. **See what already runs.** `posthog:signals-scout-config-list` lists every existing
+   scout on the project with its schedule, `enabled`, and `emit` posture. Don't duplicate
+   a surface a canonical scout already covers — adapt that one instead.
+3. **Read the closest canonical scout.** It's your template and your reference shape. Pull
+   it with `posthog:llma-skill-get {"skill_name": "signals-scout-<x>"}` (per-team rows) or
+   read it from the repo at `products/signals/skills/signals-scout-*/`. The generalist
+   (`signals-scout-general`) is the broad template; pick a specialist
+   (`-error-tracking`, `-llm-analytics`, `-logs`, `-revenue-analytics`, `-surveys`,
+   `-csp-violations`, `-observability-gaps`) if your scope is domain-tight.
+4. **Skim the inbox.** `posthog:inbox-reports-list` shows what findings are actually
+   landing — calibrate so your scout adds signal, not noise.
+
+## Choose the path
+
+There are two independent decisions: **what** you're building, and **where** it lives.
+
+### What
+
+| Situation                                                                                      | Approach                                                                                                                           |
+| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| A canonical scout is close but too broad / too noisy / missing a disqualifier for this project | **Adapt** it — narrow the scope, add disqualifiers, retune thresholds.                                                             |
+| You want a surface no canonical scout covers (a custom event, a product-specific funnel)       | **New scout from scratch** — copy the closest canonical scout as scaffolding, replace the domain discriminator + explore patterns. |
+| You only want to change _when_ / _whether_ a scout runs                                        | **No authoring** — just tune the config (see Run posture).                                                                         |
+
+### Where
+
+| Path                                 | Mechanism                                                                                                                                  | Use when                                                                                                                              |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Per-team** (the common user path)  | Create/edit a `signals-scout-*` `LLMSkill` row in the project's skills store via `posthog:llma-skill-create` / `-update` / `-file-create`. | Customizing for one project. The harness globs the row in on the next tick; canonical sync leaves your edited ("diverged") row alone. |
+| **Canonical** (PostHog contributors) | Edit disk under `products/signals/skills/signals-scout-*/`, lint/build, open a PR.                                                         | Improving a scout for _every_ enrolled project. `lazy_seed` mirrors it onto all enrolled teams on the next tick.                      |
+
+**Adapting-in-place tradeoff:** editing a canonical scout's row for your team marks it
+**diverged** — you stop receiving upstream improvements to that scout. If you only need an
+_additional_ behavior, prefer authoring a **new, differently-named** scout
+(`signals-scout-<your-scope>`) and leaving the canonical one intact.
+
+See [`references/lifecycle-and-testing.md`](references/lifecycle-and-testing.md) for the
+exact skills-store calls, the build/lint commands, and how seeding works.
+
+## Write the scout
+
+Follow [`references/scout-anatomy.md`](references/scout-anatomy.md) — it has the frontmatter
+schema, the canonical body structure (quick close-out → orient → domain discriminator →
+explore patterns → save-memory → decide → disqualifiers → close-out), the lean-body rule,
+and copy-ready skeleton templates for both a specialist and the generalist.
+
+Two craft references the whole fleet reasons in terms of — a good scout's **Decide** and
+**memory** sections are built on them, so read them before writing those sections:
+
+- [`references/emit-contract.md`](references/emit-contract.md) — what `emit-signal` takes,
+  the weight vs. confidence rubrics, severity, dedupe keys, `finding_id`, the description
+  prose contract, and a worked example. This is how your scout decides _what clears the
+  bar_ and _how to write the finding_.
+- [`references/dedupe-and-memory.md`](references/dedupe-and-memory.md) — the four-states
+  classifier (net-new / material-update / already-covered / addressed-or-noise), the
+  scratchpad key-prefix vocabulary, and the cross-project noise patterns. This is how your
+  scout avoids re-emitting and learns across runs.
+
+The single most important design decision in any scout is its **signal-vs-noise
+discriminator** — the cheap profile-shape read that separates "worth investigating" from
+"baseline". For error tracking it's the `count` vs `distinct_users` ratio; for CSP it's
+reach over raw count. Your new scout needs its own. Name it explicitly near the top of the
+body so every run anchors on it.
+
+## Run posture (config)
+
+A scout's schedule and emit behavior live on its `SignalScoutConfig`, separate from the
+skill body. Tune with `posthog:signals-scout-config-update` (find the `id` via
+`-config-list`):
+
+- `run_interval_minutes` — 10 to 43200. Default 60 (hourly). Slow a chatty or expensive
+  scout by raising this.
+- `enabled` — `false` pauses the scout entirely (coordinator skips it).
+- `emit` — **`false` = dry-run**: the scout runs and logs its reasoning but writes nothing
+  to the inbox. **New and freshly-edited scouts should run dry-run first.**
+
+## Test loop
+
+You can't force a synchronous run as a user — scouts fire on their schedule. The feedback
+loop is **dry-run + inspect**:
+
+1. Ship the scout with `emit=false` and a short `run_interval_minutes` so it fires soon.
+2. After a tick, read what it did: `posthog:signals-scout-runs-list` (run summaries),
+   `-runs-retrieve` (full reasoning for one run), and `-scratchpad-search` (the durable
+   memory it wrote). In dry-run, runs show what it _would_ have emitted.
+3. Refine the body — tighten the discriminator, add disqualifiers for whatever it
+   false-positived on, fix the emit calibration.
+4. When the dry-run findings look right, flip `emit=true`. Restore the interval to
+   something sustainable (hourly+).
+
+Repo contributors get a faster loop — `hogli sync:skill` and the harness's local run path;
+see [`references/lifecycle-and-testing.md`](references/lifecycle-and-testing.md).
+
+## Quality bar for a v1 scout
+
+- A named, cheap **signal-vs-noise discriminator** anchored near the top.
+- A **quick close-out** so a quiet run is cheap (don't pay for deep exploration when the
+  watched surface is at baseline or absent).
+- 2–4 concrete **explore patterns** with the actual queries/tools to run — starting
+  points, not a rigid checklist.
+- **Disqualifiers** listing this project's known noise (single-user quirks, dev-env
+  bursts, allowlisted entities).
+- A **Decide** section calibrated against the emit contract (confidence ≥ 0.65 to emit;
+  below that, write memory).
+- **Save-memory** guidance using the scratchpad prefixes so the scout gets smarter each run.
+- A lean body (push depth into `references/`) — every line is a recurring token cost on
+  every run.

--- a/products/signals/skills/authoring-signals-scouts/references/dedupe-and-memory.md
+++ b/products/signals/skills/authoring-signals-scouts/references/dedupe-and-memory.md
@@ -1,0 +1,98 @@
+# Dedupe and memory conventions
+
+How a scout decides what to do with a candidate observation, how it writes durable
+scratchpad entries, and the noise patterns common across PostHog projects. Author your
+scout's **Decide** and **Save-memory** sections around these — they're how the fleet avoids
+re-emitting and gets smarter every run. This mirrors
+`signals-scout-general/references/conventions.md`.
+
+## The four states
+
+Every scout classifies each candidate finding against prior runs and the scratchpad before
+emitting. Bake this classifier into the scout's Decide section:
+
+1. **Net new** — no prior run mentions the topic, no scratchpad entry covers it.
+   → Emit if it clears the confidence bar (≥ 0.65).
+2. **Material update on a prior run** — a prior run covered it, but there's new evidence (a
+   different corroborating source, a fresh deploy correlation, contradicting data, a
+   meaningful escalation in scope). → **Emit fresh, citing the prior `finding_id`** in the
+   description and the evidence list (`source_product: signals_scout`, `entity_id: <prior>`).
+   The inbox groups by dedupe key.
+3. **Same fact already covered** — a prior run emitted with the same evidence shape.
+   → Skip. Optionally rewrite a scratchpad entry confirming the topic stayed quiet.
+4. **Already-addressed or noise** — a scratchpad entry with an `addressed:` / `noise:` /
+   `dedupe:` prefix names the entity with a "team aware" note. → Skip; note it in the run
+   summary.
+
+## Scratchpad memory
+
+The scratchpad is durable, per-team prose keyed by string. It has no tags or TTLs — **the
+category is encoded in the key prefix** so a future run finds an entry with a single `text=`
+search. Re-using a key rewrites the entry in place (the idempotent refresh — use it to
+confirm a quiet observation without duplicating entries).
+
+| Prefix        | Use for                                                                     |
+| ------------- | --------------------------------------------------------------------------- |
+| `pattern:`    | Durable observation about how this team's data normally shapes (baselines). |
+| `noise:`      | Patterns to ignore (single-user, dev-only, recurring with no fix path).     |
+| `addressed:`  | Team-confirmed fix shipped, or topic the team has moved on from.            |
+| `dedupe:`     | Gates future emits on a specific issue / fingerprint / finding id.          |
+| `allowlist:`  | Vetted entities the scout should never re-surface.                          |
+| `not-in-use:` | Close-out memo for "product/surface not in use on this team".               |
+| `mcp-gap:`    | Scout-noticed gap in the MCP surface worth raising later.                   |
+
+Format: `<prefix>:<domain>:<entity>` — e.g. `pattern:error_tracking:baseline`,
+`noise:logs:rabbitmq-deploy-window`, `dedupe:csp_violations:a1b2c3d4`. Canonical `<domain>`
+values: `error_tracking`, `warehouse`, `experiments`, `llm_analytics`, `web_analytics`,
+`feature_flags`, `logs`, `surveys`, `revenue_analytics`, `csp_violations`,
+`observability_gaps`. A new scout introduces its own domain label and reuses the prefixes.
+
+## When to write memory vs. emit
+
+| Situation                                                          | Action                                                                    |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| Confirmed real signal, not yet emitted by anyone.                  | Emit (new).                                                               |
+| Confirmed real signal, prior run covered it, new evidence.         | Emit (cite prior `finding_id`).                                           |
+| Pattern observed but `confidence < 0.65`.                          | Scratchpad `pattern:` entry.                                              |
+| Investigated and ruled out; would waste a future run if rechecked. | Scratchpad `noise:` / `addressed:` entry.                                 |
+| Scratchpad already covers it; no change.                           | Skip; note in summary.                                                    |
+| Issue currently quiet but worth re-checking later.                 | Rewrite the existing entry (same key) with a fresh timestamp + condition. |
+
+## What a good entry looks like
+
+Good entries are **future-run actionable** — the next scout reads them and changes behavior:
+
+```text
+key:     dedupe:error_tracking:019de34e-2026-05-01
+content: "2026-05-01: surfaced UndefinedTable on access_control_propertyaccesscontrol
+         (issue 019de34e...) — 434 users hit it 11:31-13:22 UTC, then stopped. If a future
+         run sees this issue still firing, escalate; if quiet since 13:22, treat as
+         already-surfaced."
+```
+
+Why it works: dated, names the entity id, gives a clear conditional ("still firing →
+escalate; quiet → skip"), bounded by a precise time anchor, and the key prefix makes it
+findable. Bad entry: key `note-1`, content "we have errors today, FYI" — no actionability,
+no entity, no condition, uncategorized key the next run can't find or act on.
+
+Give your scout 2–3 worked example entries scoped to its surface so each run matches the
+format instead of inventing its own.
+
+## Cross-project noise patterns
+
+These are noise across essentially all PostHog projects — list the relevant ones in your
+scout's **Disqualifiers** so it skips them unless there's a real escalation:
+
+- **Single-user, single-session events** — one user, one occurrence, no other signal.
+  Almost always a personal browser quirk.
+- **Dev-environment bursts** — high counts whose `service` / `properties.env` is
+  `dev` / `local` / `test`. Filter before weighing.
+- **Sandbox-internal errors** — Docker `TimeoutExpired`, sandbox sync failures, `agentsh`
+  errors. Internal harness operations, not user-facing.
+- **Single-session frontend state quirks** — e.g. KEA store-path errors; not user-impacting
+  unless distinct-user counts climb.
+- **Known upstream provider errors** — Anthropic / OpenAI rate limits, third-party outages
+  already covered by past memory. Don't re-emit unless volume or shape changes meaningfully.
+
+The team's scratchpad extends this list per-project as the scout learns — which is exactly
+why the save-memory discipline matters.

--- a/products/signals/skills/authoring-signals-scouts/references/emit-contract.md
+++ b/products/signals/skills/authoring-signals-scouts/references/emit-contract.md
@@ -1,0 +1,136 @@
+# The emit contract
+
+How a scout calls `signals-scout-emit-signal`, and how to write a scout's **Decide**
+section so it emits well-calibrated findings. This mirrors the contract the canonical fleet
+runs on (`signals-scout-general/references/emit.md`) — author your scout so its findings
+fit this shape. The harness validates request shape but does **not** grade prose quality;
+that's on the scout.
+
+## Fields
+
+| Field          | Type                   | Required     | Notes                                                  |
+| -------------- | ---------------------- | ------------ | ------------------------------------------------------ |
+| `description`  | string                 | ✅           | Non-empty prose — the inbox surface and dedupe target. |
+| `weight`       | float `[0,1]`          | ✅           | Ranking score within the inbox feed.                   |
+| `confidence`   | float `[0,1]`          | ✅           | Epistemic certainty the finding is real.               |
+| `evidence`     | list (0–20)            | ✅           | `{source_product, summary, entity_id?}` per entry.     |
+| `hypothesis`   | string                 | recommended  | One-line root-cause hypothesis the finding tests.      |
+| `severity`     | `P0`–`P4`              | recommended  | Informational only; no routing.                        |
+| `dedupe_keys`  | list of strings        | recommended  | `<kind>:<entity_id>` — groups across runs/sources.     |
+| `time_range`   | `{date_from, date_to}` | when bounded | For bursts, deploys, experiments.                      |
+| `finding_id`   | string                 | recommended  | Stable trace id, **not** a dedupe key (see below).     |
+| `mcp_trace_id` | string                 | optional     | When you want a reviewer to replay MCP queries.        |
+
+## Weight vs. confidence — keep them distinct
+
+`weight` = how much human attention this deserves. `confidence` = how sure the scout is it's
+real. A confidently-real but minor finding is high-confidence, low-weight.
+
+**Weight rubric:**
+
+| Range     | Use when                                                                             |
+| --------- | ------------------------------------------------------------------------------------ |
+| 0.85–1.00 | Active customer impact, large blast radius, or a deploy regression with a clear fix. |
+| 0.65–0.84 | Material pattern worth investigating today; not yet user-impacting at scale.         |
+| 0.40–0.64 | Notable but speculative; or a confirmed minor issue worth knowing about.             |
+| 0.20–0.39 | Curiosity-level.                                                                     |
+| 0.00–0.19 | Don't emit — skip or write a scratchpad entry.                                       |
+
+**Confidence rubric:**
+
+| Range     | Use when                                                                           |
+| --------- | ---------------------------------------------------------------------------------- |
+| 0.85–1.00 | Multiple corroborating queries; pattern unambiguous; verified not already covered. |
+| 0.65–0.84 | One strong query + plausible hypothesis; minor unknowns remain.                    |
+| 0.40–0.64 | Suggestive pattern with material gaps a human should validate.                     |
+| 0.00–0.39 | Don't emit — gather more evidence or skip.                                         |
+
+**The emit gate:** if a scout can't reach `confidence ≥ 0.65`, it should write a scratchpad
+entry instead of emitting. Bake this threshold into the scout's Decide section.
+
+## Severity
+
+`P0`–`P4`, informational only — use consistently. P0: active critical (data loss, outage,
+security). P1: active material (errors hitting many users, billing). P2: confirmed,
+contained. P3: suspected or minor confirmed. P4: curiosity / FYI. Recommendation-style
+scouts (e.g. observability gaps) emit P3 by default rather than P0–P2 anomalies.
+
+## Description prose contract
+
+The description is what a busy human reads in a feed of 30 other findings. Aim for one tight
+paragraph (3–6 sentences):
+
+1. **Hook** — what's happening, **quantified** ("434 occurrences across 434 distinct users"
+   beats "many users").
+2. **Pattern** — the shape that makes this signal, not noise ("one occurrence per user →
+   per-request server path").
+3. **Hypothesis** — the suspected cause.
+4. **Lineage** — if a prior run touched a related topic, cite its `finding_id`.
+5. **Recommendation** — the action that would resolve it.
+
+Cite entity ids (issue ids, recording ids, dashboard short_ids) inline so a human pivots
+straight from prose to source.
+
+## Evidence
+
+Each entry `{source_product, summary, entity_id?}`, capped at 20. Include a citation for
+**every** concrete claim in the description. `source_product` is a short origin label —
+common values: `error_tracking`, `session_replay`, `logs`, `feature_flag`, `experiment`,
+`web_analytics`, `data_warehouse`, `query_runs`, `signals_scout` (cite a prior run/finding),
+`inbox` (cite a report). `entity_id` pins the citable id.
+
+## Dedupe keys
+
+Stable strings the inbox uses to group related findings across runs and sources. Format
+`<kind>:<entity_id>` or `<kind>:<entity_id>:<qualifier>`. Common kinds:
+`error_tracking_issue:<id>`, `experiment:<id>`, `feature_flag:<key>`, `dashboard:<id>`,
+`insight:<short_id>`, `missing_migration:<table>`, `traffic_anomaly:<event>`. Include 1–2
+per finding; more is fine when a finding spans entities. **This is the primary anti-duplicate
+mechanism — design your scout's dedupe keys deliberately.**
+
+## finding_id (not a dedupe key)
+
+`finding_id` is a stable, human-readable trace id tying the emitted signal back to its run.
+It is **not** used for idempotency: `emit_signal` dedupes on its own generated `document_id`
+and your `dedupe_keys`, never on `finding_id`. **Re-calling emit with the same `finding_id`
+writes a second signal — so a scout must never retry an emit that may already have
+succeeded.** Format `<topic>-<entity>-<date>`, e.g.
+`missing-migration-access-control-propertyaccesscontrol-2026-05-01`. A recurrence on a later
+day is a new finding that cites the prior `finding_id` in its description.
+
+## Worked example
+
+```yaml
+finding_id: missing-migration-access-control-propertyaccesscontrol-2026-05-01
+weight: 0.92
+confidence: 0.9
+severity: P1
+hypothesis: >
+  A new access_control.PropertyAccessControl model is referenced in production code paths
+  without its Postgres migration applied — every per-request ORM check hits the missing table.
+evidence:
+  - source_product: error_tracking
+    entity_id: 019de34e-e2a3-7e53-80d0-8ccdd0866a36
+    summary: >
+      UndefinedTable on access_control_propertyaccesscontrol — 434 occurrences across 434
+      distinct users between 11:31 and 13:22 UTC.
+  - source_product: signals_scout
+    entity_id: 019de09b-bd36-78a7-b3ff-fba34c252187
+    summary: Prior run surfaced the same class of bug (missing migration), internal-only blast radius.
+time_range: { date_from: 2026-05-01T11:31:30Z, date_to: 2026-05-01T13:22:02Z }
+dedupe_keys:
+  - error_tracking_issue:019de34e-e2a3-7e53-80d0-8ccdd0866a36
+  - missing_migration:access_control_propertyaccesscontrol
+description: |
+  High-volume UndefinedTable: relation "access_control_propertyaccesscontrol" does not exist
+  started firing at 2026-05-01T11:31:30Z (issue 019de34e..., active). 434 occurrences across
+  434 distinct users in a 2-hour window — one hit per user indicates a per-request ORM check
+  on the new access_control.PropertyAccessControl model. Continuation of yesterday's signals
+  refactor cluster (run 019de09b...) but with far wider blast radius. Recommend confirming the
+  migration is in the deployed set, running it, then verifying the issue stops firing.
+```
+
+Why it's good: quantified hook (434/434 in a precise window), pattern explained ("one hit
+per user" rules out alternatives), lineage cited so the inbox groups it, actionable
+recommendation, dual dedupe keys (issue-id + topic), P1 justified by blast radius, confidence
+0.9 because the pattern is unambiguous.

--- a/products/signals/skills/authoring-signals-scouts/references/lifecycle-and-testing.md
+++ b/products/signals/skills/authoring-signals-scouts/references/lifecycle-and-testing.md
@@ -1,0 +1,107 @@
+# Lifecycle, distribution, and testing
+
+How scouts get discovered, scheduled, and dispatched; the two distribution paths and their
+exact mechanics; and how to test a scout in each.
+
+## How a scout runs
+
+- **Discovery.** The harness globs `signals-scout-*` over the project's skills (`LLMSkill`
+  rows). Any matching skill is a scout. No registration step.
+- **Config.** Each scout has one `SignalScoutConfig` per `(project, skill_name)` carrying
+  `run_interval_minutes` (default 60), `enabled`, `emit`, and a `last_run_at` stamp. A
+  config is **auto-registered** the first time the coordinator sees a `signals-scout-*`
+  skill without one — authoring the skill is enough to get a scout.
+- **Coordinator.** A periodic Temporal workflow ticks (~every 30 min). Each tick it bounds
+  candidates to projects enrolled via the `signals-scout` feature-flag allowlist, then
+  dispatches every **enabled** scout whose schedule is **due** (`last_run_at is None`, or
+  `now - last_run_at ≥ run_interval_minutes`), most-overdue first, capped per tick. There is
+  no sampling — every due scout runs. `last_run_at` advances for everything dispatched.
+- **Run.** Each dispatched scout becomes one sandboxed agent run with a short budget
+  (single-digit minutes). The body is the system prompt; the agent orients, explores, emits
+  or remembers, and writes a one-paragraph summary to the run row.
+
+Pausing a scout = `enabled=false`. Slowing it = a larger `run_interval_minutes`. Dry-running
+it = `emit=false`. All three via `posthog:signals-scout-config-update` (get the `id` from
+`-config-list`).
+
+## Path A — per-team (skills store)
+
+The common path for a user customizing scouts for their own project. A scout is just an
+`LLMSkill` row named `signals-scout-*`; create or edit it with the skills-store tools, and
+the harness globs it in on the next tick.
+
+```text
+# List existing scouts and other skills
+posthog:llma-skill-list {"search": "signals-scout"}
+
+# Read a canonical scout to use as a template
+posthog:llma-skill-get {"skill_name": "signals-scout-error-tracking"}
+
+# New scout from scratch
+posthog:llma-skill-create {"name": "signals-scout-<scope>", "description": "...", "body": "...", "compatibility": "...", "metadata": {"owner_team": "<team>", "scope": "<scope>"}}
+
+# Adapt an existing per-team scout — use the SMALLEST primitive (find/replace, not full-body)
+posthog:llma-skill-get {"skill_name": "signals-scout-<scope>"}          # get current version first
+posthog:llma-skill-update {"skill_name": "signals-scout-<scope>", "base_version": N, "edits": [{"old": "...", "new": "..."}]}
+
+# Duplicate a canonical scout into a new per-team scout you then edit (keeps the canonical intact)
+posthog:llma-skill-duplicate {"skill_name": "signals-scout-general", "new_name": "signals-scout-<scope>"}
+
+# Bundle a reference file onto a per-team scout
+posthog:llma-skill-file-create {"skill_name": "signals-scout-<scope>", "path": "references/cookbook.md", "content": "...", "content_type": "text/markdown", "base_version": N}
+```
+
+Notes:
+
+- Prefer `edits` (find/replace) over a full `body` rewrite for tweaks — a full rewrite
+  forces you to reproduce the whole body and risks silently dropping unrelated content. Each
+  `old` must match exactly once. Every write bumps an immutable `version`; chain further
+  edits via `base_version`.
+- **Divergence:** once you edit a canonical scout's row for your team, canonical sync treats
+  it as **diverged** and stops force-updating it — you keep your edits but lose upstream
+  improvements to that scout. To customize _without_ diverging, `duplicate` the canonical
+  scout into a new `signals-scout-<your-scope>` row and edit that; leave the original alone.
+- Emitting needs the `signal_scout_internal:write` scope (the sandbox has it). Authoring a
+  scout doesn't require it — only the harness emits.
+
+## Path B — canonical (in-repo, for PostHog contributors)
+
+Improving a scout for **every** enrolled project. Disk under
+`products/signals/skills/signals-scout-*/` is the source of truth; `lazy_seed` mirrors
+changes onto each enrolled team's `LLMSkill` rows on the next coordinator tick (or
+immediately via `python manage.py sync_signals_scout_skills --all-enabled`). Teams that
+hand-edited a row are diverged and left alone.
+
+```sh
+hogli init:skill            # scaffold a new skill directory
+hogli lint:skills           # validate frontmatter / syntax / binaries — fast, no Django
+hogli build:skills          # render + package into dist/skills.zip
+hogli sync:skill -- --name signals-scout-<scope>   # build + sync to .agents/skills/ for local agent testing
+hogli unsync:skill -- --name signals-scout-<scope>
+```
+
+Authoring a new canonical scout is just creating `signals-scout-<scope>/SKILL.md` and
+merging — the next tick discovers it, seeds it onto enrolled teams, and auto-registers an
+enabled hourly config. **If you change the fleet shape (add/rename a scout, change the
+SKILL.md schema), update `products/signals/skills/AGENTS.md`.** On master, CI builds and
+publishes `dist/skills.zip` to the downstream distribution repos (the `ai-plugin` bundle and
+the standalone skills repo) automatically.
+
+## Testing
+
+You can't trigger a synchronous run as a user — scouts fire on their schedule. The loop is
+**dry-run + inspect**:
+
+1. Ship with `emit=false` and a short `run_interval_minutes` (e.g. 10) so it fires soon.
+2. After a tick, inspect:
+   - `posthog:signals-scout-runs-list` — run summaries (in dry-run, what it _would_ have
+     emitted and why).
+   - `posthog:signals-scout-runs-retrieve` — the full reasoning for one run.
+   - `posthog:signals-scout-scratchpad-search` — the durable memory it wrote.
+3. Refine the body for whatever it false-positived or missed — tighten the discriminator,
+   add disqualifiers, fix emit calibration. Re-edit via `llma-skill-update`.
+4. When dry-run output looks right, `config-update` to `emit=true` and restore a sustainable
+   interval (hourly or slower).
+
+Repo contributors additionally get `hogli sync:skill` to run the scout against the local
+harness for a tighter loop before merging.

--- a/products/signals/skills/authoring-signals-scouts/references/scout-anatomy.md
+++ b/products/signals/skills/authoring-signals-scouts/references/scout-anatomy.md
@@ -1,0 +1,217 @@
+# Scout anatomy
+
+A scout is a single `SKILL.md` (its body is loaded verbatim as the agent's system prompt)
+plus optional `references/` files read on demand. Keep the body lean and push depth into
+references — every line of the body is a recurring token cost on **every** run.
+
+## Naming
+
+The skill name **must** match `signals-scout-<scope>` — the harness discovers scouts by
+globbing `signals-scout-*`. `<scope>` is lowercase kebab-case naming the surface or
+question the scout watches: `signals-scout-error-tracking`, `signals-scout-checkout-funnel`,
+`signals-scout-mcp-feedback`. A skill named anything else is just a normal skill and never
+runs as a scout.
+
+## Frontmatter
+
+```yaml
+---
+name: signals-scout-<scope>
+description: >
+  One paragraph, third person. State the surface it watches, the specific shapes it
+  looks for (bursts, regressions, clusters, drops), that it emits only above the
+  confidence bar and otherwise writes memory and closes out empty, and that it's a
+  self-contained peer in the signals-scout-* fleet.
+compatibility: >
+  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
+  (read-only analytics plus signal_scout_internal:write for scratchpad and emit).
+  Assumes the signals-scout MCP family (project-profile-get, runs-list, runs-retrieve,
+  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus whatever
+  query tools the scope needs (e.g. execute-sql, read-data-schema,
+  query-error-tracking-issues-list, inbox-reports-list).
+metadata:
+  owner_team: signals # or the team that owns the scope
+  scope: <scope> # short machine label, e.g. error_tracking, csp_violations
+---
+```
+
+`name` and `description` are required and validated at build time. `compatibility` and
+`metadata` are optional but conventional — `compatibility` documents the scopes/tools the
+scout assumes; `metadata.scope` gives downstream tooling a short label.
+
+## Body structure
+
+The canonical body is a workflow, not a script — it reads like how an experienced analyst
+would approach the surface, and trusts the agent to adapt. The fleet's specialists all
+share this shape:
+
+1. **Identity + discriminator (the most important lines).** One sentence on what the scout
+   is, then **name the signal-vs-noise discriminator explicitly** and tell the agent to
+   internalize it. This is the cheap profile-shape read that separates "worth a look" from
+   "baseline". Examples: `count` vs `distinct_users` ratio (error tracking); reach over raw
+   count (CSP); negative+mixed share vs baseline (MCP feedback). Without this, the scout
+   wastes every run re-deciding what "normal" means.
+
+2. **Quick close-out.** A cheap early-exit so a quiet run costs almost nothing: if the
+   watched event is absent from the profile's `top_events` or sitting at baseline (no fresh
+   24h activity), write one scratchpad entry and stop. This keeps idle scouts cheap.
+
+   ```text
+   key:     not-in-use:<scope>:team{team_id}     # if the surface is absent entirely
+        or  pattern:<scope>:baseline-team{team_id} # if it fires at a steady baseline
+   content: "<surface> baseline ~{count}/day, no fresh 24h burst at {timestamp}"
+   ```
+
+3. **Orient.** Three cheap reads cold-start every run — bake them into the body:
+   - `signals-scout-scratchpad-search` (`text=<scope keyword>`) — durable steering from
+     past runs; the `pattern:` / `noise:` / `addressed:` / `dedupe:` entries tell the scout
+     what's normal and what's already covered.
+   - `signals-scout-runs-list` (last 7d) — what prior runs of this scout (and siblings)
+     found and ruled out. Pull `-runs-retrieve` only for a summary worth drilling into.
+   - `signals-scout-project-profile-get` — the deterministic snapshot; read the discriminator
+     metrics off the relevant `top_events` row.
+
+4. **Profile shape / discriminator table.** A small table mapping the discriminator's
+   shapes to what they usually mean, so the agent triages fast. (See the error-tracking
+   scout's `count`-vs-`distinct_users` table for the canonical example.)
+
+5. **Explore patterns.** 2–4 named investigation patterns — **starting points, not a
+   checklist**. Each names the concrete tools/queries to run and the shape that confirms it.
+   E.g. "Burst with broad reach" → list active issues, SQL hourly breakdown, look for the
+   one-occurrence-per-distinct-user shape. Give the agent real queries, not generic advice.
+
+6. **Save memory as you go.** Tell the scout to write scratchpad entries continuously,
+   encoding the category in the key prefix (see
+   [`dedupe-and-memory.md`](dedupe-and-memory.md)). Give 2–3 worked example entries scoped
+   to this surface so the agent matches the format.
+
+7. **Decide.** Emit / remember / skip, calibrated against the emit contract (see
+   [`emit-contract.md`](emit-contract.md)). State the surface-specific "strong finding"
+   thresholds (e.g. "weight ≥ 0.7, confidence ≥ 0.85, with concrete entity ids and counts
+   in the evidence"). Tell it to cross-check `inbox-reports-list` before emitting.
+
+8. **Disqualifiers.** The known noise for this surface that should be skipped (single-user
+   quirks, dev-env bursts, allowlisted domains, known upstream provider errors). "When in
+   doubt, write memory instead of emitting."
+
+9. **MCP tools.** List the direct (read-only) calls and the harness-level tools the scout
+   uses, so the agent doesn't rediscover them each run.
+
+10. **Close out.** One paragraph: looked at what, emitted what, remembered what, ruled out
+    what. The harness saves this as the run summary; future runs read it via
+    `signals-scout-runs-list`. Tell it **not** to write a separate "run metadata" scratchpad
+    entry — the summary already serves that role. "Looked but found nothing meaningful" is a
+    real outcome.
+
+Not every scout needs all ten sections, but every scout needs 1 (discriminator), 2 (quick
+close-out), 3 (orient), 7 (decide), 8 (disqualifiers), and 10 (close out). Sections 4–6 and
+9 are where a specialist earns its keep.
+
+## References
+
+The generalist carries two references the rest of the fleet reasons in terms of —
+`references/emit.md` (the emit contract) and `references/conventions.md` (the four-states
+classifier + scratchpad vocab). For a **per-team** scout you usually don't need to bundle
+your own copies — the canonical scout already encodes the conventions inline, and your
+scout body can too. Bundle a reference only when you have genuinely surface-specific depth
+(a long SQL cookbook, a taxonomy of fingerprints) that would bloat the body. Attach bundled
+files to a per-team scout with `posthog:llma-skill-file-create`; in the repo, drop them in
+`references/` and they're collected automatically.
+
+## Skeleton — specialist scout
+
+```markdown
+---
+name: signals-scout-<scope>
+description: >
+  Focused Signals scout for PostHog projects using <surface>. Watches <event/metric> for
+  <the shapes: bursts / regressions / clusters / drops>. Emits findings only when they
+  clear the confidence bar; otherwise writes durable memory and closes out empty.
+  Self-contained peer in the signals-scout-* fleet.
+compatibility: >
+  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
+  (read-only analytics plus signal_scout_internal:write). Assumes the signals-scout MCP
+  family plus <the query tools this scope needs>.
+metadata:
+  owner_team: <team>
+  scope: <scope>
+---
+
+# Signals scout: <surface>
+
+You are a focused <surface> scout. Spot meaningful changes in <event/metric> — <the
+shapes> — and emit findings only when they clear the confidence bar.
+
+<Name the discriminator here.> The relationship between <X> and <Y> is the most important
+signal-vs-noise discriminator. Internalize that shape.
+
+## Quick close-out: is <surface> even loud?
+
+If <event> is absent from `top_events` or at baseline (no fresh 24h activity), <surface>
+isn't where the signal is today. Cheap scratchpad entry + close out empty.
+
+## How a run works
+
+Cycle between these moves; skip what's not useful.
+
+### Get oriented
+
+- `signals-scout-scratchpad-search` (`text=<scope keyword>`) — durable steering.
+- `signals-scout-runs-list` (last 7d) — what prior runs found and ruled out.
+- `signals-scout-project-profile-get` — read the discriminator metrics off `top_events`.
+
+### Profile shape
+
+| Pattern   | What it usually means           |
+| --------- | ------------------------------- |
+| <shape A> | <meaning A — investigate first> |
+| <shape B> | <meaning B — usually noise>     |
+
+### Explore
+
+Patterns to watch — starting points, not a checklist.
+
+#### <Pattern 1>
+
+<the concrete queries/tools and the confirming shape>
+
+#### <Pattern 2>
+
+<...>
+
+### Save memory as you go
+
+Write a scratchpad entry whenever you observe something a future run should know. Encode the
+category in the key prefix — `pattern:`, `noise:`, `addressed:`, `dedupe:`.
+
+- key `pattern:<scope>:baseline` — "<normal shape for this project>"
+- key `dedupe:<scope>:<entity>` — "<surfaced when, with what condition for next run>"
+
+### Decide
+
+- **Emit** via `signals-scout-emit-signal` above the bar (weight ≥ 0.7, confidence ≥ 0.85,
+  concrete entity ids + counts in evidence). Cross-check `inbox-reports-list` first.
+- **Remember** if below the bar but worth carrying forward.
+- **Skip** if a `noise:` / `addressed:` / `dedupe:` entry already covers it.
+
+### Close out
+
+One paragraph: looked at what, emitted what, remembered what, ruled out what.
+
+## Disqualifiers (skip these)
+
+- <surface-specific noise: single-user, dev-env, allowlisted, known-upstream>
+
+## MCP tools
+
+Direct (read-only): <list>. Harness-level: project-profile-get, scratchpad-search,
+runs-list, runs-retrieve, emit-signal, scratchpad-remember.
+```
+
+## Skeleton — broad / cross-product scout
+
+Start from `signals-scout-general` instead. Its job is **cross-product correlations** and
+**surfaces no specialist covers** — it deliberately leaves single-surface deep dives to the
+specialists and rotates investigative lenses across runs to avoid lens-lock. Use this shape
+when your scout's question spans products (e.g. "deploy → error burst → revenue dip") rather
+than living inside one surface.


### PR DESCRIPTION
## Problem

PostHog ships a fleet of canonical Signals scouts (a cross-product generalist plus per-surface specialists), and they are also seeded into each enrolled team's Skills Store where users can edit or override them per-team. But there's no guidance for a user's agent on *how* to do that — how to adapt a canonical scout to a specific project, retune its thresholds, or write a brand-new scout from scratch for a use case the fleet doesn't cover. The scout SKILL.md anatomy, the emit contract, and the dedupe/memory conventions are all tacit knowledge living in the harness and the canonical scouts' own references.

This adds an official, user-facing skill that teaches a user's agent to author, edit, and adapt scouts — packaged and distributed as part of the PostHog AI plugin alongside `signals/` and `inbox-exploration/`.

## Changes

New skill at `products/signals/skills/authoring-signals-scouts/` (a first-party skill, not a scout — it flows through the normal `dist/skills.zip` → ai-plugin pipeline on merge):

- **`SKILL.md`** — the end-to-end workflow: ground the scout in the target project first (profile, existing configs, closest canonical scout, inbox), then choose *what* (adapt / new-from-scratch / config-only) and *where* (per-team via the skills store vs canonical in-repo), write it, set its run posture, and test via the dry-run-first loop.
- **`references/scout-anatomy.md`** — the `signals-scout-*` naming requirement, frontmatter schema, the canonical body structure, the lean-body rule, and copy-ready specialist + generalist skeletons.
- **`references/emit-contract.md`** — `emit-signal` fields, the weight-vs-confidence rubrics, severity, dedupe keys, `finding_id` semantics, the description prose contract, and a worked example.
- **`references/dedupe-and-memory.md`** — the four-states classifier, scratchpad key-prefix vocabulary, and cross-project noise patterns.
- **`references/lifecycle-and-testing.md`** — how scouts are discovered/scheduled/dispatched, the per-team (skills-store) vs canonical (in-repo) distribution mechanics, and the dry-run + inspect test loop.

The reference content intentionally inlines condensed-but-complete versions of the emit contract and conventions (rather than linking to `signals-scout-general/references/`) so the skill is self-contained once distributed outside the repo. Also registers the new skill in `products/signals/skills/AGENTS.md`.

This is a v1 — the intent is to evolve the scouts and this skill as we dogfood.

## How did you test this code?

I'm an agent (Claude Code). I ran `hogli lint:skills` (60 skills pass, including the new one) and confirmed the skill is discovered by the build pipeline via `hogli build:skills --list`. No runtime/automated tests apply — this is documentation-only skill content. Not manually exercised against a live scout run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). I mapped the signals-scout system from master (models, coordinator/scheduler/runner, the `lazy_seed` glob-based discovery, the emit pipeline) and read the existing canonical scouts and their references, plus an internal user-authored scout (`signals-scout-mcp-feedback`) as a concrete example of the per-team skills-store authoring path.

Key decisions:
- **Placed it with the official signals skills** (`products/signals/skills/`, not `posthog_ai/skills/`) so it ships in the same ai-plugin bundle as `signals/` and `inbox-exploration/`.
- **Framed two authoring paths** — per-team via the skills store (the common user path) as primary, canonical in-repo as secondary — and steered users to `duplicate` rather than edit-in-place when they only want an addition, to avoid "diverging" a canonical scout's row and losing upstream improvements.
- **Inlined condensed emit/conventions content** rather than cross-linking to the canonical scout's references, accepting some duplication so the distributed skill stands alone.
