### PR TITLE
refactor(frontend): remove defunct tabId from replay-vision scenes

### DIFF
--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -39,9 +39,9 @@ import {
     scannerTypeLabel,
 } from '../replay_scanners/types'
 import { replayObservationLogic } from './replayObservationLogic'
-import { ReplayObservationSceneLogicProps, replayObservationSceneLogic } from './replayObservationSceneLogic'
+import { replayObservationSceneLogic } from './replayObservationSceneLogic'
 
-export const scene: SceneExport<ReplayObservationSceneLogicProps> = {
+export const scene: SceneExport = {
     component: ReplayObservationSceneComponent,
     logic: replayObservationSceneLogic,
     productKey: ProductKey.REPLAY_VISION,
@@ -90,12 +90,12 @@ function AutoSeekToTime({
     return null
 }
 
-export function ReplayObservationSceneComponent({ tabId }: { tabId: string }): JSX.Element {
+export function ReplayObservationSceneComponent(): JSX.Element {
     const { observationId } = useValues(replayObservationSceneLogic)
     const [recordingExpanded, setRecordingExpanded] = useState(true)
     const [pendingSeek, setPendingSeek] = useState<{ ms: number; trigger: number } | null>(null)
 
-    const observationLogic = replayObservationLogic({ id: observationId, tabId })
+    const observationLogic = replayObservationLogic({ id: observationId })
     useAttachedLogic(observationLogic, replayObservationSceneLogic)
 
     const { observation, observationLoading } = useValues(observationLogic)

--- a/products/replay_vision/frontend/observations/replayObservationLogic.ts
+++ b/products/replay_vision/frontend/observations/replayObservationLogic.ts
@@ -12,13 +12,12 @@ import { replayObservationSceneLogic } from './replayObservationSceneLogic'
 
 export interface ReplayObservationLogicProps {
     id: string
-    tabId: string
 }
 
 export const replayObservationLogic = kea<replayObservationLogicType>([
     path(['products', 'replay_vision', 'frontend', 'observations', 'replayObservationLogic']),
     props({} as ReplayObservationLogicProps),
-    key((props) => `${props.tabId}:${props.id}`),
+    key((props) => props.id),
 
     // Mount the SSE progress stream alongside the page and listen for its completion to reload the row.
     connect((props: ReplayObservationLogicProps) => ({
@@ -58,7 +57,7 @@ export const replayObservationLogic = kea<replayObservationLogicType>([
                 const response = await visionObservationsRetrieve(String(teamId), props.id)
                 actions.loadObservationSuccess(response)
                 // Link the breadcrumb to the parent scanner so "back" returns to the scanner, not the vision home.
-                replayObservationSceneLogic({ tabId: props.tabId }).actions.setScannerContext(
+                replayObservationSceneLogic().actions.setScannerContext(
                     response.scanner_id,
                     response.scanner_snapshot?.name ?? null
                 )

--- a/products/replay_vision/frontend/observations/replayObservationSceneLogic.ts
+++ b/products/replay_vision/frontend/observations/replayObservationSceneLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, path, props, reducers, selectors } from 'kea'
+import { actions, kea, path, reducers, selectors } from 'kea'
 import { urlToAction } from 'kea-router'
 
 import { urls } from 'scenes/urls'
@@ -7,13 +7,8 @@ import { Breadcrumb } from '~/types'
 
 import type { replayObservationSceneLogicType } from './replayObservationSceneLogicType'
 
-export interface ReplayObservationSceneLogicProps {
-    tabId: string
-}
-
 export const replayObservationSceneLogic = kea<replayObservationSceneLogicType>([
     path(['products', 'replay_vision', 'frontend', 'observations', 'replayObservationSceneLogic']),
-    props({} as ReplayObservationSceneLogicProps),
 
     actions({
         setObservationId: (observationId: string) => ({ observationId }),

--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -37,20 +37,20 @@ import { ScannerTriggers } from './components/ScannerTriggers'
 import { ScannerTypeConfigEditor } from './components/ScannerTypeConfigEditor'
 import { SummarizerMaxChat } from './components/SummarizerMaxChat'
 import { replayScannerLogic } from './replayScannerLogic'
-import { ReplayScannerSceneLogicProps, replayScannerSceneLogic } from './replayScannerSceneLogic'
+import { replayScannerSceneLogic } from './replayScannerSceneLogic'
 import { EditorTab, SCANNER_TYPE_OPTIONS, MODEL_OPTIONS } from './types'
 
-export const scene: SceneExport<ReplayScannerSceneLogicProps> = {
+export const scene: SceneExport = {
     component: ReplayScannerSceneComponent,
     logic: replayScannerSceneLogic,
     productKey: ProductKey.REPLAY_VISION,
 }
 
-export function ReplayScannerSceneComponent({ tabId }: { tabId: string }): JSX.Element {
+export function ReplayScannerSceneComponent(): JSX.Element {
     const { scannerId, activeTab } = useValues(replayScannerSceneLogic)
     const { setActiveTab } = useActions(replayScannerSceneLogic)
 
-    const scannerLogic = replayScannerLogic({ id: scannerId, tabId })
+    const scannerLogic = replayScannerLogic({ id: scannerId })
     useAttachedLogic(scannerLogic, replayScannerSceneLogic)
 
     const { scanner, originalScanner, scannerLoading, isScannerSubmitting, hasUnsavedChanges, isNew } =
@@ -73,8 +73,8 @@ export function ReplayScannerSceneComponent({ tabId }: { tabId: string }): JSX.E
             label: 'Observations',
             content: (
                 <div className="space-y-4">
-                    <SummarizerMaxChat scannerId={scannerId} tabId={tabId} />
-                    <ScannerObservationsTable scannerId={scannerId} tabId={tabId} />
+                    <SummarizerMaxChat scannerId={scannerId} />
+                    <ScannerObservationsTable scannerId={scannerId} />
                 </div>
             ),
         },
@@ -151,7 +151,7 @@ export function ReplayScannerSceneComponent({ tabId }: { tabId: string }): JSX.E
                             </div>
                         )}
 
-                        <ScannerTypeConfigEditor scannerId={scannerId} tabId={tabId} />
+                        <ScannerTypeConfigEditor scannerId={scannerId} />
                     </SceneSection>
 
                     <SceneDivider />
@@ -183,7 +183,7 @@ export function ReplayScannerSceneComponent({ tabId }: { tabId: string }): JSX.E
                         description="Which completed recordings this scanner runs against."
                         titleSize="sm"
                     >
-                        <ScannerTriggers scannerId={scannerId} tabId={tabId} />
+                        <ScannerTriggers scannerId={scannerId} />
                     </SceneSection>
                 </div>
             ),
@@ -251,7 +251,7 @@ export function ReplayScannerSceneComponent({ tabId }: { tabId: string }): JSX.E
 
             <QuotaBanner />
 
-            <Form logic={replayScannerLogic} props={{ id: scannerId, tabId }} formKey="scanner" enableFormOnSubmit>
+            <Form logic={replayScannerLogic} props={{ id: scannerId }} formKey="scanner" enableFormOnSubmit>
                 <LemonTabs
                     activeKey={activeTab}
                     onChange={(key) => setActiveTab(key as EditorTab)}

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerInsightsChart.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerInsightsChart.tsx
@@ -145,14 +145,12 @@ function chartTitle(scannerType: ScannerType): string {
 export function ScannerInsightsChart({
     scannerId,
     scannerType,
-    tabId,
 }: {
     scannerId: string
     scannerType: ScannerType
-    tabId: string
 }): JSX.Element {
-    const { chartDateFrom, chartDateTo } = useValues(replayScannerLogic({ id: scannerId, tabId }))
-    const { setChartDateRange } = useActions(replayScannerLogic({ id: scannerId, tabId }))
+    const { chartDateFrom, chartDateTo } = useValues(replayScannerLogic({ id: scannerId }))
+    const { setChartDateRange } = useActions(replayScannerLogic({ id: scannerId }))
     // `tags.productKey` is required for ClickHouse query tagging; without it the runner aborts.
     const source: TrendsQuery = {
         ...buildQuery(scannerId, scannerType, chartDateFrom, chartDateTo),

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
@@ -59,8 +59,8 @@ function versionTag(
     return { type, label, tooltip }
 }
 
-export function ScannerObservationsTable({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element {
-    const logic = replayScannerLogic({ id: scannerId, tabId })
+export function ScannerObservationsTable({ scannerId }: { scannerId: string }): JSX.Element {
+    const logic = replayScannerLogic({ id: scannerId })
     const {
         observations,
         observationsLoading,
@@ -172,7 +172,7 @@ export function ScannerObservationsTable({ scannerId, tabId }: { scannerId: stri
 
     return (
         <div className="space-y-4">
-            <ScannerOverview scannerId={scannerId} tabId={tabId} />
+            <ScannerOverview scannerId={scannerId} />
             <div className="flex items-start justify-between gap-4">
                 <p className="text-muted text-sm m-0">
                     Past observations made by this scanner. Each row is one observation.

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -37,8 +37,8 @@ function OverviewPanel({
     )
 }
 
-function MonitorOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element {
-    const { monitorStats, hasActiveObservationFilters } = useValues(replayScannerLogic({ id: scannerId, tabId }))
+function MonitorOverview({ scannerId }: { scannerId: string }): JSX.Element {
+    const { monitorStats, hasActiveObservationFilters } = useValues(replayScannerLogic({ id: scannerId }))
     const { yesTotal, noTotal, inconclusiveTotal } = monitorStats
     const total = yesTotal + noTotal + inconclusiveTotal
     if (total === 0) {
@@ -83,9 +83,9 @@ function MonitorOverview({ scannerId, tabId }: { scannerId: string; tabId: strin
     )
 }
 
-function ClassifierOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element | null {
+function ClassifierOverview({ scannerId }: { scannerId: string }): JSX.Element | null {
     const { scanner, classifierTagStats, hasActiveObservationFilters } = useValues(
-        replayScannerLogic({ id: scannerId, tabId })
+        replayScannerLogic({ id: scannerId })
     )
     const { fixedRanked, freeformRanked } = classifierTagStats
     // Wait for the scanner config — without it `freeformAllowed` defaults to `false` and the panel flashes the
@@ -145,9 +145,9 @@ function ClassifierOverview({ scannerId, tabId }: { scannerId: string; tabId: st
     )
 }
 
-function ScorerOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element {
+function ScorerOverview({ scannerId }: { scannerId: string }): JSX.Element {
     const { scorerSummary, scorerHistogram, hasActiveObservationFilters } = useValues(
-        replayScannerLogic({ id: scannerId, tabId })
+        replayScannerLogic({ id: scannerId })
     )
     const theme = useMemo(() => buildTheme(), [])
     if (!scorerSummary || !scorerHistogram) {
@@ -181,8 +181,8 @@ function ScorerOverview({ scannerId, tabId }: { scannerId: string; tabId: string
     )
 }
 
-export function ScannerOverview({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element | null {
-    const { scanner, coverageStats } = useValues(replayScannerLogic({ id: scannerId, tabId }))
+export function ScannerOverview({ scannerId }: { scannerId: string }): JSX.Element | null {
+    const { scanner, coverageStats } = useValues(replayScannerLogic({ id: scannerId }))
     if (!scanner) {
         return null
     }
@@ -190,11 +190,11 @@ export function ScannerOverview({ scannerId, tabId }: { scannerId: string; tabId
     // Summarizer panel deferred to the Max chat follow-up.
     const typeOverview =
         scannerType === 'monitor' ? (
-            <MonitorOverview scannerId={scannerId} tabId={tabId} />
+            <MonitorOverview scannerId={scannerId} />
         ) : scannerType === 'classifier' ? (
-            <ClassifierOverview scannerId={scannerId} tabId={tabId} />
+            <ClassifierOverview scannerId={scannerId} />
         ) : scannerType === 'scorer' ? (
-            <ScorerOverview scannerId={scannerId} tabId={tabId} />
+            <ScorerOverview scannerId={scannerId} />
         ) : null
     if (!typeOverview && scannerType !== 'summarizer') {
         return null
@@ -213,7 +213,7 @@ export function ScannerOverview({ scannerId, tabId }: { scannerId: string; tabId
                     <span className="font-semibold text-default">{coverageStats.totalSessions}</span> total
                 </div>
             )}
-            {showChart && <ScannerInsightsChart scannerId={scannerId} scannerType={scannerType} tabId={tabId} />}
+            {showChart && <ScannerInsightsChart scannerId={scannerId} scannerType={scannerType} />}
             {typeOverview}
         </div>
     )

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
@@ -8,7 +8,6 @@ import { replayScannerLogic } from '../replayScannerLogic'
 
 interface Props {
     scannerId: string
-    tabId: string
 }
 
 const STATUS_STYLES: Record<QuotaStatus, { bar: string; text: string }> = {
@@ -17,10 +16,8 @@ const STATUS_STYLES: Record<QuotaStatus, { bar: string; text: string }> = {
     danger: { bar: 'bg-danger', text: 'text-danger' },
 }
 
-export function ScannerQuotaForecast({ scannerId, tabId }: Props): JSX.Element | null {
-    const { scanner, scannerEstimate, scannerEstimateLoading, isNew } = useValues(
-        replayScannerLogic({ id: scannerId, tabId })
-    )
+export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
+    const { scanner, scannerEstimate, scannerEstimateLoading, isNew } = useValues(replayScannerLogic({ id: scannerId }))
     const { quota } = useValues(visionQuotaLogic)
 
     if (!scanner) {

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
@@ -20,8 +20,8 @@ const RECORDING_FILTER_TYPES: TaxonomicFilterGroupType[] = [
     TaxonomicFilterGroupType.Events,
 ]
 
-export function ScannerTriggers({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element {
-    const { scanner } = useValues(replayScannerLogic({ id: scannerId, tabId }))
+export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Element {
+    const { scanner } = useValues(replayScannerLogic({ id: scannerId }))
 
     if (!scanner) {
         return <div className="text-muted">Loading…</div>
@@ -98,7 +98,7 @@ export function ScannerTriggers({ scannerId, tabId }: { scannerId: string; tabId
             </Field>
 
             <LemonDivider className="my-0" />
-            <ScannerQuotaForecast scannerId={scannerId} tabId={tabId} />
+            <ScannerQuotaForecast scannerId={scannerId} />
         </div>
     )
 }

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTypeConfigEditor.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTypeConfigEditor.tsx
@@ -14,8 +14,8 @@ const SUMMARIZER_LENGTH_OPTIONS: { value: SummarizerScannerConfig['length']; lab
     { value: 'long', label: 'Long (3-5 paragraphs)' },
 ]
 
-export function ScannerTypeConfigEditor({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element {
-    const { scanner } = useValues(replayScannerLogic({ id: scannerId, tabId }))
+export function ScannerTypeConfigEditor({ scannerId }: { scannerId: string }): JSX.Element {
+    const { scanner } = useValues(replayScannerLogic({ id: scannerId }))
 
     if (!scanner) {
         return <div className="text-muted">Loading…</div>

--- a/products/replay_vision/frontend/replay_scanners/components/SummarizerMaxChat.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/SummarizerMaxChat.tsx
@@ -10,8 +10,8 @@ import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { replayScannerLogic } from '../replayScannerLogic'
 
 /** PostHog AI entry point for summarizer scanners — lets the user chat about / digest the per-session summaries. */
-export function SummarizerMaxChat({ scannerId, tabId }: { scannerId: string; tabId: string }): JSX.Element | null {
-    const { scanner } = useValues(replayScannerLogic({ id: scannerId, tabId }))
+export function SummarizerMaxChat({ scannerId }: { scannerId: string }): JSX.Element | null {
+    const { scanner } = useValues(replayScannerLogic({ id: scannerId }))
     const isSummarizer = scanner?.scanner_type === 'summarizer'
 
     const { openMax } = useMaxTool({

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -27,7 +27,7 @@ describe('replayScannerLogic', () => {
             },
         })
         initKeaTests()
-        logic = replayScannerLogic({ id: 'new', tabId: 'test' })
+        logic = replayScannerLogic({ id: 'new' })
         logic.mount()
     })
 
@@ -341,7 +341,7 @@ describe('replayScannerLogic', () => {
                     },
                 },
             })
-            scannedLogic = replayScannerLogic({ id: 'sid', tabId: 'test-url' })
+            scannedLogic = replayScannerLogic({ id: 'sid' })
             scannedLogic.mount()
         })
 

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -37,7 +37,6 @@ import {
 
 export interface ReplayScannerLogicProps {
     id: string
-    tabId: string
 }
 
 export type ObservationStatusValue = ReplayObservationApi['status']
@@ -180,7 +179,7 @@ export function buildObservationListParams(
 export const replayScannerLogic = kea<replayScannerLogicType>([
     path(['products', 'replay_vision', 'frontend', 'replay_scanners', 'replayScannerLogic']),
     props({} as ReplayScannerLogicProps),
-    key((props) => `${props.tabId}:${props.id}`),
+    key((props) => props.id),
 
     actions({
         loadScanner: true,

--- a/products/replay_vision/frontend/replay_scanners/replayScannerSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerSceneLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, path, props, reducers, selectors } from 'kea'
+import { actions, kea, path, reducers, selectors } from 'kea'
 import { router, urlToAction } from 'kea-router'
 
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
@@ -9,13 +9,8 @@ import { Breadcrumb } from '~/types'
 import type { replayScannerSceneLogicType } from './replayScannerSceneLogicType'
 import { ALL_EDITOR_TABS, EditorTab } from './types'
 
-export interface ReplayScannerSceneLogicProps {
-    tabId: string
-}
-
 export const replayScannerSceneLogic = kea<replayScannerSceneLogicType>([
     path(['products', 'replay_vision', 'frontend', 'replay_scanners', 'replayScannerSceneLogic']),
-    props({} as ReplayScannerSceneLogicProps),
 
     actions({
         setScannerId: (scannerId: string) => ({ scannerId }),

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
@@ -62,7 +62,7 @@ describe('replayScannersLogic', () => {
             },
         })
         initKeaTests()
-        logic = replayScannersLogic({ tabId: 'test' })
+        logic = replayScannersLogic()
         logic.mount()
     })
 

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
@@ -1,5 +1,5 @@
 import equal from 'fast-deep-equal'
-import { actions, afterMount, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { router, urlToAction } from 'kea-router'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
@@ -31,10 +31,6 @@ import {
 
 // Filter fields whose change shifts the result set; auto-reset page unless the caller passes a new one.
 const FILTER_RESET_KEYS = ['search', 'enabledFilter', 'scannerTypeFilter', 'createdByFilter', 'sort'] as const
-
-export interface ReplayScannersLogicProps {
-    tabId: string
-}
 
 // Keep in sync with `SCANNER_ORDER_FIELDS` in products/replay_vision/backend/api/scanners.py.
 export const SORTABLE_COLUMN_KEYS = [
@@ -146,7 +142,6 @@ function parseSortParam(value: unknown): ScannersSorting | null {
 
 export const replayScannersLogic = kea<replayScannersLogicType>([
     path(['products', 'replay_vision', 'frontend', 'replay_scanners', 'replayScannersLogic']),
-    props({} as ReplayScannersLogicProps),
 
     actions({
         loadScanners: true,


### PR DESCRIPTION
## Problem

The in-app tab feature is gone, but the replay-vision scanner/observation scene trees still thread a per-tab `tabId` through their logic keys, props, and the scanner components.

## Changes

- `replayScannerLogic` / `replayObservationLogic`: key was `${tabId}:${id}` → now `props.id` alone; drop the `tabId` prop.
- `replayScannersLogic` / `replayScannerSceneLogic` / `replayObservationSceneLogic`: drop the vestigial `tabId` props interface + `props()` call (these roots are already singletons); the two scene roots become bare `SceneExport`.
- The scanner components (`ReplayScanner`, `ScannerOverview`, `ScannerObservationsTable`, `ScannerTriggers`, `ScannerTypeConfigEditor`, `SummarizerMaxChat`, `ScannerInsightsChart`, `ScannerQuotaForecast`) and `ReplayObservation` stop threading `tabId` into `replayScannerLogic`/`replayObservationLogic`.
- `replayObservationLogic` no longer passes `tabId` to `replayObservationSceneLogic` for breadcrumb context.
- Tests updated.

No behavioural change with a single tab.

## How did you test this code?

Agent (PostHog Code), automated only. `replayScannerLogic` + `replayScannersLogic` jest suites: 62/62 pass. `oxfmt` clean, removed the now-unused kea `props` imports from the de-keyed root logics, confirmed no `tabId` remains anywhere in `products/replay_vision/frontend/`, and no external callers pass `tabId` to these logics. Full typecheck in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

Authored with PostHog Code (Claude), part of the in-app-tab removal stack (thorough per-area de-tab).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
