### PR TITLE
refactor(frontend): remove defunct tabId from session-recordings scene

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -188,16 +188,16 @@ function Warnings(): JSX.Element {
     )
 }
 
-function MainPanel({ tabId }: { tabId: string }): JSX.Element {
+function MainPanel(): JSX.Element {
     const { tab } = useValues(sessionReplaySceneLogic)
     const isRedesignEnabled = useFeatureFlag('REPLAY_UI_REDESIGN_2026', 'test')
 
     const playlistLogicProps: SessionRecordingPlaylistLogicProps = {
-        logicKey: `scene-${tabId}`,
+        logicKey: 'scene',
         updateSearchParams: true,
     }
 
-    useAttachedLogic(sessionRecordingsPlaylistLogic(playlistLogicProps), sessionReplaySceneLogic({ tabId }))
+    useAttachedLogic(sessionRecordingsPlaylistLogic(playlistLogicProps), sessionReplaySceneLogic())
 
     return (
         <div className={cn('flex flex-col gap-y-4', ReplayTabs.Home === tab && 'grow')}>
@@ -272,16 +272,9 @@ export function SessionRecordingsPageTabs(): JSX.Element {
     )
 }
 
-export interface SessionsRecordingsProps {
-    tabId?: string
-}
-
-export function SessionsRecordings({ tabId }: SessionsRecordingsProps = {}): JSX.Element {
-    if (!tabId) {
-        throw new Error('<SessionsRecordings /> must receive a tabId prop')
-    }
+export function SessionsRecordings(): JSX.Element {
     return (
-        <BindLogic logic={sessionReplaySceneLogic} props={{ tabId }}>
+        <BindLogic logic={sessionReplaySceneLogic} props={{}}>
             <SceneContent className="h-full">
                 <SceneTitleSection
                     name={sceneConfigurations[Scene.Replay].name}
@@ -291,7 +284,7 @@ export function SessionsRecordings({ tabId }: SessionsRecordingsProps = {}): JSX
                     actions={<Header />}
                 />
                 <SessionRecordingsPageTabs />
-                <MainPanel tabId={tabId} />
+                <MainPanel />
             </SceneContent>
         </BindLogic>
     )

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
@@ -38,13 +38,12 @@ import type { sessionRecordingsPlaylistSceneLogicType } from './sessionRecording
 
 export interface SessionRecordingsPlaylistLogicProps {
     shortId: string
-    tabId?: string
 }
 
 export const sessionRecordingsPlaylistSceneLogic = kea<sessionRecordingsPlaylistSceneLogicType>([
     path((key) => ['scenes', 'session-recordings', 'playlist', 'sessionRecordingsPlaylistSceneLogic', key]),
     props({} as SessionRecordingsPlaylistLogicProps),
-    key((props) => `${props.tabId ? props.tabId + ':' : ''}${props.shortId}`),
+    key((props) => props.shortId),
     connect(() => ({
         values: [cohortsModel, ['cohortsById'], sceneLogic, ['activeSceneId'], featureFlagLogic, ['featureFlags']],
         actions: [sessionRecordingEventUsageLogic, ['reportRecordingPlaylistCreated']],

--- a/frontend/src/scenes/session-recordings/sessionReplaySceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionReplaySceneLogic.ts
@@ -12,10 +12,6 @@ import { ActivityScope, Breadcrumb, ReplayTabs } from '~/types'
 
 import type { sessionReplaySceneLogicType } from './sessionReplaySceneLogicType'
 
-export interface SessionReplaySceneLogicProps {
-    tabId?: string
-}
-
 export const humanFriendlyTabName = (tab: ReplayTabs): string => {
     switch (tab) {
         case ReplayTabs.Home:

--- a/frontend/src/scenes/session-recordings/settings/SessionRecordingsSettingsScene.tsx
+++ b/frontend/src/scenes/session-recordings/settings/SessionRecordingsSettingsScene.tsx
@@ -46,16 +46,9 @@ export const scene: SceneExport = {
     productKey: ProductKey.SESSION_REPLAY,
 }
 
-export interface SessionRecordingsSettingsSceneProps {
-    tabId?: string
-}
-
-export function SessionRecordingsSettingsScene({ tabId }: SessionRecordingsSettingsSceneProps = {}): JSX.Element {
-    if (!tabId) {
-        throw new Error('<SessionRecordingsSettingsScene /> must receive a tabId prop')
-    }
+export function SessionRecordingsSettingsScene(): JSX.Element {
     return (
-        <BindLogic logic={sessionReplaySceneLogic} props={{ tabId }}>
+        <BindLogic logic={sessionReplaySceneLogic} props={{}}>
             <SceneContent className="-mb-14">
                 <SceneTitleSection
                     name={sceneConfigurations[Scene.Replay].name}


### PR DESCRIPTION
## Problem

The in-app tab feature is gone, but the session-recordings scene still threads a per-tab `tabId` through its logic, key, and components.

## Changes

- `sessionReplaySceneLogic`: drop the vestigial `tabId` prop (the logic is already a singleton).
- `sessionRecordingsPlaylistSceneLogic`: drop the `tabId` prefix from its key — now keyed by `shortId` alone.
- `SessionRecordings` / `SessionRecordingsSettingsScene`: drop the `tabId` props, the `must receive a tabId` throws, the per-tab `logicKey` suffix, and the `BindLogic` tabId threading.

The player sidebar's own `tabId` (its inspector/overview/etc. tab keys in `PlayerSidebar`) is a different concept and is left untouched.

No behavioural change with a single tab.

## How did you test this code?

Agent (PostHog Code), automated only. Ran the `sessionRecordingsPlaylistSceneLogic` jest suite: 2/2 pass. `oxlint` 0 errors on the changed files, `oxfmt` clean. Confirmed the only remaining `tabId` in `scenes/session-recordings/` is the unrelated player-sidebar tab, and no external callers pass `tabId` to these logics/scenes. Full typecheck in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

Authored with PostHog Code (Claude), part of the in-app-tab removal stack (thorough per-area de-tab). Care taken to leave `PlayerSidebar`'s `tabId` (player inspector tabs) and `sessionReplaySceneLogic`'s `tab`/`shouldShowNewBadge` state alone — only the scene-level in-app `tabId` was removed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
