### PR TITLE
fix(max): stop AI side panel from auto-opening on app load

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.test.ts
@@ -1,3 +1,4 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -51,5 +52,42 @@ describe('sidePanelStateLogic', () => {
         // Closing the selected tab closes the panel
         logic.actions.closeSidePanel(SidePanelTab.Max)
         await expectLogic(logic).toMatchValues({ sidePanelOpen: false })
+    })
+
+    it('does not leave a #panel=max hash in the URL when opening Max', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.openSidePanel(SidePanelTab.Max)
+        }).toFinishAllListeners()
+        // No lingering hash means a reload / return to the app won't auto-reopen Max
+        expect(router.values.hashParams).not.toHaveProperty('panel')
+    })
+
+    it('clears the #panel=max:options hash after consuming options', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.openSidePanel(SidePanelTab.Max, '!Explain this insight')
+        }).toFinishAllListeners()
+        // Options live in kea state, not the URL, so reload doesn't re-run the prompt
+        expect(logic.values.selectedTabOptions).toEqual('!Explain this insight')
+        expect(router.values.hashParams).not.toHaveProperty('panel')
+    })
+
+    it('opens Max from a #panel=max hash but then strips it', async () => {
+        await expectLogic(logic, () => {
+            router.actions.push('', {}, { panel: 'max' })
+        }).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
+        expect(router.values.hashParams).not.toHaveProperty('panel')
+    })
+
+    it('keeps the #panel hash in the URL for tabs that persist it (e.g. Support)', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.openSidePanel(SidePanelTab.Support, 'bug:analytics')
+        }).toFinishAllListeners()
+        expect(router.values.hashParams['panel']).toEqual('support:bug:analytics')
+
+        // Closing removes the hash
+        await expectLogic(logic, () => {
+            logic.actions.closeSidePanel()
+        }).toFinishAllListeners()
+        expect(router.values.hashParams).not.toHaveProperty('panel')
     })
 })

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.test.ts
@@ -54,27 +54,28 @@ describe('sidePanelStateLogic', () => {
         await expectLogic(logic).toMatchValues({ sidePanelOpen: false })
     })
 
-    it('does not leave a #panel=max hash in the URL when opening Max', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.openSidePanel(SidePanelTab.Max)
-        }).toFinishAllListeners()
-        // No lingering hash means a reload / return to the app won't auto-reopen Max
+    // No lingering hash means a reload / return to the app won't auto-reopen Max
+    it.each([
+        ['opening via action', () => logic.actions.openSidePanel(SidePanelTab.Max)],
+        ['opening via URL hash', () => router.actions.push('', {}, { panel: 'max' })],
+    ])('does not leave a #panel hash in the URL after Max opens (%s)', async (_, trigger) => {
+        await expectLogic(logic, trigger).toFinishAllListeners()
         expect(router.values.hashParams).not.toHaveProperty('panel')
     })
 
-    it('clears the #panel=max:options hash after consuming options', async () => {
+    it('opens Max from a #panel=max hash before stripping it', async () => {
+        await expectLogic(logic, () => {
+            router.actions.push('', {}, { panel: 'max' })
+        }).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
+        expect(router.values.hashParams).not.toHaveProperty('panel')
+    })
+
+    it('consumes #panel=max:options into kea state and strips the hash', async () => {
         await expectLogic(logic, () => {
             logic.actions.openSidePanel(SidePanelTab.Max, '!Explain this insight')
         }).toFinishAllListeners()
         // Options live in kea state, not the URL, so reload doesn't re-run the prompt
         expect(logic.values.selectedTabOptions).toEqual('!Explain this insight')
-        expect(router.values.hashParams).not.toHaveProperty('panel')
-    })
-
-    it('opens Max from a #panel=max hash but then strips it', async () => {
-        await expectLogic(logic, () => {
-            router.actions.push('', {}, { panel: 'max' })
-        }).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
         expect(router.values.hashParams).not.toHaveProperty('panel')
     })
 

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.tsx
@@ -101,7 +101,24 @@ export const sidePanelStateLogic = kea<sidePanelStateLogicType>([
         },
     })),
     actionToUrl(({ values }) => {
+        const removePanelHash = (): any => {
+            if (!('panel' in router.values.hashParams)) {
+                return // nothing to strip — avoid a redundant history replace
+            }
+            const hashParams = { ...router.values.hashParams }
+            delete hashParams['panel']
+            return [router.values.location.pathname, router.values.searchParams, hashParams, { replace: true }]
+        }
         const updateUrl = (): any => {
+            // The PostHog AI (Max) panel is consume-and-clear: a #panel=max hash may open it, but we never
+            // leave it in the URL, otherwise it auto-reopens on reload or when returning to the app. Max reads
+            // any prefill from selectedTabOptions (kea state), so it doesn't need the hash to persist.
+            // Other tabs (e.g. Support) intentionally keep their state in the #panel hash so a refresh
+            // preserves the open form.
+            if (values.selectedTab === SidePanelTab.Max) {
+                return removePanelHash()
+            }
+
             let panelHash: string = values.selectedTab ?? ''
 
             if (values.selectedTabOptions) {
@@ -120,11 +137,7 @@ export const sidePanelStateLogic = kea<sidePanelStateLogicType>([
         return {
             openSidePanel: () => updateUrl(),
             setSidePanelOptions: () => updateUrl(),
-            closeSidePanel: () => {
-                const hashParams = { ...router.values.hashParams }
-                delete hashParams['panel']
-                return [router.values.location.pathname, router.values.searchParams, hashParams, { replace: true }]
-            },
+            closeSidePanel: () => removePanelHash(),
         }
     }),
 ])


### PR DESCRIPTION
## Problem

On loading the app, the PostHog AI (Max) side panel popped open by itself. It should only open from an explicit trigger (a click or a deep link), never on its own when reloading or returning to the app.

The `sidePanelOpen` state is deliberately **not** persisted, but opening any panel wrote its state into the URL `#panel` hash via `actionToUrl`, and `urlToAction` reopened the panel from that hash on load. So a normal click that opened Max left a `#panel=max` hash lingering in the URL, which then auto-reopened Max on the next load/return.

## Changes

Make the Max tab **consume-and-clear** in the URL:

- A `#panel=max` hash may still open Max (deep links such as the promoted "see more" link keep working), but the hash is stripped immediately after it is consumed, so a reload or return to the app never reopens it.
- Max reads any prefill from `selectedTabOptions` (kea state), not the URL, so dropping the hash does not affect prompts or auto-send.
- Other tabs that legitimately want their state preserved across a refresh — notably **Support**, whose form mirrors its fields into `#panel=support:…` — keep their existing URL-persistence behavior unchanged.

`closeSidePanel` now also no-ops the history replace when there is no `panel` hash to strip.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual browser testing. I added and ran automated unit tests:

- `sidePanelStateLogic.test.ts` — new cases covering: opening Max leaves no `#panel=max` hash; `#panel=max:options` is consumed into state then stripped; a `#panel=max` hash opens Max but is then removed; Support keeps its `#panel` hash and clears it on close. (9 passed)
- `maxLogic.test.ts` (22 passed), `maxContextLogic.test.ts` and `supportLogic.test.ts` (26 passed) — confirm the deep-link/options parsing and Support URL persistence still work.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by PostHog Code (agent). The repo was a shallow clone so git history was unavailable; I traced the behavior statically. Investigation found that `sidePanelOpen` is correctly non-persisted and no `afterMount` opens Max — the only auto-open path is the `#panel` hash round-trip between `actionToUrl` (writer) and `urlToAction` (reader).

Considered removing the hash writers entirely, but Support deliberately relies on `setSidePanelOptions` writing `#panel=support:…` so its form survives a refresh, and several legitimate deep links (`#panel=discussion`, `#panel=support:…`, `#panel=max:…`) must still open panels on load. Chose a tab-scoped fix: only Max is consume-and-clear, leaving every other tab's URL behavior untouched. This keeps the blast radius minimal and matches the documented intent that the panel "must only open from an explicit trigger, never auto-reopen on returning to the app."

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
