### PR TITLE
feat(mcp-analytics): theme-aware dashboard bars and error pills

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5271,7 +5271,7 @@ snapshots:
     scenes-app-marketing-analytics-cell-actions--source-cell-action-unmapped--light:
         hash: v1.k794b7964.4ebf2f848b10c8b2859630215a9be1ff91fb825fc334005207556310261d3a5c.UcqJY3dqyJNbi3x7oYaZ2rEu95LAEdbGmMyEpI-Wlgc
     scenes-app-mcp-analytics--dashboard--dark:
-        hash: v1.k794b7964.0c1b68368a8773b72c89be08cf37d26771e3ccf23c71ccca310c5a274a168b2f.uO4P8jw3-8Zxn5az8jg_3LJV8TsWHo-sAzWDGmwXHpk
+        hash: v1.k794b7964.3c6b02398e9549974a8f79fd1a2d33c994c561817036e93fdf931f6209bebead.SfSciYNGfgRXpksGf8rxFEKBp30Czke2bKIseYIBLrk
     scenes-app-mcp-analytics--dashboard--light:
         hash: v1.k794b7964.09589f49fe0b959b79652e6dadf9e38981aecdf5fa383dc7a1bbfd4c1e0649aa.abSoArXwTLreeJ_FkcqqbgT3I2mTbbgPy_uvrfYJous
     scenes-app-notebooks--bullet-list--dark:

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -2,7 +2,7 @@ import { useValues } from 'kea'
 import { useMemo } from 'react'
 
 import { IconBolt } from '@posthog/icons'
-import { LemonSkeleton, Link } from '@posthog/lemon-ui'
+import { LemonSkeleton, LemonTag, Link } from '@posthog/lemon-ui'
 import { type ChartTheme, MetricCard } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
@@ -202,12 +202,9 @@ function BrandingStrip(): JSX.Element {
                     <IconBolt className="h-3 w-3" />
                 </span>
                 <span className="text-[13px] font-medium">PostHog for Agents</span>
-                <span
-                    className="rounded px-1.5 py-0.5 text-[10px] font-medium"
-                    style={{ background: '#E6F1FB', color: '#0C447C' }}
-                >
-                    Preview
-                </span>
+                <LemonTag type="completion" size="small">
+                    Alpha
+                </LemonTag>
             </div>
             <span className="text-[11px] text-tertiary">Last 7 days</span>
         </div>
@@ -249,9 +246,9 @@ function errorBucket(pct: number): ErrorBucket {
 }
 
 const ERROR_PILL_CLASS: Record<ErrorBucket, string> = {
-    green: 'text-[#27500A] bg-[#EAF3DE]',
-    amber: 'text-[#633806] bg-[#FAEEDA]',
-    red: 'text-[#791F1F] bg-[#FCEBEB]',
+    green: 'text-success bg-fill-success-highlight',
+    amber: 'text-warning bg-fill-warning-highlight',
+    red: 'text-error bg-fill-error-highlight',
 }
 
 function ErrorRatePill({ pct }: { pct: number }): JSX.Element {
@@ -265,11 +262,28 @@ function ErrorRatePill({ pct }: { pct: number }): JSX.Element {
     )
 }
 
+const VOLUME_COLOR = 'var(--data-color-1)'
+const ERROR_COLOR = 'var(--data-color-5)'
+
+function VolumeBar({ totalPct, errorPct, title }: { totalPct: number; errorPct: number; title: string }): JSX.Element {
+    const errorStartPct = (Math.max(totalPct - errorPct, 0) / (totalPct || 1)) * 100
+    return (
+        <div className="relative h-[14px] overflow-hidden rounded-[3px] bg-surface-secondary" title={title}>
+            <div
+                className="h-full opacity-40"
+                style={{
+                    width: `${totalPct}%`,
+                    background: `linear-gradient(to right, ${VOLUME_COLOR} ${errorStartPct}%, ${ERROR_COLOR} ${errorStartPct}%)`,
+                }}
+            />
+        </div>
+    )
+}
+
 function ToolRowItem({ row, maxVolume, isLast }: { row: ToolRow; maxVolume: number; isLast: boolean }): JSX.Element {
     const callsPct = maxVolume ? (row.total_calls / maxVolume) * 100 : 0
     const errorsPct = maxVolume ? (row.errors / maxVolume) * 100 : 0
-    const successPct = Math.max(callsPct - errorsPct, 0)
-    const nameClass = row.error_rate_pct > 5 ? 'text-[#791F1F]' : 'text-primary'
+    const nameClass = row.error_rate_pct > 5 ? 'text-error' : 'text-primary'
     return (
         <div
             className="grid items-center gap-2.5 py-1.5"
@@ -285,13 +299,11 @@ function ToolRowItem({ row, maxVolume, isLast }: { row: ToolRow; maxVolume: numb
             >
                 {row.tool}
             </Link>
-            <div
-                className="relative flex h-[14px] overflow-hidden rounded-[3px] bg-surface-secondary"
+            <VolumeBar
+                totalPct={callsPct}
+                errorPct={errorsPct}
                 title={`${row.total_calls} calls · ${row.errors} errors`}
-            >
-                <div className="h-full bg-[#B5D4F4]" style={{ width: `${successPct}%` }} />
-                <div className="h-full bg-[#F09595]" style={{ width: `${errorsPct}%` }} />
-            </div>
+            />
             <ErrorRatePill pct={row.error_rate_pct} />
             <span className="text-right font-mono text-xs text-primary">
                 {row.p95_duration_ms ? `${Math.round(row.p95_duration_ms)}ms` : '—'}
@@ -322,9 +334,9 @@ function ToolReliabilityMatrix({
             >
                 <span>Tool</span>
                 <span>
-                    <span className="text-[#185FA5]">Calls</span>
+                    <span style={{ color: VOLUME_COLOR }}>Calls</span>
                     <span className="mx-1">·</span>
-                    <span className="text-[#A32D2D]">errors</span>
+                    <span style={{ color: ERROR_COLOR }}>errors</span>
                 </span>
                 <span>Err</span>
                 <span className="text-right">p95</span>
@@ -370,9 +382,9 @@ function HarnessBreakdown({ rows, loading }: { rows: HarnessRow[]; loading: bool
             >
                 <span>Harness</span>
                 <span>
-                    <span className="text-[#185FA5]">Calls</span>
+                    <span style={{ color: VOLUME_COLOR }}>Calls</span>
                     <span className="mx-1">·</span>
-                    <span className="text-[#A32D2D]">errors</span>
+                    <span style={{ color: ERROR_COLOR }}>errors</span>
                 </span>
                 <span>Err</span>
                 <span className="text-right">Share</span>
@@ -389,7 +401,6 @@ function HarnessBreakdown({ rows, loading }: { rows: HarnessRow[]; loading: bool
                 rows.map((row, i) => {
                     const callsPct = maxCalls ? (row.total_calls / maxCalls) * 100 : 0
                     const errorsPct = maxCalls ? (row.errors / maxCalls) * 100 : 0
-                    const successPct = Math.max(callsPct - errorsPct, 0)
                     const share = totalCalls ? (row.total_calls / totalCalls) * 100 : 0
                     const tooltip = row.raw_clients.slice(0, 8).join(', ')
                     return (
@@ -403,13 +414,11 @@ function HarnessBreakdown({ rows, loading }: { rows: HarnessRow[]; loading: bool
                             }}
                         >
                             <HarnessPill category={row.category} title={tooltip} />
-                            <div
-                                className="relative flex h-[14px] overflow-hidden rounded-[3px] bg-surface-secondary"
+                            <VolumeBar
+                                totalPct={callsPct}
+                                errorPct={errorsPct}
                                 title={`${row.total_calls} calls · ${row.errors} errors · ${row.sessions} sessions`}
-                            >
-                                <div className="h-full bg-[#B5D4F4]" style={{ width: `${successPct}%` }} />
-                                <div className="h-full bg-[#F09595]" style={{ width: `${errorsPct}%` }} />
-                            </div>
+                            />
                             <ErrorRatePill pct={row.error_rate_pct} />
                             <span className="text-right font-mono text-xs text-primary">
                                 {share.toFixed(share >= 10 ? 0 : 1)}%
@@ -442,7 +451,7 @@ function formatDuration(seconds: number): string {
 function StatusPill({ errorRatePct }: { errorRatePct: number }): JSX.Element {
     if (errorRatePct >= 100) {
         return (
-            <span className="inline-flex h-[14px] items-center rounded-[3px] bg-[#FCEBEB] px-1.5 text-[10px] font-medium text-[#791F1F]">
+            <span className="inline-flex h-[14px] items-center rounded-[3px] bg-fill-error-highlight px-1.5 text-[10px] font-medium text-error">
                 100% err
             </span>
         )
@@ -458,7 +467,7 @@ function StatusPill({ errorRatePct }: { errorRatePct: number }): JSX.Element {
         )
     }
     return (
-        <span className="inline-flex h-[14px] items-center rounded-[3px] bg-[#EAF3DE] px-1.5 text-[10px] font-medium text-[#27500A]">
+        <span className="inline-flex h-[14px] items-center rounded-[3px] bg-fill-success-highlight px-1.5 text-[10px] font-medium text-success">
             Success
         </span>
     )


### PR DESCRIPTION


use PH theme colours

![CleanShot 2026-06-07 at 22.59.39.gif](https://app.graphite.com/user-attachments/assets/3095c811-0b12-4016-a08f-22e0252a55cb.gif)

## Problem

The dashboard's volume bars and error/status pills used hardcoded hex colors. They didn't follow light/dark mode like the rest of the data viz, and the two-tone bars were a hand-picked palette rather than the design-system tokens.

## Changes

- **Volume bars** now render as a single translucent element with a hard-stop linear gradient between `data-color-1` (success) and `data-color-5` (error). A single element keeps the colour boundary crisp — two stacked divs left a muddy anti-aliased seam once the colours were vivid. Translucency (`opacity-40`) gives the soft feel of the MetricCard sparkline fill.
- **Error and status pills** use the semantic `success` / `warning` / `error` fill and text tokens.
- Extracted a shared `VolumeBar` component used by both the tool-quality and harness tables (previously duplicated markup).

All colours now follow the theme, so the bars and pills adapt correctly in dark mode.

## How did you test this code?

I'm an agent (PostHog Code). Using the Storybook story from the base PR, I rendered the dashboard in a local Storybook and verified in both light and dark mode that the bars and pills follow the theme and the gradient seam stays clean across both tables. I measured the rendered bar geometry in the browser to confirm there is no sub-pixel gap at the boundary. `oxlint`/`oxfmt` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude). Tools used: file edit/read, shell, and the Playwright MCP to render and screenshot the dashboard.

Iteration that shaped the result: first swapped the bars to full-saturation `data-color` tokens, which looked too vivid and revealed a muddy anti-aliased seam where the two adjacent vivid segments met at a sub-pixel boundary. An overlay approach (red painted over a full blue base) fixed the seam but breaks under transparency — a translucent red over blue reads purple. The final approach is one element with a hard-stop gradient at ~40% opacity, which is seam-free, transparent, and theme-following. Pills were mapped to semantic status tokens rather than the data palette since they convey good/warn/bad, not a series. Agent-authored; requires human review.