### PR TITLE
chore(signals): document session-logs tool in exploring-signals-scouts skill

### DIFF
--- a/products/signals/skills/exploring-signals-scouts/SKILL.md
+++ b/products/signals/skills/exploring-signals-scouts/SKILL.md
@@ -145,7 +145,15 @@ Returns the full run: `status`, `started_at` / `completed_at` (compute duration 
 `task_url`. The transcript — the actual tool calls and reasoning — lives in the Tasks UI behind
 `task_url`, not in this payload; hand the user that link when they want to see every step. A
 **failed** run returns an empty `summary` and **no error field** — the payload looks the same as
-the list row, so to learn _why_ it failed you must open `task_url`.
+the list row, so to learn _why_ it failed you need the transcript.
+
+You don't have to open the UI for that: **`tasks-runs-session-logs-retrieve` returns the run's
+session log (every tool call, message, and reasoning step) as data** — handy when you're
+diagnosing a failure or want to trace exactly what a run did without leaving the conversation. Pass
+the run's `task_run_id` as `id` and its `task_id` (both are on the run row). The raw stream is
+large and dominated by incremental `tool_call_update` chunks, so filter to keep it readable — e.g.
+`exclude_types: "tool_call_update,usage_update,_posthog/console,agent_thought_chunk"` leaves just
+the `tool_call` and `agent_message` events, which is enough to reconstruct the run's timeline.
 
 **Telling whether a run emitted is not as direct as you'd hope.** The run row carries no emit
 flag and no finding count — the only readily-available signal is the prose `summary`, which says
@@ -250,8 +258,12 @@ below. The full playbook, including how to read each signal and the common failu
   "scout-emitted" filter — judge emit-vs-quiet from each run's `summary`, and don't read an empty
   `source_product: "signals_scout"` inbox result as "the fleet emitted nothing."
 - **A ~30-min run that `failed` is usually a timeout, not a broken scout.** Completed runs finish
-  in a couple of minutes; a run that ran the full budget and failed over-investigated. The fleet
-  self-corrects by writing "tight-run recipe" scratchpad entries.
+  in a couple of minutes. Most often the scout over-investigated and ran the full budget (the fleet
+  self-corrects by writing "tight-run recipe" scratchpad entries) — but some are false timeouts
+  where the scout actually finished in a few minutes and the run then hung on a dropped close-out.
+  The session log (above) tells them apart: real over-investigation shows tool calls right up to the
+  wall; a false timeout goes silent long before it. Don't assume over-investigation from duration
+  alone.
 - **Lead with the run `summary`**, then offer `task_url` for the full transcript — don't dump raw
   run rows at the user.
 - **`last_run_at: null`** means a scout has never fired — check it's enabled and the project is

--- a/products/signals/skills/exploring-signals-scouts/references/assessing-performance.md
+++ b/products/signals/skills/exploring-signals-scouts/references/assessing-performance.md
@@ -34,17 +34,22 @@ dispatching it as often as configured.
 
 ### 2. Success rate — are runs completing cleanly?
 
-Count clean completions vs. `failed` runs over the window. Distinguish two failure modes by
-duration: a `failed` run that ran ~30 minutes (the per-run budget) before failing **timed out** —
-the scout over-investigated, which is common and semi-expected on high-volume surfaces (logs, error
-tracking), and the fleet self-corrects by writing "tight-run recipe" scratchpad entries. A `failed`
-run that died quickly is more likely genuinely broken.
+Count clean completions vs. `failed` runs over the window. Distinguish failure modes by duration: a
+`failed` run that ran ~30 minutes (the per-run budget) before failing **timed out**; a `failed` run
+that died quickly is more likely genuinely broken. Most timeouts are over-investigation — the scout
+ran to the wall, common and semi-expected on high-volume surfaces (logs, error tracking), and the
+fleet self-corrects by writing "tight-run recipe" scratchpad entries. But a timeout can also be a
+**false timeout**: the scout finished in a few minutes and the run then hung on a dropped close-out,
+so don't infer over-investigation from the ~30-minute duration alone.
 
-- **Diagnosis:** open the `task_url` of a failed run (the error is not in the run payload) to read
-  the transcript. A quick failure from a query tool erroring, a body referencing an event/table
-  that no longer exists, or a changed surface schema is an authoring fix — hand off to
-  `authoring-signals-scouts`. Recurring timeouts on a firehose surface point at a too-broad body
-  that needs a cheaper discriminator, also an authoring fix.
+- **Diagnosis:** read a failed run's transcript (the error is not in the run payload) — open
+  `task_url`, or pull it as data with `tasks-runs-session-logs-retrieve` (filter out the noisy
+  `tool_call_update` / `usage_update` events to get a readable action timeline). Tool calls right up
+  to the wall mean genuine over-investigation; silence long before it means a false timeout. A quick
+  failure from a query tool erroring, a body referencing an event/table that no longer exists, or a
+  changed surface schema is an authoring fix — hand off to `authoring-signals-scouts`. Recurring
+  over-investigation timeouts on a firehose surface point at a too-broad body that needs a cheaper
+  discriminator, also an authoring fix.
 
 ### 3. Emit rate — how often does it speak?
 

--- a/products/signals/skills/exploring-signals-scouts/references/scout-data-model.md
+++ b/products/signals/skills/exploring-signals-scouts/references/scout-data-model.md
@@ -50,9 +50,12 @@ as a **healthy quiet run**, not a failure — most runs should close out empty.
 - in-flight / started — currently running (`completed_at` null).
 - completed — finished cleanly. May or may not have emitted; read the `summary`.
 - failed — the run errored before closing out. Its `summary` is empty and the payload exposes
-  **no error field** — open `task_url` to see what went wrong. In practice the common failure is a
-  ~30-minute timeout (the per-run budget) from over-investigation, not a logic-broken scout; a
-  `failed` run whose duration ≈ the budget is almost always a timeout.
+  **no error field** — read the transcript to see what went wrong (open `task_url`, or pull it as
+  data with `tasks-runs-session-logs-retrieve`). In practice the common failure is a ~30-minute
+  timeout (the per-run budget), not a logic-broken scout; a `failed` run whose duration ≈ the budget
+  is almost always a timeout. The usual cause is over-investigation (the scout ran to the wall), but
+  some are false timeouts — the scout finished quickly and the run then hung on a dropped close-out;
+  the session log distinguishes the two (tool calls up to the wall vs. silence long before it).
 
 (The exact string set comes from the Tasks `TaskRun` model; match leniently — read the `summary`
 and `completed_at` together rather than keying on one status string.)


### PR DESCRIPTION
## Problem

The `exploring-signals-scouts` skill — the read-only playbook for observing the scout fleet — only ever pointed callers at the Tasks **UI** (`task_url`) to inspect a run's transcript. There's an MCP-native equivalent, `tasks-runs-session-logs-retrieve`, that returns the same per-run session log (tool calls, messages, reasoning) **as data**, but the skill never mentioned it — so an agent diagnosing a failed or timed-out run had no in-conversation way to "go deep."

It also stated, in three places, that a ~30-minute `failed` run always means the scout **over-investigated**. That's the common case but not the only one: a run can finish its work in a few minutes and then hang on a dropped close-out, hitting the same wall-clock ceiling and getting marked `failed`. Inferring over-investigation from duration alone is wrong for that class.

## Changes

Light-touch edits to the skill and its two reference files — enough that a caller knows the tool exists and roughly how to use it, without being over-prescriptive:

- **`SKILL.md`** — "drill into a single run" now notes `tasks-runs-session-logs-retrieve` as the data path to the transcript: pass the run's `task_run_id` as `id` plus its `task_id`, and a filtering tip (`exclude_types`) to keep the otherwise-large stream readable.
- **`SKILL.md` Tips** + **`references/scout-data-model.md`** + **`references/assessing-performance.md`** — soften the "timeout = over-investigation" claim to distinguish genuine over-investigation (tool calls right up to the wall) from a **false timeout** (silence long before it), and point at the session log as the way to tell them apart.

No behavior change — documentation only. The gitignored `dist/skills/` copy is regenerated by CI's skills build, so only the source under `products/signals/skills/` is touched.

## How did you test this code?

I'm an agent (Claude Code). No automated tests cover skill prose. I validated the skill sources still parse and discover cleanly via `build_skills.py --list` (the `exploring-signals-scouts` skill lists without error), and lint-staged ran the repo markdown formatter on the three changed files at commit time. No manual runtime testing beyond that.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) while dogfooding the scout fleet. The gap surfaced organically: diagnosing why the `surveys` scout was "timing out," I used `tasks-runs-session-logs-retrieve` to pull the turn-by-turn for three failed runs and found each had finished a tight pass in 2–5½ min, then sat silent until the 30-min wall — a dropped-`end_turn` false timeout, not over-investigation. The canonical skill didn't mention the tool that made that diagnosis possible, and actively asserted the over-investigation reading, so this PR closes both gaps. Kept deliberately light per reviewer steer — make the tool discoverable and show how to call it, rather than prescribe a full recipe.
