### PR TITLE
refactor(frontend): remove defunct tabId from actions scenes

### DIFF
--- a/products/actions/frontend/components/ActionHogFunctions.tsx
+++ b/products/actions/frontend/components/ActionHogFunctions.tsx
@@ -10,13 +10,13 @@ import { actionEditLogic } from '../logics/actionEditLogic'
 import { actionLogic } from '../logics/actionLogic'
 
 export function ActionHogFunctions(): JSX.Element | null {
-    const { action, tabId } = useValues(actionLogic)
-    return !action ? null : <Functions action={action} tabId={tabId} />
+    const { action } = useValues(actionLogic)
+    return !action ? null : <Functions action={action} />
 }
 
-const Functions = ({ action, tabId }: { action: ActionType; tabId?: string }): JSX.Element => {
+const Functions = ({ action }: { action: ActionType }): JSX.Element => {
     const { hasCohortFilters, actionChanged, showCohortDisablesFunctionsWarning } = useValues(
-        actionEditLogic({ id: action?.id, action, tabId })
+        actionEditLogic({ id: action?.id, action })
     )
     return (
         <LemonCollapse

--- a/products/actions/frontend/logics/actionEditLogic.tsx
+++ b/products/actions/frontend/logics/actionEditLogic.tsx
@@ -10,7 +10,6 @@ import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { Link } from 'lib/lemon-ui/Link'
 import { eventDefinitionsTableLogic } from 'scenes/data-management/events/eventDefinitionsTableLogic'
-import { sceneLogic } from 'scenes/sceneLogic'
 import { urls } from 'scenes/urls'
 
 import { deleteFromTree, getLastNewFolder, refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
@@ -37,7 +36,6 @@ export interface SetActionProps {
 export interface ActionEditLogicProps {
     id: number
     action?: ActionType | null
-    tabId?: string
 }
 
 export const DEFAULT_ACTION_STEP: ActionStepType = {
@@ -48,9 +46,7 @@ export const DEFAULT_ACTION_STEP: ActionStepType = {
 export const actionEditLogic = kea<actionEditLogicType>([
     path((key) => ['scenes', 'actions', 'actionEditLogic', key]),
     props({} as ActionEditLogicProps),
-    // Key by tabId AND id so each tab preserves its own form state across tab switches.
-    // Fall back to 'notab' for non-scene mounts (e.g. tests, side panel) to stay backwards-compatible.
-    key((props) => `${props.tabId || 'notab'}:${props.id || 'new'}`),
+    key((props) => `${props.id || 'new'}`),
     connect(() => ({
         actions: [
             actionsModel,
@@ -166,7 +162,7 @@ export const actionEditLogic = kea<actionEditLogicType>([
                     router.actions.push(urls.action(action.id))
                 } else {
                     const id = parseInt(props.id.toString()) // props.id can be a string
-                    const logic = actionLogic.findMounted({ tabId: props.tabId, id })
+                    const logic = actionLogic.findMounted({ id })
                     logic?.actions.loadActionSuccess(action)
                 }
 
@@ -313,28 +309,6 @@ export const actionEditLogic = kea<actionEditLogicType>([
             // Ignore in-page URL updates such as opening the side panel
             if (newLocation && newLocation.pathname === router.values.location.pathname) {
                 return false
-            }
-
-            // Skip the prompt for tab switches — our tab still exists, the logic stays mounted
-            // via the scene-logic cache, and the form state is preserved. A tab switch shows up
-            // in one of two ways at beforeUnload time:
-            //  - switching AWAY: sceneLogic.activateTab() has already moved active to another
-            //    tab before router.push fires, so activeTabId !== our tabId.
-            //  - switching BACK: active is now us again, and the push target is our own tab's
-            //    stored pathname.
-            // Anything else (in-tab navigation, closing our tab) should still prompt.
-            const myTabId = logic.props.tabId
-            const scene = sceneLogic.findMounted()
-            if (myTabId && scene && newLocation) {
-                const myTab = scene.values.tabs.find((t) => t.id === myTabId)
-                if (myTab) {
-                    if (scene.values.activeTabId !== myTabId) {
-                        return false
-                    }
-                    if (myTab.pathname === newLocation.pathname) {
-                        return false
-                    }
-                }
             }
 
             return true

--- a/products/actions/frontend/logics/actionLogic.ts
+++ b/products/actions/frontend/logics/actionLogic.ts
@@ -15,15 +15,11 @@ import type { actionLogicType } from './actionLogicType'
 
 export interface ActionLogicProps {
     id: ActionType['id']
-    tabId?: string
 }
 
 export const actionLogic = kea<actionLogicType>([
     props({} as ActionLogicProps),
-    // Key by tabId AND id so each tab preserves its own mounted scene-logic instance across
-    // tab switches. The scene-logic cache keeps this instance alive while another tab is
-    // active, which in turn keeps the held actionEditLogic alive (and its form state intact).
-    key((props) => `${props.tabId || 'notab'}:${props.id || 'new'}`),
+    key((props) => `${props.id || 'new'}`),
     connect(() => ({
         values: [featureFlagLogic, ['featureFlags']],
     })),
@@ -80,7 +76,6 @@ export const actionLogic = kea<actionLogicType>([
         ],
     })),
     selectors({
-        tabId: [() => [(_, p: ActionLogicProps) => p.tabId], (tabId): string | undefined => tabId],
         projectTreeRef: [(_, p) => [p.id], (id): ProjectTreeRef => ({ type: 'action', ref: String(id) })],
         hasCohortFilters: [
             (s) => [s.action],
@@ -92,9 +87,7 @@ export const actionLogic = kea<actionLogicType>([
         breadcrumbs: [
             (s) => [
                 s.action,
-                (state, props) =>
-                    actionEditLogic.findMounted({ tabId: props?.tabId, id: props?.id })?.selectors.action(state).name ||
-                    null,
+                (state, props) => actionEditLogic.findMounted({ id: props?.id })?.selectors.action(state).name || null,
             ],
             (action, inProgressName): Breadcrumb[] => [
                 {

--- a/products/actions/frontend/pages/Action.tsx
+++ b/products/actions/frontend/pages/Action.tsx
@@ -12,21 +12,20 @@ export const scene: SceneExport<ActionLogicProps> = {
     paramsToProps: ({ params: { id } }) => ({ id: parseInt(id) }),
 }
 
-export function Action({ id, tabId }: ActionLogicProps): JSX.Element {
-    // Use the scene-bound logic (BindLogic in App.tsx supplies tabId), so we don't need to
-    // duplicate the key props here.
+export function Action({ id }: ActionLogicProps): JSX.Element {
+    // Use the scene-bound logic (BindLogic in App.tsx supplies the key props), so we don't need
+    // to duplicate them here.
     const { action, actionLoading } = useValues(actionLogic)
 
     return (
         <ActionEdit
             id={id}
-            tabId={tabId}
             action={action}
             actionLoading={actionLoading}
             // Attach actionEditLogic to the scene-kept actionLogic so the form state survives
-            // tab switches: sceneLogic keeps actionLogic mounted per tab, and useAttachedLogic
-            // keeps actionEditLogic alive for as long as actionLogic is mounted.
-            attachTo={actionLogic({ id, tabId })}
+            // React remounts: useAttachedLogic keeps actionEditLogic alive for as long as
+            // actionLogic is mounted.
+            attachTo={actionLogic({ id })}
         />
     )
 }

--- a/products/actions/frontend/pages/ActionEdit.tsx
+++ b/products/actions/frontend/pages/ActionEdit.tsx
@@ -70,17 +70,16 @@ export interface ActionEditProps extends ActionEditLogicProps {
     attachTo?: BuiltLogic<Logic> | LogicWrapper<Logic>
 }
 
-export function ActionEdit({ action: loadedAction, id, tabId, actionLoading, attachTo }: ActionEditProps): JSX.Element {
+export function ActionEdit({ action: loadedAction, id, actionLoading, attachTo }: ActionEditProps): JSX.Element {
     const logicProps: ActionEditLogicProps = {
         id,
         action: loadedAction,
-        tabId,
     }
     const { isComplete } = useValues(actionLogic)
     const logic = actionEditLogic(logicProps)
-    // Attach to the scene-kept actionLogic so the form state persists across tab switches:
-    // sceneLogic keeps actionLogic mounted per tab, and useAttachedLogic keeps actionEditLogic
-    // alive for as long as actionLogic is mounted, even when this component unmounts.
+    // Attach to the scene-kept actionLogic so the form state persists across React remounts:
+    // useAttachedLogic keeps actionEditLogic alive for as long as actionLogic is mounted, even
+    // when this component unmounts.
     useAttachedLogic(logic, attachTo)
     const { action, actionChanged, isActionSubmitting } = useValues(logic)
     const { submitAction, deleteAction, setActionValue, setAction, setOriginalAction } = useActions(logic)


### PR DESCRIPTION
## Problem

PostHog's in-app browser-like tabs were removed a while ago, but the internal `tabId` scaffolding is still threaded through scene logics. This continues the per-area cleanup, this time for the **actions** scene tree.

With only ever one "tab", keying logics by `tabId` and threading a `tabId` prop is dead weight that bloats logic keys, props interfaces, and component signatures without changing behavior.

## Changes

De-tab the actions scene tree:

- `actionLogic` and `actionEditLogic` keys collapse from `${tabId || 'notab'}:${id}` to `${id || 'new'}`.
- `tabId` removed from `ActionLogicProps` and `ActionEditLogicProps` (and the `tabId` selector on `actionLogic`).
- `Action`, `ActionEdit`, and `ActionHogFunctions` stop reading/threading `tabId`; `findMounted` lookups key by `id` alone.
- The `actionEditLogic` `beforeUnload` guard had a branch that skipped the "leave action?" prompt during tab switches by reading `sceneLogic.values.tabs` / `activeTabId`. With a single tab you can never switch tabs, so that branch is unreachable — it's removed, which also drops the now-unused `sceneLogic` import. The remaining guard (prompt on real navigation away with unsaved changes, ignore in-page URL updates) is unchanged.

Behavior is unchanged: every production mount of these logics is a descendant of the action scene and already shared one instance via the scene's single `tabId`; collapsing the key to `id` keeps them sharing that one instance. Nothing relied on the old `'notab'` isolation fallback (only tests mounted without a `tabId`, and they run in isolated kea contexts).

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I actually ran:

- `git grep -nw tabId -- products/actions/frontend/` is clean.
- `hogli test products/actions/frontend/logics/actionsLogic.test.ts` passes (6/6).
- `kea-typegen write` regenerated all 908 logic types with no errors (confirms the logic action/selector wiring is intact), and `tsc --noEmit` reports no errors in `products/actions` (the only repo-wide tsc errors are a pre-existing local `@posthog/hogvm` workspace-build issue, unrelated to this change).
- oxfmt + the pre-commit lint-staged hook (oxlint) pass on all changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). Part of a Graphite stack that removes the defunct in-app `tabId` scaffolding area-by-area, lowest-risk first; this is the actions slice.

Decision worth noting for the reviewer: the old plan was to leave the `beforeUnload` tab-switch guard until the final `sceneLogic` collapse, but that guard reads `logic.props.tabId`, so it could not survive dropping `tabId` from the props interface. Since the tab-switch skip branch is unreachable in a single-tab world (verified: the `activeTabId !== myTabId` branch never fires with one tab, and the pathname-match branch is already covered by the earlier in-page-URL check), it was simplified here instead — which has the bonus of removing one of the early readers of the soon-to-be-deleted `sceneLogic.values.tabs`.

The `attachTo` + `useAttachedLogic` keep-alive machinery is intentionally kept (it is now a general "keep a child logic mounted across React remounts" utility, not tab-specific) — only the `tabId` argument was dropped.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
