### PR TITLE
refactor(frontend): de-key remaining shallow scenes

### DIFF
--- a/frontend/src/scenes/cohorts/cohortSceneLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortSceneLogic.ts
@@ -1,6 +1,5 @@
 import { kea, path, props, selectors } from 'kea'
 
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -13,7 +12,6 @@ import type { cohortSceneLogicType } from './cohortSceneLogicType'
 
 export const cohortSceneLogic = kea<cohortSceneLogicType>([
     props({} as CohortLogicProps),
-    tabAwareScene(),
     path(['scenes', 'cohorts', 'cohortLogic']),
 
     selectors({

--- a/frontend/src/scenes/cohorts/cohortsSceneLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortsSceneLogic.ts
@@ -7,7 +7,6 @@ import { PaginationManual, Sorting } from '@posthog/lemon-ui'
 
 import api, { CountedPaginatedResponse } from 'lib/api'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { objectsEqual } from 'lib/utils'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
@@ -41,7 +40,6 @@ const COHORTS_PER_PAGE = 100
 
 export const cohortsSceneLogic = kea<cohortsSceneLogicType>([
     path(['scenes', 'cohorts', 'cohortsSceneLogic']),
-    tabAwareScene(),
     connect(() => ({
         actions: [exportsLogic, ['startExport']],
     })),

--- a/frontend/src/scenes/persons/personsSceneLogic.ts
+++ b/frontend/src/scenes/persons/personsSceneLogic.ts
@@ -5,7 +5,6 @@ import { urlToAction } from 'kea-router'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
@@ -40,7 +39,6 @@ export const PEOPLE_LIST_DEFAULT_QUERY = buildDefaultQuery(false)
 
 export const personsSceneLogic = kea<personsSceneLogicType>([
     path(['scenes', 'persons', 'personsSceneLogic']),
-    tabAwareScene(),
 
     connect({ values: [teamLogic, ['currentTeam']] }),
 

--- a/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
+++ b/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
@@ -2,7 +2,6 @@ import { actions, connect, kea, path, reducers, selectors } from 'kea'
 import { router, urlToAction } from 'kea-router'
 
 import { FunnelLayout } from 'lib/constants'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { capitalizeFirstLetter, getDefaultInterval, wordPluralize } from 'lib/utils'
 import { sceneConfigurations } from 'scenes/scenes'
@@ -83,7 +82,6 @@ const setQueryParams = (params: Record<string, string>): string => {
 
 export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>([
     path(['scenes', 'customerAnalytics', 'customerAnalyticsScene']),
-    tabAwareScene(),
     connect(() => ({
         values: [
             customerAnalyticsConfigLogic,

--- a/products/metrics/frontend/metricsSceneLogic.tsx
+++ b/products/metrics/frontend/metricsSceneLogic.tsx
@@ -3,7 +3,6 @@ import { router, urlToAction } from 'kea-router'
 
 import { syncSearchParams, updateSearchParams } from '@posthog/products-error-tracking/frontend/utils'
 
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { sqlEditorLogic } from 'scenes/data-warehouse/editor/sqlEditorLogic'
 import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
@@ -24,7 +23,6 @@ export interface MetricsLogicProps {
 export const metricsSceneLogic = kea<metricsSceneLogicType>([
     props({} as MetricsLogicProps),
     path(['products', 'metrics', 'frontend', 'metricsSceneLogic']),
-    tabAwareScene(),
     actions({
         setActiveTab: (activeTab: MetricsSceneActiveTab) => ({ activeTab }),
         keepSqlEditorMounted: (editorTabId: string) => ({ editorTabId }),

--- a/products/replay_vision/frontend/observations/replayObservationSceneLogic.ts
+++ b/products/replay_vision/frontend/observations/replayObservationSceneLogic.ts
@@ -1,7 +1,6 @@
 import { actions, kea, path, props, reducers, selectors } from 'kea'
 import { urlToAction } from 'kea-router'
 
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { urls } from 'scenes/urls'
 
 import { Breadcrumb } from '~/types'
@@ -15,7 +14,6 @@ export interface ReplayObservationSceneLogicProps {
 export const replayObservationSceneLogic = kea<replayObservationSceneLogicType>([
     path(['products', 'replay_vision', 'frontend', 'observations', 'replayObservationSceneLogic']),
     props({} as ReplayObservationSceneLogicProps),
-    tabAwareScene(),
 
     actions({
         setObservationId: (observationId: string) => ({ observationId }),

--- a/products/replay_vision/frontend/replay_scanners/replayScannerSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerSceneLogic.ts
@@ -1,7 +1,6 @@
 import { actions, kea, path, props, reducers, selectors } from 'kea'
 import { router, urlToAction } from 'kea-router'
 
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { urls } from 'scenes/urls'
 
@@ -17,7 +16,6 @@ export interface ReplayScannerSceneLogicProps {
 export const replayScannerSceneLogic = kea<replayScannerSceneLogicType>([
     path(['products', 'replay_vision', 'frontend', 'replay_scanners', 'replayScannerSceneLogic']),
     props({} as ReplayScannerSceneLogicProps),
-    tabAwareScene(),
 
     actions({
         setScannerId: (scannerId: string) => ({ scannerId }),

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
@@ -3,7 +3,6 @@ import { actions, afterMount, kea, listeners, path, props, reducers, selectors }
 import { router, urlToAction } from 'kea-router'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -148,7 +147,6 @@ function parseSortParam(value: unknown): ScannersSorting | null {
 export const replayScannersLogic = kea<replayScannersLogicType>([
     path(['products', 'replay_vision', 'frontend', 'replay_scanners', 'replayScannersLogic']),
     props({} as ReplayScannersLogicProps),
-    tabAwareScene(),
 
     actions({
         loadScanners: true,

--- a/products/workflows/frontend/TemplateLibrary/messageTemplateSceneLogic.ts
+++ b/products/workflows/frontend/TemplateLibrary/messageTemplateSceneLogic.ts
@@ -1,6 +1,5 @@
 import { kea, path, props, selectors } from 'kea'
 
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -18,7 +17,6 @@ export interface MessageTemplateSceneLogicProps {
 export const messageTemplateSceneLogic = kea<messageTemplateSceneLogicType>([
     path(['products', 'workflows', 'frontend', 'messageTemplateSceneLogic']),
     props({} as MessageTemplateSceneLogicProps),
-    tabAwareScene(),
     selectors({
         breadcrumbs: [
             (_, p) => [p.id],

--- a/products/workflows/frontend/WorkflowsScene.tsx
+++ b/products/workflows/frontend/WorkflowsScene.tsx
@@ -10,7 +10,6 @@ import { TeamMembershipLevel } from 'lib/constants'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { IconSlack, IconTwilio } from 'lib/lemon-ui/icons'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { addProductIntent } from 'lib/utils/product-intents'
@@ -43,7 +42,6 @@ export type WorkflowsSceneProps = {
 export const workflowsSceneLogic = kea<workflowsSceneLogicType>([
     props({} as WorkflowsSceneProps),
     path(() => ['scenes', 'workflows', 'workflowsSceneLogic']),
-    tabAwareScene(),
     actions({
         setCurrentTab: (tab: WorkflowsSceneTab) => ({ tab }),
     }),


### PR DESCRIPTION
## Problem

PostHog's in-app tabs are gone, but many scene logics are still keyed by a per-tab `tabId` via `tabAwareScene()`. With a single tab there is nothing to key on. This is one of a series of small PRs in a stack that removes that scaffolding; it continues the earlier shallow de-key PRs by clearing the scenes those PRs left out.

## Changes

Drop `tabAwareScene()` (and its import) from the 10 remaining *shallow* scene logics — ones that used `tabId` only for the root key, with no child logic keyed on it:

- cohorts: `cohortSceneLogic`, `cohortsSceneLogic`
- persons: `personsSceneLogic`
- customer analytics: `customerAnalyticsSceneLogic`
- metrics: `metricsSceneLogic`
- message templates: `messageTemplateSceneLogic`
- workflows: `workflowsSceneLogic`
- replay vision: `replayScannerSceneLogic`, `replayScannersLogic`, `replayObservationSceneLogic`

Each logic becomes a singleton. Vestigial `tabId` props remain (still provided by `sceneLogic`) and are harmless until the later core-collapse PR removes them. No behavioural change. The deeper, child-keyed scene trees (insight, experiment, SQL editor, endpoints, logs, tracing) are handled in follow-up PRs.

## How did you test this code?

I'm an agent (PostHog Code) — automated testing only. Ran the affected scene-logic jest suites locally (`personsSceneLogic`, `cohortsSceneLogic`): 11/11 pass, confirming the logics work as singletons even when tests still construct them with a `{ tabId }` prop. `oxlint` and `oxfmt` are clean on the changed files. Full typecheck and the rest of the suite run in CI. This mirrors the earlier shallow de-key PRs in this stack, which made the identical change and left their tests untouched.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

Authored with PostHog Code (Claude) as part of a planned Graphite stack that fully removes in-app tab scaffolding in small, independently-reviewable steps. Plan: de-key "shallow" scenes mechanically first (this PR), then the child-keyed "deep" trees one area at a time (each fixing its own fallback-less keys / `activeTabId` guards), then collapse `sceneLogic`'s `tabs[]` to single-scene state, then delete dead helpers and docs. The convention here matches the merged shallow de-key PRs: remove only `tabAwareScene()` and its import, leaving singleton-safe vestigial `tabId` props for the final collapse to clean up. Each scene's depth (shallow vs child-keyed, fallback-less keys, `activeTabId` reads) was mapped before grouping.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
