### PR TITLE
fix(cdp): apply auto.offset.reset to the v2 consumer topic config

### DIFF
--- a/nodejs/src/kafka/consumer/consumer-v2.test.ts
+++ b/nodejs/src/kafka/consumer/consumer-v2.test.ts
@@ -179,18 +179,18 @@ describe('KafkaConsumerV2', () => {
 
     // auto.offset.reset is a topic-level librdkafka property — a value only in the global config
     // is ignored, so the override must be mirrored into the topic config (2nd ctor arg).
-    it('mirrors an auto.offset.reset override into the topic config', () => {
-        const RdKafkaCtor = jest.mocked(require('node-rdkafka').KafkaConsumer)
-        new KafkaConsumerV2({ groupId: 'g', topic: 't' }, { 'auto.offset.reset': 'latest' } as any)
+    it.each([
+        [
+            'mirrors an auto.offset.reset override into the topic config',
+            { 'auto.offset.reset': 'latest' } as any,
+            'latest',
+        ],
+        ['defaults the topic-config auto.offset.reset to earliest with no override', undefined, 'earliest'],
+    ])('%s', (_label, overrides, expected) => {
+        const RdKafkaCtor = jest.mocked(RdKafkaConsumer)
+        new KafkaConsumerV2({ groupId: 'g', topic: 't' }, overrides)
         const topicConfig = RdKafkaCtor.mock.calls.at(-1)![1] as any
-        expect(topicConfig['auto.offset.reset']).toBe('latest')
-    })
-
-    it('defaults the topic-config auto.offset.reset to earliest with no override', () => {
-        const RdKafkaCtor = jest.mocked(require('node-rdkafka').KafkaConsumer)
-        new KafkaConsumerV2({ groupId: 'g', topic: 't' })
-        const topicConfig = RdKafkaCtor.mock.calls.at(-1)![1] as any
-        expect(topicConfig['auto.offset.reset']).toBe('earliest')
+        expect(topicConfig['auto.offset.reset']).toBe(expected)
     })
 
     it('Smoke: connect → consume → eachBatch → offsets stored', async () => {

--- a/nodejs/src/kafka/consumer/consumer-v2.test.ts
+++ b/nodejs/src/kafka/consumer/consumer-v2.test.ts
@@ -177,6 +177,22 @@ describe('KafkaConsumerV2', () => {
         await delay(2)
     }
 
+    // auto.offset.reset is a topic-level librdkafka property — a value only in the global config
+    // is ignored, so the override must be mirrored into the topic config (2nd ctor arg).
+    it('mirrors an auto.offset.reset override into the topic config', () => {
+        const RdKafkaCtor = jest.mocked(require('node-rdkafka').KafkaConsumer)
+        new KafkaConsumerV2({ groupId: 'g', topic: 't' }, { 'auto.offset.reset': 'latest' } as any)
+        const topicConfig = RdKafkaCtor.mock.calls.at(-1)![1] as any
+        expect(topicConfig['auto.offset.reset']).toBe('latest')
+    })
+
+    it('defaults the topic-config auto.offset.reset to earliest with no override', () => {
+        const RdKafkaCtor = jest.mocked(require('node-rdkafka').KafkaConsumer)
+        new KafkaConsumerV2({ groupId: 'g', topic: 't' })
+        const topicConfig = RdKafkaCtor.mock.calls.at(-1)![1] as any
+        expect(topicConfig['auto.offset.reset']).toBe('earliest')
+    })
+
     it('Smoke: connect → consume → eachBatch → offsets stored', async () => {
         const eachBatch = jest.fn(() => Promise.resolve({}))
         await startConsuming(eachBatch)

--- a/nodejs/src/kafka/consumer/consumer-v2.ts
+++ b/nodejs/src/kafka/consumer/consumer-v2.ts
@@ -38,6 +38,10 @@ import {
 const DEFAULT_BATCH_TIMEOUT_MS = 500
 const STATISTICS_INTERVAL_MS = 5000
 const LOOP_STALL_THRESHOLD_MS_DEFAULT = 60_000
+// auto.offset.reset is a topic-level property and which config form librdkafka honors varies by
+// version (see node-rdkafka #984), so it's applied to both the global config and the explicit
+// topic config. This is the default when a consumer doesn't opt into an override.
+const DEFAULT_AUTO_OFFSET_RESET = 'earliest'
 
 export type KafkaConsumerV2Config = {
     groupId: string
@@ -142,11 +146,9 @@ export class KafkaConsumerV2 {
             'socket.timeout.ms': 30_000,
             'enable.partition.eof': this.config.enablePartitionEof ?? true,
             'statistics.interval.ms': STATISTICS_INTERVAL_MS,
-            // auto.offset.reset is a topic-level property and which form librdkafka honors
-            // varies by version (see node-rdkafka #984), so we set it in both: here as the
-            // global/default-topic-conf fallback, and explicitly in the topic config in
-            // createConsumer (the resolved value, including any override). Keep them in sync.
-            ['auto.offset.reset' as keyof ConsumerGlobalConfig]: 'earliest' as never,
+            // Global/default-topic-conf fallback; the resolved value (incl. any override) is
+            // also applied to the explicit topic config in createConsumer.
+            ['auto.offset.reset' as keyof ConsumerGlobalConfig]: DEFAULT_AUTO_OFFSET_RESET as never,
             ...getKafkaConfigFromEnv('CONSUMER'),
             ...rdKafkaOverrides,
             // Settings we don't allow callers to override.
@@ -534,14 +536,13 @@ export class KafkaConsumerV2 {
     // === RdKafkaConsumer construction + event wiring ===
 
     private createConsumer(): RdKafkaConsumer {
-        // auto.offset.reset is a topic-level property: a value in the global config is ignored by
-        // librdkafka unless mirrored into the topic config here. Honor an override carried on the
-        // resolved config (e.g. `latest`) and default to earliest.
+        // Mirror the resolved auto.offset.reset (incl. any override) into the explicit topic
+        // config — the form librdkafka honors on our version. See DEFAULT_AUTO_OFFSET_RESET.
         const autoOffsetReset =
             (this.rdKafkaConfig['auto.offset.reset' as keyof ConsumerGlobalConfig] as
                 | 'earliest'
                 | 'latest'
-                | undefined) ?? 'earliest'
+                | undefined) ?? DEFAULT_AUTO_OFFSET_RESET
         const consumer = new RdKafkaConsumer(this.rdKafkaConfig, { 'auto.offset.reset': autoOffsetReset })
 
         consumer.on('event.log', (log) => logger.info('📝', 'kafka_consumer_v2_librdkafka_log', { log }))

--- a/nodejs/src/kafka/consumer/consumer-v2.ts
+++ b/nodejs/src/kafka/consumer/consumer-v2.ts
@@ -533,7 +533,15 @@ export class KafkaConsumerV2 {
     // === RdKafkaConsumer construction + event wiring ===
 
     private createConsumer(): RdKafkaConsumer {
-        const consumer = new RdKafkaConsumer(this.rdKafkaConfig, { 'auto.offset.reset': 'earliest' })
+        // auto.offset.reset is a topic-level property: a value in the global config is ignored by
+        // librdkafka unless mirrored into the topic config here. Honor an override carried on the
+        // resolved config (e.g. `latest`) and default to earliest.
+        const autoOffsetReset =
+            (this.rdKafkaConfig['auto.offset.reset' as keyof ConsumerGlobalConfig] as
+                | 'earliest'
+                | 'latest'
+                | undefined) ?? 'earliest'
+        const consumer = new RdKafkaConsumer(this.rdKafkaConfig, { 'auto.offset.reset': autoOffsetReset })
 
         consumer.on('event.log', (log) => logger.info('📝', 'kafka_consumer_v2_librdkafka_log', { log }))
         consumer.on('event.error', (error: LibrdKafkaError) => {

--- a/nodejs/src/kafka/consumer/consumer-v2.ts
+++ b/nodejs/src/kafka/consumer/consumer-v2.ts
@@ -142,9 +142,10 @@ export class KafkaConsumerV2 {
             'socket.timeout.ms': 30_000,
             'enable.partition.eof': this.config.enablePartitionEof ?? true,
             'statistics.interval.ms': STATISTICS_INTERVAL_MS,
-            // Newer librdkafka versions require this in the global config (the topic-config
-            // form passed to RdKafkaConsumer's second arg is silently ignored for assign-based
-            // consumers in some versions). See node-rdkafka issue #984.
+            // auto.offset.reset is a topic-level property and which form librdkafka honors
+            // varies by version (see node-rdkafka #984), so we set it in both: here as the
+            // global/default-topic-conf fallback, and explicitly in the topic config in
+            // createConsumer (the resolved value, including any override). Keep them in sync.
             ['auto.offset.reset' as keyof ConsumerGlobalConfig]: 'earliest' as never,
             ...getKafkaConfigFromEnv('CONSUMER'),
             ...rdKafkaOverrides,


### PR DESCRIPTION
## Problem

`auto.offset.reset` is a topic-level librdkafka property, but `KafkaConsumerV2` hardcoded `earliest` in the **topic config** (2nd arg to `RdKafkaConsumer`), which overrides the value in the global config on the librdkafka versions we run. A consumer that opts into `latest` via the override is therefore silently pinned to `earliest`, so a brand-new consumer group replays the whole topic from the start instead of beginning at the head.

## Changes

Mirror the resolved `auto.offset.reset` (including an override) into the topic config, defaulting to `earliest`. No behavior change for consumers that don't set an override — only ones explicitly opting into `latest` are affected.

## How did you test this code?

Agent-authored; automated tests only (no manual testing performed):

- Added a unit test asserting a `latest` override reaches the topic config — fails on master, passes with this change.
- Added a unit test asserting it defaults to `earliest` when no override is set.
- Full `nodejs/src/kafka/consumer/consumer-v2.test.ts` suite passes (24/24) and `tsc --noEmit` is clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored with Claude Code. The bug surfaced while enabling a real-time consumer that must start at the head — the `latest` override it set wasn't taking effect because the topic-config form overrides the global config on our librdkafka version. Fixing it only in the global config was considered but rejected, since the topic-level form is the one actually honored; the fix sets the resolved value in the topic config (covering both forms). Verified via the two unit tests above; no manual run.