### PR TITLE
refactor(frontend): de-key tracing and new-source scenes

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
@@ -17,7 +17,6 @@ import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { useFloatingContainer } from 'lib/hooks/useFloatingContainerContext'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { nonHogFunctionTemplatesLogic } from 'scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic'
@@ -61,7 +60,6 @@ export interface NewSourceSceneLogicProps {
 export const newSourceSceneLogic = kea<newSourceSceneLogicType>([
     path(['products', 'dataWarehouse', 'newSourceSceneLogic']),
     props({} as NewSourceSceneLogicProps),
-    tabAwareScene(),
     connect(() => ({
         values: [availableSourcesLogic, ['availableSources', 'availableSourcesLoading']],
     })),

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -38,8 +38,7 @@ export const scene: SceneExport<TracingSceneLogicProps> = {
 
 export default function TracingScene(props: TracingSceneLogicProps = {}): JSX.Element {
     const sceneLogic = tracingSceneLogic(props)
-    // Keep filters + data logic alive across tab switches by attaching them to the scene
-    // root. The root itself is kept mounted by `tabAwareScene()` even when the tab is inactive.
+    // Keep filters + data logic alive across React unmounts by attaching them to the scene root.
     useAttachedLogic(tracingFiltersLogic({ tabId: props.tabId }), sceneLogic)
     useAttachedLogic(tracingDataLogic({ tabId: props.tabId }), sceneLogic)
 

--- a/products/tracing/frontend/tracingSceneLogic.ts
+++ b/products/tracing/frontend/tracingSceneLogic.ts
@@ -4,7 +4,6 @@ import { router, urlToAction } from 'kea-router'
 import posthog from 'posthog-js'
 
 import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { parseTagsFilter } from 'lib/utils'
 import { Params } from 'scenes/sceneTypes'
@@ -23,7 +22,6 @@ export interface TracingSceneLogicProps {
 export const tracingSceneLogic = kea<tracingSceneLogicType>([
     props({} as TracingSceneLogicProps),
     path(['products', 'tracing', 'frontend', 'tracingSceneLogic']),
-    tabAwareScene(),
 
     connect((p: TracingSceneLogicProps) => ({
         values: [


### PR DESCRIPTION
## Problem

PostHog's in-app tabs are gone, but several scene logics are still keyed by a per-tab `tabId` via `tabAwareScene()`. With one tab there is nothing to key on. This continues the stack that removes that scaffolding one area at a time.

## Changes

De-key the tracing and new-source scenes:

- `tracingSceneLogic` and `newSourceSceneLogic` used `tabId` only for the `tabAwareScene()` root key — dropped it from both, so each is now a singleton.
- Refreshed a stale comment in `TracingScene` that explained child-logic mounting "via `tabAwareScene()`"; `useAttachedLogic` still keeps the filters/data logics mounted across React unmounts.

These are safe because the child logics they thread `tabId` into — `tracingDataLogic`, `tracingFiltersLogic`, `sourceWizardLogic` — already key with a `?? 'default'` fallback, so they degrade to a single bucket. Vestigial `tabId` threading, the `TracingTabIdProvider` context, and NewSource's `tabId` guard are left untouched; they become no-ops cleaned up by the later `sceneLogic` collapse. No behavioural change.

## How did you test this code?

Agent (PostHog Code), automated only. Ran the `tracingDataLogic` and `sourceWizardLogic` jest suites locally: 49/49 pass (these exercise the threaded child logics). `oxlint`/`oxfmt` clean on the changed files. Full typecheck + suite run in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

Authored with PostHog Code (Claude), part of the in-app-tab removal stack. After de-keying the shallow scenes, this clears the two "deep but safe" trees — tracing and new-source thread `tabId` into children, but those children key with `?? 'default'`, so only the root wrapper needs removing for the app to be tab-free here. The remaining tab-keyed trees (insight, experiment, SQL editor, endpoints, logs) carry real crash-risk fixes (fallback-less child keys, `tabSceneUtils` reads, an `activeTabId` guard) and are being done as individual PRs.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
