### PR TITLE
refactor(frontend): remove defunct tabId from the DataTable tree

### DIFF
--- a/frontend/src/lib/logic/tabUiStateLogic.test.ts
+++ b/frontend/src/lib/logic/tabUiStateLogic.test.ts
@@ -118,8 +118,8 @@ describe('tabUiStateLogic', () => {
         logicB.unmount()
 
         // State survives both unmounts — the global owns it.
-        expect(tabUiStateLogic.values.expandedRowsFor(TAB_A, `viz-${TAB_A}`)).toEqual([1])
-        expect(tabUiStateLogic.values.expandedRowsFor(TAB_B, `viz-${TAB_B}`)).toEqual([2])
+        expect(tabUiStateLogic.values.expandedRowsFor(undefined, `viz-${TAB_A}`)).toEqual([1])
+        expect(tabUiStateLogic.values.expandedRowsFor(undefined, `viz-${TAB_B}`)).toEqual([2])
     })
 
     describe('savedQueriesByTabAndScene', () => {

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -87,8 +87,6 @@ export interface QueryProps<Q extends Node> {
     dataAttr?: string
     /** Attach ourselves to another logic, such as the scene logic */
     attachTo?: BuiltLogic | LogicWrapper
-    /** Owning internal tab; used to scope per-tab UI state across tab unmounts */
-    tabId?: string
 }
 
 export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null {
@@ -144,7 +142,6 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
                 uniqueKey={uniqueKey}
                 readOnly={readOnly}
                 dataAttr={dataAttr}
-                tabId={props.tabId}
             />
         )
     } else if (isDataVisualizationNode(query)) {

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -125,8 +125,6 @@ interface DataTableProps {
     dataAttr?: string
     /** Attach ourselves to another logic, such as the scene logic */
     attachTo?: BuiltLogic | LogicWrapper
-    /** Owning internal tab; used to scope per-tab UI state across tab unmounts */
-    tabId?: string
 }
 
 const eventGroupTypes = [
@@ -148,7 +146,6 @@ export function DataTable({
     readOnly,
     dataAttr,
     attachTo,
-    tabId,
 }: DataTableProps): JSX.Element {
     const [uniqueNodeKey] = useState(() => uniqueNode++)
     const [dataKey] = useState(() => `DataNode.${uniqueKey || uniqueNodeKey}`)
@@ -205,7 +202,6 @@ export function DataTable({
         dataKey,
         dataNodeLogicKey: dataNodeLogicProps.key,
         context,
-        tabId,
     }
     const {
         dataTableRows,
@@ -948,14 +944,9 @@ export function DataTable({
                                         ? context.expandable
                                         : expandable && columnsInResponse?.includes('*')
                                           ? {
-                                                ...(tabId !== undefined
-                                                    ? {
-                                                          isRowExpanded: (_, rowIndex) =>
-                                                              expandedRows.includes(rowIndex),
-                                                          onRowExpand: (_, rowIndex) => toggleRowExpanded(rowIndex),
-                                                          onRowCollapse: (_, rowIndex) => toggleRowExpanded(rowIndex),
-                                                      }
-                                                    : {}),
+                                                isRowExpanded: (_, rowIndex) => expandedRows.includes(rowIndex),
+                                                onRowExpand: (_, rowIndex) => toggleRowExpanded(rowIndex),
+                                                onRowCollapse: (_, rowIndex) => toggleRowExpanded(rowIndex),
                                                 expandedRowRender: function renderExpand({ result }) {
                                                     if (
                                                         (isEventsQuery(query.source) ||

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -32,8 +32,6 @@ export interface DataTableLogicProps {
     context?: QueryContext<DataTableNode>
     // Override the data logic node key if needed
     dataNodeLogicKey?: string
-    // Used to scope per-tab UI state (e.g. expanded rows) so it survives tab switches
-    tabId?: string
 }
 
 export interface DataTableRow {
@@ -88,21 +86,15 @@ export const dataTableLogic = kea<dataTableLogicType>([
     })),
     listeners(({ props, actions }) => ({
         toggleRowExpanded: ({ rowIndex }) => {
-            if (props.tabId === undefined) {
-                return
-            }
-            actions.toggleExpandedRow(props.tabId, props.vizKey, rowIndex)
+            actions.toggleExpandedRow(undefined, props.vizKey, rowIndex)
         },
     })),
     selectors({
         context: [() => [(_, props) => props.context], (context) => context],
         expandedRows: [
-            (s) => [s.expandedRowsFor, (_, p) => p.tabId, (_, p) => p.vizKey],
-            (
-                expandedRowsFor: (tabId: string | undefined, vizKey: string) => number[],
-                tabId: string | undefined,
-                vizKey: string
-            ): number[] => expandedRowsFor(tabId, vizKey),
+            (s) => [s.expandedRowsFor, (_, p) => p.vizKey],
+            (expandedRowsFor: (tabId: string | undefined, vizKey: string) => number[], vizKey: string): number[] =>
+                expandedRowsFor(undefined, vizKey),
             { resultEqualityCheck: objectsEqual },
         ],
         sourceKind: [(_, p) => [p.query], (query): NodeKind | null => query.source?.kind],


### PR DESCRIPTION
## Problem

`Query`/`DataTable`/`dataTableLogic` threaded a per-tab `tabId` to scope expanded-row UI state (via `tabUiStateLogic`). The in-app tab feature is gone and no scene passes `<Query tabId>` any more, so the threading is inert dead code.

## Changes

- Remove the `tabId` prop from `QueryProps`, `DataTableProps`, and `DataTableLogicProps` (and the `Query` → `DataTable` pass-through).
- Route expanded-row state through the single `tabUiStateLogic` bucket: pass `undefined` (the logic maps it to `__no_tab__`), keyed by `vizKey`. Drop the now-pointless `if (props.tabId === undefined) return` guard and the `tabId !== undefined` gate around the row-expand handlers.

**Behaviour note:** the row-expand handlers were previously gated on a defined `tabId`, which (after the scene de-tabs) was never the case — so expansion state wasn't being persisted. With the gate removed they're always wired, so expanded rows now persist per-table (keyed by `vizKey`) within a session via the in-memory `tabUiStateLogic`. No durable storage; nothing is lost.

## How did you test this code?

Agent (PostHog Code), automated only. `dataTableLogic` jest suite: 12/12 pass. `oxlint` 0 errors on the changed files (1 pre-existing, unrelated `jsx-key` warning untouched), `oxfmt` clean. Confirmed no `<Query tabId>` / `<DataTable tabId>` callers remain anywhere. Full typecheck in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

Authored with PostHog Code (Claude), part of the in-app-tab removal stack. This unblocks removing the `tabId` pass-throughs from the remaining scenes (since `Query`/`DataTable` no longer accept it). The single-bucket persistence choice matches the activity-scenes PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
