### PR TITLE
feat(signals): add task_run_id to scout signal extra

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -39323,6 +39323,10 @@
                 "skill_version": {
                     "type": "number"
                 },
+                "task_run_id": {
+                    "description": "The `tasks.TaskRun` id the scout span ran inside. Join key into the `signals_scouts_runs` LLM-analytics view, which is keyed on `task_run_id` (the `scout_run_id` bridge row is not).",
+                    "type": "string"
+                },
                 "time_range": {
                     "additionalProperties": false,
                     "description": "Optional time window the finding refers to.",
@@ -39338,7 +39342,15 @@
                     "type": "object"
                 }
             },
-            "required": ["scout_run_id", "finding_id", "skill_name", "skill_version", "confidence", "evidence"],
+            "required": [
+                "scout_run_id",
+                "task_run_id",
+                "finding_id",
+                "skill_name",
+                "skill_version",
+                "confidence",
+                "evidence"
+            ],
             "type": "object"
         },
         "SignalsScoutSignalInput": {

--- a/frontend/src/queries/schema/schema-signals.ts
+++ b/frontend/src/queries/schema/schema-signals.ts
@@ -304,6 +304,9 @@ export interface SignalsScoutEvidenceEntry {
 
 export interface SignalsScoutSignalExtra {
     scout_run_id: string
+    /** The `tasks.TaskRun` id the scout span ran inside. Join key into the `signals_scouts_runs`
+     * LLM-analytics view, which is keyed on `task_run_id` (the `scout_run_id` bridge row is not). */
+    task_run_id: string
     finding_id: string
     skill_name: string
     skill_version: number

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4789,6 +4789,14 @@ class SignalsScoutSignalExtra(BaseModel):
     severity: Severity | None = None
     skill_name: str
     skill_version: float
+    task_run_id: str = Field(
+        ...,
+        description=(
+            "The `tasks.TaskRun` id the scout span ran inside. Join key into the"
+            " `signals_scouts_runs` LLM-analytics view, which is keyed on `task_run_id`"
+            " (the `scout_run_id` bridge row is not)."
+        ),
+    )
     time_range: TimeRange | None = Field(default=None, description="Optional time window the finding refers to.")
 
 

--- a/products/signals/backend/scout_harness/tools/emit.py
+++ b/products/signals/backend/scout_harness/tools/emit.py
@@ -10,8 +10,10 @@ pre-emit, marking `emitted=True` post-success) was dropped in PR 2 review along 
 the `findings` field itself; this module no longer persists any scout-side state and
 provides no dedupe, so callers must not retry an emit that may have already succeeded.
 
-Attribution (`scout_run_id`, `finding_id`, `skill_name`, `skill_version`) is read
-off the run row so the agent never has to plumb it through. The `SignalsScoutSignalExtra`
+Attribution (`scout_run_id`, `task_run_id`, `finding_id`, `skill_name`, `skill_version`)
+is read off the run row so the agent never has to plumb it through. `task_run_id` is the
+join key into the `signals_scouts_runs` LLM-analytics view (the `scout_run_id` bridge row
+is not on that view). The `SignalsScoutSignalExtra`
 shape (defined in `posthog.schema`) is what the existing `_SIGNAL_VARIANT_LOOKUP`
 in `products/signals/backend/api.py` validates against.
 """
@@ -98,6 +100,7 @@ async def emit_finding(
     finding_id = finding_id or _new_finding_id()
     extra = _build_extra(
         run_id=str(run.id),
+        task_run_id=str(run.task_run_id),
         finding_id=finding_id,
         skill_name=run.skill_name,
         skill_version=run.skill_version,
@@ -178,6 +181,7 @@ def emit_finding_sync(
     finding_id = finding_id or _new_finding_id()
     extra = _build_extra(
         run_id=str(run.id),
+        task_run_id=str(run.task_run_id),
         finding_id=finding_id,
         skill_name=run.skill_name,
         skill_version=run.skill_version,
@@ -266,6 +270,7 @@ def _validate_inputs(
 def _build_extra(
     *,
     run_id: str,
+    task_run_id: str,
     finding_id: str,
     skill_name: str,
     skill_version: int,
@@ -282,6 +287,7 @@ def _build_extra(
     fields that don't accept it."""
     extra: dict[str, Any] = {
         "scout_run_id": run_id,
+        "task_run_id": task_run_id,
         "finding_id": finding_id,
         "skill_name": skill_name,
         "skill_version": float(skill_version),

--- a/products/signals/backend/test/test_scout_harness_tools.py
+++ b/products/signals/backend/test/test_scout_harness_tools.py
@@ -339,6 +339,7 @@ class TestBuildEmitExtra:
     def _minimal(self) -> dict:
         return _build_extra(
             run_id="run-uuid",
+            task_run_id="task-run-uuid",
             finding_id="finding-uuid",
             skill_name="signals-scout-errors",
             skill_version=2,
@@ -355,6 +356,7 @@ class TestBuildEmitExtra:
         extra = self._minimal()
         # Required by schema:
         assert extra["scout_run_id"] == "run-uuid"
+        assert extra["task_run_id"] == "task-run-uuid"
         assert extra["finding_id"] == "finding-uuid"
         assert extra["skill_name"] == "signals-scout-errors"
         assert extra["confidence"] == 0.7
@@ -375,6 +377,7 @@ class TestBuildEmitExtra:
     def test_full_extra_includes_all_optional_fields(self) -> None:
         extra = _build_extra(
             run_id="run-uuid",
+            task_run_id="task-run-uuid",
             finding_id="finding-uuid",
             skill_name="signals-scout-errors",
             skill_version=1,
@@ -490,6 +493,7 @@ async def test_emit_finding_happy_path_calls_emit_signal_with_deterministic_sour
     assert call_kwargs["description"] == "Checkout 500s post-deploy"
     assert call_kwargs["weight"] == 0.7
     assert call_kwargs["extra"]["scout_run_id"] == str(arun_emit.id)
+    assert call_kwargs["extra"]["task_run_id"] == str(arun_emit.task_run_id)
     assert call_kwargs["extra"]["finding_id"] == "f-happy"
     assert call_kwargs["extra"]["skill_name"] == "signals-scout-errors"
     assert call_kwargs["extra"]["skill_version"] == 3.0


### PR DESCRIPTION
## Problem

We want a "signals emitted per scout run" counter on the `signals_scouts_runs`
data-warehouse view. That view is keyed on **`task_run_id`** (the `tasks.TaskRun` id,
read from `$ai_generation`). The scout harness's `emit_signal` `extra` payload already
carries `scout_run_id` (the `SignalScoutRun` bridge row id) — but **not** `task_run_id`,
and the view has no `scout_run_id` column. So emitted signals can't be joined to their
run without the (currently permission-blocked) `signalscoutrun` warehouse mirror.

This is the follow-on to the change that flattens `extra` onto the `signal_emitted`
event — together they make the counter a one-line `GROUP BY properties.task_run_id`.

## Changes

- Add `task_run_id: str` to `SignalsScoutSignalExtra` (schema source +
  regenerated `posthog/schema.py` / `schema.json`).
- Populate it in `scout_harness/tools/emit.py:_build_extra` from `run.task_run_id` —
  read server-side off the run row, like the other attribution fields, so the agent
  never plumbs it through.

`task_run_id` joins directly to `signals_scouts_runs.task_run_id`, sidestepping both the
blocked postgres mirror and the `team.uuid`↔`team_id` bridge.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- Updated `products/signals/backend/test/test_scout_harness_tools.py::TestBuildEmitExtra`
  to pass and assert `task_run_id`, plus the `emit_finding` happy-path assertion that
  `extra["task_run_id"] == str(run.task_run_id)`. Full file (46 tests) passes.
- `pnpm schema:build` regenerated the Python/JSON schema; lint-staged (`ruff` + `ty check`
  + formatters) passed on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code at Andy's direction; follow-on to the `extra`-flattening PR.

Attribution fields in the scout `extra` (`scout_run_id`, `task_run_id`, `finding_id`,
`skill_name`, `skill_version`) are all read server-side off the `SignalScoutRun` row, so
the run linkage is deterministic and not agent-controllable — the agent only controls the
emit decision and the finding content. That makes the per-run emission count trustworthy.

Once both PRs deploy, the DWH `signals_scouts_runs` view gets a `signals_emitted_count`
column via a left join on `task_run_id` (tracked in the `signals-dwh` skill).
