### PR TITLE
fix(cdp): return hidden templates on authenticated project list

### DIFF
--- a/products/cdp/backend/api/hog_function_template.py
+++ b/products/cdp/backend/api/hog_function_template.py
@@ -145,8 +145,14 @@ class PublicHogFunctionTemplateViewSet(
             if self.request.GET.get("template_id"):
                 queryset = queryset.filter(template_id=self.request.GET["template_id"])
 
-            # Don't include deprecated or hidden templates when listing, regardless of mount
-            queryset = queryset.exclude(status="deprecated").exclude(status="hidden")
+            queryset = queryset.exclude(status="deprecated")
+
+            # Hidden templates (e.g. template-posthog-capture, template-posthog-update-person-properties,
+            # email, twilio, webhook) are internal building blocks. The workflow editor needs them on
+            # the authenticated project mount to render action configuration; the frontend hides them
+            # from the destinations chooser separately. Only strip them from the anonymous catalog.
+            if self.request.path.startswith("/api/public_hog_function_templates"):
+                queryset = queryset.exclude(status="hidden")
 
         return queryset
 

--- a/products/cdp/backend/api/test/test_hog_function_templates.py
+++ b/products/cdp/backend/api/test/test_hog_function_templates.py
@@ -305,7 +305,11 @@ class TestHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMatchingTe
         retrieve_response = self.client.get(f"/api/projects/{self.team.id}/hog_function_templates/template-hidden")
         assert retrieve_response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
 
-    def test_hidden_templates_excluded_from_project_list(self):
+    def test_hidden_templates_included_in_project_list(self):
+        # Hidden templates are internal building blocks (e.g. template-posthog-capture,
+        # template-posthog-update-person-properties, email, twilio). The workflow editor pulls them
+        # via the authenticated project list to render action configuration; the destinations chooser
+        # filters them client-side. Excluding them server-side breaks workflows containing those steps.
         HogFunctionTemplate.objects.create(
             template_id="template-hidden",
             sha="1.0.0",
@@ -321,6 +325,25 @@ class TestHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMatchingTe
         )
 
         response = self.client.get(f"/api/projects/{self.team.id}/hog_function_templates/")
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert "template-hidden" in [template["id"] for template in response.json()["results"]]
+
+    def test_hidden_templates_excluded_from_public_catalog(self):
+        HogFunctionTemplate.objects.create(
+            template_id="template-hidden",
+            sha="1.0.0",
+            name="Hidden Template",
+            description="A hidden template",
+            code="return event",
+            code_language="hog",
+            inputs_schema={},
+            type="destination",
+            status="hidden",
+            category=["Other"],
+            free=True,
+        )
+
+        response = self.client.get("/api/public_hog_function_templates/")
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert "template-hidden" not in [template["id"] for template in response.json()["results"]]
 


### PR DESCRIPTION
## Problem

After the recent scoping fix on the hog function templates API (#61901, follow-up #61920), the workflow editor stopped loading several built-in actions (Capture event, Update person properties, Group identify, Set variable). Workflows containing those steps couldn't be rendered, updated, or created.

The workflow editor loads every template via `/api/projects/:id/hog_function_templates/` and uses the resulting map to render each step's icon and configuration. The PostHog action templates — plus email, twilio, native_webhook, and ticket templates — are intentionally marked `status: 'hidden'` so they don't clutter the destinations chooser, but they are required by workflows. The scoping fix excluded `hidden` templates from list responses on every mount, so they never reached the frontend.

## Changes

`PublicHogFunctionTemplateViewSet.filter_queryset` now strips `status="hidden"` only on the anonymous public catalog (`/api/public_hog_function_templates`). The authenticated project-nested mount returns them again — the frontend already filters hidden status out of the destinations chooser separately via `shouldShowHogFunctionTemplate`.

Replaced `test_hidden_templates_excluded_from_project_list` (which pinned the broken behavior) with `test_hidden_templates_included_in_project_list`, and added `test_hidden_templates_excluded_from_public_catalog` to lock in the anonymous-catalog rule. The anonymous-access test from the scoping fix is unchanged — authentication is still required on the project route.

## How did you test this code?

I'm an agent. I did not run the test suite locally — the project venv on this machine is missing `pkg_resources`, so pytest couldn't import Django. CI will run the suite.

What I did check locally:
- Syntax-validated both modified Python files.
- Traced the workflow editor's template fetch (`workflowLogic.ts` → `api.hogFunctions.listTemplates`) to confirm it relies on the authenticated project list.
- Confirmed the affected template ids (`template-posthog-capture`, `template-posthog-update-person-properties`, `template-posthog-group-identify`, `template-posthog-set-variable`, plus `email`, `twilio`, etc.) are defined with `status: 'hidden'` in `nodejs/src/cdp/templates/_destinations/…`.
- Verified the frontend already filters hidden templates from the destinations chooser via `shouldShowHogFunctionTemplate`, so there's no chooser regression.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Diagnosis: bisected to `filter_queryset` in `hog_function_template.py:148`. The scoping PR moved the `exclude(status="hidden")` out of the public-path branch and applied it to all list calls; the follow-up only restored auth, not the filter. Considered alternatives (filtering hidden in the frontend only / introducing a separate "internal" status / passing `?include_hidden=1` from workflows) but they all required changing more code than necessary and the original split (anonymous catalog hides them, authenticated list shows them) already matches the trust boundary now that the project mount requires auth.