### PR TITLE
fix(workflows): decode html entities in tracked email link hrefs

### DIFF
--- a/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -16,7 +16,7 @@ import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { closeHub, createHub } from '~/utils/db/hub'
 
 import { Hub, Team } from '../../../types'
-import { PIXEL_GIF } from './email-tracking.service'
+import { PIXEL_GIF, addTrackingToEmail, decodeHtmlEntitiesInHref } from './email-tracking.service'
 import { generateEmailTrackingCode } from './helpers/tracking-code'
 
 describe('EmailTrackingService', () => {
@@ -33,6 +33,65 @@ describe('EmailTrackingService', () => {
 
     afterEach(async () => {
         await closeHub(hub)
+    })
+
+    describe('addTrackingToEmail', () => {
+        const invocation = {
+            functionId: 'fn-1',
+            id: 'inv-1',
+            teamId: 1,
+        } as any
+
+        const extractTarget = (html: string): string => {
+            const match = html.match(/href="[^"]*target=([^"&]+)/)
+            if (!match) {
+                throw new Error(`no tracking href in: ${html}`)
+            }
+            return decodeURIComponent(match[1])
+        }
+
+        it('preserves ampersands in URLs encoded as &amp; in the source HTML', () => {
+            const html = '<body><a href="https://example.com/?foo=bar&amp;baz=bop">click</a></body>'
+            const out = addTrackingToEmail(html, invocation)
+            expect(extractTarget(out)).toBe('https://example.com/?foo=bar&baz=bop')
+        })
+
+        it('preserves ampersands encoded via decimal and hex numeric entities', () => {
+            const decimal = addTrackingToEmail(
+                '<body><a href="https://example.com/?a=1&#38;b=2">x</a></body>',
+                invocation
+            )
+            const hex = addTrackingToEmail('<body><a href="https://example.com/?a=1&#x26;b=2">x</a></body>', invocation)
+            expect(extractTarget(decimal)).toBe('https://example.com/?a=1&b=2')
+            expect(extractTarget(hex)).toBe('https://example.com/?a=1&b=2')
+        })
+
+        it('leaves plain URLs without entities unchanged in the redirect target', () => {
+            const html = '<body><a href="https://example.com/path">x</a></body>'
+            const out = addTrackingToEmail(html, invocation)
+            expect(extractTarget(out)).toBe('https://example.com/path')
+        })
+
+        it('skips javascript: hrefs', () => {
+            const html = '<body><a href="javascript:alert(1)">x</a></body>'
+            const out = addTrackingToEmail(html, invocation)
+            expect(out).toContain('href="javascript:alert(1)"')
+            expect(out).not.toContain('target=')
+        })
+    })
+
+    describe('decodeHtmlEntitiesInHref', () => {
+        it.each([
+            ['https://example.com/?a=1&amp;b=2', 'https://example.com/?a=1&b=2'],
+            ['https://example.com/?a=1&#38;b=2', 'https://example.com/?a=1&b=2'],
+            ['https://example.com/?a=1&#x26;b=2', 'https://example.com/?a=1&b=2'],
+            ['https://example.com/?a=1&amp;b=2&amp;c=3', 'https://example.com/?a=1&b=2&c=3'],
+            ['https://example.com/path', 'https://example.com/path'],
+            // Non-entity ampersands (legacy unencoded HTML) pass through untouched.
+            ['https://example.com/?a=1&b=2', 'https://example.com/?a=1&b=2'],
+        ])('decodes %s to %s', (input, expected) => {
+            expect(decodeHtmlEntitiesInHref(input)).toBe(expected)
+        })
     })
 
     describe('api', () => {

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -50,32 +50,42 @@ describe('EmailTrackingService', () => {
             return decodeURIComponent(match[1])
         }
 
-        it('preserves ampersands in URLs encoded as &amp; in the source HTML', () => {
-            const html = '<body><a href="https://example.com/?foo=bar&amp;baz=bop">click</a></body>'
-            const out = addTrackingToEmail(html, invocation)
-            expect(extractTarget(out)).toBe('https://example.com/?foo=bar&baz=bop')
-        })
-
-        it('preserves ampersands encoded via decimal and hex numeric entities', () => {
-            const decimal = addTrackingToEmail(
+        it.each([
+            [
+                'named entity &amp;',
+                '<body><a href="https://example.com/?foo=bar&amp;baz=bop">x</a></body>',
+                'https://example.com/?foo=bar&baz=bop',
+            ],
+            [
+                'decimal numeric entity &#38;',
                 '<body><a href="https://example.com/?a=1&#38;b=2">x</a></body>',
-                invocation
-            )
-            const hex = addTrackingToEmail('<body><a href="https://example.com/?a=1&#x26;b=2">x</a></body>', invocation)
-            expect(extractTarget(decimal)).toBe('https://example.com/?a=1&b=2')
-            expect(extractTarget(hex)).toBe('https://example.com/?a=1&b=2')
+                'https://example.com/?a=1&b=2',
+            ],
+            [
+                'hex numeric entity &#x26;',
+                '<body><a href="https://example.com/?a=1&#x26;b=2">x</a></body>',
+                'https://example.com/?a=1&b=2',
+            ],
+            [
+                'plain URL with no entities',
+                '<body><a href="https://example.com/path">x</a></body>',
+                'https://example.com/path',
+            ],
+        ])('decodes %s in the redirect target', (_name, html, expected) => {
+            expect(extractTarget(addTrackingToEmail(html, invocation))).toBe(expected)
         })
 
-        it('leaves plain URLs without entities unchanged in the redirect target', () => {
-            const html = '<body><a href="https://example.com/path">x</a></body>'
-            const out = addTrackingToEmail(html, invocation)
-            expect(extractTarget(out)).toBe('https://example.com/path')
-        })
-
-        it('skips javascript: hrefs', () => {
+        it('skips literal javascript: hrefs', () => {
             const html = '<body><a href="javascript:alert(1)">x</a></body>'
             const out = addTrackingToEmail(html, invocation)
             expect(out).toContain('href="javascript:alert(1)"')
+            expect(out).not.toContain('target=')
+        })
+
+        it('skips entity-encoded javascript: hrefs after decoding', () => {
+            const html = '<body><a href="java&#x73;cript:alert(1)">x</a></body>'
+            const out = addTrackingToEmail(html, invocation)
+            expect(out).toContain('href="java&#x73;cript:alert(1)"')
             expect(out).not.toContain('target=')
         })
     })
@@ -89,6 +99,10 @@ describe('EmailTrackingService', () => {
             ['https://example.com/path', 'https://example.com/path'],
             // Non-entity ampersands (legacy unencoded HTML) pass through untouched.
             ['https://example.com/?a=1&b=2', 'https://example.com/?a=1&b=2'],
+            // Out-of-range code points (> 0x10FFFF) must not throw RangeError;
+            // the entity is left as-is.
+            ['https://example.com/?x=&#x200000;', 'https://example.com/?x=&#x200000;'],
+            ['https://example.com/?x=&#2097152;', 'https://example.com/?x=&#2097152;'],
         ])('decodes %s to %s', (input, expected) => {
             expect(decodeHtmlEntitiesInHref(input)).toBe(expected)
         })

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -56,7 +56,9 @@ export const decodeHtmlEntitiesInHref = (value: string): string => {
             return NAMED_ENTITIES[named]
         }
         const code = dec ? parseInt(dec, 10) : parseInt(hex, 16)
-        return Number.isFinite(code) ? String.fromCodePoint(code) : _match
+        // `String.fromCodePoint` throws RangeError above 0x10FFFF — `Number.isFinite` alone
+        // wouldn't catch e.g. `&#x200000;` since `parseInt` happily returns a finite value.
+        return code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : _match
     })
 }
 
@@ -65,6 +67,11 @@ export const addTrackingToEmail = (html: string, invocation: CyclotronJobInvocat
 
     html = html.replace(LINK_REGEX, (m, d, s, u) => {
         const href = decodeHtmlEntitiesInHref(d || s || u || '')
+        // LINK_REGEX skips literal `javascript:` hrefs, but an attacker could entity-encode
+        // the scheme (e.g. `java&#x73;cript:`) to slip past it; re-check after decoding.
+        if (/^\s*javascript:/i.test(href)) {
+            return m
+        }
         const tracked = generateTrackingRedirectUrl(invocation, href)
 
         // replace just the href in the original tag to preserve other attributes

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -44,11 +44,27 @@ export const generateTrackingRedirectUrl = (
     return `${defaultConfig.CDP_EMAIL_TRACKING_URL}/public/m/redirect?ph_id=${generateEmailTrackingCode(invocation)}&target=${encodeURIComponent(targetUrl)}`
 }
 
+// HTML attribute values arrive entity-encoded (e.g. `&amp;`, `&#38;`). Decode before
+// percent-encoding for the tracking redirect, otherwise `?a=1&amp;b=2` round-trips
+// through `target=` as a literal `&amp;` and breaks the destination page's query string.
+const HTML_ENTITY_REGEX = /&(?:(amp|lt|gt|quot|apos)|#(\d+)|#x([0-9a-fA-F]+));/g
+const NAMED_ENTITIES: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" }
+
+export const decodeHtmlEntitiesInHref = (value: string): string => {
+    return value.replace(HTML_ENTITY_REGEX, (_match, named, dec, hex) => {
+        if (named) {
+            return NAMED_ENTITIES[named]
+        }
+        const code = dec ? parseInt(dec, 10) : parseInt(hex, 16)
+        return Number.isFinite(code) ? String.fromCodePoint(code) : _match
+    })
+}
+
 export const addTrackingToEmail = (html: string, invocation: CyclotronJobInvocationHogFunction): string => {
     const trackingUrl = generateEmailTrackingPixelUrl(invocation)
 
     html = html.replace(LINK_REGEX, (m, d, s, u) => {
-        const href = d || s || u || ''
+        const href = decodeHtmlEntitiesInHref(d || s || u || '')
         const tracked = generateTrackingRedirectUrl(invocation, href)
 
         // replace just the href in the original tag to preserve other attributes


### PR DESCRIPTION
## Problem

URLs added to links or buttons in workflow emails were arriving at the destination with `&amp;` instead of `&` in the query string, e.g. `https://example.com/?foo=bar&baz=bop` became `https://example.com/?foo=bar&amp;baz=bop` after a click. This breaks the destination page's query parsing.

Cause: the email link-tracking rewrite in `addTrackingToEmail` (CDP email service) captured the raw `href` attribute text and percent-encoded it directly into the redirect `target=` param. HTML attribute values legitimately encode `&` as `&amp;`, so the literal string `&amp;` ended up inside `target=...`, came back through the 302 redirect, and reached the destination URL as `&amp;`. The non-tracking path was unaffected because browsers natively decode entity refs in `href` attributes.

## Changes

- Decode HTML entities on the captured `href` before passing it to `generateTrackingRedirectUrl`. Handles `&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`, plus decimal (`&#38;`) and hex (`&#x26;`) numeric entities — covers everything realistically reachable inside an `href`.
- New exported `decodeHtmlEntitiesInHref` helper kept small and inline (no new dep).

## How did you test this code?

I'm an agent. Automated tests only:

- New unit tests in `email-tracking.service.test.ts` covering the repro case (`&amp;`), decimal/hex numeric entities, plain URLs (unchanged), and the `javascript:` skip path — 10 new tests total.
- Full file suite (14 tests) passes.
- Adjacent `email.service.test.ts` (42 tests) passes — no regressions.
- `pnpm typescript:check` clean.

No manual testing of the full send → click → redirect flow against live SES.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.7). Approach: traced the captured-href value through `addTrackingToEmail` → `generateTrackingRedirectUrl` → tracking redirect handler and confirmed the round-trip preserves the literal `&amp;` string. Considered pulling in `html-entities` or `he` as a dep; chose a focused inline decoder instead since only a fixed set of entities can realistically appear in an `href` attribute value, and the regex/replace is ~10 lines.