### PR TITLE
fix(signals): bound CH readiness wait so grouping throughput can't collapse

### DIFF
--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -850,6 +850,9 @@ BATCH_SIZE = 5
 BATCH_DEBOUNCE_SECONDS = 5
 TYPE_EXAMPLES_CACHE_TTL = timedelta(minutes=5)
 
+# Per-batch ClickHouse readiness wait (Step 7). Paid on grouping's serialized critical path, so keep it short.
+CH_READINESS_WAIT_SECONDS = 120
+
 
 @dataclass
 class _ProcessedBatchSignal:
@@ -1198,22 +1201,38 @@ async def _process_signal_batch(
                 source_id=signal.source_id,
             )
 
-    # Step 7: Wait for all emitted signals to land in CH so the next batch can find them
+    # Step 7: best-effort wait for emitted signals to land in CH so the next batch can match them.
+    # The batch's assign + embed work is already committed above, so this is never fatal to the batch.
     if emitted_signals:
-        await workflow.execute_activity(
-            wait_for_signal_in_clickhouse_activity,
-            WaitForClickHouseInput(
-                team_id=team_id,
-                signals=[
-                    WaitForClickHouseSignal(signal_id=sid, timestamp=result.timestamp)
-                    for sid, result in emitted_signals
-                ],
-                max_wait_time_seconds=3600,
-            ),
-            start_to_close_timeout=timedelta(hours=1, minutes=5),
-            heartbeat_timeout=timedelta(minutes=2),
-            retry_policy=RetryPolicy(maximum_attempts=2),
+        _PATCH_CH_WAIT_NON_FATAL = "ch-readiness-wait-non-fatal-v1"
+        non_fatal_wait = workflow.patched(_PATCH_CH_WAIT_NON_FATAL)
+        wait_input = WaitForClickHouseInput(
+            team_id=team_id,
+            signals=[
+                WaitForClickHouseSignal(signal_id=sid, timestamp=result.timestamp) for sid, result in emitted_signals
+            ],
+            max_wait_time_seconds=CH_READINESS_WAIT_SECONDS if non_fatal_wait else 3600,
         )
+        if non_fatal_wait:
+            try:
+                await workflow.execute_activity(
+                    wait_for_signal_in_clickhouse_activity,
+                    wait_input,
+                    start_to_close_timeout=timedelta(seconds=CH_READINESS_WAIT_SECONDS + 120),
+                    heartbeat_timeout=timedelta(minutes=2),
+                    retry_policy=RetryPolicy(maximum_attempts=2),
+                )
+            except Exception:
+                # Readiness wait failed; the next batch may not yet match these signals (eventual dedup).
+                logger.warning("ClickHouse readiness wait failed; proceeding", team_id=team_id)
+        else:
+            await workflow.execute_activity(
+                wait_for_signal_in_clickhouse_activity,
+                wait_input,
+                start_to_close_timeout=timedelta(hours=1, minutes=5),
+                heartbeat_timeout=timedelta(minutes=2),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            )
 
     # Spawn summary workflows after CH wait. Stable ID + ALLOW_DUPLICATE: Temporal rejects concurrent
     # starts with the same ID (caught below); re-spawning is allowed only if the previous run has closed.

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -353,7 +353,6 @@ async def wait_for_signal_in_clickhouse_activity(input: WaitForClickHouseInput) 
 
     team = await Team.objects.aget(pk=input.team_id)
     inserted_at_threshold = timezone.now() - timedelta(minutes=30)
-    max_attempts = max(1, input.max_wait_time_seconds // WAIT_POLL_INTERVAL_SECONDS)
 
     signal_ids = [s.signal_id for s in input.signals]
     timestamps = [s.timestamp for s in input.signals]
@@ -384,7 +383,12 @@ async def wait_for_signal_in_clickhouse_activity(input: WaitForClickHouseInput) 
 
     expected_count = len(signal_ids)
 
-    for attempt in range(max_attempts):
+    # Bound by wall-clock, not attempt count: an attempt budget can demand more sleep than
+    # start_to_close allows, making the graceful return below unreachable so the activity
+    # times out and raises instead of proceeding.
+    deadline = timezone.now() + timedelta(seconds=input.max_wait_time_seconds)
+    attempt = 0
+    while timezone.now() < deadline:
         temporalio.activity.heartbeat(attempt)
 
         result = await execute_hogql_query_with_retry(
@@ -408,12 +412,16 @@ async def wait_for_signal_in_clickhouse_activity(input: WaitForClickHouseInput) 
             )
             return
 
-        # Sleep in chunks so we keep heartbeating during the poll interval
-        remaining = WAIT_POLL_INTERVAL_SECONDS
-        while remaining > 0:
-            chunk = min(remaining, 5)
+        attempt += 1
+
+        # Sleep up to one poll interval before the next query, in small chunks so we keep
+        # heartbeating, and never past the deadline.
+        sleep_until = min(timezone.now() + timedelta(seconds=WAIT_POLL_INTERVAL_SECONDS), deadline)
+        while timezone.now() < sleep_until:
+            chunk = min(5.0, (sleep_until - timezone.now()).total_seconds())
+            if chunk <= 0:
+                break
             await asyncio.sleep(chunk)
-            remaining -= chunk
             temporalio.activity.heartbeat(attempt)
 
     logger.warning(

--- a/products/signals/backend/test/test_signal_ch_wait.py
+++ b/products/signals/backend/test/test_signal_ch_wait.py
@@ -1,0 +1,67 @@
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from temporalio.testing import ActivityEnvironment
+
+from products.signals.backend.temporal.signal_queries import (
+    WaitForClickHouseInput,
+    WaitForClickHouseSignal,
+    wait_for_signal_in_clickhouse_activity,
+)
+
+_QUERY = "products.signals.backend.temporal.signal_queries.execute_hogql_query_with_retry"
+_AGET = "products.signals.backend.temporal.signal_queries.Team.objects.aget"
+_SLEEP = "products.signals.backend.temporal.signal_queries.asyncio.sleep"
+
+
+def _input(max_wait_time_seconds: int) -> WaitForClickHouseInput:
+    return WaitForClickHouseInput(
+        team_id=1,
+        signals=[WaitForClickHouseSignal(signal_id="sig-a", timestamp=datetime(2026, 1, 1, tzinfo=UTC))],
+        max_wait_time_seconds=max_wait_time_seconds,
+    )
+
+
+def _count(n: int) -> SimpleNamespace:
+    return SimpleNamespace(results=[[n]])
+
+
+@pytest.mark.asyncio
+async def test_returns_as_soon_as_signals_land():
+    query = AsyncMock(side_effect=[_count(0), _count(1)])
+    with (
+        patch(_QUERY, query),
+        patch(_AGET, AsyncMock(return_value=object())),
+        patch(_SLEEP, AsyncMock()),
+    ):
+        await ActivityEnvironment().run(wait_for_signal_in_clickhouse_activity, _input(120))
+    assert query.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_gives_up_at_deadline_without_raising():
+    # When signals never land, the activity must reach its graceful return before the
+    # caller's start_to_close timeout — i.e. bounded by max_wait_time, never an infinite poll.
+    clock = {"now": datetime(2026, 6, 1, tzinfo=UTC)}
+
+    def fake_now() -> datetime:
+        return clock["now"]
+
+    async def fake_sleep(seconds: float) -> None:
+        clock["now"] += timedelta(seconds=seconds)
+
+    query = AsyncMock(return_value=_count(0))
+    with (
+        patch(_QUERY, query),
+        patch(_AGET, AsyncMock(return_value=object())),
+        patch("django.utils.timezone.now", fake_now),
+        patch(_SLEEP, fake_sleep),
+    ):
+        await ActivityEnvironment().run(wait_for_signal_in_clickhouse_activity, _input(60))
+
+    # 60s budget / 10s poll interval → a handful of polls, then a clean return (no raise).
+    assert 2 <= query.await_count <= 8
+    assert clock["now"] >= datetime(2026, 6, 1, tzinfo=UTC) + timedelta(seconds=60)


### PR DESCRIPTION
## Problem

Signals emitted into a team's pipeline can silently stop landing in `document_embeddings` (and so never form reports or hit the inbox), even though emission reports success. The cause is a throughput collapse in per-team grouping, traced to the per-batch "wait for emitted signals to land in ClickHouse" readiness barrier (`wait_for_signal_in_clickhouse_activity`, grouping.py "Step 7").

That activity used an **attempt-count** budget (`max_wait_time_seconds // poll_interval` → 360 polls × 10s = 3600s of sleep) while its caller set `start_to_close_timeout` to 3900s. Once the budget's sleep alone approached the timeout, the activity's graceful "proceeding anyway" return became unreachable: it hit `start_to_close` and **raised** instead. The raise fails the batch, and the grouping workflow re-queues the failed batch at the head of its buffer and `continue_as_new`s — so a deterministically-timing-out batch is retried forever, head-of-line-blocking the team's serialized pipeline. Throughput drops far below inflow and low-volume sources starve first.

A second issue compounds it: the barrier blocks up to an hour **synchronously on the critical path of every batch**, even though by the time it runs the batch's real work (assign to report + emit embedding) is already committed. It only exists as a freshness hint so the *next* batch can semantic-match against this batch's signals.

## Changes

- **`signal_queries.py`** — bound the poll loop by **wall-clock** (`max_wait_time_seconds`) instead of an attempt count, so the activity always reaches its graceful return before `start_to_close` and never raises on timeout. This fixes the budget bug for every caller (grouping, reingestion, deletion) and is activity-internal, so it carries no workflow-replay risk.
- **`grouping.py`** — on the grouping hot path, make the readiness wait **short (120s) and non-fatal**: a timeout/failure is logged and skipped rather than failing the batch, since the batch's work is already committed. Worst case, the next batch matches against not-yet-landed embeddings and dedup happens eventually. Gated behind a `workflow.patched()` id so in-flight workflows replay deterministically.

The deeper redesign (taking the readiness barrier off the per-batch critical path entirely) is left as a follow-up; these changes stop the collapse and break the poison-pill loop.

## How did you test this code?

I'm an agent (Claude Code). Automated tests I actually ran:

- Added `products/signals/backend/test/test_signal_ch_wait.py` (2 tests, pass): returns as soon as signals land; gives up at the wall-clock deadline without raising (deterministic fake clock) — the regression that previously let the activity time out and poison-pill the batch.
- `products/signals/backend/test/test_parallel_grouping.py` — 38 existing tests pass.
- ruff + `ty check` via the pre-commit hook.

No manual/prod testing performed in this change.

## 🤖 Agent context

Authored with Claude Code (Opus) during a multi-session investigation of missing signals. Root cause was confirmed live in production via read-only Temporal workflow inspection: a team's grouping workflow was wedged on `wait_for_signal_in_clickhouse_activity` with `last_failure="activity StartToClose timeout"` and a multi-thousand-batch backlog, with the workflow `continue_as_new`-ing without ever reaching `Failed` status (which is why earlier "look for failed workflows" passes found nothing).

Decisions: fixed the budget bug at the activity level (no patch needed, benefits all call sites) and only changed call-site behaviour on the hot grouping path, behind a workflow patch for replay safety. Considered also adding a general per-batch poison-pill retry cap in `grouping_v2.py`; left it out to keep this PR focused — worth a follow-up as defense-in-depth for non-wait batch failures.
