### PR TITLE
feat(signals): add signals-scout-config-create MCP tool

### DIFF
--- a/products/signals/backend/scout_harness/serializers.py
+++ b/products/signals/backend/scout_harness/serializers.py
@@ -13,6 +13,7 @@ from rest_framework import serializers
 from posthog.schema import Severity
 
 from products.signals.backend.models import SignalScoutConfig
+from products.signals.backend.scout_harness.skill_loader import SIGNALS_SCOUT_SKILL_PREFIX
 from products.signals.backend.scout_harness.tools.scratchpad import MAX_SCRATCHPAD_CONTENT_LENGTH
 
 # --- Run history -----------------------------------------------------------
@@ -845,3 +846,40 @@ class SignalScoutConfigSerializer(serializers.ModelSerializer):
         model = SignalScoutConfig
         fields = ["id", "skill_name", "enabled", "emit", "run_interval_minutes", "last_run_at", "created_at"]
         read_only_fields = ["id", "created_at"]
+
+
+class SignalScoutConfigCreateSerializer(serializers.Serializer):
+    """Request body for creating (upserting) a per-scout config by `skill_name`.
+
+    Unlike `SignalScoutConfigSerializer` (update-by-id, `skill_name` fixed), this takes the
+    `skill_name` as the key so an author can set posture right after creating the scout skill,
+    without waiting for the coordinator's hourly tick to materialize the row. Omitted posture
+    fields keep their model defaults on create and stay untouched when the row already exists.
+    """
+
+    skill_name = serializers.CharField(
+        max_length=200,
+        help_text=(
+            "The `signals-scout-*` skill this config controls. Must already exist as a scout "
+            "skill on this project (author the skill first) and must start with `signals-scout-`."
+        ),
+    )
+    enabled = serializers.BooleanField(
+        required=False,
+        help_text="Whether this scout runs on its schedule (default true). Disabled scouts are skipped by the coordinator.",
+    )
+    emit = serializers.BooleanField(
+        required=False,
+        help_text="Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing.",
+    )
+    run_interval_minutes = serializers.IntegerField(
+        required=False,
+        min_value=10,
+        max_value=43200,
+        help_text="Minutes between runs (10–43200). The scout runs once this interval has elapsed since its last run.",
+    )
+
+    def validate_skill_name(self, value: str) -> str:
+        if not value.startswith(SIGNALS_SCOUT_SKILL_PREFIX):
+            raise serializers.ValidationError(f"Must start with `{SIGNALS_SCOUT_SKILL_PREFIX}`.")
+        return value

--- a/products/signals/backend/scout_harness/views.py
+++ b/products/signals/backend/scout_harness/views.py
@@ -39,6 +39,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
 from posthog.permissions import APIScopePermission
 
+from products.ai_observability.backend.models.skills import LLMSkill
 from products.signals.backend.models import SignalProjectProfile, SignalScoutConfig, SignalScoutRun
 from products.signals.backend.scout_harness.serializers import (
     EmitFindingRequestSerializer,
@@ -52,6 +53,7 @@ from products.signals.backend.scout_harness.serializers import (
     ScratchpadEntrySerializer,
     SearchMemoryQuerySerializer,
     SearchRecentRunsQuerySerializer,
+    SignalScoutConfigCreateSerializer,
     SignalScoutConfigSerializer,
     SignalScoutRunDetailSerializer,
     SignalScoutRunSummarySerializer,
@@ -518,6 +520,65 @@ class SignalScoutConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def list(self, request: Request, *args, **kwargs) -> Response:
         configs = SignalScoutConfig.objects.unscoped().filter(team_id=_canonical_team_id(self)).order_by("skill_name")
         return Response(SignalScoutConfigSerializer(configs, many=True).data)
+
+    @extend_schema(
+        request=SignalScoutConfigCreateSerializer,
+        responses={
+            200: OpenApiResponse(response=SignalScoutConfigSerializer, description="Existing config updated (upsert)."),
+            201: OpenApiResponse(response=SignalScoutConfigSerializer, description="New config created."),
+            400: OpenApiResponse(
+                description="`skill_name` has the wrong prefix, or no such scout skill exists on this project."
+            ),
+        },
+        summary="Create or update a scout config",
+        description=(
+            "Create the per-scout config for a `signals-scout-*` skill, or update it in place if "
+            "one already exists (upsert keyed on `skill_name`). Lets an author set `emit` (false = "
+            "dry-run), `run_interval_minutes`, and `enabled` immediately after creating the skill, "
+            "without waiting for the coordinator's hourly tick to materialize the row. The skill "
+            "must already exist on this project — author it first. Omitted posture fields keep their "
+            "defaults on create and are left untouched when the row already exists. Enabling records "
+            "`enabled_by` and is activity-logged since it drives spend."
+        ),
+        operation_id="signals_scout_config_create",
+    )
+    def create(self, request: Request, *args, **kwargs) -> Response:
+        serializer = SignalScoutConfigCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        skill_name = data["skill_name"]
+        team_id = _canonical_team_id(self)
+
+        # A config whose skill doesn't exist never runs — the coordinator dispatches by
+        # skill_name. Require the scout skill up front so the row can't dangle.
+        skill_exists = LLMSkill.objects.filter(team_id=team_id, name=skill_name, is_latest=True, deleted=False).exists()
+        if not skill_exists:
+            raise exceptions.ValidationError(
+                {"skill_name": f"No scout skill named '{skill_name}' on this project — author the skill first."}
+            )
+
+        existing = SignalScoutConfig.objects.unscoped().filter(team_id=team_id, skill_name=skill_name).first()
+        # Only the posture fields the caller actually sent: omitted fields fall to the model
+        # defaults on create and are left untouched on update (so setting just `emit` later
+        # doesn't reset the schedule).
+        posture = {field: data[field] for field in ("enabled", "emit", "run_interval_minutes") if field in data}
+
+        # Record who enabled the scout when the upsert leaves it enabled and it wasn't before,
+        # mirroring `partial_update` — enablement drives spend.
+        resulting_enabled = posture.get("enabled", existing.enabled if existing is not None else True)
+        was_enabled = existing.enabled if existing is not None else False
+        enabled_by = {"enabled_by": request.user} if resulting_enabled and not was_enabled else {}
+
+        config, created = SignalScoutConfig.objects.unscoped().update_or_create(
+            team_id=team_id,
+            skill_name=skill_name,
+            defaults={**posture, **enabled_by},
+            create_defaults={**posture, **enabled_by, "created_by": request.user},
+        )
+        return Response(
+            SignalScoutConfigSerializer(config).data,
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        )
 
     @extend_schema(
         request=SignalScoutConfigSerializer,

--- a/products/signals/backend/test/test_scout_harness_api.py
+++ b/products/signals/backend/test/test_scout_harness_api.py
@@ -18,6 +18,7 @@ from posthog.temporal.oauth import (
     create_oauth_access_token_for_user,
 )
 
+from products.ai_observability.backend.models.skills import LLMSkill
 from products.signals.backend.models import SignalProjectProfile, SignalScoutConfig, SignalScoutRun, SignalScratchpad
 from products.signals.backend.scout_harness.tools.profile import compute_project_profile
 from products.tasks.backend.models import Task, TaskRun
@@ -525,3 +526,49 @@ class TestScoutHarnessConfigAPI(APIBaseTest):
         config = SignalScoutConfig.all_teams.create(team=other_team, skill_name="signals-scout-foo")
         response = self.client.patch(self._detail_url(str(config.id)), data={"enabled": False}, format="json")
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def _create_scout_skill(self, name: str) -> LLMSkill:
+        return LLMSkill.objects.create(team=self.team, name=name, description="d", body="b")
+
+    def test_create_makes_config_when_skill_exists(self) -> None:
+        self._create_scout_skill("signals-scout-foo")
+
+        response = self.client.post(
+            self._list_url(),
+            data={"skill_name": "signals-scout-foo", "emit": True, "enabled": True, "run_interval_minutes": 30},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        config = SignalScoutConfig.objects.get(team=self.team, skill_name="signals-scout-foo")
+        assert config.emit is True
+        assert config.enabled is True
+        assert config.run_interval_minutes == 30
+        assert config.created_by_id == self.user.id
+        assert config.enabled_by_id == self.user.id
+
+    def test_create_upserts_existing_config_without_resetting_omitted_fields(self) -> None:
+        self._create_scout_skill("signals-scout-foo")
+        SignalScoutConfig.objects.create(
+            team=self.team, skill_name="signals-scout-foo", emit=False, run_interval_minutes=120
+        )
+
+        # Set only `emit` — the schedule must stay where it was.
+        response = self.client.post(
+            self._list_url(), data={"skill_name": "signals-scout-foo", "emit": True}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        config = SignalScoutConfig.objects.get(team=self.team, skill_name="signals-scout-foo")
+        assert config.emit is True
+        assert config.run_interval_minutes == 120
+
+    def test_create_rejects_non_scout_skill_name(self) -> None:
+        self._create_scout_skill("signals-scout-foo")
+        response = self.client.post(self._list_url(), data={"skill_name": "custom-helper"}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_create_rejects_when_skill_does_not_exist(self) -> None:
+        response = self.client.post(self._list_url(), data={"skill_name": "signals-scout-ghost"}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not SignalScoutConfig.objects.filter(team=self.team, skill_name="signals-scout-ghost").exists()

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -170,6 +170,32 @@ export interface SignalScoutConfigApi {
 }
 
 /**
+ * Request body for creating (upserting) a per-scout config by `skill_name`.
+
+Unlike `SignalScoutConfigSerializer` (update-by-id, `skill_name` fixed), this takes the
+`skill_name` as the key so an author can set posture right after creating the scout skill,
+without waiting for the coordinator's hourly tick to materialize the row. Omitted posture
+fields keep their model defaults on create and stay untouched when the row already exists.
+ */
+export interface SignalScoutConfigCreateApi {
+    /**
+     * The `signals-scout-*` skill this config controls. Must already exist as a scout skill on this project (author the skill first) and must start with `signals-scout-`.
+     * @maxLength 200
+     */
+    skill_name: string
+    /** Whether this scout runs on its schedule (default true). Disabled scouts are skipped by the coordinator. */
+    enabled?: boolean
+    /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. */
+    emit?: boolean
+    /**
+     * Minutes between runs (10–43200). The scout runs once this interval has elapsed since its last run.
+     * @minimum 10
+     * @maximum 43200
+     */
+    run_interval_minutes?: number
+}
+
+/**
  * Per-(team, skill) scout config: schedule, enablement, and emit posture.
 
 One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row

--- a/products/signals/frontend/generated/api.ts
+++ b/products/signals/frontend/generated/api.ts
@@ -26,6 +26,7 @@ import type {
     SignalReportApi,
     SignalReportStateRequestApi,
     SignalScoutConfigApi,
+    SignalScoutConfigCreateApi,
     SignalScoutRunDetailApi,
     SignalScoutRunSummaryApi,
     SignalSourceConfigApi,
@@ -214,6 +215,27 @@ export const signalsScoutConfigList = async (
     return apiMutator<SignalScoutConfigApi[]>(getSignalsScoutConfigListUrl(projectId), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getSignalsScoutConfigCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/signals/scout/configs/`
+}
+
+/**
+ * Create the per-scout config for a `signals-scout-*` skill, or update it in place if one already exists (upsert keyed on `skill_name`). Lets an author set `emit` (false = dry-run), `run_interval_minutes`, and `enabled` immediately after creating the skill, without waiting for the coordinator's hourly tick to materialize the row. The skill must already exist on this project — author it first. Omitted posture fields keep their defaults on create and are left untouched when the row already exists. Enabling records `enabled_by` and is activity-logged since it drives spend.
+ * @summary Create or update a scout config
+ */
+export const signalsScoutConfigCreate = async (
+    projectId: string,
+    signalScoutConfigCreateApi: SignalScoutConfigCreateApi,
+    options?: RequestInit
+): Promise<SignalScoutConfigApi> => {
+    return apiMutator<SignalScoutConfigApi>(getSignalsScoutConfigCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(signalScoutConfigCreateApi),
     })
 }
 

--- a/products/signals/frontend/generated/api.zod.ts
+++ b/products/signals/frontend/generated/api.zod.ts
@@ -68,6 +68,48 @@ export const SignalsReportsStateCreateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * Create the per-scout config for a `signals-scout-*` skill, or update it in place if one already exists (upsert keyed on `skill_name`). Lets an author set `emit` (false = dry-run), `run_interval_minutes`, and `enabled` immediately after creating the skill, without waiting for the coordinator's hourly tick to materialize the row. The skill must already exist on this project — author it first. Omitted posture fields keep their defaults on create and are left untouched when the row already exists. Enabling records `enabled_by` and is activity-logged since it drives spend.
+ * @summary Create or update a scout config
+ */
+export const signalsScoutConfigCreateBodySkillNameMax = 200
+
+export const signalsScoutConfigCreateBodyRunIntervalMinutesMin = 10
+export const signalsScoutConfigCreateBodyRunIntervalMinutesMax = 43200
+
+export const SignalsScoutConfigCreateBody = /* @__PURE__ */ zod
+    .object({
+        skill_name: zod
+            .string()
+            .max(signalsScoutConfigCreateBodySkillNameMax)
+            .describe(
+                'The `signals-scout-\*` skill this config controls. Must already exist as a scout skill on this project (author the skill first) and must start with `signals-scout-`.'
+            ),
+        enabled: zod
+            .boolean()
+            .optional()
+            .describe(
+                'Whether this scout runs on its schedule (default true). Disabled scouts are skipped by the coordinator.'
+            ),
+        emit: zod
+            .boolean()
+            .optional()
+            .describe(
+                'Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing.'
+            ),
+        run_interval_minutes: zod
+            .number()
+            .min(signalsScoutConfigCreateBodyRunIntervalMinutesMin)
+            .max(signalsScoutConfigCreateBodyRunIntervalMinutesMax)
+            .optional()
+            .describe(
+                'Minutes between runs (10–43200). The scout runs once this interval has elapsed since its last run.'
+            ),
+    })
+    .describe(
+        "Request body for creating (upserting) a per-scout config by `skill_name`.\n\nUnlike `SignalScoutConfigSerializer` (update-by-id, `skill_name` fixed), this takes the\n`skill_name` as the key so an author can set posture right after creating the scout skill,\nwithout waiting for the coordinator's hourly tick to materialize the row. Omitted posture\nfields keep their model defaults on create and stay untouched when the row already exists."
+    )
+
+/**
  * Tune one scout: change its schedule (`run_interval_minutes`), `enabled`, or `emit` (dry-run) posture. `skill_name` is fixed. Enabling records `enabled_by` and is activity-logged since it drives spend.
  * @summary Update a scout config
  */

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -179,22 +179,6 @@ tools:
             required; `enabled` and `config` are optional and keep their current values if omitted). Prefer
             `inbox-source-configs-partial-update` when you only need to flip `enabled` or tweak `config`. Enabling the
             session_analysis_cluster source requires the organization to have approved AI data processing.
-    signals-scout-config-list:
-        operation: signals_scout_config_list
-        enabled: true
-        scopes:
-            - signal_scout:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        list: true
-        title: List scout configs
-        description: >
-            List the per-scout configs for this project — one row per `signals-scout-*` skill, each with its schedule
-            (`run_interval_minutes`), `enabled` flag, and `emit` (dry-run) posture. Use this to see which scouts run,
-            how often, and whether they emit findings to the inbox. Pair with `signals-scout-config-update` to tune
-            them.
     signals-scout-config-create:
         operation: signals_scout_config_create
         enabled: true
@@ -211,6 +195,22 @@ tools:
             the inbox), `run_interval_minutes` (10–43200), and `enabled` at authoring time, without waiting for the
             coordinator to materialize the row on its next tick. The skill must already exist on this project — author
             it first. Omitted posture fields keep their defaults on create and are left untouched when the row exists.
+    signals-scout-config-list:
+        operation: signals_scout_config_list
+        enabled: true
+        scopes:
+            - signal_scout:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List scout configs
+        description: >
+            List the per-scout configs for this project — one row per `signals-scout-*` skill, each with its schedule
+            (`run_interval_minutes`), `enabled` flag, and `emit` (dry-run) posture. Use this to see which scouts run,
+            how often, and whether they emit findings to the inbox. Pair with `signals-scout-config-update` to tune
+            them.
     signals-scout-config-update:
         operation: signals_scout_config_update
         enabled: true

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -195,6 +195,22 @@ tools:
             (`run_interval_minutes`), `enabled` flag, and `emit` (dry-run) posture. Use this to see which scouts run,
             how often, and whether they emit findings to the inbox. Pair with `signals-scout-config-update` to tune
             them.
+    signals-scout-config-create:
+        operation: signals_scout_config_create
+        enabled: true
+        scopes:
+            - signal_scout:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Create or update a scout config
+        description: >
+            Create the per-scout config for a `signals-scout-*` skill, or update it in place if one already exists
+            (upsert keyed on `skill_name`). Set `emit` (false = dry-run: the scout runs and logs but writes nothing to
+            the inbox), `run_interval_minutes` (10–43200), and `enabled` at authoring time, without waiting for the
+            coordinator to materialize the row on its next tick. The skill must already exist on this project — author
+            it first. Omitted posture fields keep their defaults on create and are left untouched when the row exists.
     signals-scout-config-update:
         operation: signals_scout_config_update
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4879,6 +4879,20 @@
             "readOnlyHint": true
         }
     },
+    "signals-scout-config-create": {
+        "description": "Create the per-scout config for a `signals-scout-*` skill, or update it in place if one already exists (upsert keyed on `skill_name`). Set `emit` (false = dry-run: the scout runs and logs but writes nothing to the inbox), `run_interval_minutes` (10–43200), and `enabled` at authoring time, without waiting for the coordinator to materialize the row on its next tick. The skill must already exist on this project — author it first. Omitted posture fields keep their defaults on create and are left untouched when the row exists.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Create or update a scout config",
+        "title": "Create or update a scout config",
+        "required_scopes": ["signal_scout:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "signals-scout-config-list": {
         "description": "List the per-scout configs for this project — one row per `signals-scout-*` skill, each with its schedule (`run_interval_minutes`), `enabled` flag, and `emit` (dry-run) posture. Use this to see which scouts run, how often, and whether they emit findings to the inbox. Pair with `signals-scout-config-update` to tune them.",
         "category": "Signals",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5206,6 +5206,20 @@
             "readOnlyHint": true
         }
     },
+    "signals-scout-config-create": {
+        "description": "Create the per-scout config for a `signals-scout-*` skill, or update it in place if one already exists (upsert keyed on `skill_name`). Set `emit` (false = dry-run: the scout runs and logs but writes nothing to the inbox), `run_interval_minutes` (10–43200), and `enabled` at authoring time, without waiting for the coordinator to materialize the row on its next tick. The skill must already exist on this project — author it first. Omitted posture fields keep their defaults on create and are left untouched when the row exists.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Create or update a scout config",
+        "title": "Create or update a scout config",
+        "required_scopes": ["signal_scout:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "signals-scout-config-list": {
         "description": "List the per-scout configs for this project — one row per `signals-scout-*` skill, each with its schedule (`run_interval_minutes`), `enabled` flag, and `emit` (dry-run) posture. Use this to see which scouts run, how often, and whether they emit findings to the inbox. Pair with `signals-scout-config-update` to tune them.",
         "category": "Signals",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -38499,6 +38499,32 @@ export namespace Schemas {
     }
 
     /**
+     * Request body for creating (upserting) a per-scout config by `skill_name`.
+
+    Unlike `SignalScoutConfigSerializer` (update-by-id, `skill_name` fixed), this takes the
+    `skill_name` as the key so an author can set posture right after creating the scout skill,
+    without waiting for the coordinator's hourly tick to materialize the row. Omitted posture
+    fields keep their model defaults on create and stay untouched when the row already exists.
+     */
+    export interface SignalScoutConfigCreate {
+      /**
+         * The `signals-scout-*` skill this config controls. Must already exist as a scout skill on this project (author the skill first) and must start with `signals-scout-`.
+         * @maxLength 200
+         */
+      skill_name: string;
+      /** Whether this scout runs on its schedule (default true). Disabled scouts are skipped by the coordinator. */
+      enabled?: boolean;
+      /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. */
+      emit?: boolean;
+      /**
+         * Minutes between runs (10–43200). The scout runs once this interval has elapsed since its last run.
+         * @minimum 10
+         * @maximum 43200
+         */
+      run_interval_minutes?: number;
+    }
+
+    /**
      * Full `SignalScoutRun` projection used by `get-run`. Same shape as the summary
     today; kept distinct so future detail-only extensions (linked Signal rows,
     LLMA token-cost join) can land here without bloating the list response.

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 17 enabled ops
+ * PostHog API - MCP 18 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -130,6 +130,56 @@ export const SignalsScoutConfigListParams = /* @__PURE__ */ zod.object({
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
 })
+
+/**
+ * Create the per-scout config for a `signals-scout-*` skill, or update it in place if one already exists (upsert keyed on `skill_name`). Lets an author set `emit` (false = dry-run), `run_interval_minutes`, and `enabled` immediately after creating the skill, without waiting for the coordinator's hourly tick to materialize the row. The skill must already exist on this project — author it first. Omitted posture fields keep their defaults on create and are left untouched when the row already exists. Enabling records `enabled_by` and is activity-logged since it drives spend.
+ * @summary Create or update a scout config
+ */
+export const SignalsScoutConfigCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const signalsScoutConfigCreateBodySkillNameMax = 200
+
+export const signalsScoutConfigCreateBodyRunIntervalMinutesMin = 10
+export const signalsScoutConfigCreateBodyRunIntervalMinutesMax = 43200
+
+export const SignalsScoutConfigCreateBody = /* @__PURE__ */ zod
+    .object({
+        skill_name: zod
+            .string()
+            .max(signalsScoutConfigCreateBodySkillNameMax)
+            .describe(
+                'The `signals-scout-*` skill this config controls. Must already exist as a scout skill on this project (author the skill first) and must start with `signals-scout-`.'
+            ),
+        enabled: zod
+            .boolean()
+            .optional()
+            .describe(
+                'Whether this scout runs on its schedule (default true). Disabled scouts are skipped by the coordinator.'
+            ),
+        emit: zod
+            .boolean()
+            .optional()
+            .describe(
+                'Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing.'
+            ),
+        run_interval_minutes: zod
+            .number()
+            .min(signalsScoutConfigCreateBodyRunIntervalMinutesMin)
+            .max(signalsScoutConfigCreateBodyRunIntervalMinutesMax)
+            .optional()
+            .describe(
+                'Minutes between runs (10–43200). The scout runs once this interval has elapsed since its last run.'
+            ),
+    })
+    .describe(
+        "Request body for creating (upserting) a per-scout config by `skill_name`.\n\nUnlike `SignalScoutConfigSerializer` (update-by-id, `skill_name` fixed), this takes the\n`skill_name` as the key so an author can set posture right after creating the scout skill,\nwithout waiting for the coordinator's hourly tick to materialize the row. Omitted posture\nfields keep their model defaults on create and stay untouched when the row already exists."
+    )
 
 /**
  * Tune one scout: change its schedule (`run_interval_minutes`), `enabled`, or `emit` (dry-run) posture. `skill_name` is fixed. Enabling records `enabled_by` and is activity-logged since it drives spend.

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -7,6 +7,7 @@ import {
     SignalsReportsRetrieveParams,
     SignalsReportsStateCreateBody,
     SignalsReportsStateCreateParams,
+    SignalsScoutConfigCreateBody,
     SignalsScoutConfigUpdateBody,
     SignalsScoutConfigUpdateParams,
     SignalsScoutEmitSignalBody,
@@ -299,6 +300,35 @@ const signalsScoutConfigList = (): ToolBase<
     },
 })
 
+const SignalsScoutConfigCreateSchema = SignalsScoutConfigCreateBody
+
+const signalsScoutConfigCreate = (): ToolBase<typeof SignalsScoutConfigCreateSchema, Schemas.SignalScoutConfig> => ({
+    name: 'signals-scout-config-create',
+    schema: SignalsScoutConfigCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof SignalsScoutConfigCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.skill_name !== undefined) {
+            body['skill_name'] = params.skill_name
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        if (params.emit !== undefined) {
+            body['emit'] = params.emit
+        }
+        if (params.run_interval_minutes !== undefined) {
+            body['run_interval_minutes'] = params.run_interval_minutes
+        }
+        const result = await context.api.request<Schemas.SignalScoutConfig>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/scout/configs/`,
+            body,
+        })
+        return result
+    },
+})
+
 const SignalsScoutConfigUpdateSchema = SignalsScoutConfigUpdateParams.omit({ project_id: true }).extend(
     SignalsScoutConfigUpdateBody.shape
 )
@@ -523,6 +553,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'inbox-source-configs-retrieve': inboxSourceConfigsRetrieve,
     'inbox-source-configs-update': inboxSourceConfigsUpdate,
     'signals-scout-config-list': signalsScoutConfigList,
+    'signals-scout-config-create': signalsScoutConfigCreate,
     'signals-scout-config-update': signalsScoutConfigUpdate,
     'signals-scout-emit-signal': signalsScoutEmitSignal,
     'signals-scout-project-profile-get': signalsScoutProjectProfileGet,

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -281,25 +281,6 @@ const inboxSourceConfigsUpdate = (): ToolBase<typeof InboxSourceConfigsUpdateSch
     },
 })
 
-const SignalsScoutConfigListSchema = z.object({})
-
-const signalsScoutConfigList = (): ToolBase<
-    typeof SignalsScoutConfigListSchema,
-    WithPostHogUrl<Schemas.SignalScoutConfig[]>
-> => ({
-    name: 'signals-scout-config-list',
-    schema: SignalsScoutConfigListSchema,
-    // eslint-disable-next-line no-unused-vars
-    handler: async (context: Context, params: z.infer<typeof SignalsScoutConfigListSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.SignalScoutConfig[]>({
-            method: 'GET',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/scout/configs/`,
-        })
-        return await withPostHogUrl(context, result, '/inbox')
-    },
-})
-
 const SignalsScoutConfigCreateSchema = SignalsScoutConfigCreateBody
 
 const signalsScoutConfigCreate = (): ToolBase<typeof SignalsScoutConfigCreateSchema, Schemas.SignalScoutConfig> => ({
@@ -326,6 +307,25 @@ const signalsScoutConfigCreate = (): ToolBase<typeof SignalsScoutConfigCreateSch
             body,
         })
         return result
+    },
+})
+
+const SignalsScoutConfigListSchema = z.object({})
+
+const signalsScoutConfigList = (): ToolBase<
+    typeof SignalsScoutConfigListSchema,
+    WithPostHogUrl<Schemas.SignalScoutConfig[]>
+> => ({
+    name: 'signals-scout-config-list',
+    schema: SignalsScoutConfigListSchema,
+    // eslint-disable-next-line no-unused-vars
+    handler: async (context: Context, params: z.infer<typeof SignalsScoutConfigListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.SignalScoutConfig[]>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/scout/configs/`,
+        })
+        return await withPostHogUrl(context, result, '/inbox')
     },
 })
 
@@ -552,8 +552,8 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'inbox-source-configs-partial-update': inboxSourceConfigsPartialUpdate,
     'inbox-source-configs-retrieve': inboxSourceConfigsRetrieve,
     'inbox-source-configs-update': inboxSourceConfigsUpdate,
-    'signals-scout-config-list': signalsScoutConfigList,
     'signals-scout-config-create': signalsScoutConfigCreate,
+    'signals-scout-config-list': signalsScoutConfigList,
     'signals-scout-config-update': signalsScoutConfigUpdate,
     'signals-scout-emit-signal': signalsScoutEmitSignal,
     'signals-scout-project-profile-get': signalsScoutProjectProfileGet,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-config-create.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Request body for creating (upserting) a per-scout config by `skill_name`.\n\nUnlike `SignalScoutConfigSerializer` (update-by-id, `skill_name` fixed), this takes the\n`skill_name` as the key so an author can set posture right after creating the scout skill,\nwithout waiting for the coordinator's hourly tick to materialize the row. Omitted posture\nfields keep their model defaults on create and stay untouched when the row already exists.",
+    "properties": {
+        "emit": {
+            "description": "Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing.",
+            "type": "boolean"
+        },
+        "enabled": {
+            "description": "Whether this scout runs on its schedule (default true). Disabled scouts are skipped by the coordinator.",
+            "type": "boolean"
+        },
+        "run_interval_minutes": {
+            "description": "Minutes between runs (10–43200). The scout runs once this interval has elapsed since its last run.",
+            "maximum": 43200,
+            "minimum": 10,
+            "type": "number"
+        },
+        "skill_name": {
+            "description": "The `signals-scout-*` skill this config controls. Must already exist as a scout skill on this project (author the skill first) and must start with `signals-scout-`.",
+            "maxLength": 200,
+            "type": "string"
+        }
+    },
+    "required": ["skill_name"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

When a user authors a per-team Signals scout (a `signals-scout-*` skill), they can't configure that scout's run posture until the coordinator discovers it and materializes a `SignalScoutConfig` row on its next hourly tick. Until then there's no row to edit, so `emit` / `run_interval_minutes` / `enabled` can't be set — the "author a skill, get a scout" flow dead-ends at posture configuration.

The MCP surface only had `signals-scout-config-list` (read) and `signals-scout-config-update` (update-by-id, which can't bootstrap a row). There was no way to create the config at authoring time.

Part of the scout authoring-UX work (beads-tracking-xr6g). Independent of the companion PR that flips the `emit` default to true.

## Changes

- Added a `create` action to `SignalScoutConfigViewSet`, exposed as the **`signals-scout-config-create`** MCP tool (scope `signal_scout:write`).
- **Upsert semantics keyed on `skill_name`**: if the coordinator already materialized the row, the call updates it in place rather than erroring on the `unique(team, skill_name)` constraint — so the agent never has to branch on whether the row exists yet. Returns `201` on create, `200` on update.
- **Omitted posture fields keep model defaults on create and are left untouched on update**, so a later call setting just `emit` doesn't reset the schedule.
- **Requires the `signals-scout-*` skill to already exist** on the project (rejects with `400` otherwise — author the skill first) and enforces the `signals-scout-` prefix.
- Records `created_by` / `enabled_by` and preserves the existing enable activity logging.
- Regenerated OpenAPI types and MCP tool definitions (`hogli build:openapi`).

## How did you test this code?

I'm an agent (Claude Code). Automated tests I actually ran locally (all passing):

- New: `test_create_makes_config_when_skill_exists`, `test_create_upserts_existing_config_without_resetting_omitted_fields`, `test_create_rejects_non_scout_skill_name`, `test_create_rejects_when_skill_does_not_exist` (in `TestScoutHarnessConfigAPI`).
- Full `test_scout_harness_api.py` suite (42 tests) green.

Also verified the generated MCP tool/Zod schema (`skill_name` required, posture fields optional with bounds, `POST` returning `SignalScoutConfig`) and that `hogli build:openapi` regenerates cleanly.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Andy's direction. Of the three options the bead floated (upsert-via-update, dedicated create tool, create-at-skill-author-time), we chose a dedicated `create` verb with upsert semantics — discoverable for an agent, but idempotent so it's safe to call regardless of whether the coordinator already created the row, which avoids coupling the generic `llma-skill-create` path to the signals product. Decisions confirmed with Andy: upsert behind `create`, and require the skill to exist (rejects orphan configs).
