### PR TITLE
fix(tasks): salvage dropped-finalization turns at the poll deadline

### DIFF
--- a/products/tasks/backend/services/custom_prompt_internals.py
+++ b/products/tasks/backend/services/custom_prompt_internals.py
@@ -29,12 +29,15 @@ OutputFn = Callable[[str], object] | None
 POLL_INTERVAL_SECONDS = 10
 MAX_POLL_SECONDS = 30 * 60  # 30 minutes (matches sandbox TTL)
 MAX_CONSECUTIVE_STORAGE_ERRORS = 3
-# After this many seconds of silence carrying the null-cost usage_update fingerprint, accept
-# the last message instead of polling to MAX_POLL_SECONDS and failing a run that completed.
-# Set to the relay's continuous-silence ceiling (relay_sandbox_events.py: MAX_RECONNECT_ATTEMPTS
-# * SSE_READ_TIMEOUT_SECONDS = 5 * 300) so we never cut off a turn the relay still treats as
-# active; past that the relay has given up and the run is terminal. Keep in sync if those change.
-STALE_TURN_SALVAGE_SECONDS = 1500
+# Continuous log silence required before salvaging a dropped-finalization turn — one SSE read window
+# (SSE_READ_TIMEOUT_SECONDS). The null-cost finalization fingerprint (_ended_on_pending_finalization)
+# is the real safety gate; this floor only rules out salvaging a turn caught mid-stream. It must sit
+# well below the 1800s poll budget: a floor near the budget would only salvage turns that fell silent
+# in the first few minutes and reject a turn that does real work late and *then* drops end_turn — the
+# exact case this path exists to recover. The relay's true continuous-silence ceiling is
+# 6 × SSE_READ_TIMEOUT_SECONDS = 1800s, which can't be fully observed inside the 1800s budget; keying
+# salvage off a real terminal signal instead of the poll deadline stays the layer-2 follow-up.
+STALE_TURN_SALVAGE_SECONDS = 300
 
 # Notification method the sandbox agent emits on a terminal failure. The agent
 # classifies upstream failures (rate limits, stream/connection drops, provider
@@ -205,25 +208,9 @@ async def poll_for_turn(
                 total_lines=total_lines,
                 printed_lines=printed_lines,
             )
-        # Salvage only the dropped-finalization case: we have the agent's final message, the
-        # log tail is the null-cost usage_update fingerprint, and it's been silent long enough
-        # to be conclusive. Requiring the tail (not just any cached text) keeps a mid-turn
-        # tool/model gap from being cut off early. See STALE_TURN_SALVAGE_SECONDS.
-        if (
-            latest_assistant_text is not None
-            and stale_seconds >= STALE_TURN_SALVAGE_SECONDS
-            and _ended_on_pending_finalization(full_log)
-        ):
-            logger.warning(
-                "custom_prompt - poll_for_turn: end_turn missing but turn-accounting tail present "
-                "and log stale for %ds — salvaging last message, run=%s total_lines=%d",
-                stale_seconds,
-                task_run.id,
-                total_lines,
-            )
-            return latest_assistant_text, full_log, total_lines, printed_lines
-        # Keep the cursor monotonic — S3 eventual-consistency can briefly return
-        # fewer lines than the prior poll; without the clamp we'd re-parse old lines.
+        # Keep the cursor monotonic — S3 eventual-consistency can briefly return fewer lines than the
+        # prior poll; without the clamp we'd re-parse old lines. Doubles as the line-count high-water
+        # mark handed to salvage: every line up to here was seen (and watched go quiet) during polling.
         skip_lines = max(skip_lines, total_lines)
         refreshed = await sync_to_async(TaskRun.objects.get)(id=task_run.id)
         if refreshed.status in {
@@ -250,7 +237,139 @@ async def poll_for_turn(
                 verbose=verbose,
                 output_fn=output_fn,
             )
+    # Poll budget exhausted. A run already terminal here was marked by something else (cancel,
+    # relay-detected crash) — drain it; otherwise try to salvage below.
+    refreshed = await sync_to_async(TaskRun.objects.get)(id=task_run.id)
+    if refreshed.status in {
+        TaskRun.Status.COMPLETED,
+        TaskRun.Status.FAILED,
+        TaskRun.Status.CANCELLED,
+    }:
+        logger.warning(
+            "custom_prompt - poll_for_turn: terminal status=%s at poll timeout, run=%s, elapsed=%ds",
+            refreshed.status,
+            task_run.id,
+            elapsed,
+        )
+        return await _drain_final_log(
+            task_run,
+            refreshed_status=refreshed.status,
+            error_message=refreshed.error_message,
+            printed_lines=printed_lines,
+            original_skip_lines=original_skip_lines,
+            verbose=verbose,
+            output_fn=output_fn,
+        )
+    # Otherwise salvage a dropped-finalization turn, but only after enough continuous silence.
+    stale_seconds = elapsed - last_new_lines_at
+    if stale_seconds >= STALE_TURN_SALVAGE_SECONDS:
+        salvaged = await _salvage_dropped_finalization(
+            task_run,
+            printed_lines=printed_lines,
+            original_skip_lines=original_skip_lines,
+            max_total_lines_seen=skip_lines,
+            elapsed=elapsed,
+            stale_seconds=stale_seconds,
+            verbose=verbose,
+            output_fn=output_fn,
+        )
+        if salvaged is not None:
+            return salvaged
     raise RuntimeError(f"custom_prompt - poll_for_turn: timed out after {elapsed}s")
+
+
+async def _read_turn_log_with_retry(
+    task_run, *, skip_lines: int, context: str
+) -> tuple[bool, str | None, str | None, int, bool]:
+    """Read the turn log via _check_logs, retrying transient ObjectStorageError up to
+    MAX_CONSECUTIVE_STORAGE_ERRORS times (one POLL_INTERVAL_SECONDS apart). Re-raises the error
+    if every attempt fails, so a single S3 blip doesn't fail an otherwise-recoverable turn.
+    `context` names the caller in the warning log. Shared by the terminal drain and the salvage
+    path so the bounded-retry loop lives in one place."""
+    for attempt in range(1, MAX_CONSECUTIVE_STORAGE_ERRORS + 1):
+        try:
+            return await sync_to_async(
+                # thread_sensitive=False because of pure I/O (object_storage.read + JSON parsing) and doesn't touch the ORM
+                _check_logs,
+                thread_sensitive=False,
+            )(task_run, skip_lines=skip_lines)
+        except ObjectStorageError:
+            logger.warning(
+                "custom_prompt - %s: storage error on final log read (%d/%d), run=%s",
+                context,
+                attempt,
+                MAX_CONSECUTIVE_STORAGE_ERRORS,
+                task_run.id,
+                exc_info=True,
+            )
+            if attempt >= MAX_CONSECUTIVE_STORAGE_ERRORS:
+                raise
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    raise AssertionError("unreachable: loop returns on success or raises on exhaustion")  # pragma: no cover
+
+
+async def _salvage_dropped_finalization(
+    task_run,
+    *,
+    printed_lines: int,
+    original_skip_lines: int,
+    max_total_lines_seen: int,
+    elapsed: int,
+    stale_seconds: int,
+    verbose: bool,
+    output_fn: OutputFn,
+) -> tuple[str, str | None, int, int] | None:
+    """Recover a turn whose closing end_turn was dropped (final message + null-cost usage_update,
+    then silence). Re-reads from the start-of-turn cursor so a chunked response is recovered in full.
+
+    Classified by the reread's tail:
+    - the real end_turn present -> the turn completed (the close just landed late); return it;
+    - the null-cost finalization fingerprint -> dropped-finalization; salvage the last message — but
+      only if nothing new arrived since polling beyond that single accounting line. A null-cost
+      usage_update is also emitted *between* chunks of an active turn, so fresh activity that landed
+      after the final poll has had no silence window and may still be live; decline it;
+    - anything else (a tool call / bare message / error tail) -> still live or failed; decline.
+
+    Declining falls back to the caller's timeout failure. A storage outage on the reread propagates
+    (like the poll loop and terminal drain) rather than masquerading as a timeout."""
+    finished, last_message, full_log, total_lines, _ = await _read_turn_log_with_retry(
+        task_run, skip_lines=original_skip_lines, context="salvage_dropped_finalization"
+    )
+    if finished and last_message is not None:
+        printed_lines = _stream_new_lines(full_log, printed_lines, verbose=verbose, output_fn=output_fn)
+        logger.warning(
+            "custom_prompt - salvage_dropped_finalization: end_turn recovered on reread at poll timeout "
+            "(%ds) — completing, run=%s total_lines=%d",
+            elapsed,
+            task_run.id,
+            total_lines,
+        )
+        return last_message, full_log, total_lines, printed_lines
+    if last_message is None or not _ended_on_pending_finalization(full_log):
+        return None
+    # The fingerprint also matches a mid-turn pause between chunks. The log is append-only, so the only
+    # benign growth since polling is the finalization usage_update itself landing late (+1 line beyond
+    # the high-water mark). Any more than that — a new message chunk, a tool call, etc. — is fresh
+    # activity that has had no silence window and could still be live, so decline rather than truncate.
+    if total_lines - max_total_lines_seen > 1:
+        logger.warning(
+            "custom_prompt - salvage_dropped_finalization: reread grew %d line(s) past the high-water "
+            "mark (%d) — fresh activity, no silence window; declining salvage, run=%s",
+            total_lines - max_total_lines_seen,
+            max_total_lines_seen,
+            task_run.id,
+        )
+        return None
+    printed_lines = _stream_new_lines(full_log, printed_lines, verbose=verbose, output_fn=output_fn)
+    logger.warning(
+        "custom_prompt - salvage_dropped_finalization: end_turn missing, turn-accounting tail present, "
+        "stale %ds at poll timeout (%ds) — salvaging last message, run=%s total_lines=%d",
+        stale_seconds,
+        elapsed,
+        task_run.id,
+        total_lines,
+    )
+    return last_message, full_log, total_lines, printed_lines
 
 
 async def _drain_final_log(
@@ -274,28 +393,9 @@ async def _drain_final_log(
     stale earlier-turn response in multi-turn sessions). For single-turn callers `original_skip_lines == 0`, so
     the scan covers the full log as before. The walk is idempotent and only runs once at terminal status.
     """
-    final_message = None
-    final_log = None
-    final_lines = 0
-    final_empty_end_turn = False
-    for attempt in range(MAX_CONSECUTIVE_STORAGE_ERRORS):
-        try:
-            _, final_message, final_log, final_lines, final_empty_end_turn = await sync_to_async(
-                # thread_sensitive=False because of pure I/O (object_storage.read + JSON parsing) and doesn't touch the ORM
-                _check_logs,
-                thread_sensitive=False,
-            )(task_run, skip_lines=original_skip_lines)
-            break
-        except ObjectStorageError:
-            logger.warning(
-                "custom_prompt - drain_final_log: storage error on final log read (%d/%d)",
-                attempt + 1,
-                MAX_CONSECUTIVE_STORAGE_ERRORS,
-                exc_info=True,
-            )
-            if attempt + 1 >= MAX_CONSECUTIVE_STORAGE_ERRORS:
-                raise
-            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    _, final_message, final_log, final_lines, final_empty_end_turn = await _read_turn_log_with_retry(
+        task_run, skip_lines=original_skip_lines, context="drain_final_log"
+    )
     printed_lines = _stream_new_lines(final_log, printed_lines, verbose=verbose, output_fn=output_fn)
     if final_message:
         return final_message, final_log, final_lines, printed_lines

--- a/products/tasks/backend/tests/agent_log_fixtures.py
+++ b/products/tasks/backend/tests/agent_log_fixtures.py
@@ -25,6 +25,37 @@ def _agent_message_line(text: str) -> str:
     )
 
 
+def _tool_call_line(name: str = "grep") -> str:
+    # A tool call is activity that does NOT change the trailing agent_message, so it can land
+    # between an observed message and a null-cost usage_update without altering last_message.
+    return json.dumps(
+        {
+            "notification": {
+                "method": "session/update",
+                "params": {"update": {"sessionUpdate": "tool_call", "title": name}},
+            }
+        }
+    )
+
+
+def _agent_message_chunk_line(text: str) -> str:
+    # The agent sometimes streams its response as consecutive agent_message_chunk slices;
+    # _check_logs concatenates them when reconstructing the turn's final message.
+    return json.dumps(
+        {
+            "notification": {
+                "method": "session/update",
+                "params": {
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": text},
+                    }
+                },
+            }
+        }
+    )
+
+
 def _end_turn_line() -> str:
     return json.dumps({"notification": {"result": {"stopReason": "end_turn"}}})
 

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from posthog.models import Integration, Organization, Team
 from posthog.models.user import User
+from posthog.storage.object_storage import ObjectStorageError
 
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.services.custom_prompt_internals import (
@@ -24,9 +25,11 @@ from products.tasks.backend.services.custom_prompt_multi_turn_runner import _EMP
 from products.tasks.backend.tests.agent_log_fixtures import (
     FakeTaskRun,
     _agent_error_line,
+    _agent_message_chunk_line,
     _agent_message_line,
     _cost_less_usage_update_line,
     _end_turn_line,
+    _tool_call_line,
     _usage_update_line,
     _user_message_line,
 )
@@ -137,22 +140,22 @@ class TestPollForTurnEmptyEndTurn:
 
 
 class TestPollForTurnStaleSalvage:
-    """When the sandbox SDK never emits the closing end_turn after the agent's final
-    message (an intermittent race — the turn's cost is left null and the log goes quiet),
-    poll_for_turn must salvage the last message once the log is conclusively stale rather
-    than polling until MAX_POLL_SECONDS and failing a run that actually completed."""
+    """When the SDK drops the closing end_turn after the agent's final message (cost left null,
+    log goes quiet), poll_for_turn salvages the message on the timeout path — gated on the
+    null-cost fingerprint, a non-terminal status, and STALE_TURN_SALVAGE_SECONDS of silence so a
+    turn still emitting near the deadline isn't cut off. Tests patch the budget and floor small."""
 
     @pytest.mark.asyncio
     async def test_salvages_last_message_when_end_turn_never_arrives(self):
-        # Agent's close-out message + a final usage_update, but no end_turn line — the
-        # exact shape of the prod failures (no result of any stopReason ever written).
+        # Final message + null-cost usage_update, no end_turn — the prod failure shape.
         log = "\n".join([_agent_message_line("close-out summary"), _usage_update_line(165000)])
         fake = FakeTaskRun()
         with (
             patch("posthog.storage.object_storage.read", return_value=log),
             patch("asyncio.sleep", new=AsyncMock()),
             patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
-            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
@@ -161,11 +164,371 @@ class TestPollForTurnStaleSalvage:
         assert total_lines == 2
 
     @pytest.mark.asyncio
-    async def test_does_not_salvage_while_log_approaches_threshold(self):
-        # New lines arrive after 2 silent polls (stale climbs to 20, one poll short of the
-        # 30s threshold) and each tail carries the null-cost usage_update fingerprint. So the
-        # ONLY thing keeping this still-active turn from being salvaged is the staleness
-        # reset on each new line — it completes via its real end_turn, not the salvage path.
+    async def test_salvages_dropped_finalization_after_active_work(self):
+        # Real work across several polls, then end_turn dropped — must still be salvaged. Uses the
+        # REAL STALE_TURN_SALVAGE_SECONDS (deliberately not patched) against a 600s budget so a floor
+        # set too close to the budget — which would reject a turn that works for minutes and only then
+        # drops end_turn (the exact prod failure) — fails this test instead of silently regressing.
+        work = [_agent_message_line("partial-1"), _usage_update_line()]
+        more = [*work, _agent_message_line("partial-2"), _usage_update_line()]
+        done = [*more, _agent_message_line("close-out summary"), _usage_update_line(165000)]
+        # Grow for the first three polls (last new lines ~elapsed 30), then quiet to the 600s deadline.
+        poll_logs = ["\n".join(work), "\n".join(more), "\n".join(done)]
+        poll_iter = iter(poll_logs)
+
+        def next_log(*_args, **_kwargs):
+            return next(poll_iter, "\n".join(done))
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 600),
+            # STALE_TURN_SALVAGE_SECONDS intentionally NOT patched — exercise the production floor.
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "close-out summary"
+        assert total_lines == len(done)
+
+    @pytest.mark.asyncio
+    async def test_salvage_reassembles_chunked_message(self):
+        # Response split across agent_message_chunk slices, then null-cost usage_update — salvage
+        # reparses from start-of-turn and returns all chunks, not just the last.
+        log = "\n".join(
+            [
+                _agent_message_chunk_line("Part-one."),
+                _agent_message_chunk_line("Part-two."),
+                _agent_message_chunk_line("Part-three."),
+                _usage_update_line(165000),
+            ]
+        )
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", return_value=log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, _, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "Part-one.Part-two.Part-three."
+
+    @pytest.mark.asyncio
+    async def test_does_not_salvage_turn_active_near_deadline(self):
+        # New lines (with the fingerprint tail) arrive on every poll right up to the deadline, so
+        # silence never clears the floor — the still-active turn must fail, not be salvaged.
+        lines: list[str] = []
+        logs = []
+        for i in range(1, 6):
+            lines += [_agent_message_line(f"chunk-{i}"), _usage_update_line()]
+            logs.append("\n".join(lines))
+        poll_iter = iter(logs)
+
+        def next_log(*_args, **_kwargs):
+            return next(poll_iter, logs[-1])
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 50),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                await poll_for_turn(fake, skip_lines=0)
+
+    @pytest.mark.asyncio
+    async def test_declines_salvage_when_reread_shows_nonterminal_activity(self):
+        # The silence floor was crossed, but the salvage reread's tail is a bare agent_message (no
+        # end_turn, no null-cost usage_update) — the turn was still producing output, not finalized.
+        # The tail, not a line count, is the discriminator: a non-terminal tail must decline and time
+        # out rather than truncate a possibly-live turn.
+        quiet = [_agent_message_line("close-out summary"), _usage_update_line(165000)]  # fingerprint tail
+        grown = [*quiet, _agent_message_line("actually still going")]  # non-terminal tail on the reread
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            # Polls 1-3 are steady (quiet); the 4th read is the salvage reread, which ends mid-stream.
+            return "\n".join(grown) if calls["n"] > 3 else "\n".join(quiet)
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                await poll_for_turn(fake, skip_lines=0)
+
+    @pytest.mark.asyncio
+    async def test_completes_when_end_turn_recovered_on_reread(self):
+        # The final polls missed the closing line; the salvage reread sees the real end_turn. The turn
+        # completed (late), so it's returned as a normal completion, not declined as "grown" activity.
+        quiet = "\n".join([_agent_message_line("final answer")])  # no end_turn yet
+        completed = "\n".join([_agent_message_line("final answer"), _end_turn_line()])  # end_turn on reread
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            # polls 1-3 miss the closing line; the salvage reread (4th) sees the real end_turn.
+            return completed if calls["n"] > 3 else quiet
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, _, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "final answer"
+
+    @pytest.mark.asyncio
+    async def test_salvages_despite_eventually_consistent_short_final_poll(self):
+        # An earlier poll saw the full log; the final polls got a stale, shorter S3 read. The salvage
+        # reread recovers the full log and salvages off its fingerprint tail — no line-count comparison
+        # is involved, so an eventually-consistent short final read can't cause a false decline.
+        full = "\n".join(
+            [
+                _user_message_line("prompt"),
+                _agent_message_line("close-out summary"),
+                _usage_update_line(165000),
+            ]
+        )
+        short = "\n".join([_user_message_line("prompt"), _agent_message_line("close-out summary")])
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            # poll 1 sees the full 3-line log; polls 2-3 get a stale 2-line read; the salvage reread is full.
+            return short if calls["n"] in (2, 3) else full
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, _, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "close-out summary"
+
+    @pytest.mark.asyncio
+    async def test_salvages_when_finalization_fingerprint_lands_on_reread(self):
+        # The agent's final message was seen during polling, but the closing null-cost usage_update
+        # only becomes visible on the timeout reread. The completed fingerprint must be salvaged — not
+        # declined as "new activity" just because the reread has one more line than the polls saw.
+        seen = "\n".join([_agent_message_line("close-out summary")])  # message only, no fingerprint yet
+        finalized = "\n".join([_agent_message_line("close-out summary"), _usage_update_line(165000)])
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            # polls 1-3 see only the message; the salvage reread (4th) sees the null-cost usage_update.
+            return finalized if calls["n"] > 3 else seen
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, _, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "close-out summary"
+
+    @pytest.mark.asyncio
+    async def test_declines_salvage_when_reread_shows_new_chunk_after_final_poll(self):
+        # A null-cost usage_update is also emitted between chunks of an active turn. If the agent emits
+        # another chunk (message + null-cost usage) after the final poll, the reread's tail is still
+        # fingerprint-shaped but it grew 2 lines past the high-water mark — fresh activity with no
+        # silence window, so it could still be live. Salvaging would truncate it; this declines.
+        polled = "\n".join([_agent_message_line("working"), _usage_update_line()])  # fingerprint tail
+        active = "\n".join(
+            [
+                _agent_message_line("working"),
+                _usage_update_line(),
+                _agent_message_line("still working"),
+                _usage_update_line(),
+            ]
+        )  # a fresh chunk landed; tail is still fingerprint-shaped (+2 lines)
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            # polls 1-3 see only "working"; the salvage reread (4th) sees the newly-emitted chunk.
+            return active if calls["n"] > 3 else polled
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                await poll_for_turn(fake, skip_lines=0)
+
+    @pytest.mark.asyncio
+    async def test_declines_salvage_when_reread_shows_new_tool_activity(self):
+        # A tool call is activity that does NOT change the trailing agent_message. If one lands after
+        # the final poll followed by a null-cost usage_update, last_message is unchanged and the tail is
+        # fingerprint-shaped — but the reread grew 2 lines past the high-water mark, so it's fresh
+        # activity with no silence window and must decline (the line count, not the message, catches it).
+        polled = "\n".join([_agent_message_line("working"), _usage_update_line()])  # fingerprint tail
+        active = "\n".join(
+            [_agent_message_line("working"), _usage_update_line(), _tool_call_line("grep"), _usage_update_line()]
+        )  # last_message still "working", tail still fingerprint-shaped (+2 lines)
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            return active if calls["n"] > 3 else polled
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                await poll_for_turn(fake, skip_lines=0)
+
+    @pytest.mark.asyncio
+    async def test_salvages_chunked_message_streamed_across_polls(self):
+        # The final response streams as agent_message_chunks over several polls (each poll's slice holds
+        # only the latest chunk), then end_turn is dropped. All chunks landed during polling, so the
+        # reread adds nothing past the high-water mark (+0) and the full reassembled message is salvaged.
+        c1 = _agent_message_chunk_line("Part-one.")
+        full = "\n".join(
+            [
+                c1,
+                _agent_message_chunk_line("Part-two."),
+                _agent_message_chunk_line("Part-three."),
+                _usage_update_line(165000),
+            ]
+        )
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            # poll 1 sees the first chunk; from poll 2 on the whole chunked message + usage is present.
+            return c1 if calls["n"] == 1 else full
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 60),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, _, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "Part-one.Part-two.Part-three."
+
+    @pytest.mark.asyncio
+    async def test_salvage_propagates_exhausted_storage_error(self):
+        # If every salvage reread attempt fails, the storage error propagates (like the poll loop and
+        # terminal drain) instead of masquerading as a generic poll timeout.
+        quiet = "\n".join([_agent_message_line("close-out summary"), _usage_update_line(165000)])
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            if calls["n"] >= 4:  # polls 1-3 succeed; every salvage reread blips
+                raise ObjectStorageError("s3 down")
+            return quiet
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            with pytest.raises(ObjectStorageError):
+                await poll_for_turn(fake, skip_lines=0)
+
+    @pytest.mark.asyncio
+    async def test_salvage_retries_transient_storage_error(self):
+        # A transient S3 error on the salvage read is retried (like the poll loop and terminal drain),
+        # so a single blip doesn't fail a turn that is otherwise recoverable.
+        quiet = "\n".join([_agent_message_line("close-out summary"), _usage_update_line(165000)])
+        calls = {"n": 0}
+
+        def next_log(*_args, **_kwargs):
+            calls["n"] += 1
+            if calls["n"] == 4:  # the first salvage read blips; the retry (5th) succeeds
+                raise ObjectStorageError("transient")
+            return quiet
+
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", side_effect=next_log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, _, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "close-out summary"
+
+    @pytest.mark.asyncio
+    async def test_terminal_status_at_timeout_drains_instead_of_salvaging(self):
+        # Fingerprint present but no agent_message, and the run is terminal by the deadline — the
+        # timeout path drains (raises the real failure) instead of reporting a bare timeout.
+        log = "\n".join([_user_message_line("prompt"), _usage_update_line()])  # fingerprint, no agent_message
+        running = FakeTaskRun(status="running")
+        failed = FakeTaskRun(status="failed", error_message="sandbox killed")
+        statuses = iter([running] * 3 + [failed])
+
+        def next_status(*_args, **_kwargs):
+            return next(statuses, failed)
+
+        with (
+            patch("posthog.storage.object_storage.read", return_value=log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.models.TaskRun.objects.get", side_effect=next_status),
+        ):
+            with pytest.raises(RuntimeError, match="terminal status"):
+                await poll_for_turn(running, skip_lines=0)
+
+    @pytest.mark.asyncio
+    async def test_active_turn_completes_via_end_turn_not_salvage(self):
+        # A still-active turn completes via its real end_turn before the budget runs out.
         c1 = [_agent_message_line("working"), _usage_update_line()]
         c2 = [*c1, _agent_message_line("still working"), _usage_update_line()]
         final = [*c2, _agent_message_line("final answer"), _end_turn_line()]
@@ -180,7 +543,6 @@ class TestPollForTurnStaleSalvage:
             patch("posthog.storage.object_storage.read", side_effect=next_log),
             patch("asyncio.sleep", new=AsyncMock()),
             patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
-            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 30),
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
@@ -197,17 +559,16 @@ class TestPollForTurnStaleSalvage:
         ]
     )
     async def test_does_not_salvage_without_finalization_fingerprint(self, _name, tail_lines):
-        # Agent message present and the log is long-stale, but the tail is not an explicit
-        # null-cost usage_update — a mid-turn gap, an old cost-less usage line, or a terminal
-        # error after accounting. None are the dropped-finalization case, so keep polling
-        # (here to the cap) rather than salvage an unfinished or failed turn.
+        # Silence floor cleared, but the tail isn't a null-cost usage_update — so the fingerprint
+        # gate (not the floor) blocks salvage and the run times out.
         log = "\n".join([_agent_message_line("intermediate"), *tail_lines])
         fake = FakeTaskRun()
         with (
             patch("posthog.storage.object_storage.read", return_value=log),
             patch("asyncio.sleep", new=AsyncMock()),
-            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 600),
-            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
         ):
             with pytest.raises(RuntimeError, match="timed out"):


### PR DESCRIPTION
## TLDR

- When the agent sandbox drops the closing `end_turn`, a run that *actually finished* sits idle until the 30-min timeout and gets marked **FAILED** — even though the work is done. #61903 tried to fix this, but its salvage only fires if the turn goes quiet in the first ~5 min, so the common case (longer runs) still false-fails.
- We hit this while dogfooding the Signals scout agents on our own project: a noticeable share of scout runs were showing up as failed despite having completed their work, and digging into the run logs traced it to this dropped-`end_turn` pattern.
- This PR makes the salvage reliable: at the deadline, if the log shows the turn really finished — a real `end_turn`, or the agent's final message + finalization accounting that we already watched go quiet — we return that result instead of failing. If it still looks like the turn is mid-flight, we time out exactly as before.
- It's a **stopgap that fixes the bookkeeping**, not the root cause. The real fix is a proper "turn done" signal from the sandbox so we don't have to infer completion — that's a follow-up. Most of the diff is the careful "actually finished vs still running" logic and its tests.

## Problem

When the sandbox SDK drops a turn's closing `end_turn` — the agent's final message and null-cost `usage_update` land, then the log goes silent — `poll_for_turn` waited out the full 30-min budget and marked a run that actually completed as `FAILED`. #61903 added a salvage for this, but it fired off an in-loop timer that only triggered when the turn went quiet in the first ~5 min, so a turn that works longer and then drops `end_turn` (the common case) still false-failed.

## Changes

Move the salvage onto the **poll-timeout path** and make the **null-cost finalization fingerprint** (`_ended_on_pending_finalization`) the real gate — a live turn's tail is tool calls, not that stamp — so the silence floor is just a guard against catching a turn mid-stream.

At the deadline, `poll_for_turn` drains via `_drain_final_log` if the run is already terminal (`COMPLETED`/`FAILED`/`CANCELLED`), so a cancelled/failed run surfaces its real outcome instead of being salvaged as success. Otherwise, after `STALE_TURN_SALVAGE_SECONDS` of silence, it re-reads from the start-of-turn cursor and classifies by the log tail:

- the real `end_turn` now present → **completed** (the close landed after the final poll); return it;
- a null-cost finalization fingerprint → **salvage** the final message, but only when nothing arrived since polling beyond that one accounting line. The log is append-only, so `+1` line past the high-water mark is just the finalization stamp landing late, while `+2` or more is fresh activity (a chunk, a tool call) that has had no silence window and could still be live → **decline**;
- anything else (tool call / bare message / error tail) → **decline**.

Comparing against the high-water mark (max line count seen across polls), not the last poll's count, tolerates eventually-consistent short final reads. `STALE_TURN_SALVAGE_SECONDS` is one SSE read window (300s), well below the 1800s budget, so a late completion is still recovered. Transient S3 errors on the final reads are retried via a shared `_read_turn_log_with_retry` helper (also used by `_drain_final_log`); an exhausted storage error propagates rather than masquerading as a timeout.

Still a stopgap: it recovers the result at the deadline but the run holds its slot for the full budget. The relay measures silence from the last event, so relay-level silence can't be observed inside the budget — keying salvage off a real terminal/relay signal is the follow-up.

## How did you test this code?

I'm an agent (Claude Code). Added unit tests that drive the timeout path with a patched budget:

- `test_salvages_dropped_finalization_after_active_work` — uses the **real, unpatched** floor against a 600s budget, so a floor set too close to the budget fails the test instead of silently regressing prod.
- `test_completes_when_end_turn_recovered_on_reread` — a late `end_turn` on the reread completes, not declined.
- `test_salvages_when_finalization_fingerprint_lands_on_reread` — the finalization stamp (`+1`) becoming visible only on the reread is salvaged.
- `test_salvages_despite_eventually_consistent_short_final_poll` — a stale short final read doesn't block salvage (compares to the high-water mark).
- `test_salvages_chunked_message_streamed_across_polls` — a chunked message streamed over several polls is reassembled and salvaged in full.
- `test_declines_salvage_when_reread_shows_new_chunk_after_final_poll` / `test_declines_salvage_when_reread_shows_new_tool_activity` — fresh activity (`+2`) with no silence window declines and times out.
- `test_salvage_retries_transient_storage_error` / `test_salvage_propagates_exhausted_storage_error` — transient S3 blips are retried; an exhausted outage propagates instead of looking like a timeout.
- Plus existing coverage for the fingerprint gate, chunked-message reassembly, terminal drain, and active-turn completion.
- `hogli test products/tasks/backend/tests/test_multi_turn_session.py products/tasks/backend/tests/test_check_logs.py` → **62 passed**. ruff + `ty check` clean.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Andy's direction. Key decision: rather than chase a silence threshold that proves the relay is done (structurally impossible inside the budget — the relay's give-up point always trails the poll deadline), lean on the finalization fingerprint and resolve the relay-still-active failure modes at the deadline reread (late `end_turn` → complete; non-terminal growth → decline; error tail → decline)

