### PR TITLE
fix(tasks): salvage dropped finalization at poll timeout, not on a stale timer

### DIFF
--- a/products/tasks/backend/services/custom_prompt_internals.py
+++ b/products/tasks/backend/services/custom_prompt_internals.py
@@ -29,12 +29,6 @@ OutputFn = Callable[[str], object] | None
 POLL_INTERVAL_SECONDS = 10
 MAX_POLL_SECONDS = 30 * 60  # 30 minutes (matches sandbox TTL)
 MAX_CONSECUTIVE_STORAGE_ERRORS = 3
-# After this many seconds of silence carrying the null-cost usage_update fingerprint, accept
-# the last message instead of polling to MAX_POLL_SECONDS and failing a run that completed.
-# Set to the relay's continuous-silence ceiling (relay_sandbox_events.py: MAX_RECONNECT_ATTEMPTS
-# * SSE_READ_TIMEOUT_SECONDS = 5 * 300) so we never cut off a turn the relay still treats as
-# active; past that the relay has given up and the run is terminal. Keep in sync if those change.
-STALE_TURN_SALVAGE_SECONDS = 1500
 
 # Notification method the sandbox agent emits on a terminal failure. The agent
 # classifies upstream failures (rate limits, stream/connection drops, provider
@@ -205,23 +199,6 @@ async def poll_for_turn(
                 total_lines=total_lines,
                 printed_lines=printed_lines,
             )
-        # Salvage only the dropped-finalization case: we have the agent's final message, the
-        # log tail is the null-cost usage_update fingerprint, and it's been silent long enough
-        # to be conclusive. Requiring the tail (not just any cached text) keeps a mid-turn
-        # tool/model gap from being cut off early. See STALE_TURN_SALVAGE_SECONDS.
-        if (
-            latest_assistant_text is not None
-            and stale_seconds >= STALE_TURN_SALVAGE_SECONDS
-            and _ended_on_pending_finalization(full_log)
-        ):
-            logger.warning(
-                "custom_prompt - poll_for_turn: end_turn missing but turn-accounting tail present "
-                "and log stale for %ds — salvaging last message, run=%s total_lines=%d",
-                stale_seconds,
-                task_run.id,
-                total_lines,
-            )
-            return latest_assistant_text, full_log, total_lines, printed_lines
         # Keep the cursor monotonic — S3 eventual-consistency can briefly return
         # fewer lines than the prior poll; without the clamp we'd re-parse old lines.
         skip_lines = max(skip_lines, total_lines)
@@ -250,7 +227,87 @@ async def poll_for_turn(
                 verbose=verbose,
                 output_fn=output_fn,
             )
+    # Poll budget exhausted. MAX_POLL_SECONDS coincides with the relay's continuous-silence
+    # ceiling — relay_sandbox_events.py allows (MAX_RECONNECT_ATTEMPTS + 1) read windows of
+    # SSE_READ_TIMEOUT_SECONDS (6 × 300s) — so by here the relay has stopped treating the turn as
+    # active. Honour a terminal status first (drains cancelled/failed correctly, no race with an
+    # in-loop salvage), then try to salvage a dropped-finalization turn before declaring a timeout.
+    # Keying salvage off a real terminal signal rather than the poll deadline stays a follow-up.
+    refreshed = await sync_to_async(TaskRun.objects.get)(id=task_run.id)
+    if refreshed.status in {
+        TaskRun.Status.COMPLETED,
+        TaskRun.Status.FAILED,
+        TaskRun.Status.CANCELLED,
+    }:
+        logger.warning(
+            "custom_prompt - poll_for_turn: terminal status=%s at poll timeout, run=%s, elapsed=%ds",
+            refreshed.status,
+            task_run.id,
+            elapsed,
+        )
+        return await _drain_final_log(
+            task_run,
+            refreshed_status=refreshed.status,
+            error_message=refreshed.error_message,
+            printed_lines=printed_lines,
+            original_skip_lines=original_skip_lines,
+            verbose=verbose,
+            output_fn=output_fn,
+        )
+    salvaged = await _salvage_dropped_finalization(
+        task_run,
+        printed_lines=printed_lines,
+        original_skip_lines=original_skip_lines,
+        elapsed=elapsed,
+        verbose=verbose,
+        output_fn=output_fn,
+    )
+    if salvaged is not None:
+        return salvaged
     raise RuntimeError(f"custom_prompt - poll_for_turn: timed out after {elapsed}s")
+
+
+async def _salvage_dropped_finalization(
+    task_run,
+    *,
+    printed_lines: int,
+    original_skip_lines: int,
+    elapsed: int,
+    verbose: bool,
+    output_fn: OutputFn,
+) -> tuple[str, str | None, int, int] | None:
+    """Recover a turn whose closing end_turn was dropped: the agent wrote its final message and
+    the SDK's null-cost usage_update accounting, then went silent until the poll budget ran out.
+
+    Re-reads from the start-of-turn cursor (like _drain_final_log) so a response split across
+    agent_message_chunk slices is recovered in full, not just the last chunk that happened to land
+    in the most recent poll window. Returns None when the log tail is not the dropped-finalization
+    fingerprint or no message is recoverable, so the caller falls back to the timeout failure
+    rather than salvaging an unfinished or failed turn."""
+    try:
+        _, last_message, full_log, total_lines, _ = await sync_to_async(
+            # thread_sensitive=False because of pure I/O (object_storage.read + JSON parsing) and doesn't touch the ORM
+            _check_logs,
+            thread_sensitive=False,
+        )(task_run, skip_lines=original_skip_lines)
+    except ObjectStorageError:
+        logger.warning(
+            "custom_prompt - salvage_dropped_finalization: storage error on final read, run=%s",
+            task_run.id,
+            exc_info=True,
+        )
+        return None
+    if last_message is None or not _ended_on_pending_finalization(full_log):
+        return None
+    printed_lines = _stream_new_lines(full_log, printed_lines, verbose=verbose, output_fn=output_fn)
+    logger.warning(
+        "custom_prompt - poll_for_turn: end_turn missing but turn-accounting tail present at poll "
+        "timeout (%ds) — salvaging last message, run=%s total_lines=%d",
+        elapsed,
+        task_run.id,
+        total_lines,
+    )
+    return last_message, full_log, total_lines, printed_lines
 
 
 async def _drain_final_log(

--- a/products/tasks/backend/services/custom_prompt_internals.py
+++ b/products/tasks/backend/services/custom_prompt_internals.py
@@ -29,10 +29,15 @@ OutputFn = Callable[[str], object] | None
 POLL_INTERVAL_SECONDS = 10
 MAX_POLL_SECONDS = 30 * 60  # 30 minutes (matches sandbox TTL)
 MAX_CONSECUTIVE_STORAGE_ERRORS = 3
-# Continuous log silence required before salvaging a dropped-finalization turn, so a turn still
-# emitting near the deadline (possibly live) isn't cut off. Heuristic: the relay's true ceiling is
-# 6 × SSE_READ_TIMEOUT_SECONDS = 1800s, which can't be fully waited inside the 1800s poll budget.
-STALE_TURN_SALVAGE_SECONDS = 1500
+# Continuous log silence required before salvaging a dropped-finalization turn — one SSE read window
+# (SSE_READ_TIMEOUT_SECONDS). The null-cost finalization fingerprint (_ended_on_pending_finalization)
+# is the real safety gate; this floor only rules out salvaging a turn caught mid-stream. It must sit
+# well below the 1800s poll budget: a floor near the budget would only salvage turns that fell silent
+# in the first few minutes and reject a turn that does real work late and *then* drops end_turn — the
+# exact case this path exists to recover. The relay's true continuous-silence ceiling is
+# 6 × SSE_READ_TIMEOUT_SECONDS = 1800s, which can't be fully observed inside the 1800s budget; keying
+# salvage off a real terminal signal instead of the poll deadline stays the layer-2 follow-up.
+STALE_TURN_SALVAGE_SECONDS = 300
 
 # Notification method the sandbox agent emits on a terminal failure. The agent
 # classifies upstream failures (rate limits, stream/connection drops, provider
@@ -129,6 +134,9 @@ async def poll_for_turn(
     # Track the timing/errors
     elapsed = 0
     consecutive_storage_errors = 0
+    # Newest absolute log-line count seen by the loop — handed to salvage so it can tell whether its
+    # reread surfaced lines the last poll missed (i.e. the turn isn't actually silent).
+    total_lines = 0
     # Elapsed time when we last saw new log lines
     last_new_lines_at = 0
     # Remember assistant text, as the agent message and end_message could arrive in different poll slices
@@ -261,6 +269,7 @@ async def poll_for_turn(
             task_run,
             printed_lines=printed_lines,
             original_skip_lines=original_skip_lines,
+            prev_total_lines=total_lines,
             elapsed=elapsed,
             stale_seconds=stale_seconds,
             verbose=verbose,
@@ -271,11 +280,42 @@ async def poll_for_turn(
     raise RuntimeError(f"custom_prompt - poll_for_turn: timed out after {elapsed}s")
 
 
+async def _read_turn_log_with_retry(
+    task_run, *, skip_lines: int, context: str
+) -> tuple[bool, str | None, str | None, int, bool]:
+    """Read the turn log via _check_logs, retrying transient ObjectStorageError up to
+    MAX_CONSECUTIVE_STORAGE_ERRORS times (one POLL_INTERVAL_SECONDS apart). Re-raises the error
+    if every attempt fails, so a single S3 blip doesn't fail an otherwise-recoverable turn.
+    `context` names the caller in the warning log. Shared by the terminal drain and the salvage
+    path so the bounded-retry loop lives in one place."""
+    for attempt in range(1, MAX_CONSECUTIVE_STORAGE_ERRORS + 1):
+        try:
+            return await sync_to_async(
+                # thread_sensitive=False because of pure I/O (object_storage.read + JSON parsing) and doesn't touch the ORM
+                _check_logs,
+                thread_sensitive=False,
+            )(task_run, skip_lines=skip_lines)
+        except ObjectStorageError:
+            logger.warning(
+                "custom_prompt - %s: storage error on final log read (%d/%d), run=%s",
+                context,
+                attempt,
+                MAX_CONSECUTIVE_STORAGE_ERRORS,
+                task_run.id,
+                exc_info=True,
+            )
+            if attempt >= MAX_CONSECUTIVE_STORAGE_ERRORS:
+                raise
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    raise AssertionError("unreachable: loop returns on success or raises on exhaustion")  # pragma: no cover
+
+
 async def _salvage_dropped_finalization(
     task_run,
     *,
     printed_lines: int,
     original_skip_lines: int,
+    prev_total_lines: int,
     elapsed: int,
     stale_seconds: int,
     verbose: bool,
@@ -286,16 +326,21 @@ async def _salvage_dropped_finalization(
     full. Returns None when the tail isn't the dropped-finalization fingerprint or no message is
     recoverable, so the caller falls back to the timeout failure."""
     try:
-        _, last_message, full_log, total_lines, _ = await sync_to_async(
-            # thread_sensitive=False because of pure I/O (object_storage.read + JSON parsing) and doesn't touch the ORM
-            _check_logs,
-            thread_sensitive=False,
-        )(task_run, skip_lines=original_skip_lines)
+        _, last_message, full_log, total_lines, _ = await _read_turn_log_with_retry(
+            task_run, skip_lines=original_skip_lines, context="salvage_dropped_finalization"
+        )
     except ObjectStorageError:
+        return None
+    # The reread can surface lines the final poll missed (S3 eventual consistency, or the agent wrote
+    # between that poll and now). New lines mean the turn wasn't actually silent for stale_seconds —
+    # the silence gate was decided on stale data, so decline rather than truncate a possibly-live turn.
+    if total_lines > prev_total_lines:
         logger.warning(
-            "custom_prompt - salvage_dropped_finalization: storage error on final read, run=%s",
+            "custom_prompt - salvage_dropped_finalization: %d new line(s) on reread (poll saw %d) — turn "
+            "not silent, declining salvage, run=%s",
+            total_lines - prev_total_lines,
+            prev_total_lines,
             task_run.id,
-            exc_info=True,
         )
         return None
     if last_message is None or not _ended_on_pending_finalization(full_log):
@@ -333,28 +378,9 @@ async def _drain_final_log(
     stale earlier-turn response in multi-turn sessions). For single-turn callers `original_skip_lines == 0`, so
     the scan covers the full log as before. The walk is idempotent and only runs once at terminal status.
     """
-    final_message = None
-    final_log = None
-    final_lines = 0
-    final_empty_end_turn = False
-    for attempt in range(MAX_CONSECUTIVE_STORAGE_ERRORS):
-        try:
-            _, final_message, final_log, final_lines, final_empty_end_turn = await sync_to_async(
-                # thread_sensitive=False because of pure I/O (object_storage.read + JSON parsing) and doesn't touch the ORM
-                _check_logs,
-                thread_sensitive=False,
-            )(task_run, skip_lines=original_skip_lines)
-            break
-        except ObjectStorageError:
-            logger.warning(
-                "custom_prompt - drain_final_log: storage error on final log read (%d/%d)",
-                attempt + 1,
-                MAX_CONSECUTIVE_STORAGE_ERRORS,
-                exc_info=True,
-            )
-            if attempt + 1 >= MAX_CONSECUTIVE_STORAGE_ERRORS:
-                raise
-            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    _, final_message, final_log, final_lines, final_empty_end_turn = await _read_turn_log_with_retry(
+        task_run, skip_lines=original_skip_lines, context="drain_final_log"
+    )
     printed_lines = _stream_new_lines(final_log, printed_lines, verbose=verbose, output_fn=output_fn)
     if final_message:
         return final_message, final_log, final_lines, printed_lines

--- a/products/tasks/backend/services/custom_prompt_internals.py
+++ b/products/tasks/backend/services/custom_prompt_internals.py
@@ -134,9 +134,6 @@ async def poll_for_turn(
     # Track the timing/errors
     elapsed = 0
     consecutive_storage_errors = 0
-    # Newest absolute log-line count seen by the loop — handed to salvage so it can tell whether its
-    # reread surfaced lines the last poll missed (i.e. the turn isn't actually silent).
-    total_lines = 0
     # Elapsed time when we last saw new log lines
     last_new_lines_at = 0
     # Remember assistant text, as the agent message and end_message could arrive in different poll slices
@@ -211,8 +208,10 @@ async def poll_for_turn(
                 total_lines=total_lines,
                 printed_lines=printed_lines,
             )
-        # Keep the cursor monotonic — S3 eventual-consistency can briefly return
-        # fewer lines than the prior poll; without the clamp we'd re-parse old lines.
+        # Keep the cursor monotonic — S3 eventual-consistency can briefly return fewer lines than the
+        # prior poll; without the clamp we'd re-parse old lines. Doubles as the line-count high-water
+        # mark handed to salvage, so a stale short final read can't make the reread's recovered lines
+        # look like newly-produced ones.
         skip_lines = max(skip_lines, total_lines)
         refreshed = await sync_to_async(TaskRun.objects.get)(id=task_run.id)
         if refreshed.status in {
@@ -269,7 +268,7 @@ async def poll_for_turn(
             task_run,
             printed_lines=printed_lines,
             original_skip_lines=original_skip_lines,
-            prev_total_lines=total_lines,
+            max_total_lines_seen=skip_lines,
             elapsed=elapsed,
             stale_seconds=stale_seconds,
             verbose=verbose,
@@ -315,7 +314,7 @@ async def _salvage_dropped_finalization(
     *,
     printed_lines: int,
     original_skip_lines: int,
-    prev_total_lines: int,
+    max_total_lines_seen: int,
     elapsed: int,
     stale_seconds: int,
     verbose: bool,
@@ -326,20 +325,33 @@ async def _salvage_dropped_finalization(
     full. Returns None when the tail isn't the dropped-finalization fingerprint or no message is
     recoverable, so the caller falls back to the timeout failure."""
     try:
-        _, last_message, full_log, total_lines, _ = await _read_turn_log_with_retry(
+        finished, last_message, full_log, total_lines, _ = await _read_turn_log_with_retry(
             task_run, skip_lines=original_skip_lines, context="salvage_dropped_finalization"
         )
     except ObjectStorageError:
         return None
-    # The reread can surface lines the final poll missed (S3 eventual consistency, or the agent wrote
-    # between that poll and now). New lines mean the turn wasn't actually silent for stale_seconds —
-    # the silence gate was decided on stale data, so decline rather than truncate a possibly-live turn.
-    if total_lines > prev_total_lines:
+    # If the reread now shows the real end_turn — the closing event simply landed after the final poll
+    # — the turn genuinely completed. Return it as a normal completion rather than timing out.
+    if finished and last_message is not None:
+        printed_lines = _stream_new_lines(full_log, printed_lines, verbose=verbose, output_fn=output_fn)
         logger.warning(
-            "custom_prompt - salvage_dropped_finalization: %d new line(s) on reread (poll saw %d) — turn "
+            "custom_prompt - salvage_dropped_finalization: end_turn recovered on reread at poll timeout "
+            "(%ds) — completing, run=%s total_lines=%d",
+            elapsed,
+            task_run.id,
+            total_lines,
+        )
+        return last_message, full_log, total_lines, printed_lines
+    # Decline if the reread reveals lines that no poll ever saw — the turn was still producing output,
+    # so it wasn't actually silent for stale_seconds and could still be live. Compare against the
+    # high-water mark, NOT the last poll's count: S3 is eventually consistent and a final short read
+    # would otherwise make the reread's *recovered* (not new) lines look like fresh activity.
+    if total_lines > max_total_lines_seen:
+        logger.warning(
+            "custom_prompt - salvage_dropped_finalization: reread has %d line(s), high-water was %d — turn "
             "not silent, declining salvage, run=%s",
-            total_lines - prev_total_lines,
-            prev_total_lines,
+            total_lines,
+            max_total_lines_seen,
             task_run.id,
         )
         return None

--- a/products/tasks/backend/services/custom_prompt_internals.py
+++ b/products/tasks/backend/services/custom_prompt_internals.py
@@ -29,6 +29,10 @@ OutputFn = Callable[[str], object] | None
 POLL_INTERVAL_SECONDS = 10
 MAX_POLL_SECONDS = 30 * 60  # 30 minutes (matches sandbox TTL)
 MAX_CONSECUTIVE_STORAGE_ERRORS = 3
+# Continuous log silence required before salvaging a dropped-finalization turn, so a turn still
+# emitting near the deadline (possibly live) isn't cut off. Heuristic: the relay's true ceiling is
+# 6 × SSE_READ_TIMEOUT_SECONDS = 1800s, which can't be fully waited inside the 1800s poll budget.
+STALE_TURN_SALVAGE_SECONDS = 1500
 
 # Notification method the sandbox agent emits on a terminal failure. The agent
 # classifies upstream failures (rate limits, stream/connection drops, provider
@@ -227,12 +231,8 @@ async def poll_for_turn(
                 verbose=verbose,
                 output_fn=output_fn,
             )
-    # Poll budget exhausted. MAX_POLL_SECONDS coincides with the relay's continuous-silence
-    # ceiling — relay_sandbox_events.py allows (MAX_RECONNECT_ATTEMPTS + 1) read windows of
-    # SSE_READ_TIMEOUT_SECONDS (6 × 300s) — so by here the relay has stopped treating the turn as
-    # active. Honour a terminal status first (drains cancelled/failed correctly, no race with an
-    # in-loop salvage), then try to salvage a dropped-finalization turn before declaring a timeout.
-    # Keying salvage off a real terminal signal rather than the poll deadline stays a follow-up.
+    # Poll budget exhausted. A run already terminal here was marked by something else (cancel,
+    # relay-detected crash) — drain it; otherwise try to salvage below.
     refreshed = await sync_to_async(TaskRun.objects.get)(id=task_run.id)
     if refreshed.status in {
         TaskRun.Status.COMPLETED,
@@ -254,16 +254,20 @@ async def poll_for_turn(
             verbose=verbose,
             output_fn=output_fn,
         )
-    salvaged = await _salvage_dropped_finalization(
-        task_run,
-        printed_lines=printed_lines,
-        original_skip_lines=original_skip_lines,
-        elapsed=elapsed,
-        verbose=verbose,
-        output_fn=output_fn,
-    )
-    if salvaged is not None:
-        return salvaged
+    # Otherwise salvage a dropped-finalization turn, but only after enough continuous silence.
+    stale_seconds = elapsed - last_new_lines_at
+    if stale_seconds >= STALE_TURN_SALVAGE_SECONDS:
+        salvaged = await _salvage_dropped_finalization(
+            task_run,
+            printed_lines=printed_lines,
+            original_skip_lines=original_skip_lines,
+            elapsed=elapsed,
+            stale_seconds=stale_seconds,
+            verbose=verbose,
+            output_fn=output_fn,
+        )
+        if salvaged is not None:
+            return salvaged
     raise RuntimeError(f"custom_prompt - poll_for_turn: timed out after {elapsed}s")
 
 
@@ -273,17 +277,14 @@ async def _salvage_dropped_finalization(
     printed_lines: int,
     original_skip_lines: int,
     elapsed: int,
+    stale_seconds: int,
     verbose: bool,
     output_fn: OutputFn,
 ) -> tuple[str, str | None, int, int] | None:
-    """Recover a turn whose closing end_turn was dropped: the agent wrote its final message and
-    the SDK's null-cost usage_update accounting, then went silent until the poll budget ran out.
-
-    Re-reads from the start-of-turn cursor (like _drain_final_log) so a response split across
-    agent_message_chunk slices is recovered in full, not just the last chunk that happened to land
-    in the most recent poll window. Returns None when the log tail is not the dropped-finalization
-    fingerprint or no message is recoverable, so the caller falls back to the timeout failure
-    rather than salvaging an unfinished or failed turn."""
+    """Recover a turn whose closing end_turn was dropped (final message + null-cost usage_update,
+    then silence). Re-reads from the start-of-turn cursor so a chunked response is recovered in
+    full. Returns None when the tail isn't the dropped-finalization fingerprint or no message is
+    recoverable, so the caller falls back to the timeout failure."""
     try:
         _, last_message, full_log, total_lines, _ = await sync_to_async(
             # thread_sensitive=False because of pure I/O (object_storage.read + JSON parsing) and doesn't touch the ORM
@@ -301,8 +302,9 @@ async def _salvage_dropped_finalization(
         return None
     printed_lines = _stream_new_lines(full_log, printed_lines, verbose=verbose, output_fn=output_fn)
     logger.warning(
-        "custom_prompt - poll_for_turn: end_turn missing but turn-accounting tail present at poll "
-        "timeout (%ds) — salvaging last message, run=%s total_lines=%d",
+        "custom_prompt - salvage_dropped_finalization: end_turn missing, turn-accounting tail present, "
+        "stale %ds at poll timeout (%ds) — salvaging last message, run=%s total_lines=%d",
+        stale_seconds,
         elapsed,
         task_run.id,
         total_lines,

--- a/products/tasks/backend/tests/agent_log_fixtures.py
+++ b/products/tasks/backend/tests/agent_log_fixtures.py
@@ -25,6 +25,24 @@ def _agent_message_line(text: str) -> str:
     )
 
 
+def _agent_message_chunk_line(text: str) -> str:
+    # The agent sometimes streams its response as consecutive agent_message_chunk slices;
+    # _check_logs concatenates them when reconstructing the turn's final message.
+    return json.dumps(
+        {
+            "notification": {
+                "method": "session/update",
+                "params": {
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": text},
+                    }
+                },
+            }
+        }
+    )
+
+
 def _end_turn_line() -> str:
     return json.dumps({"notification": {"result": {"stopReason": "end_turn"}}})
 

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from posthog.models import Integration, Organization, Team
 from posthog.models.user import User
+from posthog.storage.object_storage import ObjectStorageError
 
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.services.custom_prompt_internals import (
@@ -163,12 +164,16 @@ class TestPollForTurnStaleSalvage:
 
     @pytest.mark.asyncio
     async def test_salvages_dropped_finalization_after_active_work(self):
-        # Real work across several polls, then end_turn dropped — salvaged once silence clears the
-        # floor (last activity at elapsed 30, then quiet to the elapsed-50 deadline).
-        early = [_agent_message_line("partial"), _usage_update_line()]
-        done = [*early, _agent_message_line("close-out summary"), _usage_update_line(165000)]
-        logs = ["\n".join(early)] * 2 + ["\n".join(done)]
-        poll_iter = iter(logs)
+        # Real work across several polls, then end_turn dropped — must still be salvaged. Uses the
+        # REAL STALE_TURN_SALVAGE_SECONDS (deliberately not patched) against a 600s budget so a floor
+        # set too close to the budget — which would reject a turn that works for minutes and only then
+        # drops end_turn (the exact prod failure) — fails this test instead of silently regressing.
+        work = [_agent_message_line("partial-1"), _usage_update_line()]
+        more = [*work, _agent_message_line("partial-2"), _usage_update_line()]
+        done = [*more, _agent_message_line("close-out summary"), _usage_update_line(165000)]
+        # Grow for the first three polls (last new lines ~elapsed 30), then quiet to the 600s deadline.
+        poll_logs = ["\n".join(work), "\n".join(more), "\n".join(done)]
+        poll_iter = iter(poll_logs)
 
         def next_log(*_args, **_kwargs):
             return next(poll_iter, "\n".join(done))
@@ -178,8 +183,8 @@ class TestPollForTurnStaleSalvage:
             patch("posthog.storage.object_storage.read", side_effect=next_log),
             patch("asyncio.sleep", new=AsyncMock()),
             patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
-            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 50),
-            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 600),
+            # STALE_TURN_SALVAGE_SECONDS intentionally NOT patched — exercise the production floor.
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
@@ -237,6 +242,58 @@ class TestPollForTurnStaleSalvage:
         ):
             with pytest.raises(RuntimeError, match="timed out"):
                 await poll_for_turn(fake, skip_lines=0)
+
+    @pytest.mark.asyncio
+    async def test_declines_salvage_when_reread_reveals_new_lines(self):
+        # The silence floor was crossed on stale poll data, but the salvage reread surfaces a line the
+        # last poll missed (S3 caught up, or the agent wrote between that poll and the reread). The
+        # turn wasn't actually silent, so salvage must decline and let it time out, not truncate it.
+        quiet = [_agent_message_line("close-out summary"), _usage_update_line(165000)]  # fingerprint tail
+        grown = [*quiet, _agent_message_line("actually still going")]  # +1 line, only on the reread
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            # Polls 1-3 are steady (quiet); the 4th read is the salvage reread, which has grown.
+            return "\n".join(grown) if calls["n"] > 3 else "\n".join(quiet)
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                await poll_for_turn(fake, skip_lines=0)
+
+    @pytest.mark.asyncio
+    async def test_salvage_retries_transient_storage_error(self):
+        # A transient S3 error on the salvage read is retried (like the poll loop and terminal drain),
+        # so a single blip doesn't fail a turn that is otherwise recoverable.
+        quiet = "\n".join([_agent_message_line("close-out summary"), _usage_update_line(165000)])
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            if calls["n"] == 4:  # the first salvage read blips; the retry (5th) succeeds
+                raise ObjectStorageError("transient")
+            return quiet
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, _, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "close-out summary"
 
     @pytest.mark.asyncio
     async def test_terminal_status_at_timeout_drains_instead_of_salvaging(self):

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -24,6 +24,7 @@ from products.tasks.backend.services.custom_prompt_multi_turn_runner import _EMP
 from products.tasks.backend.tests.agent_log_fixtures import (
     FakeTaskRun,
     _agent_error_line,
+    _agent_message_chunk_line,
     _agent_message_line,
     _cost_less_usage_update_line,
     _end_turn_line,
@@ -139,12 +140,15 @@ class TestPollForTurnEmptyEndTurn:
 class TestPollForTurnStaleSalvage:
     """When the sandbox SDK never emits the closing end_turn after the agent's final
     message (an intermittent race — the turn's cost is left null and the log goes quiet),
-    poll_for_turn must salvage the last message once the log is conclusively stale rather
-    than polling until MAX_POLL_SECONDS and failing a run that actually completed."""
+    poll_for_turn must salvage the last message once the poll budget is exhausted (the
+    relay's continuous-silence ceiling) rather than failing a run that actually completed.
+    The salvage runs on the timeout path, gated on the null-cost usage_update fingerprint and
+    a non-terminal status, so it can recover runs that complete at any point — not only those
+    that go quiet within the first few minutes."""
 
     @pytest.mark.asyncio
     async def test_salvages_last_message_when_end_turn_never_arrives(self):
-        # Agent's close-out message + a final usage_update, but no end_turn line — the
+        # Agent's close-out message + a final null-cost usage_update, but no end_turn line — the
         # exact shape of the prod failures (no result of any stopReason ever written).
         log = "\n".join([_agent_message_line("close-out summary"), _usage_update_line(165000)])
         fake = FakeTaskRun()
@@ -152,7 +156,7 @@ class TestPollForTurnStaleSalvage:
             patch("posthog.storage.object_storage.read", return_value=log),
             patch("asyncio.sleep", new=AsyncMock()),
             patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
-            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
@@ -161,11 +165,89 @@ class TestPollForTurnStaleSalvage:
         assert total_lines == 2
 
     @pytest.mark.asyncio
-    async def test_does_not_salvage_while_log_approaches_threshold(self):
-        # New lines arrive after 2 silent polls (stale climbs to 20, one poll short of the
-        # 30s threshold) and each tail carries the null-cost usage_update fingerprint. So the
-        # ONLY thing keeping this still-active turn from being salvaged is the staleness
-        # reset on each new line — it completes via its real end_turn, not the salvage path.
+    async def test_salvages_dropped_finalization_after_active_work(self):
+        # Regression for the old stale-window approach: the turn does real work (new lines across
+        # several polls) and only THEN drops end_turn, leaving the null-cost fingerprint. Because
+        # the work ran past the old salvage/MAX_POLL gap it could never be salvaged before; the
+        # timeout-path salvage recovers it regardless of when the turn went quiet.
+        early = [_agent_message_line("partial"), _usage_update_line()]
+        done = [*early, _agent_message_line("close-out summary"), _usage_update_line(165000)]
+        logs = ["\n".join(early)] * 2 + ["\n".join(done)]
+        poll_iter = iter(logs)
+
+        def next_log(*_args, **_kwargs):
+            return next(poll_iter, "\n".join(done))
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 50),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "close-out summary"
+        assert total_lines == len(done)
+
+    @pytest.mark.asyncio
+    async def test_salvage_reassembles_chunked_message(self):
+        # The final response arrives as multiple agent_message_chunk slices (as it would across
+        # different poll windows), then the null-cost usage_update with no end_turn. Salvage must
+        # return the FULL reassembled message by re-reading from the start-of-turn cursor, not
+        # just the last chunk that landed in the most recent poll.
+        log = "\n".join(
+            [
+                _agent_message_chunk_line("Part-one."),
+                _agent_message_chunk_line("Part-two."),
+                _agent_message_chunk_line("Part-three."),
+                _usage_update_line(165000),
+            ]
+        )
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", return_value=log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, _, _ = await poll_for_turn(fake, skip_lines=0)
+
+        # All three chunks reassembled — not just the last slice ("Part-three.").
+        assert last_message == "Part-one.Part-two.Part-three."
+
+    @pytest.mark.asyncio
+    async def test_terminal_status_at_timeout_drains_instead_of_salvaging(self):
+        # The null-cost fingerprint is present but the turn emitted no agent_message, and the run
+        # is marked terminal by the time the budget runs out. The timeout path must refresh status
+        # and drain through the terminal handler (raising the real failure) rather than reporting a
+        # bare timeout. `objects.get` stays running for the three in-loop polls, then flips failed
+        # at the timeout refresh.
+        log = "\n".join([_user_message_line("prompt"), _usage_update_line()])  # fingerprint, no agent_message
+        running = FakeTaskRun(status="running")
+        failed = FakeTaskRun(status="failed", error_message="sandbox killed")
+        statuses = iter([running] * 3 + [failed])
+
+        def next_status(*_args, **_kwargs):
+            return next(statuses, failed)
+
+        with (
+            patch("posthog.storage.object_storage.read", return_value=log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.models.TaskRun.objects.get", side_effect=next_status),
+        ):
+            with pytest.raises(RuntimeError, match="terminal status"):
+                await poll_for_turn(running, skip_lines=0)
+
+    @pytest.mark.asyncio
+    async def test_active_turn_completes_via_end_turn_not_salvage(self):
+        # New lines keep arriving and each tail carries the null-cost usage_update fingerprint,
+        # but the turn is still active — it must complete via its real end_turn before the budget
+        # runs out, never via the timeout-path salvage.
         c1 = [_agent_message_line("working"), _usage_update_line()]
         c2 = [*c1, _agent_message_line("still working"), _usage_update_line()]
         final = [*c2, _agent_message_line("final answer"), _end_turn_line()]
@@ -180,7 +262,6 @@ class TestPollForTurnStaleSalvage:
             patch("posthog.storage.object_storage.read", side_effect=next_log),
             patch("asyncio.sleep", new=AsyncMock()),
             patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
-            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 30),
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
@@ -197,17 +278,17 @@ class TestPollForTurnStaleSalvage:
         ]
     )
     async def test_does_not_salvage_without_finalization_fingerprint(self, _name, tail_lines):
-        # Agent message present and the log is long-stale, but the tail is not an explicit
+        # Agent message present and the poll budget exhausted, but the tail is not an explicit
         # null-cost usage_update — a mid-turn gap, an old cost-less usage line, or a terminal
-        # error after accounting. None are the dropped-finalization case, so keep polling
-        # (here to the cap) rather than salvage an unfinished or failed turn.
+        # error after accounting. None are the dropped-finalization case, so fail with a timeout
+        # rather than salvage an unfinished or failed turn.
         log = "\n".join([_agent_message_line("intermediate"), *tail_lines])
         fake = FakeTaskRun()
         with (
             patch("posthog.storage.object_storage.read", return_value=log),
             patch("asyncio.sleep", new=AsyncMock()),
-            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 600),
-            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             with pytest.raises(RuntimeError, match="timed out"):

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -270,6 +270,65 @@ class TestPollForTurnStaleSalvage:
                 await poll_for_turn(fake, skip_lines=0)
 
     @pytest.mark.asyncio
+    async def test_completes_when_end_turn_recovered_on_reread(self):
+        # The final polls missed the closing line; the salvage reread sees the real end_turn. The turn
+        # completed (late), so it's returned as a normal completion, not declined as "grown" activity.
+        quiet = "\n".join([_agent_message_line("final answer")])  # no end_turn yet
+        completed = "\n".join([_agent_message_line("final answer"), _end_turn_line()])  # end_turn on reread
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            # polls 1-3 miss the closing line; the salvage reread (4th) sees the real end_turn.
+            return completed if calls["n"] > 3 else quiet
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, _, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "final answer"
+
+    @pytest.mark.asyncio
+    async def test_salvages_despite_eventually_consistent_short_final_poll(self):
+        # An earlier poll saw the full log; the final polls got a stale, shorter S3 read. The salvage
+        # reread recovers the full log — the freshness check compares against the high-water mark (not
+        # the last poll's shrunken count), so the recovered lines aren't mistaken for new activity.
+        full = "\n".join(
+            [
+                _user_message_line("prompt"),
+                _agent_message_line("close-out summary"),
+                _usage_update_line(165000),
+            ]
+        )
+        short = "\n".join([_user_message_line("prompt"), _agent_message_line("close-out summary")])
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            # poll 1 sees the full 3-line log; polls 2-3 get a stale 2-line read; the salvage reread is full.
+            return short if calls["n"] in (2, 3) else full
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, _, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "close-out summary"
+
+    @pytest.mark.asyncio
     async def test_salvage_retries_transient_storage_error(self):
         # A transient S3 error on the salvage read is retried (like the poll loop and terminal drain),
         # so a single blip doesn't fail a turn that is otherwise recoverable.

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -138,18 +138,14 @@ class TestPollForTurnEmptyEndTurn:
 
 
 class TestPollForTurnStaleSalvage:
-    """When the sandbox SDK never emits the closing end_turn after the agent's final
-    message (an intermittent race — the turn's cost is left null and the log goes quiet),
-    poll_for_turn must salvage the last message once the poll budget is exhausted (the
-    relay's continuous-silence ceiling) rather than failing a run that actually completed.
-    The salvage runs on the timeout path, gated on the null-cost usage_update fingerprint and
-    a non-terminal status, so it can recover runs that complete at any point — not only those
-    that go quiet within the first few minutes."""
+    """When the SDK drops the closing end_turn after the agent's final message (cost left null,
+    log goes quiet), poll_for_turn salvages the message on the timeout path — gated on the
+    null-cost fingerprint, a non-terminal status, and STALE_TURN_SALVAGE_SECONDS of silence so a
+    turn still emitting near the deadline isn't cut off. Tests patch the budget and floor small."""
 
     @pytest.mark.asyncio
     async def test_salvages_last_message_when_end_turn_never_arrives(self):
-        # Agent's close-out message + a final null-cost usage_update, but no end_turn line — the
-        # exact shape of the prod failures (no result of any stopReason ever written).
+        # Final message + null-cost usage_update, no end_turn — the prod failure shape.
         log = "\n".join([_agent_message_line("close-out summary"), _usage_update_line(165000)])
         fake = FakeTaskRun()
         with (
@@ -157,6 +153,7 @@ class TestPollForTurnStaleSalvage:
             patch("asyncio.sleep", new=AsyncMock()),
             patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
             patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
@@ -166,10 +163,8 @@ class TestPollForTurnStaleSalvage:
 
     @pytest.mark.asyncio
     async def test_salvages_dropped_finalization_after_active_work(self):
-        # Regression for the old stale-window approach: the turn does real work (new lines across
-        # several polls) and only THEN drops end_turn, leaving the null-cost fingerprint. Because
-        # the work ran past the old salvage/MAX_POLL gap it could never be salvaged before; the
-        # timeout-path salvage recovers it regardless of when the turn went quiet.
+        # Real work across several polls, then end_turn dropped — salvaged once silence clears the
+        # floor (last activity at elapsed 30, then quiet to the elapsed-50 deadline).
         early = [_agent_message_line("partial"), _usage_update_line()]
         done = [*early, _agent_message_line("close-out summary"), _usage_update_line(165000)]
         logs = ["\n".join(early)] * 2 + ["\n".join(done)]
@@ -184,6 +179,7 @@ class TestPollForTurnStaleSalvage:
             patch("asyncio.sleep", new=AsyncMock()),
             patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
             patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 50),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
@@ -193,10 +189,8 @@ class TestPollForTurnStaleSalvage:
 
     @pytest.mark.asyncio
     async def test_salvage_reassembles_chunked_message(self):
-        # The final response arrives as multiple agent_message_chunk slices (as it would across
-        # different poll windows), then the null-cost usage_update with no end_turn. Salvage must
-        # return the FULL reassembled message by re-reading from the start-of-turn cursor, not
-        # just the last chunk that landed in the most recent poll.
+        # Response split across agent_message_chunk slices, then null-cost usage_update — salvage
+        # reparses from start-of-turn and returns all chunks, not just the last.
         log = "\n".join(
             [
                 _agent_message_chunk_line("Part-one."),
@@ -211,20 +205,43 @@ class TestPollForTurnStaleSalvage:
             patch("asyncio.sleep", new=AsyncMock()),
             patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
             patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             last_message, _, _, _ = await poll_for_turn(fake, skip_lines=0)
 
-        # All three chunks reassembled — not just the last slice ("Part-three.").
         assert last_message == "Part-one.Part-two.Part-three."
 
     @pytest.mark.asyncio
+    async def test_does_not_salvage_turn_active_near_deadline(self):
+        # New lines (with the fingerprint tail) arrive on every poll right up to the deadline, so
+        # silence never clears the floor — the still-active turn must fail, not be salvaged.
+        lines: list[str] = []
+        logs = []
+        for i in range(1, 6):
+            lines += [_agent_message_line(f"chunk-{i}"), _usage_update_line()]
+            logs.append("\n".join(lines))
+        poll_iter = iter(logs)
+
+        def next_log(*_args, **_kwargs):
+            return next(poll_iter, logs[-1])
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 50),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                await poll_for_turn(fake, skip_lines=0)
+
+    @pytest.mark.asyncio
     async def test_terminal_status_at_timeout_drains_instead_of_salvaging(self):
-        # The null-cost fingerprint is present but the turn emitted no agent_message, and the run
-        # is marked terminal by the time the budget runs out. The timeout path must refresh status
-        # and drain through the terminal handler (raising the real failure) rather than reporting a
-        # bare timeout. `objects.get` stays running for the three in-loop polls, then flips failed
-        # at the timeout refresh.
+        # Fingerprint present but no agent_message, and the run is terminal by the deadline — the
+        # timeout path drains (raises the real failure) instead of reporting a bare timeout.
         log = "\n".join([_user_message_line("prompt"), _usage_update_line()])  # fingerprint, no agent_message
         running = FakeTaskRun(status="running")
         failed = FakeTaskRun(status="failed", error_message="sandbox killed")
@@ -245,9 +262,7 @@ class TestPollForTurnStaleSalvage:
 
     @pytest.mark.asyncio
     async def test_active_turn_completes_via_end_turn_not_salvage(self):
-        # New lines keep arriving and each tail carries the null-cost usage_update fingerprint,
-        # but the turn is still active — it must complete via its real end_turn before the budget
-        # runs out, never via the timeout-path salvage.
+        # A still-active turn completes via its real end_turn before the budget runs out.
         c1 = [_agent_message_line("working"), _usage_update_line()]
         c2 = [*c1, _agent_message_line("still working"), _usage_update_line()]
         final = [*c2, _agent_message_line("final answer"), _end_turn_line()]
@@ -278,10 +293,8 @@ class TestPollForTurnStaleSalvage:
         ]
     )
     async def test_does_not_salvage_without_finalization_fingerprint(self, _name, tail_lines):
-        # Agent message present and the poll budget exhausted, but the tail is not an explicit
-        # null-cost usage_update — a mid-turn gap, an old cost-less usage line, or a terminal
-        # error after accounting. None are the dropped-finalization case, so fail with a timeout
-        # rather than salvage an unfinished or failed turn.
+        # Silence floor cleared, but the tail isn't a null-cost usage_update — so the fingerprint
+        # gate (not the floor) blocks salvage and the run times out.
         log = "\n".join([_agent_message_line("intermediate"), *tail_lines])
         fake = FakeTaskRun()
         with (
@@ -289,6 +302,7 @@ class TestPollForTurnStaleSalvage:
             patch("asyncio.sleep", new=AsyncMock()),
             patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
             patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             with pytest.raises(RuntimeError, match="timed out"):


### PR DESCRIPTION
## Problem

Follow-up to #61903, which salvages a turn whose closing `end_turn` is dropped (the agent's final message + null-cost `usage_update` land, then the log goes silent). Codex reviews surfaced that the salvage gate was still wrong:

- It only fired when the turn went quiet in the first ~5 min, so a turn that works longer and *then* drops `end_turn` — the exact ~5½-min run that motivated #61903 — still false-failed at the 30-min wall.
- The freshness check used the last poll's line count, which S3 eventual consistency can shrink, so a completed turn could be falsely declined.
- If the salvage reread saw the real `end_turn` (it landed late), the turn was declined instead of completed.
- A single transient S3 error on the salvage read failed an otherwise-recoverable turn.

## Changes

The null-cost finalization fingerprint (`_ended_on_pending_finalization`) is the real safety gate — a live turn's tail is tool calls, not that stamp — so the silence floor is just a guard against catching a turn mid-stream.

- Lower `STALE_TURN_SALVAGE_SECONDS` 1500 → 300 (one SSE read window), well below the 1800s budget, so a late completion is still salvaged.
- On the salvage reread: complete the turn if it now shows the real `end_turn`; otherwise decline if it grew beyond the monotonic high-water line count (not the last poll's possibly-shrunken count); otherwise salvage only on the fingerprint.
- Retry transient storage errors on the salvage read, via a new `_read_turn_log_with_retry` helper shared with `_drain_final_log`.

Still a stopgap: it recovers the result at the poll deadline but the run holds its slot for the full budget. The relay measures silence from the last event, so relay-level silence can't be observed inside the budget — keying salvage off a real terminal/relay signal stays the follow-up.

## How did you test this code?

I'm an agent (Claude Code). Added/updated unit tests that drive the timeout path with a patched budget:

- `test_salvages_dropped_finalization_after_active_work` — now uses the **real, unpatched** floor against a 600s budget, so a floor set too close to the budget fails the test instead of silently regressing prod.
- `test_completes_when_end_turn_recovered_on_reread` — the reread sees a late `end_turn` → completes, not declined.
- `test_salvages_despite_eventually_consistent_short_final_poll` — a stale short final read doesn't make the reread's recovered lines look new.
- `test_declines_salvage_when_reread_reveals_new_lines` — genuine non-terminal growth → declines, times out.
- `test_salvage_retries_transient_storage_error` — a transient `ObjectStorageError` on the salvage read is retried.
- `hogli test products/tasks/backend/tests/test_multi_turn_session.py products/tasks/backend/tests/test_check_logs.py` → **57 passed**. ruff + `ty check` clean.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Andy's direction, addressing follow-up Codex passes on this branch. Key decision: rather than chase a silence threshold that proves the relay is done (structurally impossible inside the budget — the relay's give-up point always trails the poll deadline), lean on the finalization fingerprint as the gate, keep the floor small, and resolve the relay-still-active failure modes at the deadline reread (late `end_turn` → complete; non-terminal growth → decline; error tail → decline). Agent-authored; requires human review.
