### PR TITLE
refactor(frontend): remove defunct tabId from activity scenes

### DIFF
--- a/frontend/src/scenes/activity/explore/EventsScene.tsx
+++ b/frontend/src/scenes/activity/explore/EventsScene.tsx
@@ -13,9 +13,9 @@ import { ActivityTab } from '~/types'
 
 import { eventsSceneLogic } from './eventsSceneLogic'
 
-export function EventsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
-    const { query } = useValues(eventsSceneLogic({ tabId }))
-    const { setQuery } = useActions(eventsSceneLogic({ tabId }))
+export function EventsScene(): JSX.Element {
+    const { query } = useValues(eventsSceneLogic())
+    const { setQuery } = useActions(eventsSceneLogic())
 
     return (
         <SceneContent>
@@ -28,9 +28,8 @@ export function EventsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
                 }}
             />
             <Query
-                attachTo={eventsSceneLogic({ tabId })}
-                uniqueKey={`events-scene-${tabId}`}
-                tabId={tabId}
+                attachTo={eventsSceneLogic()}
+                uniqueKey="events-scene"
                 query={query}
                 setQuery={setQuery}
                 context={{

--- a/frontend/src/scenes/activity/explore/SessionsScene.tsx
+++ b/frontend/src/scenes/activity/explore/SessionsScene.tsx
@@ -15,9 +15,9 @@ import { ActivityTab } from '~/types'
 import { createSessionsRowTransformer, getSessionsColumns } from './sessionsColumns'
 import { sessionsSceneLogic } from './sessionsSceneLogic'
 
-export function SessionsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
-    const { query } = useValues(sessionsSceneLogic({ tabId }))
-    const { setQuery } = useActions(sessionsSceneLogic({ tabId }))
+export function SessionsScene(): JSX.Element {
+    const { query } = useValues(sessionsSceneLogic())
+    const { setQuery } = useActions(sessionsSceneLogic())
 
     // Create the row transformer based on the current query
     const dataTableRowsTransformer = useMemo(() => createSessionsRowTransformer(query as DataTableNode), [query])
@@ -33,9 +33,8 @@ export function SessionsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
                 }}
             />
             <Query
-                attachTo={sessionsSceneLogic({ tabId })}
-                uniqueKey={`sessions-scene-${tabId}`}
-                tabId={tabId}
+                attachTo={sessionsSceneLogic()}
+                uniqueKey="sessions-scene"
                 query={query}
                 setQuery={setQuery}
                 context={{

--- a/frontend/src/scenes/activity/explore/eventsSceneLogic.tsx
+++ b/frontend/src/scenes/activity/explore/eventsSceneLogic.tsx
@@ -1,5 +1,5 @@
 import equal from 'fast-deep-equal'
-import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, reducers, selectors } from 'kea'
 import { urlToAction } from 'kea-router'
 import { UrlToActionPayload } from 'kea-router/lib/types'
 
@@ -21,13 +21,8 @@ import { ActivityTab, Breadcrumb } from '~/types'
 
 import type { eventsSceneLogicType } from './eventsSceneLogicType'
 
-export interface EventsSceneLogicProps {
-    tabId?: string
-}
-
 export const eventsSceneLogic = kea<eventsSceneLogicType>([
-    props({} as EventsSceneLogicProps),
-    key((props) => props.tabId || 'scene'),
+    key(() => 'scene'),
     path((key) => ['scenes', 'events', 'eventsSceneLogic', key]),
     connect(() => ({
         values: [
@@ -45,17 +40,10 @@ export const eventsSceneLogic = kea<eventsSceneLogicType>([
 
     actions({ setQuery: (query: Node) => ({ query }) }),
     reducers({ savedQuery: [null as Node | null, { setQuery: (_, { query }) => query }] }),
-    listeners(({ props, actions, values }) => ({
+    listeners(({ actions, values }) => ({
         setQuery: ({ query }) => {
-            // No owning tab → no removeTab cleanup will ever clear this slot.
-            // sceneKey is constant ('events') so it'd be a single overwriting slot under
-            // '__no_tab__', but we still skip it for consistency with dataTableLogic and
-            // because persistence semantically requires a tab.
-            if (props.tabId === undefined) {
-                return
-            }
             const isDefault = objectsEqual(query, values.defaultQuery)
-            actions.setSavedQueryForTab(props.tabId, 'events', isDefault ? null : query)
+            actions.setSavedQueryForTab(undefined, 'events', isDefault ? null : query)
         },
     })),
     selectors({
@@ -94,13 +82,13 @@ export const eventsSceneLogic = kea<eventsSceneLogicType>([
         ],
     })),
 
-    urlToAction(({ actions, values, props }) => {
+    urlToAction(({ actions, values }) => {
         const eventsQueryHandler: UrlToActionPayload[keyof UrlToActionPayload] = (_, __, { q: queryParam }): void => {
             if (!equal(queryParam, values.query)) {
                 // nothing in the URL
                 if (!queryParam) {
-                    // restore from per-tab persisted query if present, else fall back to default
-                    const persisted = values.savedQueryFor(props.tabId, 'events')
+                    // restore from the persisted query if present, else fall back to default
+                    const persisted = values.savedQueryFor(undefined, 'events')
                     const target = persisted ?? values.defaultQuery
                     if (!objectsEqual(values.query, target)) {
                         actions.setQuery(target)

--- a/frontend/src/scenes/activity/explore/sessionsSceneLogic.tsx
+++ b/frontend/src/scenes/activity/explore/sessionsSceneLogic.tsx
@@ -1,5 +1,5 @@
 import equal from 'fast-deep-equal'
-import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, reducers, selectors } from 'kea'
 import { urlToAction } from 'kea-router'
 import { UrlToActionPayload } from 'kea-router/lib/types'
 
@@ -19,13 +19,8 @@ import { ActivityTab, Breadcrumb } from '~/types'
 
 import type { sessionsSceneLogicType } from './sessionsSceneLogicType'
 
-export interface SessionsSceneLogicProps {
-    tabId?: string
-}
-
 export const sessionsSceneLogic = kea<sessionsSceneLogicType>([
-    props({} as SessionsSceneLogicProps),
-    key((props) => props.tabId || 'scene'),
+    key(() => 'scene'),
     path((key) => ['scenes', 'sessions', 'sessionsSceneLogic', key]),
     connect(() => ({
         values: [
@@ -41,14 +36,10 @@ export const sessionsSceneLogic = kea<sessionsSceneLogicType>([
 
     actions({ setQuery: (query: Node) => ({ query }) }),
     reducers({ savedQuery: [null as Node | null, { setQuery: (_, { query }) => query }] }),
-    listeners(({ props, actions, values }) => ({
+    listeners(({ actions, values }) => ({
         setQuery: ({ query }) => {
-            // No owning tab → no removeTab cleanup will reach this slot. See eventsSceneLogic.
-            if (props.tabId === undefined) {
-                return
-            }
             const isDefault = objectsEqual(query, values.defaultQuery)
-            actions.setSavedQueryForTab(props.tabId, 'sessions', isDefault ? null : query)
+            actions.setSavedQueryForTab(undefined, 'sessions', isDefault ? null : query)
         },
     })),
     selectors({
@@ -78,16 +69,16 @@ export const sessionsSceneLogic = kea<sessionsSceneLogicType>([
         ],
     })),
 
-    urlToAction(({ actions, values, props }) => {
+    urlToAction(({ actions, values }) => {
         const sessionsQueryHandler: UrlToActionPayload[keyof UrlToActionPayload] = (_, __, { q: queryParam }): void => {
             // If query hasn't changed, do nothing
             if (equal(queryParam, values.query)) {
                 return
             }
 
-            // Handle missing query param - restore from per-tab persisted query, else fall back to default
+            // Handle missing query param - restore from the persisted query, else fall back to default
             if (!queryParam) {
-                const persisted = values.savedQueryFor(props.tabId, 'sessions')
+                const persisted = values.savedQueryFor(undefined, 'sessions')
                 const target = persisted ?? values.defaultQuery
                 if (!objectsEqual(values.query, target)) {
                     actions.setQuery(target)

--- a/frontend/src/scenes/activity/live/liveEventsTableSceneLogic.ts
+++ b/frontend/src/scenes/activity/live/liveEventsTableSceneLogic.ts
@@ -1,4 +1,4 @@
-import { kea, key, path, props, selectors } from 'kea'
+import { kea, key, path, selectors } from 'kea'
 
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
@@ -7,13 +7,8 @@ import { Breadcrumb } from '~/types'
 
 import type { liveEventsTableSceneLogicType } from './liveEventsTableSceneLogicType'
 
-export interface LiveEventsTableSceneProps {
-    tabId?: string
-}
-
 export const liveEventsTableSceneLogic = kea<liveEventsTableSceneLogicType>([
-    props({} as LiveEventsTableSceneProps),
-    key((props) => props.tabId || 'scene'),
+    key(() => 'scene'),
     path((key) => ['scenes', 'activity', 'live-events', 'liveEventsTableSceneLogic', key]),
     selectors(() => ({
         breadcrumbs: [


### PR DESCRIPTION
## Problem

The in-app tab feature is gone, but the activity scenes (events, sessions, live events) still thread a per-tab `tabId` through their logic keys and components. With one tab it's dead ceremony.

## Changes

- `eventsSceneLogic`, `sessionsSceneLogic`, `liveEventsTableSceneLogic`: drop the `tabId` prop and the `props.tabId || 'scene'` key — each is now a plain singleton (constant key).
- `EventsScene`, `SessionsScene`: drop the `tabId` prop, the `eventsSceneLogic({ tabId })` threading, the `attachTo` tabId, the per-tab `uniqueKey` suffix, and the `tabId` pass-through to `<Query>` (its prop is optional and gets removed with the DataTable tree later).
- **Query persistence preserved.** events/sessions persist the user's query via `tabUiStateLogic`, which already maps a missing `tabId` to a single `__no_tab__` bucket. So I pass `undefined` and remove the now-pointless `if (props.tabId === undefined) return` guard — same in-session query memory, one bucket. (Verified: `tabUiStateLogic` reads and writes `tabId ?? '__no_tab__'` symmetrically, and it's in-memory, so nothing on disk is orphaned.)

No behavioural change with a single tab.

## How did you test this code?

Agent (PostHog Code), automated only. These three logics have no direct jest coverage, so CI typecheck is the gate here. Locally: `oxlint` 0 errors on the changed files (it removed the now-unused `props` imports), `oxfmt` clean, no remaining `tabId` in `scenes/activity/`, and no external callers pass `tabId` to these logics or scenes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

Authored with PostHog Code (Claude), part of the in-app-tab removal stack (thorough per-area de-tab). The one judgment call here — what to do with the per-tab query persistence — was made deliberately: keep it (single in-memory bucket) rather than drop it, since `tabUiStateLogic` is in-memory and the per-tab buckets were already ephemeral (a fresh random tab id per page load), so the single-bucket version preserves today's behaviour with no data loss. `dataTableLogic`'s identical guard will get the same treatment when the DataTable tree is de-tabbed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
