### PR TITLE
refactor(frontend): de-tab customer-analytics and groups scenes

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -60,10 +60,7 @@ export const scene: SceneExport<GroupLogicProps> = {
     }),
 }
 
-export function Group({ tabId }: { tabId?: string }): JSX.Element {
-    if (!tabId) {
-        throw new Error('GroupScene rendered with no tabId')
-    }
+export function Group(): JSX.Element {
     const mountedGroupLogic = useMountedLogic(groupLogic)
     const {
         logicProps,
@@ -129,13 +126,7 @@ export function Group({ tabId }: { tabId?: string }): JSX.Element {
                               {
                                   key: GroupsTabType.PROFILE,
                                   label: <span data-attr="groups-profile-tab">Profile</span>,
-                                  content: (
-                                      <GroupProfileCanvas
-                                          group={groupData}
-                                          tabId={tabId}
-                                          attachTo={mountedGroupLogic}
-                                      />
-                                  ),
+                                  content: <GroupProfileCanvas group={groupData} attachTo={mountedGroupLogic} />,
                               },
                           ]
                         : []),

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -32,10 +32,7 @@ export const scene: SceneExport = {
     productKey: ProductKey.GROUP_ANALYTICS,
 }
 
-export function GroupsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
-    if (!tabId) {
-        throw new Error('GroupsScene rendered with no tabId')
-    }
+export function GroupsScene(): JSX.Element {
     const { groupTypeIndex, groupTypeName, groupTypeNamePlural } = useValues(groupsSceneLogic)
 
     const mountedGroupsListLogic = groupsListLogic({ groupTypeIndex })
@@ -102,8 +99,8 @@ export function GroupsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
             />
 
             <Query
-                uniqueKey={`groups-query-${tabId}`}
-                attachTo={groupsSceneLogic({ tabId })}
+                uniqueKey="groups-query"
+                attachTo={groupsSceneLogic()}
                 query={{ ...query, showCount: true, showTableViews: true }}
                 setQuery={setQuery}
                 context={{

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -50,12 +50,11 @@ function getGroupEventsQuery(groupTypeIndex: number, groupKey: string): DataTabl
 export type GroupLogicProps = {
     groupTypeIndex: number
     groupKey: string
-    tabId?: string
 }
 
 export const groupLogic = kea<groupLogicType>([
     props({} as GroupLogicProps),
-    key(({ groupKey, groupTypeIndex, tabId }) => `${groupTypeIndex}-${groupKey}-${tabId}`),
+    key(({ groupKey, groupTypeIndex }) => `${groupTypeIndex}-${groupKey}`),
     path((key) => ['scenes', 'groups', 'groupLogic', key]),
     connect(() => ({
         actions: [groupsModel, ['createDetailDashboard']],

--- a/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
+++ b/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
@@ -48,15 +48,15 @@ export const scene: SceneExport = {
     productKey: ProductKey.CUSTOMER_ANALYTICS,
 }
 
-export function CustomerAnalyticsScene(props: { tabId?: string }): JSX.Element {
+export function CustomerAnalyticsScene(): JSX.Element {
     return (
         <FeaturePreviewSceneGate config={customerAnalyticsFeaturePreviewGate}>
-            <CustomerAnalyticsSceneContent {...props} />
+            <CustomerAnalyticsSceneContent />
         </FeaturePreviewSceneGate>
     )
 }
 
-function CustomerAnalyticsSceneContent({ tabId }: { tabId?: string }): JSX.Element {
+function CustomerAnalyticsSceneContent(): JSX.Element {
     const { addProductIntent } = useActions(teamLogic)
     const { reportCustomerAnalyticsDashboardConfigurationButtonClicked, reportCustomerAnalyticsViewed } =
         useActions(eventUsageLogic)
@@ -72,10 +72,6 @@ function CustomerAnalyticsSceneContent({ tabId }: { tabId?: string }): JSX.Eleme
         AccessControlResourceType.CustomerAnalytics,
         AccessControlLevel.Editor
     )
-
-    if (!tabId) {
-        throw new Error('CustomerAnalyticsScene was rendered with no tabId')
-    }
 
     useOnMountEffect(() => {
         reportCustomerAnalyticsViewed()

--- a/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
+++ b/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
@@ -27,7 +27,6 @@ import { ConfigureWithAIButton } from './ConfigureWithAIButton'
 
 interface CustomerAnalyticsQueryCardProps {
     insight: InsightDefinition
-    tabId?: string
 }
 
 function anyValueIsNull(object: object): boolean {
@@ -40,16 +39,16 @@ function getEmptySeriesNames(requiredSeries: Record<string, AnyEntityNode | null
         .map(([key]) => key)
 }
 
-function generateUniqueKey(name: string, tabId: string, businessType: string, groupType?: number): string {
+function generateUniqueKey(name: string, businessType: string, groupType?: number): string {
     const suffix = businessType === 'b2b' ? groupType : 'users'
-    return `${name}-${tabId}-${businessType}-${suffix}`
+    return `${name}-${businessType}-${suffix}`
 }
 
-export function CustomerAnalyticsQueryCard({ insight, tabId }: CustomerAnalyticsQueryCardProps): JSX.Element {
+export function CustomerAnalyticsQueryCard({ insight }: CustomerAnalyticsQueryCardProps): JSX.Element {
     const { businessType, selectedGroupType } = useValues(customerAnalyticsSceneLogic)
     const { eventSelectors } = useValues(customerAnalyticsDashboardEventsLogic)
     const needsConfig = insight?.requiredSeries ? anyValueIsNull(insight.requiredSeries) : false
-    const uniqueKey = generateUniqueKey(insight.name, tabId || '', businessType, selectedGroupType)
+    const uniqueKey = generateUniqueKey(insight.name, businessType, selectedGroupType)
     const insightProps: InsightLogicProps<QuerySchema> = {
         dataNodeCollectionId: CUSTOMER_ANALYTICS_DATA_COLLECTION_NODE_ID,
         dashboardItemId: buildDashboardItemId(uniqueKey),
@@ -105,7 +104,7 @@ export function CustomerAnalyticsQueryCard({ insight, tabId }: CustomerAnalytics
 
     return (
         <QueryCard
-            uniqueKey={`${insight.name}-${tabId}`}
+            uniqueKey={insight.name}
             title={insight.name}
             description={insight.description}
             query={insight.query}

--- a/products/customer_analytics/frontend/components/GroupProfileCanvas.tsx
+++ b/products/customer_analytics/frontend/components/GroupProfileCanvas.tsx
@@ -16,18 +16,17 @@ import { CustomerProfileMenu } from './CustomerProfileMenu'
 
 interface GroupProfileCanvasProps {
     group: Group
-    tabId: string
     attachTo: BuiltLogic | LogicWrapper
 }
 
-export const GroupProfileCanvas = ({ group, tabId, attachTo }: GroupProfileCanvasProps): JSX.Element => {
+export const GroupProfileCanvas = ({ group, attachTo }: GroupProfileCanvasProps): JSX.Element => {
     const { aggregationLabel } = useValues(groupsModel)
     const { reportGroupProfileViewed } = useActions(eventUsageLogic)
 
     const groupKey = group.group_key
     const groupTypeIndex = group.group_type_index
     const mode = 'canvas'
-    const shortId = `${mode}-${groupKey}-${tabId}`
+    const shortId = `${mode}-${groupKey}`
     const attrs = useMemo(
         () => ({
             groupKey,
@@ -38,7 +37,7 @@ export const GroupProfileCanvas = ({ group, tabId, attachTo }: GroupProfileCanva
     const customerProfileLogicProps = {
         attrs,
         scope: CustomerProfileScope[`GROUP_${groupTypeIndex}`],
-        key: `customer-profile-${groupKey}-${tabId}`,
+        key: `customer-profile-${groupKey}`,
         canvasShortId: shortId,
     }
     const { content } = useValues(customerProfileLogic(customerProfileLogicProps))
@@ -66,7 +65,7 @@ export const GroupProfileCanvas = ({ group, tabId, attachTo }: GroupProfileCanva
 
     return (
         <BindLogic logic={notebookLogic} props={notebookLogicProps}>
-            <BindLogic logic={groupLogic} props={{ groupKey, groupTypeIndex, tabId }}>
+            <BindLogic logic={groupLogic} props={{ groupKey, groupTypeIndex }}>
                 <BindLogic logic={customerProfileLogic} props={customerProfileLogicProps}>
                     <CustomerProfileMenu />
                     <Notebook

--- a/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
@@ -18,7 +18,7 @@ import { buildDashboardItemId, isPageviewWithoutFilters } from '../../utils'
 import { CustomerAnalyticsQueryCard } from '../CustomerAnalyticsQueryCard'
 
 export function ActiveUsersInsights(): JSX.Element {
-    const { activityEvent, activeUsersInsights, customerLabel, tabId } = useValues(customerAnalyticsSceneLogic)
+    const { activityEvent, activeUsersInsights, customerLabel } = useValues(customerAnalyticsSceneLogic)
 
     // Check if using pageview as default, with no properties filter
     const isOnlyPageview = isPageviewWithoutFilters(activityEvent)
@@ -43,9 +43,7 @@ export function ActiveUsersInsights(): JSX.Element {
             <h2 className="ml-1">Active {customerLabel.plural}</h2>
             <div className="grid grid-cols-[3fr_1fr] gap-2">
                 {activeUsersInsights.map((insight, index) => {
-                    return (
-                        <CustomerAnalyticsQueryCard key={index} insight={insight as InsightDefinition} tabId={tabId} />
-                    )
+                    return <CustomerAnalyticsQueryCard key={index} insight={insight as InsightDefinition} />
                 })}
             </div>
             <PowerUsersTable />
@@ -54,13 +52,13 @@ export function ActiveUsersInsights(): JSX.Element {
 }
 
 function PowerUsersTable(): JSX.Element {
-    const { businessType, customerLabel, dauSeries, selectedGroupType, tabId, filterTestAccounts } =
+    const { businessType, customerLabel, dauSeries, selectedGroupType, filterTestAccounts } =
         useValues(customerAnalyticsSceneLogic)
     const { isRevenueAnalyticsEnabled, baseCurrency } = useValues(revenueAnalyticsLogic)
     const { currentTeam } = useValues(teamLogic)
     const lastSeenEnabled = currentTeam?.extra_settings?.person_last_seen_at_enabled === true
     const revenueFieldsEnabled = useFeatureFlag('REVENUE_FIELDS_IN_POWER_USERS_TABLE')
-    const uniqueKey = `power-users-${tabId}`
+    const uniqueKey = 'power-users'
     const insightProps: InsightLogicProps<InsightVizNode> = {
         dataNodeCollectionId: CUSTOMER_ANALYTICS_DATA_COLLECTION_NODE_ID,
         dashboardItemId: buildDashboardItemId(uniqueKey),

--- a/products/customer_analytics/frontend/components/Insights/SessionInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/SessionInsights.tsx
@@ -12,7 +12,7 @@ import {
 } from 'products/customer_analytics/frontend/customerAnalyticsSceneLogic'
 
 export function SessionInsights(): JSX.Element {
-    const { sessionInsights, tabId } = useValues(customerAnalyticsSceneLogic)
+    const { sessionInsights } = useValues(customerAnalyticsSceneLogic)
 
     return (
         <div className="space-y-2">
@@ -28,9 +28,7 @@ export function SessionInsights(): JSX.Element {
             </div>
             <div className="grid grid-cols-3 gap-2">
                 {sessionInsights.map((insight, index) => {
-                    return (
-                        <CustomerAnalyticsQueryCard key={index} insight={insight as InsightDefinition} tabId={tabId} />
-                    )
+                    return <CustomerAnalyticsQueryCard key={index} insight={insight as InsightDefinition} />
                 })}
             </div>
         </div>

--- a/products/customer_analytics/frontend/components/Insights/SignupInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/SignupInsights.tsx
@@ -7,7 +7,7 @@ import {
 } from 'products/customer_analytics/frontend/customerAnalyticsSceneLogic'
 
 export function SignupInsights(): JSX.Element {
-    const { signupInsights, tabId } = useValues(customerAnalyticsSceneLogic)
+    const { signupInsights } = useValues(customerAnalyticsSceneLogic)
 
     return (
         <div className="space-y-2">
@@ -16,23 +16,17 @@ export function SignupInsights(): JSX.Element {
             </div>
             <div className="grid grid-cols-[1fr_1fr_2fr] gap-2">
                 {signupInsights.slice(0, 3).map((insight, index) => {
-                    return (
-                        <CustomerAnalyticsQueryCard key={index} insight={insight as InsightDefinition} tabId={tabId} />
-                    )
+                    return <CustomerAnalyticsQueryCard key={index} insight={insight as InsightDefinition} />
                 })}
             </div>
             <div className="grid grid-cols-3 gap-2">
                 {signupInsights.slice(3, 6).map((insight, index) => {
-                    return (
-                        <CustomerAnalyticsQueryCard key={index} insight={insight as InsightDefinition} tabId={tabId} />
-                    )
+                    return <CustomerAnalyticsQueryCard key={index} insight={insight as InsightDefinition} />
                 })}
             </div>
             <div className="grid grid-cols-2 gap-2">
                 {signupInsights.slice(6).map((insight, index) => {
-                    return (
-                        <CustomerAnalyticsQueryCard key={index} insight={insight as InsightDefinition} tabId={tabId} />
-                    )
+                    return <CustomerAnalyticsQueryCard key={index} insight={insight as InsightDefinition} />
                 })}
             </div>
         </div>

--- a/products/customer_analytics/frontend/customerAnalyticsSceneLogic.test.ts
+++ b/products/customer_analytics/frontend/customerAnalyticsSceneLogic.test.ts
@@ -16,7 +16,7 @@ describe('customerAnalyticsSceneLogic', () => {
         localStorage.clear()
         sceneLogic.mount()
         router.actions.push(urls.customerAnalytics())
-        logic = customerAnalyticsSceneLogic({ tabId: sceneLogic.values.activeTabId || '' })
+        logic = customerAnalyticsSceneLogic()
         logic.mount()
     })
 

--- a/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
+++ b/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
@@ -40,10 +40,6 @@ import type { customerAnalyticsSceneLogicType } from './customerAnalyticsSceneLo
 
 export type BusinessType = 'b2c' | 'b2b'
 
-export interface CustomerAnalyticsSceneLogicProps {
-    tabId: string
-}
-
 export interface InsightDefinition {
     name: string
     description?: string
@@ -140,10 +136,6 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
         ],
     })),
     selectors({
-        tabId: [
-            () => [(_, props: CustomerAnalyticsSceneLogicProps) => props.tabId],
-            (tabIdProp: string): string => tabIdProp,
-        ],
         activeTab: [
             (s) => [s.sceneKey],
             (sceneKey): 'dashboard' | 'journeys' | 'accounts' => {


### PR DESCRIPTION
## Problem

The in-app tab feature is gone, but the customer-analytics scene tree and the groups scene tree still thread a per-tab `tabId`. They're coupled: `Group.tsx` renders `GroupProfileCanvas` (a customer-analytics component) and passed it `tabId`, which it required.

## Changes

**customer-analytics**
- `customerAnalyticsSceneLogic`: drop the `tabId` props interface and the `tabId` selector.
- `CustomerAnalyticsScene` / `CustomerAnalyticsQueryCard` / `GroupProfileCanvas` / `ActiveUsersInsights` / `SessionInsights` / `SignupInsights`: drop the `tabId` props/threading. `generateUniqueKey`, the `power-users` key, the QueryCard `uniqueKey`, and `GroupProfileCanvas`'s notebook `shortId` / `customer-profile` key all drop the `tabId` suffix.

**groups**
- `groupLogic`: key was `${groupTypeIndex}-${groupKey}-${tabId}` → drop the `tabId` segment.
- `Group` / `Groups`: drop the `tabId` prop, the `rendered with no tabId` throws, the `groups-query` `uniqueKey` suffix, and `groupsSceneLogic({ tabId })`.

No behavioural change with a single tab.

## How did you test this code?

Agent (PostHog Code), automated only. `customerAnalyticsSceneLogic` jest suite: 4/4 pass. `oxfmt` clean, no remaining `tabId` in `products/customer_analytics/frontend/` or `frontend/src/scenes/groups/`, and no external callers. Full typecheck in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

Authored with PostHog Code (Claude), part of the in-app-tab removal stack. Groups was bundled with customer-analytics because `Group.tsx` → `GroupProfileCanvas` (customer-analytics) had a required `tabId` — de-tabbing one without the other wouldn't typecheck.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
