### PR TITLE
fix(phai): keep dashboard URL when opening Max side panel

### DIFF
--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -674,8 +674,13 @@ export const maxLogic = kea<maxLogicType>([
         },
     })),
 
-    trackedActionToUrl(({ values }) => ({
+    trackedActionToUrl(({ values, props }) => ({
         toggleConversationHistory: () => {
+            // The side panel instance lives at #panel=max over the current scene; it must not
+            // push the main pathname to /ai or it would navigate away from the underlying page.
+            if (props.tabId === 'sidepanel') {
+                return undefined
+            }
             if (values.conversationHistoryVisible) {
                 return [urls.aiHistory(), {}, router.values.location.hash]
             } else if (values.conversationId) {
@@ -684,12 +689,21 @@ export const maxLogic = kea<maxLogicType>([
             return [urls.ai(), {}, router.values.location.hash]
         },
         startNewConversation: () => {
+            if (props.tabId === 'sidepanel') {
+                return undefined
+            }
             return [urls.ai(), {}, router.values.location.hash]
         },
         openConversation: ({ conversationId }) => {
+            if (props.tabId === 'sidepanel') {
+                return undefined
+            }
             return [urls.ai(conversationId), {}, router.values.location.hash]
         },
         setConversationId: ({ conversationId }) => {
+            if (props.tabId === 'sidepanel') {
+                return undefined
+            }
             // Only set the URL parameter if this is a new conversation (using frontendConversationId)
             if (conversationId && conversationId === values.frontendConversationId) {
                 return [urls.ai(conversationId), {}, router.values.location.hash, { replace: true }]


### PR DESCRIPTION
## Problem

Opening the Max AI side panel from a dashboard (or any scene) navigates the whole page to `/project/:id/ai#panel=max`, losing the underlying scene. The panel should open as an overlay while the dashboard stays on screen.

This is a regression from #61978 (`refactor(frontend): replace tabAwareActionToUrl with trackedActionToUrl`). The old `tabAwareActionToUrl` only pushed to the router when `sceneLogic.values.activeTabId === logic.props.tabId`, and suppressed URL updates for every other instance. The side-panel Max instance is keyed `tabId: 'sidepanel'`, which is never the active scene tab, so it always took the suppression branch and never touched the main URL.

`trackedActionToUrl` dropped that guard (the PR reasoned the inactive-tab branch was dead — true for scene tabs, but it overlooked the side panel's second `maxLogic` instance). So on mount, `startNewConversation` / `setConversationId` now push `/ai` and overwrite the scene's pathname.

## Changes

`maxLogic`'s `trackedActionToUrl` now returns `undefined` for the `'sidepanel'` instance across `toggleConversationHistory`, `startNewConversation`, `openConversation`, and `setConversationId`. The side panel's visible state stays owned by `sidePanelStateLogic`'s `#panel=max` hash, matching the existing `props.tabId !== 'sidepanel'` guards already used by listeners in this file. Scene/active-tab instances and the `trackUrlChange` observability are unaffected.

This restores the pre-#61978 behaviour with a targeted guard rather than reintroducing the `sceneLogic.activeTabId` machinery the in-app-tabs-removal stack is intentionally deleting.

## How did you test this code?

I'm an agent (PostHog Slack app). I have **not** run the app manually. Automated checks I ran: `pnpm --filter=@posthog/frontend typescript:check` surfaced no errors referencing `maxLogic.tsx` (remaining errors were pre-existing, from missing dev deps in a shallow clone).

Suggested manual verification:
1. Open a dashboard, click the AI side panel → dashboard stays visible, URL becomes `…/dashboard/<id>#panel=max` (not `…/ai#panel=max`).
2. From inside the panel, start a new chat and open conversation history → the main pathname does not change.
3. Open the full-page Max scene at `/ai` directly → still routes/updates URL as before.

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) from a Slack bug report. Traced the regression to #61978 via `git blame` + `git show` on the deleted `tabAwareActionToUrl.ts`, confirming its `activeTabId === tabId` guard was what kept the side-panel instance from driving the main URL. Chose a minimal `props.tabId === 'sidepanel'` guard over restoring the full tab-state machinery, since that machinery is being removed by the in-app-tabs stack. Requires human review and manual UI verification before merge.
