### PR TITLE
chore(signals): fix anomaly-scout skill doc inconsistencies from review

### DIFF
--- a/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
@@ -84,8 +84,10 @@ For each, pull the latest complete bucket and score it against its stored baseli
 the baseline as you go). Fetch fresh data with:
 
 - `insight-query` (`insightId`, `output_format=json`) — runs one saved insight. **It returns the insight's own date range (often just `-7d`) — too short to baseline, so always widen it with `filters_override` (e.g. `{"date_from": "-63d"}`) or fall back to `execute-sql`.**
-- `dashboard-insights-run` (`id`, `refresh=blocking`, `filters_override`) — runs every tile
-  on a dashboard at once; efficient for sweeping a whole high-value dashboard.
+- `dashboard-insights-run` (`id`, `output_format=json`, `refresh=blocking`, `filters_override`)
+  — runs every tile on a dashboard at once; efficient for sweeping a whole high-value
+  dashboard. Pass `output_format=json` — the default `optimized` returns prose summaries, not
+  the raw bucket series the z-score needs.
 - `execute-sql` — when you need a clean hourly/daily series with a long trailing baseline in
   one query (the most reliable path for the z-score; recipes in `anomaly-methods.md`). Use
   `insight-get` first to read the insight's event(s) / filters so your SQL matches it.

--- a/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
@@ -117,7 +117,7 @@ Then in your reasoning: take the most recent `day` as `x`, filter the rest to th
 compute median + MAD over those, and score. (Compute the robust stats in your head / from the
 rows — keep the SQL simple and do the small stats on the returned series.)
 
-**Hourly series for a high-volume metric** (last 21 days, hourly, for hour-of-week baseline):
+**Hourly series for a high-volume metric** (last 21 days, hourly, for same-hour-of-day baseline):
 
 ```sql
 SELECT toStartOfHour(timestamp) AS hour,
@@ -132,7 +132,11 @@ GROUP BY hour, dow, hod
 ORDER BY hour DESC
 ```
 
-Score the latest complete `hour` against prior rows sharing its `(dow, hod)`.
+Score the latest complete `hour` against prior rows sharing its `hod` (same-hour-of-day) —
+~14–28 comparable points over 21 days, so the ≥ 12 baseline floor is reachable. Only upgrade
+to full hour-of-week (rows sharing both `dow` and `hod`) once you have ~8+ weeks of history,
+since same-hour-of-week yields just one point per week. (`dow` is still selected above so the
+upgrade needs no query change.)
 
 **Tips**
 

--- a/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
@@ -133,10 +133,11 @@ ORDER BY hour DESC
 ```
 
 Score the latest complete `hour` against prior rows sharing its `hod` (same-hour-of-day) —
-~14–28 comparable points over 21 days, so the ≥ 12 baseline floor is reachable. Only upgrade
-to full hour-of-week (rows sharing both `dow` and `hod`) once you have ~8+ weeks of history,
-since same-hour-of-week yields just one point per week. (`dow` is still selected above so the
-upgrade needs no query change.)
+~14–28 comparable points over 21 days, so the ≥ 12 baseline floor is reachable. To upgrade to
+a full hour-of-week baseline (rows sharing both `dow` and `hod`), **first widen the `WHERE
+timestamp >= ...` window to ~8+ weeks** — at 21 days `(dow, hod)` yields only ~3 points per
+bucket, far below the floor. (`dow` is already selected above, so only the window needs to
+change.)
 
 **Tips**
 

--- a/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
@@ -65,9 +65,12 @@ the baseline median, the z-score, and the time window in the summaries.
 
 ## Dedupe keys
 
-Stable strings the inbox groups on. Use `insight:<short_id>` and a metric-anomaly key like
-`metric_anomaly:<short_id>:<date>` so a recurrence on a later day is a new finding that cites
-the prior one rather than silently colliding. Add `dashboard:<id>` when relevant. Include 1–2.
+Stable strings stored on the signal for traceability and grouping context — they are recorded
+in the signal's `extra`, **not** enforced as idempotency keys by `emit_signal` (grouping is
+semantic). Your own dedupe is the scratchpad / run-history check before emitting. Use
+`insight:<short_id>` and a metric-anomaly key like `metric_anomaly:<short_id>:<date>` so a
+recurrence on a later day reads as a new finding citing the prior one. Add `dashboard:<id>`
+when relevant. Include 1–2.
 
 ## finding_id (not a dedupe key)
 

--- a/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
@@ -75,8 +75,10 @@ when relevant. Include 1–2.
 ## finding_id (not a dedupe key)
 
 A stable, human-readable trace id tying the signal to its run — e.g.
-`anomaly-revenue-over-time-ym0K91uz-2026-06-07`. It is **not** used for idempotency:
-`emit_signal` dedupes on its own `document_id` and your `dedupe_keys`, never on `finding_id`.
+`anomaly-revenue-over-time-ym0K91uz-2026-06-07`. It is **not** used for idempotency: the
+pipeline assigns every signal a fresh random `document_id` and dedupes on that, never on
+`finding_id` — and never on your `dedupe_keys` either (those are stored in `extra` for the
+inbox to group on _after_ ingest, they don't make a repeat emit idempotent).
 **Re-calling emit with the same `finding_id` writes a second signal — never retry an emit that
 may already have succeeded.** A recurrence on a later day is a new finding citing the prior id.
 


### PR DESCRIPTION
## Problem

Follow-on to #62037 (dashboard & insight anomaly-detection scout). Three bot review comments on that PR were left unaddressed before merge. Two are genuine internal inconsistencies the merge left behind, and one is a doc-accuracy correction — all doc-only, in the scout's skill content.

## Changes

- **Hourly cookbook vs. baseline floor** (`anomaly-methods.md`) — the merge fixed the baseline-windows *table* to default hourly checks to same-hour-of-day (~14–28 points over 21 days, clearing the skill's own ≥ 12-bucket floor), but the SQL cookbook right below still said *hour-of-week* and scored against `(dow, hod)` — only ~2–3 comparable points over the same window, contradicting the floor. The cookbook now defaults to same-hour-of-day and frames hour-of-week as an ~8+ week upgrade. `dow` stays selected so the upgrade needs no query change.
- **Dashboard sweep output format** (`SKILL.md`) — `dashboard-insights-run` defaults `output_format` to `optimized`, which returns LLM-friendly prose, not the raw bucket series the robust-z/MAD logic needs (confirmed in `products/dashboards/backend/api/dashboard.py`). The sweep path now passes `output_format=json`, matching the `insight-query` path.
- **Dedupe-key wording** (`emit-contract.md`) — the contract implied `dedupe_keys` are enforced for idempotency/grouping by `emit_signal`, but the harness only records them in the signal's `extra` (grouping is semantic). Reworded to say the scratchpad / run-history check is the real dedupe mechanism, consistent with the existing "never retry an emit" warning.

No code or behavior change — scout skill markdown only.

## How did you test this code?

I'm an agent (Claude Code). Checks actually run:

- `hogli lint:skills` passes (62 skills).
- pre-commit markdownlint + oxfmt formatting hook passed on the three changed files.

Claims #2 and #3 were verified against the live code paths (`dashboard.py` `output_format` default; `scout_harness/tools/emit.py` `_build_extra` only copying `dedupe_keys` into `extra`), not just the prose.

## Docs update

Internal scout-fleet skill content, no public docs change — recommend the `skip-inkeep-docs` label.

## 🤖 Agent context

Authored with Claude Code. Andy flagged that several Codex/Greptile comments on the merged #62037 went unanswered and asked which were worth a small follow-on. Of the four unaddressed comments, two (#1 hourly cookbook, #2 dashboard output format) were confirmed real inconsistencies/bugs and fixed here; #3 (dedupe wording) was a partial-truth doc nit folded in while touching the file. The fourth (per-tile baseline keying — a saved insight on multiple dashboards colliding on one `short_id` baseline) is a real but edge-case design nuance and was deliberately left out of this minimal follow-on.

Agent-authored; requires human review, not for self-merge.
