### PR TITLE
refactor(data-warehouse): inline tabAwareScene in SQL editor

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -1,8 +1,7 @@
 import equal from 'fast-deep-equal'
-import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { removeUndefinedAndNull } from 'lib/utils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { Scene } from 'scenes/sceneTypes'
@@ -56,7 +55,7 @@ export interface EditorSceneLogicProps {
 export const editorSceneLogic = kea<editorSceneLogicType>([
     path(['data-warehouse', 'editor', 'editorSceneLogic']),
     props({} as EditorSceneLogicProps),
-    tabAwareScene(),
+    key((props) => props.tabId),
     connect((props: EditorSceneLogicProps) => ({
         values: [
             sqlEditorLogic({ tabId: props.tabId }),

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -6,6 +6,7 @@ import {
     beforeUnmount,
     connect,
     kea,
+    key,
     listeners,
     path,
     props,
@@ -27,7 +28,6 @@ import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { clearLogicReference, initModel } from 'lib/monaco/CodeEditor'
 import { codeEditorLogic } from 'lib/monaco/codeEditorLogic'
@@ -395,7 +395,7 @@ function applyUndoableModelEdit(monaco: Monaco | null | undefined, uri: Uri | un
 export const sqlEditorLogic = kea<sqlEditorLogicType>([
     path(['data-warehouse', 'editor', 'sqlEditorLogic']),
     props({ mode: SQLEditorMode.FullScene } as SqlEditorLogicProps),
-    tabAwareScene(),
+    key((props) => props.tabId),
     connect((props: SqlEditorLogicProps) => ({
         values: [
             dataWarehouseViewsLogic,


### PR DESCRIPTION
## Problem

`tabAwareScene()` is just `key((props) => props.tabId)` with a guard, and the SQL editor (`sqlEditorLogic`, `editorSceneLogic`) is its last caller — blocking removal of the helper.

## Changes

Inline it to `key((props) => props.tabId)` in both logics. No behaviour change: both stay keyed by `tabId`, so the full-scene editor and every embedded editor (notebooks, models, endpoints, logs, metrics) keep their isolated instances and Monaco models. The helper itself is deleted in the cleanup PR.

## How did you test this code?

PostHog Code (agent): `sqlEditorLogic.test.ts` 56/56, `tsc` clean for `data-warehouse/editor`, oxfmt clean.

## 🤖 Agent context

Smallest change that frees `tabAwareScene` for deletion without touching SQL editor behaviour (owners want `tabId` kept as a prop). 2 files. Part of the stack removing the defunct in-app-tab scaffolding.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
