### PR TITLE
refactor(experiments): remove defunct scene tabId from experiment tree

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.test.tsx
+++ b/frontend/src/scenes/experiments/Experiment.test.tsx
@@ -89,17 +89,16 @@ function cleanupKea(...logics: Array<{ unmount: () => void }>): void {
     featureFlagLogic.unmount()
 }
 
-function renderExperimentViewPage(
-    tabId: string,
-    experimentData: ExperimentType
-): { sceneLogic: ReturnType<typeof experimentSceneLogic> } {
+function renderExperimentViewPage(experimentData: ExperimentType): {
+    sceneLogic: ReturnType<typeof experimentSceneLogic>
+} {
     // Set the URL so urlToAction initializes correctly
     router.actions.push('/experiments/123')
-    const sceneLogic = experimentSceneLogic({ tabId, experimentId: 123, formMode: FORM_MODES.update })
+    const sceneLogic = experimentSceneLogic({ experimentId: 123, formMode: FORM_MODES.update })
     sceneLogic.mount()
     sceneLogic.actions.setSceneState(123, FORM_MODES.update)
     sceneLogic.values.experimentLogicRef!.logic.actions.loadExperimentSuccess(experimentData)
-    render(<Experiment tabId={tabId} />)
+    render(<Experiment />)
     return { sceneLogic }
 }
 
@@ -116,13 +115,12 @@ describe('Experiment component', () => {
         useMocks(apiMocks)
         mountKeaLogics()
 
-        const tabId = 'test-tab-create'
-        const createSceneLogic = experimentSceneLogic({ tabId, experimentId: 'new', formMode: FORM_MODES.create })
+        const createSceneLogic = experimentSceneLogic({ experimentId: 'new', formMode: FORM_MODES.create })
         createSceneLogic.mount()
         // Explicitly set create mode since urlToAction may override props default
         createSceneLogic.actions.setSceneState('new', FORM_MODES.create)
 
-        render(<Experiment tabId={tabId} />)
+        render(<Experiment />)
 
         expect(screen.getByTestId('experiment-wizard')).toBeInTheDocument()
         cleanupKea(createSceneLogic)
@@ -134,7 +132,6 @@ describe('Experiment component', () => {
             description: 'draft',
             expectLaunchButton: true,
             expectWarningBanner: false,
-            tabId: 'test-tab-draft-no-metrics',
         },
         {
             experimentOverrides: {
@@ -144,18 +141,17 @@ describe('Experiment component', () => {
             description: 'running experiment',
             expectLaunchButton: false,
             expectWarningBanner: true,
-            tabId: 'test-tab-running-no-metrics',
         },
     ])(
         '$description without metrics shows add metric buttons',
-        async ({ experimentOverrides, expectLaunchButton, expectWarningBanner, tabId }) => {
+        async ({ experimentOverrides, expectLaunchButton, expectWarningBanner }) => {
             const experimentData: ExperimentType = { ...DRAFT_EXPERIMENT, ...experimentOverrides }
             localStorage.clear()
             sessionStorage.clear()
             useMocks(mockApiForExperiment(experimentData))
             mountKeaLogics()
 
-            const { sceneLogic } = renderExperimentViewPage(tabId, experimentData)
+            const { sceneLogic } = renderExperimentViewPage(experimentData)
 
             await waitFor(() => {
                 screen.getAllByText('Add primary metric')

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -10,29 +10,23 @@ import { ProductKey } from '~/queries/schema/schema-general'
 
 import { createExperimentLogic } from './ExperimentForm/createExperimentLogic'
 import { type ExperimentLogicProps, FORM_MODES, experimentLogic } from './experimentLogic'
-import { type ExperimentSceneLogicProps, experimentSceneLogic } from './experimentSceneLogic'
+import { experimentSceneLogic } from './experimentSceneLogic'
 import { ExperimentView } from './ExperimentView/ExperimentView'
 import { ExperimentWizard } from './ExperimentWizard/ExperimentWizard'
 import { experimentWizardLogic } from './ExperimentWizard/experimentWizardLogic'
 
-export const scene: SceneExport<ExperimentSceneLogicProps> = {
+export const scene: SceneExport = {
     component: Experiment,
     logic: experimentSceneLogic,
     productKey: ProductKey.EXPERIMENTS,
     paramsToProps: ({ params: { id, formMode } }) => ({
         experimentId: id === 'new' ? 'new' : parseInt(id, 10),
         formMode: formMode || (id === 'new' ? FORM_MODES.create : FORM_MODES.update),
-        // tabId is automatically added by sceneLogic
     }),
 }
 
-export function Experiment(props: ExperimentSceneLogicProps): JSX.Element {
-    const { tabId } = props
-
-    if (!tabId) {
-        throw new Error('<Experiment /> must receive a tabId prop')
-    }
-    const { formMode, experimentMissing, experimentId } = useValues(experimentSceneLogic({ tabId }))
+export function Experiment(): JSX.Element {
+    const { formMode, experimentMissing, experimentId } = useValues(experimentSceneLogic)
     const { currentTeamId } = useValues(teamLogic)
 
     useFileSystemLogView({
@@ -41,8 +35,8 @@ export function Experiment(props: ExperimentSceneLogicProps): JSX.Element {
         enabled: Boolean(currentTeamId && !experimentMissing && typeof experimentId === 'number'),
     })
 
-    const logicProps: ExperimentLogicProps = { experimentId, formMode, tabId }
-    useAttachedLogic(experimentLogic(logicProps), experimentSceneLogic({ tabId }))
+    const logicProps: ExperimentLogicProps = { experimentId, formMode }
+    useAttachedLogic(experimentLogic(logicProps), experimentSceneLogic)
 
     if (experimentMissing) {
         return <NotFound object="experiment" />
@@ -52,17 +46,17 @@ export function Experiment(props: ExperimentSceneLogicProps): JSX.Element {
 
     return (
         <BindLogic logic={experimentLogic} props={logicProps}>
-            {isCreateMode ? <ExperimentCreateMode tabId={tabId} /> : <ExperimentView tabId={tabId} />}
+            {isCreateMode ? <ExperimentCreateMode /> : <ExperimentView />}
         </BindLogic>
     )
 }
 
-function ExperimentCreateMode({ tabId }: { tabId: string }): JSX.Element {
-    const logic = createExperimentLogic({ tabId })
+function ExperimentCreateMode(): JSX.Element {
+    const logic = createExperimentLogic()
     useMountedLogic(logic)
 
     return (
-        <BindLogic logic={experimentWizardLogic} props={{ tabId }}>
+        <BindLogic logic={experimentWizardLogic} props={{}}>
             <ExperimentWizard />
         </BindLogic>
     )

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.test.tsx
@@ -17,6 +17,8 @@ describe('ExperimentForm Integration', () => {
     beforeEach(() => {
         // Clear localStorage to prevent persisted state from affecting tests
         localStorage.clear()
+        // Drafts persist in sessionStorage; clear so one test's draft can't leak into the next
+        sessionStorage.clear()
 
         useMocks({
             post: {

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.test.ts
@@ -11,7 +11,7 @@ import { initKeaTests } from '~/test/init'
 import type { Experiment } from '~/types'
 
 import { NEW_EXPERIMENT } from '../constants'
-import { createExperimentLogic } from './createExperimentLogic'
+import { createExperimentLogic, DRAFT_STORAGE_KEY } from './createExperimentLogic'
 
 jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
     lemonToast: {
@@ -29,8 +29,9 @@ describe('createExperimentLogic', () => {
     let routerPushSpy: jest.SpyInstance
 
     beforeEach(() => {
-        // Clear localStorage to prevent persisted state from affecting tests
+        // Clear persisted state to prevent it from affecting tests
         localStorage.clear()
+        sessionStorage.clear()
 
         useMocks({
             post: {
@@ -65,7 +66,9 @@ describe('createExperimentLogic', () => {
     })
 
     afterEach(() => {
-        logic.unmount()
+        if (logic.isMounted()) {
+            logic.unmount()
+        }
         routerPushSpy.mockRestore()
     })
 
@@ -336,10 +339,11 @@ describe('createExperimentLogic', () => {
     })
 
     describe('form navigation scenarios', () => {
-        const TAB_ID = 'test-tab'
-
         beforeEach(() => {
             sessionStorage.clear()
+            // Fully unmount the shared singleton so each test controls the
+            // mount lifecycle and afterMount/beforeUnmount fire as expected.
+            logic.unmount()
         })
 
         it('draft from sessionStorage is loaded when creating a new experiment', async () => {
@@ -350,11 +354,11 @@ describe('createExperimentLogic', () => {
             }
 
             sessionStorage.setItem(
-                `experiment-draft-${TAB_ID}`,
+                DRAFT_STORAGE_KEY,
                 JSON.stringify({ experiment: storedDraft, timestamp: Date.now() })
             )
 
-            const newLogic = createExperimentLogic({ tabId: TAB_ID })
+            const newLogic = createExperimentLogic()
             newLogic.mount()
 
             await expectLogic(newLogic).toMatchValues({
@@ -368,8 +372,8 @@ describe('createExperimentLogic', () => {
             newLogic.unmount()
         })
 
-        it('form state does not leak between new experiment sessions in the same tab', async () => {
-            const firstNew = createExperimentLogic({ tabId: TAB_ID })
+        it('form state does not leak between new experiment sessions', async () => {
+            const firstNew = createExperimentLogic()
             firstNew.mount()
 
             firstNew.actions.setExperimentValue('name', 'First Attempt')
@@ -383,7 +387,7 @@ describe('createExperimentLogic', () => {
 
             sessionStorage.clear()
 
-            const secondNew = createExperimentLogic({ tabId: TAB_ID })
+            const secondNew = createExperimentLogic()
             secondNew.mount()
 
             await expectLogic(secondNew).toMatchValues({
@@ -394,71 +398,63 @@ describe('createExperimentLogic', () => {
         })
 
         it('unmount/remount with no draft starts fresh', async () => {
-            logic.actions.setExperiment({
+            const freshLogic = createExperimentLogic()
+            freshLogic.mount()
+
+            freshLogic.actions.setExperiment({
                 ...NEW_EXPERIMENT,
                 id: 123,
                 name: 'Saved Experiment',
                 description: 'Already saved',
             })
 
-            logic.unmount()
+            freshLogic.unmount()
 
-            const freshLogic = createExperimentLogic()
-            freshLogic.mount()
+            const remounted = createExperimentLogic()
+            remounted.mount()
 
-            await expectLogic(freshLogic).toMatchValues({
+            await expectLogic(remounted).toMatchValues({
                 experiment: partial({ id: 'new', name: '', description: '' }),
             })
 
-            freshLogic.unmount()
+            remounted.unmount()
         })
 
-        it('two in-app tabs with new experiment forms maintain independent state', async () => {
-            const tab1Logic = createExperimentLogic({ tabId: 'tab-1' })
-            const tab2Logic = createExperimentLogic({ tabId: 'tab-2' })
-            tab1Logic.mount()
-            tab2Logic.mount()
+        it('draft written on unmount is read back by a freshly-built logic', async () => {
+            const firstNew = createExperimentLogic()
+            firstNew.mount()
 
-            // Type into tab 1
-            tab1Logic.actions.setExperimentValue('name', 'Tab 1 Experiment')
-            tab1Logic.actions.setExperimentValue('feature_flag_key', 'tab-1-flag')
+            firstNew.actions.setExperimentValue('name', 'Work In Progress')
+            firstNew.actions.setExperimentValue('feature_flag_key', 'wip-flag')
 
-            // Type into tab 2
-            tab2Logic.actions.setExperimentValue('name', 'Tab 2 Experiment')
-            tab2Logic.actions.setExperimentValue('feature_flag_key', 'tab-2-flag')
-
-            // Both tabs retain their own data
-            await expectLogic(tab1Logic).toMatchValues({
-                experiment: partial({ name: 'Tab 1 Experiment', feature_flag_key: 'tab-1-flag' }),
-            })
-            await expectLogic(tab2Logic).toMatchValues({
-                experiment: partial({ name: 'Tab 2 Experiment', feature_flag_key: 'tab-2-flag' }),
+            await expectLogic(firstNew).toMatchValues({
+                experiment: partial({ name: 'Work In Progress', feature_flag_key: 'wip-flag' }),
             })
 
-            // Modify tab 1 again — tab 2 is unaffected
-            tab1Logic.actions.setExperimentValue('name', 'Tab 1 Updated')
+            // Navigating away without saving writes the draft to sessionStorage
+            firstNew.unmount()
 
-            await expectLogic(tab1Logic).toMatchValues({
-                experiment: partial({ name: 'Tab 1 Updated', feature_flag_key: 'tab-1-flag' }),
-            })
-            await expectLogic(tab2Logic).toMatchValues({
-                experiment: partial({ name: 'Tab 2 Experiment', feature_flag_key: 'tab-2-flag' }),
+            const secondNew = createExperimentLogic()
+            secondNew.mount()
+
+            await expectLogic(secondNew).toMatchValues({
+                experiment: partial({ id: 'new', name: 'Work In Progress', feature_flag_key: 'wip-flag' }),
             })
 
-            tab1Logic.unmount()
-            tab2Logic.unmount()
+            secondNew.unmount()
         })
     })
 
     describe('post-save state reset', () => {
-        const TAB_ID = 'test-tab'
-
         beforeEach(() => {
             sessionStorage.clear()
+            // Fully unmount the shared singleton so each test controls the
+            // mount lifecycle and afterMount/beforeUnmount fire as expected.
+            logic.unmount()
         })
 
         it('form resets to NEW_EXPERIMENT after saving and re-entering create mode', async () => {
-            const firstLogic = createExperimentLogic({ tabId: TAB_ID })
+            const firstLogic = createExperimentLogic()
             firstLogic.mount()
 
             await expectLogic(firstLogic).toMatchValues({
@@ -483,7 +479,7 @@ describe('createExperimentLogic', () => {
             firstLogic.unmount()
 
             // User navigates back to /experiments/new — component remounts the logic
-            const secondLogic = createExperimentLogic({ tabId: TAB_ID })
+            const secondLogic = createExperimentLogic()
             secondLogic.mount()
 
             await expectLogic(secondLogic).toMatchValues({
@@ -494,7 +490,7 @@ describe('createExperimentLogic', () => {
         })
 
         it('navigating away without saving preserves draft for next visit', async () => {
-            const firstLogic = createExperimentLogic({ tabId: TAB_ID })
+            const firstLogic = createExperimentLogic()
             firstLogic.mount()
 
             firstLogic.actions.setExperimentValue('name', 'Work In Progress')
@@ -504,11 +500,11 @@ describe('createExperimentLogic', () => {
                 experiment: partial({ name: 'Work In Progress', feature_flag_key: 'wip-flag' }),
             })
 
-            // User navigates away (e.g. switches tab) — no cancel, no save
+            // User navigates away — no cancel, no save
             firstLogic.unmount()
 
             // User comes back to /experiments/new
-            const secondLogic = createExperimentLogic({ tabId: TAB_ID })
+            const secondLogic = createExperimentLogic()
             secondLogic.mount()
 
             await expectLogic(secondLogic).toMatchValues({
@@ -519,7 +515,7 @@ describe('createExperimentLogic', () => {
         })
 
         it('cancel clears draft so re-entering create mode starts fresh', async () => {
-            const firstLogic = createExperimentLogic({ tabId: TAB_ID })
+            const firstLogic = createExperimentLogic()
             firstLogic.mount()
 
             firstLogic.actions.setExperimentValue('name', 'Will Cancel')
@@ -534,7 +530,7 @@ describe('createExperimentLogic', () => {
             firstLogic.unmount()
 
             // User navigates back to /experiments/new
-            const secondLogic = createExperimentLogic({ tabId: TAB_ID })
+            const secondLogic = createExperimentLogic()
             secondLogic.mount()
 
             await expectLogic(secondLogic).toMatchValues({
@@ -542,38 +538,6 @@ describe('createExperimentLogic', () => {
             })
 
             secondLogic.unmount()
-        })
-
-        it('canceling one tab does not affect the other', async () => {
-            const tab1Logic = createExperimentLogic({ tabId: 'tab-1' })
-            const tab2Logic = createExperimentLogic({ tabId: 'tab-2' })
-            tab1Logic.mount()
-            tab2Logic.mount()
-
-            tab1Logic.actions.setExperimentValue('name', 'Tab 1 Experiment')
-            tab1Logic.actions.setExperimentValue('feature_flag_key', 'tab-1-flag')
-            tab2Logic.actions.setExperimentValue('name', 'Tab 2 Experiment')
-            tab2Logic.actions.setExperimentValue('feature_flag_key', 'tab-2-flag')
-
-            // Cancel tab 1
-            tab1Logic.actions.cancelForm()
-            tab1Logic.unmount()
-
-            // Tab 2 is unaffected
-            await expectLogic(tab2Logic).toMatchValues({
-                experiment: partial({ name: 'Tab 2 Experiment', feature_flag_key: 'tab-2-flag' }),
-            })
-
-            // Re-opening tab 1 starts fresh
-            const newTab1Logic = createExperimentLogic({ tabId: 'tab-1' })
-            newTab1Logic.mount()
-
-            await expectLogic(newTab1Logic).toMatchValues({
-                experiment: partial({ id: 'new', name: '', feature_flag_key: '' }),
-            })
-
-            newTab1Logic.unmount()
-            tab2Logic.unmount()
         })
     })
 

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -32,18 +32,19 @@ import { validateVariants } from './variantsPanelValidation'
 
 const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000
 
-const draftStorageKey = (tabId: string): string => `experiment-draft-${tabId}`
+// Scope the draft key per project so a draft started in one project can't prefill or be submitted in another within the same browser session.
+export const DRAFT_STORAGE_KEY = `experiment-draft-${window.POSTHOG_APP_CONTEXT?.current_team?.id ?? 'unknown'}`
 
 type ExperimentDraft = {
     experiment: Experiment
     timestamp: number
 }
 
-const readDraftFromStorage = (tabId?: string): Experiment | null => {
-    if (!tabId || typeof sessionStorage === 'undefined') {
+const readDraftFromStorage = (): Experiment | null => {
+    if (typeof sessionStorage === 'undefined') {
         return null
     }
-    const raw = sessionStorage.getItem(draftStorageKey(tabId))
+    const raw = sessionStorage.getItem(DRAFT_STORAGE_KEY)
     if (!raw) {
         return null
     }
@@ -52,7 +53,7 @@ const readDraftFromStorage = (tabId?: string): Experiment | null => {
         if (parsed && typeof parsed === 'object' && 'experiment' in parsed && 'timestamp' in parsed) {
             const { experiment, timestamp } = parsed as ExperimentDraft
             if (Date.now() - timestamp > DRAFT_TTL_MS) {
-                sessionStorage.removeItem(draftStorageKey(tabId))
+                sessionStorage.removeItem(DRAFT_STORAGE_KEY)
                 return null
             }
             return experiment
@@ -63,32 +64,30 @@ const readDraftFromStorage = (tabId?: string): Experiment | null => {
     }
 }
 
-const writeDraftToStorage = (tabId: string | undefined, experiment: Experiment): void => {
-    if (!tabId || typeof sessionStorage === 'undefined') {
+const writeDraftToStorage = (experiment: Experiment): void => {
+    if (typeof sessionStorage === 'undefined') {
         return
     }
     const draft: ExperimentDraft = { experiment, timestamp: Date.now() }
-    sessionStorage.setItem(draftStorageKey(tabId), JSON.stringify(draft))
+    sessionStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft))
 }
 
-const clearDraftStorage = (tabId?: string): void => {
-    if (!tabId || typeof sessionStorage === 'undefined') {
+const clearDraftStorage = (): void => {
+    if (typeof sessionStorage === 'undefined') {
         return
     }
-    sessionStorage.removeItem(draftStorageKey(tabId))
+    sessionStorage.removeItem(DRAFT_STORAGE_KEY)
 }
 
-export interface CreateExperimentLogicProps {
-    tabId?: string
-}
+export interface CreateExperimentLogicProps {}
 
 export const createExperimentLogic = kea<createExperimentLogicType>([
     props({} as CreateExperimentLogicProps),
-    key((props) => `${props.tabId ?? 'global'}-create-experiment`),
+    key(() => 'create-experiment'),
     path((key) => ['scenes', 'experiments', 'create', 'createExperimentLogic', key]),
-    connect((props: CreateExperimentLogicProps) => ({
+    connect(() => ({
         values: [
-            variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: props.tabId }),
+            variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false }),
             ['featureFlagKeyValidation', 'featureFlagKeyValidationLoading'],
             projectLogic,
             ['currentProjectId'],
@@ -188,7 +187,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
             },
         ],
     })),
-    selectors(({ props }) => ({
+    selectors(() => ({
         canSubmitExperiment: [
             (s) => [s.experiment, s.featureFlagKeyValidation, s.mode, s.experimentErrors],
             (
@@ -226,12 +225,11 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
         mode: [
             (s) => [s.experiment],
             (): 'create' | 'link' => {
-                return variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: props.tabId })
-                    .values.mode
+                return variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false }).values.mode
             },
         ],
     })),
-    events(({ actions, values, props }) => ({
+    events(({ actions, values }) => ({
         afterMount: () => {
             if (values.experiment.id !== 'new') {
                 return
@@ -260,7 +258,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                 // Continue to draft fallback
             }
 
-            const draft = readDraftFromStorage(props.tabId)
+            const draft = readDraftFromStorage()
             if (draft) {
                 actions.setExperiment(draft)
             }
@@ -270,17 +268,16 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                 return
             }
             // Use cases covered:
-            // - switching in-app tabs to avoid side effects while having multiple experiment forms open
             // - navigating away from the form without saving
-            writeDraftToStorage(props.tabId, values.experiment)
+            writeDraftToStorage(values.experiment)
         },
     })),
-    listeners(({ values, actions, props }) => ({
+    listeners(({ values, actions }) => ({
         cancelForm: () => {
             if (values.experiment.id !== 'new') {
                 return
             }
-            clearDraftStorage(props.tabId)
+            clearDraftStorage()
         },
         setExperiment: () => {},
         setExperimentValue: () => {},
@@ -389,10 +386,10 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                     // Don't reset - we just set the fresh data above
 
                     actions.saveExperimentSuccess()
-                    clearDraftStorage(props.tabId)
+                    clearDraftStorage()
 
-                    if (props.tabId) {
-                        const sceneLogicInstance = experimentSceneLogic({ tabId: props.tabId })
+                    const sceneLogicInstance = experimentSceneLogic.findMounted()
+                    if (sceneLogicInstance) {
                         sceneLogicInstance.actions.setSceneState(response.id, FORM_MODES.update)
                         const logicRef = sceneLogicInstance.values.experimentLogicRef
 
@@ -401,7 +398,6 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                         } else {
                             experimentLogic({
                                 experimentId: response.id,
-                                tabId: props.tabId,
                             }).actions.loadExperimentSuccess(response)
                         }
                     } else {

--- a/frontend/src/scenes/experiments/ExperimentForm/variantsPanelLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/variantsPanelLogic.ts
@@ -18,16 +18,14 @@ export type FeatureFlagKeyValidation = {
 }
 
 export const variantsPanelLogic = kea<variantsPanelLogicType>({
-    key: (props) => props.tabId || props.experiment?.id || 'new',
+    key: (props) => props.experiment?.id || 'new',
     path: (key) => ['scenes', 'experiments', 'create', 'panels', 'variantsPanelLogic', key],
     props: {
         experiment: {} as Experiment,
         disabled: false as boolean,
-        tabId: undefined as string | undefined,
     } as {
         experiment: Experiment
         disabled: boolean
-        tabId?: string
     },
     connect: {
         values: [

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -17,7 +17,6 @@ import { SummarizeSessionReplaysButton } from '../components/SummarizeSessionRep
 import { EmptyMetricsPanel } from '../ExperimentForm/MetricsPanel/EmptyMetricsPanel'
 import { ExperimentImplementationDetails } from '../ExperimentImplementationDetails'
 import { experimentLogic } from '../experimentLogic'
-import type { ExperimentSceneLogicProps } from '../experimentSceneLogic'
 import { experimentSceneLogic } from '../experimentSceneLogic'
 import { ExperimentMetricModal } from '../Metrics/ExperimentMetricModal'
 import { experimentMetricModalLogic } from '../Metrics/experimentMetricModalLogic'
@@ -120,7 +119,7 @@ const VariantsTab = (): JSX.Element => {
     )
 }
 
-export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.Element {
+export function ExperimentView(): JSX.Element {
     const { experimentLoading, experimentId, experiment, isExperimentDraft, exposureCriteria, showDebugPanel } =
         useValues(experimentLogic)
     const {
@@ -133,19 +132,15 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
         removeMetric,
     } = useActions(experimentLogic)
 
-    if (!tabId) {
-        throw new Error('<ExperimentView /> must receive a tabId prop')
-    }
-
-    const { activeTabKey } = useValues(experimentSceneLogic({ tabId }))
-    const { setActiveTabKey } = useActions(experimentSceneLogic({ tabId }))
+    const { activeTabKey } = useValues(experimentSceneLogic)
+    const { setActiveTabKey } = useActions(experimentSceneLogic)
 
     const { closeExperimentMetricModal } = useActions(experimentMetricModalLogic)
     const { closeSharedMetricModal } = useActions(sharedMetricModalLogic)
 
     // Branch to legacy view for legacy experiments
     if (!experimentLoading && isLegacyExperiment(experiment)) {
-        return <LegacyExperimentView tabId={tabId} />
+        return <LegacyExperimentView />
     }
 
     return (
@@ -170,7 +165,7 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
                             context="experiment"
                         />
                     )}
-                    <Info tabId={tabId} />
+                    <Info />
                     <ExperimentHeader />
                     <LemonTabs
                         activeKey={activeTabKey}

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -16,7 +16,6 @@ import { ExperimentStatsMethod, ExperimentStatus } from '~/types'
 
 import { CONCLUSION_DISPLAY_CONFIG } from '../constants'
 import { experimentLogic, previousRefreshAnalytics } from '../experimentLogic'
-import type { ExperimentSceneLogicProps } from '../experimentSceneLogic'
 import { getExperimentStatus, isExperimentPaused } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
 import { ExperimentDuration } from './ExperimentDuration'
@@ -24,7 +23,7 @@ import { ExperimentReloadAction } from './ExperimentReloadAction'
 import { RunningTime } from './RunningTime'
 import { StatusTag } from './StatusTag'
 
-export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.Element {
+export function Info(): JSX.Element {
     const {
         experiment,
         primaryMetricsResults,
@@ -199,14 +198,11 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
                     {/* Row 2: Running time, Last refreshed, Created by */}
                     <div className="flex flex-col overflow-hidden items-start min-[1100px]:items-end">
                         <div className="flex flex-wrap gap-x-8 gap-y-2 justify-end">
-                            {tabId && (
-                                <RunningTime
-                                    experiment={experiment}
-                                    tabId={tabId}
-                                    onClick={openRunningTimeConfigModal}
-                                    isExperimentDraft={isExperimentDraft}
-                                />
-                            )}
+                            <RunningTime
+                                experiment={experiment}
+                                onClick={openRunningTimeConfigModal}
+                                isExperimentDraft={isExperimentDraft}
+                            />
                             {status !== ExperimentStatus.Draft && (
                                 <ExperimentReloadAction
                                     isRefreshing={primaryMetricsResultsLoading || secondaryMetricsResultsLoading}

--- a/frontend/src/scenes/experiments/ExperimentView/RunningTime.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/RunningTime.tsx
@@ -13,12 +13,10 @@ import { runningTimeLogic } from '../RunningTimeCalculator/runningTimeLogic'
 
 export const RunningTime = ({
     experiment,
-    tabId,
     onClick,
     isExperimentDraft,
 }: {
     experiment: Experiment
-    tabId: string
     onClick: () => void
     isExperimentDraft: boolean
 }): JSX.Element => {
@@ -29,7 +27,7 @@ export const RunningTime = ({
         isComplete,
         isManualMode,
         primaryMetricsResultsLoading,
-    } = useValues(runningTimeLogic({ experimentId: experiment.id, tabId }))
+    } = useValues(runningTimeLogic({ experimentId: experiment.id }))
 
     const showProgress = currentExposures !== null && targetSampleSize !== null
 
@@ -82,7 +80,7 @@ export const RunningTime = ({
                     />
                 </div>
             </div>
-            <RunningTimeConfigModal experimentId={experiment.id} tabId={tabId} />
+            <RunningTimeConfigModal experimentId={experiment.id} />
         </>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.test.tsx
@@ -39,8 +39,6 @@ beforeAll(() => {
     document.body.appendChild(modalRoot)
 })
 
-const TAB_ID = 'test-tab'
-
 const mockEligibleFlags: Partial<FeatureFlagType>[] = [
     {
         id: 10,
@@ -98,7 +96,7 @@ describe('guide panel localStorage persistence', () => {
 
         featureFlagsLogic.mount()
         experimentsLogic.mount()
-        createExperimentLogic({ tabId: TAB_ID }).mount()
+        createExperimentLogic().mount()
     })
 
     afterEach(() => {
@@ -115,14 +113,14 @@ describe('guide panel localStorage persistence', () => {
             localStorage.setItem('experiment-wizard-show-guide', stored)
         }
 
-        logic = experimentWizardLogic({ tabId: TAB_ID })
+        logic = experimentWizardLogic()
         logic.mount()
 
         await expectLogic(logic).toMatchValues({ showGuide: expected })
     })
 
     it('persists to localStorage when toggled', async () => {
-        logic = experimentWizardLogic({ tabId: TAB_ID })
+        logic = experimentWizardLogic()
         logic.mount()
 
         await expectLogic(logic).toMatchValues({ showGuide: true })
@@ -151,10 +149,10 @@ describe('experimentWizardLogic', () => {
             featureFlagsLogic.mount()
             experimentsLogic.mount()
 
-            createLogic = createExperimentLogic({ tabId: TAB_ID })
+            createLogic = createExperimentLogic()
             createLogic.mount()
 
-            logic = experimentWizardLogic({ tabId: TAB_ID })
+            logic = experimentWizardLogic()
             logic.mount()
         })
 
@@ -168,7 +166,7 @@ describe('experimentWizardLogic', () => {
 
         it('typing a name auto-generates the feature flag key with sanitization', async () => {
             render(
-                <BindLogic logic={experimentWizardLogic} props={{ tabId: TAB_ID }}>
+                <BindLogic logic={experimentWizardLogic} props={{}}>
                     <AboutStep />
                 </BindLogic>
             )
@@ -205,7 +203,7 @@ describe('experimentWizardLogic', () => {
 
         it('shows "Use this flag" button when feature flag key already exists', async () => {
             // Set validation result with existingFlag BEFORE rendering
-            const vpLogic = variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: TAB_ID })
+            const vpLogic = variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false })
             vpLogic.actions.validateFeatureFlagKeySuccess({
                 valid: false,
                 error: 'A feature flag with this key already exists.',
@@ -221,7 +219,7 @@ describe('experimentWizardLogic', () => {
             })
 
             render(
-                <BindLogic logic={experimentWizardLogic} props={{ tabId: TAB_ID }}>
+                <BindLogic logic={experimentWizardLogic} props={{}}>
                     <AboutStep />
                 </BindLogic>
             )
@@ -236,7 +234,7 @@ describe('experimentWizardLogic', () => {
             const flag = mockEligibleFlags[0] as FeatureFlagType
 
             // Set validation result with existingFlag BEFORE rendering
-            const vpLogic = variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: TAB_ID })
+            const vpLogic = variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false })
             vpLogic.actions.validateFeatureFlagKeySuccess({
                 valid: false,
                 error: 'A feature flag with this key already exists.',
@@ -251,7 +249,7 @@ describe('experimentWizardLogic', () => {
             })
 
             render(
-                <BindLogic logic={experimentWizardLogic} props={{ tabId: TAB_ID }}>
+                <BindLogic logic={experimentWizardLogic} props={{}}>
                     <AboutStep />
                 </BindLogic>
             )
@@ -302,10 +300,10 @@ describe('experimentWizardLogic', () => {
             featureFlagsLogic.mount()
             experimentsLogic.mount()
 
-            createLogic = createExperimentLogic({ tabId: TAB_ID })
+            createLogic = createExperimentLogic()
             createLogic.mount()
 
-            logic = experimentWizardLogic({ tabId: TAB_ID })
+            logic = experimentWizardLogic()
             logic.mount()
         })
 
@@ -370,42 +368,33 @@ describe('experimentWizardLogic', () => {
             logic.unmount()
             createLogic.unmount()
 
-            createLogic = createExperimentLogic({ tabId: TAB_ID })
+            createLogic = createExperimentLogic()
             createLogic.mount()
-            logic = experimentWizardLogic({ tabId: TAB_ID })
+            logic = experimentWizardLogic()
             logic.mount()
 
             await expectLogic(logic).toMatchValues({ currentStep: 'variants' })
         })
 
-        it('two tabs maintain independent step state', async () => {
-            const createLogic1 = createExperimentLogic({ tabId: 'tab-1' })
-            createLogic1.mount()
-            const wizardLogic1 = experimentWizardLogic({ tabId: 'tab-1' })
-            wizardLogic1.mount()
+        it('wizard logic is a singleton that shares step state', async () => {
+            const wizardLogicA = experimentWizardLogic()
+            wizardLogicA.mount()
+            const wizardLogicB = experimentWizardLogic()
+            wizardLogicB.mount()
 
-            const createLogic2 = createExperimentLogic({ tabId: 'tab-2' })
-            createLogic2.mount()
-            const wizardLogic2 = experimentWizardLogic({ tabId: 'tab-2' })
-            wizardLogic2.mount()
+            wizardLogicA.actions.setStep('variants')
 
-            // Advance tab 1 to variants, tab 2 to analytics
-            wizardLogic1.actions.setStep('variants')
-            wizardLogic2.actions.setStep('analytics')
+            // Both references resolve to the same singleton instance
+            await expectLogic(wizardLogicA).toMatchValues({ currentStep: 'variants' })
+            await expectLogic(wizardLogicB).toMatchValues({ currentStep: 'variants' })
 
-            await expectLogic(wizardLogic1).toMatchValues({ currentStep: 'variants' })
-            await expectLogic(wizardLogic2).toMatchValues({ currentStep: 'analytics' })
+            wizardLogicB.actions.setStep('analytics')
 
-            // Advancing tab 2 does not affect tab 1
-            wizardLogic2.actions.setStep('about')
+            await expectLogic(wizardLogicA).toMatchValues({ currentStep: 'analytics' })
+            await expectLogic(wizardLogicB).toMatchValues({ currentStep: 'analytics' })
 
-            await expectLogic(wizardLogic1).toMatchValues({ currentStep: 'variants' })
-            await expectLogic(wizardLogic2).toMatchValues({ currentStep: 'about' })
-
-            wizardLogic1.unmount()
-            createLogic1.unmount()
-            wizardLogic2.unmount()
-            createLogic2.unmount()
+            wizardLogicA.unmount()
+            wizardLogicB.unmount()
         })
 
         it('resets step to about on saveExperimentSuccess', async () => {
@@ -419,20 +408,20 @@ describe('experimentWizardLogic', () => {
                 linkedFeatureFlag: null,
                 departedSteps: {},
             })
-            expect(sessionStorage.getItem(stepStorageKey(TAB_ID))).toBeNull()
+            expect(sessionStorage.getItem(stepStorageKey())).toBeNull()
         })
 
         it('clears sessionStorage step on saveExperimentSuccess so remount starts fresh', async () => {
             logic.actions.setStep('analytics')
-            expect(sessionStorage.getItem(stepStorageKey(TAB_ID))).toBe('analytics')
+            expect(sessionStorage.getItem(stepStorageKey())).toBe('analytics')
 
             logic.actions.saveExperimentSuccess()
             logic.unmount()
             createLogic.unmount()
 
-            createLogic = createExperimentLogic({ tabId: TAB_ID })
+            createLogic = createExperimentLogic()
             createLogic.mount()
-            logic = experimentWizardLogic({ tabId: TAB_ID })
+            logic = experimentWizardLogic()
             logic.mount()
 
             await expectLogic(logic).toMatchValues({ currentStep: 'about' })
@@ -440,34 +429,34 @@ describe('experimentWizardLogic', () => {
 
         it('stale sessionStorage from previous session is cleared on fresh navigation', () => {
             // Simulate stale state: step saved from a previous experiment session
-            sessionStorage.setItem(stepStorageKey(TAB_ID), 'analytics')
+            sessionStorage.setItem(stepStorageKey(), 'analytics')
 
             // Simulate what experimentSceneLogic does on fresh navigation to /experiments/new
-            sessionStorage.removeItem(stepStorageKey(TAB_ID))
+            sessionStorage.removeItem(stepStorageKey())
 
             // Now mount the wizard — should start on 'about'
             logic.unmount()
             createLogic.unmount()
 
-            createLogic = createExperimentLogic({ tabId: TAB_ID })
+            createLogic = createExperimentLogic()
             createLogic.mount()
-            logic = experimentWizardLogic({ tabId: TAB_ID })
+            logic = experimentWizardLogic()
             logic.mount()
 
             expect(logic.values.currentStep).toBe('about')
         })
 
-        it('tab switch preserves step when sessionStorage is not cleared', async () => {
+        it('remount preserves step when sessionStorage is not cleared', async () => {
             logic.actions.setStep('variants')
             await expectLogic(logic).toMatchValues({ currentStep: 'variants' })
 
-            // Simulate tab switch: unmount and remount without clearing sessionStorage
+            // Unmount and remount without clearing sessionStorage
             logic.unmount()
             createLogic.unmount()
 
-            createLogic = createExperimentLogic({ tabId: TAB_ID })
+            createLogic = createExperimentLogic()
             createLogic.mount()
-            logic = experimentWizardLogic({ tabId: TAB_ID })
+            logic = experimentWizardLogic()
             logic.mount()
 
             await expectLogic(logic).toMatchValues({ currentStep: 'variants' })
@@ -487,10 +476,10 @@ describe('experimentWizardLogic', () => {
             featureFlagsLogic.mount()
             experimentsLogic.mount()
 
-            createLogic = createExperimentLogic({ tabId: TAB_ID })
+            createLogic = createExperimentLogic()
             createLogic.mount()
 
-            logic = experimentWizardLogic({ tabId: TAB_ID })
+            logic = experimentWizardLogic()
             logic.mount()
         })
 
@@ -578,7 +567,7 @@ describe('experimentWizardLogic', () => {
         it('existing feature flag key shows error when validation fails', async () => {
             // Directly set the validation result on the variantsPanelLogic instance
             // (the same instance createExperimentLogic connects to)
-            const vpLogic = variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: TAB_ID })
+            const vpLogic = variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false })
             vpLogic.actions.validateFeatureFlagKeySuccess({
                 valid: false,
                 error: 'A feature flag with this key already exists.',
@@ -592,9 +581,9 @@ describe('experimentWizardLogic', () => {
             })
         })
 
-        it('validation error is kept when switching back to original tab', async () => {
+        it('feature flag key is re-validated on remount', async () => {
             // Set up: trigger a duplicate-key validation error
-            const vpLogic = variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: TAB_ID })
+            const vpLogic = variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false })
             createLogic.actions.setExperimentValue('feature_flag_key', 'existing-flag')
             vpLogic.actions.validateFeatureFlagKeySuccess({
                 valid: false,
@@ -608,14 +597,14 @@ describe('experimentWizardLogic', () => {
                 }),
             })
 
-            // Simulate tab switch: unmount and remount
+            // Unmount and remount
             logic.unmount()
             vpLogic.unmount()
             createLogic.unmount()
 
-            createLogic = createExperimentLogic({ tabId: TAB_ID })
+            createLogic = createExperimentLogic()
             createLogic.mount()
-            logic = experimentWizardLogic({ tabId: TAB_ID })
+            logic = experimentWizardLogic()
             logic.mount()
 
             // afterMount should re-validate since feature_flag_key is set
@@ -673,10 +662,10 @@ describe('experimentWizardLogic', () => {
             featureFlagsLogic.mount()
             experimentsLogic.mount()
 
-            createLogic = createExperimentLogic({ tabId: TAB_ID })
+            createLogic = createExperimentLogic()
             createLogic.mount()
 
-            logic = experimentWizardLogic({ tabId: TAB_ID })
+            logic = experimentWizardLogic()
             logic.mount()
         })
 
@@ -723,10 +712,10 @@ describe('experimentWizardLogic', () => {
             featureFlagsLogic.mount()
             experimentsLogic.mount()
 
-            createLogic = createExperimentLogic({ tabId: TAB_ID })
+            createLogic = createExperimentLogic()
             createLogic.mount()
 
-            logic = experimentWizardLogic({ tabId: TAB_ID })
+            logic = experimentWizardLogic()
             logic.mount()
         })
 
@@ -740,7 +729,7 @@ describe('experimentWizardLogic', () => {
 
         const renderVariantsStep = (): void => {
             render(
-                <BindLogic logic={experimentWizardLogic} props={{ tabId: TAB_ID }}>
+                <BindLogic logic={experimentWizardLogic} props={{}}>
                     <VariantsStep />
                 </BindLogic>
             )
@@ -824,11 +813,9 @@ describe('experimentWizardLogic', () => {
         })
     })
 
-    describe('tab isolation of validation state', () => {
-        let createLogic1: ReturnType<typeof createExperimentLogic.build>
-        let createLogic2: ReturnType<typeof createExperimentLogic.build>
-        let wizardLogic1: ReturnType<typeof experimentWizardLogic.build>
-        let wizardLogic2: ReturnType<typeof experimentWizardLogic.build>
+    describe('auto-link guard against the shared flag-load singleton', () => {
+        let createLogic: ReturnType<typeof createExperimentLogic.build>
+        let logic: ReturnType<typeof experimentWizardLogic.build>
 
         beforeEach(() => {
             localStorage.clear()
@@ -839,61 +826,35 @@ describe('experimentWizardLogic', () => {
             featureFlagsLogic.mount()
             experimentsLogic.mount()
 
-            createLogic1 = createExperimentLogic({ tabId: 'tab-1' })
-            createLogic1.mount()
-            wizardLogic1 = experimentWizardLogic({ tabId: 'tab-1' })
-            wizardLogic1.mount()
-
-            createLogic2 = createExperimentLogic({ tabId: 'tab-2' })
-            createLogic2.mount()
-            wizardLogic2 = experimentWizardLogic({ tabId: 'tab-2' })
-            wizardLogic2.mount()
+            createLogic = createExperimentLogic()
+            createLogic.mount()
+            logic = experimentWizardLogic()
+            logic.mount()
         })
 
         afterEach(() => {
-            wizardLogic1?.unmount()
-            createLogic1?.unmount()
-            wizardLogic2?.unmount()
-            createLogic2?.unmount()
+            logic?.unmount()
+            createLogic?.unmount()
             experimentsLogic.unmount()
             featureFlagsLogic.unmount()
         })
 
-        it('validation error on tab 1 does not leak to tab 2', async () => {
-            // Tab 1: simulate validation result on the per-tab instance
-            const vpLogic = variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: 'tab-1' })
-            vpLogic.actions.validateFeatureFlagKeySuccess({
-                valid: false,
-                error: 'A feature flag with this key already exists.',
-                existingFlag: mockEligibleFlags[0] as FeatureFlagType,
+        it('a later flag load does not auto-link once the initial check is done', async () => {
+            // afterMount fires loadFeatureFlagsForAutocomplete; wait for the first
+            // success to mark the initial check done before a matching key is set.
+            await expectLogic(logic).toDispatchActions(['loadFeatureFlagsSuccess']).toMatchValues({
+                initialFlagCheckDone: true,
             })
 
-            await expectLogic(wizardLogic1).toMatchValues({
-                featureFlagKeyValidation: partial({
-                    valid: false,
-                    error: 'A feature flag with this key already exists.',
-                }),
-            })
+            createLogic.actions.setExperimentValue('feature_flag_key', 'existing-flag')
 
-            // Tab 2: should still have no validation state
-            await expectLogic(wizardLogic2).toMatchValues({
-                featureFlagKeyValidation: null,
-            })
-        })
+            // A subsequent flag load (e.g. from the shared selectExistingFeatureFlagModalLogic)
+            // must not retroactively auto-link the now-matching key.
+            await expectLogic(logic, () => {
+                logic.actions.loadFeatureFlagsForAutocomplete()
+            }).toDispatchActions(['loadFeatureFlagsSuccess'])
 
-        it('opening tab 2 does not auto-link flag on tab 1', async () => {
-            // Tab 1: set a feature flag key that matches an existing flag
-            createLogic1.actions.setExperimentValue('feature_flag_key', 'existing-flag')
-
-            // Simulate tab 2 mounting (which triggers loadFeatureFlagsForAutocomplete)
-            // This fires loadFeatureFlagsSuccess globally
-            wizardLogic2.actions.loadFeatureFlagsForAutocomplete()
-
-            // Wait for flags to load
-            await expectLogic(wizardLogic2).delay(100)
-
-            // Tab 1 should NOT have auto-linked the flag
-            await expectLogic(wizardLogic1).toMatchValues({
+            await expectLogic(logic).toMatchValues({
                 linkedFeatureFlag: null,
             })
         })

--- a/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentWizard/experimentWizardLogic.ts
@@ -18,15 +18,13 @@ const SHOW_GUIDE_DEFAULT = true
 
 const WIZARD_STEPS: ExperimentWizardStep[] = ['about', 'variants', 'analytics']
 
-export function stepStorageKey(tabId: string): string {
-    return `tab-${tabId}-experiment-wizard-step`
+export function stepStorageKey(): string {
+    return 'experiment-wizard-step'
 }
 
-// Writing step to storage is needed to support multiple in-app tabs open
-// while keeping its step state isolated.
-function readStoredStep(tabId: string): ExperimentWizardStep {
+function readStoredStep(): ExperimentWizardStep {
     try {
-        const stored = sessionStorage.getItem(stepStorageKey(tabId))
+        const stored = sessionStorage.getItem(stepStorageKey())
         if (stored && WIZARD_STEPS.includes(stored as ExperimentWizardStep)) {
             return stored as ExperimentWizardStep
         }
@@ -42,20 +40,18 @@ export const STEP_ORDER: Record<ExperimentWizardStep, number> = {
     analytics: 2,
 }
 
-export interface ExperimentWizardLogicProps {
-    tabId: string
-}
+export interface ExperimentWizardLogicProps {}
 
 export const experimentWizardLogic = kea<experimentWizardLogicType>([
     path(['scenes', 'experiments', 'wizard', 'experimentWizardLogic']),
 
     props({} as ExperimentWizardLogicProps),
 
-    key((props) => `${props.tabId}-create-experiment`),
+    key(() => 'create-experiment'),
 
-    connect((props: ExperimentWizardLogicProps) => ({
+    connect(() => ({
         values: [
-            createExperimentLogic({ tabId: props.tabId }),
+            createExperimentLogic(),
             [
                 'experiment',
                 'sharedMetrics',
@@ -65,7 +61,7 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
             ],
         ],
         actions: [
-            createExperimentLogic({ tabId: props.tabId }),
+            createExperimentLogic(),
             [
                 'setExperiment',
                 'setExperimentValue',
@@ -75,7 +71,7 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
                 'saveExperiment',
                 'saveExperimentSuccess',
             ],
-            variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false, tabId: props.tabId }),
+            variantsPanelLogic({ experiment: { ...NEW_EXPERIMENT }, disabled: false }),
             ['validateFeatureFlagKey', 'clearFeatureFlagKeyValidation'],
             selectExistingFeatureFlagModalLogic,
             ['loadFeatureFlagsForAutocomplete', 'loadFeatureFlagsSuccess'],
@@ -98,9 +94,9 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
         setLinkedFeatureFlag: (flag: FeatureFlagType | null) => ({ flag }),
     }),
 
-    reducers(({ props }: { props: ExperimentWizardLogicProps }) => ({
+    reducers(() => ({
         // Tracks whether the initial flag auto-link check has been performed.
-        // Prevents repeated auto-linking when other tabs trigger loadFeatureFlagsSuccess
+        // Prevents repeated auto-linking when loadFeatureFlagsSuccess fires again
         // on the shared selectExistingFeatureFlagModalLogic singleton.
         initialFlagCheckDone: [
             false,
@@ -124,7 +120,7 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
             },
         ],
         currentStep: [
-            readStoredStep(props.tabId),
+            readStoredStep(),
             {
                 _applyStep: (_, { step }) => step,
                 resetWizard: () => 'about',
@@ -229,24 +225,24 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
         ],
     }),
 
-    listeners(({ actions, props, values }) => ({
+    listeners(({ actions, values }) => ({
         _applyStep: ({ step }) => {
             try {
-                sessionStorage.setItem(stepStorageKey(props.tabId), step)
+                sessionStorage.setItem(stepStorageKey(), step)
             } catch {
                 // ignore
             }
         },
         resetWizard: () => {
             try {
-                sessionStorage.removeItem(stepStorageKey(props.tabId))
+                sessionStorage.removeItem(stepStorageKey())
             } catch {
                 // ignore
             }
         },
         saveExperimentSuccess: () => {
             try {
-                sessionStorage.removeItem(stepStorageKey(props.tabId))
+                sessionStorage.removeItem(stepStorageKey())
             } catch {
                 // ignore
             }
@@ -264,9 +260,9 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
         }: {
             featureFlags: { results: FeatureFlagType[]; count: number }
         }) => {
-            // Only auto-link on the first load for this tab. The
-            // selectExistingFeatureFlagModalLogic is a singleton, so other
-            // tabs loading flags would otherwise trigger auto-linking here.
+            // Only auto-link on the first load. The
+            // selectExistingFeatureFlagModalLogic is a shared singleton, so a
+            // later flag load elsewhere would otherwise trigger auto-linking here.
             if (values.initialFlagCheckDone) {
                 return
             }
@@ -318,8 +314,8 @@ export const experimentWizardLogic = kea<experimentWizardLogicType>([
             actions.reportExperimentWizardStarted(values.showGuide)
             actions.loadFeatureFlagsForAutocomplete()
             // Re-validate the feature flag key if one is already set.
-            // The per-tab variantsPanelLogic unmounts when switching tabs,
-            // so validation state is lost and needs to be re-checked.
+            // variantsPanelLogic unmounts when leaving the form, so validation
+            // state is lost and needs to be re-checked on remount.
             const key = values.experiment?.feature_flag_key
             if (key) {
                 actions.validateFeatureFlagKey(key)

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeConfigModal.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeConfigModal.tsx
@@ -14,7 +14,6 @@ import { runningTimeLogic } from './runningTimeLogic'
 
 export interface RunningTimeConfigModalProps {
     experimentId: Experiment['id']
-    tabId: string
 }
 
 const METRIC_TYPE_OPTIONS: { value: ManualCalculatorMetricType; label: string }[] = [
@@ -45,7 +44,7 @@ function getBaselineHelp(metricType: ManualCalculatorMetricType): string {
     }
 }
 
-export function RunningTimeConfigModal({ experimentId, tabId }: RunningTimeConfigModalProps): JSX.Element {
+export function RunningTimeConfigModal({ experimentId }: RunningTimeConfigModalProps): JSX.Element {
     const {
         config,
         manualFormPreview,
@@ -55,8 +54,8 @@ export function RunningTimeConfigModal({ experimentId, tabId }: RunningTimeConfi
         remainingDays,
         isRunningTimeConfigModalOpen,
         experiment,
-    } = useValues(runningTimeLogic({ experimentId, tabId }))
-    const { setConfig, save, cancel } = useActions(runningTimeLogic({ experimentId, tabId }))
+    } = useValues(runningTimeLogic({ experimentId }))
+    const { setConfig, save, cancel } = useActions(runningTimeLogic({ experimentId }))
 
     const hasAutomaticData = remainingDays !== null
     const isPreLaunch = !isLaunched(experiment)

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
@@ -22,7 +22,6 @@ import type { runningTimeLogicType } from './runningTimeLogicType'
 
 export interface RunningTimeLogicProps {
     experimentId: Experiment['id']
-    tabId: string
 }
 
 export interface RunningTimeConfig {
@@ -36,11 +35,11 @@ export interface RunningTimeConfig {
 export const runningTimeLogic = kea<runningTimeLogicType>([
     path(['scenes', 'experiments', 'RunningTimeCalculator', 'runningTimeLogic']),
     props({} as RunningTimeLogicProps),
-    key((props) => `${props.experimentId}-${props.tabId}`),
+    key((props) => `${props.experimentId}`),
 
     connect((props: RunningTimeLogicProps) => ({
         values: [
-            experimentLogic({ experimentId: props.experimentId, tabId: props.tabId }),
+            experimentLogic({ experimentId: props.experimentId }),
             ['experiment', 'orderedPrimaryMetricsWithResults', 'primaryMetricsResultsLoading', 'currentProjectId'],
             modalsLogic,
             ['isRunningTimeConfigModalOpen'],
@@ -48,7 +47,7 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
             ['defaultMinimumDetectableEffect'],
         ],
         actions: [
-            experimentLogic({ experimentId: props.experimentId, tabId: props.tabId }),
+            experimentLogic({ experimentId: props.experimentId }),
             ['updateExperiment', 'setExperiment'],
             modalsLogic,
             ['closeRunningTimeConfigModal'],

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -166,7 +166,6 @@ export interface ExperimentWarning {
 export interface ExperimentLogicProps {
     experimentId?: Experiment['id']
     formMode?: FormModes
-    tabId?: string
 }
 
 export type ExperimentTriggeredBy = 'page_load' | 'manual' | 'auto_refresh' | 'config_change'
@@ -555,10 +554,7 @@ export type ExperimentSavedMetric = {
 
 export const experimentLogic = kea<experimentLogicType>([
     props({} as ExperimentLogicProps),
-    key((props) => {
-        const baseKey = props.experimentId ?? 'new'
-        return `${baseKey}${props.tabId ? `-${props.tabId}` : ''}`
-    }),
+    key((props) => props.experimentId ?? 'new'),
     path((key) => ['scenes', 'experiment', 'experimentLogic', key]),
     connect(() => ({
         values: [
@@ -1387,8 +1383,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 const experimentId = response.id
                 refreshTreeItem('experiment', String(experimentId))
                 const navigateToExperiment = (): void => {
-                    const tabId = values.props.tabId
-                    const scene = tabId ? experimentSceneLogic.findMounted({ tabId }) : null
+                    const scene = experimentSceneLogic.findMounted()
                     if (scene) {
                         scene.actions.setSceneState(experimentId, FORM_MODES.update)
                     } else {

--- a/frontend/src/scenes/experiments/experimentSceneLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.test.ts
@@ -45,21 +45,7 @@ jest.mock('./experimentLogic', () => {
     }
 })
 
-jest.mock('scenes/sceneLogic', () => ({
-    sceneLogic: {
-        values: {
-            activeTabId: 'test-tab',
-            tabs: [],
-        },
-        actions: {
-            setTabs: jest.fn(),
-        },
-        isMounted: jest.fn(() => true),
-    },
-}))
-
 const mockModule = require('./experimentLogic') as ExperimentLogicMock
-const tabId = 'test-tab'
 
 describe('experimentSceneLogic', () => {
     beforeEach(() => {
@@ -70,7 +56,7 @@ describe('experimentSceneLogic', () => {
     })
 
     it('mounts experiment logic on scene state change', async () => {
-        const logic = experimentSceneLogic({ tabId, experimentId: 'new', formMode: FORM_MODES.create })
+        const logic = experimentSceneLogic({ experimentId: 'new', formMode: FORM_MODES.create })
         logic.mount()
 
         mockModule.experimentLogic.build.mockClear()
@@ -87,7 +73,7 @@ describe('experimentSceneLogic', () => {
     })
 
     it('does not rebuild logic when experiment id and mode stay the same', async () => {
-        const logic = experimentSceneLogic({ tabId, experimentId: 456 as any, formMode: FORM_MODES.update })
+        const logic = experimentSceneLogic({ experimentId: 456 as any, formMode: FORM_MODES.update })
         logic.mount()
 
         const initialBuildCount = mockModule.experimentLogic.build.mock.calls.length
@@ -111,7 +97,7 @@ describe('experimentSceneLogic', () => {
     })
 
     it('loads experiment data when scene state changes', async () => {
-        const logic = experimentSceneLogic({ tabId, experimentId: 789 as any, formMode: FORM_MODES.update })
+        const logic = experimentSceneLogic({ experimentId: 789 as any, formMode: FORM_MODES.update })
         logic.mount()
 
         mockModule.experimentLogic.__logic.actions.loadExperiment.mockClear()

--- a/frontend/src/scenes/experiments/experimentSceneLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.tsx
@@ -1,7 +1,6 @@
 import { BuiltLogic, actions, kea, listeners, path, props, reducers, selectors, sharedListeners } from 'kea'
 import { router, urlToAction } from 'kea-router'
 
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
@@ -21,14 +20,11 @@ import type { experimentLogicType } from './experimentLogicType'
 import type { experimentSceneLogicType } from './experimentSceneLogicType'
 import { stepStorageKey } from './ExperimentWizard/experimentWizardLogic'
 
-export interface ExperimentSceneLogicProps extends ExperimentLogicProps {
-    tabId?: string
-}
+export interface ExperimentSceneLogicProps extends ExperimentLogicProps {}
 
 export const experimentSceneLogic = kea<experimentSceneLogicType>([
     props({} as ExperimentSceneLogicProps),
     path(['scenes', 'experiments', 'experimentSceneLogic']),
-    tabAwareScene(),
     actions({
         setActiveTabKey: (activeTabKey: string) => ({ activeTabKey }),
         setSceneState: (experimentId: Experiment['id'], formMode: FormModes) => ({ experimentId, formMode }),
@@ -77,7 +73,6 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
         ],
     }),
     selectors({
-        tabId: [() => [(_, props) => props.tabId], (tabId: string | undefined): string | undefined => tabId],
         experimentSelector: [
             (s) => [s.experimentLogicRef],
             (experimentLogicRef) => experimentLogicRef?.logic.selectors.experiment,
@@ -164,10 +159,6 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
     }),
     sharedListeners(({ actions, values }) => ({
         ensureExperimentLogicMounted: () => {
-            if (!values.tabId) {
-                throw new Error('Tab-aware scene logic must have a tabId prop')
-            }
-
             const currentProps = values.experimentLogicRef?.props
             const desiredExperimentId = values.experimentId ?? 'new'
             const desiredFormMode = values.formMode ?? FORM_MODES.update
@@ -175,15 +166,13 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
             if (
                 !values.experimentLogicRef ||
                 currentProps?.experimentId !== desiredExperimentId ||
-                currentProps?.formMode !== desiredFormMode ||
-                currentProps?.tabId !== values.tabId
+                currentProps?.formMode !== desiredFormMode
             ) {
                 const oldRef = values.experimentLogicRef
 
                 const logicProps: ExperimentLogicProps = {
                     experimentId: desiredExperimentId,
                     formMode: desiredFormMode,
-                    tabId: values.tabId,
                 }
 
                 const logic = experimentLogic.build(logicProps)
@@ -273,7 +262,7 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
                     if (shouldReset) {
                         // Clear wizard step before the wizard mounts so it starts on 'about'
                         try {
-                            sessionStorage.removeItem(stepStorageKey(values.tabId!))
+                            sessionStorage.removeItem(stepStorageKey())
                         } catch {
                             // ignore
                         }

--- a/frontend/src/scenes/experiments/legacy/LegacyExperimentView.tsx
+++ b/frontend/src/scenes/experiments/legacy/LegacyExperimentView.tsx
@@ -25,7 +25,6 @@ import {
 import { Experiment } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
-import type { ExperimentSceneLogicProps } from '../experimentSceneLogic'
 import { experimentSceneLogic } from '../experimentSceneLogic'
 import { DistributionModal, DistributionTable } from '../ExperimentView/DistributionTable'
 import { ExperimentWarningBanner } from '../ExperimentView/ExperimentWarningBanners'
@@ -147,19 +146,14 @@ const VariantsTab = (): JSX.Element => {
  * @deprecated This component exists only to support existing legacy experiments.
  * New experiments use the modern ExperimentView component.
  */
-export function LegacyExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.Element {
-    if (!tabId) {
-        throw new Error('<LegacyExperimentView /> must receive a tabId prop')
-    }
-
+export function LegacyExperimentView(): JSX.Element {
     const { experimentLoading, experiment } = useValues(experimentLogic)
-    const { activeTabKey } = useValues(experimentSceneLogic({ tabId }))
-    const { setActiveTabKey } = useActions(experimentSceneLogic({ tabId }))
+    const { activeTabKey } = useValues(experimentSceneLogic)
+    const { setActiveTabKey } = useActions(experimentSceneLogic)
 
     // Props for legacy logic - uses experiment data from parent experimentLogic
     const legacyLogicProps = {
         experiment,
-        tabId,
     }
 
     // Mount the logic and load metrics when experiment is available

--- a/frontend/src/scenes/experiments/legacy/legacyExperimentLogic.tsx
+++ b/frontend/src/scenes/experiments/legacy/legacyExperimentLogic.tsx
@@ -24,7 +24,6 @@ import type { legacyExperimentLogicType } from './legacyExperimentLogicType'
 
 export interface LegacyExperimentLogicProps {
     experiment: Experiment
-    tabId: string
 }
 
 export type LegacyExperimentTriggeredBy = 'page_load' | 'manual' | 'auto_refresh' | 'config_change'
@@ -328,7 +327,7 @@ export const legacyExperimentLogic = kea<legacyExperimentLogicType>([
     props({} as LegacyExperimentLogicProps),
     key((props) => {
         const baseKey = props.experiment.id ?? 'new'
-        return `${baseKey}${props.tabId ? `-${props.tabId}` : ''}-legacy`
+        return `${baseKey}-legacy`
     }),
     path((key) => ['scenes', 'experiments', 'legacy', 'legacyExperimentLogic', key]),
     connect(() => ({


### PR DESCRIPTION
## Problem

PostHog's in-app browser-like scene tabs were removed a while ago. The experiment scene was still keyed by the scene `tabId` via `tabAwareScene()`, threaded it through the experiment logic tree, and used it to scope two `sessionStorage` keys (the create-experiment draft and the wizard step).

## Changes

De-tab the experiment scene tree:

- The experiment logics become singletons keyed by their real ids: `experimentSceneLogic` (drops `tabAwareScene()`), `experimentLogic` / `legacyExperimentLogic` (key drops the `-${tabId}` segment), `runningTimeLogic` (`${experimentId}`), `createExperimentLogic` / `experimentWizardLogic` (`'create-experiment'`), `variantsPanelLogic` (`experiment?.id || 'new'`).
- `tabId` props and threading are removed from all experiment components (`Experiment`, `ExperimentView`, `Info`, `RunningTime`, `RunningTimeConfigModal`, `LegacyExperimentView`).
- The two `sessionStorage` keys are now constants: `experiment-draft` and `experiment-wizard-step`.
- The `selfManagedSourceLogic` / `sourceSettingsLogic`-style `findMounted({ tabId: activeTabId })` lookups in the experiment tree drop the `tabId`. *(Note: the data-warehouse source `findMounted` hot-spots are a separate upcoming PR; this PR is experiments-only.)*

### Behaviour note

Because the scene `tabId` was random per navigation, the create-experiment draft and wizard step never survived a reload. With constant keys they now persist across reloads — which is exactly what the existing read/write/clear code intends. Within-session behaviour is unchanged; sessionStorage is per-browser-tab and short-lived, so any old per-tab entries are harmless.

The per-tab **isolation** tests (tab-1 vs tab-2 had independent drafts/steps) describe behaviour that no longer exists with one tab. They're rewritten as single-source lifecycle tests: a draft/step written on unmount is read back by a freshly-built logic, navigating away preserves it, and cancel clears it. Two `experimentWizardLogic()` references now correctly resolve to the same singleton.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I ran:

- `git grep -nw tabId -- frontend/src/scenes/experiments/` is empty (no scene tabId left); no external callers pass tabId to these logics.
- `kea-typegen write` regenerated all 908 logic types with no errors; `tsc --noEmit` reports no errors in experiments (only a pre-existing local `@posthog/hogvm` build issue remains, unrelated).
- `hogli test` passes: `createExperimentLogic.test` (25/25), `experimentWizardLogic.test` (38/38), `Experiment.test` (3/3); `experimentSceneLogic` and `variantsPanelLogic` suites also pass.
- oxfmt + the pre-commit lint-staged hook pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). Part of a Graphite stack removing the defunct in-app `tabId` scaffolding area-by-area. This is the experiments slice — behavioural because of the two sessionStorage keys.

Key decisions: (1) the storage keys become constants, which incidentally restores the intended across-reload persistence of drafts/wizard-step (the random per-navigation tabId had silently disabled it); (2) the per-tab isolation tests were replaced with single-source lifecycle tests rather than deleted, keeping read/write/clear coverage; making the logic a singleton required explicit per-test mount/unmount + `sessionStorage.clear()` so the shared instance doesn't leak state across tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
