### PR TITLE
fix(gateway): check org membership when projecting first-party policy

### DIFF
--- a/posthog/storage/first_party_gateway_policy_cache.py
+++ b/posthog/storage/first_party_gateway_policy_cache.py
@@ -46,6 +46,7 @@ import structlog
 from posthog.caching.ai_gateway_redis_cache import AI_GATEWAY_DEDICATED_CACHE_ALIAS
 from posthog.models.gateway import GATEWAY_SLUG_PATTERN, Gateway
 from posthog.models.oauth import OAuthAccessToken
+from posthog.models.organization import OrganizationMembership
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import SHA256_HASH_PREFIX, hash_key_value
 from posthog.storage.hypercache import HyperCache, HyperCacheStoreMissing, KeyType
@@ -138,7 +139,8 @@ def _policy_for_credential(credential: Credential) -> dict[str, Any] | HyperCach
 
     The bound gateway is the source of truth for the billed team (not the user's
     current team), so team_id is deterministic. Fails closed on missing scope,
-    inactive user, expired token, unbound credential, or a team with no token.
+    inactive user, expired token, unbound credential, a team with no token, or a
+    user who is no longer a member of the billed team's org.
     """
     if not credential_has_gateway_scope(credential):
         return HyperCacheStoreMissing()
@@ -174,6 +176,12 @@ def _policy_for_credential(credential: Credential) -> dict[str, Any] | HyperCach
     if credential.scoped_teams and team_id not in credential.scoped_teams:
         return HyperCacheStoreMissing()
     if credential.scoped_organizations and str(team.organization_id) not in credential.scoped_organizations:
+        return HyperCacheStoreMissing()
+
+    # scoped_organizations is a static ceiling — it doesn't track the user leaving
+    # the org. The gateway can't re-check membership, so verify the user still
+    # belongs to the billed team's org here and fail closed otherwise.
+    if not OrganizationMembership.objects.filter(organization_id=team.organization_id, user_id=user.id).exists():
         return HyperCacheStoreMissing()
 
     return {

--- a/posthog/storage/first_party_gateway_policy_signal_handlers.py
+++ b/posthog/storage/first_party_gateway_policy_signal_handlers.py
@@ -27,12 +27,13 @@ from uuid import UUID
 
 from django.conf import settings
 from django.db import transaction
-from django.db.models.signals import post_init, post_save, pre_delete, pre_save
+from django.db.models.signals import post_delete, post_init, post_save, pre_delete, pre_save
 
 import structlog
 
 from posthog.models.gateway import Gateway
 from posthog.models.oauth import OAuthAccessToken
+from posthog.models.organization import OrganizationMembership
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.user import User
 from posthog.models.utils import SHA256_HASH_PREFIX
@@ -202,6 +203,18 @@ def _reproject_user_on_save(sender: type[User], instance: User, created: bool, *
     transaction.on_commit(lambda: reproject_user_first_party_policies_task.delay(user_id))
 
 
+def _reproject_on_membership_delete(
+    sender: type[OrganizationMembership], instance: OrganizationMembership, **kwargs: Any
+) -> None:
+    # Losing org membership revokes gateway access, but it touches neither the
+    # credential nor is_active, so nothing else re-projects. Re-project the user's
+    # credentials — the policy now fails closed for a non-member and clears the blob.
+    if not settings.AI_GATEWAY_REDIS_URL:
+        return
+    user_id = instance.user_id
+    transaction.on_commit(lambda: reproject_user_first_party_policies_task.delay(user_id))
+
+
 def _snapshot_gateway(sender: type[Gateway], instance: Gateway, **kwargs: Any) -> None:
     if not settings.AI_GATEWAY_REDIS_URL:
         return
@@ -272,6 +285,8 @@ def connect_signal_handlers() -> None:
 
     post_init.connect(_snapshot_user, sender=User)
     post_save.connect(_reproject_user_on_save, sender=User)
+
+    post_delete.connect(_reproject_on_membership_delete, sender=OrganizationMembership)
 
     post_init.connect(_snapshot_gateway, sender=Gateway)
     post_save.connect(_reproject_gateway_on_save, sender=Gateway)

--- a/posthog/storage/test/test_first_party_gateway_policy_cache.py
+++ b/posthog/storage/test/test_first_party_gateway_policy_cache.py
@@ -247,6 +247,18 @@ class TestFirstPartyPolicyFailClosed(FirstPartyPolicyTestMixin):
         project_first_party_policy(credential)
         self.assertIsNotNone(self._read_blob(credential_hash(credential)))
 
+    def test_non_member_user_fails_closed(self):
+        # A user removed from the billed team's org loses gateway access even
+        # though the key, gateway, and is_active are untouched.
+        credential, _ = self._make_pak([GATEWAY_SCOPE])
+        project_first_party_policy(credential)
+        cache_hash = credential_hash(credential)
+        assert self._read_blob(cache_hash) is not None
+
+        self.organization_membership.delete()
+        project_first_party_policy(credential)
+        self.assertIsNone(self._read_blob(cache_hash))
+
 
 class TestFirstPartyPolicyRefresh(FirstPartyPolicyTestMixin):
     def test_refresh_projects_eligible_credentials(self):
@@ -374,6 +386,17 @@ class TestFirstPartyPolicySignals(FirstPartyPolicyTestMixin):
         user.save()
 
         mock_delay.assert_called_with(user.pk)
+
+    @patch("posthog.storage.first_party_gateway_policy_signal_handlers.transaction")
+    @patch("posthog.storage.first_party_gateway_policy_signal_handlers.settings")
+    @patch("posthog.storage.first_party_gateway_policy_signal_handlers.reproject_user_first_party_policies_task.delay")
+    def test_membership_delete_reprojects(self, mock_delay, mock_settings, mock_transaction):
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
+        mock_transaction.on_commit.side_effect = lambda fn: fn()
+
+        self.organization_membership.delete()
+
+        mock_delay.assert_called_with(self.user.pk)
 
     def test_reproject_task_clears_inactive_user_blobs(self):
         pak, _ = self._make_pak([GATEWAY_SCOPE])

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -59,6 +59,7 @@
     'posthog.tasks.email.send_two_factor_reset_email',
     'posthog.tasks.exporter.export_asset',
     'posthog.tasks.first_party_gateway_policy.refresh_first_party_gateway_policies',
+    'posthog.tasks.first_party_gateway_policy.reproject_gateway_first_party_policies_task',
     'posthog.tasks.first_party_gateway_policy.reproject_user_first_party_policies_task',
     'posthog.tasks.first_party_gateway_policy.update_first_party_policy_cache_task',
     'posthog.tasks.health_checks.evaluate_health_check_for_team',


### PR DESCRIPTION
## Problem

The first-party gateway policy projection authorized a `phx_`/`pha_` credential from its scope, `is_active`, and its static `scoped_teams`/`scoped_organizations`, but never verified the credential's user is still a member of the bound gateway's team org. A user removed from the org kept a valid projected blob until the key was deleted — removal touches neither the key, the gateway, nor `is_active`, and nothing reprojected on membership change. The Go gateway trusts the blob without a membership re-check.

Closes #62012

## Changes

- Live membership check in `_policy_for_credential`: fail closed when the credential's user is not a member of the billed team's org. `scoped_organizations` is a static ceiling and doesn't track the user leaving the org, so this is the enforcement point the gateway can't provide.
- New `OrganizationMembership` `post_delete` signal that reprojects the affected user's gateway credentials, mirroring the existing `is_active` handling — the now-non-member's blobs fail closed and clear.

This is the per-dimension fix for the membership gap. The broader signal-bypass backstop (a reconciler driven from the cache side) is noted on #62012 and deferred.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only — no manual testing:

- `test_non_member_user_fails_closed` — projecting after the user's org membership is removed clears the blob.
- `test_membership_delete_reprojects` — deleting an `OrganizationMembership` enqueues the user reprojection task.
- Full `posthog/storage/test/test_first_party_gateway_policy_cache.py` suite (40 tests) passes locally.

## 🤖 Agent context

Authored with PostHog Code (Claude) as a stacked follow-up to #62008, implementing the fix direction described in #62012. The membership check is placed in `_policy_for_credential` (projection time) and backed by a `post_delete` signal so removals propagate promptly; bulk/`.update()` membership removals that bypass signals remain covered only by blob TTL until the reconciler backstop noted on #62012 lands. Requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
