### PR TITLE
refactor(frontend): remove defunct tabId from subscriptions scene

### DIFF
--- a/frontend/src/scenes/subscriptions/SubscriptionScene.tsx
+++ b/frontend/src/scenes/subscriptions/SubscriptionScene.tsx
@@ -6,8 +6,7 @@ import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 import { NotFound } from 'lib/components/NotFound'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
-import { sceneLogic } from 'scenes/sceneLogic'
-import { SceneExport, type SceneProps } from 'scenes/sceneTypes'
+import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import type { SubscriptionApi } from '~/generated/core/api.schemas'
@@ -20,12 +19,10 @@ import { SubscriptionSummary } from './components/SubscriptionSummary'
 import { subscriptionSceneLogic } from './subscriptionSceneLogic'
 import { subscriptionsSceneLogic } from './subscriptionsSceneLogic'
 
-function SubscriptionDetailActions({ sub, tabId }: { sub: SubscriptionApi; tabId?: string }): JSX.Element {
+function SubscriptionDetailActions({ sub }: { sub: SubscriptionApi }): JSX.Element {
     const { push } = useActions(router)
-    const { activeTabId } = useValues(sceneLogic)
     const { setEnabled } = useActions(subscriptionSceneLogic)
     const { subscriptionLoading } = useValues(subscriptionSceneLogic)
-    const listTabId = tabId ?? activeTabId ?? undefined
     const editHref = subscriptionEditHref(sub)
     const enabled = isSubscriptionEnabled(sub)
 
@@ -38,9 +35,7 @@ function SubscriptionDetailActions({ sub, tabId }: { sub: SubscriptionApi; tabId
                 name,
             },
             callback: () => {
-                if (listTabId) {
-                    subscriptionsSceneLogic.findMounted({ tabId: listTabId })?.actions.deleteSubscriptionSuccess()
-                }
+                subscriptionsSceneLogic.findMounted()?.actions.deleteSubscriptionSuccess()
                 push(urls.subscriptions())
             },
         })
@@ -76,7 +71,7 @@ function SubscriptionDetailActions({ sub, tabId }: { sub: SubscriptionApi; tabId
     )
 }
 
-export function SubscriptionScene({ tabId }: SceneProps): JSX.Element {
+export function SubscriptionScene(): JSX.Element {
     const {
         subscription,
         subscriptionLoading,
@@ -101,9 +96,7 @@ export function SubscriptionScene({ tabId }: SceneProps): JSX.Element {
                         description={null}
                         resourceType={{ type: 'inbox' }}
                         isLoading={subscriptionLoading}
-                        actions={
-                            subscription ? <SubscriptionDetailActions sub={subscription} tabId={tabId} /> : undefined
-                        }
+                        actions={subscription ? <SubscriptionDetailActions sub={subscription} /> : undefined}
                     />
                     {subscription ? (
                         // Mute the body when the subscription is paused — the LemonTag in the

--- a/frontend/src/scenes/subscriptions/subscriptionSceneLogic.test.ts
+++ b/frontend/src/scenes/subscriptions/subscriptionSceneLogic.test.ts
@@ -68,7 +68,7 @@ describe('subscriptionSceneLogic', () => {
             [FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS]: true,
         })
 
-        const logic = subscriptionSceneLogic({ id: '1', tabId: 'tab-filter' })
+        const logic = subscriptionSceneLogic({ id: '1' })
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
         expect(deliveriesRequestUrls).toHaveLength(1)
@@ -98,7 +98,7 @@ describe('subscriptionSceneLogic', () => {
         featureFlagLogic.mount()
         featureFlagLogic.actions.setFeatureFlags([], {})
 
-        const logic = subscriptionSceneLogic({ id: '1', tabId: 'tab-a' })
+        const logic = subscriptionSceneLogic({ id: '1' })
         logic.mount()
 
         await expectLogic(logic).toDispatchActions(['loadSubscriptionSuccess'])
@@ -123,7 +123,7 @@ describe('subscriptionSceneLogic', () => {
             [FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS]: true,
         })
 
-        const logic = subscriptionSceneLogic({ id: '1', tabId: 'tab-b' })
+        const logic = subscriptionSceneLogic({ id: '1' })
         logic.mount()
 
         await expectLogic(logic).toFinishAllListeners()
@@ -146,7 +146,7 @@ describe('subscriptionSceneLogic', () => {
         featureFlagLogic.mount()
         featureFlagLogic.actions.setFeatureFlags([], {})
 
-        const logic = subscriptionSceneLogic({ id: '1', tabId: 'tab-c' })
+        const logic = subscriptionSceneLogic({ id: '1' })
         logic.mount()
         await expectLogic(logic).toDispatchActions(['loadSubscriptionSuccess'])
         expect(deliveriesRequestUrls).toHaveLength(0)

--- a/frontend/src/scenes/subscriptions/subscriptionSceneLogic.tsx
+++ b/frontend/src/scenes/subscriptions/subscriptionSceneLogic.tsx
@@ -29,7 +29,6 @@ import type { subscriptionSceneLogicType } from './subscriptionSceneLogicType'
 
 export type SubscriptionSceneLogicProps = {
     id: string
-    tabId?: string
 }
 
 function parseCursorFromPaginationUrl(url: string | null | undefined): string | undefined {
@@ -47,7 +46,7 @@ function parseCursorFromPaginationUrl(url: string | null | undefined): string | 
 
 export const subscriptionSceneLogic = kea<subscriptionSceneLogicType>([
     props({} as SubscriptionSceneLogicProps),
-    key(({ id, tabId }) => `${tabId ?? ''}-${id}`),
+    key(({ id }) => id),
     path((key) => ['scenes', 'subscriptions', 'subscriptionSceneLogic', key]),
     connect(() => ({
         values: [featureFlagLogic, ['featureFlags']],

--- a/frontend/src/scenes/subscriptions/subscriptionsSceneLogic.test.ts
+++ b/frontend/src/scenes/subscriptions/subscriptionsSceneLogic.test.ts
@@ -45,7 +45,7 @@ describe('subscriptionsSceneLogic', () => {
         userLogic.mount()
         userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
         router.actions.push(urls.subscriptions())
-        logic = subscriptionsSceneLogic({ tabId: '1' })
+        logic = subscriptionsSceneLogic()
         logic.mount()
     })
 


### PR DESCRIPTION
## Problem

The in-app tab feature is gone, but the subscription detail scene still threads a per-tab `tabId` through its logic key and reads `sceneLogic.values.activeTabId`. With one tab it's dead ceremony.

## Changes

- `subscriptionSceneLogic`: drop the `tabId` prop and the `${tabId ?? ''}-${id}` key — now keyed by `id` alone.
- `SubscriptionScene`: drop the `tabId` prop from the scene component and `SubscriptionDetailActions`, and remove the `sceneLogic.values.activeTabId` read used to find the list logic. `subscriptionsSceneLogic` is already a singleton, so `findMounted()` needs no key (the previous `if (listTabId)` guard goes too). oxlint removed the now-unused `sceneLogic` / `SceneProps` imports.
- Tests: drop the `tabId` args from the subscription scene-logic tests.

No behavioural change with a single tab.

## How did you test this code?

Agent (PostHog Code), automated only. Ran `subscriptionSceneLogic` + `subscriptionsSceneLogic` jest suites: 13/13 pass. `oxlint` 0 errors, `oxfmt` clean. Confirmed no remaining `tabId` in `scenes/subscriptions/` and no external callers passing `tabId` to these logics. Full typecheck in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

Authored with PostHog Code (Claude), part of the in-app-tab removal stack (thorough per-area de-tab). Subscriptions was carved out as its own clean area: its sibling "groups" scene couples to a customer_analytics component (`GroupProfileCanvas`) with a required `tabId`, so groups will land with the customer_analytics area instead. Coupled `sceneLogic` core pieces remain for the final collapse.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
