### PR TITLE
fix(experiments): expose exposure_criteria on the experiment-update MCP tool

### DIFF
--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -702,6 +702,7 @@ tools:
             - metrics
             - metrics_secondary
             - stats_config
+            - exposure_criteria
             - holdout_id
             - conclusion
             - conclusion_comment

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -643,7 +643,6 @@ const ExperimentUpdateSchema = ExperimentsPartialUpdateParams.omit({ project_id:
             filters: true,
             deleted: true,
             type: true,
-            exposure_criteria: true,
             scheduling_config: true,
             _create_in_folder: true,
             primary_metrics_ordered_uuids: true,
@@ -674,6 +673,9 @@ const experimentUpdate = (): ToolBase<typeof ExperimentUpdateSchema, WithPostHog
             }
             if (params.archived !== undefined) {
                 body['archived'] = params.archived
+            }
+            if (params.exposure_criteria !== undefined) {
+                body['exposure_criteria'] = params.exposure_criteria
             }
             if (params.metrics !== undefined) {
                 body['metrics'] = params.metrics

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
@@ -45,6 +45,159 @@
             ],
             "description": "Description of the experiment hypothesis and expected outcomes."
         },
+        "exposure_criteria": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "exposure_config": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "event": {
+                                            "description": "Custom exposure event name.",
+                                            "type": "string"
+                                        },
+                                        "kind": {
+                                            "const": "ExperimentEventExposureConfig",
+                                            "default": "ExperimentEventExposureConfig",
+                                            "type": "string"
+                                        },
+                                        "properties": {
+                                            "description": "Event property filters. Pass an empty array if no filters needed.",
+                                            "items": {
+                                                "properties": {
+                                                    "key": {
+                                                        "type": "string"
+                                                    },
+                                                    "label": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "operator": {
+                                                        "anyOf": [
+                                                            {
+                                                                "enum": [
+                                                                    "exact",
+                                                                    "is_not",
+                                                                    "icontains",
+                                                                    "not_icontains",
+                                                                    "regex",
+                                                                    "not_regex",
+                                                                    "gt",
+                                                                    "gte",
+                                                                    "lt",
+                                                                    "lte",
+                                                                    "is_set",
+                                                                    "is_not_set",
+                                                                    "is_date_exact",
+                                                                    "is_date_before",
+                                                                    "is_date_after",
+                                                                    "between",
+                                                                    "not_between",
+                                                                    "min",
+                                                                    "max",
+                                                                    "in",
+                                                                    "not_in",
+                                                                    "is_cleaned_path_exact",
+                                                                    "flag_evaluates_to",
+                                                                    "semver_eq",
+                                                                    "semver_neq",
+                                                                    "semver_gt",
+                                                                    "semver_gte",
+                                                                    "semver_lt",
+                                                                    "semver_lte",
+                                                                    "semver_tilde",
+                                                                    "semver_caret",
+                                                                    "semver_wildcard",
+                                                                    "icontains_multi",
+                                                                    "not_icontains_multi"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "default": "exact"
+                                                    },
+                                                    "type": {
+                                                        "const": "event",
+                                                        "default": "event",
+                                                        "description": "Event properties",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "anyOf": [
+                                                            {
+                                                                "items": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "boolean"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["key"],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": ["event", "properties"],
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "filterTestAccounts": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Exposure configuration including filter test accounts and custom exposure events."
+        },
         "holdout_id": {
             "anyOf": [
                 {


### PR DESCRIPTION
## Problem

The `experiment-update` MCP tool could not set a custom exposure event. Passing `exposure_criteria` (with an `exposure_config`) to the tool was silently dropped — the experiment kept its default `$feature_flag_called` exposure. This was hit setting up a real experiment: the metrics could be added via MCP, but the custom exposure event had to be set by hand in the UI.

The backend was never the problem: the `ExperimentSerializer.exposure_criteria` field is writable and validated, and `ExperimentService.update_experiment` already applies it. The gap was purely in the MCP tool definition.

## Changes

`experiment-update`'s `include_params` allowlist in `products/experiments/mcp/tools.yaml` omitted `exposure_criteria` (while `experiment-create`'s allowlist includes it). Added it, matching create.

After regenerating with `hogli build:openapi`, the generated tool (`services/mcp/src/tools/generated/experiments.ts`) no longer omits `exposure_criteria` from the update schema and the handler forwards it to the PATCH body — so agents can now set the custom exposure event when updating an experiment.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks only:

- Regenerated the tool from the Django OpenAPI schema (`hogli build:openapi-schema` against a local Postgres, then the MCP `generate-orval-schemas` / `generate-mcp-types` / `generate-tools` chain). The generation was clean — only `services/mcp/src/tools/generated/experiments.ts` changed, confirming no unrelated drift.
- Verified the diff: the update schema's `.omit({...})` no longer drops `exposure_criteria`, and the handler now sets `body['exposure_criteria']`.

No backend logic changed, so the existing experiment-update behaviour is unaffected for callers that don't pass `exposure_criteria`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change — this is an MCP tool capability fix.

## 🤖 Agent context

Authored with PostHog Code. While setting up a live web-analytics experiment via MCP, the custom exposure event silently failed to apply on `experiment-update`. Traced it to the tool's `include_params` allowlist (not the serializer or service, both of which already support `exposure_criteria` on update). Fix is a one-line YAML addition mirroring `experiment-create`, plus the regenerated tool file. Regeneration required the dev stack (Postgres) for the Django OpenAPI schema. Agent-authored — requires human review; not for self-merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
