### PR TITLE
fix(annotations): make emoji annotation markers legible

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.scss
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.scss
@@ -25,6 +25,16 @@
         transform: scale(var(--annotations-badge-scale));
         transform-origin: center;
     }
+
+    // An emoji is illegible at the small count-badge size on the saturated data fill,
+    // so give it a larger disc and a plain surface background to read against.
+    > .LemonBadge.AnnotationsBadge__emoji {
+        --lemon-badge-size: 1.5rem;
+        --lemon-badge-font-size: 1rem;
+
+        color: inherit;
+        background: var(--color-bg-surface-primary);
+    }
 }
 
 .AnnotationsPopover {

--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
@@ -322,7 +322,13 @@ const AnnotationsBadge = React.memo(function AnnotationsBadgeRaw({
         >
             {annotations.length ? (
                 singleEmoji ? (
-                    <LemonBadge content={singleEmoji} status="data" size="small" active={active && isDateLocked} />
+                    <LemonBadge
+                        content={singleEmoji}
+                        status="data"
+                        size="small"
+                        active={active && isDateLocked}
+                        className="AnnotationsBadge__emoji"
+                    />
                 ) : (
                     <LemonBadge.Number
                         count={annotations.length}


### PR DESCRIPTION
## Problem

We recently added optional emoji support for annotations (#61671), but the emoji is rendered inside the small count badge (`size="small"`, ~18px disc, 10px font) on the saturated `--data-color-1` blue fill. At that size and against that background the emoji is tiny and hard to make out on a chart.

## Changes

When an annotation bucket resolves to a single emoji, the badge now:

- uses a larger disc (1.5rem) and larger glyph (1rem) so the emoji is actually legible
- drops the blue fill for a plain `--color-bg-surface-primary` background, so the emoji reads cleanly instead of competing with the colour

The surface-coloured disc still masks the axis line behind it (keeping the floating-marker look), and the active/pinned blue outline is retained for click feedback. Count buckets and the add-annotation `+` badge are unchanged.

Scoped entirely to a new `.AnnotationsBadge__emoji` modifier rather than touching `LemonBadge` globally.

## How did you test this code?

I'm an agent. I ran `stylelint` on the changed SCSS (passes). I did not run the app to visually verify — the change is a self-contained CSS sizing/colour tweak on the single-emoji code path, and there is no Storybook story for `AnnotationsOverlay` to snapshot.

## 🤖 Agent context

Authored with PostHog Code (Claude). The maintainer flagged that the shipped emoji markers were too small and illegible on the blue badge fill, and suggested a simpler background plus a larger size for the emoji case. I scoped the change to the single-emoji branch via a dedicated `.AnnotationsBadge__emoji` class, kept `status="data"` so the active-state outline still uses the data colour, and left the count/add badges untouched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
