### PR TITLE
fix(insights): handle non-array values on List SQL variables

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/VariableFields.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/VariableFields.tsx
@@ -43,6 +43,11 @@ export const formatVariableReference = (codeName: string): string => {
     return `{variables.${codeName}}`
 }
 
+// `values` is backed by a JSONField that can hold non-array data for older records,
+// so coerce defensively before mapping/rendering to avoid runtime crashes.
+export const getListVariableValues = (variable: ListVariable): string[] =>
+    Array.isArray(variable.values) ? variable.values : []
+
 // Field components for direct prop binding (used in modal)
 export interface DirectFieldProps<T extends Variable = Variable> {
     variable: T
@@ -81,7 +86,7 @@ export const BooleanField = ({ variable, updateVariable }: DirectFieldProps<Bool
 
 export const ListValuesField = ({ variable, updateVariable }: DirectFieldProps<ListVariable>): JSX.Element => (
     <LemonInputSelect
-        value={variable.values}
+        value={getListVariableValues(variable)}
         onChange={(value) => updateVariable({ ...variable, values: value })}
         placeholder="Options..."
         mode="multiple"
@@ -96,7 +101,7 @@ export const ListDefaultField = ({ variable, updateVariable }: DirectFieldProps<
         className="w-full"
         placeholder="Select default value"
         value={variable.default_value}
-        options={(variable.values ?? []).map((n: string) => ({ label: n, value: n }))}
+        options={getListVariableValues(variable).map((n: string) => ({ label: n, value: n }))}
         onChange={(value) => updateVariable({ ...variable, default_value: value ?? '' })}
         allowClear
         dropdownMaxContentWidth

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -26,6 +26,7 @@ import { dataVisualizationLogic } from '../../dataVisualizationLogic'
 import { Variable } from '../../types'
 import { NewVariableModal } from './NewVariableModal'
 import { VariableCalendar } from './VariableCalendar'
+import { getListVariableValues } from './VariableFields'
 import { variableModalLogic } from './variableModalLogic'
 import { variablesLogic } from './variablesLogic'
 
@@ -185,7 +186,7 @@ export const VariableInput = ({
                         className="grow"
                         value={localInputValue}
                         onChange={(value) => setLocalInputValue(String(value))}
-                        options={(variable.values ?? []).map((n) => ({ label: n, value: n }))}
+                        options={getListVariableValues(variable).map((n) => ({ label: n, value: n }))}
                     />
                 )}
                 {variable.type === 'Date' && (
@@ -347,7 +348,7 @@ export const VariableComponent = ({
                     disabledReason={variableOverridesAreSet && 'Discard dashboard variables to change'}
                     value={variable.isNull ? null : (variable.value ?? variable.default_value ?? null)}
                     onChange={(value) => onChange(variable.id, value, !value)}
-                    options={(variable.values ?? []).map((n) => ({ label: n, value: n }))}
+                    options={getListVariableValues(variable).map((n) => ({ label: n, value: n }))}
                     size={size}
                     allowClear
                 />

--- a/products/product_analytics/backend/api/insight_variable.py
+++ b/products/product_analytics/backend/api/insight_variable.py
@@ -35,10 +35,18 @@ class InsightVariableSerializer(serializers.ModelSerializer):
         variable_type = attrs.get("type", getattr(self.instance, "type", None))
         if variable_type == InsightVariable.Type.LIST:
             values = attrs.get("values", getattr(self.instance, "values", None))
-            if values is None:
+            if not isinstance(values, list):
                 attrs["values"] = []
 
         return attrs
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        # `values` is a JSONField; older List records may hold null or a non-array
+        # value, which crashes clients that iterate it. Always present an array.
+        if instance.type == InsightVariable.Type.LIST and not isinstance(data.get("values"), list):
+            data["values"] = []
+        return data
 
     def create(self, validated_data):
         validated_data["team_id"] = self.context["team_id"]

--- a/products/product_analytics/backend/api/test/test_insight_variable.py
+++ b/products/product_analytics/backend/api/test/test_insight_variable.py
@@ -148,6 +148,27 @@ class TestInsightVariable(APIBaseTest):
         assert response.status_code == 200
         assert response.json()["values"] == []
 
+    @parameterized.expand(
+        [
+            ("null_values", None),
+            ("dict_values", {"unexpected": "shape"}),
+            ("string_values", "not-a-list"),
+        ]
+    )
+    def test_update_list_variable_with_non_array_values_coerces_to_empty_list(self, _name, new_values):
+        variable = InsightVariable.objects.create(
+            team=self.team, name="List Var", type="List", code_name="list_var", values=["a"]
+        )
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/insight_variables/{variable.id}/",
+            data={"values": new_values},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["values"] == []
+        variable.refresh_from_db()
+        assert variable.values == []
+
     def test_update_type_to_list_coerces_null_values(self):
         variable = InsightVariable.objects.create(team=self.team, name="Str Var", type="String", code_name="str_var")
         response = self.client.patch(

--- a/products/product_analytics/backend/api/test/test_insight_variable.py
+++ b/products/product_analytics/backend/api/test/test_insight_variable.py
@@ -133,6 +133,21 @@ class TestInsightVariable(APIBaseTest):
         assert response.status_code == 200
         assert response.json()["values"] == ["a", "b", "c"]
 
+    @parameterized.expand(
+        [
+            ("null_values", None),
+            ("dict_values", {"unexpected": "shape"}),
+            ("string_values", "not-a-list"),
+        ]
+    )
+    def test_list_variable_with_non_array_values_is_normalized_on_read(self, _name, stored_values):
+        variable = InsightVariable.objects.create(
+            team=self.team, name="List Var", type="List", code_name="list_var", values=stored_values
+        )
+        response = self.client.get(f"/api/environments/{self.team.pk}/insight_variables/{variable.id}/")
+        assert response.status_code == 200
+        assert response.json()["values"] == []
+
     def test_update_type_to_list_coerces_null_values(self):
         variable = InsightVariable.objects.create(team=self.team, name="Str Var", type="String", code_name="str_var")
         response = self.client.patch(


### PR DESCRIPTION
## Problem

Users could not open a SQL / data-viz insight that has a List-type SQL variable — the whole view crashed with `TypeError: (e.values ?? []).map is not a function`.

The `InsightVariable.values` column is a `JSONField` that can hold any JSON value (array, object, string, `null`). The render code guarded each `.map` with `(variable.values ?? []).map(...)`, but `?? []` only rescues `null`/`undefined`. A stored object or string passes the guard unchanged and `{}.map`/`"foo".map` is `undefined`, crashing the view. The frontend `ListVariable` type declares `values: string[]`, but that's only a compile-time guarantee — the API returns whatever is in the database.

## Changes

- **Frontend (crash fix):** added a shared `getListVariableValues()` helper that coerces with `Array.isArray(...) ? ... : []`, and routed the three previous `(variable.values ?? []).map(...)` sites (`VariableInput`, `VariableComponent`, `ListDefaultField`) plus the `ListValuesField` value prop through it.
- **Backend (root-cause fix):** added `to_representation` to the `InsightVariableSerializer` so List variables always return an array for `values`, and tightened the existing `validate` from `values is None` to `not isinstance(values, list)` so non-array writes are coerced too.

No generated types change (behavioral-only serializer change; `values` field/`help_text` unchanged).

## How did you test this code?

I'm an agent. I added a parameterized backend regression test (`null`, `dict`, `string` stored values) asserting the API returns `values == []` on read. I could not execute the test suite or full TypeScript check in this environment (no reachable Postgres; an unrelated workspace was missing `node_modules`), so CI should be relied on to run them. The frontend changes are minimal and follow existing patterns.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) from a bug report referencing a production exception. Investigation traced the crash to a JSONField/TS-type mismatch: `values` can be non-array at runtime while typed `string[]`, and the `?? []` guard only handles null. Chose a two-layer fix — defensive coercion at all frontend render sites (resolves the user-facing crash) plus serializer normalization at the source (so other API consumers don't hit the same bad data). Used the `improving-drf-endpoints` skill before editing the serializer per repo conventions.

A possible follow-up (not in this PR): a data migration to backfill existing List `InsightVariable` rows whose `values` aren't arrays.
