### PR TITLE
feat(insights): add animated hog loading state for trends charts

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -163,7 +163,8 @@ export function InsightVizDisplay({
 
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {
-        if (insightDataLoading) {
+        // Fresh load — no previous result to show behind the loader
+        if (insightDataLoading && insightData?.result == null) {
             return (
                 <InsightLoadingState
                     queryId={queryId}

--- a/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
@@ -4,6 +4,7 @@ import { drawArea, drawGrid, drawHighlightPoint, drawLine, drawPoints } from '..
 import type { DrawContext } from '../../core/canvas-renderer'
 import { Chart } from '../../core/Chart'
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
+import { dimColor } from '../../core/color-utils'
 import {
     buildSegmentResolveValue,
     buildStackedPositionValue,
@@ -35,6 +36,9 @@ interface LineChartPrivate {
     __lineChart: ScaleSet
 }
 
+const DEFAULT_LINE_GLOW_BLUR = 5
+const LINE_GLOW_ALPHA = 0.5
+
 export interface LineChartProps<Meta = unknown> {
     series: Series<Meta>[]
     labels: string[]
@@ -47,6 +51,8 @@ export interface LineChartProps<Meta = unknown> {
     dataAttr?: string
     children?: React.ReactNode
     onError?: (error: Error, info: React.ErrorInfo) => void
+    /** Draw the empty scaled grid (no data line) and show the loading hog. */
+    loading?: boolean
 }
 
 export function LineChart<Meta = unknown>({ onError, ...rest }: LineChartProps<Meta>): React.ReactElement {
@@ -67,8 +73,10 @@ function LineChartInner<Meta = unknown>({
     className,
     dataAttr,
     children,
+    loading = false,
 }: LineChartProps<Meta>): React.ReactElement {
-    const { yScaleType = 'linear', percentStackView = false, showGrid = false, valueDomain } = config ?? {}
+    const { yScaleType = 'linear', percentStackView = false, showGrid = false, valueDomain, lineGlow } = config ?? {}
+    const glowBlur = lineGlow === true ? DEFAULT_LINE_GLOW_BLUR : typeof lineGlow === 'number' ? lineGlow : 0
 
     const hasMultipleFilledSeries = useMemo(() => {
         const filledSeries = series.filter((s) => s.fill && !s.fill.lowerData)
@@ -148,7 +156,15 @@ function LineChartInner<Meta = unknown>({
     )
 
     const drawStatic = useCallback(
-        ({ ctx, dimensions, scales, series: coloredSeries, labels: drawLabels, theme }: ChartDrawArgs) => {
+        ({
+            ctx,
+            dimensions,
+            scales,
+            series: coloredSeries,
+            labels: drawLabels,
+            theme,
+            revealProgress = 1,
+        }: ChartDrawArgs) => {
             const d3Scales = (scales._private as LineChartPrivate | undefined)?.__lineChart
             if (!d3Scales) {
                 return
@@ -171,6 +187,12 @@ function LineChartInner<Meta = unknown>({
                 drawGrid(baseDrawCtx, { gridColor: theme.gridColor })
             }
 
+            // While loading, draw the real grid/scales but no data line — the shimmer + hog render
+            // on top via the overlay layer.
+            if (loading) {
+                return
+            }
+
             // Clip data drawing to the plot area so an overlay series with values outside
             // the y-domain (e.g. a trendline projecting below 0) doesn't bleed into the
             // axis-label gutter beneath the chart. A small pad on top/bottom keeps strokes
@@ -187,6 +209,11 @@ function LineChartInner<Meta = unknown>({
             )
             ctx.clip()
 
+            // Fade the data in as a load completes — grid (drawn above) stays at full opacity.
+            if (revealProgress < 1) {
+                ctx.globalAlpha = revealProgress
+            }
+
             for (const s of coloredSeries) {
                 if (s.visibility?.excluded) {
                     continue
@@ -200,14 +227,24 @@ function LineChartInner<Meta = unknown>({
                     drawArea(drawCtx, s, yValues, s.fill.lowerData ?? band?.bottom)
                 }
                 if (!s.fill?.lowerData) {
-                    drawLine(drawCtx, s, yValues)
+                    if (glowBlur > 0) {
+                        ctx.save()
+                        // Translucent halo (crisp stroke stays opaque) so overlapping near-baseline
+                        // series don't compound into one bright band.
+                        ctx.shadowColor = dimColor(s.color, LINE_GLOW_ALPHA)
+                        ctx.shadowBlur = glowBlur
+                        drawLine(drawCtx, s, yValues)
+                        ctx.restore()
+                    } else {
+                        drawLine(drawCtx, s, yValues)
+                    }
                     drawPoints(drawCtx, s, yValues)
                 }
             }
 
             ctx.restore()
         },
-        [showGrid, stackedData]
+        [showGrid, stackedData, loading, glowBlur]
     )
 
     const drawHover = useCallback(
@@ -259,6 +296,7 @@ function LineChartInner<Meta = unknown>({
             dataAttr={dataAttr}
             resolveValue={resolveValue}
             resolvePositionValue={resolvePositionValue}
+            loading={loading}
         >
             {children}
         </Chart>

--- a/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import { Meta, StoryObj } from '@storybook/react'
 
 import type { Series } from '../../core/types'
@@ -246,6 +248,32 @@ export const DateAxis: Story = {
                     </div>
                 ))}
             </div>
+        )
+    },
+}
+
+export const Loading: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const [loading, setLoading] = useState(true)
+        return (
+            <Stage>
+                <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', gap: 12 }}>
+                    <TimeSeriesLineChart
+                        series={SERIES}
+                        labels={DAYS}
+                        theme={theme}
+                        config={{ yAxis: { showGrid: true } }}
+                        loading={loading}
+                    />
+                    <button
+                        onClick={() => setLoading((v) => !v)}
+                        style={{ alignSelf: 'center', padding: '4px 16px', cursor: 'pointer' }}
+                    >
+                        {loading ? 'Stop loading' : 'Start loading'}
+                    </button>
+                </div>
+            </Stage>
         )
     },
 }

--- a/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -48,6 +48,8 @@ export interface TimeSeriesLineChartConfig {
     showCrosshair?: boolean
     /** Tooltip behaviour (pinning, placement). Tooltip *content* is the `tooltip` render prop. */
     tooltip?: TooltipConfig
+    /** Soft glow around each line, in the line's own color. `true` for the default blur, or a px radius. */
+    lineGlow?: boolean | number
 }
 
 export interface TimeSeriesLineChartProps<Meta = unknown> {
@@ -61,6 +63,8 @@ export interface TimeSeriesLineChartProps<Meta = unknown> {
     className?: string
     children?: React.ReactNode
     onError?: (error: Error, info: React.ErrorInfo) => void
+    /** Show the PostHog logo loading animation over the chart. */
+    loading?: boolean
 }
 
 export function TimeSeriesLineChart<Meta = unknown>({
@@ -74,6 +78,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
     className,
     children,
     onError,
+    loading,
 }: TimeSeriesLineChartProps<Meta>): React.ReactElement {
     const {
         xAxis,
@@ -87,6 +92,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
         percentStackView,
         showCrosshair,
         tooltip: tooltipConfig,
+        lineGlow,
     } = config ?? {}
     const xTickFormatter = useXTickFormatter(xAxis, labels)
     const yTickFormatter = useYTickFormatter(yAxis)
@@ -123,6 +129,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
         showCrosshair,
         tooltip: tooltipConfig,
         valueDomain,
+        lineGlow,
     }
 
     return (
@@ -136,6 +143,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
             className={className}
             dataAttr={dataAttr}
             onError={onError}
+            loading={loading}
         >
             {referenceLines.length > 0 && <ReferenceLines lines={referenceLines} />}
             {valueLabelsConfig && <ValueLabels valueFormatter={valueLabelFormatter} />}

--- a/packages/quill/packages/charts/src/components/ChartLoadingOverlay/ChartLoadingOverlay.stories.tsx
+++ b/packages/quill/packages/charts/src/components/ChartLoadingOverlay/ChartLoadingOverlay.stories.tsx
@@ -1,0 +1,47 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { Stage } from '../../story-helpers'
+import { ChartLoadingOverlay, HogLoader } from './ChartLoadingOverlay'
+
+const meta: Meta = { title: 'Components/HogCharts/ChartLoadingOverlay', parameters: { layout: 'centered' } }
+export default meta
+
+type Story = StoryObj<{}>
+
+export const Loader: Story = {
+    render: () => (
+        <Stage width={200} height={120}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
+                <HogLoader size={80} />
+            </div>
+        </Stage>
+    ),
+}
+
+export const SmallLoader: Story = {
+    render: () => (
+        <Stage width={200} height={120}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
+                <HogLoader size={40} />
+            </div>
+        </Stage>
+    ),
+}
+
+export const OverlaidOnChart: Story = {
+    render: () => (
+        <Stage width={480} height={240}>
+            <div style={{ position: 'relative', width: '100%', height: '100%', background: 'var(--bg-surface-primary, #fff)', borderRadius: 8 }}>
+                {/* Simulate a chart skeleton */}
+                <svg width="100%" height="100%" style={{ opacity: 0.08 }}>
+                    <line x1="48" y1="16" x2="48" y2="200" stroke="currentColor" strokeWidth="1" />
+                    <line x1="48" y1="200" x2="464" y2="200" stroke="currentColor" strokeWidth="1" />
+                    {[0.2, 0.45, 0.7, 0.9].map((v, i) => (
+                        <line key={i} x1="48" y1={200 - v * 184} x2="464" y2={200 - v * 184} stroke="currentColor" strokeWidth="1" strokeDasharray="4 4" />
+                    ))}
+                </svg>
+                <ChartLoadingOverlay size={64} />
+            </div>
+        </Stage>
+    ),
+}

--- a/packages/quill/packages/charts/src/components/ChartLoadingOverlay/ChartLoadingOverlay.tsx
+++ b/packages/quill/packages/charts/src/components/ChartLoadingOverlay/ChartLoadingOverlay.tsx
@@ -1,0 +1,173 @@
+import React from 'react'
+
+const CSS = `
+    @keyframes ph-ldr-spike {
+        0%, 100% { transform: scaleY(1); }
+        50% { transform: scaleY(1.15); }
+    }
+    .ph-ldr-spike {
+        transform-box: fill-box;
+        transform-origin: bottom center;
+        animation: ph-ldr-spike 1.4s ease-in-out infinite;
+    }
+    .ph-ldr-blue   { animation-delay: 0ms; }
+    .ph-ldr-red    { animation-delay: 180ms; }
+    .ph-ldr-yellow { animation-delay: 360ms; }
+
+    @keyframes ph-ldr-glow {
+        0%, 100% { filter: drop-shadow(0 0 5px rgba(255, 255, 255, 0.12)); }
+        50% { filter: drop-shadow(0 0 11px rgba(255, 255, 255, 0.3)); }
+    }
+    .ph-ldr-glow {
+        animation: ph-ldr-glow 1.4s ease-in-out infinite;
+    }
+
+    @keyframes ph-ldr-sweep {
+        0% { transform: translateX(-130%); }
+        100% { transform: translateX(130%); }
+    }
+    .ph-ldr-sweep {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 80%;
+        animation: ph-ldr-sweep 3s ease-in-out infinite;
+        will-change: transform;
+    }
+`
+
+export interface HogLoaderProps {
+    /** Width in px — height scales proportionally. Defaults to 64. */
+    size?: number
+    className?: string
+    style?: React.CSSProperties
+}
+
+/** Animated PostHog logo — spikes breathe in staggered sequence. */
+export function HogLoader({ size = 64, className, style }: HogLoaderProps): React.ReactElement {
+    // viewBox: x -0.5→52, y -4.5→28.5 — extra headroom for scaleY(1.15) tip overshoot
+    return (
+        <svg
+            width={size}
+            height={Math.round((size * 33) / 52.5)}
+            viewBox="-0.5 -4.5 52.5 33"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-label="Loading"
+            role="img"
+            className={className ? `ph-ldr-glow ${className}` : 'ph-ldr-glow'}
+            style={style}
+        >
+            <style>{CSS}</style>
+            <defs>
+                {/* Blue spike — 3 gradient slices sharing one userSpaceOnUse gradient each */}
+                <linearGradient id="ph-ldr-b1" x1="-5.33" y1="1.8" x2="10.58" y2="19.52" gradientUnits="userSpaceOnUse">
+                    <stop stopColor="#3F80FF" />
+                    <stop offset="1" stopColor="#084FE0" />
+                </linearGradient>
+                <linearGradient id="ph-ldr-b2" x1="-4.88" y1="13.81" x2="8.63" y2="27.98" gradientUnits="userSpaceOnUse">
+                    <stop stopColor="#0255FF" />
+                    <stop offset="1" stopColor="#0145D2" />
+                </linearGradient>
+                <linearGradient id="ph-ldr-b3" x1="-0.23" y1="18.94" x2="8.996" y2="28.27" gradientUnits="userSpaceOnUse">
+                    <stop stopColor="#0041C6" />
+                    <stop offset="1" stopColor="#0045D0" />
+                </linearGradient>
+                {/* Red spike */}
+                <linearGradient id="ph-ldr-r1" x1="10.55" y1="7.25" x2="21.74" y2="18.65" gradientUnits="userSpaceOnUse">
+                    <stop stopColor="#FF651E" />
+                    <stop offset="1" stopColor="#E4400A" />
+                </linearGradient>
+                <linearGradient id="ph-ldr-r2" x1="10.43" y1="7.37" x2="22.44" y2="28.23" gradientUnits="userSpaceOnUse">
+                    <stop stopColor="#EF3C00" />
+                    <stop offset="1" stopColor="#D63601" />
+                </linearGradient>
+                <linearGradient id="ph-ldr-r3" x1="10.13" y1="19.68" x2="16.4" y2="27.98" gradientUnits="userSpaceOnUse">
+                    <stop stopColor="#C42C00" />
+                    <stop offset="1" stopColor="#D63600" />
+                </linearGradient>
+                {/* Yellow spike */}
+                <linearGradient id="ph-ldr-y1" x1="21.69" y1="1.96" x2="33.1" y2="18.78" gradientUnits="userSpaceOnUse">
+                    <stop stopColor="#FFD849" />
+                    <stop offset="0.956" stopColor="#FBAE01" />
+                </linearGradient>
+                <linearGradient id="ph-ldr-y2" x1="21.69" y1="7.97" x2="33.1" y2="27.93" gradientUnits="userSpaceOnUse">
+                    <stop stopColor="#FFB700" />
+                    <stop offset="1" stopColor="#F9AA01" />
+                </linearGradient>
+                <linearGradient id="ph-ldr-y3" x1="21.84" y1="18.91" x2="30.76" y2="27.98" gradientUnits="userSpaceOnUse">
+                    <stop stopColor="#FF9500" />
+                    <stop offset="1" stopColor="#F8AA00" />
+                </linearGradient>
+            </defs>
+
+            {/* Blue spike — leftmost, tallest */}
+            <g className="ph-ldr-spike ph-ldr-blue">
+                <path d="M10.7401 7.14295L4.58711 0.815297C2.91642 -0.907781 0 0.279746 0 2.67808V7.50968L10.7401 18.733V7.14295Z" fill="url(#ph-ldr-b1)" />
+                <path d="M10.74 18.725V28.0001H8.94141L0 18.1836V7.50946L10.74 18.725Z" fill="url(#ph-ldr-b2)" />
+                <path d="M0 25.4097C0 26.8403 1.15978 28.0001 2.59044 28.0001H8.94531L0 18.18V25.4097Z" fill="url(#ph-ldr-b3)" />
+            </g>
+
+            {/* Red spike — middle */}
+            <g className="ph-ldr-spike ph-ldr-red">
+                <path d="M21.9693 7.64927L15.3273 0.815174C13.6567 -0.907902 10.7402 0.279623 10.7402 2.67796V7.14998L21.9693 18.6921V7.64927Z" fill="url(#ph-ldr-r1)" />
+                <path d="M10.7402 7.14294V18.733L19.6001 28.0003H21.9693V18.6922L10.7402 7.14294Z" fill="url(#ph-ldr-r2)" />
+                <path d="M10.7402 28.0003H19.6001L10.7402 18.733V28.0003Z" fill="url(#ph-ldr-r3)" />
+            </g>
+
+            {/* Yellow spike — closest to head */}
+            <g className="ph-ldr-spike ph-ldr-yellow">
+                <path d="M33.2915 19.2975V7.74241L26.5563 0.815175C24.8857 -0.907902 21.9692 0.279624 21.9692 2.67796V7.64998L33.2915 19.2917V19.2975Z" fill="url(#ph-ldr-y1)" />
+                <path d="M21.9692 7.64935V18.6922L31.0154 28.0003H33.2915V19.29L21.9692 7.64935Z" fill="url(#ph-ldr-y2)" />
+                <path d="M21.9692 28.0003H31.0154L21.9692 18.6922V28.0003Z" fill="url(#ph-ldr-y3)" />
+            </g>
+
+            {/* Head — static */}
+            <path
+                d="M50.01 23.3376L49.6723 23.2968C48.6653 23.1687 47.7281 22.7031 47.0179 21.9696L33.2856 7.74255V28.0003H48.9971C50.4757 28.0003 51.669 26.8012 51.669 25.3284V25.2236C51.669 24.2631 50.953 23.454 50.0041 23.3376H50.01ZM39.2 23.5471C38.2162 23.5471 37.4187 22.7496 37.4187 21.7658C37.4187 20.7821 38.2162 19.9845 39.2 19.9845C40.1838 19.9845 40.9813 20.7821 40.9813 21.7658C40.9813 22.7496 40.1838 23.5471 39.2 23.5471Z"
+                fill="#111111"
+            />
+        </svg>
+    )
+}
+
+export interface ChartLoadingOverlayProps {
+    /** Width of the logo in px. Defaults to 64. */
+    size?: number
+    /** Render an animated shimmer sweep behind the hog. */
+    shimmer?: boolean
+    /** Colour of the shimmer band (a translucent value reads best). Defaults to a neutral grey. */
+    shimmerColor?: string
+}
+
+/** Absolutely-positioned loading overlay for use inside a chart container. */
+export function ChartLoadingOverlay({
+    size = 64,
+    shimmer = false,
+    shimmerColor = 'rgba(127, 127, 127, 0.06)',
+}: ChartLoadingOverlayProps): React.ReactElement {
+    return (
+        <div
+            style={{
+                position: 'absolute',
+                inset: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                overflow: 'hidden',
+                pointerEvents: 'none',
+            }}
+        >
+            {shimmer && (
+                <div
+                    className="ph-ldr-sweep"
+                    style={{
+                        left: 0,
+                        background: `linear-gradient(90deg, transparent, ${shimmerColor}, transparent)`,
+                    }}
+                />
+            )}
+            <HogLoader size={size} />
+        </div>
+    )
+}

--- a/packages/quill/packages/charts/src/core/Chart.tsx
+++ b/packages/quill/packages/charts/src/core/Chart.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { ChartLoadingOverlay } from '../components/ChartLoadingOverlay/ChartLoadingOverlay'
 import { AxisLabels } from '../overlays/AxisLabels'
 import { AxisTitles } from '../overlays/AxisTitles'
 import { DefaultTooltip } from '../overlays/DefaultTooltip'
@@ -57,6 +58,8 @@ const OVERLAY_CANVAS_STYLE: React.CSSProperties = {
 }
 const DEFAULT_AXIS_COLOR = 'rgba(0, 0, 0, 0.5)'
 const DEFAULT_HOVER_ANIMATION_MS = 150
+const LOADING_FADE_MS = 500
+const LOADING_REVEAL_MS = 650
 
 function resolveHoverAnimationMs(animateHover: boolean | number | undefined): number {
     if (animateHover === true) {
@@ -113,6 +116,9 @@ export interface ChartProps<Meta = unknown> {
      *  cursor) before it reaches `onPointClick`, using the committed `scales` from this render.
      *  Chart-type adapters provide this; consumers do not. */
     wrapClickData?: (data: PointClickData<Meta>, scales: ChartScales) => PointClickData<Meta>
+    /** Loading: keep the real scales/grid but hide the axis tick labels and show the hog loader
+     *  where the data would render. The data line itself is suppressed by the chart-type `drawStatic`. */
+    loading?: boolean
 }
 
 export function Chart<Meta = unknown>({
@@ -133,6 +139,7 @@ export function Chart<Meta = unknown>({
     labelToCoord,
     valueRangeSeries,
     wrapClickData,
+    loading = false,
 }: ChartProps<Meta>): React.ReactElement {
     const {
         xTickFormatter,
@@ -222,6 +229,34 @@ export function Chart<Meta = unknown>({
         [showCrosshair, theme.crosshairColor, axisOrientation, labelToCoord, drawHoverRef.current]
     )
 
+    // Reveal: when a load completes, fade the data in from 0..1 while the loader overlay fades out.
+    // Steady states stay pinned at 1 so charts don't re-animate the reveal on unrelated re-renders.
+    const [revealProgress, setRevealProgress] = useState(loading ? 0 : 1)
+    const prevLoadingRef = useRef(loading)
+    useEffect(() => {
+        const wasLoading = prevLoadingRef.current
+        prevLoadingRef.current = loading
+        if (loading) {
+            setRevealProgress(0)
+            return
+        }
+        if (!wasLoading) {
+            setRevealProgress(1)
+            return
+        }
+        let raf = 0
+        const start = performance.now()
+        const tick = (): void => {
+            const p = Math.min(1, (performance.now() - start) / LOADING_REVEAL_MS)
+            setRevealProgress(p)
+            if (p < 1) {
+                raf = requestAnimationFrame(tick)
+            }
+        }
+        raf = requestAnimationFrame(tick)
+        return () => cancelAnimationFrame(raf)
+    }, [loading])
+
     useChartDraw({
         ctx,
         overlayCtx,
@@ -235,6 +270,7 @@ export function Chart<Meta = unknown>({
         drawStatic,
         drawHover: composedDrawHover,
         hoverAnimationMs,
+        revealProgress,
     })
 
     const wrapperStyle = hoverIndex >= 0 && onPointClick ? WRAPPER_STYLE_POINTER : WRAPPER_STYLE_DEFAULT
@@ -286,6 +322,21 @@ export function Chart<Meta = unknown>({
 
     const hoverValue = useMemo<ChartHoverContextValue>(() => ({ hoverIndex }), [hoverIndex])
 
+    // Keep the loading overlay mounted through a fade-out so the chart data eases in underneath
+    // rather than the overlay snapping away the moment `loading` flips off.
+    const [overlayMounted, setOverlayMounted] = useState(loading)
+    const [overlayVisible, setOverlayVisible] = useState(loading)
+    useEffect(() => {
+        if (loading) {
+            setOverlayMounted(true)
+            setOverlayVisible(true)
+            return
+        }
+        setOverlayVisible(false)
+        const timer = setTimeout(() => setOverlayMounted(false), LOADING_FADE_MS)
+        return () => clearTimeout(timer)
+    }, [loading])
+
     return (
         <ChartLayoutContext.Provider value={layoutValue}>
             <ChartHoverContext.Provider value={hoverValue}>
@@ -308,7 +359,7 @@ export function Chart<Meta = unknown>({
                                 yTickFormatter={resolvedYFormatter}
                                 yRightTickFormatter={resolvedYRightFormatter}
                                 hideXAxis={hideXAxis}
-                                hideYAxis={hideYAxis}
+                                hideYAxis={loading || hideYAxis}
                                 axisColor={axisColor}
                                 orientation={axisOrientation}
                                 labelToCoord={labelToCoord}
@@ -324,7 +375,21 @@ export function Chart<Meta = unknown>({
 
                             {children}
 
-                            {tooltipCtx && showTooltip && (
+                            {overlayMounted && (
+                                <div
+                                    style={{
+                                        position: 'absolute',
+                                        inset: 0,
+                                        pointerEvents: 'none',
+                                        opacity: overlayVisible ? 1 : 0,
+                                        transition: `opacity ${LOADING_FADE_MS}ms ease`,
+                                    }}
+                                >
+                                    <ChartLoadingOverlay shimmer />
+                                </div>
+                            )}
+
+                            {!loading && tooltipCtx && showTooltip && (
                                 <Tooltip
                                     context={tooltipCtx}
                                     renderTooltip={renderTooltip}

--- a/packages/quill/packages/charts/src/core/hooks/useChartDraw.ts
+++ b/packages/quill/packages/charts/src/core/hooks/useChartDraw.ts
@@ -19,6 +19,8 @@ interface UseChartDrawOptions {
     drawHover: (args: ChartDrawArgs) => DrawHoverResult
     /** Duration (ms) of the hover-overlay fade-in. `0` disables. */
     hoverAnimationMs?: number
+    /** Data reveal progress (0..1) forwarded to the static draw — redraws when it changes. */
+    revealProgress?: number
 }
 
 function clearAndPrepare(ctx: CanvasRenderingContext2D, dimensions: ChartDimensions): void {
@@ -41,6 +43,7 @@ export function useChartDraw({
     drawStatic,
     drawHover,
     hoverAnimationMs = 0,
+    revealProgress = 1,
 }: UseChartDrawOptions): void {
     // Cancel the prior RAF on effect re-run — relying on cleanup ordering alone leaves a
     // window where a stale RAF can paint after the new setup runs.
@@ -81,6 +84,7 @@ export function useChartDraw({
                 theme,
                 hoverProgress: 1,
                 resetHoverFade: () => 1,
+                revealProgress,
             })
             ctx.restore()
         })
@@ -91,7 +95,7 @@ export function useChartDraw({
             }
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [ctx, dimensions, scales, series, labels, theme, drawStatic])
+    }, [ctx, dimensions, scales, series, labels, theme, drawStatic, revealProgress])
 
     // The RAF loop ticks until hoverProgress reaches 1, then exits and waits for the next
     // dep change. Timer is held in a ref so cancel/restart cycles resume the fade smoothly.

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -286,6 +286,9 @@ export interface LineChartConfig extends ChartConfig {
     percentStackView?: boolean
     /** Value-axis domain control — omit for data-derived auto-scaling. See {@link ValueDomain}. */
     valueDomain?: ValueDomain
+    /** Soft glow around each line stroke, in the line's own color. `true` uses the default blur;
+     *  pass a number to set the blur radius in px. Defaults to off. */
+    lineGlow?: boolean | number
 }
 
 /** Arguments passed to a chart type's canvas draw function. */
@@ -311,6 +314,9 @@ export interface ChartDrawArgs {
     /** Restart the hover-fade at progress 0; returns the new value to use this frame.
      *  Call when the chart type detects a visible-state change at the same hoverIndex. */
     resetHoverFade: () => number
+    /** Data reveal progress (0..1) — chart types fade the series in over this as a load completes.
+     *  Defaults to 1 (fully revealed) for charts that don't animate a reveal. */
+    revealProgress?: number
 }
 
 /** `true` = drew a visible highlight; `false` = nothing visible (freeze the fade timer). */

--- a/packages/quill/packages/charts/src/index.ts
+++ b/packages/quill/packages/charts/src/index.ts
@@ -1,3 +1,7 @@
+// Loading overlay
+export { ChartLoadingOverlay, HogLoader } from './components/ChartLoadingOverlay/ChartLoadingOverlay'
+export type { ChartLoadingOverlayProps, HogLoaderProps } from './components/ChartLoadingOverlay/ChartLoadingOverlay'
+
 // Components
 export { BarChart } from './charts/BarChart/BarChart'
 export type { BarChartProps } from './charts/BarChart/BarChart'

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -16,6 +16,7 @@ import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisForma
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
@@ -76,11 +77,14 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
         showConfidenceIntervals,
         confidenceLevel,
     } = useValues(trendsDataLogic(insightProps))
+    const { insightDataLoading } = useValues(insightVizDataLogic(insightProps))
     const { timezone, weekStartDay, baseCurrency } = useValues(teamLogic)
     const { aggregationLabel } = useValues(groupsModel)
 
     const isPercentStackView = !!showPercentStackView && !!supportsPercentStackView
     const resolvedGroupTypeLabel = context?.groupTypeLabel ?? resolveGroupTypeLabel(labelGroupType, aggregationLabel)
+
+    const loading = insightDataLoading
 
     const labels = currentPeriodResult?.labels ?? []
 
@@ -264,7 +268,9 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
         ]
     )
 
-    if (!hasData) {
+    // While a query is in flight we keep the previous chart frame (with the loading hog) rather than
+    // flashing the empty state — only show it once we've settled with genuinely no data.
+    if (!hasData && !loading) {
         return <InsightEmptyState heading={context?.emptyStateHeading} detail={context?.emptyStateDetail} />
     }
 
@@ -282,8 +288,9 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
             className="LineGraph"
             dataAttr="trend-line-graph"
             onError={handleChartError}
+            loading={loading}
         >
-            {insight.id ? (
+            {insight.id && !loading ? (
                 <TrendsAlertOverlays
                     insightId={insight.id}
                     insightProps={insightProps}
@@ -293,7 +300,9 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
                     isHidden={getTrendsHidden}
                 />
             ) : null}
-            {showAnnotations && <AnnotationsLayer insightNumericId={insight.id || 'new'} dates={annotationsDates} />}
+            {showAnnotations && !loading && (
+                <AnnotationsLayer insightNumericId={insight.id || 'new'} dates={annotationsDates} />
+            )}
         </TimeSeriesLineChart>
     )
 }

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
@@ -230,5 +230,6 @@ export function buildTrendsLineTimeSeriesConfig<R extends TrendsResultLike>(
         percentStackView: opts.isPercentStackView,
         showCrosshair: opts.showCrosshair,
         tooltip: opts.tooltip,
+        lineGlow: true,
     }
 }


### PR DESCRIPTION
## Problem

When a trends line chart re-queries, the whole graph is replaced by the full-screen hedgehog loading text, so the chart frame disappears and the result snaps back in when the query finishes. This is a polish pass on the hog-charts trends line chart loading state.

## Changes

- New `ChartLoadingOverlay` / `HogLoader` component in quill-charts: an animated PostHog logo (staggered spike bounce) with a soft pulsing glow and a gentle shimmer sweep.
- `loading` support threaded through `TimeSeriesLineChart` → `LineChart` → `Chart`. While loading, the chart keeps its real grid and x-axis, hides the y-axis labels and the data line, and shows the hog where the data will land.
- Data reveal animation: a `revealProgress` value (0→1) threaded through the draw pipeline (`types`, `useChartDraw`, `Chart`, `LineChart`) fades the line in per-frame when the query completes, while the loader overlay fades out.
- `lineGlow` config option on `LineChart` / `TimeSeriesLineChart` — a soft glow around each line stroke in the line's own colour (translucent halo so overlapping near-baseline series don't compound into one bright band). Enabled for trends.
- `InsightVizDisplay` only shows the full-screen loading state on a fresh load (no prior result); during a re-query it keeps the chart mounted so the in-chart loader can render.
- `TrendsLineChart` wires `insightDataLoading` to the new `loading` prop, hides annotation/alert overlays while loading, and only shows the empty state once loading has settled with no data.
- Stories for the loading overlay and the line-chart loading state.

## How did you test this code?

I'm an agent — I haven't manually tested this beyond per-file TypeScript checks on the changed quill-charts files (no type errors) and confirming the dev server compiled without errors. No automated tests were added for the new visual behavior. Manual visual verification of the loading animation and glow is still needed by a human reviewer.

## Publish to changelog?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The work was iterative and design-driven: started from a request to give insight charts a nicer loading state than the existing hedgehog text.

Key decisions along the way:
- Initially implemented against the legacy Chart.js `LineGraph`, then discovered trends render through the quill hog-charts `TimeSeriesLineChart` when the `product-analytics-hog-charts-trends` flag is on — reverted the Chart.js changes and reimplemented in quill.
- Tried a faint placeholder "wave" line and a stronger shimmer first; dropped the fake line and softened the shimmer based on review.
- Made the line glow halo translucent + tighter-blurred after a multi-series chart showed the glow compounding into a bright band at the baseline.
- A temporary debug flag forced the loader on with a 3s timer for inspection; it was decoupled from real loading and caused premature empty states on slow insights, so it was removed and `loading` now tracks `insightDataLoading`.