### PR TITLE
feat(mcp-store): show built-in PostHog server in installed list

### DIFF
--- a/products/mcp_store/frontend/mcpStoreLogic.ts
+++ b/products/mcp_store/frontend/mcpStoreLogic.ts
@@ -18,6 +18,29 @@ export type ToolApprovalState = 'approved' | 'needs_approval' | 'do_not_use'
 
 export type McpSceneView = 'marketplace' | 'detail'
 
+/**
+ * Servers PostHog Code injects into every agent session automatically (see
+ * `get_sandbox_ph_mcp_configs` in products/tasks). They are not user
+ * installations — there is no DB row, and nothing to connect, enable, or
+ * remove — so we surface them as read-only synthetic cards in the Installed
+ * list to reflect that they're always on.
+ */
+export interface BuiltinServer {
+    id: string
+    name: string
+    description: string
+    icon_key: string
+}
+
+export const BUILTIN_SERVERS: BuiltinServer[] = [
+    {
+        id: 'builtin:posthog',
+        name: 'PostHog',
+        description: 'Query analytics, insights, flags, experiments, and more. Always on in every session.',
+        icon_key: 'posthog',
+    },
+]
+
 export interface CustomServerFormValues {
     name: string
     url: string
@@ -312,6 +335,19 @@ export const mcpStoreLogic = kea<mcpStoreLogicType>([
                     (installation) =>
                         installation.name.toLowerCase().includes(q) ||
                         (installation.description ?? '').toLowerCase().includes(q)
+                )
+            },
+        ],
+        filteredBuiltinServers: [
+            (s) => [s.searchQuery],
+            (searchQuery: string): BuiltinServer[] => {
+                const q = searchQuery.trim().toLowerCase()
+                if (!q) {
+                    return BUILTIN_SERVERS
+                }
+                return BUILTIN_SERVERS.filter(
+                    (server) =>
+                        server.name.toLowerCase().includes(q) || server.description.toLowerCase().includes(q)
                 )
             },
         ],

--- a/products/mcp_store/frontend/scene/InstalledServersList.tsx
+++ b/products/mcp_store/frontend/scene/InstalledServersList.tsx
@@ -1,26 +1,44 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonCard, LemonTag } from '@posthog/lemon-ui'
+import { LemonCard, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { mcpStoreLogic } from '../mcpStoreLogic'
 import { ServerIcon } from './icons'
 
 export function InstalledServersList(): JSX.Element | null {
-    const { installations, filteredInstallations } = useValues(mcpStoreLogic)
+    const { filteredInstallations, filteredBuiltinServers } = useValues(mcpStoreLogic)
     const { selectServer } = useActions(mcpStoreLogic)
 
-    if (installations.length === 0) {
-        return null
-    }
+    const hasResults = filteredBuiltinServers.length > 0 || filteredInstallations.length > 0
 
     return (
         <div className="deprecated-space-y-2">
             <h2 className="mb-0 text-base font-semibold">Installed</h2>
 
-            {filteredInstallations.length === 0 ? (
+            {!hasResults ? (
                 <div className="text-sm text-secondary px-1 py-2">No installed servers match your search.</div>
             ) : (
                 <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+                    {filteredBuiltinServers.map((server) => (
+                        <Tooltip
+                            key={server.id}
+                            title="Built-in — automatically available in every PostHog Code session. It can't be disabled or removed."
+                        >
+                            <LemonCard className="cursor-default">
+                                <div className="flex items-center gap-3">
+                                    <ServerIcon iconKey={server.icon_key} size={32} />
+                                    <div className="flex-1 min-w-0">
+                                        <h4 className="mb-0 truncate">{server.name}</h4>
+                                        <div className="text-xs text-secondary truncate">{server.description}</div>
+                                    </div>
+                                    <LemonTag type="highlight" size="small">
+                                        Built-in
+                                    </LemonTag>
+                                </div>
+                            </LemonCard>
+                        </Tooltip>
+                    ))}
+
                     {filteredInstallations.map((installation) => {
                         const statusTag = installation.pending_oauth ? (
                             <LemonTag type="warning" size="small">

--- a/products/mcp_store/frontend/scene/icons.tsx
+++ b/products/mcp_store/frontend/scene/icons.tsx
@@ -1,5 +1,6 @@
 import { IconServer } from '@posthog/icons'
 
+import IconPostHogService from 'public/posthog-icon.svg'
 import IconAirOpsService from 'public/services/airops.png'
 import IconAtlassianService from 'public/services/atlassian.svg'
 import IconAttioService from 'public/services/attio.png'
@@ -65,6 +66,7 @@ const SERVER_ICONS: Record<string, string> = {
     notion: IconNotionService,
     pagerduty: IconPagerDutyService,
     planetscale: IconPlanetScaleService,
+    posthog: IconPostHogService,
     postman: IconPostmanService,
     prisma: IconPrismaService,
     render: IconRenderService,


### PR DESCRIPTION
## Problem

PostHog Code injects the PostHog MCP server into every agent session automatically (via `get_sandbox_ph_mcp_configs` in `products/tasks`). But it's never a user *installation* — there's no DB row for it. The MCP servers pane only renders marketplace templates + user installations (`api.mcpServerInstallations.list()`), so PostHog never appeared anywhere in the pane. Users could use PostHog tools in a session yet saw an empty **Installed** list, which reads as "PostHog isn't connected" even though it always is.

## Changes

Add a synthetic, read-only **built-in** card to the Installed section so the always-on PostHog server is visible:

- New `BuiltinServer` type + `BUILTIN_SERVERS` constant in `mcpStoreLogic.ts` (currently just PostHog), with a `filteredBuiltinServers` selector that respects the search box exactly like `filteredInstallations`.
- `InstalledServersList` renders built-in cards first, ahead of real installations. The card is intentionally **read-only**: no enable toggle, no remove button, not clickable, tagged `Built-in` with a tooltip ("automatically available in every PostHog Code session. It can't be disabled or removed.").
- The Installed section no longer hides itself when there are zero user installs — the built-in is always present.
- Mapped `icon_key: 'posthog'` → `public/posthog-icon.svg` so the card shows the PostHog logo instead of the generic server icon.

The built-in card deliberately does **not** open the detail/tools panel: that panel is keyed by an installation ID and calls the per-installation tools endpoint, which the built-in server has no row for. A read-only card is the honest representation — it's on, you don't manage it.

This is frontend-only; no change to how the server is actually injected into sessions.

## How did you test this code?

I'm an agent (PostHog Code). I have **not** run the app or done manual testing, and I did **not** add automated tests. This was developed in a shallow clone without `node_modules`, so I could not run `typescript:check`, kea-typegen, or lint locally. Before merge this needs a typecheck/typegen run in a full environment, and ideally a screenshot of the Installed list showing the built-in card. The change follows the existing patterns in these files; the `public/*` alias and svg import were verified against `tsconfig.json`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

Authored by PostHog Code in response to an internal report that PostHog wasn't listed in the MCP servers pane despite its tools working in every session.

Investigation traced the two MCP config sources in `products/tasks/.../start_agent_server.py`: `get_sandbox_ph_mcp_configs` (always-on built-in, no DB row) vs `get_user_mcp_server_configs` (mcp_store installations). The pane (`products/mcp_store`) only knew about the latter. Considered a backend approach (surface the built-in as a virtual `is_builtin` installation from the list endpoint, single source of truth) vs a frontend-only synthetic card; chose the frontend-only card per the requester's preference for a lightweight, cosmetic fix. Made the card read-only/non-clickable rather than wiring a fake detail panel, since there's no installation ID or tools endpoint behind it.

Requires human review; not for self-merge.
