### PR TITLE
feat(signals): flatten emit extra onto signal_emitted analytics events

### DIFF
--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -80,7 +80,10 @@ async def emit_signal(
         source_id: Unique identifier within the source (e.g., experiment UUID)
         description: Human-readable description that will be embedded
         weight: Importance/confidence of signal (0.0-1.0). Weight of 1.0 triggers summary.
-        extra: Optional product-specific metadata
+        extra: Optional product-specific metadata. Flattened onto the `signal_emission_started`
+            and `signal_emitted` analytics events alongside the core `source_*` keys (which win
+            on conflict), so per-source attribution (e.g. the scout harness's `scout_run_id` /
+            `skill_name`) is queryable downstream without a schema change.
 
     Example:
         await emit_signal(
@@ -150,6 +153,7 @@ async def emit_signal(
             event="signal_emission_started",
             distinct_id=str(team.uuid),
             properties={
+                **(extra or {}),
                 "source_product": source_product,
                 "source_type": source_type,
                 "source_id": source_id,
@@ -206,6 +210,7 @@ async def emit_signal(
             event="signal_emitted",
             distinct_id=str(team.uuid),
             properties={
+                **(extra or {}),
                 "source_product": source_product,
                 "source_type": source_type,
                 "source_id": source_id,

--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -58,6 +58,27 @@ for _variant_type in get_args(SignalInput.model_fields["root"].annotation):
             _SIGNAL_VARIANT_LOOKUP[(_product, _source_type)] = _variant_type
 
 
+# Telemetry only forwards top-level *scalar* `extra` values, each truncated — never nested
+# lists/dicts. Source `extra` payloads nest customer-derived content (pganalyze
+# `references[].queryText` raw SQL, session-replay `event_history`, scout `evidence`
+# summaries) that must not leak into product analytics; scalars are the cheap-to-query
+# attribution we actually want (`scout_run_id`, `task_run_id`, `skill_name`, …). The cap
+# bounds top-level strings that could still be large (e.g. an `error_message`).
+_MAX_TELEMETRY_STR_LEN = 256
+
+
+def _telemetry_props_from_extra(extra: dict | None) -> dict:
+    if not extra:
+        return {}
+    props: dict = {}
+    for key, value in extra.items():
+        if isinstance(value, str):
+            props[key] = value[:_MAX_TELEMETRY_STR_LEN]
+        elif isinstance(value, (bool, int, float)):
+            props[key] = value
+    return props
+
+
 async def emit_signal(
     team: Team,
     source_product: str,
@@ -80,10 +101,12 @@ async def emit_signal(
         source_id: Unique identifier within the source (e.g., experiment UUID)
         description: Human-readable description that will be embedded
         weight: Importance/confidence of signal (0.0-1.0). Weight of 1.0 triggers summary.
-        extra: Optional product-specific metadata. Flattened onto the `signal_emission_started`
-            and `signal_emitted` analytics events alongside the core `source_*` keys (which win
-            on conflict), so per-source attribution (e.g. the scout harness's `scout_run_id` /
-            `skill_name`) is queryable downstream without a schema change.
+        extra: Optional product-specific metadata. Its top-level scalar values (truncated) are
+            flattened onto the `signal_emission_started` and `signal_emitted` analytics events
+            alongside the core `source_*` keys (which win on conflict) — see
+            `_telemetry_props_from_extra` — so per-source attribution (e.g. the scout harness's
+            `scout_run_id` / `skill_name`) is queryable downstream without a schema change.
+            Nested lists/dicts are never forwarded.
 
     Example:
         await emit_signal(
@@ -153,7 +176,7 @@ async def emit_signal(
             event="signal_emission_started",
             distinct_id=str(team.uuid),
             properties={
-                **(extra or {}),
+                **_telemetry_props_from_extra(extra),
                 "source_product": source_product,
                 "source_type": source_type,
                 "source_id": source_id,
@@ -210,7 +233,7 @@ async def emit_signal(
             event="signal_emitted",
             distinct_id=str(team.uuid),
             properties={
-                **(extra or {}),
+                **_telemetry_props_from_extra(extra),
                 "source_product": source_product,
                 "source_type": source_type,
                 "source_id": source_id,

--- a/products/signals/backend/test/test_api.py
+++ b/products/signals/backend/test/test_api.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pydantic
 import temporalio.exceptions
 
-from products.signals.backend.facade.api import emit_signal
+from products.signals.backend.facade.api import _MAX_TELEMETRY_STR_LEN, _telemetry_props_from_extra, emit_signal
 from products.signals.backend.models import SignalSourceConfig
 from products.signals.backend.temporal.buffer import BufferSignalsWorkflow
 from products.signals.backend.temporal.emitter import SignalEmitterWorkflow
@@ -159,10 +159,15 @@ class TestEmitSignalAnalytics:
         # Both the "started" marker and the final "emitted" event fire
         events = [call.kwargs["event"] for call in capture.call_args_list]
         assert events == ["signal_emission_started", "signal_emitted"]
-        # `extra` is flattened onto the event so per-source attribution is queryable
-        # downstream; the core `source_*` keys win on conflict.
+        # Only top-level scalar `extra` values are flattened onto the event (the `labels`
+        # list is dropped); the core `source_*` keys win on conflict.
         expected_properties = {
-            **GITHUB_ISSUE_EXTRA,
+            "html_url": "https://github.com/org/repo/issues/42",
+            "number": 42,
+            "created_at": "2025-06-01T12:00:00Z",
+            "updated_at": "2025-06-02T08:00:00Z",
+            "locked": False,
+            "state": "open",
             "source_product": "github",
             "source_type": "issue",
             "source_id": "posthog/posthog#42",
@@ -170,4 +175,29 @@ class TestEmitSignalAnalytics:
         for call in capture.call_args_list:
             assert call.kwargs["distinct_id"] == str(team_stub.uuid)
             assert call.kwargs["properties"] == expected_properties
+            assert "labels" not in call.kwargs["properties"]
             assert "project" in call.kwargs["groups"]
+
+
+class TestTelemetryPropsFromExtra:
+    def test_none_and_empty(self) -> None:
+        assert _telemetry_props_from_extra(None) == {}
+        assert _telemetry_props_from_extra({}) == {}
+
+    def test_keeps_scalars_drops_nested(self) -> None:
+        props = _telemetry_props_from_extra(
+            {
+                "scout_run_id": "run-1",
+                "number": 42,
+                "confidence": 0.9,
+                "locked": False,
+                "labels": ["bug", "p1"],  # list — dropped
+                "references": [{"queryText": "SELECT * FROM customers"}],  # nested — dropped
+                "time_range": {"date_from": "a", "date_to": "b"},  # dict — dropped
+            }
+        )
+        assert props == {"scout_run_id": "run-1", "number": 42, "confidence": 0.9, "locked": False}
+
+    def test_truncates_long_strings(self) -> None:
+        props = _telemetry_props_from_extra({"error_message": "x" * 1000})
+        assert len(props["error_message"]) == _MAX_TELEMETRY_STR_LEN

--- a/products/signals/backend/test/test_api.py
+++ b/products/signals/backend/test/test_api.py
@@ -159,7 +159,10 @@ class TestEmitSignalAnalytics:
         # Both the "started" marker and the final "emitted" event fire
         events = [call.kwargs["event"] for call in capture.call_args_list]
         assert events == ["signal_emission_started", "signal_emitted"]
+        # `extra` is flattened onto the event so per-source attribution is queryable
+        # downstream; the core `source_*` keys win on conflict.
         expected_properties = {
+            **GITHUB_ISSUE_EXTRA,
             "source_product": "github",
             "source_type": "issue",
             "source_id": "posthog/posthog#42",


### PR DESCRIPTION
## Problem

The `emit_signal()` facade captures `signal_emission_started` and `signal_emitted`
analytics events, but only ever forwards three properties — `source_product`,
`source_type`, `source_id`. The per-source `extra` payload that every caller already
builds (GitHub issue metadata, session-replay segment, LLM eval, scout finding
attribution, …) is dropped, so none of it is queryable downstream in LLM analytics.

This is the blocker for attribution work like rolling up emitted signals per source
entity — the identifying metadata exists at emit time but never reaches the event.

## Changes

`emit_signal()` now flattens the `extra` dict onto the properties of both the
`signal_emission_started` and `signal_emitted` events. The core `source_*` keys are
merged last so they always win on conflict. No new parameter, no schema change — the
existing `extra` each source already passes simply becomes queryable.

`extra` carries structured metadata (ids, labels, titles, segment names, finding
attribution) rather than the embedded signal `description`, so this surfaces
attribution without dumping the full signal body onto an analytics event.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- Updated and ran `products/signals/backend/test/test_api.py::TestEmitSignalAnalytics::test_capture_called_on_emit`
  to assert `extra` is flattened onto both events with `source_*` keys taking precedence. Passes.
- `ruff check` / `ruff format` clean on the changed files; lint-staged (`ruff` + `ty check`) passed on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code at Andy's direction. This is the first of two PRs. It is a
generic, source-agnostic change: make the `extra` each caller already passes queryable
on the emit events.

The motivating use case is a "signals emitted per scout run" counter on the
`signals_scouts_runs` data-warehouse view. We deliberately kept this PR generic and
did **not** add scout-specific fields here. A follow-on PR will ensure the scout
harness's `extra` (`SignalsScoutSignalExtra`) carries `task_run_id` so emissions join
directly to `signals_scouts_runs.task_run_id` — sidestepping both the (currently
permission-blocked) `signalscoutrun` warehouse mirror and the `team.uuid`↔`team_id`
bridge.

Considered but rejected: a separate `analytics_properties` parameter on `emit_signal`.
Reusing the existing `extra` keeps the surface smaller and matches how callers already
think about per-signal metadata.
