### PR TITLE
refactor(frontend): remove defunct tabId from persons and cohorts

### DIFF
--- a/frontend/src/scenes/cohorts/AddPersonToCohortModal.tsx
+++ b/frontend/src/scenes/cohorts/AddPersonToCohortModal.tsx
@@ -8,8 +8,8 @@ import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { AddPersonToCohortModalBody } from './AddPersonToCohortModalBody'
 import { AddPersonToCohortModalProps, addPersonToCohortModalLogic } from './addPersonToCohortModalLogic'
 
-export function AddPersonToCohortModal({ id, tabId }: AddPersonToCohortModalProps): JSX.Element {
-    const logicProps = { id, tabId }
+export function AddPersonToCohortModal({ id }: AddPersonToCohortModalProps): JSX.Element {
+    const logicProps = { id }
     const logic = addPersonToCohortModalLogic(logicProps)
     const { hideAddPersonToCohortModal, addPersonsToCohort } = useActions(logic)
     const { addPersonToCohortModalVisible, personsToAddToCohort, isCohortUpdating } = useValues(logic)

--- a/frontend/src/scenes/cohorts/Cohort.tsx
+++ b/frontend/src/scenes/cohorts/Cohort.tsx
@@ -7,7 +7,6 @@ import { cohortSceneLogic } from './cohortSceneLogic'
 
 interface CohortSceneProps {
     id?: CohortType['id']
-    tabId?: string
 }
 export const scene: SceneExport<CohortSceneProps> = {
     component: Cohort,
@@ -19,12 +18,8 @@ export const scene: SceneExport<CohortSceneProps> = {
 
 interface CohortProps {
     id?: CohortType['id']
-    tabId?: string
 }
 
-export function Cohort({ id, tabId }: CohortProps): JSX.Element {
-    if (!tabId) {
-        throw new Error('Cohort must receive a tabId prop')
-    }
-    return <CohortEdit id={id} attachTo={cohortSceneLogic({ tabId })} tabId={tabId} />
+export function Cohort({ id }: CohortProps): JSX.Element {
+    return <CohortEdit id={id} attachTo={cohortSceneLogic()} />
 }

--- a/frontend/src/scenes/cohorts/CohortEdit.test.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.test.tsx
@@ -209,7 +209,7 @@ describe('cohortEditLogic', () => {
                 },
             })
 
-            render(<CohortEdit id={cohortId} tabId="test-tab" />)
+            render(<CohortEdit id={cohortId} />)
 
             const inProgressElements = await screen.findAllByText('In progress...')
             expect(inProgressElements.length).toBeGreaterThan(0)
@@ -237,7 +237,7 @@ describe('cohortEditLogic', () => {
                 },
             })
 
-            render(<CohortEdit id={cohortId} tabId="test-tab" />)
+            render(<CohortEdit id={cohortId} />)
 
             const inProgressElements = await screen.findAllByText('In progress...')
             expect(inProgressElements.length).toBeGreaterThan(0)
@@ -265,7 +265,7 @@ describe('cohortEditLogic', () => {
                 },
             })
 
-            render(<CohortEdit id={cohortId} tabId="test-tab" />)
+            render(<CohortEdit id={cohortId} />)
 
             await screen.findByText(
                 "We're queuing a recalculation. The table below shows results from the previous calculation."
@@ -292,7 +292,7 @@ describe('cohortEditLogic', () => {
                 },
             })
 
-            render(<CohortEdit id={cohortId} tabId="test-tab" />)
+            render(<CohortEdit id={cohortId} />)
 
             // Wait a bit for component to render then verify no loading states
             await new Promise((resolve) => setTimeout(resolve, 100))
@@ -301,7 +301,6 @@ describe('cohortEditLogic', () => {
 
         it('shows retry button and contact support link when calculation fails', async () => {
             const cohortId = 2
-            const tabId = 'test-tab-error'
 
             useMocks({
                 get: {
@@ -333,7 +332,7 @@ describe('cohortEditLogic', () => {
                 },
             })
 
-            render(<CohortEdit id={cohortId} tabId={tabId} />)
+            render(<CohortEdit id={cohortId} />)
 
             // Verify error message is shown
             await screen.findByText(/Calculation failed:/)
@@ -349,7 +348,7 @@ describe('cohortEditLogic', () => {
             expect(screen.getByText('contact support')).toBeInTheDocument()
 
             // Get the logic instance and verify clicking retry triggers submitCohort
-            logic = cohortEditLogic({ id: cohortId, tabId })
+            logic = cohortEditLogic({ id: cohortId })
             logic.mount()
 
             await expectLogic(logic, async () => {

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -54,11 +54,10 @@ const RESOURCE_TYPE = 'cohort'
 export interface CohortEditProps {
     id?: CohortType['id']
     attachTo?: BuiltLogic<Logic> | LogicWrapper<Logic>
-    tabId: string
 }
 
-export function CohortEdit({ id, attachTo, tabId }: CohortEditProps): JSX.Element {
-    const logicProps = { id, tabId }
+export function CohortEdit({ id, attachTo }: CohortEditProps): JSX.Element {
+    const logicProps = { id }
 
     const renderRemovePersonFromCohortButton = ({ record }: { record: unknown }): JSX.Element => {
         if (!Array.isArray(record)) {
@@ -125,7 +124,7 @@ export function CohortEdit({ id, attachTo, tabId }: CohortEditProps): JSX.Elemen
     if (cohort.deleted) {
         return (
             <div>
-                <CohortSceneMenuBar id={id} tabId={tabId} />
+                <CohortSceneMenuBar id={id} />
                 <LemonBanner type="error">The cohort '{cohort.name}' has been soft deleted.</LemonBanner>
                 <ScenePanel>
                     <ButtonPrimitive
@@ -145,8 +144,8 @@ export function CohortEdit({ id, attachTo, tabId }: CohortEditProps): JSX.Elemen
     return (
         <BindLogic logic={cohortEditLogic} props={logicProps}>
             <div className="cohort">
-                <AddPersonToCohortModal id={id} tabId={tabId} />
-                <CohortSceneMenuBar id={id} tabId={tabId} />
+                <AddPersonToCohortModal id={id} />
+                <CohortSceneMenuBar id={id} />
 
                 <ScenePanel>
                     <ScenePanelInfoSection>

--- a/frontend/src/scenes/cohorts/CohortSceneMenuBar.tsx
+++ b/frontend/src/scenes/cohorts/CohortSceneMenuBar.tsx
@@ -24,16 +24,16 @@ import { CohortType } from '~/types'
 
 const RESOURCE_TYPE = 'cohort'
 
-export function CohortSceneMenuBar({ id, tabId }: { id?: CohortType['id']; tabId: string }): JSX.Element | null {
+export function CohortSceneMenuBar({ id }: { id?: CohortType['id'] }): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
     if (!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]) {
         return null
     }
-    return <CohortSceneMenuBarInner id={id} tabId={tabId} />
+    return <CohortSceneMenuBarInner id={id} />
 }
 
-function CohortSceneMenuBarInner({ id, tabId }: { id?: CohortType['id']; tabId: string }): JSX.Element | null {
-    const logic = cohortEditLogic({ id, tabId })
+function CohortSceneMenuBarInner({ id }: { id?: CohortType['id'] }): JSX.Element | null {
+    const logic = cohortEditLogic({ id })
     const { cohort, cohortLoading } = useValues(logic)
     const { duplicateCohort, deleteCohort, restoreCohort } = useActions(logic)
     const { canCopyToProject } = useValues(interProjectCopyLogic)

--- a/frontend/src/scenes/cohorts/addPersonToCohortModalLogic.ts
+++ b/frontend/src/scenes/cohorts/addPersonToCohortModalLogic.ts
@@ -14,7 +14,6 @@ import { createCohortDataNodeLogicKey } from './cohortUtils'
 
 export type AddPersonToCohortModalProps = {
     id?: CohortType['id']
-    tabId: string
 }
 
 const DEFAULT_QUERY: ActorsQuery = {
@@ -26,12 +25,7 @@ const DEFAULT_QUERY: ActorsQuery = {
 export const addPersonToCohortModalLogic = kea<addPersonToCohortModalLogicType>([
     props({} as AddPersonToCohortModalProps),
     path(['scenes', 'cohorts', 'addPersonToCohortModalLogic']),
-    key((props) => {
-        if (props.id === 'new' || !props.id) {
-            return 'new'
-        }
-        return `${props.id}-${props.tabId}`
-    }),
+    key((props) => (props.id === 'new' || !props.id ? 'new' : `${props.id}`)),
     actions({
         showAddPersonToCohortModal: true,
         hideAddPersonToCohortModal: true,
@@ -107,7 +101,7 @@ export const addPersonToCohortModalLogic = kea<addPersonToCohortModalLogicType>(
                 await actions.loadCohortPersons()
                 if (response) {
                     lemonToast.success('Users added to cohort')
-                    const mountedCohortEditLogic = cohortEditLogic.findMounted({ id: cohortId, tabId: props.tabId })
+                    const mountedCohortEditLogic = cohortEditLogic.findMounted({ id: cohortId })
                     await mountedCohortEditLogic?.actions.updateCohortCount()
 
                     const mountedDataNodeLogic = dataNodeLogic.findMounted({

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -63,7 +63,6 @@ import type { cohortEditLogicType } from './cohortEditLogicType'
 
 export type CohortLogicProps = {
     id?: CohortType['id']
-    tabId?: string
 }
 
 export type StaticCohortMode = 'criteria' | 'people'
@@ -87,18 +86,7 @@ const inferStaticCohortMode = (cohort: CohortType): StaticCohortMode =>
 
 export const cohortEditLogic = kea<cohortEditLogicType>([
     props({} as CohortLogicProps),
-    key((props) => {
-        if (props.id === 'new' || !props.id) {
-            if (props.tabId == null) {
-                return 'new'
-            }
-            return `new-${props.tabId}`
-        }
-        if (props.tabId == null) {
-            return props.id
-        }
-        return `${props.id}-${props.tabId}`
-    }),
+    key((props) => (props.id === 'new' || !props.id ? 'new' : props.id)),
     path(['scenes', 'cohorts', 'cohortLogicEdit']),
     connect(() => ({
         actions: [eventUsageLogic, ['reportExperimentExposureCohortEdited']],

--- a/frontend/src/scenes/cohorts/cohortsSceneLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortsSceneLogic.test.ts
@@ -72,7 +72,7 @@ describe('cohortsSceneLogic', () => {
         sceneLogic.actions.setTabs([
             { id: '1', title: '...', pathname: '/', search: '', hash: '', active: true, iconType: 'blank' },
         ])
-        logic = cohortsSceneLogic({ tabId: '1' })
+        logic = cohortsSceneLogic()
         logic.mount()
     })
 

--- a/frontend/src/scenes/persons/MergeSplitPerson.tsx
+++ b/frontend/src/scenes/persons/MergeSplitPerson.tsx
@@ -11,9 +11,9 @@ import { PersonType } from '~/types'
 import { mergeSplitPersonLogic, SplitMode } from './mergeSplitPersonLogic'
 import { personsLogic } from './personsLogic'
 
-export function MergeSplitPerson({ person, tabId }: { person: PersonType; tabId?: string }): JSX.Element {
+export function MergeSplitPerson({ person }: { person: PersonType }): JSX.Element {
     const { urlId } = useValues(personsLogic)
-    const logicProps = { person, urlId: urlId ?? '', tabId }
+    const logicProps = { person, urlId: urlId ?? '' }
     const { executedLoading, splitMode, distinctIdsToSplit } = useValues(mergeSplitPersonLogic(logicProps))
     const { execute, cancel } = useActions(mergeSplitPersonLogic(logicProps))
 

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -169,7 +169,7 @@ function LaunchToolbarButton({ distinctId }: LaunchToolbarButtonProps): JSX.Elem
     )
 }
 
-export function PersonScene({ tabId }: { tabId?: string }): JSX.Element | null {
+export function PersonScene(): JSX.Element | null {
     const mountedPersonsLogic = useMountedLogic(personsLogic)
     const {
         feedEnabled,
@@ -204,7 +204,7 @@ export function PersonScene({ tabId }: { tabId?: string }): JSX.Element | null {
     const { currentTeam } = useValues(teamLogic)
     const { addProductIntentForCrossSell } = useActions(teamLogic)
     const { user } = useValues(userLogic)
-    const eventsQueryLogicKey = `${PERSON_EVENTS_CONTEXT_KEY}-${tabId ?? mountedPersonsLogic.key}`
+    const eventsQueryLogicKey = `${PERSON_EVENTS_CONTEXT_KEY}-${mountedPersonsLogic.key}`
 
     if (personError) {
         return (
@@ -324,15 +324,13 @@ export function PersonScene({ tabId }: { tabId?: string }): JSX.Element | null {
                         label: <span data-attr="persons-events-tab">Events</span>,
                         content: (
                             <Query
-                                uniqueKey={`person-profile-events-${tabId}`}
+                                uniqueKey="person-profile-events"
                                 attachTo={mountedPersonsLogic}
                                 query={eventsQuery}
                                 setQuery={(q) => setEventsQuery(q)}
-                                tabId={tabId}
                                 context={{
                                     insightProps: {
                                         dashboardItemId: `new-${PERSON_EVENTS_CONTEXT_KEY}`,
-                                        tabId,
                                         dataNodeCollectionId: eventsQueryLogicKey,
                                     },
                                     customActions: (
@@ -399,11 +397,10 @@ export function PersonScene({ tabId }: { tabId?: string }): JSX.Element | null {
                         label: <span data-attr="persons-exceptions-tab">Exceptions</span>,
                         content: (
                             <Query
-                                uniqueKey={`person-profile-exceptions-${tabId}`}
+                                uniqueKey="person-profile-exceptions"
                                 attachTo={mountedPersonsLogic}
                                 query={exceptionsQuery}
                                 setQuery={(q) => setExceptionsQuery(q)}
-                                tabId={tabId}
                             />
                         ),
                     },
@@ -412,11 +409,10 @@ export function PersonScene({ tabId }: { tabId?: string }): JSX.Element | null {
                         label: <span data-attr="persons-survey-responses-tab">Surveys</span>,
                         content: (
                             <Query
-                                uniqueKey={`person-profile-surveys-${tabId}`}
+                                uniqueKey="person-profile-surveys"
                                 attachTo={mountedPersonsLogic}
                                 query={surveyResponsesQuery}
                                 setQuery={(q) => setSurveyResponsesQuery(q)}
-                                tabId={tabId}
                             />
                         ),
                     },
@@ -513,7 +509,7 @@ export function PersonScene({ tabId }: { tabId?: string }): JSX.Element | null {
                 ]}
             />
 
-            {splitMergeModalShown && person && <MergeSplitPerson person={person} tabId={tabId} />}
+            {splitMergeModalShown && person && <MergeSplitPerson person={person} />}
         </SceneContent>
     )
 }

--- a/frontend/src/scenes/persons/PersonsScene.tsx
+++ b/frontend/src/scenes/persons/PersonsScene.tsx
@@ -35,22 +35,13 @@ export const scene: SceneExport = {
     productKey: ProductKey.PRODUCT_ANALYTICS,
 }
 
-export function PersonsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
-    if (!tabId) {
-        // TODO: sometimes when opening a property filter on a scene, the tabId is suddently empty.
-        // If I remove the "{closable && !disabledReason && ...}" block from within
-        // "frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx"
-        // ... then the issue goes away. We should still figure out why this happens.
-        // Throwing seems to make it go away.
-        throw new Error('PersonsScene rendered with no tabId')
-    }
-
+export function PersonsScene(): JSX.Element {
     const { query } = useValues(personsSceneLogic)
     const { setQuery } = useActions(personsSceneLogic)
     const { resetDeletedDistinctId } = useAsyncActions(personsSceneLogic)
     const { currentTeam, baseCurrency } = useValues(teamLogic)
     const { loadConfigs } = useActions(customerProfileConfigLogic({ scope: CustomerProfileScope.PERSON }))
-    const queryUniqueKey = `persons-query-${tabId}`
+    const queryUniqueKey = 'persons-query'
     const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
 
     useOnMountEffect(() => {
@@ -146,7 +137,7 @@ export function PersonsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
 
             <Query
                 uniqueKey={queryUniqueKey}
-                attachTo={personsSceneLogic({ tabId })}
+                attachTo={personsSceneLogic()}
                 query={{ ...query, showCount: true, showTableViews: true }}
                 setQuery={setQuery}
                 context={{

--- a/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
+++ b/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
@@ -14,7 +14,6 @@ import { personsLogic } from './personsLogic'
 export interface SplitPersonLogicProps {
     person: PersonType
     urlId: string
-    tabId?: string
 }
 
 export type PersonUuids = NonNullable<PersonType['uuid']>[]
@@ -23,14 +22,14 @@ export type SplitMode = 'all' | 'partial'
 
 export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>([
     props({} as SplitPersonLogicProps),
-    key((props) => `${props.tabId ?? 'notab'}:${props.person.id ?? 'new'}`),
+    key((props) => `${props.person.id ?? 'new'}`),
     path((key) => ['scenes', 'persons', 'mergeSplitPersonLogic', key]),
     connect((props: SplitPersonLogicProps) => ({
         actions: [
-            personsLogic({ syncWithUrl: true, urlId: props.urlId, tabId: props.tabId }),
+            personsLogic({ syncWithUrl: true, urlId: props.urlId }),
             ['setListFilters', 'loadPersons', 'setPerson', 'setSplitMergeModalShown'],
         ],
-        values: [personsLogic({ syncWithUrl: true, urlId: props.urlId, tabId: props.tabId }), ['persons']],
+        values: [personsLogic({ syncWithUrl: true, urlId: props.urlId }), ['persons']],
     })),
     actions({
         setSelectedPersonToAssignSplit: (id: string) => ({ id }),

--- a/frontend/src/scenes/persons/personsLogic.test.ts
+++ b/frontend/src/scenes/persons/personsLogic.test.ts
@@ -199,34 +199,6 @@ describe('personsLogic', () => {
         })
     })
 
-    describe('tab-aware person scene state', () => {
-        it('isolates person event query state by tab id', () => {
-            logic.unmount()
-
-            const firstTabLogic = personsLogic({ syncWithUrl: true, urlId: 'same-person', tabId: 'tab-a' })
-            const secondTabLogic = personsLogic({ syncWithUrl: true, urlId: 'same-person', tabId: 'tab-b' })
-            firstTabLogic.mount()
-            secondTabLogic.mount()
-
-            const eventsQuery = {
-                kind: NodeKind.DataTableNode,
-                source: {
-                    kind: NodeKind.EventsQuery,
-                    select: ['event', 'timestamp'],
-                    personId: 'person-1',
-                },
-            } as DataTableNode
-
-            firstTabLogic.actions.setEventsQuery(eventsQuery)
-
-            expect(firstTabLogic.values.eventsQuery).toEqual(eventsQuery)
-            expect(secondTabLogic.values.eventsQuery).toBeNull()
-
-            firstTabLogic.unmount()
-            secondTabLogic.unmount()
-        })
-    })
-
     describe('Load cohorts', () => {
         it("Doesn't load cohort if we're on", async () => {
             await expectLogic(logic, () => {

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -48,7 +48,6 @@ export interface PersonsLogicProps {
     syncWithUrl?: boolean
     urlId?: string
     fixedProperties?: PersonPropertyFilter[]
-    tabId?: string
 }
 
 export const PERSON_EVENTS_CONTEXT_KEY = 'person-profile-events'
@@ -106,10 +105,8 @@ function createInitialSurveyResponsesPayload(personId: string): DataTableNode {
 export const personsLogic = kea<personsLogicType>([
     props({} as PersonsLogicProps),
     key((props) => {
-        const tabKey = props.tabId ? `tab_${props.tabId}_` : ''
-
         if (props.urlId) {
-            return `${tabKey}url_${props.urlId}`
+            return `url_${props.urlId}`
         }
 
         if (props.fixedProperties) {

--- a/frontend/src/scenes/persons/personsSceneLogic.test.ts
+++ b/frontend/src/scenes/persons/personsSceneLogic.test.ts
@@ -27,7 +27,7 @@ describe('personsSceneLogic', () => {
         sceneLogic.actions.setTabs([
             { id: '1', title: '...', pathname: '/', search: '', hash: '', active: true, iconType: 'blank' },
         ])
-        logic = personsSceneLogic({ tabId: '1' })
+        logic = personsSceneLogic()
         logic.mount()
     })
 


### PR DESCRIPTION
## Problem

PostHog's in-app tabs are gone, but the persons and cohorts scene trees still thread a per-tab `tabId` through their logics, props, keys, and components. With one tab it's dead ceremony — and it leaves singleton logics pretending to be tab-keyed.

## Changes

Remove `tabId` from the persons and cohorts scene trees entirely:

- **Logics** — drop `tabId` from props and keys: `personsLogic` (`tab_${tabId}_` prefix gone), `cohortEditLogic` and `addPersonToCohortModalLogic` (`new-${tabId}` / `${id}-${tabId}` → `'new'` / `id`), `mergeSplitPersonLogic` (`${tabId}:${id}` → `${id}`). Each is now a plain singleton keyed only by its own id/url.
- **Components** — drop the `tabId` props, the `throw new Error('… rendered with no tabId')` guards (`PersonsScene`, `Cohort`), and the per-tab `uniqueKey` suffixes: `PersonScene`, `PersonsScene`, `Cohort`, `CohortEdit`, `CohortSceneMenuBar`, `AddPersonToCohortModal`, `MergeSplitPerson`.
- **Tests** — drop the now-obsolete per-tab isolation test in `personsLogic.test` (with one tab, the same urlId is the same instance by design); drop `tabId` args from the cohort/person scene-logic tests.

No behavioural change with a single tab. `sceneLogic`'s own tab state is untouched (that's the later collapse).

## How did you test this code?

Agent (PostHog Code), automated only. Ran the persons + cohorts jest suites locally: `personsLogic`, `personsSceneLogic`, `cohortsSceneLogic`, `CohortEdit` — 55/55 pass. `oxlint` reports 0 errors on the changed files (two pre-existing warnings untouched); `oxfmt` clean. Confirmed no remaining `tabId` references in the persons/cohorts dirs and no external callers of these logics passing `tabId`. Full typecheck runs in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

Authored with PostHog Code (Claude), part of the in-app-tab removal stack. This is the first "thorough per-area" PR: rather than only removing the `tabAwareScene()` root (done earlier for these scenes), it strips all the now-defunct scene-level `tabId` from the area. A full inventory of every `tabId` touchpoint was mapped first so the prop removals don't break callers at typecheck — all 61 references were inside the persons/cohorts dirs with zero external callers. Coupled pieces (`SceneProps.tabId` injection, `sceneLogic`'s `tabs[]`) are deliberately left for the final collapse PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
