### PR TITLE
chore(signals): rename llm-analytics scout to ai-observability

### DIFF
--- a/products/signals/ARCHITECTURE.md
+++ b/products/signals/ARCHITECTURE.md
@@ -1186,7 +1186,7 @@ products/signals/
 │   ├── signals/                     # Official PostHog skill (published via posthog_ai/dist): querying signals data
 │   ├── inbox-exploration/           # Official PostHog skill (published via posthog_ai/dist): browsing the inbox
 │   ├── signals-scout-general/       # Scout fleet: cross-product generalist (SKILL.md + emit.md + conventions.md)
-│   ├── signals-scout-llm-analytics/ # Scout fleet: LLM analytics anomaly watcher
+│   ├── signals-scout-ai-observability/ # Scout fleet: AI observability anomaly watcher
 │   ├── signals-scout-logs/          # Scout fleet: logs anomaly watcher
 │   ├── signals-scout-error-tracking/         # Scout fleet: error tracking anomaly watcher
 │   ├── signals-scout-revenue-analytics/      # Scout fleet: revenue anomaly watcher

--- a/products/signals/backend/management/AGENTS.md
+++ b/products/signals/backend/management/AGENTS.md
@@ -115,7 +115,7 @@ the agent loop until budget exhaustion or natural completion, finalizes the run.
 # Single specialist run against a dogfood team
 python manage.py run_signals_scout \
     --team-id 1 \
-    --skill-name signals-scout-llm-analytics
+    --skill-name signals-scout-ai-observability
 
 # Pin a skill version (default: latest LLMSkill row for the team)
 python manage.py run_signals_scout --team-id 1 --skill-name signals-scout-general --skill-version 4

--- a/products/signals/backend/test/test_scout_harness_lazy_seed.py
+++ b/products/signals/backend/test/test_scout_harness_lazy_seed.py
@@ -246,7 +246,7 @@ class TestDiscoverCanonicalSkills:
         # when shipping.
         expected = {
             "signals-scout-general",
-            "signals-scout-llm-analytics",
+            "signals-scout-ai-observability",
             "signals-scout-logs",
             "signals-scout-error-tracking",
             "signals-scout-revenue-analytics",

--- a/products/signals/skills/AGENTS.md
+++ b/products/signals/skills/AGENTS.md
@@ -38,7 +38,7 @@ agent-enabled team's `LLMSkill` rows by `scout_harness/lazy_seed.py` — see
   emit contract) and `references/conventions.md` (scratchpad key prefixes + the
   four-states dedupe classifier + cross-project noise patterns). This is the entry
   point if you want to understand how a scout decides what to investigate end-to-end.
-- `signals-scout-llm-analytics/` — anomaly watcher for LLM analytics
+- `signals-scout-ai-observability/` — anomaly watcher for AI observability
   (cost / latency / error / token-share regressions).
 - `signals-scout-logs/` — anomaly watcher for logs (rate / level / pattern shifts).
 - `signals-scout-error-tracking/` — anomaly watcher for error tracking

--- a/products/signals/skills/authoring-signals-scouts/SKILL.md
+++ b/products/signals/skills/authoring-signals-scouts/SKILL.md
@@ -47,7 +47,7 @@ only as good as its fit to the data it watches.
    it with `posthog:llma-skill-get {"skill_name": "signals-scout-<x>"}` (per-team rows) or
    read it from the repo at `products/signals/skills/signals-scout-*/`. The generalist
    (`signals-scout-general`) is the broad template; pick a specialist
-   (`-error-tracking`, `-llm-analytics`, `-logs`, `-revenue-analytics`, `-surveys`,
+   (`-error-tracking`, `-ai-observability`, `-logs`, `-revenue-analytics`, `-surveys`,
    `-csp-violations`, `-observability-gaps`) if your scope is domain-tight.
 4. **Skim the inbox.** `posthog:inbox-reports-list` shows what findings are actually
    landing — calibrate so your scout adds signal, not noise.

--- a/products/signals/skills/exploring-signals-scouts/SKILL.md
+++ b/products/signals/skills/exploring-signals-scouts/SKILL.md
@@ -21,7 +21,7 @@ A **scout** is a scheduled agent that wakes on its own interval, looks at one Po
 decides what's genuinely worth surfacing, and either emits it as a **finding** into the Signals
 inbox or closes out empty (a real, valid outcome). PostHog ships a fleet of canonical scouts — a
 cross-product generalist (`signals-scout-general`) plus per-surface specialists
-(`-error-tracking`, `-llm-analytics`, `-logs`, `-revenue-analytics`, `-surveys`,
+(`-error-tracking`, `-ai-observability`, `-logs`, `-revenue-analytics`, `-surveys`,
 `-csp-violations`, `-observability-gaps`). A project may also have **custom scouts** beyond the
 canonical fleet — any `signals-scout-*` skill a team authored (e.g. `-brand-mentions`,
 `-mcp-feedback`) shows up here too, so don't assume the roster is only the canonical set.

--- a/products/signals/skills/signals-scout-ai-observability/SKILL.md
+++ b/products/signals/skills/signals-scout-ai-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: signals-scout-llm-analytics
+name: signals-scout-ai-observability
 description: >
-  Focused Signals scout for PostHog projects using LLM analytics. Watches `$ai_generation`,
+  Focused Signals scout for PostHog projects using AI observability. Watches `$ai_generation`,
   `$ai_evaluation`, `$ai_trace` and related events for cost spikes, latency drift, eval
   pass-rate drops, runaway loops, and error rates. Emits findings only when they clear
   the confidence bar; otherwise writes durable memory and closes out empty. Self-contained
@@ -18,25 +18,25 @@ metadata:
   scope: llm_analytics
 ---
 
-# Signals scout: LLM analytics
+# Signals scout: AI observability
 
-You are a focused LLM analytics scout. Spot meaningful changes in this team's LLM usage
+You are a focused AI observability scout. Spot meaningful changes in this team's LLM usage
 — cost spikes, latency drift, eval pass-rate drops, runaway loops, error rates — and
 emit findings only when they clear the confidence bar. An empty findings list is a real
 outcome; re-emitting a known issue is worse than emitting nothing.
 
-## Quick close-out: is LLM analytics even in use?
+## Quick close-out: is AI observability even in use?
 
 If `$ai_generation`, `$ai_evaluation`, `$ai_trace`, `$ai_span`, `$ai_metric`, `$ai_feedback`
 are all absent from `top_events` **and** `get-llm-total-costs-for-project` shows
-near-zero spend, this team isn't using LLM analytics. Write one scratchpad entry:
+near-zero spend, this team isn't using AI observability. Write one scratchpad entry:
 
 - key: `not-in-use:llm_analytics:team{team_id}`
 - content: brief note ("checked at {timestamp}, no LLM events in top_events, $0 cost")
 
-Close out empty. Future LLM-analytics runs will read this entry cold and short-circuit
+Close out empty. Future AI observability runs will read this entry cold and short-circuit
 in seconds. Re-running with the same key idempotently refreshes the timestamp — the
-entry stays until LLM analytics actually shows up, at which point the next run rewrites
+entry stays until AI observability actually shows up, at which point the next run rewrites
 or deletes it.
 
 ## How a run works
@@ -51,7 +51,7 @@ Three cheap reads cold-start a run:
   steering inherited from past LLM-focused runs. **Entries with `pattern:`, `noise:`,
   `addressed:`, or `dedupe:` key prefixes tell you what's normal, what's already
   surfaced, what to skip.**
-- `signals-scout-runs-list` (last 7d) — what prior LLM-analytics scouts found and ruled
+- `signals-scout-runs-list` (last 7d) — what prior AI observability scouts found and ruled
   out. Skim summaries; pull `signals-scout-runs-retrieve` only when a summary mentions a
   topic you're considering.
 - `signals-scout-project-profile-get` — `top_events` for the LLM event reach + recent
@@ -108,7 +108,7 @@ use case or a regression.
 ### Save memory as you go
 
 Memory is a continuous activity, not an end-of-run wrap-up. Write a scratchpad entry
-whenever you observe something a future LLM-analytics run should know. Encode the
+whenever you observe something a future AI observability run should know. Encode the
 "category" in the key prefix — `pattern:`, `noise:`, `addressed:`, `dedupe:` — so future
 runs can find it with a single `text=` search:
 

--- a/products/signals/skills/signals-scout-general/SKILL.md
+++ b/products/signals/skills/signals-scout-general/SKILL.md
@@ -3,7 +3,7 @@ name: signals-scout-general
 description: >
   General Signals scout for PostHog projects. Cross-product explorer that scans a
   team's project and emits findings into the Signals inbox. Sibling specialists
-  (signals-scout-llm-analytics, -logs, -error-tracking, -revenue-analytics, -surveys,
+  (signals-scout-ai-observability, -logs, -error-tracking, -revenue-analytics, -surveys,
   -observability-gaps, -csp-violations) cover individual product surfaces; this
   scout looks for cross-product correlations and explores what specialists don't
   cover. Each scout runs on its own schedule (default hourly), so general fires
@@ -44,7 +44,7 @@ already covered. Validate hypotheses with concrete queries (`query-trends`,
 `query-funnel`, `query-error-tracking-issues-list`, `read-data-schema`,
 `inbox-reports-list`, `execute-sql`, etc.) before emitting.
 
-If a sibling specialist already covers a surface in depth (LLM analytics, logs,
+If a sibling specialist already covers a surface in depth (AI observability, logs,
 error tracking, revenue, surveys, observability gaps, CSP), leave the deep dive
 to it on a future tick. Spend your time on **cross-product correlations** or on
 **surfaces no specialist covers**.


### PR DESCRIPTION
## Problem

The LLM analytics product is now branded **AI observability** (UI, `/ai-observability/` routes, and the other `posthog:exploring-llm-*` skills already use the new name). The Signals scout fleet still referred to it as "LLM analytics" — both in user-facing prose and in the canonical skill slug `signals-scout-llm-analytics` — so the fleet was out of step with the rest of the product surface.

## Changes

Renames the canonical scout from `signals-scout-llm-analytics` → `signals-scout-ai-observability` and updates the user-facing "LLM analytics" → "AI observability" wording across the scout fleet:

- The scout `SKILL.md` (dir + slug + frontmatter `name` + body prose)
- Sibling references: `signals-scout-general`, `authoring-signals-scouts`, `exploring-signals-scouts`, the skills `AGENTS.md` (and its `CLAUDE.md` symlink)
- `ARCHITECTURE.md` scout-tree entry, the `run_signals_scout` example in `backend/management/AGENTS.md`, and the canonical-fleet lock in `test_scout_harness_lazy_seed.py`

**Deliberately *not* renamed** (kept aligned with the backend, would require a separate migration-bearing PR):

- The backend `SignalSourceConfig.SourceProduct.LLM_ANALYTICS = "llm_analytics"` enum value — it's a **DB-persisted CharField** referenced by 7 historical migrations, `emit_eval_signal.py`, API tests, eval fixtures, and the generated frontend types. Renaming it is a data migration + codegen change, out of scope here.
- The scout's `scope:` metadata and scratchpad `<domain>` keys (`pattern:llm_analytics:…`, `not-in-use:llm_analytics:…`) — kept as `llm_analytics` so the scout's memory namespace stays aligned with the unchanged `SourceProduct` slug and existing cross-run memory isn't orphaned.
- Event names (`$ai_generation` etc.) and MCP tool names (`query-llm-traces-list`, `llma-*`, `get-llm-total-costs-for-project`) — external contracts.

Note: renaming the scout slug means the coordinator treats the old `signals-scout-llm-analytics` as removed and seeds a fresh `signals-scout-ai-observability` config on the next tick; per-team schedule/emit-posture customizations on the old name won't carry over. If the backend `llm_analytics` enum should eventually be rebranded too, that's a follow-up migration.

## How did you test this code?

I'm an agent. Ran the canonical skill-discovery test suite, which includes the fleet manifest lock that asserts the renamed skill is discovered:

```
hogli test products/signals/backend/test/test_scout_harness_lazy_seed.py::TestDiscoverCanonicalSkills
# 17 passed
```

Also grep-verified the old slug `signals-scout-llm-analytics` no longer appears anywhere outside the generated `dist/` (gitignored, rebuilt by `hogli build:skills`).

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). The main decision was scoping the rename: an early sweep surfaced that `llm_analytics` is both a user-facing product name *and* a DB-persisted `SourceProduct` enum value baked into migrations, temporal, codegen, and fixtures. We deliberately split those — this PR does the cosmetic/skill-fleet rename only and leaves the backend enum (and the scout's enum-aligned scratchpad domain + `scope`) untouched to avoid a data migration and orphaned cross-run memory. The backend enum rebrand is called out as a separate follow-up.
