### PR TITLE
fix(dashboards): stop auto-refresh re-requesting forbidden insight tiles

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -9,11 +9,12 @@ import * as dashboardWidgetUtils from '@posthog/products-dashboards/frontend/uti
 import { DASHBOARD_WIDGET_FETCH_ERROR_MESSAGE } from '@posthog/products-dashboards/frontend/widgets/constants'
 
 import api from 'lib/api'
+import { ApiError } from 'lib/api-error'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs, now } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { DashboardLoadAction, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { DashboardLoadAction, dashboardLogic, RefreshDashboardItemsAction } from 'scenes/dashboard/dashboardLogic'
 import * as dashboardUtils from 'scenes/dashboard/dashboardUtils'
 import * as widgetFetchUtils from 'scenes/dashboard/widgetFetchUtils'
 import { teamLogic } from 'scenes/teamLogic'
@@ -1041,6 +1042,73 @@ describe('dashboardLogic', () => {
                             total: 1,
                         },
                     })
+            })
+
+            it('auto-refresh skips tiles that returned a 403, but a user refresh retries them', async () => {
+                const dashboard = dashboards[5]
+                const forbiddenInsight = {
+                    ...dashboard.tiles[0].insight!,
+                    cache_target_age: now().subtract(1, 'minute').toISOString(),
+                }
+                const okInsight = {
+                    ...dashboard.tiles[1].insight!,
+                    cache_target_age: now().subtract(1, 'minute').toISOString(),
+                }
+                dashboard.tiles[0].insight = forbiddenInsight
+                dashboard.tiles[1].insight = okInsight
+
+                const getInsightWithRetrySpy = jest
+                    .spyOn(dashboardUtils, 'getInsightWithRetry')
+                    .mockImplementation(async (_teamId, insight) => {
+                        if (insight.id === forbiddenInsight.id) {
+                            throw new ApiError('Forbidden', 403)
+                        }
+                        return insight
+                    })
+                const refreshedShortIds = (): (string | undefined)[] =>
+                    getInsightWithRetrySpy.mock.calls.map((c) => c[1].short_id)
+
+                try {
+                    // initial load records the 403 in the circuit breaker
+                    await expectLogic(logic, () => {
+                        logic.actions.loadDashboard({ action: DashboardLoadAction.InitialLoad })
+                    })
+                        .toDispatchActions([
+                            'refreshDashboardItems',
+                            (a) =>
+                                a.type === logic.actionTypes.setRefreshError &&
+                                a.payload.shortId === forbiddenInsight.short_id,
+                        ])
+                        .toFinishAllListeners()
+
+                    expect(logic.values.forbiddenTiles[forbiddenInsight.short_id]).toBe(true)
+
+                    // an automatic refresh must not re-request the forbidden tile
+                    getInsightWithRetrySpy.mockClear()
+                    await expectLogic(logic, () => {
+                        logic.actions.refreshDashboardItems({
+                            action: RefreshDashboardItemsAction.Refresh,
+                            forceRefresh: true,
+                            isAutoRefresh: true,
+                        })
+                    }).toFinishAllListeners()
+
+                    expect(refreshedShortIds()).toContain(okInsight.short_id)
+                    expect(refreshedShortIds()).not.toContain(forbiddenInsight.short_id)
+
+                    // a user-initiated refresh clears the breaker and tries the tile again
+                    getInsightWithRetrySpy.mockClear()
+                    await expectLogic(logic, () => {
+                        logic.actions.refreshDashboardItems({
+                            action: RefreshDashboardItemsAction.Refresh,
+                            forceRefresh: true,
+                        })
+                    }).toFinishAllListeners()
+
+                    expect(refreshedShortIds()).toContain(forbiddenInsight.short_id)
+                } finally {
+                    getInsightWithRetrySpy.mockRestore()
+                }
             })
         })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1095,6 +1095,8 @@ describe('dashboardLogic', () => {
 
                     expect(refreshedShortIds()).toContain(okInsight.short_id)
                     expect(refreshedShortIds()).not.toContain(forbiddenInsight.short_id)
+                    // ...but the tile keeps showing its error instead of silently going blank
+                    expect(logic.values.refreshStatus[forbiddenInsight.short_id]?.errored).toBe(true)
 
                     // a user-initiated refresh clears the breaker and tries the tile again
                     getInsightWithRetrySpy.mockClear()

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -263,6 +263,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
         refreshDashboardItems: (payload: {
             action: RefreshDashboardItemsAction | DashboardLoadAction
             forceRefresh?: boolean
+            /** True only for the periodic auto-refresh interval, so it can skip permanently-forbidden tiles. */
+            isAutoRefresh?: boolean
         }) => payload,
         refreshDashboardWidgets: (payload: { tileIds: number[]; forceRefresh?: boolean }) => payload,
         setWidgetRunResults: (results: Record<number, DashboardWidgetRunResultApi>) => ({ results }),
@@ -1030,6 +1032,23 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 refreshDashboardItems: () => ({}),
                 abortQuery: () => ({}),
                 cancelDashboardRefresh: () => ({}),
+            },
+        ],
+        /**
+         * Short IDs of insight tiles that returned a permanent permission error (401/403).
+         * The periodic auto-refresh skips these so an open tab doesn't re-request forbidden
+         * tiles forever. Cleared on full dashboard load and on any user-initiated refresh,
+         * so a genuine access change is picked up the next time the user acts.
+         */
+        forbiddenTiles: [
+            {} as Record<string, boolean>,
+            {
+                setRefreshError: (state, { shortId, error }) =>
+                    error instanceof ApiError && (error.status === 403 || error.status === 401)
+                        ? { ...state, [shortId]: true }
+                        : state,
+                loadDashboardSuccess: () => ({}),
+                refreshDashboardItems: (state, { isAutoRefresh }) => (isAutoRefresh ? state : {}),
             },
         ],
         columns: [
@@ -2322,7 +2341,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 actions.setRefreshError(insight.short_id, e)
             }
         },
-        refreshDashboardItems: async ({ action, forceRefresh }, breakpoint) => {
+        refreshDashboardItems: async ({ action, forceRefresh, isAutoRefresh }, breakpoint) => {
             const dashboardRefreshStartTime = performance.now()
             const isInitialLoad =
                 action === DashboardLoadAction.InitialLoad || action === DashboardLoadAction.InitialLoadWithVariables
@@ -2346,6 +2365,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         !t.insight.cache_target_age ||
                         dayjs(t.insight.cache_target_age).isBefore(dayjs())
                 )
+                // circuit breaker: the periodic auto-refresh skips tiles that returned a
+                // permission error, so an open tab doesn't re-request forbidden tiles forever
+                .filter((t) => !isAutoRefresh || !values.forbiddenTiles[t.insight.short_id])
 
             const tilesStaleCount = sortedTilesToRefresh.length
             let tilesRefreshedCount = 0
@@ -2742,6 +2764,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     actions.refreshDashboardItems({
                         action: RefreshDashboardItemsAction.Refresh,
                         forceRefresh: true,
+                        isAutoRefresh: true,
                     })
                 }
                 cache.disposables.add(() => {
@@ -2749,6 +2772,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         actions.refreshDashboardItems({
                             action: RefreshDashboardItemsAction.Refresh,
                             forceRefresh: true,
+                            isAutoRefresh: true,
                         })
                     }, values.autoRefresh.interval * 1000)
                     return () => clearInterval(intervalId)

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1037,8 +1037,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
         /**
          * Short IDs of insight tiles that returned a permanent permission error (401/403).
          * The periodic auto-refresh skips these so an open tab doesn't re-request forbidden
-         * tiles forever. Cleared on full dashboard load and on any user-initiated refresh,
-         * so a genuine access change is picked up the next time the user acts.
+         * tiles forever. A tile leaves the set as soon as it refreshes successfully (e.g. a
+         * single-tile refresh after access is granted), and the whole set is cleared on full
+         * dashboard load and on any user-initiated refresh — so a genuine access change is
+         * always picked up the next time the tile loads or the user acts.
          */
         forbiddenTiles: [
             {} as Record<string, boolean>,
@@ -1047,6 +1049,15 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     error instanceof ApiError && (error.status === 403 || error.status === 401)
                         ? { ...state, [shortId]: true }
                         : state,
+                setRefreshStatus: (state, { shortId, loading, queued }) => {
+                    // a successful refresh (not the loading/queued markers) clears the breaker
+                    if (loading || queued || !state[shortId]) {
+                        return state
+                    }
+                    const rest = { ...state }
+                    delete rest[shortId]
+                    return rest
+                },
                 loadDashboardSuccess: () => ({}),
                 refreshDashboardItems: (state, { isAutoRefresh }) => (isAutoRefresh ? state : {}),
             },
@@ -2365,9 +2376,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         !t.insight.cache_target_age ||
                         dayjs(t.insight.cache_target_age).isBefore(dayjs())
                 )
-                // circuit breaker: the periodic auto-refresh skips tiles that returned a
-                // permission error, so an open tab doesn't re-request forbidden tiles forever
-                .filter((t) => !isAutoRefresh || !values.forbiddenTiles[t.insight.short_id])
 
             const tilesStaleCount = sortedTilesToRefresh.length
             let tilesRefreshedCount = 0
@@ -2403,6 +2411,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     lastDashboardRefresh,
                     isAnalyzing,
                     refreshAnalysisCacheKey,
+                    forbiddenTiles,
                 } = values
 
                 const fetchSyncInsightFunctions = sortedTilesToRefresh.map((tile) => async () => {
@@ -2410,6 +2419,16 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     const queryId = uuid()
                     const queryStartTime = performance.now()
                     const dashboardId: number = props.id
+
+                    // Circuit breaker: on the periodic auto-refresh, don't re-request a tile that
+                    // previously returned a permission error — an open tab would otherwise hammer
+                    // forbidden tiles forever. Keep the errored status visible and skip the network
+                    // call. A user-initiated refresh clears `forbiddenTiles` and tries again.
+                    if (isAutoRefresh && forbiddenTiles[insight.short_id]) {
+                        actions.setRefreshError(insight.short_id)
+                        tilesErroredCount++
+                        return
+                    }
 
                     // Set insight as refreshing
                     actions.setRefreshStatus(insight.short_id, true, true)


### PR DESCRIPTION
## Problem

Dashboard auto-refresh re-requested forbidden insight tiles indefinitely. The auto-refresh setting is persisted to localStorage and fires every 30 minutes, force-refreshing **every** tile on the dashboard with no circuit breaker. When a dashboard contains tiles the current user is forbidden from (`403`), an open tab keeps re-requesting those tiles on every cycle, forever — each failure firing a `client_request_failure` event. A small number of long-lived sessions can generate a very large, sustained volume of `403`s on `/insights` this way.

The per-insight `getInsightWithRetry` only retries on rate-limit responses, so a `403` is recorded as an errored tile and then re-requested unchanged on the next interval.

## Changes

Added a per-dashboard circuit breaker in `dashboardLogic`:

- A new `forbiddenTiles` reducer records the `short_id` of any tile whose refresh fails with a `401`/`403` `ApiError`.
- The periodic auto-refresh now skips tiles in that set, so an open tab stops re-requesting forbidden tiles.
- A new `isAutoRefresh` flag distinguishes the interval-driven refresh from user actions — it is set **only** at the two interval call sites. The breaker suppresses requests on auto-refresh only.
- The breaker is self-healing: it is cleared on full dashboard load and on any user-initiated refresh (or filter/variable change), so if access is actually restored, the next intentional action retries the tile.

Net effect: a forbidden tile is requested at most once per load instead of every 30 minutes indefinitely. Manual reloads are unaffected.

## How did you test this code?

I'm an agent (PostHog Slack app). I did **not** perform manual testing.

Automated test added (not run locally — this was authored in an environment without frontend dependencies installed, so CI is the source of truth):

- `auto-refresh skips tiles that returned a 403, but a user refresh retries them` in `dashboardLogic.test.ts` — asserts that after a tile 403s, the automatic refresh does not re-request it while still refreshing accessible tiles, and that a user-initiated refresh clears the breaker and retries the tile.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored by the PostHog Slack app (Claude) via the PostHog code tools and MCP analytics tools.

Investigation: a `client_request_failure`/`403`/`/insights` spike was traced via HogQL queries to a tiny set of `distinct_id`s and a handful of sessions repeatedly loading a few dashboards — pointing at unbounded client-side re-requests rather than a backend regression. From there I located the capture site (`lib/api.ts`), then the dashboard auto-refresh loop (`dashboardLogic.tsx`), and confirmed auto-refresh is persisted, fires every 1800s, and force-refreshes all tiles.

Decisions: scoped the fix to the auto-refresh path only (via an explicit `isAutoRefresh` flag) rather than suppressing all retries, so user-initiated refreshes and access changes still work. Made the breaker clear on load and user refresh to avoid permanently masking a tile after access is granted. Considered backing off inside `getInsightWithRetry`, but that helper has no per-dashboard memory across cycles, so the breaker lives in the logic's state instead.
