### PR TITLE
fix(signals): grace the scout due-check so hourly scouts don't halve

### DIFF
--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -49,6 +49,10 @@ MAX_RUNS_PER_TICK = 50
 # just the polling granularity — the floor on how often any scout can run.
 COORDINATOR_INTERVAL_MINUTES = 30
 
+# Slack on the due-check so a scout that's a few seconds short at a tick still counts as due —
+# else stamp jitter makes it skip every other tick (a 60-min scout runs every 2h).
+DUE_GRACE_SECONDS = 60
+
 
 @dataclass
 class PlannedRun:
@@ -281,11 +285,11 @@ def _register_missing_configs(team: Team) -> set[str]:
 
 
 def _overdue_seconds(config: SignalScoutConfig, now: datetime) -> float | None:
-    """Seconds past due, or None if not yet due. Never-run rows are maximally overdue."""
+    """Seconds past due (down to `-DUE_GRACE_SECONDS`), or None if not yet due. Never-run rows are maximally overdue."""
     if config.last_run_at is None:
         return float("inf")
     overdue = (now - config.last_run_at).total_seconds() - config.run_interval_minutes * 60
-    return overdue if overdue >= 0 else None
+    return overdue if overdue >= -DUE_GRACE_SECONDS else None
 
 
 @workflow.defn(name="run-signals-scout-coordinator")

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -281,6 +281,35 @@ async def test_config_within_interval_is_not_due(ateam):
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
+async def test_config_just_short_of_interval_is_due_within_grace(ateam):
+    # A few seconds short of the interval (stamp jitter) still counts as due — without this the
+    # scout skips every other tick and runs at half cadence.
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-foo")
+    last_run = timezone.now() - timedelta(minutes=60) + timedelta(seconds=5)
+    await database_sync_to_async(_create_config)(
+        ateam, "signals-scout-foo", enabled=True, run_interval_minutes=60, last_run_at=last_run
+    )
+
+    planned = await _run_activity()
+
+    assert [p.skill_name for p in planned] == ["signals-scout-foo"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_config_short_beyond_grace_is_not_due(ateam):
+    # Short by more than the grace window → genuinely not due yet.
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-foo")
+    last_run = timezone.now() - timedelta(minutes=60) + timedelta(seconds=120)
+    await database_sync_to_async(_create_config)(
+        ateam, "signals-scout-foo", enabled=True, run_interval_minutes=60, last_run_at=last_run
+    )
+
+    assert await _run_activity() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
 async def test_overdue_config_is_planned_without_stamping(ateam):
     # Planning only selects due runs — it must NOT advance last_run_at. The schedule is
     # stamped after dispatch (see test_stamp_activity_advances_dispatched_configs) so a

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -284,8 +284,8 @@ async def test_config_within_interval_is_not_due(ateam):
 @pytest.mark.parametrize(
     "seconds_short,expected_skill_names",
     [
-        (5, ["signals-scout-foo"]),    # within grace — stamp jitter shouldn't halve cadence
-        (120, []),                     # beyond grace — genuinely not due yet
+        (5, ["signals-scout-foo"]),  # within grace — stamp jitter shouldn't halve cadence
+        (120, []),  # beyond grace — genuinely not due yet
     ],
 )
 async def test_due_check_grace_boundary(ateam, seconds_short, expected_skill_names):

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -281,31 +281,23 @@ async def test_config_within_interval_is_not_due(ateam):
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
-async def test_config_just_short_of_interval_is_due_within_grace(ateam):
-    # A few seconds short of the interval (stamp jitter) still counts as due — without this the
-    # scout skips every other tick and runs at half cadence.
+@pytest.mark.parametrize(
+    "seconds_short,expected_skill_names",
+    [
+        (5, ["signals-scout-foo"]),    # within grace — stamp jitter shouldn't halve cadence
+        (120, []),                     # beyond grace — genuinely not due yet
+    ],
+)
+async def test_due_check_grace_boundary(ateam, seconds_short, expected_skill_names):
     await database_sync_to_async(_create_skill)(ateam, "signals-scout-foo")
-    last_run = timezone.now() - timedelta(minutes=60) + timedelta(seconds=5)
+    last_run = timezone.now() - timedelta(minutes=60) + timedelta(seconds=seconds_short)
     await database_sync_to_async(_create_config)(
         ateam, "signals-scout-foo", enabled=True, run_interval_minutes=60, last_run_at=last_run
     )
 
     planned = await _run_activity()
 
-    assert [p.skill_name for p in planned] == ["signals-scout-foo"]
-
-
-@pytest.mark.asyncio
-@pytest.mark.django_db
-async def test_config_short_beyond_grace_is_not_due(ateam):
-    # Short by more than the grace window → genuinely not due yet.
-    await database_sync_to_async(_create_skill)(ateam, "signals-scout-foo")
-    last_run = timezone.now() - timedelta(minutes=60) + timedelta(seconds=120)
-    await database_sync_to_async(_create_config)(
-        ateam, "signals-scout-foo", enabled=True, run_interval_minutes=60, last_run_at=last_run
-    )
-
-    assert await _run_activity() == []
+    assert [p.skill_name for p in planned] == expected_skill_names
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Hourly Signals scouts on the dogfood fleet are effectively running **every 2 hours**, not every hour.

The coordinator polls on a fixed schedule and dispatches every scout whose full `run_interval_minutes` has elapsed since `last_run_at`. But `last_run_at` is stamped a few seconds *into* a tick (after planning + child dispatch), so at the next equal-period tick a 60-minute scout is ~5 seconds short of the strict `>= interval` bar and gets deferred a whole tick. That repeats forever, so the scout runs every other tick — half its configured cadence. The phase a scout lands on is locked by whichever tick it first ran (observed today: the main fleet on even hours, anomaly-detection on odd).

This is purely the due-check boundary; it's independent of the per-tick concurrency/stagger discussion.

## Changes

- Add a small `DUE_GRACE_SECONDS = 60` slack to `_overdue_seconds`: a scout within the grace window of its interval now counts as due. `grace` is far below the smallest allowed interval (10 min), so it can never cause an early double-run — once dispatched, `last_run_at` advances and the scout isn't due again until a full interval later.
- Tests: a just-short run (5 s under a 60-min interval) is now planned; a run short by more than the grace window (120 s) is still correctly not due.

No schedule/config changes — this fixes the cadence for all scouts at once regardless of the coordinator's poll interval.

## How did you test this code?

I'm an agent (Claude Code). I did **not** manually test against a live worker. Automated only:

- `hogli test products/signals/backend/test/test_scout_coordinator.py` — 31 passed, including the two new boundary tests.
- `ruff check` + `ruff format --check` clean on both files; pre-commit `ty` check passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code while sampling the dogfood scout fleet and noticing the 2-hourly cadence. We diagnosed it from `scout_coordinator.py` (`_overdue_seconds` strict `>= 0`, `last_run_at` stamped at dispatch) plus run-history data showing only `:00` dispatches.

Considered three fixes: (1) a per-config workaround setting `run_interval_minutes` below 60 to buy slack — rejected as a hack that lies about the cadence; (2) lowering `COORDINATOR_INTERVAL_MINUTES` — rejected because alone it yields a 90-min cadence, not 60, so the boundary still needs slack; (3) the grace in the due-check — chosen as the smallest fix that's correct for every scout. Stamping `last_run_at` to the tick's scheduled time was the alternative but is a larger change. A separate backlog item tracks staggering/concurrency-capping the `:00` kickoffs, which is orthogonal to this.
