### PR TITLE
refactor(insights): remove defunct scene tabId from insight tree

### DIFF
--- a/frontend/src/scenes/insights/InsightAsScene.tsx
+++ b/frontend/src/scenes/insights/InsightAsScene.tsx
@@ -21,11 +21,10 @@ import { InsightSceneHeader } from './InsightSceneHeader'
 
 export interface InsightAsSceneProps {
     insightId: InsightShortId | 'new'
-    tabId: string
     attachTo?: BuiltLogic<Logic> | LogicWrapper<Logic>
 }
 
-export function InsightAsScene({ insightId, attachTo, tabId }: InsightAsSceneProps): JSX.Element | null {
+export function InsightAsScene({ insightId, attachTo }: InsightAsSceneProps): JSX.Element | null {
     // insightSceneLogic
     const { insightMode, insight, filtersOverride, variablesOverride, hasOverrides, dashboardId } =
         useValues(insightSceneLogic)
@@ -33,9 +32,8 @@ export function InsightAsScene({ insightId, attachTo, tabId }: InsightAsScenePro
 
     // insightLogic
     const logic = insightLogic({
-        dashboardItemId: insightId || `new-${tabId}`,
+        dashboardItemId: insightId || 'new',
         dashboardId: dashboardId ?? undefined,
-        tabId,
         // don't use cached insight if we have overrides
         cachedInsight: hasOverrides && insight?.short_id === insightId ? insight : null,
         filtersOverride,

--- a/frontend/src/scenes/insights/InsightPageHeader.spec.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.spec.tsx
@@ -22,7 +22,6 @@ jest.mock('scenes/max/useMaxTool', () => ({
     useMaxTool: (...args: unknown[]) => mockUseMaxTool(...args),
 }))
 
-const TAB_ID = 'test-tab'
 const SAVED_INSIGHT_ID = 'abc123' as InsightShortId
 
 const MOCK_INSIGHT_BASE: QueryBasedInsightModel = {
@@ -97,7 +96,7 @@ describe('InsightPageHeader', () => {
         const { insightMode, dashboardItemId, insight } = opts
         const insightData = insight ?? makeInsight({ user_access_level: AccessControlLevel.Editor })
 
-        const sceneLogic = insightSceneLogic({ tabId: TAB_ID })
+        const sceneLogic = insightSceneLogic()
         sceneLogic.mount()
         sceneLogic.actions.setSceneState(
             (dashboardItemId === 'new' ? 'new' : dashboardItemId) as InsightShortId,
@@ -120,7 +119,7 @@ describe('InsightPageHeader', () => {
         mountedLogics.push(iLogic, sceneLogic)
 
         render(
-            <BindLogic logic={insightSceneLogic} props={{ tabId: TAB_ID }}>
+            <BindLogic logic={insightSceneLogic} props={{}}>
                 <InsightPageHeader insightLogicProps={insightLogicProps} />
             </BindLogic>
         )

--- a/frontend/src/scenes/insights/InsightScene.tsx
+++ b/frontend/src/scenes/insights/InsightScene.tsx
@@ -12,15 +12,8 @@ import { urls } from 'scenes/urls'
 import { NodeKind, ProductKey } from '~/queries/schema/schema-general'
 import { ItemMode } from '~/types'
 
-export interface InsightSceneProps {
-    tabId?: string
-}
-
-export function InsightScene({ tabId }: InsightSceneProps = {}): JSX.Element {
-    if (!tabId) {
-        throw new Error('<InsightScene /> must receive a tabId prop')
-    }
-    const { insightId, insight, insightLogicRef, insightMode, dashboardId } = useValues(insightSceneLogic({ tabId }))
+export function InsightScene(): JSX.Element {
+    const { insightId, insight, insightLogicRef, insightMode, dashboardId } = useValues(insightSceneLogic)
     useEffect(() => {
         // Redirect data viz nodes to the sql editor
         if (insightId && insight?.query?.kind === NodeKind.DataVisualizationNode && insightMode === ItemMode.Edit) {
@@ -41,7 +34,7 @@ export function InsightScene({ tabId }: InsightSceneProps = {}): JSX.Element {
             insight?.short_id &&
             (insight?.query?.kind !== NodeKind.DataVisualizationNode || insightMode !== ItemMode.Edit))
     ) {
-        return <InsightAsScene insightId={insightId} tabId={tabId} attachTo={insightSceneLogic({ tabId })} />
+        return <InsightAsScene insightId={insightId} attachTo={insightSceneLogic} />
     }
 
     if (insightLogicRef?.logic?.values?.insightLoading) {

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -41,6 +41,10 @@ import { insightUsageLogic } from './insightUsageLogic'
 import { crushDraftQueryForLocalStorage, isQueryTooLarge } from './utils'
 import { compareQuery } from './utils/queryUtils'
 
+export const isInsightSceneInstance = (props: InsightLogicProps): boolean =>
+    sceneLogic.values.activeSceneId === Scene.Insight &&
+    insightSceneLogic.findMounted()?.values.insightLogicRef?.logic.key === keyForInsightLogicProps('new')(props)
+
 export const insightDataLogic = kea<insightDataLogicType>([
     props({} as InsightLogicProps),
     key(keyForInsightLogicProps('new')),
@@ -305,11 +309,11 @@ export const insightDataLogic = kea<insightDataLogicType>([
             actions.setInsightData({ ...values.insightData, result: savedResult ? savedResult : null })
         },
         setQuery: ({ query }) => {
-            // If we have a tabId, then this is an insight scene on a tab. Sync the query to the URL
-            if (props.tabId && sceneLogic.values.activeTabId === props.tabId) {
-                const insightId = insightSceneLogic.findMounted({ tabId: props.tabId })?.values.insightId
+            // When this is the insight scene's own insight, sync the query to the URL
+            if (isInsightSceneInstance(props)) {
+                const insightId = insightSceneLogic.findMounted()?.values.insightId
                 const { pathname, searchParams, hashParams } = router.values.currentLocation
-                if (query && (values.queryChanged || insightId === 'new' || insightId?.startsWith('new-'))) {
+                if (query && (values.queryChanged || insightId === 'new')) {
                     const { insight: _, ...hash } = hashParams // remove existing /new#insight=TRENDS param
                     router.actions.replace(pathname, searchParams, {
                         ...hash,
@@ -332,9 +336,9 @@ export const insightDataLogic = kea<insightDataLogicType>([
             }
 
             // don't save for saved insights
-            if (props.tabId && sceneLogic.values.activeTabId === props.tabId) {
-                const insightId = insightSceneLogic.findMounted({ tabId: props.tabId })?.values.insightId
-                if (insightId && insightId !== 'new' && !insightId.startsWith('new-')) {
+            if (isInsightSceneInstance(props)) {
+                const insightId = insightSceneLogic.findMounted()?.values.insightId
+                if (insightId && insightId !== 'new') {
                     return
                 }
             }
@@ -418,7 +422,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
     }),
     actionToUrl(({ props }) => ({
         cancelChanges: () => {
-            if (props.tabId && sceneLogic.values.activeTabId === props.tabId) {
+            if (isInsightSceneInstance(props)) {
                 const { pathname, searchParams, hashParams } = router.values.currentLocation
                 const { q: _, ...hash } = hashParams
                 return [pathname, searchParams, hash]

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -474,13 +474,10 @@ describe('insightLogic', () => {
         it('does not load from the savedInsightLogic when in a dashboard context', async () => {
             // 1. open saved insights
             router.actions.push(urls.savedInsights(), {}, {})
-            savedInsightsLogic({ tabId: '1' }).mount()
+            savedInsightsLogic().mount()
 
             // 2. the insights are loaded
-            await expectLogic(savedInsightsLogic({ tabId: '1' })).toDispatchActions([
-                'loadInsights',
-                'loadInsightsSuccess',
-            ])
+            await expectLogic(savedInsightsLogic()).toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
 
             // 3. mount the insight
             logic = insightLogic({ dashboardItemId: Insight42, dashboardId: 33 })
@@ -557,7 +554,7 @@ describe('insightLogic', () => {
     })
 
     test('saveInsight and updateInsight update the saved insights list', async () => {
-        savedInsightsLogic({ tabId: '1' }).mount()
+        savedInsightsLogic().mount()
 
         const insightProps: InsightLogicProps = {
             dashboardItemId: Insight42,
@@ -574,10 +571,10 @@ describe('insightLogic', () => {
         insightDataLogic(insightProps).mount()
 
         logic.actions.saveInsight()
-        await expectLogic(logic).toDispatchActions([savedInsightsLogic({ tabId: '1' }).actionTypes.addInsight])
+        await expectLogic(logic).toDispatchActions([savedInsightsLogic().actionTypes.addInsight])
 
         logic.actions.updateInsight({ name: 'my new name' })
-        await expectLogic(logic).toDispatchActions([savedInsightsLogic({ tabId: '1' }).actionTypes.updateInsight])
+        await expectLogic(logic).toDispatchActions([savedInsightsLogic().actionTypes.updateInsight])
     })
 
     test('saveInsight updates dashboards', async () => {
@@ -585,7 +582,7 @@ describe('insightLogic', () => {
         dashLogic.mount()
         await expectLogic(dashLogic).toDispatchActions(['loadDashboard'])
 
-        savedInsightsLogic({ tabId: '1' }).mount()
+        savedInsightsLogic().mount()
 
         const insightProps: InsightLogicProps = {
             dashboardItemId: Insight43,
@@ -601,7 +598,7 @@ describe('insightLogic', () => {
     })
 
     test('updateInsight updates dashboards', async () => {
-        savedInsightsLogic({ tabId: '1' }).mount()
+        savedInsightsLogic().mount()
         logic = insightLogic({
             dashboardItemId: Insight43,
             cachedInsight: {
@@ -633,7 +630,7 @@ describe('insightLogic', () => {
     })
 
     test('after save as from a dashboard tile, the editor state stays on the tile insight until navigation opens the copy', async () => {
-        savedInsightsLogic({ tabId: '1' }).mount()
+        savedInsightsLogic().mount()
 
         const insightProps: InsightLogicProps = {
             dashboardItemId: Insight42,
@@ -652,7 +649,7 @@ describe('insightLogic', () => {
         await expectLogic(logic, () => {
             logic.actions.saveAsConfirmation('New Insight (copy)')
         })
-            .toDispatchActions(savedInsightsLogic({ tabId: '1' }), ['loadInsights'])
+            .toDispatchActions(savedInsightsLogic(), ['loadInsights'])
             .toMatchValues({
                 savedInsight: partial({ query: partial({ source: partial({ kind: NodeKind.FunnelsQuery }) }) }),
                 insight: partial({

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -69,7 +69,7 @@ import {
 } from '~/types'
 
 import { teamLogic } from '../teamLogic'
-import { insightDataLogic } from './insightDataLogic'
+import { insightDataLogic, isInsightSceneInstance } from './insightDataLogic'
 import type { insightLogicType } from './insightLogicType'
 import { getInsightId } from './utils'
 import { insightsApi } from './utils/api'
@@ -662,12 +662,10 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                     // redirect new insights added to dashboard to the dashboard
                     router.actions.push(urls.dashboard(dashboards[0], savedInsight.short_id))
                 } else if (insightNumericId) {
-                    if (props.tabId) {
-                        const mountedInsightSceneLogic = insightSceneLogic.findMounted({ tabId: props.tabId })
-                        mountedInsightSceneLogic?.actions.setInsightMode(
-                            ItemMode.View,
-                            InsightEventSource.InsightHeader
-                        )
+                    if (isInsightSceneInstance(props)) {
+                        insightSceneLogic
+                            .findMounted()
+                            ?.actions.setInsightMode(ItemMode.View, InsightEventSource.InsightHeader)
                     }
                 } else {
                     router.actions.push(urls.insightView(savedInsight.short_id))

--- a/frontend/src/scenes/insights/insightSceneLogic.test.ts
+++ b/frontend/src/scenes/insights/insightSceneLogic.test.ts
@@ -20,7 +20,6 @@ const Insight42 = '42' as InsightShortId
 
 describe('insightSceneLogic', () => {
     let logic: ReturnType<typeof insightSceneLogic.build>
-    let tabId: string = ''
     beforeEach(async () => {
         useMocks({
             get: {
@@ -40,12 +39,11 @@ describe('insightSceneLogic', () => {
         })
         initKeaTests()
         sceneLogic.mount()
-        tabId = sceneLogic.values.activeTabId || ''
     })
 
     it('keeps url /insight/new', async () => {
         router.actions.push(urls.insightNew())
-        logic = insightSceneLogic({ tabId })
+        logic = insightSceneLogic()
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
         await expectLogic(router)
@@ -57,7 +55,7 @@ describe('insightSceneLogic', () => {
 
     it('redirects maintaining url params when opening /insight/new with insight type in theurl', async () => {
         router.actions.push(urls.insightNew({ type: InsightType.FUNNELS }))
-        logic = insightSceneLogic({ tabId })
+        logic = insightSceneLogic()
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
 
@@ -68,7 +66,7 @@ describe('insightSceneLogic', () => {
 
     it('tags new default insights with product_analytics productKey', async () => {
         router.actions.push(urls.insightNew())
-        logic = insightSceneLogic({ tabId })
+        logic = insightSceneLogic()
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
 
@@ -78,7 +76,7 @@ describe('insightSceneLogic', () => {
 
     it('tags new typed insights with product_analytics productKey', async () => {
         router.actions.push(urls.insightNew({ type: InsightType.FUNNELS }))
-        logic = insightSceneLogic({ tabId })
+        logic = insightSceneLogic()
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
 
@@ -98,7 +96,7 @@ describe('insightSceneLogic', () => {
                 } as InsightVizNode,
             })
         )
-        logic = insightSceneLogic({ tabId })
+        logic = insightSceneLogic()
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
 
@@ -115,13 +113,13 @@ describe('insightSceneLogic', () => {
                 } as InsightVizNode,
             })
         )
-        logic = insightSceneLogic({ tabId })
+        logic = insightSceneLogic()
         logic.mount()
         await expectLogic(logic).toDispatchActions(['upgradeQuery']).toFinishAllListeners()
     })
 
     it('persists edit mode in the url', async () => {
-        logic = insightSceneLogic({ tabId })
+        logic = insightSceneLogic()
         logic.mount()
         const viewUrl = combineUrl(urls.insightView(Insight42))
         const editUrl = combineUrl(urls.insightEdit(Insight42))
@@ -141,7 +139,7 @@ describe('insightSceneLogic', () => {
 
     it('resets insight state when navigating to /insights/new again after previous visit', async () => {
         router.actions.push(urls.insightNew({ type: InsightType.TRENDS, dashboardId: 6 }))
-        logic = insightSceneLogic({ tabId })
+        logic = insightSceneLogic()
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
 
@@ -164,13 +162,13 @@ describe('insightSceneLogic', () => {
             { logic: insightSceneLogic, component: () => null as any },
             Scene.Insight,
             'insightNew',
-            tabId,
+            sceneLogic.values.activeTabId || '',
             { params: {}, searchParams: {}, hashParams: {} }
         )
         sceneLogic.actions.setScene(
             Scene.Insight,
             'insightNew',
-            tabId,
+            sceneLogic.values.activeTabId || '',
             { params: {}, searchParams: {}, hashParams: {} },
             false
         )
@@ -216,7 +214,7 @@ describe('insightSceneLogic', () => {
             },
         })
 
-        logic = insightSceneLogic({ tabId })
+        logic = insightSceneLogic()
         logic.mount()
 
         router.actions.push(urls.insightEdit(Insight42))
@@ -264,7 +262,7 @@ describe('insightSceneLogic', () => {
             },
         })
 
-        logic = insightSceneLogic({ tabId })
+        logic = insightSceneLogic()
         logic.mount()
 
         router.actions.push(urls.insightView(Insight42))
@@ -277,13 +275,13 @@ describe('insightSceneLogic', () => {
             { logic: insightSceneLogic, component: () => null as any },
             Scene.Insight,
             'insightView',
-            tabId,
+            sceneLogic.values.activeTabId || '',
             { params: {}, searchParams: {}, hashParams: {} }
         )
         sceneLogic.actions.setScene(
             Scene.Insight,
             'insightView',
-            tabId,
+            sceneLogic.values.activeTabId || '',
             { params: {}, searchParams: {}, hashParams: {} },
             false
         )
@@ -305,7 +303,7 @@ describe('insightSceneLogic', () => {
     ])(
         'updates itemId when navigating from subscriptions list to %s',
         async (_label, subscriptionId, expectedItemId) => {
-            logic = insightSceneLogic({ tabId })
+            logic = insightSceneLogic()
             logic.mount()
 
             router.actions.push(urls.insightSubcriptions(Insight42))
@@ -319,13 +317,13 @@ describe('insightSceneLogic', () => {
                 { logic: insightSceneLogic, component: () => null as any },
                 Scene.Insight,
                 'insightSubcriptions',
-                tabId,
+                sceneLogic.values.activeTabId || '',
                 { params: {}, searchParams: {}, hashParams: {} }
             )
             sceneLogic.actions.setScene(
                 Scene.Insight,
                 'insightSubcriptions',
-                tabId,
+                sceneLogic.values.activeTabId || '',
                 { params: {}, searchParams: {}, hashParams: {} },
                 false
             )
@@ -352,7 +350,7 @@ describe('insightSceneLogic', () => {
             },
         })
 
-        logic = insightSceneLogic({ tabId })
+        logic = insightSceneLogic()
         logic.mount()
 
         router.actions.push(urls.insightView(Insight42))

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -5,7 +5,6 @@ import { objectsEqual } from 'kea-test-utils'
 import api from 'lib/api'
 import { AlertType } from 'lib/components/Alerts/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { isEmptyObject, isObject } from 'lib/utils'
 import { InsightEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -54,10 +53,6 @@ import { getInsightIconTypeFromQuery, parseDraftQueryFromURL } from './utils'
 const NEW_INSIGHT = 'new' as const
 export type InsightId = InsightShortId | typeof NEW_INSIGHT | null
 
-export interface InsightSceneLogicProps {
-    tabId?: string
-}
-
 function normalizeItemId(itemId: string | undefined): string | number | null {
     if (itemId === undefined) {
         return null
@@ -73,7 +68,6 @@ function normalizeItemId(itemId: string | undefined): string | number | null {
 
 export const insightSceneLogic = kea<insightSceneLogicType>([
     path(['scenes', 'insights', 'insightSceneLogic']),
-    tabAwareScene(),
     connect(() => ({
         logic: [eventUsageLogic],
         values: [
@@ -210,7 +204,6 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
         freshQuery: [false, { setFreshQuery: (_, { freshQuery }) => freshQuery }],
     }),
     selectors({
-        tabId: [() => [(_, props: InsightSceneLogicProps) => props.tabId], (tabId) => tabId],
         insightQuerySelector: [
             (s) => [s.insightDataLogicRef],
             (insightDataLogicRef) => insightDataLogicRef?.logic.selectors.query,
@@ -258,16 +251,8 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             (insight) => insight,
         ],
         breadcrumbs: [
-            (s) => [
-                s.insightLogicRef,
-                s.insight,
-                s.insightQuery,
-                s.dashboardId,
-                s.dashboardName,
-                (_, props: InsightSceneLogicProps) => props.tabId,
-                s.sceneSource,
-            ],
-            (insightLogicRef, insight, insightQuery, dashboardId, dashboardName, tabId, sceneSource): Breadcrumb[] => {
+            (s) => [s.insightLogicRef, s.insight, s.insightQuery, s.dashboardId, s.dashboardName, s.sceneSource],
+            (insightLogicRef, insight, insightQuery, dashboardId, dashboardName, sceneSource): Breadcrumb[] => {
                 const dashboardLabel = dashboardName ?? 'Dashboard'
                 return [
                     ...(dashboardId !== null
@@ -315,7 +300,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                                         },
                           ]),
                     {
-                        key: [Scene.Insight, insight?.short_id || `new-${tabId}`],
+                        key: [Scene.Insight, insight?.short_id || 'new'],
                         name: insightLogicRef?.logic.values.insightName,
                         forceEditMode: insightLogicRef?.logic.values.canEditInsight,
                         iconType: getInsightIconTypeFromQuery(insightQuery),
@@ -393,7 +378,6 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                         filtersOverride: values.filtersOverride,
                         variablesOverride: values.variablesOverride,
                         tileFiltersOverride: values.tileFiltersOverride,
-                        tabId: values.tabId,
                     }
 
                     const logic = insightLogic.build(insightProps)
@@ -448,7 +432,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             if (values.insightId === 'new' || values.insightId?.startsWith('new-')) {
                 values.insightLogicRef?.logic.actions.setInsight(
                     {
-                        ...createEmptyInsight(`new-${values.tabId}`),
+                        ...createEmptyInsight('new'),
                         ...(values.dashboardId ? { dashboards: [values.dashboardId] } : {}),
                         query: upgradedQuery,
                     },
@@ -488,7 +472,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                           : ItemMode.View
             let insightId = String(shortId) as InsightShortId
             if (insightId === 'new') {
-                insightId = `new-${values.tabId}` as InsightShortId
+                insightId = 'new' as InsightShortId
             }
 
             const currentScene = sceneLogic.findMounted()?.values
@@ -595,7 +579,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                             : query
                     values.insightLogicRef?.logic.actions.setInsight(
                         {
-                            ...createEmptyInsight(`new-${values.tabId}`),
+                            ...createEmptyInsight('new'),
                             ...(dashboard ? { dashboards: [dashboard] } : {}),
                             query: taggedQuery,
                         },

--- a/frontend/src/scenes/insights/insightUsageLogic.ts
+++ b/frontend/src/scenes/insights/insightUsageLogic.ts
@@ -5,7 +5,6 @@ import api from 'lib/api'
 import { objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { projectLogic } from 'scenes/projectLogic'
-import { sceneLogic } from 'scenes/sceneLogic'
 
 import { isSharedView } from '~/exporter/exporterViewLogic'
 import { DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
@@ -32,8 +31,6 @@ export const insightUsageLogic = kea<insightUsageLogicType>([
             ['insight'],
             dataNodeLogic({ key: insightVizDataNodeKey(props) } as DataNodeLogicProps),
             ['query'],
-            sceneLogic,
-            ['activeTabId'],
         ],
         actions: [eventUsageLogic, ['reportInsightViewed']],
     })),
@@ -55,7 +52,7 @@ export const insightUsageLogic = kea<insightUsageLogicType>([
     listeners(({ actions, values }) => ({
         onQueryChange: async ({ query }, breakpoint) => {
             // We only want to report direct views on the insights page.
-            const logic = insightSceneLogic.findMounted({ tabId: values.activeTabId })
+            const logic = insightSceneLogic.findMounted()
             const shortId = logic?.values.insight?.short_id
 
             if (!logic || shortId !== values.insight?.short_id) {

--- a/frontend/src/scenes/max/messages/VisualizationArtifactAnswer.tsx
+++ b/frontend/src/scenes/max/messages/VisualizationArtifactAnswer.tsx
@@ -41,8 +41,8 @@ interface VisualizationArtifactAnswerProps {
     activeSceneId?: string | null
 }
 
-function InsightSuggestionButton({ tabId }: { tabId: string }): JSX.Element {
-    const { insight } = useValues(insightSceneLogic({ tabId }))
+function InsightSuggestionButton(): JSX.Element {
+    const { insight } = useValues(insightSceneLogic)
     const insightProps = { dashboardItemId: insight?.short_id }
     const { suggestedQuery, previousQuery } = useValues(insightLogic(insightProps))
     const { onRejectSuggestedInsight, onReapplySuggestedInsight } = useActions(insightLogic(insightProps))
@@ -142,9 +142,7 @@ export const VisualizationArtifactAnswer = React.memo(function VisualizationArti
                     </h5>
                 )}
                 <div className="flex items-center gap-1.5">
-                    {isEditingInsight && activeTabId && activeSceneId === Scene.Insight && (
-                        <InsightSuggestionButton tabId={activeTabId} />
-                    )}
+                    {isEditingInsight && activeTabId && activeSceneId === Scene.Insight && <InsightSuggestionButton />}
                     {!isEditingInsight && (
                         <LemonButton
                             to={


### PR DESCRIPTION
## Problem

PostHog's in-app browser-like scene tabs were removed a while ago. The insight scene was still keyed by the scene `tabId` (`tabAwareScene()`), threaded it through `insightSceneLogic` / `insightLogic` / `insightDataLogic`, and used `props.tabId && sceneLogic.values.activeTabId === props.tabId` as the "am I the insight the scene is showing?" signal for URL sync and draft saving.

## Changes

Remove the insight **scene's** use of the scene `tabId`:

- `insightSceneLogic` drops `tabAwareScene()` and becomes a keyless singleton; the `new-${tabId}` placeholder insight ids become `'new'`.
- `InsightScene` / `InsightAsScene` stop passing `tabId`; the scene insight's logic key naturally loses its `/tab-...` suffix.
- The three `insightDataLogic` URL-sync guards and the `insightLogic` save-redirect guard no longer rely on `props.tabId`. They now identify the scene's insight via a key match against the scene's tracked logic:

  ```ts
  const isInsightSceneInstance = (props) =>
      sceneLogic.values.activeSceneId === Scene.Insight &&
      insightSceneLogic.findMounted()?.values.insightLogicRef?.logic.key === keyForInsightLogicProps('new')(props)
  ```

  `insightLogic` and `insightDataLogic` share `keyForInsightLogicProps`, so this precisely matches the scene's current insight and excludes dashboard tiles (different key) and web-analytics insights (different key + not the Insight scene).

### ⚠️ Deliberately KEPT — `InsightLogicProps.tabId` is NOT only a scene tab

`InsightLogicProps.tabId` and `keyForInsightLogicProps`'s `tabId` branch are **web-analytics' tile-tab key**, introduced in March 2025 (#29902 "page reports v0.0.1") — months before in-app scene tabs existed. Stripping the field (as a naive de-tab would) breaks web-analytics tile keying. So `types.ts`, `sharedUtils.ts`, `sharedUtils.test.ts`, and all of `scenes/web-analytics/**` are untouched; only the insight *scene* stops passing `tabId`.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I ran:

- `git grep -nw tabId -- frontend/src/scenes/insights/` leaves only the three intentional web-analytics lines in `sharedUtils`.
- Confirmed `types.ts`, `sharedUtils.ts`, `sharedUtils.test.ts`, and `scenes/web-analytics/**` are unchanged.
- `kea-typegen write` regenerated all 908 logic types with no errors; `tsc --noEmit` has no errors in insights / max / web-analytics (only a pre-existing local `@posthog/hogvm` build issue remains, unrelated).
- `hogli test insightSceneLogic.test.ts` (13/13) and `insightLogic.test.ts` (45/45) pass.

**Reviewer note — worth a browser smoke test.** The URL-sync guard rewrite is the one change here that the unit tests don't fully exercise (the scene-vs-dashboard-tile distinction). Suggested manual check: edit an insight (query should sync to the URL `q` hash), cancel changes (hash clears), and confirm a dashboard tile of the same insight doesn't clobber the insight scene's URL.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). Part of a Graphite stack removing the defunct in-app `tabId` scaffolding area-by-area. This is the insight slice — behavioural, so done surgically.

Key decisions: (1) `props.tabId` was the "I am the scene insight" marker; with one tab it's replaced by matching the scene's `insightLogicRef.logic.key`, which is robust against dashboard tiles and web-analytics. (2) `InsightLogicProps.tabId` is shared with web-analytics (a legitimate tile-tab concept predating in-app tabs), so it and `keyForInsightLogicProps` are preserved — only the scene's usage is removed. One external consumer outside the insight dir (`max/messages/VisualizationArtifactAnswer`) read the now-singleton `insightSceneLogic` and was updated to match; Max's own chat-tab concept is untouched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
