### PR TITLE
refactor(frontend): remove defunct tabId from workflows scenes

### DIFF
--- a/products/workflows/frontend/TemplateLibrary/messageTemplateSceneLogic.ts
+++ b/products/workflows/frontend/TemplateLibrary/messageTemplateSceneLogic.ts
@@ -11,7 +11,6 @@ import type { messageTemplateSceneLogicType } from './messageTemplateSceneLogicT
 export interface MessageTemplateSceneLogicProps {
     id: string
     messageId?: string | null
-    tabId?: string
 }
 
 export const messageTemplateSceneLogic = kea<messageTemplateSceneLogicType>([

--- a/products/workflows/frontend/Workflows/WorkflowScene.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowScene.tsx
@@ -41,7 +41,6 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
     const workflowSceneProps: WorkflowSceneLogicProps = {
         id: props.id || 'new',
         tab: props.tab || 'workflow',
-        tabId: props.tabId || 'default',
     }
     const sceneLogic = workflowSceneLogic(workflowSceneProps)
     const { currentTab } = useValues(sceneLogic)
@@ -51,7 +50,7 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
 
     const batchJobsLogic = batchWorkflowJobsLogic({ id: workflowSceneProps.id })
 
-    const logic = workflowLogic({ id: props.id, tabId: props.tabId, templateId, editTemplateId })
+    const logic = workflowLogic({ id: props.id, templateId, editTemplateId })
     const { workflowLoading, originalWorkflow, lastSavedAt, isAutoSavePending, autoSaveEnabled } = useValues(logic)
     const { setAutoSaveEnabled } = useActions(logic)
     const showSaving = useDebouncedValue(isAutoSavePending || workflowLoading, 1000)
@@ -103,7 +102,7 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
 
     return (
         <SceneContent className="h-full flex flex-col grow" data-attr="workflow-scene">
-            <BindLogic logic={workflowLogic} props={{ id: props.id, tabId: props.tabId, templateId, editTemplateId }}>
+            <BindLogic logic={workflowLogic} props={{ id: props.id, templateId, editTemplateId }}>
                 <WorkflowSceneHeader {...props} />
                 {/* Only show Logs and Metrics tabs if the workflow has already been created */}
                 {!props.id || props.id === 'new' ? (

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -17,7 +17,6 @@ import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
-import { WorkflowsSceneProps } from '../WorkflowsScene'
 import { getHogFlowStep } from './hogflows/steps/HogFlowSteps'
 import { HogFlow } from './hogflows/types'
 import { newWorkflowLogic } from './newWorkflowLogic'
@@ -90,7 +89,7 @@ function WorkflowActionsSummary({ workflow }: { workflow: HogFlow }): JSX.Elemen
     )
 }
 
-export function WorkflowsTable(props: WorkflowsSceneProps): JSX.Element {
+export function WorkflowsTable(): JSX.Element {
     const logic = workflowsLogic()
     const {
         filteredWorkflows,
@@ -124,7 +123,6 @@ export function WorkflowsTable(props: WorkflowsSceneProps): JSX.Element {
         // We can't just reset state within the logic's unmount as that would trigger when switching tabs
         const newWorkflowLogic = workflowLogic.findMounted({
             id: 'new',
-            tabId: props.tabId,
         })
         newWorkflowLogic?.unmount()
 

--- a/products/workflows/frontend/Workflows/hogflows/filters/HogFlowPropertyFiltersSearch.test.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/filters/HogFlowPropertyFiltersSearch.test.tsx
@@ -53,7 +53,7 @@ describe('HogFlowPropertyFilters search', () => {
         groupsModel.mount()
         propertyDefinitionsModel.mount()
         recentTaxonomicFiltersLogic.mount()
-        mountedWorkflowLogic = workflowLogic({ id: 'new', tabId: 'default' })
+        mountedWorkflowLogic = workflowLogic({ id: 'new' })
         unmountWorkflowLogic = mountedWorkflowLogic.mount()
     })
 

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -148,7 +148,7 @@ export type CreateActionType = Pick<HogFlowAction, 'type' | 'config' | 'name' | 
 export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
     props({} as WorkflowLogicProps),
     path((key) => ['scenes', 'hogflows', 'hogFlowEditorLogic', key]),
-    key((props) => `hog-flow-editor-${props.id}-${props.tabId}`),
+    key((props) => `hog-flow-editor-${props.id}`),
     connect(() => ({
         values: [
             workflowLogic,

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepDelayLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepDelayLogic.test.ts
@@ -20,7 +20,7 @@ describe('stepDelayLogic', () => {
             plugins: [testUtilsPlugin],
         })
 
-        wfLogic = workflowLogic({ id: 'new', tabId: 'default' })
+        wfLogic = workflowLogic({ id: 'new' })
         wfLogic.mount()
 
         sdLogic = stepDelayLogic({ workflowLogicProps: wfLogic.props })

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.test.ts
@@ -21,7 +21,7 @@ describe('stepWaitUntilTimeWindowLogic', () => {
             plugins: [testUtilsPlugin],
         })
 
-        wfLogic = workflowLogic({ id: 'new', tabId: 'default' })
+        wfLogic = workflowLogic({ id: 'new' })
         wfLogic.mount()
 
         logic = stepWaitUntilTimeWindowLogic({ workflowLogicProps: wfLogic.props })

--- a/products/workflows/frontend/Workflows/workflowLogic.autosave.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.autosave.test.ts
@@ -71,7 +71,7 @@ describe('workflowLogic auto-save', () => {
     describe('debouncing existing workflow', () => {
         beforeEach(async () => {
             initKeaTests()
-            logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+            logic = workflowLogic({ id: WORKFLOW_ID })
             logic.mount()
             await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
         })
@@ -122,7 +122,7 @@ describe('workflowLogic auto-save', () => {
             ['template editing', { id: WORKFLOW_ID, editTemplateId: 'tpl-1' }],
         ])('does not auto-save for %s', async (_label, props) => {
             initKeaTests()
-            logic = workflowLogic({ ...props, tabId: 'default' })
+            logic = workflowLogic({ ...props })
             logic.mount()
 
             jest.useFakeTimers()
@@ -134,7 +134,7 @@ describe('workflowLogic auto-save', () => {
 
         it('does not auto-save when there are validation errors', async () => {
             initKeaTests()
-            logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+            logic = workflowLogic({ id: WORKFLOW_ID })
             logic.mount()
             await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
 
@@ -149,7 +149,7 @@ describe('workflowLogic auto-save', () => {
 
         it('does not auto-save when nothing has changed', async () => {
             initKeaTests()
-            logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+            logic = workflowLogic({ id: WORKFLOW_ID })
             logic.mount()
             await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
 
@@ -162,7 +162,7 @@ describe('workflowLogic auto-save', () => {
 
         it('clears isAutoSavePending when auto-save is skipped', async () => {
             initKeaTests()
-            logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+            logic = workflowLogic({ id: WORKFLOW_ID })
             logic.mount()
             await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
 
@@ -193,7 +193,7 @@ describe('workflowLogic auto-save', () => {
             })
 
             initKeaTests()
-            logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+            logic = workflowLogic({ id: WORKFLOW_ID })
             logic.mount()
             await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
 
@@ -208,7 +208,7 @@ describe('workflowLogic auto-save', () => {
     describe('auto-save toggle', () => {
         beforeEach(async () => {
             initKeaTests()
-            logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+            logic = workflowLogic({ id: WORKFLOW_ID })
             logic.mount()
             await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
         })
@@ -259,7 +259,7 @@ describe('workflowLogic auto-save', () => {
     describe('navigation guard', () => {
         it('does not fire save on unmount (no silent flush)', async () => {
             initKeaTests()
-            logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+            logic = workflowLogic({ id: WORKFLOW_ID })
             logic.mount()
             await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
 
@@ -275,7 +275,7 @@ describe('workflowLogic auto-save', () => {
             // The beforeUnload guard skips when id is 'new', even if
             // the form has unsaved changes (e.g. freshly created draft).
             initKeaTests()
-            logic = workflowLogic({ id: 'new', tabId: 'default' })
+            logic = workflowLogic({ id: 'new' })
             logic.mount()
             await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
 

--- a/products/workflows/frontend/Workflows/workflowLogic.emailValidation.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.emailValidation.test.ts
@@ -116,7 +116,7 @@ describe('workflowLogic email step "from" validation', () => {
             },
         })
         initKeaTests()
-        logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+        logic = workflowLogic({ id: WORKFLOW_ID })
         logic.mount()
         await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
 
@@ -133,7 +133,7 @@ describe('workflowLogic email step "from" validation', () => {
             },
         })
         initKeaTests()
-        logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+        logic = workflowLogic({ id: WORKFLOW_ID })
         logic.mount()
         await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
 
@@ -150,7 +150,7 @@ describe('workflowLogic email step "from" validation', () => {
             },
         })
         initKeaTests()
-        logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+        logic = workflowLogic({ id: WORKFLOW_ID })
         logic.mount()
         await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess', 'loadHogFunctionTemplatesByIdSuccess'])
 
@@ -167,7 +167,7 @@ describe('workflowLogic email step "from" validation', () => {
             },
         })
         initKeaTests()
-        logic = workflowLogic({ id: WORKFLOW_ID, tabId: 'default' })
+        logic = workflowLogic({ id: WORKFLOW_ID })
         logic.mount()
         await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
 

--- a/products/workflows/frontend/Workflows/workflowLogic.schedule.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.schedule.test.ts
@@ -22,7 +22,7 @@ describe('workflowLogic schedule reducers', () => {
 
     beforeEach(() => {
         initKeaTests()
-        logic = workflowLogic({ id: 'new', tabId: 'default' })
+        logic = workflowLogic({ id: 'new' })
         logic.mount()
     })
 

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -50,7 +50,6 @@ import { workflowsLogic } from './workflowsLogic'
 
 export interface WorkflowLogicProps {
     id?: string
-    tabId?: string
     templateId?: string
     editTemplateId?: string
 }
@@ -136,10 +135,9 @@ export function sanitizeWorkflow(
 
 export const workflowLogic = kea<workflowLogicType>([
     path((key) => ['products', 'workflows', 'frontend', 'Workflows', 'workflowLogic', key]),
-    props({ id: 'new', tabId: 'default' } as WorkflowLogicProps),
+    props({ id: 'new' } as WorkflowLogicProps),
     key(
-        (props) =>
-            `workflow-${props.id || 'new'}-${props.tabId || 'default'}-${props.templateId || 'default'}-${props.editTemplateId || 'default'}`
+        (props) => `workflow-${props.id || 'new'}-${props.templateId || 'default'}-${props.editTemplateId || 'default'}`
     ),
     connect(() => ({
         values: [userLogic, ['user'], projectLogic, ['currentProjectId']],

--- a/products/workflows/frontend/Workflows/workflowSceneLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowSceneLogic.ts
@@ -14,13 +14,12 @@ export type WorkflowTab = (typeof WorkflowTabs)[number]
 export interface WorkflowSceneLogicProps {
     id?: string
     tab?: WorkflowTab
-    tabId?: string
 }
 
 export const workflowSceneLogic = kea<workflowSceneLogicType>([
     path(['products', 'workflows', 'frontend', 'workflowSceneLogic']),
-    props({ id: 'new', tabId: 'default' } as WorkflowSceneLogicProps),
-    key((props) => `workflow-scene-${props.id || 'new'}-${props.tabId || 'default'}`),
+    props({ id: 'new' } as WorkflowSceneLogicProps),
+    key((props) => `workflow-scene-${props.id || 'new'}`),
     actions({
         setCurrentTab: (tab: WorkflowTab) => ({ tab }),
     }),

--- a/products/workflows/frontend/WorkflowsScene.tsx
+++ b/products/workflows/frontend/WorkflowsScene.tsx
@@ -36,7 +36,6 @@ export type WorkflowsSceneTab = (typeof WORKFLOW_SCENE_TABS)[number]
 
 export type WorkflowsSceneProps = {
     tab?: WorkflowsSceneTab
-    tabId?: string
 }
 
 export const workflowsSceneLogic = kea<workflowsSceneLogicType>([
@@ -143,7 +142,7 @@ export function WorkflowsScene(props: WorkflowsSceneProps = {}): JSX.Element {
         {
             label: 'Workflows',
             key: 'workflows',
-            content: <WorkflowsTable {...props} />,
+            content: <WorkflowsTable />,
             link: urls.workflows(),
         },
         {


### PR DESCRIPTION
## Problem

PostHog's in-app browser-like tabs were removed a while ago, but the internal `tabId` scaffolding is still threaded through scene logics. This PR continues the per-area cleanup, this time for the **workflows** product.

With only ever one "tab", keying logics by `tabId` and threading a `tabId` prop through the scene tree is dead weight: it bloats logic keys, props interfaces, and test setup without changing behavior.

## Changes

De-tab the workflows scene tree:

- `workflowSceneLogic`, `workflowLogic`, and `hogFlowEditorLogic` logic keys drop the `${tabId}` segment (and `workflowLogic`'s `props` default `tabId: 'default'`).
- `tabId` removed from `WorkflowSceneLogicProps`, `WorkflowLogicProps`, `WorkflowsSceneProps`, and `MessageTemplateSceneLogicProps`.
- `WorkflowScene` and `WorkflowsTable` stop threading `tabId`. `WorkflowsTable` no longer takes any props (it never used anything but `tabId`), so the `{...props}` spread at its call site is dropped too.
- Test files drop the now-meaningless `tabId: 'default'` from `workflowLogic` props.

Behavior is unchanged — there is only ever one workflows scene instance, so collapsing the per-tab keys to singletons is behavior-preserving.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I actually ran:

- `git grep -nw tabId -- products/workflows/frontend/` is clean (no scene-level `tabId` left).
- `hogli test products/workflows/frontend/Workflows/workflowLogic.schedule.test.ts` passes (36/36).
- oxfmt + the pre-commit lint-staged hook (oxlint) pass on all changed files.

The broader workflows jest suites and `typescript:check` run in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). Part of a Graphite stack that removes the defunct in-app `tabId` scaffolding area-by-area, lowest-risk first; this is the workflows slice.

Decision worth noting for the reviewer: `WorkflowsTable`'s only use of its `props` was `props.tabId`, so once that's gone the parameter is entirely unused — rather than keep a dead `_props`, the parameter and the `<WorkflowsTable {...props} />` spread were both removed. `workflowLogic`'s key still distinguishes `id` / `templateId` / `editTemplateId`; only the `tabId` segment was dropped.

The core `sceneLogic` `tabs[]` collapse (which removes the `SceneProps.tabId` injection entirely) lands later in the stack — this PR only removes workflows-local vestiges and is safe on its own.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
