### PR TITLE
feat(data-warehouse): limit custom source resources and per-team count

### DIFF
--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -53,8 +53,13 @@ PROBE_MAX_RESOURCES = 5
 # hostile response from being buffered into worker memory (cf. URL_MAX_BYTES, sized
 # down here because the probe only needs a short diagnostic snippet).
 PROBE_ERROR_SNIPPET_BYTES = 2048
-# Upper bound on declared resources, matching business_knowledge MAX_URLS_PER_SOURCE.
-MAX_MANIFEST_RESOURCES = 500
+# Upper bound on the number of resources (tables/endpoints) a single custom
+# source may declare. Also bounds the create-time outbound-request amplifier.
+MAX_MANIFEST_RESOURCES = 50
+
+# Upper bound on the number of custom sources a single team/project may create.
+# Enforced in the external_data_source create endpoint.
+MAX_CUSTOM_SOURCES_PER_TEAM = 5
 
 
 def is_custom_source_available_for_team(team_id: int | None) -> bool:

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1202,36 +1202,35 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 data={"message": credentials_error or "Invalid credentials"},
             )
 
-        source_create_kwargs: dict[str, Any] = {
-            "source_id": str(uuid.uuid4()),
-            "connection_id": str(uuid.uuid4()),
-            "destination_id": str(uuid.uuid4()),
-            "created_by": request.user if isinstance(request.user, User) else None,
-            "created_via": created_via,
-            "team": self.team,
-            "status": "Running",
-            "source_type": source_type_model,
-            "job_inputs": source_config.to_dict(),
-            "prefix": prefix,
-            "description": description,
-            "access_method": access_method,
-        }
-
-        if source_type_model == ExternalDataSourceType.CUSTOM:
-            # Authoritative quota check: re-count under a per-team advisory lock so
-            # parallel submissions can't each pass the fast-path check and exceed the
-            # cap. The lock is taken here, after the credential probe, so it is never
-            # held across the outbound request.
-            with transaction.atomic():
+        # Short transaction around the insert so the custom-source quota can be enforced
+        # race-safely under a per-team advisory lock. For other source types this is just
+        # a single-statement transaction (no lock taken, negligible cost).
+        with transaction.atomic():
+            if source_type_model == ExternalDataSourceType.CUSTOM:
+                # Authoritative quota check: re-count under the lock so parallel
+                # submissions can't each pass the fast-path check and exceed the cap.
+                # The lock is taken here, after the credential probe, so it is never
+                # held across the outbound request.
                 acquire_custom_source_quota_lock(self.team_id)
                 if count_active_custom_sources(self.team_id) >= MAX_CUSTOM_SOURCES_PER_TEAM:
                     return Response(
                         status=status.HTTP_400_BAD_REQUEST,
                         data={"message": CUSTOM_SOURCE_LIMIT_MESSAGE},
                     )
-                new_source_model = ExternalDataSource.objects.create(**source_create_kwargs)
-        else:
-            new_source_model = ExternalDataSource.objects.create(**source_create_kwargs)
+            new_source_model = ExternalDataSource.objects.create(
+                source_id=str(uuid.uuid4()),
+                connection_id=str(uuid.uuid4()),
+                destination_id=str(uuid.uuid4()),
+                created_by=request.user if isinstance(request.user, User) else None,
+                created_via=created_via,
+                team=self.team,
+                status="Running",
+                source_type=source_type_model,
+                job_inputs=source_config.to_dict(),
+                prefix=prefix,
+                description=description,
+                access_method=access_method,
+            )
 
         # CDC: gate per-source-type adapter availability up front so downstream blocks
         # can `if cdc_enabled` without repeating the source-type check.

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1136,12 +1136,12 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 if isinstance(value, str):
                     payload[key] = value.strip()
         source_type_model = ExternalDataSourceType(source_type)
-        if source_type_model == ExternalDataSourceType.CUSTOM and not is_custom_source_available_for_team(self.team_id):
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={"message": "Custom REST source is not available for this team."},
-            )
         if source_type_model == ExternalDataSourceType.CUSTOM:
+            if not is_custom_source_available_for_team(self.team_id):
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={"message": "Custom REST source is not available for this team."},
+                )
             custom_source_count = (
                 ExternalDataSource.objects.filter(team_id=self.team_id, source_type=ExternalDataSourceType.CUSTOM)
                 .exclude(deleted=True)

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
-from django.db import connection, transaction
+from django.db import transaction
 from django.db.models import Prefetch, Q
 
 import structlog
@@ -371,11 +371,6 @@ def get_postgres_source_table_location(
 
 CUSTOM_SOURCE_LIMIT_MESSAGE = f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
 
-# Advisory-lock namespace ("DW") so per-team custom-source creates don't collide
-# with other lock users. pg_advisory_xact_lock takes a bigint; the namespace is
-# packed into the high bits and team_id into the low 32.
-_CUSTOM_SOURCE_LOCK_NAMESPACE = 0x4457
-
 
 def count_active_custom_sources(team_id: int) -> int:
     return (
@@ -383,19 +378,6 @@ def count_active_custom_sources(team_id: int) -> int:
         .exclude(deleted=True)
         .count()
     )
-
-
-def acquire_custom_source_quota_lock(team_id: int) -> None:
-    """Serialize concurrent custom-source creates for a team.
-
-    Must be called inside ``transaction.atomic()``; the lock releases when the
-    transaction ends. Closes the READ COMMITTED window where two concurrent
-    creates both read a count below the cap and both insert — without it the
-    per-team limit is bypassable under parallel submissions.
-    """
-    lock_id = (_CUSTOM_SOURCE_LOCK_NAMESPACE << 32) | (team_id & 0xFFFFFFFF)
-    with connection.cursor() as cursor:
-        cursor.execute("SELECT pg_advisory_xact_lock(%s)", [lock_id])
 
 
 class ExternalDataSourceRevenueAnalyticsConfigSerializer(serializers.ModelSerializer):
@@ -1170,9 +1152,6 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": "Custom REST source is not available for this team."},
             )
-        # Fast path: reject an already-over-quota team before running the
-        # (outbound) credential probe. The authoritative, race-safe check runs
-        # under an advisory lock right before the insert below.
         if (
             source_type_model == ExternalDataSourceType.CUSTOM
             and count_active_custom_sources(self.team_id) >= MAX_CUSTOM_SOURCES_PER_TEAM
@@ -1202,35 +1181,20 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 data={"message": credentials_error or "Invalid credentials"},
             )
 
-        # Short transaction around the insert so the custom-source quota can be enforced
-        # race-safely under a per-team advisory lock. For other source types this is just
-        # a single-statement transaction (no lock taken, negligible cost).
-        with transaction.atomic():
-            if source_type_model == ExternalDataSourceType.CUSTOM:
-                # Authoritative quota check: re-count under the lock so parallel
-                # submissions can't each pass the fast-path check and exceed the cap.
-                # The lock is taken here, after the credential probe, so it is never
-                # held across the outbound request.
-                acquire_custom_source_quota_lock(self.team_id)
-                if count_active_custom_sources(self.team_id) >= MAX_CUSTOM_SOURCES_PER_TEAM:
-                    return Response(
-                        status=status.HTTP_400_BAD_REQUEST,
-                        data={"message": CUSTOM_SOURCE_LIMIT_MESSAGE},
-                    )
-            new_source_model = ExternalDataSource.objects.create(
-                source_id=str(uuid.uuid4()),
-                connection_id=str(uuid.uuid4()),
-                destination_id=str(uuid.uuid4()),
-                created_by=request.user if isinstance(request.user, User) else None,
-                created_via=created_via,
-                team=self.team,
-                status="Running",
-                source_type=source_type_model,
-                job_inputs=source_config.to_dict(),
-                prefix=prefix,
-                description=description,
-                access_method=access_method,
-            )
+        new_source_model = ExternalDataSource.objects.create(
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            created_by=request.user if isinstance(request.user, User) else None,
+            created_via=created_via,
+            team=self.team,
+            status="Running",
+            source_type=source_type_model,
+            job_inputs=source_config.to_dict(),
+            prefix=prefix,
+            description=description,
+            access_method=access_method,
+        )
 
         # CDC: gate per-source-type adapter availability up front so downstream blocks
         # can `if cdc_enabled` without repeating the source-type check.

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -50,6 +50,7 @@ from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.common.sql import filter_dwh_columns_by_enabled_columns, sql_schema_metadata
 from posthog.temporal.data_imports.sources.common.sql.base import SQLSource
 from posthog.temporal.data_imports.sources.custom.source import (
+    MAX_CUSTOM_SOURCES_PER_TEAM,
     is_custom_source_available_for_team,
     manifest_request_hosts,
 )
@@ -1140,6 +1141,19 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": "Custom REST source is not available for this team."},
             )
+        if source_type_model == ExternalDataSourceType.CUSTOM:
+            custom_source_count = (
+                ExternalDataSource.objects.filter(team_id=self.team_id, source_type=ExternalDataSourceType.CUSTOM)
+                .exclude(deleted=True)
+                .count()
+            )
+            if custom_source_count >= MAX_CUSTOM_SOURCES_PER_TEAM:
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={
+                        "message": f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
+                    },
+                )
         source = SourceRegistry.get_source(source_type_model)
         is_valid, errors = source.validate_config(payload)
         if not is_valid:

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.models import Prefetch, Q
 
 import structlog
@@ -367,6 +367,35 @@ def get_postgres_source_table_location(
         },
         default_schema=default_schema,
     )
+
+
+CUSTOM_SOURCE_LIMIT_MESSAGE = f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
+
+# Advisory-lock namespace ("DW") so per-team custom-source creates don't collide
+# with other lock users. pg_advisory_xact_lock takes a bigint; the namespace is
+# packed into the high bits and team_id into the low 32.
+_CUSTOM_SOURCE_LOCK_NAMESPACE = 0x4457
+
+
+def count_active_custom_sources(team_id: int) -> int:
+    return (
+        ExternalDataSource.objects.filter(team_id=team_id, source_type=ExternalDataSourceType.CUSTOM)
+        .exclude(deleted=True)
+        .count()
+    )
+
+
+def acquire_custom_source_quota_lock(team_id: int) -> None:
+    """Serialize concurrent custom-source creates for a team.
+
+    Must be called inside ``transaction.atomic()``; the lock releases when the
+    transaction ends. Closes the READ COMMITTED window where two concurrent
+    creates both read a count below the cap and both insert — without it the
+    per-team limit is bypassable under parallel submissions.
+    """
+    lock_id = (_CUSTOM_SOURCE_LOCK_NAMESPACE << 32) | (team_id & 0xFFFFFFFF)
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT pg_advisory_xact_lock(%s)", [lock_id])
 
 
 class ExternalDataSourceRevenueAnalyticsConfigSerializer(serializers.ModelSerializer):
@@ -1141,19 +1170,17 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": "Custom REST source is not available for this team."},
             )
-        if source_type_model == ExternalDataSourceType.CUSTOM:
-            custom_source_count = (
-                ExternalDataSource.objects.filter(team_id=self.team_id, source_type=ExternalDataSourceType.CUSTOM)
-                .exclude(deleted=True)
-                .count()
+        # Fast path: reject an already-over-quota team before running the
+        # (outbound) credential probe. The authoritative, race-safe check runs
+        # under an advisory lock right before the insert below.
+        if (
+            source_type_model == ExternalDataSourceType.CUSTOM
+            and count_active_custom_sources(self.team_id) >= MAX_CUSTOM_SOURCES_PER_TEAM
+        ):
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": CUSTOM_SOURCE_LIMIT_MESSAGE},
             )
-            if custom_source_count >= MAX_CUSTOM_SOURCES_PER_TEAM:
-                return Response(
-                    status=status.HTTP_400_BAD_REQUEST,
-                    data={
-                        "message": f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
-                    },
-                )
         source = SourceRegistry.get_source(source_type_model)
         is_valid, errors = source.validate_config(payload)
         if not is_valid:
@@ -1175,20 +1202,36 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 data={"message": credentials_error or "Invalid credentials"},
             )
 
-        new_source_model = ExternalDataSource.objects.create(
-            source_id=str(uuid.uuid4()),
-            connection_id=str(uuid.uuid4()),
-            destination_id=str(uuid.uuid4()),
-            created_by=request.user if isinstance(request.user, User) else None,
-            created_via=created_via,
-            team=self.team,
-            status="Running",
-            source_type=source_type_model,
-            job_inputs=source_config.to_dict(),
-            prefix=prefix,
-            description=description,
-            access_method=access_method,
-        )
+        source_create_kwargs: dict[str, Any] = {
+            "source_id": str(uuid.uuid4()),
+            "connection_id": str(uuid.uuid4()),
+            "destination_id": str(uuid.uuid4()),
+            "created_by": request.user if isinstance(request.user, User) else None,
+            "created_via": created_via,
+            "team": self.team,
+            "status": "Running",
+            "source_type": source_type_model,
+            "job_inputs": source_config.to_dict(),
+            "prefix": prefix,
+            "description": description,
+            "access_method": access_method,
+        }
+
+        if source_type_model == ExternalDataSourceType.CUSTOM:
+            # Authoritative quota check: re-count under a per-team advisory lock so
+            # parallel submissions can't each pass the fast-path check and exceed the
+            # cap. The lock is taken here, after the credential probe, so it is never
+            # held across the outbound request.
+            with transaction.atomic():
+                acquire_custom_source_quota_lock(self.team_id)
+                if count_active_custom_sources(self.team_id) >= MAX_CUSTOM_SOURCES_PER_TEAM:
+                    return Response(
+                        status=status.HTTP_400_BAD_REQUEST,
+                        data={"message": CUSTOM_SOURCE_LIMIT_MESSAGE},
+                    )
+                new_source_model = ExternalDataSource.objects.create(**source_create_kwargs)
+        else:
+            new_source_model = ExternalDataSource.objects.create(**source_create_kwargs)
 
         # CDC: gate per-source-type adapter availability up front so downstream blocks
         # can `if cdc_enabled` without repeating the source-type check.

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1136,12 +1136,12 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 if isinstance(value, str):
                     payload[key] = value.strip()
         source_type_model = ExternalDataSourceType(source_type)
+        if source_type_model == ExternalDataSourceType.CUSTOM and not is_custom_source_available_for_team(self.team_id):
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": "Custom REST source is not available for this team."},
+            )
         if source_type_model == ExternalDataSourceType.CUSTOM:
-            if not is_custom_source_available_for_team(self.team_id):
-                return Response(
-                    status=status.HTTP_400_BAD_REQUEST,
-                    data={"message": "Custom REST source is not available for this team."},
-                )
             custom_source_count = (
                 ExternalDataSource.objects.filter(team_id=self.team_id, source_type=ExternalDataSourceType.CUSTOM)
                 .exclude(deleted=True)

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -31,6 +31,7 @@ from posthog.temporal.data_imports.sources import SourceRegistry
 from posthog.temporal.data_imports.sources.bigquery.bigquery import BigQuerySourceConfig
 from posthog.temporal.data_imports.sources.common.base import FieldType
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
+from posthog.temporal.data_imports.sources.custom.source import MAX_CUSTOM_SOURCES_PER_TEAM
 from posthog.temporal.data_imports.sources.postgres.postgres import PostgresDiscoveredSchema
 from posthog.temporal.data_imports.sources.postgres.source import PostgresSource
 from posthog.temporal.data_imports.sources.stripe.constants import (
@@ -5693,6 +5694,71 @@ class TestExternalDataSource(APIBaseTest):
         # than on availability — i.e. the eligibility check no longer blocks it.
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["message"] != "Custom REST source is not available for this team."
+
+    def test_create_custom_source_rejected_when_team_at_source_limit(self):
+        for i in range(MAX_CUSTOM_SOURCES_PER_TEAM):
+            ExternalDataSource.objects.create(
+                team_id=self.team.pk,
+                source_id=str(uuid.uuid4()),
+                connection_id=str(uuid.uuid4()),
+                destination_id=str(uuid.uuid4()),
+                source_type="Custom",
+                prefix=f"custom_{i}_",
+                job_inputs={"manifest_json": "{}"},
+            )
+
+        with patch(
+            "products.data_warehouse.backend.api.external_data_source.is_custom_source_available_for_team",
+            return_value=True,
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/",
+                data={
+                    "source_type": "Custom",
+                    "prefix": "custom_new_",
+                    "payload": {"manifest_json": "{}"},
+                },
+            )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert (
+            response.json()["message"]
+            == f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
+        )
+
+    def test_create_custom_source_limit_ignores_deleted_and_other_teams(self):
+        # Soft-deleted custom sources and other teams' sources don't count toward the limit.
+        for i in range(MAX_CUSTOM_SOURCES_PER_TEAM):
+            ExternalDataSource.objects.create(
+                team_id=self.team.pk,
+                source_id=str(uuid.uuid4()),
+                connection_id=str(uuid.uuid4()),
+                destination_id=str(uuid.uuid4()),
+                source_type="Custom",
+                prefix=f"custom_deleted_{i}_",
+                job_inputs={"manifest_json": "{}"},
+                deleted=True,
+            )
+
+        with patch(
+            "products.data_warehouse.backend.api.external_data_source.is_custom_source_available_for_team",
+            return_value=True,
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/",
+                data={
+                    "source_type": "Custom",
+                    "prefix": "custom_new_",
+                    "payload": {"manifest_json": "{}"},
+                },
+            )
+
+        # Not blocked by the per-team limit — it fails later on the (empty) manifest instead.
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert (
+            response.json()["message"]
+            != f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
+        )
 
     def test_revenue_analytics_config_created_automatically(self):
         """Test that revenue analytics config is created automatically when external data source is created."""

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -5695,16 +5695,29 @@ class TestExternalDataSource(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["message"] != "Custom REST source is not available for this team."
 
-    def test_create_custom_source_rejected_when_team_at_source_limit(self):
+    @parameterized.expand(
+        [
+            # name, seed sources soft-deleted?, seed for a different team?, expect the limit error
+            ("active_sources_at_limit", False, False, True),
+            ("soft_deleted_excluded", True, False, False),
+            ("other_team_excluded", False, True, False),
+        ]
+    )
+    def test_create_custom_source_per_team_limit(self, _name, deleted, other_team, expect_blocked):
+        seed_team_id = self.team.pk
+        if other_team:
+            seed_team_id = Team.objects.create(organization=self.organization, name="other team").pk
+
         for i in range(MAX_CUSTOM_SOURCES_PER_TEAM):
             ExternalDataSource.objects.create(
-                team_id=self.team.pk,
+                team_id=seed_team_id,
                 source_id=str(uuid.uuid4()),
                 connection_id=str(uuid.uuid4()),
                 destination_id=str(uuid.uuid4()),
                 source_type="Custom",
                 prefix=f"custom_{i}_",
                 job_inputs={"manifest_json": "{}"},
+                deleted=deleted,
             )
 
         with patch(
@@ -5720,45 +5733,14 @@ class TestExternalDataSource(APIBaseTest):
                 },
             )
 
+        # Every case 400s; only the at-limit case is blocked *by the per-team limit* — the
+        # excluded cases pass the gate and fail later on the (empty) manifest instead.
+        limit_message = f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert (
-            response.json()["message"]
-            == f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
-        )
-
-    def test_create_custom_source_limit_ignores_deleted_and_other_teams(self):
-        # Soft-deleted custom sources and other teams' sources don't count toward the limit.
-        for i in range(MAX_CUSTOM_SOURCES_PER_TEAM):
-            ExternalDataSource.objects.create(
-                team_id=self.team.pk,
-                source_id=str(uuid.uuid4()),
-                connection_id=str(uuid.uuid4()),
-                destination_id=str(uuid.uuid4()),
-                source_type="Custom",
-                prefix=f"custom_deleted_{i}_",
-                job_inputs={"manifest_json": "{}"},
-                deleted=True,
-            )
-
-        with patch(
-            "products.data_warehouse.backend.api.external_data_source.is_custom_source_available_for_team",
-            return_value=True,
-        ):
-            response = self.client.post(
-                f"/api/environments/{self.team.pk}/external_data_sources/",
-                data={
-                    "source_type": "Custom",
-                    "prefix": "custom_new_",
-                    "payload": {"manifest_json": "{}"},
-                },
-            )
-
-        # Not blocked by the per-team limit — it fails later on the (empty) manifest instead.
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert (
-            response.json()["message"]
-            != f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
-        )
+        if expect_blocked:
+            assert response.json()["message"] == limit_message
+        else:
+            assert response.json()["message"] != limit_message
 
     def test_revenue_analytics_config_created_automatically(self):
         """Test that revenue analytics config is created automatically when external data source is created."""

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -5742,49 +5742,6 @@ class TestExternalDataSource(APIBaseTest):
         else:
             assert response.json()["message"] != limit_message
 
-    def test_create_custom_source_quota_enforced_under_race(self):
-        # Simulate a concurrent insert landing between the fast-path check and the
-        # authoritative locked recount: the fast-path sees the team under the cap, but
-        # by the time we hold the lock the count has crossed it. The locked guard must
-        # still reject, and no source row may be created.
-        fake_source = MagicMock()
-        fake_source.validate_config.return_value = (True, [])
-        fake_source.validate_credentials.return_value = (True, None)
-        fake_source.parse_config.return_value = MagicMock()
-
-        with (
-            patch(
-                "products.data_warehouse.backend.api.external_data_source.is_custom_source_available_for_team",
-                return_value=True,
-            ),
-            patch(
-                "products.data_warehouse.backend.api.external_data_source.SourceRegistry.get_source",
-                return_value=fake_source,
-            ),
-            patch(
-                "products.data_warehouse.backend.api.external_data_source.count_active_custom_sources",
-                side_effect=[0, MAX_CUSTOM_SOURCES_PER_TEAM],
-            ),
-        ):
-            response = self.client.post(
-                f"/api/environments/{self.team.pk}/external_data_sources/",
-                data={
-                    "source_type": "Custom",
-                    "prefix": "custom_race_",
-                    "payload": {"manifest_json": "{}"},
-                },
-            )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert (
-            response.json()["message"]
-            == f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
-        )
-        assert (
-            ExternalDataSource.objects.filter(team_id=self.team.pk, source_type="Custom").exclude(deleted=True).count()
-            == 0
-        )
-
     def test_revenue_analytics_config_created_automatically(self):
         """Test that revenue analytics config is created automatically when external data source is created."""
         source = self._create_external_data_source()

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -5742,6 +5742,49 @@ class TestExternalDataSource(APIBaseTest):
         else:
             assert response.json()["message"] != limit_message
 
+    def test_create_custom_source_quota_enforced_under_race(self):
+        # Simulate a concurrent insert landing between the fast-path check and the
+        # authoritative locked recount: the fast-path sees the team under the cap, but
+        # by the time we hold the lock the count has crossed it. The locked guard must
+        # still reject, and no source row may be created.
+        fake_source = MagicMock()
+        fake_source.validate_config.return_value = (True, [])
+        fake_source.validate_credentials.return_value = (True, None)
+        fake_source.parse_config.return_value = MagicMock()
+
+        with (
+            patch(
+                "products.data_warehouse.backend.api.external_data_source.is_custom_source_available_for_team",
+                return_value=True,
+            ),
+            patch(
+                "products.data_warehouse.backend.api.external_data_source.SourceRegistry.get_source",
+                return_value=fake_source,
+            ),
+            patch(
+                "products.data_warehouse.backend.api.external_data_source.count_active_custom_sources",
+                side_effect=[0, MAX_CUSTOM_SOURCES_PER_TEAM],
+            ),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/",
+                data={
+                    "source_type": "Custom",
+                    "prefix": "custom_race_",
+                    "payload": {"manifest_json": "{}"},
+                },
+            )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert (
+            response.json()["message"]
+            == f"You can create at most {MAX_CUSTOM_SOURCES_PER_TEAM} custom sources per project."
+        )
+        assert (
+            ExternalDataSource.objects.filter(team_id=self.team.pk, source_type="Custom").exclude(deleted=True).count()
+            == 0
+        )
+
     def test_revenue_analytics_config_created_automatically(self):
         """Test that revenue analytics config is created automatically when external data source is created."""
         source = self._create_external_data_source()


### PR DESCRIPTION
## Problem

Custom REST sources let users declare an arbitrary REST API manifest. Today a single custom source could declare up to 500 resources, and a team could create an unbounded number of custom sources. Both are larger than the product wants to support during the alpha, and an unbounded resource/source count is also an outbound-request and operational risk.

## Changes

Two limits for custom sources:

- **50 resources per custom source** (down from 500) — enforced via `MAX_MANIFEST_RESOURCES` in the manifest schema, so it applies anywhere the manifest is validated (create, schema discovery, sync).
- **5 custom sources per team/project** — new `MAX_CUSTOM_SOURCES_PER_TEAM`, checked in the `external_data_sources` create endpoint. Soft-deleted sources and other teams' sources don't count.

Both limits live as named constants in `posthog/temporal/data_imports/sources/custom/source.py`.

## How did you test this code?

I'm an agent. I ran the relevant automated tests; no manual testing.

- `posthog/temporal/data_imports/sources/custom/test_custom_source.py -k resource` — existing manifest resource-count tests (reference the constant, so they validate the new 50 cap) — 9 passed.
- `products/data_warehouse/backend/api/test/test_external_data_source.py -k custom_source` — 11 passed, including two new tests:
  - rejects creation when the team already has `MAX_CUSTOM_SOURCES_PER_TEAM` custom sources
  - the count ignores soft-deleted sources

## 🤖 Agent context

Authored by Claude Code (Opus) at the request of the human PR author. The "resource" limit maps to manifest resources (each becomes an `ExternalDataSchema`), so it was implemented by lowering the existing `MAX_MANIFEST_RESOURCES` structural cap rather than adding a parallel limit. The per-team cap is enforced in the create viewset right after the existing custom-source availability gate, mirroring the existing soft-delete-aware count patterns in the model. Requires human review.
