### PR TITLE
chore(mcp-analytics): add storybook story for the dashboard

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -452,6 +452,10 @@ snapshots:
         hash: v1.k794b7964.ea8c43650b4092cbc2e77d3c1434956791b055450fc71b250d80ce2d3797ab95.NbHdkbeXdOFxKNuQGpkrJ6DhLvrMg8UzB_p4T4U3_Ww
     components-hogcharts-barchart--custom-corner-radius--light:
         hash: v1.k794b7964.0dac747f4e25c20af8ae87b1298ce78f740b1d61ffe17111e374beebbd4d4b67.qEe6wuSeislWK6Y_E6sW1cuocrbad55E7TCYPcqp9Fk
+    components-hogcharts-barchart--fill-styles--dark:
+        hash: v1.k794b7964.d6cadc93fb478e2708c459038ecf8e346aaaa853e2b8bf6be0704b5b725b8cae.SChUWxF3G94XS5uP9xKy4hYC76gLoOT-tCXrTAh5HCc
+    components-hogcharts-barchart--fill-styles--light:
+        hash: v1.k794b7964.4b98e3eb72e45de1042b2c623f54af0b41ade4b7161af608bd7a77353797e816.STp13FHni4h7ubxy2eOTkopHD5D6dfEBzo5U6gwmREs
     components-hogcharts-barchart--grouped--dark:
         hash: v1.k794b7964.519966f77e2f7f689d1ca8cc96a0af90e063e479964b28056a3a681457cd5d31.0phGCRGTRo6sxln_-Z2GAgJnsQBBTnZR4d9OH7anc60
     components-hogcharts-barchart--grouped--light:
@@ -5266,6 +5270,10 @@ snapshots:
         hash: v1.k794b7964.8aea696aaded1149932df0fef206cdc318e123ddb986bedab762c2cb6cccce4b.XWQDM2uZNH0Zp1eY4Vc1D5XnJrqtToEthNbKFNN95Ms
     scenes-app-marketing-analytics-cell-actions--source-cell-action-unmapped--light:
         hash: v1.k794b7964.4ebf2f848b10c8b2859630215a9be1ff91fb825fc334005207556310261d3a5c.UcqJY3dqyJNbi3x7oYaZ2rEu95LAEdbGmMyEpI-Wlgc
+    scenes-app-mcp-analytics--dashboard--dark:
+        hash: v1.k794b7964.0c1b68368a8773b72c89be08cf37d26771e3ccf23c71ccca310c5a274a168b2f.uO4P8jw3-8Zxn5az8jg_3LJV8TsWHo-sAzWDGmwXHpk
+    scenes-app-mcp-analytics--dashboard--light:
+        hash: v1.k794b7964.09589f49fe0b959b79652e6dadf9e38981aecdf5fa383dc7a1bbfd4c1e0649aa.abSoArXwTLreeJ_FkcqqbgT3I2mTbbgPy_uvrfYJous
     scenes-app-notebooks--bullet-list--dark:
         hash: v1.k794b7964.92b730d52ab36684be26e6553326b5325ec30479049b955e0c21b680786a1b0a.DxqaNZeZRaXD6cbT74fO1NrIXGkrJt3Q_x5kz2xkgII
     scenes-app-notebooks--bullet-list--light:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3135,6 +3135,9 @@ importers:
 
   products/mcp_analytics:
     dependencies:
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboard.stories.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboard.stories.tsx
@@ -1,0 +1,109 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { App } from 'scenes/App'
+import { urls } from 'scenes/urls'
+
+import { mswDecorator } from '~/mocks/browser'
+
+const KPI_RESULTS = [
+    ['2026-05-25', 320, 4100, 120, 1900, false],
+    ['2026-05-26', 310, 3950, 140, 2050, false],
+    ['2026-05-27', 298, 3800, 110, 1880, false],
+    ['2026-06-01', 340, 4300, 150, 2100, true],
+    ['2026-06-02', 355, 4500, 165, 2200, true],
+    ['2026-06-03', 372, 4720, 158, 2080, true],
+    ['2026-06-04', 360, 4600, 170, 2290, true],
+    ['2026-06-05', 388, 4900, 182, 2150, true],
+    ['2026-06-06', 401, 5100, 176, 2240, true],
+    ['2026-06-07', 415, 5300, 168, 2290, true],
+]
+
+const TOOL_RESULTS = [
+    ['exec', 5200, 208, 4.0, 2290],
+    ['execute-sql', 1480, 144, 9.7, 3525],
+    ['read-data-schema', 760, 3, 0.4, 1298],
+    ['query-trends', 540, 5, 1.0, 2122],
+    ['insight-create', 410, 8, 2.0, 727],
+    ['dashboard-create', 260, 2, 0.8, 940],
+    ['feature-flag-list', 180, 1, 0.6, 510],
+    ['cohort-create', 95, 6, 6.3, 1620],
+]
+
+const SESSION_RESULTS = [
+    ['0193f2a1-aaaa-bbbb-cccc-000000000001', 42, 18, 42.9, 610, 7, '2026-06-07T10:00:00Z'],
+    ['0193f2a1-aaaa-bbbb-cccc-000000000002', 6, 6, 100.0, 95, 2, '2026-06-07T09:30:00Z'],
+    ['0193f2a1-aaaa-bbbb-cccc-000000000003', 31, 0, 0.0, 240, 11, '2026-06-07T08:15:00Z'],
+    ['0193f2a1-aaaa-bbbb-cccc-000000000004', 14, 1, 7.1, 180, 5, '2026-06-07T07:45:00Z'],
+    ['0193f2a1-aaaa-bbbb-cccc-000000000005', 9, 0, 0.0, 120, 4, '2026-06-07T07:00:00Z'],
+    ['0193f2a1-aaaa-bbbb-cccc-000000000006', 22, 3, 13.6, 410, 6, '2026-06-06T16:20:00Z'],
+]
+
+const HARNESS_RESULTS = [
+    ['claude-code/1.2.0', 6200, 240, 820],
+    ['cursor-vscode/0.42', 2100, 96, 410],
+    ['codex-cli', 980, 71, 180],
+    ['claude-ai', 760, 22, 240],
+    ['visual studio code', 540, 12, 120],
+]
+
+const CLUSTER_SNAPSHOT = {
+    status: 'ready',
+    error_message: '',
+    last_computed_at: '2026-06-07T06:00:00Z',
+    last_computed_by_email: 'paul@posthog.com',
+    computed_with: null,
+    clusters: Array.from({ length: 6 }, (_, i) => ({
+        id: i + 1,
+        label: `Cluster ${i + 1}`,
+        summary: '',
+        session_count: 10 * (i + 1),
+        tool_call_count: 40 * (i + 1),
+        error_rate_pct: i,
+        sample_session_ids: [],
+        top_tools: [],
+    })),
+}
+
+const meta: Meta = {
+    component: App,
+    title: 'Scenes-App/MCP Analytics',
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/environments/:team_id/mcp_analytics/intent_clusters/': CLUSTER_SNAPSHOT,
+            },
+            post: {
+                '/api/environments/:team_id/query/:kind': (req, res, ctx) => {
+                    const body = req.body as Record<string, any>
+                    const query: string = body?.query?.query ?? ''
+                    if (query.includes('$mcp_client_name')) {
+                        return res(ctx.json({ results: HARNESS_RESULTS }))
+                    }
+                    if (query.includes('AS session_id')) {
+                        return res(ctx.json({ results: SESSION_RESULTS }))
+                    }
+                    if (query.includes('p95_duration_ms')) {
+                        return res(ctx.json({ results: TOOL_RESULTS }))
+                    }
+                    if (query.includes('AS bucket')) {
+                        return res(ctx.json({ results: KPI_RESULTS }))
+                    }
+                    return res(ctx.json({ results: [] }))
+                },
+            },
+        }),
+    ],
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2026-06-07',
+        pageUrl: urls.mcpAnalyticsDashboard(),
+        featureFlags: [FEATURE_FLAGS.MCP_ANALYTICS],
+    },
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+export const Dashboard: Story = {}

--- a/products/mcp_analytics/package.json
+++ b/products/mcp_analytics/package.json
@@ -9,6 +9,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
+        "@storybook/react": "catalog:",
         "@types/react": "*",
         "react": "*"
     }


### PR DESCRIPTION
## Problem

The MCP analytics dashboard overview had no Storybook coverage. That meant its layout carried no visual-regression safety net, and there was no way to view the scene without live project data.

## Changes

Adds a Storybook story for the dashboard overview scene (`Scenes-App / MCP Analytics / Dashboard`). It mocks the four HogQL queries the page issues (KPI buckets, tool rows, session rows, harness rows) plus the intent-clusters endpoint, branching the query mock on the SQL text so each loader receives the right shape. The real scene renders at the dashboard URL behind the `MCP_ANALYTICS` flag.

This is the base of a stack — the styling changes that follow build on this story so they can be eyeballed and snapshotted.

## How did you test this code?

I'm an agent (PostHog Code). I ran the story in a local Storybook (`pnpm storybook`) and confirmed the scene renders with the mocked data in both light and dark mode. No assertions beyond the story itself, which feeds visual-regression snapshots. `oxlint`/`oxfmt` clean on the file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude). Tools used: file edit/read, shell, and the Playwright MCP to render and screenshot the story. The query mock branches on substrings unique to each HogQL statement (`$mcp_client_name`, `AS session_id`, `p95_duration_ms`, `AS bucket`) since all four are `HogQLQuery` nodes hitting the same endpoint. Agent-authored; requires human review.
