### PR TITLE
feat(taxonomic-filter): emit legacy telemetry contract from the rebuild menu

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
@@ -20,6 +20,11 @@ jest.mock('~/queries/query', () => ({
     performQuery: jest.fn(),
 }))
 
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: jest.fn() },
+}))
+
 jest.mock('lib/api', () => {
     const emptyPaginated = (): Promise<{ results: any[]; count: number; next: null }> =>
         Promise.resolve({ results: [], count: 0, next: null })
@@ -38,6 +43,7 @@ jest.mock('lib/api', () => {
 })
 
 const apiGet = jest.requireMock('lib/api').default.get as jest.MockedFunction<any>
+const captureMock = jest.requireMock('posthog-js').default.capture as jest.Mock
 
 function renderCombobox(): ReturnType<typeof render> {
     return render(
@@ -96,6 +102,7 @@ describe('MenuFilterCombobox', () => {
     beforeEach(() => {
         __clearTaxonomicResourceCache()
         apiGet.mockReset()
+        captureMock.mockClear()
         ;(performQuery as jest.Mock).mockResolvedValue({ tables: {}, joins: [] })
         useMocks({})
         initKeaTests()
@@ -400,5 +407,56 @@ describe('MenuFilterCombobox', () => {
         await user.click(screen.getByRole('combobox', { name: 'Filter category' }))
         expect(await screen.findByRole('option', { name: 'Recent' })).toBeInTheDocument()
         expect(screen.getByRole('option', { name: 'Pinned' })).toBeInTheDocument()
+    })
+
+    it('captures `taxonomic filter item selected` with the legacy contract on row click', async () => {
+        const user = userEvent.setup()
+        apiGet.mockResolvedValue({ results: [], count: 0 })
+
+        renderAll({
+            groupTypes: [TaxonomicFilterGroupType.Events],
+            recentEntries: [makeEntry(TaxonomicFilterGroupType.Events, 'pageview', 'Events')],
+        })
+
+        await waitFor(() => expect(document.querySelector('[data-slot="taxonomic-filter-menu-row"]')).toBeTruthy())
+        await user.click(document.querySelector('[data-slot="taxonomic-filter-menu-row"]') as HTMLElement)
+
+        expect(captureMock).toHaveBeenCalledWith(
+            'taxonomic filter item selected',
+            expect.objectContaining({
+                sourceGroupType: TaxonomicFilterGroupType.Events,
+                wasFromRecents: true,
+                wasFromPinnedList: false,
+                wasQuickFilter: false,
+                hadSearchInput: false,
+                position: 0,
+            })
+        )
+    })
+
+    it('captures debounced `taxonomic_filter_search_query` for a typed query', async () => {
+        apiGet.mockResolvedValue({ results: [], count: 0 })
+
+        renderAll({ groupTypes: [TaxonomicFilterGroupType.Events], searchQuery: 'pageview' })
+
+        await waitFor(() =>
+            expect(captureMock).toHaveBeenCalledWith(
+                'taxonomic_filter_search_query',
+                expect.objectContaining({ searchQuery: 'pageview', inputMode: 'typed', pastedFraction: 0 })
+            )
+        )
+    })
+
+    it('captures `taxonomic filter empty result` for a no-match search', async () => {
+        apiGet.mockResolvedValue({ results: [], count: 0 })
+
+        renderAll({ groupTypes: [TaxonomicFilterGroupType.Events], searchQuery: 'zzz_no_match' })
+
+        await waitFor(() =>
+            expect(captureMock).toHaveBeenCalledWith(
+                'taxonomic filter empty result',
+                expect.objectContaining({ searchQuery: 'zzz_no_match' })
+            )
+        )
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -80,6 +80,10 @@ const HIDDEN_FROM_CHIPS: ReadonlySet<TaxonomicFilterGroupType> = new Set([
  *  the pill variant's top-3 face. */
 const RECENT_PINNED_PREFIX_LIMIT = 3
 
+/** Debounce before emitting `taxonomic_filter_search_query` — matches the
+ *  legacy picker so the search telemetry is comparable across variants. */
+const SEARCH_QUERY_DEBOUNCE_MS = 500
+
 /** Identity for an entry's underlying definition — source group + value.
  *  Uses `::` as separator to serve as a dedup key (distinct from DOM ids). */
 function entryKey(entry: MenuFilterEntry): string {
@@ -496,6 +500,79 @@ export function MenuFilterCombobox({
         }
     }, [filtered.length, showChips, activeChip, drillTo, groups, searchQuery, isAnyLoading])
 
+    // --- Telemetry parity ---------------------------------------------------
+    // Emit the legacy `taxonomic filter *` contract so the rebuild is
+    // comparable to the control/pill variants by feature-flag value (PostHog
+    // auto-attaches the active flag to every event). The meta scopes
+    // (all/recent/pinned) have no single source group, so groupType is
+    // undefined there — matching how legacy reports the active content tab.
+    const telemetryGroupType = useMemo<TaxonomicFilterGroupType | undefined>(() => {
+        const scope = showChips ? activeChip : drillTo
+        return scope === 'all' || scope === 'recent' || scope === 'pinned' ? undefined : scope
+    }, [showChips, activeChip, drillTo])
+
+    const pastedCharsRef = useRef(0)
+
+    // `taxonomic_filter_search_query` — debounced; `inputMode`/`pastedFraction`
+    // distinguish typed vs pasted input.
+    useEffect(() => {
+        const trimmed = searchQuery.trim()
+        if (!trimmed) {
+            return
+        }
+        const timer = setTimeout(() => {
+            const pastedChars = pastedCharsRef.current
+            pastedCharsRef.current = 0
+            const totalLength = searchQuery.length
+            const inputMode =
+                pastedChars >= totalLength && pastedChars > 0 ? 'pasted' : pastedChars > 0 ? 'mixed' : 'typed'
+            posthog.capture('taxonomic_filter_search_query', {
+                searchQuery,
+                groupType: telemetryGroupType,
+                inputMode,
+                pastedFraction: totalLength > 0 ? Math.min(1, pastedChars / totalLength) : 0,
+            })
+        }, SEARCH_QUERY_DEBOUNCE_MS)
+        return () => clearTimeout(timer)
+    }, [searchQuery, telemetryGroupType])
+
+    // `taxonomic filter empty result` — once per scope+query when a real search
+    // returns nothing. `emptyState.body` marks the "type more" prompt, which is
+    // not an empty result.
+    const emptyResultFiredRef = useRef<Set<string>>(new Set())
+    useEffect(() => {
+        const trimmed = searchQuery.trim()
+        if (!emptyState || emptyState.body || !trimmed) {
+            return
+        }
+        const key = `${telemetryGroupType ?? 'all'}::${trimmed}`
+        if (emptyResultFiredRef.current.has(key)) {
+            return
+        }
+        emptyResultFiredRef.current.add(key)
+        posthog.capture('taxonomic filter empty result', {
+            groupType: telemetryGroupType,
+            searchQuery: trimmed,
+        })
+    }, [emptyState, searchQuery, telemetryGroupType])
+
+    const captureItemSelected = useCallback(
+        (entry: MenuFilterEntry, position: number): void => {
+            const key = entryKey(entry)
+            posthog.capture('taxonomic filter item selected', {
+                groupType: entry.group.type,
+                sourceGroupType: entry.group.type,
+                wasFromRecents: recentKeys.has(key),
+                wasFromPinnedList: pinnedKeys.has(key),
+                wasQuickFilter: false,
+                hadSearchInput: !!searchQuery.trim(),
+                position,
+                query: searchQuery.trim() || undefined,
+            })
+        },
+        [recentKeys, pinnedKeys, searchQuery]
+    )
+
     const headerTitle =
         title ??
         (drillTo === 'all'
@@ -585,6 +662,9 @@ export function MenuFilterCombobox({
                                             data-attr="menu-filter-search"
                                             placeholder={activePlaceholder}
                                             onKeyDown={handleInputKeyDown}
+                                            onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
+                                                pastedCharsRef.current += e.clipboardData.getData('text').length
+                                            }}
                                         />
                                     }
                                     value={searchQuery}
@@ -690,7 +770,10 @@ export function MenuFilterCombobox({
                                             // signal that with a chevron.
                                             opensSubmenu={drillTo === TaxonomicFilterGroupType.DataWarehouse}
                                             selectedRowId={selectedRowId}
-                                            onCommit={onCommit}
+                                            onSelect={() => {
+                                                captureItemSelected(entry, filtered.indexOf(entry))
+                                                onCommit(entry)
+                                            }}
                                         />
                                     )}
                                 </Autocomplete.Collection>
@@ -718,7 +801,8 @@ interface RowProps {
     opensSubmenu?: boolean
     /** DOM id of the currently-selected row (for the trailing checkmark). */
     selectedRowId?: string | null
-    onCommit: CommitFn
+    /** Commit this row (also fires item-selected telemetry). */
+    onSelect: () => void
 }
 
 /**
@@ -745,7 +829,7 @@ function resolveRowCells(entry: MenuFilterEntry): { name: string; value?: string
     return { name: entry.name, category: entry.group.name }
 }
 
-function Row({ entry, showCategory, recency, opensSubmenu, selectedRowId, onCommit }: RowProps): JSX.Element {
+function Row({ entry, showCategory, recency, opensSubmenu, selectedRowId, onSelect }: RowProps): JSX.Element {
     const { name, value, category } = resolveRowCells(entry)
     const stableId = rowDomId(entry)
     const isSelected = selectedRowId === stableId
@@ -754,7 +838,7 @@ function Row({ entry, showCategory, recency, opensSubmenu, selectedRowId, onComm
             value={entry}
             onClick={(e) => {
                 e.preventDefault()
-                onCommit(entry)
+                onSelect()
             }}
             data-slot="taxonomic-filter-menu-row"
             className={cn(

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -158,10 +158,18 @@ export function TaxonomicFilterMenu({
             })
         } else if (previous !== 'closed' && next === 'closed') {
             const closedAt = Date.now()
+            const dwellMs = openedAtRef.current ? closedAt - openedAtRef.current : null
             posthog.capture('taxonomic filter menu closed', {
-                dwellMs: openedAtRef.current ? closedAt - openedAtRef.current : null,
+                dwellMs,
                 hadCommit: hadCommitRef.current,
                 lastState: previous,
+            })
+            // Legacy `taxonomic filter *` contract — emitted alongside the
+            // menu-specific events so the rebuild is comparable to the
+            // control/pill variants by feature-flag value.
+            posthog.capture('taxonomic filter closed', {
+                dwellMs,
+                hadSelection: hadCommitRef.current,
             })
             lastMenuClosedAtMs = closedAt
             openedAtRef.current = null


### PR DESCRIPTION
## Problem

We A/B test the TaxonomicFilter across variants. The rebuild menu emitted its own `taxonomic filter menu *` events, which don't match the `taxonomic filter *` contract the control/pill variants emit — so the arms couldn't be compared apples-to-apples. (PostHog auto-attaches the active feature flag to every event, so matching event names + property shapes is all that's needed to compare by arm.)

## Changes

Emit the legacy contract from the menu's own surfaces, alongside the existing menu-specific events:

- `taxonomic filter item selected` (on row click) — `sourceGroupType`, `wasFromRecents`, `wasFromPinnedList`, `wasQuickFilter`, `hadSearchInput`, `position`, `query`
- `taxonomic_filter_search_query` — debounced (500ms), with `inputMode` (typed/mixed/pasted) + `pastedFraction`
- `taxonomic filter empty result` — once per scope+query on a no-match search (not the "type more" prompt)
- `taxonomic filter closed` — `dwellMs` + `hadSelection`, from the menu's open/close lifecycle

Property shapes mirror the legacy emitters in `taxonomicFilterLogic` / `infiniteListLogic`. The meta scopes (All/Recent/Pinned) have no single source group, so `groupType` is undefined there.

## How did you test this code?

I'm an agent (PostHog Code) — no manual QA. Added RTL tests (`menu/Combobox.test.tsx`): item-selected fires with the legacy shape on row click (recency + position), the debounced search-query event fires for a typed query, and empty-result fires for a no-match search. Full `TaxonomicFilter/` jest suite green (398); `tsc` clean on the changed files.

## 🤖 Agent context

Authored with PostHog Code (Claude). This PR was originally telemetry wiring on the headless `Panel` (via a `useTaxonomicTelemetry` hook). That surface isn't rendered in production — the menu Combobox is, and its lifecycle (stays mounted across open/close) doesn't fit the hook's unmount-based `closed`. So the PR was repointed: emit the contract directly from the menu's surfaces (Combobox for select/search/empty, the menu state machine for closed). The headless hook was dropped.

The old PR for this branch (#61669) was auto-closed when its base branch was deleted during the stack rework; this is its replacement, re-based on the recents/pinned-scoping PR.

Telemetry property shapes are a public contract — they were kept identical to the legacy events so dashboards keep working across both arms.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
