### PR TITLE
chore(signals): correct exploring-signals-scouts after bot review

### DIFF
--- a/products/signals/skills/exploring-signals-scouts/SKILL.md
+++ b/products/signals/skills/exploring-signals-scouts/SKILL.md
@@ -57,15 +57,23 @@ signals-scout-config-list
 
 Read the result against three cases:
 
-- **Empty (`count: 0`)** — no scouts are registered. The project isn't enrolled in the scout
+The config list is unpaginated — it comes back as `{ results: [...] }` (a bare array), with no
+`count` field. Read the result against three cases:
+
+- **Empty (`results: []`)** — no scouts are registered. The project isn't enrolled in the scout
   fleet (or hasn't ticked yet). Say so plainly; don't go fishing for runs. Point the user at the
   Signals scout settings / PostHog Code onboarding rather than inventing activity.
 - **Configs exist but all `enabled: false`** — the fleet is registered but paused. Nothing is
   running. Tell the user which scouts exist and that they're all off.
-- **At least one `enabled: true`** — the fleet is live. For each enabled scout note its
-  `run_interval_minutes` (cadence), `emit` (false = **dry-run**, runs but writes nothing to the
-  inbox), and `last_run_at` (when it last fired — `null` means it has never run). Now proceed to
-  the user's actual question.
+- **At least one `enabled: true`** — the fleet is registered and that scout is allowed to run. For
+  each enabled scout note its `run_interval_minutes` (cadence), `emit` (false = **dry-run**, runs
+  but writes nothing to the inbox), and `last_run_at` (when it last fired — `null` means it has
+  never run). One caveat before reporting "it's live": runs are gated by the `signals-scout` feature
+  flag, not by `enabled`. A project that was enrolled and later drained from the flag keeps its
+  `enabled: true` rows, but the coordinator no longer plans runs for it — so a stale or `null`
+  `last_run_at` on an enabled scout usually means the project is no longer enrolled, not that the
+  scout is idle. When `last_run_at` is recent, the scout is genuinely running; proceed to the user's
+  actual question.
 
 A scout that is `enabled: true` but `emit: false` is the most common source of "my scout isn't
 doing anything" confusion: it _is_ running and reasoning every tick, it just isn't allowed to post
@@ -192,22 +200,25 @@ in terms of are documented in
 
 ## Workflow: see what scouts have surfaced
 
-Scout findings reach the user as inbox reports. You might expect to filter the inbox to the scout
-source:
+Scout findings reach the user as inbox reports. Filter the inbox to the scout source:
 
 ```json
 inbox-reports-list
 { "source_product": "signals_scout", "limit": 20 }
 ```
 
-**In practice this often returns nothing even on a project where scouts are actively emitting** —
-scout findings flow through the same grouping pipeline as every other source and get attributed to
-the underlying product (`error_tracking`, `llm_analytics`, …), not tagged `signals_scout` at the
-report layer. So don't treat an empty result here as "the fleet emitted nothing." The reliable way
-to know what a specific run surfaced is its `summary`; to browse the inbox generally, use the
-[`inbox-exploration`](../inbox-exploration/SKILL.md) skill (statuses, suggested reviewers, drilling
-into a report's underlying signals). The emit contract behind each finding — weight, confidence,
-severity, the description prose — is documented in
+This is the direct way to find scout-backed reports. Each finding is emitted with
+`source_product="signals_scout"`, that tag rides through grouping into the report's signal metadata,
+and the inbox filter keeps any report whose contributing signals include `signals_scout` — so the
+result is the set of reports the fleet has surfaced.
+
+An empty result means the fleet hasn't emitted (yet), **not** that the filter is broken. Scouts hold
+a high bar — most runs close out without emitting — so on a quiet or newly enrolled project zero
+scout-backed reports is the normal, expected state. Read it as "nothing surfaced," and fall back to
+each run's `summary` for the per-run record of what was (or wasn't) emitted. To browse the inbox more
+broadly, use the [`inbox-exploration`](../inbox-exploration/SKILL.md) skill (statuses, suggested
+reviewers, drilling into a report's underlying signals). The emit contract behind each finding —
+weight, confidence, severity, the description prose — is documented in
 [`../authoring-signals-scouts/references/emit-contract.md`](../authoring-signals-scouts/references/emit-contract.md).
 
 ## Workflow: assess health and performance

--- a/products/signals/skills/exploring-signals-scouts/references/scout-data-model.md
+++ b/products/signals/skills/exploring-signals-scouts/references/scout-data-model.md
@@ -60,20 +60,24 @@ and `completed_at` together rather than keying on one status string.)
 ## Run → finding link (and why it's awkward)
 
 Findings are **not** stored on the run row, and there is no emit flag or finding count on it
-either — so you cannot query "which runs emitted" directly. When a scout emits, the finding goes
-through `emit_signal()` with `source_product="signals_scout"` / `source_type="cross_source_issue"`
-and flows through the same grouping pipeline as every other source. Each finding gets a
-deterministic `source_id = run:<run_id>:finding:<finding_id>`, **but**:
+either — so you cannot query "which runs emitted" directly from the run. When a scout emits, the
+finding goes through `emit_signal()` with `source_product="signals_scout"` /
+`source_type="cross_source_issue"` and flows through the same grouping pipeline as every other
+source. Each finding gets a deterministic `source_id = run:<run_id>:finding:<finding_id>`:
 
-- The `source_id` is stored in the signal's `metadata.extra`, not a top-level field, and grouping
-  v2 generates its own `document_id` and dedupes on that — never on `source_id`.
-- Grouping merges scout findings into clusters alongside other sources, so the resulting
-  `SignalReport` is attributed to the underlying product (`error_tracking`, …). On a live project,
-  `inbox-reports-list { "source_product": "signals_scout" }` can return **zero** even while scouts
-  are actively emitting — don't rely on it to count or find scout output.
+- The `source_id` is stored at the **top level** of the signal's `metadata` (i.e.
+  `metadata.source_id`), alongside `metadata.source_product` — not inside `metadata.extra`. Grouping
+  v2 generates its own `document_id` and dedupes on that — never on `source_id` — so re-emitting the
+  same `finding_id` creates a second signal rather than updating the first.
+- The `source_product="signals_scout"` tag rides through grouping into the persisted signal
+  metadata, so a report that contains a scout finding carries `signals_scout` among its contributing
+  signals. That's what `inbox-reports-list { "source_product": "signals_scout" }` filters on, and
+  it's the direct way to list scout-backed reports.
 
-So in practice the run's prose `summary` is the readily-available record of what a run did or
-didn't emit. A run that closed out empty has no findings — expected and correct most of the time.
+Two ways to follow a finding, then: filter the inbox by `source_product="signals_scout"` to see the
+reports the fleet produced, or read the run's prose `summary` for the per-run record of what a single
+run did or didn't emit. A run that closed out empty has no findings — expected and correct most of
+the time, since scouts only emit when they clear a high bar.
 
 ## SignalScratchpad — durable fleet memory
 


### PR DESCRIPTION
## Problem

Follow-on to #62027 (already merged). A bot review on that PR flagged four claims in the new `exploring-signals-scouts` skill that, on verification against the backend code, turned out to be wrong. The original PR merged before the corrections landed, so master still carries the incorrect text.

The root cause: several claims came from a live dogfooding pass against project 2 that observed an empty `inbox-reports-list { source_product: "signals_scout" }` and inferred the wrong mechanism. That empty result was a project-2 pipeline gap (no `signals_scout` signals present at all), not the documented behavior.

## Changes

Corrects the skill to match the backend code:

- **Inbox source filter works.** `source_product=signals_scout` **is** the direct way to find scout-backed reports. Findings emit with `source_product="signals_scout"` (`emit.py:33,140`), the tag rides through grouping into the signal metadata (`grouping.py:693`), and `fetch_report_ids_for_source_products` filters on exactly that (`signal_queries.py:530`). Removed the "findings get re-attributed to the underlying product" claim; an empty result now reads as "nothing emitted yet" (scouts hold a high bar), not "filter broken."
- **`source_id` location.** Stored at the top level of signal metadata (`metadata.source_id`), not inside `metadata.extra` (`grouping.py:692-695`, `signal_queries.py:116`).
- **config-list shape.** `signals-scout-config-list` is unpaginated (`views.py:502` — `pagination_class = None`); it returns `{ results: [...] }` with no `count`, so the empty state is `results: []`.
- **"Live" check accounts for enrollment.** Runs are gated by the `signals-scout` feature flag (`scout_coordinator.py:201-227`), not by `enabled` — a drained project keeps `enabled: true` rows that no longer run, so only a recent `last_run_at` proves a scout is genuinely live.

## How did you test this code?

- `hogli lint:skills` — passes (61 skills).
- Each claim verified against the backend source (file:line references above), and the config-list shape and empty inbox filter confirmed live against project 2 via the read-only MCP tools.

## Docs update

`skip-inkeep-docs` — agent-facing skill, not user docs.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Andy's direction. The four corrections were each cross-checked against the backend (`emit.py`, `grouping.py`, `signal_queries.py`, `views.py`, `scout_coordinator.py`) rather than re-derived from the project-2 observation, since that observation was itself the source of the original errors. Inline replies documenting each fix are on the #62027 review threads.
