### PR TITLE
feat(taxonomic-filter): stamp explicit surface on legacy telemetry

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -14,6 +14,7 @@ import {
     hasPinnedContext,
     taxonomicFilterPinnedPropertiesLogic,
 } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
+import { legacyTaxonomicSurface } from 'lib/components/TaxonomicFilter/taxonomicFilterSurface'
 import {
     ExcludedOperators,
     InfiniteListLogicProps,
@@ -29,6 +30,7 @@ import {
     TaxonomicFilterGroupType,
 } from 'lib/components/TaxonomicFilter/types'
 import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { createFuse } from 'lib/utils/fuseSearch'
 import { mapGroupQueryResponse } from 'lib/utils/groups'
 
@@ -1091,6 +1093,9 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 if (cache.lastEmptyResultDedupeKey !== dedupeKey) {
                     cache.lastEmptyResultDedupeKey = dedupeKey
                     posthog.capture('taxonomic filter empty result', {
+                        surface: legacyTaxonomicSurface(
+                            posthog.getFeatureFlag(FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN)
+                        ),
                         groupType: props.listGroupType,
                         searchQuery: trimmedQuery,
                     })

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -31,6 +31,7 @@ import {
     stripRecentContext,
 } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
 import { hasPinnedContext } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
+import { legacyTaxonomicSurface } from 'lib/components/TaxonomicFilter/taxonomicFilterSurface'
 import {
     DataWarehousePopoverField,
     ExcludedProperties,
@@ -1766,6 +1767,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         // and inflates the abandonment metric (top sessions hit 100+ closes pre-gate).
         if (values.hadInteraction) {
             posthog.capture('taxonomic filter closed', {
+                surface: legacyTaxonomicSurface(values.featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN]),
                 dwellMs: Date.now() - (cache.openedAt ?? Date.now()),
                 hadSelection: !!cache.hadSelection,
                 groupType: values.activeTab,
@@ -1797,6 +1799,9 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         : undefined
 
                 posthog.capture('taxonomic filter item selected', {
+                    surface: legacyTaxonomicSurface(
+                        values.featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN]
+                    ),
                     groupType: values.activeTab,
                     sourceGroupType,
                     wasFromPinnedList,
@@ -1950,6 +1955,9 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 const inputMode: 'pasted' | 'mixed' | 'typed' =
                     pastedChars >= totalLength && pastedChars > 0 ? 'pasted' : pastedChars > 0 ? 'mixed' : 'typed'
                 posthog.capture('taxonomic_filter_search_query', {
+                    surface: legacyTaxonomicSurface(
+                        values.featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN]
+                    ),
                     searchQuery,
                     groupType: activeTaxonomicGroup?.type,
                     inputMode,

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterSurface.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterSurface.test.ts
@@ -6,6 +6,8 @@ describe('legacyTaxonomicSurface', () => {
         ['control', 'legacy-control'],
         [undefined, 'legacy-control'],
         [true, 'legacy-control'],
+        // `posthog.getFeatureFlag` returns `false` (not undefined) for a loaded flag with no variant.
+        [false, 'legacy-control'],
         ['', 'legacy-control'],
     ])('maps category-dropdown variant %p to %p', (variant, expected) => {
         expect(legacyTaxonomicSurface(variant as string | boolean | undefined)).toBe(expected)

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterSurface.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterSurface.test.ts
@@ -1,0 +1,13 @@
+import { legacyTaxonomicSurface } from './taxonomicFilterSurface'
+
+describe('legacyTaxonomicSurface', () => {
+    it.each([
+        ['pill', 'legacy-pill'],
+        ['control', 'legacy-control'],
+        [undefined, 'legacy-control'],
+        [true, 'legacy-control'],
+        ['', 'legacy-control'],
+    ])('maps category-dropdown variant %p to %p', (variant, expected) => {
+        expect(legacyTaxonomicSurface(variant as string | boolean | undefined)).toBe(expected)
+    })
+})

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterSurface.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterSurface.ts
@@ -1,0 +1,9 @@
+/** The legacy TaxonomicFilter surface, derived from the category-dropdown A/B
+ *  variant, stamped on the `taxonomic filter *` telemetry events so the arms are
+ *  distinguishable by an explicit property rather than a feature-flag join. The
+ *  rebuild menu emits `rebuild-menu` for the same purpose. */
+export function legacyTaxonomicSurface(
+    categoryDropdownVariant: string | boolean | undefined
+): 'legacy-control' | 'legacy-pill' {
+    return categoryDropdownVariant === 'pill' ? 'legacy-pill' : 'legacy-control'
+}


### PR DESCRIPTION
## Problem

We are A/B testing a rebuilt TaxonomicFilter (staff-only) against the existing one, whose `pill` arm performs well. To compare the arms we rely on the `taxonomic filter *` telemetry, but the legacy filter does not record *which* surface produced an event — so distinguishing arms means joining on a feature-flag property. That join is brittle and couples analysis to flag-evaluation history.

This is the legacy half of making the surface concrete. The rebuild menu already emits an explicit `surface: 'rebuild-menu'` on its events (#62043).

## Changes

- New `taxonomicFilterSurface.ts` with `legacyTaxonomicSurface(variant)`, deriving `legacy-control` / `legacy-pill` from the `TAXONOMIC_FILTER_CATEGORY_DROPDOWN` variant.
- Stamp `surface` on the four legacy emitters: `taxonomic filter closed`, `taxonomic filter item selected`, `taxonomic_filter_search_query` (in `taxonomicFilterLogic`), and `taxonomic filter empty result` (in `infiniteListLogic`, which reads the flag via `posthog.getFeatureFlag` since it does not connect `featureFlags`).

No property shapes change beyond the additive `surface` field; no behaviour changes.

## How did you test this code?

I am an agent. Automated only:

- New parameterized unit test `taxonomicFilterSurface.test.ts` (5 cases) covering the variant -> surface mapping.
- `taxonomicFilterLogic.test.ts` + `infiniteListLogic.test.ts` (111 tests) still pass.
- Local `typescript:check` shows only the pre-existing stale kea-typegen noise (missing `*LogicType` modules); nothing references these additions.

## 🤖 Agent context

Authored with PostHog Code (Claude). The user asked to stop relying on a feature-flag join to tell the TaxonomicFilter A/B arms apart and instead stamp an explicit `surface` on both implementations. The rebuild side shipped on #62043; this is the legacy companion. A shared helper keeps the control/pill mapping in one place and parameterized-testable. `infiniteListLogic` reads the flag directly via `posthog.getFeatureFlag` rather than wiring a new `featureFlags` connection, to keep the change minimal.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
