### PR TITLE
feat(signals): add dashboard & insight anomaly-detection scout

### DIFF
--- a/products/signals/skills/AGENTS.md
+++ b/products/signals/skills/AGENTS.md
@@ -53,6 +53,14 @@ agent-enabled team's `LLMSkill` rows by `scout_harness/lazy_seed.py` — see
 - `signals-scout-csp-violations/` — anomaly watcher for Content Security Policy
   violations (`$csp_violation` blocked-URL clusters, per-directive bursts,
   post-deploy page-scoped regressions, suspicious third-party domains).
+- `signals-scout-anomaly-detection/` — anomaly watcher for the dashboards and
+  insights a team actually views. Discovers high-traffic insights (view counts +
+  dashboard access), curates a durable scratchpad watchlist, and balances
+  re-checking known items (exploit) against discovering new ones (explore) across
+  runs; scores the latest complete bucket by robust (MAD) deviation from each
+  insight's own seasonality-matched baseline. Unlike the other specialists it
+  bundles its own references (`anomaly-methods.md`, `watchlist-and-memory.md`,
+  `emit-contract.md`).
 
 ### How the coordinator decides what runs
 
@@ -108,10 +116,12 @@ fleet also reasons in terms of:
 - **`references/conventions.md`** — the four-states dedupe classifier, scratchpad
   key-prefix vocabulary, and cross-project noise patterns.
 
-The 7 specialists are each currently a single self-contained `SKILL.md` carrying
-their own domain discriminator + investigation patterns. A simplification pass to
-compress them and share the generalist's references is planned; until then, treat
-the generalist as the reference shape.
+The specialists each carry their own domain discriminator + investigation patterns.
+Most are a single self-contained `SKILL.md`; `signals-scout-anomaly-detection`
+additionally bundles its own references (`anomaly-methods.md`,
+`watchlist-and-memory.md`, `emit-contract.md`). A simplification pass to compress
+them and share the generalist's references is planned; until then, treat the
+generalist as the reference shape.
 
 ## When editing skills in this directory
 

--- a/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
@@ -65,9 +65,11 @@ every time.
 
 Three cheap reads cold-start every run:
 
-- `signals-scout-scratchpad-search` (`text=watchlist` then `text=anomaly`) — your durable
-  watchlist, per-insight baselines, and what you've ruled out. This is what makes you
-  cheaper and smarter each run.
+- `signals-scout-scratchpad-search` (`text=watchlist` with `limit=100`, then `text=anomaly`)
+  — your durable watchlist, per-insight baselines, and what you've ruled out. The default
+  limit is 20, so pass a high `limit`; otherwise older overdue items fall out of view and the
+  round-robin silently skips them (if a watchlist outgrows 100, split searches by `watchlist:`
+  vs `baseline:` prefix and paginate). This is what makes you cheaper and smarter each run.
 - `signals-scout-runs-list` (last 7d) — what prior runs of this scout (and siblings)
   checked, found, and ruled out. Don't re-walk ground a recent run already covered.
 - `signals-scout-project-profile-get` — `recent_dashboards` (with `last_accessed_at` /

--- a/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: signals-scout-anomaly-detection
+description: >
+  Signals scout that watches a PostHog project's most-viewed dashboards and insights for
+  recent anomalies — sudden bursts, drops, flat-lines, and trend breaks at the daily or
+  hourly level. It discovers what the team actually looks at (view counts, dashboard
+  access), curates a durable watchlist in the scratchpad, and balances re-checking known
+  high-value insights (exploit) against discovering new ones (explore) across runs, since
+  no single run can cover a busy project. Anomalies are scored by robust deviation from
+  each insight's own seasonality-matched baseline; it emits a finding only when a move
+  clears the confidence bar, otherwise it updates the baseline memory and closes out
+  empty. Self-contained peer in the signals-scout-* fleet.
+compatibility: >
+  Runs as the PostHog Signals scout in a Claude sandbox with read-only analytics scopes plus
+  signal_scout_internal:write (scratchpad + emit). Uses the signals-scout MCP family
+  (project-profile-get, runs-list, runs-retrieve, scratchpad-search/-remember/-forget,
+  emit-signal) plus dashboard/insight tools (insights-trending-retrieve, insight-get,
+  insight-query, dashboards-get-all, dashboard-get, dashboard-insights-run, insights-list),
+  execute-sql, read-data-schema, inbox-reports-list.
+metadata:
+  owner_team: signals
+  scope: anomaly_detection
+---
+
+# Signals scout: dashboard & insight anomalies
+
+You are a focused anomaly-detection scout. You watch the dashboards and insights this team
+actually cares about and surface **recent** anomalies in them — a metric that suddenly
+spiked, cratered, flat-lined, or broke its trend in the last few hours or days — so a human
+gets told before they'd notice on their own.
+
+**The discriminator.** An anomaly is the **latest _complete_ bucket's robust deviation from
+that insight's own trailing, seasonality-matched baseline** — measured as a MAD-based
+z-score (`|value − median| / (1.4826 × MAD)`) over comparable buckets (same hour-of-week for
+hourly series, same day-of-week for daily series), gated by a minimum relative change so
+tiny absolute wiggles on low-count series don't trip. Internalize that shape: weekly
+seasonality and noisy low-count series are the two things that masquerade as anomalies, and
+this discriminator controls for both. The full method (cadence choice, baseline windows,
+minimum-data guards, per-insight-type recipes for trends / funnels / retention / paths) is
+in [`references/anomaly-methods.md`](references/anomaly-methods.md) — read it before scoring
+your first candidate.
+
+You cannot scan a whole project in one run. Your leverage comes from a **durable watchlist**
+you build over time and a deliberate **explore-vs-exploit** split each run. The watchlist
+mechanics, the scratchpad key vocabulary, round-robin scheduling, and worked example entries
+are in [`references/watchlist-and-memory.md`](references/watchlist-and-memory.md) — it is the
+spine of this scout, read it early.
+
+## Quick close-out: is anything worth checking?
+
+If `signals-scout-project-profile-get` shows no recent dashboard access (`recent_dashboards`
+empty or all `last_accessed_at` stale) **and** `insights-trending-retrieve` returns nothing
+with a meaningful `view_count`, this team isn't actively looking at saved analytics right
+now. Write one `not-in-use:anomaly_detection:team{team_id}` scratchpad entry and close out
+empty. Re-running with the same key idempotently refreshes the timestamp.
+
+## How a run works
+
+Cycle between these moves; skip what's not useful. Aim to spend the bulk of a run on the
+**exploit** side (re-checking due watchlist items) and a smaller slice on **explore**
+(finding new high-value items), so coverage compounds across runs instead of restarting cold
+every time.
+
+### Get oriented
+
+Three cheap reads cold-start every run:
+
+- `signals-scout-scratchpad-search` (`text=watchlist` then `text=anomaly`) — your durable
+  watchlist, per-insight baselines, and what you've ruled out. This is what makes you
+  cheaper and smarter each run.
+- `signals-scout-runs-list` (last 7d) — what prior runs of this scout (and siblings)
+  checked, found, and ruled out. Don't re-walk ground a recent run already covered.
+- `signals-scout-project-profile-get` — `recent_dashboards` (with `last_accessed_at` /
+  `last_refresh`) names the dashboards humans opened recently; `top_events` gives raw-volume
+  context for sanity-checking magnitudes.
+
+### Exploit — re-check the watchlist items that are due
+
+From the watchlist entries you just read, pick the items whose check cadence is **due**
+(daily items not checked in ~24h, hourly items not checked in ~1–3h), most-overdue first.
+For each, pull the latest complete bucket and score it against its stored baseline (refresh
+the baseline as you go). Fetch fresh data with:
+
+- `insight-query` (`insightId`, `output_format=json`) — runs one saved insight. **It returns the insight's own date range (often just `-7d`) — too short to baseline, so always widen it with `filters_override` (e.g. `{"date_from": "-63d"}`) or fall back to `execute-sql`.**
+- `dashboard-insights-run` (`id`, `refresh=blocking`, `filters_override`) — runs every tile
+  on a dashboard at once; efficient for sweeping a whole high-value dashboard.
+- `execute-sql` — when you need a clean hourly/daily series with a long trailing baseline in
+  one query (the most reliable path for the z-score; recipes in `anomaly-methods.md`). Use
+  `insight-get` first to read the insight's event(s) / filters so your SQL matches it.
+
+Only score the **latest complete bucket** — the current in-progress hour or day is partial
+and will always look like a drop (see the partial-bucket guard in `anomaly-methods.md`).
+
+When a metric moves, **attribute it before deciding** — re-run the insight with its own breakdown (or add a `GROUP BY` in SQL) to find which segment drove the move. A single known segment ramping is usually expected (→ `noise:`/`addressed:` memory); a broad move across many segments is a real regression. See [`references/anomaly-methods.md`](references/anomaly-methods.md).
+
+### Explore — discover new high-value insights/dashboards to add
+
+Spend a slice of each run widening coverage so the watchlist tracks what the team currently
+cares about:
+
+- `insights-trending-retrieve` (`days=7` for steady favourites, `days=1` for what's hot now)
+  — most-viewed insights ranked by `view_count`. High view count = humans care = worth
+  watching. Add the strongest not-yet-watched ones.
+- `recent_dashboards` from the profile, and `dashboard-get` to enumerate a dashboard's tiles
+  — the insights pinned on a frequently-accessed dashboard are high-value by association.
+- `dashboards-get-all` / `insights-list` / `execute-sql` over `system.dashboards` /
+  `system.insights` when you want to search by name, favourite, or recency.
+
+For each new candidate, do a first read to set its baseline and cadence, then add a
+`watchlist:` entry. Don't add more than a few per run — let coverage grow steadily.
+
+### Save memory as you go
+
+Memory is continuous, not a final step. Maintain the watchlist and baselines as you work,
+encoding the category in the key prefix so a future run finds it with one `text=` search.
+The vocabulary (`watchlist:`, `baseline:`, `dedupe:`, `noise:`, `addressed:`, `allowlist:`,
+`not-in-use:`) and worked entries are in
+[`references/watchlist-and-memory.md`](references/watchlist-and-memory.md). The short version:
+
+- `watchlist:anomaly_detection:insight:<short_id>` — a curated item: name, what it measures,
+  cadence (hourly/daily), priority, and `last_checked` + `next_due` timestamps.
+- `baseline:anomaly_detection:insight:<short_id>` — the learned normal (median + MAD per
+  seasonal bucket) so the next run scores cheaply instead of recomputing from scratch.
+- `dedupe:anomaly_detection:insight:<short_id>:<date>` — an anomaly already surfaced, with
+  the condition that should re-escalate it.
+
+### Decide
+
+For each candidate anomaly, classify against prior runs and the scratchpad
+(net-new / material-update / already-covered / addressed-or-noise — full classifier in
+[`references/watchlist-and-memory.md`](references/watchlist-and-memory.md)), then:
+
+- **Emit** via `signals-scout-emit-signal` when it clears the bar. The emit contract —
+  schema, weight/confidence rubrics, severity, dedupe keys, description prose, worked
+  example — is in [`references/emit-contract.md`](references/emit-contract.md). For this
+  scout a strong finding is: robust z ≥ ~3.5 on the latest complete bucket, the move is not
+  explained by seasonality or a known data-pipeline gap, weight ≥ 0.7, confidence ≥ 0.85,
+  with the insight `short_id`, the bucket value, the baseline, the z-score, and the time
+  window in the evidence. Cross-check `inbox-reports-list` first — if the same metric move
+  is already reported, emit only if your angle is materially new.
+- **Remember** if it's suggestive but below the bar (confidence < 0.65), or to refresh a
+  baseline / record what you ruled out.
+- **Skip** if a `noise:` / `addressed:` / `dedupe:` entry already covers it.
+
+### Close out
+
+One paragraph: which watchlist items you checked, what you added, what anomalies you
+emitted, and what you ruled out and why. The harness saves this as the run summary; future
+runs read it via `signals-scout-runs-list`. Do **not** write a separate "run metadata"
+scratchpad entry. "Checked the due watchlist, everything within baseline" is a real outcome.
+
+## Disqualifiers (skip these)
+
+- **Seasonal swings** — the regular daily/weekly rhythm (weekday vs weekend, business-hours
+  vs overnight). Only real once the move clears the **seasonality-matched** baseline.
+- **The current partial bucket** — the in-progress hour/day is incomplete; never score it.
+- **Data-pipeline gaps, not real drops** — a metric that flat-lines to zero across _every_
+  insight at the same timestamp is almost always missing/late data or a deploy gap, not a
+  product anomaly. Note it (it may be worth its own finding) but don't emit it as a metric
+  anomaly per insight.
+- **Low-count noise** — series whose baseline counts are tiny; a few events of movement is
+  not signal. Enforce the minimum relative-change and minimum-absolute-count floors.
+- **Dev / test / internal-only segments** — bursts whose `properties.$environment` or
+  service is `dev`/`local`/`test`, or single-user/single-session quirks.
+- **Expected one-offs the team already knows about** — launches, migrations, backfills,
+  known experiments. If a `noise:` / `addressed:` entry names it, skip.
+
+When in doubt, refresh the baseline memory instead of emitting.
+
+## MCP tools
+
+Direct (read-only):
+
+- `insights-trending-retrieve` — most-viewed insights (discovery / explore).
+- `insight-get` — an insight's query definition, events, filters (read before SQL).
+- `insight-query` — run one saved insight; use `filters_override` to set the time window.
+- `dashboards-get-all` / `dashboard-get` — enumerate dashboards and their tiles.
+- `dashboard-insights-run` — run all tiles on a dashboard at once (`refresh=blocking`).
+- `insights-list` / `execute-sql` over `system.*` — search insights/dashboards by name.
+- `execute-sql` over `events` — compute hourly/daily series + trailing baseline for scoring.
+- `read-data-schema` — confirm events/properties before any SQL.
+- `inbox-reports-list` — check whether the move is already reported before emitting.
+
+Harness-level: `signals-scout-project-profile-get`, `signals-scout-scratchpad-search`,
+`signals-scout-runs-list`, `signals-scout-runs-retrieve` (orientation + dedupe);
+`signals-scout-emit-signal`, `signals-scout-scratchpad-remember`,
+`signals-scout-scratchpad-forget` (emit + memory).
+
+## When to stop
+
+- Nothing worth checking (quick close-out) → close out empty.
+- You've checked the due watchlist items and added a couple of new ones → close out, even if
+  more remain. Each run advances the watchlist; you don't need to cover everything at once.
+- A candidate matches a `noise:` / `addressed:` / `dedupe:` entry → skip.
+
+Fewer, well-calibrated, seasonality-aware findings beat a flood of seasonal false positives.

--- a/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
@@ -1,0 +1,189 @@
+# Anomaly detection methods
+
+How to turn an insight into a clean time series, choose the right cadence, build a
+seasonality-matched baseline, and score the latest bucket. The goal is a method robust
+enough that you can trust a high z-score, and conservative enough that weekly seasonality and
+low-count noise don't generate false positives.
+
+## The core score: robust z on the latest complete bucket
+
+For a series of bucket values, the anomaly score of the latest **complete** bucket `x` is:
+
+```text
+median  = median(baseline buckets)
+MAD     = median(|b - median| for b in baseline buckets)
+robust_z = |x - median| / (1.4826 * MAD)
+```
+
+- `1.4826 * MAD` is the normal-consistent robust estimate of standard deviation. It is far
+  more resistant to the occasional past spike than a plain mean/stddev — past anomalies in
+  the baseline window won't desensitize you.
+- **Emit threshold: `robust_z ≥ ~3.5`** on the latest complete bucket. Treat `2.5–3.5` as
+  "watch / remember", below `2.5` as normal.
+- **Direction matters**: a spike (`x > median`) and a drop (`x < median`) are both anomalies;
+  say which in the finding. A drop to exactly zero across a previously non-zero series is the
+  highest-signal shape (possible outage or pipeline break).
+
+### Guards (apply before trusting the score)
+
+- **Partial-bucket guard.** Never score the in-progress bucket. For daily series, the latest
+  complete day is _yesterday_ (in the project's timezone — read it from the environment
+  block); for hourly, the latest complete hour is the one before the current one. Exclude the
+  current partial bucket from both scoring and baseline.
+- **Minimum-data guard.** Need at least ~12 comparable baseline buckets after seasonal
+  matching. Fewer → don't score; set the insight's cadence wider or mark it `low-data` on the
+  watchlist and move on.
+- **MAD-zero guard.** If `MAD == 0` (a flat series, e.g. constant or mostly zeros), the
+  z-score explodes on any movement. Fall back to: emit only if the absolute change is large
+  _and_ the relative change clears the floor below; otherwise remember, don't emit.
+- **Low-count floor.** Require both a **relative** move (`|x - median| / max(median, 1) ≥
+~0.5`, i.e. ≥50%) **and** a **minimum absolute** baseline (`median ≥ ~20` events/bucket)
+  before emitting. Tiny series move around a lot in percentage terms — this is the single
+  biggest false-positive source after seasonality.
+
+## Cadence: hourly vs daily
+
+Pick per insight and store it on the watchlist entry. Infer it from the insight's own
+definition (`insight-get`) and its volume:
+
+| Pick **hourly** when…                                             | Pick **daily** when…                                       |
+| ----------------------------------------------------------------- | ---------------------------------------------------------- |
+| High-volume operational metric (≫ hundreds/hour)                  | Business / product metric that moves on a daily rhythm     |
+| The insight itself uses an hourly interval or a short (≤7d) range | Revenue, signups, conversions, retention, weekly actives   |
+| You want to catch a regression within the same day                | Hourly buckets would be too sparse to baseline (low-count) |
+
+When unsure, start **daily** (cheaper, less noisy) and promote an insight to hourly only if
+it's high-volume and a human would care about a same-day move.
+
+## Seasonality matching
+
+Compare like with like — this is what separates a real anomaly from the normal rhythm.
+
+- **Daily cadence → match day-of-week.** Baseline = the same weekday over the trailing
+  ~6–8 weeks (e.g. score this Monday against the last ~6–8 Mondays). A Monday is not
+  comparable to a Sunday.
+- **Hourly cadence → match hour-of-week** (hour-of-day × weekday) when you have enough
+  history, or at minimum hour-of-day over the trailing ~2–4 weeks. 3pm Tuesday is not
+  comparable to 4am Sunday.
+- If history is too short for full seasonal matching, fall back to a shorter window with
+  weaker matching (hour-of-day only) and lower your confidence accordingly — or mark the item
+  `low-data` and skip emitting.
+
+## Baseline windows (defaults)
+
+| Cadence | Baseline window    | Seasonal match    | Min buckets after matching |
+| ------- | ------------------ | ----------------- | -------------------------- |
+| Daily   | trailing 6–8 weeks | same day-of-week  | ≥ 6 same-weekday points    |
+| Hourly  | trailing 2–4 weeks | same hour-of-week | ≥ 12 matched points        |
+
+Exclude the latest complete bucket itself from its own baseline, and exclude the current
+partial bucket entirely.
+
+## execute-sql cookbook
+
+`execute-sql` is the most reliable path: it gives you the full series and the baseline in one
+query, with exact control over the bucket and the comparison window. Always
+`read-data-schema` to confirm the event/properties first, and `insight-get` to learn which
+event(s)/filters the insight actually uses so your SQL matches it.
+
+PostHog SQL is HogQL (ClickHouse dialect). Use the project timezone for bucket boundaries.
+
+**Daily series with same-weekday baseline** (score yesterday vs the last 8 same-weekdays):
+
+```sql
+-- Replace <event> and any property filters to match the insight (from insight-get).
+WITH daily AS (
+    SELECT toStartOfDay(timestamp) AS day, count() AS value
+    FROM events
+    WHERE event = '<event>'
+      AND timestamp >= now() - INTERVAL 60 DAY
+      AND timestamp < toStartOfDay(now())          -- exclude today (partial)
+    GROUP BY day
+)
+SELECT day, toDayOfWeek(day) AS dow, value
+FROM daily
+ORDER BY day DESC
+```
+
+Then in your reasoning: take the most recent `day` as `x`, filter the rest to the same `dow`,
+compute median + MAD over those, and score. (Compute the robust stats in your head / from the
+rows — keep the SQL simple and do the small stats on the returned series.)
+
+**Hourly series for a high-volume metric** (last 21 days, hourly, for hour-of-week baseline):
+
+```sql
+SELECT toStartOfHour(timestamp) AS hour,
+       toDayOfWeek(timestamp)   AS dow,
+       toHour(timestamp)        AS hod,
+       count() AS value
+FROM events
+WHERE event = '<event>'
+  AND timestamp >= now() - INTERVAL 21 DAY
+  AND timestamp < toStartOfHour(now())            -- exclude current partial hour
+GROUP BY hour, dow, hod
+ORDER BY hour DESC
+```
+
+Score the latest complete `hour` against prior rows sharing its `(dow, hod)`.
+
+**Tips**
+
+- For unique-user or sum metrics, swap `count()` for `count(DISTINCT person_id)` or
+  `sum(toFloat(properties.<prop>))` to match the insight's math.
+- If the insight is a saved one and you only need its standard windows, prefer `insight-query`
+  with `filters_override` (`{"date_from": "-30d"}`) and read the returned series rather than
+  rebuilding the SQL — fall back to SQL when you need a custom bucket or a longer baseline
+  than the insight defines.
+- A move that appears identically across many unrelated insights at the same timestamp is a
+  data/pipeline artifact, not per-insight signal — see the disqualifier in the body.
+
+## Attribute the move via the breakdown
+
+When a metric moves, don't stop at the top-line number — find _which segment_ drove it. Most
+saved insights already carry a breakdown; re-run the insight (`insight-query`, widened with
+`filters_override`) or add a `GROUP BY <dimension>` to your SQL and score the leading segment
+against its own baseline. Attribution sharpens the finding ("the move is entirely segment X")
+and separates noise from signal: a single known segment ramping — a new feature, a backfill,
+an internal product dialing up usage — is usually expected and belongs in a
+`noise:`/`addressed:` memory, whereas a move spread across many unrelated segments is a real
+broad regression. Put the driving segment and its share of the move in the evidence.
+
+## Per-insight-type recipes (all insight types are in scope)
+
+Most dashboard tiles are trends-style numeric series and the method above applies directly.
+For the other insight types, adapt the same "deviation from the metric's own baseline" idea —
+the discriminator is always _the latest value vs its seasonality-matched history_, just on a
+different metric.
+
+### Trends (counts / sums / uniques over time) — primary
+
+The core method above. This is the bulk of dashboards. Pull the series via `insight-query`
+(json) or rebuild with `execute-sql`; score the latest complete bucket.
+
+### Funnels — overall conversion rate as the metric
+
+Run the funnel over a recent window and the trailing baseline window (`insight-query` with
+`filters_override` date ranges, or `query-funnel`). The tracked metric is **overall
+conversion rate** (and optionally the largest per-step drop-off). Baseline = conversion rate
+over comparable prior windows. Anomaly = the conversion rate moves materially (e.g. ≥ a few
+points, clearing the relative floor) vs baseline, especially a sudden drop at one step.
+Daily cadence is almost always right for funnels.
+
+### Retention — first-period or cohort-curve shift
+
+Run the retention insight and track the **Day-1 / Week-1 retention value** (and the overall
+curve shape) for the most recent fully-observed cohort vs prior cohorts. Anomaly = the latest
+mature cohort's early-period retention drops/jumps materially vs the trailing cohorts. Only
+score cohorts old enough to be fully observed for the period you're measuring; never score a
+cohort whose retention window hasn't elapsed.
+
+### Paths / stickiness / lifecycle
+
+Track the single headline number these expose (e.g. lifecycle's new/returning/resurrecting
+/dormant counts, stickiness's active-days distribution mode) and score that number against
+its trailing seasonality-matched baseline. These are noisier and lower priority — prefer to
+spend the run on trends/funnels/retention, and only deep-dive these when a dashboard the team
+clearly cares about is built around one.
+
+For any type, if you can't get a clean comparable baseline, mark the item `low-data` on the
+watchlist and skip emitting rather than guessing.

--- a/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
@@ -30,9 +30,10 @@ robust_z = |x - median| / (1.4826 * MAD)
   complete day is _yesterday_ (in the project's timezone — read it from the environment
   block); for hourly, the latest complete hour is the one before the current one. Exclude the
   current partial bucket from both scoring and baseline.
-- **Minimum-data guard.** Need at least ~12 comparable baseline buckets after seasonal
-  matching. Fewer → don't score; set the insight's cadence wider or mark it `low-data` on the
-  watchlist and move on.
+- **Minimum-data guard.** Need enough comparable baseline buckets after seasonal matching —
+  **≥ 6 same-weekday points for daily, ≥ 12 matched points for hourly** (matching the
+  Baseline windows table below). Fewer → don't score; widen the cadence or mark it `low-data`
+  on the watchlist and move on.
 - **MAD-zero guard.** If `MAD == 0` (a flat series, e.g. constant or mostly zeros), the
   z-score explodes on any movement. Fall back to: emit only if the absolute change is large
   _and_ the relative change clears the floor below; otherwise remember, don't emit.
@@ -86,7 +87,9 @@ query, with exact control over the bucket and the comparison window. Always
 `read-data-schema` to confirm the event/properties first, and `insight-get` to learn which
 event(s)/filters the insight actually uses so your SQL matches it.
 
-PostHog SQL is HogQL (ClickHouse dialect). Use the project timezone for bucket boundaries.
+PostHog SQL is HogQL (ClickHouse dialect). Its date functions (`toStartOfDay`,
+`toStartOfHour`, `now()`) already evaluate in the **project timezone** automatically — the
+buckets below come back project-local with no explicit timezone argument needed.
 
 **Daily series with same-weekday baseline** (score yesterday vs the last 8 same-weekdays):
 

--- a/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
@@ -31,8 +31,8 @@ robust_z = |x - median| / (1.4826 * MAD)
   block); for hourly, the latest complete hour is the one before the current one. Exclude the
   current partial bucket from both scoring and baseline.
 - **Minimum-data guard.** Need enough comparable baseline buckets after seasonal matching —
-  **≥ 6 same-weekday points for daily, ≥ 12 matched points for hourly** (matching the
-  Baseline windows table below). Fewer → don't score; widen the cadence or mark it `low-data`
+  **≥ 6 same-weekday points for daily, ≥ 12 same-hour-of-day points for hourly** (matching
+  the Baseline windows table below). Fewer → don't score; widen the cadence or mark it `low-data`
   on the watchlist and move on.
 - **MAD-zero guard.** If `MAD == 0` (a flat series, e.g. constant or mostly zeros), the
   z-score explodes on any movement. Fall back to: emit only if the absolute change is large
@@ -72,10 +72,15 @@ Compare like with like — this is what separates a real anomaly from the normal
 
 ## Baseline windows (defaults)
 
-| Cadence | Baseline window    | Seasonal match    | Min buckets after matching |
-| ------- | ------------------ | ----------------- | -------------------------- |
-| Daily   | trailing 6–8 weeks | same day-of-week  | ≥ 6 same-weekday points    |
-| Hourly  | trailing 2–4 weeks | same hour-of-week | ≥ 12 matched points        |
+| Cadence | Baseline window    | Seasonal match     | Min buckets after matching   |
+| ------- | ------------------ | ------------------ | ---------------------------- |
+| Daily   | trailing 6–8 weeks | same day-of-week   | ≥ 6 same-weekday points      |
+| Hourly  | trailing 2–4 weeks | same hour-of-day † | ≥ 12 same-hour-of-day points |
+
+† Hour-of-day over 2–4 weeks gives ~14–28 comparable points, so the ≥ 12 floor is
+attainable. Upgrade to full **hour-of-week** (hour-of-day × weekday) only once you have ~8+
+weeks of history — same-hour-of-week yields just one point per week, far too few over 2–4
+weeks.
 
 Exclude the latest complete bucket itself from its own baseline, and exclude the current
 partial bucket entirely.
@@ -131,6 +136,12 @@ Score the latest complete `hour` against prior rows sharing its `(dow, hod)`.
 
 **Tips**
 
+- **Zero buckets produce no row — guard the drop-to-zero case.** `GROUP BY day`/`hour` omits
+  buckets that had zero events, so the most recent _returned_ row may not be the latest
+  complete bucket. Verify the expected latest bucket (yesterday / last complete hour) is
+  actually present; if it's missing, its true value is **0** — score that as a drop-to-zero
+  (the highest-signal shape), don't silently fall back to the prior non-zero row. A date/hour
+  spine (`arrayJoin`/`range` join) or an explicit presence check avoids the trap.
 - For unique-user or sum metrics, swap `count()` for `count(DISTINCT person_id)` or
   `sum(toFloat(properties.<prop>))` to match the insight's math.
 - If the insight is a saved one and you only need its standard windows, prefer `insight-query`

--- a/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
@@ -1,0 +1,112 @@
+# The emit contract
+
+How this scout calls `signals-scout-emit-signal` and writes a well-calibrated finding. The
+harness validates request shape but does **not** grade prose — that's on you. This mirrors the
+contract the whole signals-scout fleet runs on.
+
+## Fields
+
+| Field         | Type                   | Required     | Notes                                                  |
+| ------------- | ---------------------- | ------------ | ------------------------------------------------------ |
+| `description` | string                 | ✅           | Non-empty prose — the inbox surface and dedupe target. |
+| `weight`      | float `[0,1]`          | ✅           | How much human attention this deserves.                |
+| `confidence`  | float `[0,1]`          | ✅           | How sure you are the finding is real.                  |
+| `evidence`    | list (0–20)            | ✅           | `{source_product, summary, entity_id?}` per entry.     |
+| `hypothesis`  | string                 | recommended  | One-line root-cause hypothesis.                        |
+| `severity`    | `P0`–`P4`              | recommended  | Informational only; no routing.                        |
+| `dedupe_keys` | list of strings        | recommended  | `<kind>:<entity_id>` — groups across runs/sources.     |
+| `time_range`  | `{date_from, date_to}` | when bounded | The anomalous window.                                  |
+| `finding_id`  | string                 | recommended  | Stable trace id, **not** a dedupe key (see below).     |
+
+## Weight vs confidence — keep distinct
+
+`weight` = how much attention it deserves; `confidence` = how sure it's real. A confidently
+real but minor blip is high-confidence, low-weight.
+
+**Weight:** 0.85–1.00 active customer/business impact or large blast radius; 0.65–0.84
+material move worth looking at today; 0.40–0.64 notable but speculative; < 0.20 don't emit.
+
+**Confidence:** 0.85–1.00 unambiguous (high z, guards passed, seasonality ruled out, not
+already reported); 0.65–0.84 one strong read + plausible cause, minor unknowns; < 0.65 don't
+emit — refresh the baseline instead.
+
+**The emit gate:** if you can't reach `confidence ≥ 0.65`, write a scratchpad entry, don't
+emit. For this scout, a strong finding is **robust z ≥ ~3.5 on the latest complete bucket**,
+the guards in `anomaly-methods.md` passed, the move not explained by seasonality or a pipeline
+gap, weight ≥ 0.7, confidence ≥ 0.85.
+
+## Severity
+
+`P0` active critical (outage / data loss); `P1` active material (revenue/conversion drop
+hitting the business now); `P2` confirmed contained; `P3` suspected or minor confirmed; `P4`
+FYI / curiosity. A sustained drop-to-zero on a key metric is typically P1; a one-bucket spike
+that's already receding is P2–P3.
+
+## Description prose contract
+
+One tight paragraph (3–6 sentences) a busy human reads in a feed of 30:
+
+1. **Hook** — what moved, **quantified**: "daily signups dropped to 412 yesterday vs an
+   ~1,050 same-weekday baseline (robust z = 4.8)".
+2. **Pattern** — the shape that makes it signal not noise: direction, that it cleared the
+   seasonality-matched baseline, whether it's one bucket or sustained.
+3. **Hypothesis** — the suspected cause (deploy, experiment, pipeline, real behavior change).
+4. **Lineage** — if a prior run touched this insight, cite its `finding_id`.
+5. **Recommendation** — the next action (which insight to open, what to check).
+
+Cite the insight `short_id` and dashboard id inline so a human pivots straight to the source.
+
+## Evidence
+
+Each entry `{source_product, summary, entity_id?}`, ≤ 20. Cite every concrete claim. For this
+scout: `source_product: query_runs` (the SQL/insight-query reads), `entity_id` = the insight
+`short_id`; add `signals_scout` entries to cite a prior run/finding. Put the bucket value,
+the baseline median, the z-score, and the time window in the summaries.
+
+## Dedupe keys
+
+Stable strings the inbox groups on. Use `insight:<short_id>` and a metric-anomaly key like
+`metric_anomaly:<short_id>:<date>` so a recurrence on a later day is a new finding that cites
+the prior one rather than silently colliding. Add `dashboard:<id>` when relevant. Include 1–2.
+
+## finding_id (not a dedupe key)
+
+A stable, human-readable trace id tying the signal to its run — e.g.
+`anomaly-revenue-over-time-ym0K91uz-2026-06-07`. It is **not** used for idempotency:
+`emit_signal` dedupes on its own `document_id` and your `dedupe_keys`, never on `finding_id`.
+**Re-calling emit with the same `finding_id` writes a second signal — never retry an emit that
+may already have succeeded.** A recurrence on a later day is a new finding citing the prior id.
+
+## Worked example
+
+```yaml
+finding_id: anomaly-daily-signups-9aBcDeF-2026-06-07
+weight: 0.86
+confidence: 0.88
+severity: P1
+hypothesis: >
+  Daily signups dropped ~60% below the same-weekday baseline starting yesterday — likely a
+  broken signup flow or a tracking regression from a recent deploy.
+evidence:
+  - source_product: query_runs
+    entity_id: 9aBcDeF
+    summary: >
+      'Daily signups' (insight 9aBcDeF on dashboard Growth/41233): yesterday 412 vs
+      8-same-weekday median 1,048 (MAD 95) → robust z = 4.8. Prior 7 same-weekdays all
+      within ±1.5 z. Latest complete day only; today's partial bucket excluded.
+time_range: { date_from: 2026-06-06T00:00:00Z, date_to: 2026-06-07T00:00:00Z }
+dedupe_keys:
+  - insight:9aBcDeF
+  - metric_anomaly:9aBcDeF:2026-06-06
+description: |
+  Daily signups dropped to 412 yesterday (2026-06-06) against an ~1,048 same-weekday baseline
+  (robust z = 4.8, MAD 95) on insight 9aBcDeF, pinned to the Growth dashboard (41233). This is
+  a single complete-day drop of ~60%, well outside the weekday rhythm — the last 8 same
+  weekdays were all within ±1.5 z, so it's not seasonality. Likely a broken signup flow or a
+  tracking regression from a recent deploy. Recommend opening insight 9aBcDeF, checking
+  whether the drop is broad or segment-specific, and correlating with today's deploys.
+```
+
+Why it's good: quantified hook with the baseline and z, seasonality explicitly ruled out,
+partial bucket excluded, actionable recommendation, dual dedupe keys (insight + dated
+metric anomaly), P1 justified by business impact, confidence 0.88 because the read is clean.

--- a/products/signals/skills/signals-scout-anomaly-detection/references/watchlist-and-memory.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/watchlist-and-memory.md
@@ -1,0 +1,136 @@
+# Watchlist, explore-vs-exploit, and memory
+
+This scout's leverage is that it gets smarter every run instead of restarting cold. A busy
+project has far more dashboards and insights than one short run can score, so you maintain a
+**durable watchlist** in the scratchpad and split each run between **exploiting** it
+(re-checking what's due) and **exploring** (adding new high-value items). This file is the
+design for that ledger and the memory conventions around it.
+
+## The scratchpad is your only persistence
+
+The scratchpad is durable, per-team prose keyed by string. No tags, no TTLs — **the category
+is the key prefix**, so a future run finds an entry with one `text=` search. Re-using a key
+rewrites the entry in place (the idempotent refresh — use it to update a baseline or a
+`last_checked` timestamp without creating duplicates).
+
+### Key vocabulary
+
+| Key prefix                                           | Holds                                                                      |
+| ---------------------------------------------------- | -------------------------------------------------------------------------- |
+| `watchlist:anomaly_detection:insight:<short_id>`     | A curated insight to watch (the ledger row — see schema below).            |
+| `watchlist:anomaly_detection:dashboard:<id>`         | A curated whole dashboard to sweep (when its tiles are collectively key).  |
+| `baseline:anomaly_detection:insight:<short_id>`      | The learned normal: median + MAD per seasonal bucket, so scoring is cheap. |
+| `dedupe:anomaly_detection:insight:<short_id>:<date>` | An anomaly already surfaced, with the re-escalation condition.             |
+| `noise:anomaly_detection:<topic>`                    | A pattern to ignore (a chronically erratic insight, a seasonal quirk).     |
+| `addressed:anomaly_detection:<topic>`                | Team-confirmed expected (a launch/backfill) or fix shipped — skip.         |
+| `allowlist:anomaly_detection:insight:<short_id>`     | An insight to never surface (deprecated, sandbox, test).                   |
+| `not-in-use:anomaly_detection:team{team_id}`         | Close-out memo: team isn't actively using saved analytics right now.       |
+
+### Watchlist entry schema
+
+Keep each `watchlist:` entry a compact, parseable line so the next run can read and update it
+cheaply:
+
+```text
+key:     watchlist:anomaly_detection:insight:ym0K91uz
+content: "Revenue over time | dashboards: go/revenue(198672) | metric: daily revenue sum |
+         cadence: daily | priority: high | last_checked: 2026-06-07T12:00Z |
+         next_due: 2026-06-08T12:00Z | last_status: normal (z=0.8) | added: 2026-06-05"
+```
+
+Fields: human name, the dashboard(s) it lives on, what metric you actually score, cadence
+(`hourly`/`daily`), priority (`high`/`med`/`low`, from view count + business importance),
+`last_checked`, `next_due`, `last_status` (normal / watch / emitted with the last z), and when
+you added it. `low-data` is a valid `last_status` for items you can't baseline yet.
+
+### Baseline entry schema
+
+```text
+key:     baseline:anomaly_detection:insight:ym0K91uz
+content: "daily revenue sum, same-weekday baseline over 8 weeks (computed 2026-06-07):
+         Mon median ~$X MAD ~$Y; Tue median ~$X MAD ~$Y; ... weekend lower. Refresh weekly."
+```
+
+Store enough that the next run can score the latest bucket without recomputing the whole
+baseline — but re-derive from fresh data periodically (≈weekly) so the baseline tracks real
+drift instead of going stale.
+
+## Explore vs exploit
+
+Each run, budget deliberately:
+
+- **Exploit (most of the run).** Re-check the watchlist items that are **due**: daily items
+  whose `next_due` has passed (~24h cadence), hourly items past their ~1–3h cadence. Sort
+  **most-overdue first** and work down until your time budget is nearly spent. Update each
+  item's `last_checked` / `next_due` / `last_status` as you go. This is where anomalies are
+  actually caught.
+- **Explore (a slice of the run).** Add a few new high-value items so coverage tracks what
+  the team currently cares about:
+  - `insights-trending-retrieve` — `days=7` for durable favourites, `days=1` for what's hot
+    right now. High `view_count` is the primary "the team cares" signal.
+  - `recent_dashboards` (profile) + `dashboard-get` tiles — insights on recently-accessed
+    dashboards are high-value by association.
+  - Cross-check against the watchlist you already have; only add genuinely new items, at most
+    ~2–3 per run, each with a first baseline + cadence.
+
+**Round-robin, don't re-scan everything.** The watchlist + `next_due` timestamps are what let
+successive runs cover different items instead of all repeating the same top insights every
+hour. Trust the ledger: if an item was checked 20 minutes ago by a prior run, it's not due.
+
+**Leave yourself pointers.** When you run low on budget mid-sweep, write a quick note (reuse
+the run summary, or a `watchlist:` `next_due` you set to "now" on the next item) so the next
+run knows where to resume. The run summary (`signals-scout-runs-list`) is the natural place to
+say "checked items A–F; G–K still due next run."
+
+## The four states (classify every candidate before emitting)
+
+1. **Net new** — no prior run or scratchpad entry covers this metric move. → Emit if it
+   clears the bar (robust z ≥ ~3.5, confidence ≥ 0.65, guards passed).
+2. **Material update** — a prior run surfaced this insight's anomaly, but there's new
+   evidence (it's still firing, escalated, spread to related insights, or correlates with a
+   fresh deploy). → Emit fresh, **cite the prior `finding_id`** in the description and
+   evidence; the inbox groups by dedupe key.
+3. **Already covered** — a prior run emitted the same move with the same shape, still within
+   the window. → Skip; optionally refresh the `dedupe:` entry's timestamp.
+4. **Addressed or noise** — a `noise:` / `addressed:` / `allowlist:` entry names it (chronic
+   erratic insight, known launch/backfill, deprecated insight). → Skip; note in the summary.
+
+## Worked memory examples
+
+Good entries are future-run actionable — the next run reads them and changes behavior.
+
+```text
+key:     dedupe:anomaly_detection:insight:SRVNODib:2026-06-07
+content: "2026-06-07: emitted spike on 'LLM Costs By AI Product' — daily sum 3.4x the
+         8-Saturday baseline (z=5.1), started 06-06. If still elevated next run, escalate as
+         sustained; if back within baseline, treat as surfaced and stop."
+```
+
+```text
+key:     noise:anomaly_detection:insight:tQnsSMoI
+content: "'Generation calls' is chronically spiky — big legit swings on model launches and
+         backfills. Require z>=4.5 AND a same-day deploy/launch correlation before emitting;
+         otherwise refresh baseline only."
+```
+
+```text
+key:     addressed:anomaly_detection:revenue-backfill-2026-06
+content: "Revenue insights show a one-off step on 2026-06-03 from a Stripe backfill, not a
+         real change. Team aware. Don't emit revenue-series steps dated 2026-06-03."
+```
+
+Bad entry: key `note-1`, content "revenue looked weird today" — no entity, no condition, no
+category prefix, unfindable and unactionable.
+
+## Bootstrapping a cold team (first few runs)
+
+The very first run has no watchlist. Bootstrap it:
+
+1. `insights-trending-retrieve` (`days=7`, `limit=15`) → the team's most-viewed insights.
+2. `recent_dashboards` from the profile → the dashboards humans actually open.
+3. Pick the ~5–10 highest-value of those, set a baseline + cadence for each, write their
+   `watchlist:` entries.
+4. Score whatever you have time for this run; the rest become due next run.
+
+By run ~3–5 you'll have a stable watchlist and most of each run goes to fast, cheap re-checks
+against stored baselines — which is the whole point.

--- a/products/signals/skills/signals-scout-anomaly-detection/references/watchlist-and-memory.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/watchlist-and-memory.md
@@ -85,7 +85,7 @@ say "checked items A–F; G–K still due next run."
 ## The four states (classify every candidate before emitting)
 
 1. **Net new** — no prior run or scratchpad entry covers this metric move. → Emit if it
-   clears the bar (robust z ≥ ~3.5, confidence ≥ 0.65, guards passed).
+   clears the bar (robust z ≥ ~3.5, weight ≥ 0.7, confidence ≥ 0.65, guards passed).
 2. **Material update** — a prior run surfaced this insight's anomaly, but there's new
    evidence (it's still firing, escalated, spread to related insights, or correlates with a
    fresh deploy). → Emit fresh, **cite the prior `finding_id`** in the description and

--- a/products/signals/skills/signals-scout-general/SKILL.md
+++ b/products/signals/skills/signals-scout-general/SKILL.md
@@ -4,7 +4,8 @@ description: >
   General Signals scout for PostHog projects. Cross-product explorer that scans a
   team's project and emits findings into the Signals inbox. Sibling specialists
   (signals-scout-llm-analytics, -logs, -error-tracking, -revenue-analytics, -surveys,
-  -observability-gaps, -csp-violations) cover individual product surfaces; this
+  -observability-gaps, -csp-violations, -anomaly-detection) cover individual product
+  surfaces; this
   scout looks for cross-product correlations and explores what specialists don't
   cover. Each scout runs on its own schedule (default hourly), so general fires
   independently of the specialists over time.
@@ -45,9 +46,9 @@ already covered. Validate hypotheses with concrete queries (`query-trends`,
 `inbox-reports-list`, `execute-sql`, etc.) before emitting.
 
 If a sibling specialist already covers a surface in depth (LLM analytics, logs,
-error tracking, revenue, surveys, observability gaps, CSP), leave the deep dive
-to it on a future tick. Spend your time on **cross-product correlations** or on
-**surfaces no specialist covers**.
+error tracking, revenue, surveys, observability gaps, CSP, or dashboard/insight
+anomalies), leave the deep dive to it on a future tick. Spend your time on
+**cross-product correlations** or on **surfaces no specialist covers**.
 
 ## Decide
 


### PR DESCRIPTION
## Problem

The Signals scout fleet has per-surface anomaly watchers (error tracking, logs, LLM analytics, revenue, surveys, CSP) but nothing watching the saved **dashboards and insights a team actually looks at**. A regression that only shows up in a team's own key chart — a revenue trend, a conversion funnel, an activation metric — can go unnoticed until a human happens to open it. This adds a generalist scout that watches those high-value insights and surfaces recent anomalies into the Signals inbox.

## Changes

- New canonical scout `products/signals/skills/signals-scout-anomaly-detection/` — `SKILL.md` plus three bundled references.
- **Discriminator:** robust MAD-based z of the latest *complete* bucket vs the insight's own **seasonality-matched** baseline (same-weekday for daily, same-hour-of-week for hourly), gated by relative-change and min-count floors so weekly seasonality and low-count noise don't trip it.
- **Discovery + coverage:** finds high-traffic insights via `insights-trending-retrieve` (view counts) and recent dashboard access, curates a durable scratchpad **watchlist**, and balances **exploit** (re-check due items) against **explore** (add new ones) across runs — so a busy project gets covered over time rather than in one run.
- All insight types in scope (trends primary; funnel / retention / paths recipes in the references).
- References: `anomaly-methods.md` (method + HogQL cookbook + per-type recipes), `watchlist-and-memory.md` (watchlist ledger + scratchpad key vocabulary), `emit-contract.md` (self-contained emit contract).
- Updates `products/signals/skills/AGENTS.md` to list the new fleet member (its own rule for fleet-shape changes).
- Seeding and scheduling are automatic — `lazy_seed` mirrors it onto enrolled teams and the coordinator auto-registers an hourly config. No coordinator code change.

## How did you test this code?

I'm an agent (Claude Code) — stating only checks actually run, no manual product testing claimed.

- `hogli lint:skills` passes (62 skills, including the new one).
- The pre-commit markdownlint + oxfmt formatting hook passes on the changed markdown.

Scouts only execute on the coordinator's schedule, so there is no end-to-end product run here. I did **dry-run the methodology by hand** against an internal project — walking the scout's own playbook with the same read-only MCP tools (discovery, both data-fetch paths `insight-query` and `execute-sql`, and the robust-z scoring). It produced sensible, well-calibrated results (correctly held a +47% same-weekday move below the emit bar against a noisy baseline), which motivated two refinements now baked into the skill.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal scout-fleet skill content, no public docs change — recommend the `skip-inkeep-docs` label.

## 🤖 Agent context

Authored with Claude Code via the PostHog MCP, invoked through the `/phs make-pr` workflow skill. Tools used: PostHog MCP (`llma-skill-*`, `signals-scout-*`, `insights-trending-retrieve`, `insight-query`, `execute-sql`), plus git / gh.

Decisions along the way: first deployed to a single project's skills store for live dogfooding, then (per request) moved to the canonical in-repo path so other early users can dogfood from the repo. The discriminator is a robust MAD z over same-weekday / same-hour baselines because weekly seasonality and low-count noise are the dominant false-positive sources for metric anomaly detection. The body is kept lean with depth pushed into references, per the `authoring-signals-scouts` convention. Two refinements came from the hand dry-run: `insight-query` returns the insight's native (~7d) window which is too short to baseline — so the scout must widen via `filters_override` or fall back to `execute-sql`; and it should attribute a move via the insight's own breakdown before deciding (a single known segment ramping is expected noise, a broad move is a real regression).

Agent-authored; requires human review, not for self-merge.
