### PR TITLE
feat(insights): glossy rounded trends bars with eased hover

### DIFF
--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.stories.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import type { BarChartConfig, Series } from '../../core/types'
+import type { BarChartConfig, BarFillStyle, Series } from '../../core/types'
 import { ReferenceLine } from '../../overlays/ReferenceLine'
 import { ValueLabels } from '../../overlays/ValueLabels'
 import { Stage, useReactiveTheme } from '../../story-helpers'
@@ -249,4 +249,47 @@ export const CustomCornerRadius: Story = {
             </Stage>
         )
     },
+}
+
+const BREAKDOWN_LABELS = ['/login', 'Other', '/projects', '/surveys', '/dashboard', '/insights', '/persons', '/events']
+const BREAKDOWN_DATA = [9200, 8400, 6100, 5200, 4300, 3600, 2800, 2100]
+
+function FillStyleColumn({ title, fillStyle }: { title: string; fillStyle: BarFillStyle }): JSX.Element {
+    const theme = useReactiveTheme()
+    // One series with a value per category — per-bar colors echo a breakdown chart.
+    const series: Series[] = [
+        {
+            key: 'pages',
+            label: 'Pageviews',
+            color: theme.colors[0],
+            data: BREAKDOWN_DATA,
+            bars: BREAKDOWN_DATA.map((_, i) => ({ color: theme.colors[i % theme.colors.length] })),
+        },
+    ]
+    const config: BarChartConfig = {
+        barLayout: 'grouped',
+        showGrid: true,
+        axisOrientation: 'horizontal',
+        bars: { cornerRadius: 4, fillStyle },
+    }
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <span className="text-xs font-semibold text-muted-foreground">{title}</span>
+            <Stage width={340} height={360}>
+                <BarChart series={series} labels={BREAKDOWN_LABELS} config={config} theme={theme} />
+            </Stage>
+        </div>
+    )
+}
+
+export const FillStyles: Story = {
+    render: () => (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ display: 'flex', gap: 24, alignItems: 'flex-start' }}>
+            <FillStyleColumn title="flat (current)" fillStyle="flat" />
+            <FillStyleColumn title="gradient" fillStyle="gradient" />
+            <FillStyleColumn title="gloss" fillStyle="gloss" />
+        </div>
+    ),
 }

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -163,6 +163,7 @@ function BarChartInner<Meta = unknown>({
         fitToHeight = false,
         valueDomain,
         roundStackEnds = false,
+        fillStyle: barFillStyle = 'flat',
     } = config?.bars ?? {}
     const isHorizontal = axisOrientation === 'horizontal'
 
@@ -419,7 +420,7 @@ function BarChartInner<Meta = unknown>({
                 clipToRoundedRects(ctx, stackPills, barCornerRadius)
             }
             for (const { series: s, bars } of seriesBars) {
-                drawBars(baseDrawCtx, s, bars, stackPills.length > 0 ? 0 : barCornerRadius)
+                drawBars(baseDrawCtx, s, bars, stackPills.length > 0 ? 0 : barCornerRadius, barFillStyle)
             }
             if (stackPills.length > 0) {
                 ctx.restore()
@@ -439,6 +440,7 @@ function BarChartInner<Meta = unknown>({
             barTrack,
             xTickFormatter,
             barShadow,
+            barFillStyle,
         ]
     )
 

--- a/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 
 import type {
     BarChartConfig,
+    BarFillStyle,
     ChartTheme,
     PointClickData,
     Series,
@@ -41,6 +42,10 @@ export interface TimeSeriesBarChartConfig {
     tooltip?: TooltipConfig
     /** Stacked layout only — stack negatives below the zero baseline (d3.stackOffsetDiverging). */
     divergingStack?: boolean
+    /** Bar fill treatment — `flat` (default), `gradient`, or `gloss`. */
+    fillStyle?: BarFillStyle
+    /** Ease the hover highlight in over this many ms (`true` = default duration). Omit to snap. */
+    animateHover?: boolean | number
 }
 
 export interface TimeSeriesBarChartProps<Meta = unknown> {
@@ -79,6 +84,8 @@ export function TimeSeriesBarChart<Meta = unknown>({
         showCrosshair,
         tooltip: tooltipConfig,
         divergingStack,
+        fillStyle,
+        animateHover,
     } = config ?? {}
     const xTickFormatter = useXTickFormatter(xAxis, labels)
     const yTickFormatter = useYTickFormatter(yAxis)
@@ -119,10 +126,12 @@ export function TimeSeriesBarChart<Meta = unknown>({
         axisOrientation,
         showCrosshair,
         tooltip: tooltipConfig,
+        animateHover,
         bars: {
             cornerRadius: barCornerRadius,
             divergingStack,
             valueDomain,
+            fillStyle,
         },
     }
 

--- a/packages/quill/packages/charts/src/core/bar-canvas-renderer.test.ts
+++ b/packages/quill/packages/charts/src/core/bar-canvas-renderer.test.ts
@@ -9,6 +9,7 @@ import {
     type DrawContext,
     traceRoundedBarPath,
 } from './canvas-renderer'
+import type { BarFillStyle } from './types'
 
 function mockCanvasContext(): jest.Mocked<CanvasRenderingContext2D> {
     return {
@@ -23,6 +24,8 @@ function mockCanvasContext(): jest.Mocked<CanvasRenderingContext2D> {
         save: jest.fn(),
         restore: jest.fn(),
         createPattern: jest.fn(() => ({}) as CanvasPattern),
+        createLinearGradient: jest.fn(() => ({ addColorStop: jest.fn() }) as unknown as CanvasGradient),
+        createRadialGradient: jest.fn(() => ({ addColorStop: jest.fn() }) as unknown as CanvasGradient),
         strokeStyle: '',
         fillStyle: '',
         lineWidth: 0,
@@ -140,6 +143,28 @@ describe('hog-charts canvas-renderer (bars)', () => {
             const series = makeSeries({ key: 's', data: [1], color: '#abcdef' })
             drawBars(drawCtx, series, [BASE_BAR])
             expect(ctx.fillStyle).toBe('#abcdef')
+        })
+
+        describe('fillStyle', () => {
+            const series = makeSeries({ key: 's', data: [1], color: '#abcdef' })
+
+            it.each<{ style: BarFillStyle; linear: number; radial: number }>([
+                { style: 'flat', linear: 0, radial: 0 },
+                { style: 'gradient', linear: 1, radial: 0 },
+                { style: 'gloss', linear: 0, radial: 1 },
+            ])('routes fillStyle=$style to the matching gradient call', ({ style, linear, radial }) => {
+                const ctx = mockCanvasContext()
+                drawBars(makeDrawContext(ctx, ['a']), series, [BASE_BAR], 0, style)
+                expect(ctx.createLinearGradient).toHaveBeenCalledTimes(linear)
+                expect(ctx.createRadialGradient).toHaveBeenCalledTimes(radial)
+            })
+
+            it('falls back to a solid color for dashed (hatched) bars regardless of fillStyle', () => {
+                const ctx = mockCanvasContext()
+                const dashed = makeSeries({ key: 's', data: [1], color: '#abcdef', stroke: { partial: { fromIndex: 0 } } })
+                drawBars(makeDrawContext(ctx, ['a']), dashed, [BASE_BAR], 0, 'gloss')
+                expect(ctx.createRadialGradient).not.toHaveBeenCalled()
+            })
         })
 
         it('uses per-bar colors from bars[i].color, falling back to series.color where absent', () => {

--- a/packages/quill/packages/charts/src/core/canvas-renderer.ts
+++ b/packages/quill/packages/charts/src/core/canvas-renderer.ts
@@ -1,8 +1,8 @@
 import { type ScaleLinear, type ScaleLogarithmic } from 'd3-scale'
 
-import { barColorAt } from './color-utils'
+import { barColorAt, mixColors } from './color-utils'
 import { yTickCountForHeight } from './scales'
-import type { ChartDimensions, ChartDrawArgs, DrawHoverResult, ResolvedSeries } from './types'
+import type { BarFillStyle, ChartDimensions, ChartDrawArgs, DrawHoverResult, ResolvedSeries } from './types'
 
 export interface DrawContext {
     ctx: CanvasRenderingContext2D
@@ -486,13 +486,49 @@ export interface BarShadow {
     offsetY?: number
 }
 
+const BAR_FILL_LIGHTEN = 0.22
+const BAR_FILL_DARKEN = 0.16
+
+/** Bar fill for a given style. `gradient` is a diagonal (top-left → bottom-right) light→dark sheen
+ *  matching the PostHog logo's light direction; `gloss` is a curved radial highlight. */
+function makeBarFill(
+    ctx: CanvasRenderingContext2D,
+    color: string,
+    bar: BarRect,
+    style: BarFillStyle
+): string | CanvasGradient {
+    if (style === 'flat') {
+        return color
+    }
+    const light = mixColors(color, '#ffffff', BAR_FILL_LIGHTEN)
+    const dark = mixColors(color, '#000000', BAR_FILL_DARKEN)
+    if (style === 'gloss') {
+        // Curved highlight: a radial sheen rising from a focus near the top, so the light falls off
+        // in arcs for a glassy, rounded look rather than a flat linear band.
+        const cx = bar.x + bar.width * 0.5
+        const cy = bar.y + bar.height * 0.12
+        const radius = Math.max(bar.width, bar.height) * 0.95
+        const radial = ctx.createRadialGradient(cx, cy, 0, cx, cy, radius)
+        radial.addColorStop(0, light)
+        radial.addColorStop(0.45, color)
+        radial.addColorStop(1, dark)
+        return radial
+    }
+    // gradient — smooth diagonal light → dark
+    const gradient = ctx.createLinearGradient(bar.x, bar.y, bar.x + bar.width, bar.y + bar.height)
+    gradient.addColorStop(0, light)
+    gradient.addColorStop(1, dark)
+    return gradient
+}
+
 /** Hatch ranges (`series.stroke?.partial`) clamp against `series.data.length`. Any ctx
  *  state (shadow / clip / globalAlpha) is the caller's responsibility. */
 export function drawBars(
     drawCtx: DrawContext,
     series: ResolvedSeries,
     bars: BarRect[],
-    cornerRadius: number = DEFAULT_BAR_CORNER_RADIUS
+    cornerRadius: number = DEFAULT_BAR_CORNER_RADIUS,
+    fillStyle: BarFillStyle = 'flat'
 ): void {
     const { ctx } = drawCtx
     if (bars.length === 0) {
@@ -511,7 +547,7 @@ export function drawBars(
         const useHatch =
             hatch !== null &&
             ((dashedFrom !== null && bar.dataIndex >= dashedFrom) || (dashedTo !== null && bar.dataIndex <= dashedTo))
-        ctx.fillStyle = useHatch ? hatch : barColorAt(series, bar.dataIndex)
+        ctx.fillStyle = useHatch ? hatch : makeBarFill(ctx, barColorAt(series, bar.dataIndex), bar, fillStyle)
         ctx.beginPath()
         traceRoundedBarPath(ctx, bar.x, bar.y, bar.width, bar.height, cornerRadius, bar.corners)
         ctx.fill()

--- a/packages/quill/packages/charts/src/core/hooks/clearCanvas.ts
+++ b/packages/quill/packages/charts/src/core/hooks/clearCanvas.ts
@@ -1,0 +1,10 @@
+import type { ChartDimensions } from '../types'
+
+/** Reset the transform to device-pixel scale and clear the whole canvas, leaving the ctx in a
+ *  saved state the caller restores after drawing. Shared by the static and hover draw loops. */
+export function clearAndPrepare(ctx: CanvasRenderingContext2D, dimensions: ChartDimensions): void {
+    const dpr = window.devicePixelRatio || 1
+    ctx.save()
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, dimensions.width, dimensions.height)
+}

--- a/packages/quill/packages/charts/src/core/hooks/useChartDraw.ts
+++ b/packages/quill/packages/charts/src/core/hooks/useChartDraw.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from 'react'
 
 import type { ChartDimensions, ChartDrawArgs, ChartScales, ChartTheme, DrawHoverResult, ResolvedSeries } from '../types'
-import { useLatest } from './useLatest'
+import { clearAndPrepare } from './clearCanvas'
+import { useHoverAnimation } from './useHoverAnimation'
 
 interface UseChartDrawOptions {
     /** Context for the static layer (grid, lines, areas, points). Redrawn only when chart inputs change. */
@@ -17,15 +18,8 @@ interface UseChartDrawOptions {
     theme: ChartTheme
     drawStatic: (args: ChartDrawArgs) => void
     drawHover: (args: ChartDrawArgs) => DrawHoverResult
-    /** Duration (ms) of the hover-overlay fade-in. `0` disables. */
+    /** Duration (ms) of the hover-overlay fade-in/out. `0` disables. */
     hoverAnimationMs?: number
-}
-
-function clearAndPrepare(ctx: CanvasRenderingContext2D, dimensions: ChartDimensions): void {
-    const dpr = window.devicePixelRatio || 1
-    ctx.save()
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-    ctx.clearRect(0, 0, dimensions.width, dimensions.height)
 }
 
 export function useChartDraw({
@@ -45,18 +39,6 @@ export function useChartDraw({
     // Cancel the prior RAF on effect re-run — relying on cleanup ordering alone leaves a
     // window where a stale RAF can paint after the new setup runs.
     const staticRafRef = useRef<number | null>(null)
-    const hoverRafRef = useRef<number | null>(null)
-    const hoverAnimRef = useRef<{ idx: number; startTime: number }>({ idx: -1, startTime: 0 })
-    // Freezes the fade timer while invisible (cursor in a band gap) so the fade always
-    // starts at progress 0 when something visible first appears.
-    const drewVisibleRef = useRef(false)
-    // Mirror everything that changes per-mousemove so the hover effect's dep array stays
-    // small — otherwise we'd tear down and re-arm the RAF every mouse pixel.
-    const drawHoverRef = useLatest(drawHover)
-    const hoverPositionRef = useLatest(hoverPosition)
-    const seriesRef = useLatest(series)
-    const labelsRef = useLatest(labels)
-    const themeRef = useLatest(theme)
 
     // hoverIndex is deliberately not a dep — a hover sweep shouldn't repaint the static layer.
     useEffect(() => {
@@ -93,72 +75,16 @@ export function useChartDraw({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [ctx, dimensions, scales, series, labels, theme, drawStatic])
 
-    // The RAF loop ticks until hoverProgress reaches 1, then exits and waits for the next
-    // dep change. Timer is held in a ref so cancel/restart cycles resume the fade smoothly.
-    useEffect(() => {
-        if (hoverRafRef.current != null) {
-            cancelAnimationFrame(hoverRafRef.current)
-            hoverRafRef.current = null
-        }
-        if (!overlayCtx || !dimensions || !scales) {
-            return
-        }
-        // Restart the fade on hoverIndex change — invalidate drewVisible too so the next
-        // visible frame starts at progress 0, not where the previous bar's fade left off.
-        if (hoverIndex !== hoverAnimRef.current.idx) {
-            hoverAnimRef.current.idx = hoverIndex
-            hoverAnimRef.current.startTime = performance.now()
-            drewVisibleRef.current = false
-        }
-        const resetHoverFade = (): number => {
-            hoverAnimRef.current.startTime = performance.now()
-            return 0
-        }
-        const tick = (): void => {
-            // Pin progress to 0 while invisible — see drewVisibleRef comment above.
-            if (!drewVisibleRef.current) {
-                hoverAnimRef.current.startTime = performance.now()
-            }
-            const elapsed = performance.now() - hoverAnimRef.current.startTime
-            const hoverProgress = hoverAnimationMs > 0 ? Math.min(1, elapsed / hoverAnimationMs) : 1
-            clearAndPrepare(overlayCtx, dimensions)
-            const drewVisible = drawHoverRef.current({
-                ctx: overlayCtx,
-                dimensions,
-                scales,
-                series: seriesRef.current,
-                labels: labelsRef.current,
-                hoverIndex,
-                hoverPosition: hoverPositionRef.current,
-                theme: themeRef.current,
-                hoverProgress,
-                resetHoverFade,
-            })
-            overlayCtx.restore()
-            drewVisibleRef.current = drewVisible
-            // Recompute after the draw — the chart type may have called resetHoverFade
-            // mid-draw, which would leave the cached hoverProgress stale.
-            const liveElapsed = performance.now() - hoverAnimRef.current.startTime
-            const liveProgress = hoverAnimationMs > 0 ? Math.min(1, liveElapsed / hoverAnimationMs) : 1
-            if (drewVisible && liveProgress < 1 && hoverIndex >= 0) {
-                hoverRafRef.current = requestAnimationFrame(tick)
-            } else {
-                hoverRafRef.current = null
-            }
-        }
-        hoverRafRef.current = requestAnimationFrame(tick)
-        return () => {
-            if (hoverRafRef.current != null) {
-                cancelAnimationFrame(hoverRafRef.current)
-                hoverRafRef.current = null
-            }
-        }
-        // hoverPosition is in the dep array (not the ref) so the overlay redraws when the
-        // cursor moves *within* the same band — bar charts decide on a hit per-frame in
-        // `drawHover`, and entering a bar from canvas-empty-space doesn't change hoverIndex.
-        // The fade timer only resets on hoverIndex change (see check above), so re-running
-        // the effect per mousemove doesn't restart the animation.
-        // series/labels/theme/drawHover are read via refs — see top of hook.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [overlayCtx, dimensions, scales, hoverIndex, hoverPosition, hoverAnimationMs])
+    useHoverAnimation({
+        overlayCtx,
+        dimensions,
+        scales,
+        series,
+        labels,
+        hoverIndex,
+        hoverPosition,
+        theme,
+        drawHover,
+        hoverAnimationMs,
+    })
 }

--- a/packages/quill/packages/charts/src/core/hooks/useHoverAnimation.ts
+++ b/packages/quill/packages/charts/src/core/hooks/useHoverAnimation.ts
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from 'react'
+
+import type { ChartDimensions, ChartDrawArgs, ChartScales, ChartTheme, DrawHoverResult, ResolvedSeries } from '../types'
+import { clearAndPrepare } from './clearCanvas'
+import { useLatest } from './useLatest'
+
+interface UseHoverAnimationOptions {
+    /** Context for the hover overlay (highlight rings). Redrawn on every hoverIndex change. */
+    overlayCtx: CanvasRenderingContext2D | null
+    dimensions: ChartDimensions | null
+    scales: ChartScales | null
+    series: ResolvedSeries[]
+    labels: string[]
+    hoverIndex: number
+    hoverPosition: { x: number; y: number } | null
+    theme: ChartTheme
+    drawHover: (args: ChartDrawArgs) => DrawHoverResult
+    /** Duration (ms) of the hover-overlay fade-in. `0` snaps instantly. */
+    hoverAnimationMs: number
+}
+
+/**
+ * Drives the hover overlay's fade-in on its own RAF loop. The highlight eases in (progress 0→1)
+ * when the cursor enters a band and cross-fades when it moves between bands. The overlay clears
+ * when the cursor leaves (hoverIndex < 0).
+ */
+export function useHoverAnimation({
+    overlayCtx,
+    dimensions,
+    scales,
+    series,
+    labels,
+    hoverIndex,
+    hoverPosition,
+    theme,
+    drawHover,
+    hoverAnimationMs,
+}: UseHoverAnimationOptions): void {
+    // Cancel the prior RAF on effect re-run — relying on cleanup ordering alone leaves a
+    // window where a stale RAF can paint after the new setup runs.
+    const hoverRafRef = useRef<number | null>(null)
+    const hoverAnimRef = useRef<{ idx: number; startTime: number }>({ idx: -1, startTime: 0 })
+    // Freezes the fade timer while invisible (cursor in a band gap) so the fade always
+    // starts at progress 0 when something visible first appears.
+    const drewVisibleRef = useRef(false)
+    // Mirror everything that changes per-mousemove so the effect's dep array stays small —
+    // otherwise we'd tear down and re-arm the RAF every mouse pixel.
+    const drawHoverRef = useLatest(drawHover)
+    const hoverPositionRef = useLatest(hoverPosition)
+    const seriesRef = useLatest(series)
+    const labelsRef = useLatest(labels)
+    const themeRef = useLatest(theme)
+
+    // The RAF loop ticks until hoverProgress reaches 1, then exits and waits for the next
+    // dep change. Timer is held in a ref so cancel/restart cycles resume the fade smoothly.
+    useEffect(() => {
+        if (hoverRafRef.current != null) {
+            cancelAnimationFrame(hoverRafRef.current)
+            hoverRafRef.current = null
+        }
+        if (!overlayCtx || !dimensions || !scales) {
+            return
+        }
+        // Restart the fade on hoverIndex change — invalidate drewVisible too so the next
+        // visible frame starts at progress 0, not where the previous bar's fade left off.
+        if (hoverIndex !== hoverAnimRef.current.idx) {
+            hoverAnimRef.current.idx = hoverIndex
+            hoverAnimRef.current.startTime = performance.now()
+            drewVisibleRef.current = false
+        }
+        const resetHoverFade = (): number => {
+            hoverAnimRef.current.startTime = performance.now()
+            return 0
+        }
+        const tick = (): void => {
+            // Pin progress to 0 while invisible — see drewVisibleRef comment above.
+            if (!drewVisibleRef.current) {
+                hoverAnimRef.current.startTime = performance.now()
+            }
+            const elapsed = performance.now() - hoverAnimRef.current.startTime
+            const hoverProgress = hoverAnimationMs > 0 ? Math.min(1, elapsed / hoverAnimationMs) : 1
+            clearAndPrepare(overlayCtx, dimensions)
+            const drewVisible = drawHoverRef.current({
+                ctx: overlayCtx,
+                dimensions,
+                scales,
+                series: seriesRef.current,
+                labels: labelsRef.current,
+                hoverIndex,
+                hoverPosition: hoverPositionRef.current,
+                theme: themeRef.current,
+                hoverProgress,
+                resetHoverFade,
+            })
+            overlayCtx.restore()
+            drewVisibleRef.current = drewVisible
+            // Recompute after the draw — the chart type may have called resetHoverFade
+            // mid-draw, which would leave the cached hoverProgress stale.
+            const liveElapsed = performance.now() - hoverAnimRef.current.startTime
+            const liveProgress = hoverAnimationMs > 0 ? Math.min(1, liveElapsed / hoverAnimationMs) : 1
+            if (drewVisible && liveProgress < 1 && hoverIndex >= 0) {
+                hoverRafRef.current = requestAnimationFrame(tick)
+            } else {
+                hoverRafRef.current = null
+            }
+        }
+        hoverRafRef.current = requestAnimationFrame(tick)
+        return () => {
+            if (hoverRafRef.current != null) {
+                cancelAnimationFrame(hoverRafRef.current)
+                hoverRafRef.current = null
+            }
+        }
+        // hoverPosition is in the dep array (not the ref) so the overlay redraws when the
+        // cursor moves *within* the same band — bar charts decide on a hit per-frame in
+        // `drawHover`, and entering a bar from canvas-empty-space doesn't change hoverIndex.
+        // The fade timer only resets on hoverIndex change (see check above), so re-running
+        // the effect per mousemove doesn't restart the animation.
+        // series/labels/theme/drawHover are read via refs — see top of hook.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [overlayCtx, dimensions, scales, hoverIndex, hoverPosition, hoverAnimationMs])
+}

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -235,6 +235,8 @@ export type ValueDomain =
 
 /** Bar appearance + band-layout details. Grouped under {@link BarChartConfig.bars} to keep the
  *  config flat at the top level. `barLayout` stays top-level as the primary discriminator. */
+export type BarFillStyle = 'flat' | 'gradient' | 'gloss'
+
 export interface BarsConfig {
     /** Corner radius in px for the rounded end(s) of a bar. Stacked bars only round the topmost
      *  segment. Defaults to 0 (square). */
@@ -246,6 +248,9 @@ export interface BarsConfig {
     track?: boolean
     /** Drop shadow under each bar so it reads as layered over a `track`. */
     shadow?: boolean | { color: string; blur: number; offsetX?: number; offsetY?: number }
+    /** Bar fill treatment. `flat` (default) is a solid color. `gradient` is a smooth diagonal
+     *  light→dark sheen. `gloss` is a curved radial highlight for a glassy look. */
+    fillStyle?: BarFillStyle
     /** Stacked layout only — use d3.stackOffsetDiverging so negative values stack below the zero
      *  baseline (positives above). Default `false` clamps negatives to 0. */
     divergingStack?: boolean

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -241,6 +241,7 @@ export function TrendsBarChart({
             yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
             axisOrientation: 'horizontal',
             barLayout: 'stacked',
+            animateHover: 180,
             yTickFormatter: aggregatedYTickFormatter,
             xTickFormatter,
             xAxisLabel: trendsFilter?.xAxisLabel,
@@ -253,7 +254,7 @@ export function TrendsBarChart({
             // the URL) — so it keeps the grow-to-fit-all behavior and renders every breakdown row.
             // divergingStack keeps negative values (e.g. a `A*(-1)` formula) below the zero baseline
             // instead of clamping them to 0.
-            bars: { fitToHeight: embedded, divergingStack: true },
+            bars: { fitToHeight: embedded, divergingStack: true, fillStyle: 'gloss', cornerRadius: 4 },
         }
     }, [
         yAxisScaleType,

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
@@ -117,6 +117,9 @@ export function buildTrendsBarTimeSeriesConfig(opts: BuildTrendsBarTimeSeriesCon
         // below the zero baseline instead of being clamped to 0. Only the stacked layout stacks.
         divergingStack: !opts.isPercentStackView && !opts.isGrouped,
         tooltip: opts.tooltip,
+        fillStyle: 'gloss',
+        barCornerRadius: 4,
+        animateHover: 180,
     }
 }
 


### PR DESCRIPTION
## Problem

Trends bar charts render flat, square-cornered bars with a hover highlight that snaps in. This is a visual polish pass applying the new quill-charts bar fill-style to trends.

> **Stacked on #62017** (the quill-charts capability). Review/merge that first; this PR's diff is just the trends usage.

## Changes

- Trends bar charts now use `gloss` fill + a 4px corner radius + an eased hover-in (`animateHover: 180`), on both render paths: the vertical time-series config (`buildTrendsBarTimeSeriesConfig`) and the horizontal breakdown config (`aggregatedConfig` in `TrendsBarChart`).

## How did you test this code?

I'm an agent — verified via per-file TypeScript checks (no errors) and the running dev server compiling. No automated tests added (this is config wiring onto the library capability). Visual verification of the gloss fill, rounded corners, and hover ease-in on real trends bar insights still needs a human.

## Publish to changelog?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Trends half of a two-PR split; depends on #62017 for the `fillStyle` / `animateHover` config fields. The hover ease-in duration (180ms) is set here in the trends config rather than in the library, so other `TimeSeriesBarChart` consumers are unaffected.