### PR TITLE
chore(ci): stop CI dual-write of PR stats to project 2 (org webhook covers it)

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -83,12 +83,6 @@ jobs:
                   echo "pr_title_escaped<<EOF" >> $GITHUB_ENV
                   echo "$pr_title_escaped" >> $GITHUB_ENV
                   echo "EOF" >> $GITHUB_ENV
-            - name: Capture PR age to PostHog
-              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
-              with:
-                  posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
-                  event: 'posthog-ci-pr-stats'
-                  properties: '{"prAgeInSeconds": ${{ env.pr_age }}, "isRevert": ${{env.is_revert}}, "prTitle": ${{ env.pr_title_escaped }}, "prNumber": "${{ github.event.pull_request.number}}"  }'
             - name: Capture PR age to DevEx PostHog
               continue-on-error: true
               uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0


### PR DESCRIPTION
## Problem

PR throughput and age-to-merge are tracked in PostHog via the `posthog-pr-metrics` action (project 2). The `report-pr-age` job here dual-wrote the `posthog-ci-pr-stats` event to both project 2 and the DevEx project. Project 2 is now fed org-wide by a single GitHub organization webhook → PostHog incoming-webhook HogFunction (emitting `posthog-ci-pr-merged`) for every repo, so the project-2 capture in this job is redundant and would double-count.

## Changes

Removes only the **"Capture PR age to PostHog"** (project 2) step from `report-pr-age`. The **DevEx** capture step is intentionally kept — the org webhook feeds project 2 only, and the DevEx team will be moved to the new approach separately. `Calculate PR age` and the other jobs are unchanged.

The `posthog-pr-metrics` action now matches `posthog-ci-pr-stats` (history) + `posthog-ci-pr-merged` (new), so project-2 insights transition with no edits.

Note: the kept DevEx step retains `continue-on-error: true`, so DevEx capture failures stay silent — worth that team knowing, since that's how a feed can break unnoticed.

## How did you test this code?

I'm an agent (PostHog Code). CI-only change, no automated tests. Verified the diff removes only the project-2 capture step (6 lines) and leaves `Calculate PR age` + the DevEx step intact; YAML passed lint-staged formatting on commit. The org webhook → `posthog-ci-pr-merged` path is live; first captured event pending the next org merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by PostHog Code on behalf of @pauldambra. Part of moving project-2 PR-merge metrics to an org-level GitHub webhook → incoming-webhook HogFunction (`posthog-ci-pr-merged`); the `posthog-pr-metrics` action (id 28216) matches both legacy and new events. Scope was narrowed from "remove the whole job" to "remove only the project-2 capture" at the author's request — the DevEx dual-write stays until that team migrates.
