### PR TITLE
refactor(data-warehouse): remove defunct scene tabId from sources

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
@@ -1,4 +1,4 @@
-import { BindLogic, connect, kea, path, props, selectors, useActions, useValues } from 'kea'
+import { BindLogic, connect, kea, path, selectors, useActions, useValues } from 'kea'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { IconCopy, IconQuestion } from '@posthog/icons'
@@ -53,13 +53,8 @@ export const getEffectiveAccessMethod = (
     return persistedAccessMethod
 }
 
-export interface NewSourceSceneLogicProps {
-    tabId: string
-}
-
 export const newSourceSceneLogic = kea<newSourceSceneLogicType>([
     path(['products', 'dataWarehouse', 'newSourceSceneLogic']),
-    props({} as NewSourceSceneLogicProps),
     connect(() => ({
         values: [availableSourcesLogic, ['availableSources', 'availableSourcesLoading']],
     })),
@@ -89,31 +84,21 @@ export const scene: SceneExport = {
     logic: newSourceSceneLogic,
 }
 
-export function NewSourceScene({ tabId }: { tabId?: string }): JSX.Element {
-    if (!tabId) {
-        throw new Error('NewSourceScene rendered with no tabId')
-    }
-
-    const sceneRootLogic = newSourceSceneLogic({ tabId })
+export function NewSourceScene(): JSX.Element {
+    const sceneRootLogic = newSourceSceneLogic()
     const { availableSources, availableSourcesLoading } = useValues(sceneRootLogic)
 
     if (availableSourcesLoading || availableSources === null) {
         return <LemonSkeleton />
     }
 
-    return <MountedNewSourceScene availableSources={availableSources} tabId={tabId} />
+    return <MountedNewSourceScene availableSources={availableSources} />
 }
 
-function MountedNewSourceScene({
-    availableSources,
-    tabId,
-}: {
-    availableSources: Record<string, SourceConfig>
-    tabId: string
-}): JSX.Element {
-    const sourceWizardLogicProps = useMemo(() => ({ availableSources, tabId }), [availableSources, tabId])
+function MountedNewSourceScene({ availableSources }: { availableSources: Record<string, SourceConfig> }): JSX.Element {
+    const sourceWizardLogicProps = useMemo(() => ({ availableSources }), [availableSources])
     const wizardLogic = sourceWizardLogic(sourceWizardLogicProps)
-    const sceneRootLogic = newSourceSceneLogic({ tabId })
+    const sceneRootLogic = newSourceSceneLogic()
 
     useAttachedLogic(wizardLogic, sceneRootLogic)
 

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/selfManagedSourceLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/selfManagedSourceLogic.tsx
@@ -7,7 +7,6 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
-import { sceneLogic } from 'scenes/sceneLogic'
 import { urls } from 'scenes/urls'
 
 import { DataTableNode } from '~/queries/schema/schema-general'
@@ -81,10 +80,7 @@ export const selfManagedSourceLogic = kea<selfManagedSourceLogicType>([
         },
         loadTableSuccess: async ({ table }) => {
             if (props.id) {
-                const activeTabId = sceneLogic.findMounted()?.values.activeTabId ?? undefined
-                sourceSceneLogic
-                    .findMounted({ id: `self-managed-${props.id}`, tabId: activeTabId })
-                    ?.actions.setBreadcrumbName(table.name)
+                sourceSceneLogic.findMounted({ id: `self-managed-${props.id}` })?.actions.setBreadcrumbName(table.name)
             }
         },
     })),

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
@@ -290,7 +290,6 @@ function syncExpandedDirectQuerySchemaKeys(
 export interface SourceWizardLogicProps {
     onComplete?: () => void
     availableSources: Record<string, SourceConfig>
-    tabId?: string
     /** When set, only these tables will be pre-selected and they cannot be deselected */
     requiredTables?: string[]
 }
@@ -298,7 +297,6 @@ export interface SourceWizardLogicProps {
 export const sourceWizardLogic = kea<sourceWizardLogicType>([
     path(['products', 'dataWarehouse', 'sourceWizardLogic']),
     props({} as SourceWizardLogicProps),
-    key((props) => props.tabId ?? 'default'),
     actions({
         selectConnector: (connector: SourceConfig | null, accessMethod?: 'warehouse' | 'direct') => ({
             connector,

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
@@ -16,7 +16,7 @@ describe('sourceWizardLogic', () => {
         initKeaTests()
     })
 
-    it('keeps wizard state isolated by tab id', () => {
+    it('shares a single wizard instance across references with the same props', () => {
         const postgresSource = {
             name: 'Postgres',
             iconPath: '',
@@ -24,61 +24,20 @@ describe('sourceWizardLogic', () => {
             fields: [],
         } as SourceConfig
         const availableSources = { Postgres: postgresSource }
-        const firstTabLogic = sourceWizardLogic({ availableSources, tabId: 'first-tab' })
-        const secondTabLogic = sourceWizardLogic({ availableSources, tabId: 'second-tab' })
-        const unmountFirstTabLogic = firstTabLogic.mount()
-        const unmountSecondTabLogic = secondTabLogic.mount()
+        const firstReference = sourceWizardLogic({ availableSources })
+        const secondReference = sourceWizardLogic({ availableSources })
+        const unmount = firstReference.mount()
 
         try {
-            firstTabLogic.actions.selectConnector(postgresSource)
-            firstTabLogic.actions.setStep(2)
-            firstTabLogic.actions.setSourceConnectionDetailsValue(['payload', 'host'], 'first.example.com')
-            secondTabLogic.actions.setStep(3)
-            secondTabLogic.actions.setSourceConnectionDetailsValue(['payload', 'host'], 'second.example.com')
+            firstReference.actions.selectConnector(postgresSource)
+            firstReference.actions.setStep(2)
+            firstReference.actions.setSourceConnectionDetailsValue(['payload', 'host'], 'shared.example.com')
 
-            expect(firstTabLogic.values.selectedConnector?.name).toEqual('Postgres')
-            expect(firstTabLogic.values.currentStep).toEqual(2)
-            expect(firstTabLogic.values.sourceConnectionDetails.payload.host).toEqual('first.example.com')
-            expect(secondTabLogic.values.selectedConnector).toBeNull()
-            expect(secondTabLogic.values.currentStep).toEqual(3)
-            expect(secondTabLogic.values.sourceConnectionDetails.payload.host).toEqual('second.example.com')
+            expect(secondReference.values.selectedConnector?.name).toEqual('Postgres')
+            expect(secondReference.values.currentStep).toEqual(2)
+            expect(secondReference.values.sourceConnectionDetails.payload.host).toEqual('shared.example.com')
         } finally {
-            unmountFirstTabLogic()
-            unmountSecondTabLogic()
-        }
-    })
-
-    it('preserves wizard state while attached to the mounted scene tab', () => {
-        const postgresSource = {
-            name: 'Postgres',
-            iconPath: '',
-            caption: null,
-            fields: [],
-        } as SourceConfig
-        const availableSources = { Postgres: postgresSource }
-        const attachedLogic = sourceWizardLogic({ availableSources, tabId: 'remounted-tab' })
-        const unmountAttached = attachedLogic.mount()
-        const firstMount = sourceWizardLogic({ availableSources, tabId: 'remounted-tab' })
-        const unmountFirst = firstMount.mount()
-
-        try {
-            firstMount.actions.selectConnector(postgresSource)
-            firstMount.actions.setStep(2)
-            firstMount.actions.setSourceConnectionDetailsValue(['payload', 'host'], 'kept.example.com')
-            unmountFirst()
-
-            const secondMount = sourceWizardLogic({ availableSources, tabId: 'remounted-tab' })
-            const unmountSecond = secondMount.mount()
-
-            try {
-                expect(secondMount.values.selectedConnector?.name).toEqual('Postgres')
-                expect(secondMount.values.currentStep).toEqual(2)
-                expect(secondMount.values.sourceConnectionDetails.payload.host).toEqual('kept.example.com')
-            } finally {
-                unmountSecond()
-            }
-        } finally {
-            unmountAttached()
+            unmount()
         }
     })
 
@@ -703,7 +662,6 @@ describe('sourceWizardLogic', () => {
         ): { logic: ReturnType<typeof sourceWizardLogic>; unmount: () => void } => {
             const logic = sourceWizardLogic({
                 availableSources: { Stripe: stripeSource },
-                tabId: `perm-test-${Math.random()}`,
             })
             const unmount = logic.mount()
             logic.actions.selectConnector(stripeSource)

--- a/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
@@ -46,7 +46,6 @@ export type SourceSceneTab = (typeof SOURCE_SCENE_TABS)[number]
 
 export interface SourceSceneProps {
     id: string
-    tabId?: string
 }
 
 export function getDefaultDataWarehouseSourceSceneTab(id?: string): SourceSceneTab {
@@ -65,7 +64,7 @@ export function shouldShowManagedSourceSyncsTab(
 
 export const sourceSceneLogic = kea<sourceSceneLogicType>([
     props({} as SourceSceneProps),
-    key(({ id, tabId }: SourceSceneProps) => (tabId ? `${id}-${tabId}` : id)),
+    key(({ id }: SourceSceneProps) => id),
     path((key) => ['products', 'dataWarehouse', 'sourceSceneLogic', key]),
     actions({
         setCurrentTab: (tab: SourceSceneTab) => ({ tab }),
@@ -159,8 +158,8 @@ export const scene: SceneExport<(typeof sourceSceneLogic)['props']> = {
     paramsToProps: ({ params: { id } }) => ({ id }),
 }
 
-export function SourceScene({ id, tabId }: SourceSceneProps): JSX.Element {
-    const logic = sourceSceneLogic({ id, tabId })
+export function SourceScene({ id }: SourceSceneProps): JSX.Element {
+    const logic = sourceSceneLogic({ id })
     const { currentTab, breadcrumbName } = useValues(logic)
     const { setCurrentTab } = useActions(logic)
 
@@ -184,7 +183,6 @@ export function SourceScene({ id, tabId }: SourceSceneProps): JSX.Element {
                     currentTab={currentTab}
                     setCurrentTab={setCurrentTab}
                     attachTo={logic}
-                    tabId={tabId}
                 />
             ) : (
                 <LemonTabs
@@ -209,13 +207,11 @@ function ManagedSourceTabs({
     currentTab,
     setCurrentTab,
     attachTo,
-    tabId,
 }: {
     sourceId: string
     currentTab: SourceSceneTab
     setCurrentTab: (tab: SourceSceneTab) => void
     attachTo: BuiltLogic | LogicWrapper
-    tabId?: string
 }): JSX.Element {
     const settingsLogic = sourceSettingsLogic({ id: sourceId, availableSources: {} })
     const { featureFlags } = useValues(featureFlagLogic)
@@ -261,7 +257,7 @@ function ManagedSourceTabs({
         tabs.push({
             label: 'Webhook',
             key: 'webhook',
-            content: <WebhookTab id={sourceId} tabId={tabId} />,
+            content: <WebhookTab id={sourceId} />,
         })
     }
 

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/WebhookTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/WebhookTab.tsx
@@ -45,7 +45,7 @@ const WEBHOOK_METRICS_INFO: Record<string, { name: string; description: string; 
     },
 }
 
-export function WebhookTab({ id, tabId }: { id: string; tabId?: string }): JSX.Element {
+export function WebhookTab({ id }: { id: string }): JSX.Element {
     const {
         webhookInfo,
         webhookInfoLoading,
@@ -59,10 +59,8 @@ export function WebhookTab({ id, tabId }: { id: string; tabId?: string }): JSX.E
         canDeleteWebhook,
         webhookDeleting,
         currentSection,
-    } = useValues(webhookTabLogic({ id, tabId }))
-    const { createWebhook, loadWebhookInfo, deleteWebhook, setCurrentSection } = useActions(
-        webhookTabLogic({ id, tabId })
-    )
+    } = useValues(webhookTabLogic({ id }))
+    const { createWebhook, loadWebhookInfo, deleteWebhook, setCurrentSection } = useActions(webhookTabLogic({ id }))
 
     if (webhookInfoLoading && !webhookInfo) {
         return (
@@ -75,7 +73,7 @@ export function WebhookTab({ id, tabId }: { id: string; tabId?: string }): JSX.E
     }
 
     // No webhook exists yet — show setup flow (or re-creation if external webhook is missing)
-    const logicProps = { id, tabId }
+    const logicProps = { id }
 
     if (!webhookInfo?.exists) {
         return (
@@ -133,7 +131,6 @@ export function WebhookTab({ id, tabId }: { id: string; tabId?: string }): JSX.E
                             webhookCreating={webhookCreating}
                             createWebhookResult={createWebhookResult}
                             onCreateWebhook={createWebhook}
-                            tabId={tabId}
                         />
                     )}
                     <WebhookDetailsSection webhookInfo={webhookInfo} />
@@ -197,7 +194,7 @@ function WebhookConfigurationSection({
     formLogicProps,
 }: {
     sourceConfig: SourceConfig
-    formLogicProps: { id: string; tabId?: string }
+    formLogicProps: { id: string }
 }): JSX.Element {
     const { webhookFieldInputs, isWebhookFieldInputsSubmitting } = useValues(webhookTabLogic(formLogicProps))
     const webhookFields = sourceConfig.webhookFields ?? []
@@ -297,7 +294,6 @@ function WebhookStatusSection({
 
 function WebhookRecreateSection({
     id,
-    tabId,
     sourceName,
     sourceConfig,
     webhookCreating,
@@ -305,7 +301,6 @@ function WebhookRecreateSection({
     onCreateWebhook,
 }: {
     id: string
-    tabId?: string
     sourceName: string
     sourceConfig: any
     webhookCreating: boolean
@@ -319,7 +314,7 @@ function WebhookRecreateSection({
             webhookResult={createWebhookResult}
             webhookCreating={webhookCreating}
             onCreateWebhook={onCreateWebhook}
-            formLogic={webhookTabLogic({ id, tabId })}
+            formLogic={webhookTabLogic({ id })}
             formKey="webhookFieldInputs"
         />
     )

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
@@ -128,9 +128,7 @@ describe('sourceSettingsLogic', () => {
         expect(logic.values.source?.schemas[0].should_sync).toBe(false)
     })
 
-    it('uses separate logic instances per browser tab', () => {
-        expect(sourceSettingsLogic({ id: 'source-1', tabId: 'tab-a' }).key).toEqual('source-1-tab-a')
-        expect(sourceSettingsLogic({ id: 'source-1', tabId: 'tab-b' }).key).toEqual('source-1-tab-b')
+    it('keys the logic by source id', () => {
         expect(sourceSettingsLogic({ id: 'source-1' }).key).toEqual('source-1')
     })
 
@@ -145,18 +143,18 @@ describe('sourceSettingsLogic', () => {
         expect(loadJobsSpy).not.toHaveBeenCalled()
     })
 
-    it('dispatches breadcrumb name to the sourceSceneLogic keyed with props.tabId', async () => {
-        const sceneLogicForTab = sourceSceneLogic({ id: 'managed-source-1', tabId: 'tab-a' })
-        sceneLogicForTab.mount()
+    it('dispatches breadcrumb name to the sourceSceneLogic for the source', async () => {
+        const sceneLogicForSource = sourceSceneLogic({ id: 'managed-source-1' })
+        sceneLogicForSource.mount()
 
-        logic = sourceSettingsLogic({ id: 'source-1', tabId: 'tab-a' })
+        logic = sourceSettingsLogic({ id: 'source-1' })
         logic.mount()
 
         await expectLogic(logic).toFinishAllListeners()
 
-        expect(sceneLogicForTab.values.breadcrumbName).toEqual('warehouse')
+        expect(sceneLogicForSource.values.breadcrumbName).toEqual('warehouse')
 
-        sceneLogicForTab.unmount()
+        sceneLogicForSource.unmount()
     })
 
     it.each([408, 502, 503, 504])(

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
@@ -8,7 +8,6 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { objectsEqual, pluralize } from 'lib/utils'
-import { sceneLogic } from 'scenes/sceneLogic'
 import { urls } from 'scenes/urls'
 
 import { SourceConfig, SourceFieldConfig } from '~/queries/schema/schema-general'
@@ -31,7 +30,6 @@ import type { sourceSettingsLogicType } from './sourceSettingsLogicType'
 
 export interface SourceSettingsLogicProps {
     id: string
-    tabId?: string
     availableSources?: Record<string, SourceConfig>
 }
 
@@ -263,7 +261,7 @@ function reportBulkResult(verb: string, total: number, failed: number, skipped: 
 export const sourceSettingsLogic = kea<sourceSettingsLogicType>([
     path(['products', 'dataWarehouse', 'sourceSettingsLogic']),
     props({} as SourceSettingsLogicProps),
-    key(({ id, tabId }) => (tabId ? `${id}-${tabId}` : id)),
+    key(({ id }) => id),
     connect(() => ({
         values: [availableSourcesLogic, ['availableSources']],
         actions: [sourcesDataLogic, ['updateSource']],
@@ -774,10 +772,9 @@ export const sourceSettingsLogic = kea<sourceSettingsLogicType>([
                     }, 'sourceRefreshTimeout')
                 }
 
-                const tabId = props.tabId ?? sceneLogic.findMounted()?.values.activeTabId ?? undefined
                 const sceneLogicInstance =
-                    sourceSceneLogic.findMounted({ id: `managed-${props.id}`, tabId }) ??
-                    sourceSceneLogic.findMounted({ id: props.id, tabId })
+                    sourceSceneLogic.findMounted({ id: `managed-${props.id}` }) ??
+                    sourceSceneLogic.findMounted({ id: props.id })
 
                 sceneLogicInstance?.actions.setBreadcrumbName(breadcrumbName)
             },

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/webhookTabLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/webhookTabLogic.ts
@@ -17,7 +17,6 @@ import type { webhookTabLogicType } from './webhookTabLogicType'
 
 export interface WebhookTabLogicProps {
     id: string
-    tabId?: string
 }
 
 export const WEBHOOK_SECTIONS = ['overview', 'configuration', 'activity'] as const


### PR DESCRIPTION
## Problem

PostHog's in-app browser-like scene tabs were removed a while ago. The data-warehouse **source** scenes (SourceScene + NewSourceScene) were still keyed by the scene `tabId` and threaded it through their logics and components, including two `findMounted` lookups that fell back to `sceneLogic.values.activeTabId`.

## Changes

De-tab the source scene trees, making the logics singletons keyed by their real ids:

- `sourceSceneLogic` and `sourceSettingsLogic`: key `({ id, tabId }) => (tabId ? \`${id}-${tabId}\` : id)` -> `({ id }) => id`.
- `webhookTabLogic`: removed the vestigial `tabId` prop (its key was already `({ id }) => id`).
- `sourceWizardLogic`: key `(props) => props.tabId ?? 'default'` -> singleton (`() => 'new-source'`); the inline `newSourceSceneLogic` becomes a bare singleton.
- `selfManagedSourceLogic` and `sourceSettingsLogic`: the breadcrumb `findMounted` lookups stop reading `sceneLogic.values.activeTabId` — they now find the source scene logic by `id` alone.
- `SourceScene`, `NewSourceScene`, `WebhookTab` stop threading `tabId` (and `NewSourceScene` drops its `if (!tabId) throw`).

The SQL **editor** (`sqlEditorLogic` and its instance-keyed tree) is deliberately untouched — that's a separate upcoming PR.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I ran:

- `git grep -nw tabId` over both source scene trees is empty; no editor files touched; no external callers passed `tabId` into these logics.
- `kea-typegen write` regenerated all 908 logic types with no errors; `tsc --noEmit` reports no errors in `data_warehouse` (only a pre-existing local `@posthog/hogvm` build issue remains, unrelated).
- `hogli test` passes: `sourceWizardLogic.test` (36/36), `dataWarehouseSourceSettingsLogic.test` (10/10).
- oxfmt + the pre-commit lint-staged hook pass.

The per-tab isolation tests in `sourceWizardLogic.test` (two tabs with independent wizard state) no longer apply with a singleton; they're rewritten as a single-instance test (two references share one instance + state). The `sourceSettingsLogic` key assertion `'source-1-tab-a'` becomes `'source-1'`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). Part of a Graphite stack removing the defunct in-app `tabId` scaffolding area-by-area. This is the data-warehouse source-scenes slice. All `tabId` here was the scene tab (no shared/legitimate tab concept like insights' web-analytics case), so the de-key is straightforward; the only behavioural nuance was the two `findMounted` lookups that previously fell back to `activeTabId`, now keyed by source id alone.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
