### PR TITLE
fix(experiments): add loading state to end experiment button

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
@@ -198,8 +198,7 @@ export function ResumeExperimentModal(): JSX.Element {
 }
 
 export function FinishExperimentModal(): JSX.Element {
-    const { experiment, isSingleVariantShipped, shippedVariantKey, endExperimentLoading } =
-        useValues(experimentLogic)
+    const { experiment, isSingleVariantShipped, shippedVariantKey, endExperimentLoading } = useValues(experimentLogic)
     const { finishExperiment, endExperimentWithoutShipping, restoreUnmodifiedExperiment } = useActions(experimentLogic)
     const { closeFinishExperimentModal } = useActions(modalsLogic)
     const { isFinishExperimentModalOpen } = useValues(modalsLogic)

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
@@ -259,6 +259,10 @@ export function FinishExperimentModal(): JSX.Element {
             <LemonModal
                 isOpen={isFinishExperimentModalOpen}
                 onClose={() => {
+                    // Don't allow dismissing (X / backdrop / escape) while the request is in flight.
+                    if (endExperimentLoading) {
+                        return
+                    }
                     restoreUnmodifiedExperiment()
                     closeFinishExperimentModal()
                 }}

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
@@ -198,7 +198,8 @@ export function ResumeExperimentModal(): JSX.Element {
 }
 
 export function FinishExperimentModal(): JSX.Element {
-    const { experiment, isSingleVariantShipped, shippedVariantKey } = useValues(experimentLogic)
+    const { experiment, isSingleVariantShipped, shippedVariantKey, endExperimentLoading } =
+        useValues(experimentLogic)
     const { finishExperiment, endExperimentWithoutShipping, restoreUnmodifiedExperiment } = useActions(experimentLogic)
     const { closeFinishExperimentModal } = useActions(modalsLogic)
     const { isFinishExperimentModalOpen } = useValues(modalsLogic)
@@ -267,6 +268,7 @@ export function FinishExperimentModal(): JSX.Element {
                     <div className="flex items-center gap-2">
                         <LemonButton
                             type="secondary"
+                            disabledReason={endExperimentLoading && 'Ending experiment…'}
                             onClick={() => {
                                 restoreUnmodifiedExperiment()
                                 closeFinishExperimentModal()
@@ -277,6 +279,7 @@ export function FinishExperimentModal(): JSX.Element {
                         <LemonButton
                             onClick={handleEndExperiment}
                             type="primary"
+                            loading={endExperimentLoading}
                             disabledReason={!experiment.conclusion && 'Select a conclusion'}
                         >
                             End experiment

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
@@ -258,10 +258,6 @@ export function FinishExperimentModal(): JSX.Element {
             <LemonModal
                 isOpen={isFinishExperimentModalOpen}
                 onClose={() => {
-                    // Don't allow dismissing (X / backdrop / escape) while the request is in flight.
-                    if (endExperimentLoading) {
-                        return
-                    }
                     restoreUnmodifiedExperiment()
                     closeFinishExperimentModal()
                 }}
@@ -271,7 +267,6 @@ export function FinishExperimentModal(): JSX.Element {
                     <div className="flex items-center gap-2">
                         <LemonButton
                             type="secondary"
-                            disabledReason={endExperimentLoading && 'Ending experiment…'}
                             onClick={() => {
                                 restoreUnmodifiedExperiment()
                                 closeFinishExperimentModal()

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -1092,49 +1092,6 @@ describe('experimentLogic', () => {
             keyed.unmount()
         })
 
-        it('toggles endExperimentLoading on and off around the request', async () => {
-            const runningExperiment = {
-                ...experiment,
-                start_date: '2026-03-17T10:00:00Z',
-                status: 'running',
-                conclusion: 'won',
-            } as Experiment
-            const createSpy = jest.spyOn(api, 'create').mockResolvedValue({
-                ...runningExperiment,
-                end_date: '2026-03-24T10:00:00Z',
-                status: 'stopped',
-            })
-
-            const keyed = experimentLogic({ experimentId: experiment.id })
-            keyed.mount()
-            keyed.actions.setExperiment(runningExperiment)
-
-            await expectLogic(keyed, () => {
-                keyed.actions.endExperiment()
-            })
-                // loading flips on before the request and off after it resolves
-                .toDispatchActions(['setEndExperimentLoading', 'setExperiment', 'setEndExperimentLoading'])
-                .toFinishAllListeners()
-                .toMatchValues({ endExperimentLoading: false })
-
-            createSpy.mockRestore()
-            keyed.unmount()
-        })
-
-        it('resets endExperimentLoading after a failed request', async () => {
-            const createSpy = jest.spyOn(api, 'create').mockRejectedValue({ detail: 'boom' })
-
-            logic.actions.setExperiment(experiment)
-
-            await expectLogic(logic, () => {
-                logic.actions.endExperiment()
-            })
-                .toFinishAllListeners()
-                .toMatchValues({ endExperimentLoading: false })
-
-            createSpy.mockRestore()
-        })
-
         it('shows error toast on validation error', async () => {
             const createSpy = jest.spyOn(api, 'create').mockRejectedValue({
                 detail: 'Experiment has already ended.',
@@ -1234,21 +1191,6 @@ describe('experimentLogic', () => {
             keyed.unmount()
         })
 
-        it('resets endExperimentLoading after a failed ship_variant request', async () => {
-            const createSpy = jest.spyOn(api, 'create').mockRejectedValue({ detail: 'boom' })
-
-            logic.actions.setExperiment(experiment)
-
-            await expectLogic(logic, () => {
-                logic.actions.finishExperiment({ selectedVariantKey: 'test', releaseToEveryone: false })
-            })
-                .toDispatchActions(['setEndExperimentLoading', 'setEndExperimentLoading'])
-                .toFinishAllListeners()
-                .toMatchValues({ endExperimentLoading: false })
-
-            createSpy.mockRestore()
-        })
-
         it('shows error toast on validation error', async () => {
             const createSpy = jest.spyOn(api, 'create').mockRejectedValue({
                 detail: 'Experiment has not been launched yet.',
@@ -1307,6 +1249,60 @@ describe('experimentLogic', () => {
             )
             // Should NOT show the generic error toast
             expect(errorMock).not.toHaveBeenCalled()
+            createSpy.mockRestore()
+        })
+    })
+
+    describe('endExperimentLoading', () => {
+        // The end and ship-variant lifecycle calls both drive the single endExperimentLoading flag.
+        const triggers: { name: string; run: (l: ReturnType<typeof experimentLogic>) => void }[] = [
+            { name: 'endExperiment', run: (l) => l.actions.endExperiment() },
+            {
+                name: 'finishExperiment',
+                run: (l) => l.actions.finishExperiment({ selectedVariantKey: 'test', releaseToEveryone: false }),
+            },
+        ]
+
+        it.each(triggers)('flips the flag on then off around a successful $name', async ({ run }) => {
+            const runningExperiment = {
+                ...experiment,
+                start_date: '2026-03-17T10:00:00Z',
+                status: 'running',
+                conclusion: 'won',
+            } as Experiment
+            const createSpy = jest.spyOn(api, 'create').mockResolvedValue({
+                ...runningExperiment,
+                end_date: '2026-03-24T10:00:00Z',
+                status: 'stopped',
+            })
+
+            const keyed = experimentLogic({ experimentId: experiment.id })
+            keyed.mount()
+            keyed.actions.setExperiment(runningExperiment)
+
+            await expectLogic(keyed, () => {
+                run(keyed)
+            })
+                // loading flips on before the request and off after it resolves
+                .toDispatchActions(['setEndExperimentLoading', 'setExperiment', 'setEndExperimentLoading'])
+                .toFinishAllListeners()
+                .toMatchValues({ endExperimentLoading: false })
+
+            createSpy.mockRestore()
+            keyed.unmount()
+        })
+
+        it.each(triggers)('resets the flag after a failed $name', async ({ run }) => {
+            const createSpy = jest.spyOn(api, 'create').mockRejectedValue({ detail: 'boom' })
+
+            logic.actions.setExperiment(experiment)
+
+            await expectLogic(logic, () => {
+                run(logic)
+            })
+                .toFinishAllListeners()
+                .toMatchValues({ endExperimentLoading: false })
+
             createSpy.mockRestore()
         })
     })

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -1092,6 +1092,49 @@ describe('experimentLogic', () => {
             keyed.unmount()
         })
 
+        it('toggles endExperimentLoading on and off around the request', async () => {
+            const runningExperiment = {
+                ...experiment,
+                start_date: '2026-03-17T10:00:00Z',
+                status: 'running',
+                conclusion: 'won',
+            } as Experiment
+            const createSpy = jest.spyOn(api, 'create').mockResolvedValue({
+                ...runningExperiment,
+                end_date: '2026-03-24T10:00:00Z',
+                status: 'stopped',
+            })
+
+            const keyed = experimentLogic({ experimentId: experiment.id })
+            keyed.mount()
+            keyed.actions.setExperiment(runningExperiment)
+
+            await expectLogic(keyed, () => {
+                keyed.actions.endExperiment()
+            })
+                // loading flips on before the request and off after it resolves
+                .toDispatchActions(['setEndExperimentLoading', 'setExperiment', 'setEndExperimentLoading'])
+                .toFinishAllListeners()
+                .toMatchValues({ endExperimentLoading: false })
+
+            createSpy.mockRestore()
+            keyed.unmount()
+        })
+
+        it('resets endExperimentLoading after a failed request', async () => {
+            const createSpy = jest.spyOn(api, 'create').mockRejectedValue({ detail: 'boom' })
+
+            logic.actions.setExperiment(experiment)
+
+            await expectLogic(logic, () => {
+                logic.actions.endExperiment()
+            })
+                .toFinishAllListeners()
+                .toMatchValues({ endExperimentLoading: false })
+
+            createSpy.mockRestore()
+        })
+
         it('shows error toast on validation error', async () => {
             const createSpy = jest.spyOn(api, 'create').mockRejectedValue({
                 detail: 'Experiment has already ended.',
@@ -1189,6 +1232,21 @@ describe('experimentLogic', () => {
 
             createSpy.mockRestore()
             keyed.unmount()
+        })
+
+        it('resets endExperimentLoading after a failed ship_variant request', async () => {
+            const createSpy = jest.spyOn(api, 'create').mockRejectedValue({ detail: 'boom' })
+
+            logic.actions.setExperiment(experiment)
+
+            await expectLogic(logic, () => {
+                logic.actions.finishExperiment({ selectedVariantKey: 'test', releaseToEveryone: false })
+            })
+                .toDispatchActions(['setEndExperimentLoading', 'setEndExperimentLoading'])
+                .toFinishAllListeners()
+                .toMatchValues({ endExperimentLoading: false })
+
+            createSpy.mockRestore()
         })
 
         it('shows error toast on validation error', async () => {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1469,15 +1469,7 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         endExperimentWithoutShipping: async () => {
-            // endExperiment swallows its own error, so success is detected by whether *this* call
-            // set the end date. Capture the prior state first: a pre-existing end_date (or a failed
-            // request that leaves it unchanged) must not be mistaken for a successful end here.
-            const alreadyEnded = !!values.experiment.end_date
-            // Await so the button keeps its loading state until the request resolves.
-            await asyncActions.endExperiment()
-            if (alreadyEnded || !values.experiment.end_date) {
-                return
-            }
+            actions.endExperiment()
             actions.closeFinishExperimentModal()
             lemonToast.success('Experiment ended successfully')
 

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1469,10 +1469,13 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         endExperimentWithoutShipping: async () => {
+            // endExperiment swallows its own error, so success is detected by whether *this* call
+            // set the end date. Capture the prior state first: a pre-existing end_date (or a failed
+            // request that leaves it unchanged) must not be mistaken for a successful end here.
+            const alreadyEnded = !!values.experiment.end_date
             // Await so the button keeps its loading state until the request resolves.
             await asyncActions.endExperiment()
-            // endExperiment surfaces its own error toast; only celebrate if it actually ended.
-            if (!values.experiment.end_date) {
+            if (alreadyEnded || !values.experiment.end_date) {
                 return
             }
             actions.closeFinishExperimentModal()

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -638,6 +638,7 @@ export const experimentLogic = kea<experimentLogicType>([
         createExperiment: (draft?: boolean, folder?: string | null) => ({ draft, folder }),
         setCreateExperimentLoading: (loading: boolean) => ({ loading }),
         setLaunchExperimentLoading: (loading: boolean) => ({ loading }),
+        setEndExperimentLoading: (loading: boolean) => ({ loading }),
         setEditExperiment: (editing: boolean) => ({ editing }),
         refreshExperimentResults: (forceRefresh?: boolean, triggeredBy?: ExperimentTriggeredBy) => ({
             forceRefresh,
@@ -1216,6 +1217,12 @@ export const experimentLogic = kea<experimentLogicType>([
                 setLaunchExperimentLoading: (_, { loading }) => loading,
             },
         ],
+        endExperimentLoading: [
+            false,
+            {
+                setEndExperimentLoading: (_, { loading }) => loading,
+            },
+        ],
         hogfettiTrigger: [
             null as (() => void) | null,
             {
@@ -1444,6 +1451,7 @@ export const experimentLogic = kea<experimentLogicType>([
             actions.refreshExperimentResults(true, 'config_change')
         },
         endExperiment: async () => {
+            actions.setEndExperimentLoading(true)
             try {
                 const response: Experiment = await api.create(
                     `/api/projects/${values.currentProjectId}/experiments/${values.experimentId}/end`,
@@ -1456,10 +1464,17 @@ export const experimentLogic = kea<experimentLogicType>([
                 refreshTreeItem('experiment', String(values.experimentId))
             } catch (error: any) {
                 lemonToast.error(error.detail || 'Failed to end experiment')
+            } finally {
+                actions.setEndExperimentLoading(false)
             }
         },
         endExperimentWithoutShipping: async () => {
-            actions.endExperiment()
+            // Await so the button keeps its loading state until the request resolves.
+            await asyncActions.endExperiment()
+            // endExperiment surfaces its own error toast; only celebrate if it actually ended.
+            if (!values.experiment.end_date) {
+                return
+            }
             actions.closeFinishExperimentModal()
             lemonToast.success('Experiment ended successfully')
 
@@ -1706,6 +1721,7 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         finishExperiment: async ({ selectedVariantKey, releaseToEveryone }) => {
+            actions.setEndExperimentLoading(true)
             try {
                 const response: Experiment = await api.create(
                     `/api/projects/${values.currentProjectId}/experiments/${values.experimentId}/ship_variant`,
@@ -1746,6 +1762,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 } else {
                     lemonToast.error(error.detail || 'Failed to ship variant')
                 }
+            } finally {
+                actions.setEndExperimentLoading(false)
             }
         },
         updateExperimentVariantImages: async ({ variantPreviewMediaIds }) => {


### PR DESCRIPTION
## Problem

Clicking **End experiment** in the experiment modal triggered the `ship_variant` / `end` API request with no loading state. On the common "ship a variant" path the modal stays open until the request resolves, so with any latency the button looks unresponsive and users wonder if it's broken. This also violated our own convention (CLAUDE.md: any button that triggers a network request must disable + show a loading state).

## Changes

- Added a `setEndExperimentLoading` action + `endExperimentLoading` reducer to `experimentLogic`, mirroring the existing `launchExperimentLoading` pattern.
- `endExperiment` and `finishExperiment` (ship variant) now flip the flag on before the request and reset it in a `finally` (covers both success and error paths).
- `endExperimentWithoutShipping` now `await`s `endExperiment` so the button keeps its loading state until the request resolves (previously it fired-and-forgot and closed the modal instantly), and only shows the success toast / celebration when the experiment actually ended — avoiding a false success toast on failure.
- Wired `loading={endExperimentLoading}` onto the **End experiment** button and a `disabledReason` onto **Cancel** while a request is in flight, preventing double-submission.

The deprecated legacy experiment view (`legacyExperimentLogic`) was left untouched — the current experiment view is the active path.

## How did you test this code?

I'm an agent. I added automated kea-logic tests in `experimentLogic.test.ts` asserting that `endExperimentLoading` flips on→off around both the `end` and `ship_variant` requests and resets to `false` on failure. I did **not** run the test suite or typecheck locally — this was authored in a no-repo session without `node_modules` installed, so CI is the first run. The changes follow the existing `launchExperimentLoading` pattern and the `boolean && string` `disabledReason` idiom already used on this button.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) from a support ticket reporting that the end-experiment button had no loading state and a delay that made it look broken.

Investigation traced the trigger to the `FinishExperimentModal` button, whose `onClick` dispatches `finishExperiment` (ship variant) or `endExperimentWithoutShipping` — both async listeners issuing `api.create` with no in-flight state. I reused the existing `launchExperimentLoading` reducer pattern rather than introducing local component state, to keep business logic in the kea layer.

One decision worth noting: I initially had `endExperiment` rethrow so the caller could branch on failure, but reverted it because the existing `endExperiment` error tests dispatch the action directly and a rethrown listener error risked failing `toFinishAllListeners()`. Instead `endExperimentWithoutShipping` checks `experiment.end_date` after awaiting to decide whether to celebrate.
