### PR TITLE
refactor(frontend): remove defunct tabId from metrics scene

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -452,6 +452,10 @@ snapshots:
         hash: v1.k794b7964.ea8c43650b4092cbc2e77d3c1434956791b055450fc71b250d80ce2d3797ab95.NbHdkbeXdOFxKNuQGpkrJ6DhLvrMg8UzB_p4T4U3_Ww
     components-hogcharts-barchart--custom-corner-radius--light:
         hash: v1.k794b7964.0dac747f4e25c20af8ae87b1298ce78f740b1d61ffe17111e374beebbd4d4b67.qEe6wuSeislWK6Y_E6sW1cuocrbad55E7TCYPcqp9Fk
+    components-hogcharts-barchart--fill-styles--dark:
+        hash: v1.k794b7964.d6cadc93fb478e2708c459038ecf8e346aaaa853e2b8bf6be0704b5b725b8cae.SChUWxF3G94XS5uP9xKy4hYC76gLoOT-tCXrTAh5HCc
+    components-hogcharts-barchart--fill-styles--light:
+        hash: v1.k794b7964.4b98e3eb72e45de1042b2c623f54af0b41ade4b7161af608bd7a77353797e816.STp13FHni4h7ubxy2eOTkopHD5D6dfEBzo5U6gwmREs
     components-hogcharts-barchart--grouped--dark:
         hash: v1.k794b7964.519966f77e2f7f689d1ca8cc96a0af90e063e479964b28056a3a681457cd5d31.0phGCRGTRo6sxln_-Z2GAgJnsQBBTnZR4d9OH7anc60
     components-hogcharts-barchart--grouped--light:

--- a/products/metrics/frontend/MetricsScene.tsx
+++ b/products/metrics/frontend/MetricsScene.tsx
@@ -37,7 +37,7 @@ export function MetricsScene(): JSX.Element {
 }
 
 const MetricsSceneContent = (): JSX.Element => {
-    const { tabId, activeTab } = useValues(metricsSceneLogic)
+    const { activeTab } = useValues(metricsSceneLogic)
     const { setActiveTab } = useActions(metricsSceneLogic)
     const { teamHasMetricsCheckFailed } = useValues(metricsIngestionLogic)
 
@@ -66,8 +66,8 @@ const MetricsSceneContent = (): JSX.Element => {
             <LemonTabs<MetricsSceneActiveTab> activeKey={activeTab} onChange={setActiveTab} tabs={TABS} sceneInset />
             <MetricsSetupPrompt>
                 <div className="flex flex-col gap-2 py-2 flex-1 min-h-0">
-                    {activeTab === 'viewer' && <MetricsViewer id={tabId} />}
-                    {activeTab === 'sql' && <MetricsSqlEditor id={tabId} />}
+                    {activeTab === 'viewer' && <MetricsViewer />}
+                    {activeTab === 'sql' && <MetricsSqlEditor />}
                 </div>
             </MetricsSetupPrompt>
         </>

--- a/products/metrics/frontend/components/MetricNameFilter.tsx
+++ b/products/metrics/frontend/components/MetricNameFilter.tsx
@@ -5,7 +5,7 @@ import { List } from 'react-window'
 import { IconChevronDown } from '@posthog/icons'
 import { LemonButton, LemonDropdown, LemonInput } from '@posthog/lemon-ui'
 
-import { metricNamePickerLogic, MetricNamePickerLogicProps } from './metricNamePickerLogic'
+import { metricNamePickerLogic } from './metricNamePickerLogic'
 
 const ROW_HEIGHT = 44
 const MAX_DROPDOWN_HEIGHT = 320
@@ -52,8 +52,6 @@ export interface MetricNameFilterProps {
     /** Currently selected metric name (empty string when nothing is picked). */
     value: string
     onChange: (name: string) => void
-    /** Per-tab keying so picker state doesn't leak across tabs. */
-    tabId: string
     /** Placeholder shown on the trigger when no metric is picked. */
     placeholder?: string
 }
@@ -61,13 +59,10 @@ export interface MetricNameFilterProps {
 export const MetricNameFilter = ({
     value,
     onChange,
-    tabId,
     placeholder = 'Pick a metric',
 }: MetricNameFilterProps): JSX.Element => {
-    const logicProps: MetricNamePickerLogicProps = { tabId }
-
     return (
-        <BindLogic logic={metricNamePickerLogic} props={logicProps}>
+        <BindLogic logic={metricNamePickerLogic} props={{}}>
             <MetricNameFilterInner value={value} onChange={onChange} placeholder={placeholder} />
         </BindLogic>
     )

--- a/products/metrics/frontend/components/MetricsSqlEditor.tsx
+++ b/products/metrics/frontend/components/MetricsSqlEditor.tsx
@@ -8,7 +8,7 @@ import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
 import { NodeKind } from '~/queries/schema/schema-general'
 import { ChartDisplayType } from '~/types'
 
-import { getMetricsSqlEditorTabId, metricsSceneLogic } from '../metricsSceneLogic'
+import { METRICS_SQL_EDITOR_TAB_ID, metricsSceneLogic } from '../metricsSceneLogic'
 import { metricsSqlEditorTrackingLogic } from './metricsSqlEditorTrackingLogic'
 
 // `metrics` is only registered under the `posthog.` HogQL namespace
@@ -16,12 +16,8 @@ import { metricsSqlEditorTrackingLogic } from './metricsSqlEditorTrackingLogic'
 // referenced fully qualified.
 const DEFAULT_METRICS_QUERY = 'SELECT * FROM posthog.metrics LIMIT 10'
 
-export interface MetricsSqlEditorProps {
-    id: string
-}
-
-export const MetricsSqlEditor = ({ id }: MetricsSqlEditorProps): JSX.Element => {
-    const sqlEditorTabId = getMetricsSqlEditorTabId(id)
+export const MetricsSqlEditor = (): JSX.Element => {
+    const sqlEditorTabId = METRICS_SQL_EDITOR_TAB_ID
     const { keepSqlEditorMounted } = useActions(metricsSceneLogic)
     const logic = sqlEditorLogic({ tabId: sqlEditorTabId, mode: SQLEditorMode.Embedded })
     const { queryInput } = useValues(logic)

--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -68,15 +68,11 @@ const DATE_OPTIONS: DateMappingOption[] = [
     },
 ]
 
-export interface MetricsViewerProps {
-    id: string
-}
-
-export const MetricsViewer = ({ id }: MetricsViewerProps): JSX.Element => {
-    const logic = metricsViewerLogic({ tabId: id })
+export const MetricsViewer = (): JSX.Element => {
+    const logic = metricsViewerLogic()
     // Keep the picker logic mounted alongside the viewer so the chosen metric's
     // metric_type stays available for the aggregation hint after the dropdown closes.
-    const pickerLogic = useMountedLogic(metricNamePickerLogic({ tabId: id }))
+    const pickerLogic = useMountedLogic(metricNamePickerLogic())
     const {
         metricName,
         aggregation,
@@ -149,7 +145,7 @@ export const MetricsViewer = ({ id }: MetricsViewerProps): JSX.Element => {
         <div className="flex flex-col gap-3">
             <div className="flex flex-wrap items-end gap-2">
                 <div className="flex flex-col gap-1">
-                    <MetricNameFilter tabId={id} value={metricName} onChange={setMetricName} />
+                    <MetricNameFilter value={metricName} onChange={setMetricName} />
                     {selectedMetricType && recommendedAggregation && aggregation !== recommendedAggregation && (
                         <span className="text-xs text-secondary">
                             {selectedMetricType} — {recommendedAggregation} recommended

--- a/products/metrics/frontend/components/metricNamePickerLogic.ts
+++ b/products/metrics/frontend/components/metricNamePickerLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, kea, key, listeners, path, props, reducers } from 'kea'
+import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -10,14 +10,8 @@ export interface MetricNameItem {
     metric_type: string
 }
 
-export interface MetricNamePickerLogicProps {
-    tabId: string
-}
-
 export const metricNamePickerLogic = kea<metricNamePickerLogicType>([
     path(['products', 'metrics', 'frontend', 'components', 'metricNamePickerLogic']),
-    props({} as MetricNamePickerLogicProps),
-    key((p) => p.tabId),
     actions({
         setSearch: (search: string) => ({ search }),
     }),

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -8,10 +8,6 @@ import { dateStringToDayJs } from 'lib/utils'
 import type { metricsViewerLogicType } from './metricsViewerLogicType'
 
 export type MetricAggregation = 'sum' | 'avg' | 'count' | 'p95'
-
-export interface MetricsViewerLogicProps {
-    tabId: string
-}
 
 export interface MetricsViewerPoint {
     time: string
@@ -32,8 +28,6 @@ const resolveDate = (value: string | null | undefined): string | null => {
 
 export const metricsViewerLogic = kea<metricsViewerLogicType>([
     path(['products', 'metrics', 'frontend', 'components', 'metricsViewerLogic']),
-    props({} as MetricsViewerLogicProps),
-    key((p) => p.tabId),
     actions({
         setMetricName: (metricName: string) => ({ metricName }),
         setAggregation: (aggregation: MetricAggregation) => ({ aggregation }),

--- a/products/metrics/frontend/metricsSceneLogic.tsx
+++ b/products/metrics/frontend/metricsSceneLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, kea, listeners, path, reducers } from 'kea'
 import { router, urlToAction } from 'kea-router'
 
 import { syncSearchParams, updateSearchParams } from '@posthog/products-error-tracking/frontend/utils'
@@ -10,18 +10,13 @@ import { Params } from 'scenes/sceneTypes'
 
 import type { metricsSceneLogicType } from './metricsSceneLogicType'
 
-export const getMetricsSqlEditorTabId = (id: string): string => `metrics-sql-editor-${id}`
+export const METRICS_SQL_EDITOR_TAB_ID = 'metrics-sql-editor'
 
 export type MetricsSceneActiveTab = 'viewer' | 'sql'
 const VALID_ACTIVE_TABS: MetricsSceneActiveTab[] = ['viewer', 'sql']
 export const DEFAULT_ACTIVE_TAB: MetricsSceneActiveTab = 'viewer'
 
-export interface MetricsLogicProps {
-    tabId: string
-}
-
 export const metricsSceneLogic = kea<metricsSceneLogicType>([
-    props({} as MetricsLogicProps),
     path(['products', 'metrics', 'frontend', 'metricsSceneLogic']),
     actions({
         setActiveTab: (activeTab: MetricsSceneActiveTab) => ({ activeTab }),
@@ -29,9 +24,6 @@ export const metricsSceneLogic = kea<metricsSceneLogicType>([
     }),
     reducers({
         activeTab: [DEFAULT_ACTIVE_TAB as MetricsSceneActiveTab, { setActiveTab: (_, { activeTab }) => activeTab }],
-    }),
-    selectors({
-        tabId: [(_, p) => [p.tabId], (tabId: string) => tabId],
     }),
     urlToAction(({ actions, values, cache }) => {
         const urlToAction = (_: any, params: Params): void => {


### PR DESCRIPTION
## Problem

The in-app tab feature is gone, but the metrics scene still threads a per-tab `tabId` through its logic, its viewer child logics' keys, and the embedded SQL editor's instance id.

## Changes

- `metricsSceneLogic`: drop the `tabId` prop and the `tabId` selector.
- `metricsViewerLogic` / `metricNamePickerLogic`: drop the `tabId` prop and the `key((p) => p.tabId)` — now plain singletons.
- Embedded SQL editor: its instance id was `metrics-sql-editor-${sceneTabId}`. Make `getMetricsSqlEditorTabId()` a stable constant (`'metrics-sql-editor'`) so the editor keeps a unique, scene-stable key without the tab.
- Components (`MetricsScene`, `MetricsViewer`, `MetricNameFilter`, `MetricsSqlEditor`) drop the `id`/`tabId` threading.

`sqlEditorLogic`'s own `tabId` param (the generic editor-instance discriminator) is untouched — that's the SQL-editor tree's concern.

No behavioural change with a single tab.

## How did you test this code?

Agent (PostHog Code), automated only. No jest coverage for these metrics logics, so CI typecheck is the gate. Locally: `oxfmt` clean, removed the now-unused kea `props`/`key`/`selectors` imports and the dangling `MetricNamePickerLogicProps` import, and confirmed no scene-`tabId` remains in `products/metrics/frontend/` (only the SQL-editor instance-id usages).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

Authored with PostHog Code (Claude), part of the in-app-tab removal stack (thorough per-area de-tab). The embedded SQL editor's instance key was derived from the scene tab, so it's converted to a stable constant rather than removed — mirroring how the SQL-editor tree itself keeps `sqlEditorLogic`'s key for notebook/embedded isolation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
