### PR TITLE
refactor(replay-vision): connect scene logic instead of direct call

### DIFF
--- a/products/replay_vision/frontend/observations/replayObservationLogic.ts
+++ b/products/replay_vision/frontend/observations/replayObservationLogic.ts
@@ -21,7 +21,12 @@ export const replayObservationLogic = kea<replayObservationLogicType>([
 
     // Mount the SSE progress stream alongside the page and listen for its completion to reload the row.
     connect((props: ReplayObservationLogicProps) => ({
-        actions: [observationProgressLogic({ observationId: props.id }), ['streamCompleted']],
+        actions: [
+            observationProgressLogic({ observationId: props.id }),
+            ['streamCompleted'],
+            replayObservationSceneLogic,
+            ['setScannerContext'],
+        ],
     })),
 
     actions({
@@ -57,10 +62,7 @@ export const replayObservationLogic = kea<replayObservationLogicType>([
                 const response = await visionObservationsRetrieve(String(teamId), props.id)
                 actions.loadObservationSuccess(response)
                 // Link the breadcrumb to the parent scanner so "back" returns to the scanner, not the vision home.
-                replayObservationSceneLogic().actions.setScannerContext(
-                    response.scanner_id,
-                    response.scanner_snapshot?.name ?? null
-                )
+                actions.setScannerContext(response.scanner_id, response.scanner_snapshot?.name ?? null)
             } catch (error: any) {
                 lemonToast.error(`Failed to load observation${error.detail ? `: ${error.detail}` : ''}`)
                 actions.loadObservationFailure()


### PR DESCRIPTION
## Problem

Inside `replayObservationLogic`, the `loadObservation` listener reached into the scene logic with a direct `replayObservationSceneLogic().actions.setScannerContext(...)` call. Direct cross-logic calls hide the dependency from kea and sit outside the mount lifecycle — exactly the coupling our kea conventions ask us to avoid.

## Changes

Pull `setScannerContext` from `replayObservationSceneLogic` through the existing `connect` (the logic already connects `observationProgressLogic`) and dispatch it as a local action. No behaviour change — the breadcrumb still links back to the parent scanner once an observation loads — but the dependency is now explicit and lifecycle-managed.

`replayObservationSceneLogic` is a singleton and does not import `replayObservationLogic`, so there is no circular dependency; the `connect(() => …)` function form keeps it safe regardless.

This sits on top of the in-app-tab removal stack (`detab-*`) as an independent kea-conventions cleanup, kept as its own PR so the de-tab PRs stay focused.

## How did you test this code?

I'm an agent (PostHog Code) — automated checks only, no manual browser testing:
- `typegen:write` regenerates the logic type cleanly, which validates the `connect` wiring.
- `typescript:check` and the rest of CI run on the PR.

The change is behaviour-preserving: the same action is dispatched with the same arguments, just routed through `connect` instead of a direct call.

## 🤖 Agent context

Prompted by a review note on the replay-vision de-tab PR flagging the direct `someLogic().actions.foo()` call inside a listener. I verified `replayObservationSceneLogic` is a singleton with no back-reference to `replayObservationLogic` (no circular-import risk), moved `setScannerContext` into the existing `connect` block, and switched the call site to a local action dispatch. Kept it as a separate PR on top of the stack rather than amending the in-review de-tab PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
